### PR TITLE
Remove redundant trimmer warning suppressions

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
@@ -19,7 +19,7 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Internal.Runtime.InteropServices.InMemoryAssemblyLoader.LoadInMemoryAssemblyInContextImplLocal(System.IntPtr,System.IntPtr)</property>
+      <property name="Target">M:Internal.Runtime.InteropServices.InMemoryAssemblyLoader.LoadInMemoryAssemblyInContextWhenSupported(System.IntPtr,System.IntPtr)</property>
       <property name="Justification">This warning is left in the product so developers get an ILLink warning when trimming an app with Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported=true.</property>
     </attribute>
   </assembly>

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
@@ -19,7 +19,7 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Internal.Runtime.InteropServices.InMemoryAssemblyLoader.LoadInMemoryAssembly(System.IntPtr,System.IntPtr)</property>
+      <property name="Target">M:Internal.Runtime.InteropServices.InMemoryAssemblyLoader.LoadInMemoryAssemblyInContextImplLocal(System.IntPtr,System.IntPtr)</property>
       <property name="Justification">This warning is left in the product so developers get an ILLink warning when trimming an app with Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported=true.</property>
     </attribute>
   </assembly>

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
@@ -29,13 +29,18 @@ namespace Internal.Runtime.InteropServices
             if (!IsSupported)
                 throw new NotSupportedException(SR.NotSupported_CppCli);
 
-            LoadInMemoryAssemblyInContextImplLocal(moduleHandle, assemblyPath);
+            LoadInMemoryAssemblyInContextWhenSupported(moduleHandle, assemblyPath);
+        }
 
-            void LoadInMemoryAssemblyInContextImplLocal(IntPtr moduleHandle, IntPtr assemblyPath){
+        // The call to `LoadInMemoryAssemblyInContextImpl` will produce a warning IL2026.
+        // It is intentionally left in the product, so developers get a warning when trimming an app which enabled `Internal.Runtime.InteropServices.InMemoryAssemblyLoader.IsSupported`.
+        // For runtime build the warning is suppressed in the ILLink.Suppressions.LibraryBuild.xml, but we only want to suppress it if the feature is enabled (IsSupported is true).
+        // The call is extracted into a separate method which is the sole target of the suppression.
+        private static unsafe void LoadInMemoryAssemblyInContextWhenSupported(IntPtr moduleHandle, IntPtr assemblyPath)
+        {
 #pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
-                LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath);
+            LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath);
 #pragma warning restore IL2026
-            }
         }
 
         /// <summary>

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/InMemoryAssemblyLoader.cs
@@ -29,9 +29,13 @@ namespace Internal.Runtime.InteropServices
             if (!IsSupported)
                 throw new NotSupportedException(SR.NotSupported_CppCli);
 
+            LoadInMemoryAssemblyInContextImplLocal(moduleHandle, assemblyPath);
+
+            void LoadInMemoryAssemblyInContextImplLocal(IntPtr moduleHandle, IntPtr assemblyPath){
 #pragma warning disable IL2026 // suppressed in ILLink.Suppressions.LibraryBuild.xml
-            LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath);
+                LoadInMemoryAssemblyInContextImpl(moduleHandle, assemblyPath);
 #pragma warning restore IL2026
+            }
         }
 
         /// <summary>

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
@@ -119,8 +119,6 @@ namespace System.Reflection.Emit
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
-            Justification = "Linker doesn't recognize always throwing method. https://github.com/mono/linker/issues/2025")]
         public override Type GetInterface(string name, bool ignoreCase) { throw new NotSupportedException(); }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/SymbolType.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/SymbolType.cs
@@ -398,8 +398,6 @@ namespace System.Reflection.Emit
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
-            Justification = "Linker doesn't recognize always throwing method. https://github.com/mono/linker/issues/2025")]
         public override Type GetInterface(string name, bool ignoreCase)
         {
             throw new NotSupportedException(SR.NotSupported_NonReflectedType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -178,8 +178,6 @@ namespace System.Reflection.Emit
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
-            Justification = "Linker doesn't recognize always throwing method. https://github.com/mono/linker/issues/2025")]
         public override Type GetInterface(string name, bool ignoreCase) { throw new NotSupportedException(); }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -789,19 +789,12 @@ namespace System.Runtime.InteropServices
                 Release(bindctx);
             }
         }
-        // Revist after https://github.com/mono/linker/issues/1989 is fixed
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2050:UnrecognizedReflectionPattern",
-            Justification = "The calling method is annotated with RequiresUnreferencedCode")]
         [LibraryImport(Interop.Libraries.Ole32)]
         private static partial int CreateBindCtx(uint reserved, out IntPtr ppbc);
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2050:UnrecognizedReflectionPattern",
-            Justification = "The calling method is annotated with RequiresUnreferencedCode")]
         [LibraryImport(Interop.Libraries.Ole32)]
         private static partial int MkParseDisplayName(IntPtr pbc, [MarshalAs(UnmanagedType.LPWStr)] string szUserName, out uint pchEaten, out IntPtr ppmk);
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2050:UnrecognizedReflectionPattern",
-            Justification = "The calling method is annotated with RequiresUnreferencedCode")]
         [LibraryImport(Interop.Libraries.Ole32)]
         private static partial int BindMoniker(IntPtr pmk, uint grfOpt, ref Guid iidResult, out IntPtr ppvResult);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3929,7 +3929,6 @@ namespace System
                     }
 
                     // fast path??
-                    // IL2082
                     instance = CreateInstanceLocal(this, nonPublic: true, wrapExceptions: wrapExceptions);
                 }
                 else

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3850,8 +3850,6 @@ namespace System
                 throw new NotSupportedException(SR.Acc_CreateVoid);
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2082:UnrecognizedReflectionPattern",
-            Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
         internal object? CreateInstanceImpl(
             BindingFlags bindingAttr, Binder? binder, object?[]? args, CultureInfo? culture)
         {
@@ -3932,7 +3930,7 @@ namespace System
 
                     // fast path??
                     // IL2082
-                    instance = Activator.CreateInstance(this, nonPublic: true, wrapExceptions: wrapExceptions);
+                    instance = CreateInstanceLocal(this, nonPublic: true, wrapExceptions: wrapExceptions);
                 }
                 else
                 {
@@ -3943,6 +3941,13 @@ namespace System
             }
 
             return instance;
+
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2082:UnrecognizedReflectionPattern",
+                Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
+            object? CreateInstanceLocal(Type type, bool nonPublic, bool wrapExceptions)
+            {
+                return Activator.CreateInstance(this, nonPublic: true, wrapExceptions: wrapExceptions);
+            }
         }
 
         /// <summary>

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3852,8 +3852,6 @@ namespace System
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2082:UnrecognizedReflectionPattern",
             Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
-            Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
         internal object? CreateInstanceImpl(
             BindingFlags bindingAttr, Binder? binder, object?[]? args, CultureInfo? culture)
         {
@@ -3933,6 +3931,7 @@ namespace System
                     }
 
                     // fast path??
+                    // IL2082
                     instance = Activator.CreateInstance(this, nonPublic: true, wrapExceptions: wrapExceptions);
                 }
                 else

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Assignability.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/Assignability.cs
@@ -17,8 +17,6 @@ namespace System.Reflection.Runtime.General
             Justification = "Just instantiating over formals for desktop compat reasons")]
         [UnconditionalSuppressMessage("AotAnalysis", "IL3050:AotUnfriendlyApi",
             Justification = "Just instantiating over formals for desktop compat reasons")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
-            Justification = "Looking at interface list is safe because we wouldn't remove reflection-visible interface from a reflection-visible type")]
         public static bool IsAssignableFrom(Type toTypeInfo, Type fromTypeInfo)
         {
             if (toTypeInfo == null)

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Operators.cs
@@ -1834,8 +1834,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             Bind a shift operator: <<, >>. These can have integer or long first operands,
             and second operand must be int.
         */
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "All types used here are builtin and will not be trimmed.")]
         private static ExprBinOp BindShiftOp(ExpressionBinder _, ExpressionKind ek, EXPRFLAG flags, Expr arg1, Expr arg2)
         {
             Debug.Assert(ek == ExpressionKind.LeftShirt || ek == ExpressionKind.RightShift);
@@ -1902,8 +1900,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return BindBoolBinOp(this, ek, flags, expr1, expr2);
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "All types used here are builtin and will not be trimmed.")]
         private static Expr BindLiftedBoolBitwiseOp(ExpressionBinder _, ExpressionKind ek, EXPRFLAG flags, Expr expr1, Expr expr2) => null;
 
         /*

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Helpers/UnsafeNativeMethods.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Helpers/UnsafeNativeMethods.vb
@@ -31,8 +31,6 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
         <DllImport("oleaut32", PreserveSig:=False, CharSet:=CharSet.Unicode, EntryPoint:="VarNumFromParseNum")>
         <RequiresUnreferencedCode("Marshalling COM Objects is not trim safe.")>
-        <UnconditionalSuppressMessage("ReflectionAnalysis", "IL2050:COMMarshalling",
-            Justification:="RequiresUnreferencedCode attribute currently doesn't suppress IL2050. This should be removed once it does. https://github.com/mono/linker/issues/1989")>
         Friend Shared Function VarNumFromParseNum(
                 <MarshalAs(UnmanagedType.LPArray)> ByVal numprsPtr As Byte(),
                 <MarshalAs(UnmanagedType.LPArray)> ByVal DigitArray As Byte(),
@@ -41,8 +39,6 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
         <DllImport("oleaut32", PreserveSig:=False, CharSet:=CharSet.Unicode, EntryPoint:="VariantChangeType")>
         <RequiresUnreferencedCode("Marshalling COM Objects is not trim safe.")>
-        <UnconditionalSuppressMessage("ReflectionAnalysis", "IL2050:COMMarshalling",
-            Justification:="RequiresUnreferencedCode attribute currently doesn't suppress IL2050. This should be removed once it does. https://github.com/mono/linker/issues/1989")>
         Friend Shared Sub VariantChangeType(
             <Out()> ByRef dest As Object,
             <[In]()> ByRef Src As Object,

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Interaction.vb
@@ -134,8 +134,6 @@ Namespace Microsoft.VisualBasic
             Return DirectCast(InvokeMethod("MsgBox", Prompt, Buttons, Title), MsgBoxResult)
         End Function
 
-        <UnconditionalSuppressMessage("ReflectionAnalsys", "IL2075:UnrecognizedReflectionPattern",
-                Justification:="Trimmer warns because it can't see Microsoft.VisualBasic.Forms. If the assembly is there, the trimmer will be able to tell to preserve the method specified.")>
         Private Function InvokeMethod(methodName As String, ParamArray args As Object()) As Object
             Dim type As Type = Type.GetType("Microsoft.VisualBasic._Interaction, Microsoft.VisualBasic.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError:=False)
             Dim method As MethodInfo = type?.GetMethod(methodName)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -71,7 +71,9 @@ namespace System.ComponentModel
         private static readonly Type[] s_skipInterfaceAttributeList = InitializeSkipInterfaceAttributeList();
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2121:RedundantSuppression",
-            Justification = "The suppression is necessary when the feature is turned on")]
+            Justification = "Removal of the attributes depends on the System.Runtime.InteropServices.BuiltInComInterop.IsSupported feature switch." +
+            "Building with feature switch enabled will not trigger attribute removal making the suppression unnecessary." +
+            "When disabled, the attributes are removed and the suppression is necessary.")]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2045:AttributeRemoval",
             Justification = "The ComVisibleAttribute is marked for removal and it's referenced here. Since this array" +
                             "contains only attributes which are going to be ignored, removing such attribute" +

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -70,7 +70,9 @@ namespace System.ComponentModel
         // not merge them into the attribute set for a class.
         private static readonly Type[] s_skipInterfaceAttributeList = InitializeSkipInterfaceAttributeList();
 
-        [UnconditionalSuppressMessage ("ReflectionAnalysis", "IL2045:AttributeRemoval",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2121:RedundantSuppression",
+            Justification = "The suppression is necessary when the feature is turned on")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2045:AttributeRemoval",
             Justification = "The ComVisibleAttribute is marked for removal and it's referenced here. Since this array" +
                             "contains only attributes which are going to be ignored, removing such attribute" +
                             "will not break the functionality in any way.")]

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2821,9 +2821,6 @@ namespace System.ComponentModel
         {
             private readonly TypeDescriptionProvider _comNativeDescriptor;
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
-                Justification = "The trimmer can't find the ComNativeDescriptor type when System.Windows.Forms isn't available. " +
-                "When System.Windows.Forms is available, the type will be seen by the trimmer and the ctor will be preserved.")]
             public ComNativeDescriptorProxy()
             {
                 Type realComNativeDescriptor = Type.GetType("System.Windows.Forms.ComponentModel.Com2Interop.ComNativeDescriptor, System.Windows.Forms", throwOnError: true)!;

--- a/src/libraries/System.Data.Common/src/System/Data/DataRowExtensions.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataRowExtensions.cs
@@ -144,8 +144,6 @@ namespace System.Data
         {
             internal static readonly Func<object, T?> s_unbox = Create();
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090:MakeGenericMethod",
-                Justification = "'NullableField<TElem> where TElem : struct' implies 'TElem : new()'. Nullable does not make use of new() so it is safe.")]
             private static Func<object, T?> Create()
             {
                 if (typeof(T).IsValueType && default(T) == null)
@@ -153,14 +151,22 @@ namespace System.Data
                     if (!RuntimeFeature.IsDynamicCodeSupported)
                         return NullableFieldUsingReflection;
 
-#pragma warning disable IL3050 // There is a path that is safe for AOT executed when IsDynamicCodeSupported is false.
-                    return typeof(UnboxT<T>)
-                        .GetMethod("NullableField", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
-                        .MakeGenericMethod(Nullable.GetUnderlyingType(typeof(T))!)
-                        .CreateDelegate<Func<object, T>>();
-#pragma warning restore IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+                    return CreateWhenDynamicCodeSupported();
                 }
                 return NonNullableField;
+
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2090:MakeGenericMethod",
+                    Justification = "'NullableField<TElem> where TElem : struct' implies 'TElem : new()'. Nullable does not make use of new() so it is safe." +
+                    "The warning is only issued when IsDynamicCodeSupported is true.")]
+                static Func<object, T?> CreateWhenDynamicCodeSupported()
+                {
+#pragma warning disable IL3050 // There is a path that is safe for AOT executed when IsDynamicCodeSupported is false.
+                    return typeof(UnboxT<T>)
+                       .GetMethod("NullableField", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
+                       .MakeGenericMethod(Nullable.GetUnderlyingType(typeof(T))!)
+                       .CreateDelegate<Func<object, T>>();
+#pragma warning restore IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.
+                }
             }
 
             private static T? NonNullableField(object value)

--- a/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
@@ -6925,8 +6925,6 @@ namespace System.Data
             }
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "This is unsafe only when columns have associated expression. All ways to add such expression are marked unsafe.")]
         internal void EvaluateExpressions(DataRow row, DataRowAction action, List<DataRow>? cachedRows)
         {
             // evaluate all expressions for specified row

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -1054,11 +1054,7 @@ namespace System.Diagnostics
                                 Interlocked.CompareExchange(ref _implicitTransformsTable,
                                     new ConcurrentDictionary<Type, TransformSpec?>(1, 8), null);
                             }
-                            implicitTransforms = _implicitTransformsTable.GetOrAdd(argType, type => MakeImplicitTransformsWrapper(type));
-
-                            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                                Justification = "The Morph method has RequiresUnreferencedCode, but the trimmer can't see through lamdba calls.")]
-                            static TransformSpec? MakeImplicitTransformsWrapper(Type transformType) => MakeImplicitTransforms(transformType);
+                            implicitTransforms = _implicitTransformsTable.GetOrAdd(argType, MakeImplicitTransforms);
                         }
 
                         // implicitTransformas now fetched from cache or constructed, use it to Fetch all the implicit fields.

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -136,21 +136,11 @@ namespace System.Linq
                 return typeof(IEnumerable);
             return t;
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
-                Justification = "The IGrouping<,> is kept since it's directly referenced here" +
-                    "and so it will also be preserved in all places where it's implemented." +
-                    "The GetInterfaces may return less after trimming but it will include" +
-                    "the IGrouping<,> if it was there before trimming, which is enough for this" +
-                    "method to work.")]
+            // IL2075
             static bool ImplementsIGrouping(Type type) =>
                 type.GetGenericTypeDefinition().GetInterfaces().Contains(typeof(IGrouping<,>));
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
-                Justification = "The IEnumerable<> is kept since it's directly referenced here" +
-                    "and so it will also be preserved in all places where it's implemented." +
-                    "The GetInterfaces may return less after trimming but it will include" +
-                    "the IEnumerable<> if it was there before trimming, which is enough for this" +
-                    "method to work.")]
+            // IL2070
             static bool TryGetImplementedIEnumerable(Type type, [NotNullWhen(true)] out Type? interfaceType)
             {
                 foreach (Type iType in type.GetInterfaces())
@@ -257,9 +247,7 @@ namespace System.Linq
 
             return matchingMethods[0];
 
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
-                Justification = "This method is intentionally hiding the Enumerable type from the trimmer so it doesn't preserve all Enumerable's methods. " +
-                "This is safe because all Queryable methods have a DynamicDependency to the corresponding Enumerable method.")]
+            // IL2070
             static MethodInfo[] GetEnumerableStaticMethods(Type type) =>
                 type.GetMethods(BindingFlags.Public | BindingFlags.Static);
             [RequiresDynamicCodeAttribute("Calls System.Reflection.MethodInfo.MakeGenericMethod(params Type[])")]

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableRewriter.cs
@@ -136,11 +136,9 @@ namespace System.Linq
                 return typeof(IEnumerable);
             return t;
 
-            // IL2075
             static bool ImplementsIGrouping(Type type) =>
                 type.GetGenericTypeDefinition().GetInterfaces().Contains(typeof(IGrouping<,>));
 
-            // IL2070
             static bool TryGetImplementedIEnumerable(Type type, [NotNullWhen(true)] out Type? interfaceType)
             {
                 foreach (Type iType in type.GetInterfaces())
@@ -247,7 +245,6 @@ namespace System.Linq
 
             return matchingMethods[0];
 
-            // IL2070
             static MethodInfo[] GetEnumerableStaticMethods(Type type) =>
                 type.GetMethods(BindingFlags.Public | BindingFlags.Static);
             [RequiresDynamicCodeAttribute("Calls System.Reflection.MethodInfo.MakeGenericMethod(params Type[])")]

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Delete.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Delete.cs
@@ -257,19 +257,8 @@ namespace System.Net.Http.Json
                 // Nullable forgiving reason:
                 // DeleteAsync will usually return Content as not-null.
                 // If Content happens to be null, the extension will throw.
-                return await ReadFromJsonAsyncHelper(response.Content!, type, options, cancellationToken).ConfigureAwait(false);
+                return await response.Content!.ReadFromJsonAsync(type, options, cancellationToken).ConfigureAwait(false);
             }
-
-            // Workaround for https://github.com/mono/linker/issues/1416, extracting the offending call into a separate method
-            // which can be annotated with suppressions.
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-            [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresDynamicCode.")]
-            static Task<object?> ReadFromJsonAsyncHelper(HttpContent content, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken)
-                => content.ReadFromJsonAsync(type, options, cancellationToken);
         }
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
@@ -282,7 +271,7 @@ namespace System.Net.Http.Json
                 // Nullable forgiving reason:
                 // DeleteAsync will usually return Content as not-null.
                 // If Content happens to be null, the extension will throw.
-                return await ReadFromJsonAsyncHelper<T>(response.Content!, options, cancellationToken).ConfigureAwait(false);
+                return await response.Content!.ReadFromJsonAsync<T>(options, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.cs
@@ -141,19 +141,8 @@ namespace System.Net.Http.Json
                 // Nullable forgiving reason:
                 // GetAsync will usually return Content as not-null.
                 // If Content happens to be null, the extension will throw.
-                return await ReadFromJsonAsyncHelper(response.Content!, type, options, cancellationToken).ConfigureAwait(false);
+                return await response.Content!.ReadFromJsonAsync(type, options, cancellationToken).ConfigureAwait(false);
             }
-
-            // Workaround for https://github.com/mono/linker/issues/1416, extracting the offending call into a separate method
-            // which can be annotated with suppressions.
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-            [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresDynamicCode.")]
-            static Task<object?> ReadFromJsonAsyncHelper(HttpContent content, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken)
-                => content.ReadFromJsonAsync(type, options, cancellationToken);
         }
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
@@ -166,23 +155,9 @@ namespace System.Net.Http.Json
                 // Nullable forgiving reason:
                 // GetAsync will usually return Content as not-null.
                 // If Content happens to be null, the extension will throw.
-                return await ReadFromJsonAsyncHelper<T>(response.Content!, options, cancellationToken).ConfigureAwait(false);
+                return await response.Content!.ReadFromJsonAsync<T>(options, cancellationToken).ConfigureAwait(false);
             }
         }
-
-        // Workaround for https://github.com/mono/linker/issues/1416, extracting the offending call into a separate method
-        // which can be annotated with suppressions.
-        // Note that in this case it can't be a local function since that inherits a generic parameter from the parent method
-        // which causes a trimmer warning coming from compiler generated code, which is very hard to suppress.
-        // Avoid that by declaring it a normal method which fully defines its own generic parameters.
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:UnrecognizedReflectionPattern",
-            Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresDynamicCode.")]
-        private static Task<T?> ReadFromJsonAsyncHelper<T>(HttpContent content, JsonSerializerOptions? options, CancellationToken cancellationToken)
-            => content.ReadFromJsonAsync<T>(options, cancellationToken);
 
         private static async Task<object?> GetFromJsonAsyncCore(Task<HttpResponseMessage> taskResponse, Type type, JsonSerializerContext context, CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
@@ -51,17 +51,8 @@ namespace System.Net.Http.Json
         {
             using (Stream contentStream = await GetContentStream(content, sourceEncoding, cancellationToken).ConfigureAwait(false))
             {
-                return await DeserializeAsyncHelper(contentStream, type, options ?? JsonHelpers.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync(contentStream, type, options ?? JsonHelpers.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(false);
             }
-
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-            [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresDynamicCode.")]
-            static ValueTask<object?> DeserializeAsyncHelper(Stream contentStream, Type returnType, JsonSerializerOptions? options, CancellationToken cancellationToken)
-                => JsonSerializer.DeserializeAsync(contentStream, returnType, options, cancellationToken);
         }
 
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
@@ -70,18 +61,9 @@ namespace System.Net.Http.Json
         {
             using (Stream contentStream = await GetContentStream(content, sourceEncoding, cancellationToken).ConfigureAwait(false))
             {
-                return await DeserializeAsyncHelper<T>(contentStream, options ?? JsonHelpers.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(false);
+                return await JsonSerializer.DeserializeAsync<T>(contentStream, options ?? JsonHelpers.s_defaultSerializerOptions, cancellationToken).ConfigureAwait(false);
             }
         }
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:UnrecognizedReflectionPattern",
-            Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresDynamicCode.")]
-        private static ValueTask<TValue?> DeserializeAsyncHelper<TValue>(Stream contentStream, JsonSerializerOptions? options, CancellationToken cancellationToken)
-            => JsonSerializer.DeserializeAsync<TValue>(contentStream, options, cancellationToken);
 
         public static Task<object?> ReadFromJsonAsync(this HttpContent content, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default)
         {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -105,7 +105,7 @@ namespace System.Net.Http.Json
 
                 using (TranscodingWriteStream transcodingStream = new TranscodingWriteStream(targetStream, targetEncoding))
                 {
-                    await SerializeAsyncHelper(transcodingStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                    await JsonSerializer.SerializeAsync(transcodingStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
                     // The transcoding streams use Encoders and Decoders that have internal buffers. We need to flush these
                     // when there is no more data to be written. Stream.FlushAsync isn't suitable since it's
                     // acceptable to Flush a Stream (multiple times) prior to completion.

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -80,11 +80,11 @@ namespace System.Net.Http.Json
                 {
                     if (async)
                     {
-                        await SerializeAsyncHelper(transcodingStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                        await JsonSerializer.SerializeAsync(transcodingStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
-                        SerializeSyncHelper(transcodingStream, Value, ObjectType, _jsonSerializerOptions);
+                        JsonSerializer.Serialize(transcodingStream, Value, ObjectType, _jsonSerializerOptions);
                     }
                 }
                 finally
@@ -117,32 +117,17 @@ namespace System.Net.Http.Json
             {
                 if (async)
                 {
-                    await SerializeAsyncHelper(targetStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+                    await JsonSerializer.SerializeAsync(targetStream, Value, ObjectType, _jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
 #if NETCOREAPP
-                    SerializeSyncHelper(targetStream, Value, ObjectType, _jsonSerializerOptions);
+                    JsonSerializer.Serialize(targetStream, Value, ObjectType, _jsonSerializerOptions);
 #else
                     Debug.Fail("Synchronous serialization is only supported since .NET 5.0");
 #endif
                 }
             }
-#if NETCOREAPP
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-            [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresDynamicCode.")]
-            static void SerializeSyncHelper(Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options)
-                => JsonSerializer.Serialize(utf8Json, value, inputType, options);
-#endif
-
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresUnreferencedCode.")]
-            [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-                Justification = "Workaround for https://github.com/mono/linker/issues/1416. The outer method is marked as RequiresDynamicCode.")]
-            static Task SerializeAsyncHelper(Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options, CancellationToken cancellationToken)
-                => JsonSerializer.SerializeAsync(utf8Json, value, inputType, options, cancellationToken);
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Suppressions.Mobile.LibraryBuild.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Suppressions.Mobile.LibraryBuild.xml
@@ -5,13 +5,6 @@
       <argument>ILLink</argument>
       <argument>IL2075</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Net.Http.HttpClientHandler.CreateNativeHandler()</property>
-      <property name="Justification">The Xamarin.iOS and Mono.Android libraries are not present when running the trimmer analysis during our build. A consuming application will get a warning if these libraries aren't present when trimming the full app.</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2075</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.Net.Http.HttpClientHandler.InvokeNativeHandlerMethod(System.String,System.Object[])</property>
       <property name="Justification">The Xamarin.iOS and Mono.Android libraries are not present when running the trimmer analysis during our build. A consuming application will get a warning if these libraries aren't present when trimming the full app.</property>
     </attribute>

--- a/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
@@ -102,8 +102,6 @@ namespace System
             Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
             Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2096:UnrecognizedReflectionPattern",
-            Justification = "Implementation detail of Activator that linker intrinsically recognizes")]
         private static ObjectHandle? CreateInstanceInternal(string assemblyString,
                                                            string typeName,
                                                            bool ignoreCase,
@@ -125,8 +123,10 @@ namespace System
                 assembly = RuntimeAssembly.InternalLoad(assemblyName, ref stackMark, AssemblyLoadContext.CurrentContextualReflectionContext);
             }
 
+            // Issues IL2026 warning.
             Type? type = assembly.GetType(typeName, throwOnError: true, ignoreCase);
 
+            //Issues IL2072 warning.
             object? o = CreateInstance(type!, bindingAttr, binder, args, culture, activationAttributes);
 
             return o != null ? new ObjectHandle(o) : null;

--- a/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
@@ -126,7 +126,7 @@ namespace System
             // Issues IL2026 warning.
             Type? type = assembly.GetType(typeName, throwOnError: true, ignoreCase);
 
-            //Issues IL2072 warning.
+            // Issues IL2072 warning.
             object? o = CreateInstance(type!, bindingAttr, binder, args, culture, activationAttributes);
 
             return o != null ? new ObjectHandle(o) : null;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3606,11 +3606,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="method">The method to probe.</param>
         /// <returns>The literal value or -1 if the value could not be determined. </returns>
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                   Justification = "The method calls MethodBase.GetMethodBody. Trimming application can change IL of various methods" +
-                                   "which can lead to change of behavior. This method only uses this to validate usage of event source APIs." +
-                                   "In the worst case it will not be able to determine the value it's looking for and will not perform" +
-                                   "any validation.")]
         private static int GetHelperCallFirstArg(MethodInfo method)
         {
 #if !NATIVEAOT
@@ -3625,7 +3620,7 @@ namespace System.Diagnostics.Tracing
             // RET
             //
             // If we find this pattern we return the XXX.  Otherwise we return -1.
-            byte[] instrs = method.GetMethodBody()!.GetILAsByteArray()!;
+            byte[] instrs = GetMethodBodyLocal(method)!.GetILAsByteArray()!;
             int retVal = -1;
             for (int idx = 0; idx < instrs.Length;)
             {
@@ -3726,6 +3721,16 @@ namespace System.Diagnostics.Tracing
                         return -1;
                 }
                 idx++;
+            }
+
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                        Justification = "The method calls MethodBase.GetMethodBody. Trimming application can change IL of various methods" +
+                                        "which can lead to change of behavior. This method only uses this to validate usage of event source APIs." +
+                                        "In the worst case it will not be able to determine the value it's looking for and will not perform" +
+                                        "any validation.")]
+            static MethodBody? GetMethodBodyLocal(MethodInfo method)
+            {
+                return method.GetMethodBody();
             }
 #endif
             return -1;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3606,6 +3606,13 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="method">The method to probe.</param>
         /// <returns>The literal value or -1 if the value could not be determined. </returns>
+#if !NATIVEAOT
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                    Justification = "The method calls MethodBase.GetMethodBody. Trimming application can change IL of various methods" +
+                                    "which can lead to change of behavior. This method only uses this to validate usage of event source APIs." +
+                                    "In the worst case it will not be able to determine the value it's looking for and will not perform" +
+                                    "any validation.")]
+#endif
         private static int GetHelperCallFirstArg(MethodInfo method)
         {
 #if !NATIVEAOT
@@ -3620,7 +3627,7 @@ namespace System.Diagnostics.Tracing
             // RET
             //
             // If we find this pattern we return the XXX.  Otherwise we return -1.
-            byte[] instrs = GetMethodBodyLocal(method)!.GetILAsByteArray()!;
+            byte[] instrs = method.GetMethodBody()!.GetILAsByteArray()!;
             int retVal = -1;
             for (int idx = 0; idx < instrs.Length;)
             {
@@ -3721,16 +3728,6 @@ namespace System.Diagnostics.Tracing
                         return -1;
                 }
                 idx++;
-            }
-
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                        Justification = "The method calls MethodBase.GetMethodBody. Trimming application can change IL of various methods" +
-                                        "which can lead to change of behavior. This method only uses this to validate usage of event source APIs." +
-                                        "In the worst case it will not be able to determine the value it's looking for and will not perform" +
-                                        "any validation.")]
-            static MethodBody? GetMethodBodyLocal(MethodInfo method)
-            {
-                return method.GetMethodBody();
             }
 #endif
             return -1;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -75,10 +75,6 @@ namespace System.Diagnostics.Tracing
             base.WriteEvent((int)EventId.ProcessorCount, processorCount);
         }
 
-        [UnconditionalSuppressMessage ("ReflectionAnalysis", "IL2119",
-            Justification = "DAM on EventSource references the compiler-generated lambda methods some of which call PInvokes " +
-                            "which are considered potentially dangerous. Event source will not use these lambdas.")]
-
         protected override void OnEventCommand(EventCommandEventArgs command)
         {
             if (command.Command == EventCommand.Enable)

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureType.cs
@@ -175,8 +175,6 @@ namespace System.Reflection
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
-            Justification = "Linker doesn't recognize always throwing method. https://github.com/mono/linker/issues/2025")]
         public sealed override Type GetInterface(string name, bool ignoreCase) => throw new NotSupportedException(SR.NotSupported_SignatureType);
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.Core.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.Core.cs
@@ -65,10 +65,7 @@ namespace System.Resources
                 Justification = "InitializeBinaryFormatter will get trimmed out when AllowCustomResourceTypes is set to false. " +
                 "When set to true, we will already throw a warning for this feature switch, so we suppress this one in order for" +
                 "the user to only get one error.")]
-            bool InitializeBinaryFormatterLocal()
-            {
-                return InitializeBinaryFormatter();
-            }
+            bool InitializeBinaryFormatterLocal() => InitializeBinaryFormatter();
 
             if (Volatile.Read(ref _binaryFormatter) is null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.Core.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.Core.cs
@@ -45,14 +45,6 @@ namespace System.Resources
             ReadResources();
         }
 
-        [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "InitializeBinaryFormatter will get trimmed out when AllowCustomResourceTypes is set to false. " +
-            "When set to true, we will already throw a warning for this feature switch, so we suppress this one in order for" +
-            "the user to only get one error.")]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "InitializeBinaryFormatter will get trimmed out when AllowCustomResourceTypes is set to false. " +
-            "When set to true, we will already throw a warning for this feature switch, so we suppress this one in order for" +
-            "the user to only get one error.")]
         private object DeserializeObject(int typeIndex)
         {
             if (!AllowCustomResourceTypes)
@@ -65,9 +57,22 @@ namespace System.Resources
                 throw new NotSupportedException(SR.NotSupported_ResourceObjectSerialization);
             }
 
+            [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
+                Justification = "InitializeBinaryFormatter will get trimmed out when AllowCustomResourceTypes is set to false. " +
+                "When set to true, we will already throw a warning for this feature switch, so we suppress this one in order for" +
+                "the user to only get one error.")]
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                Justification = "InitializeBinaryFormatter will get trimmed out when AllowCustomResourceTypes is set to false. " +
+                "When set to true, we will already throw a warning for this feature switch, so we suppress this one in order for" +
+                "the user to only get one error.")]
+            bool InitializeBinaryFormatterLocal()
+            {
+                return InitializeBinaryFormatter();
+            }
+
             if (Volatile.Read(ref _binaryFormatter) is null)
             {
-                if (!InitializeBinaryFormatter())
+                if (!InitializeBinaryFormatterLocal())
                 {
                     // The linker trimmed away the BinaryFormatter implementation and we can't call into it.
                     // We'll throw an exception with the same text that BinaryFormatter would have thrown

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
@@ -955,10 +955,7 @@ namespace System.Resources
                 Justification = "UseReflectionToGetType will get trimmed out when AllowCustomResourceTypes is set to false. " +
                 "When set to true, we will already throw a warning for this feature switch, so we suppress this one in order for" +
                 "the user to only get one error.")]
-            Type UseReflectionToGetTypeLocal(int typeIndex)
-            {
-                return UseReflectionToGetType(typeIndex);
-            }
+            Type UseReflectionToGetTypeLocal(int typeIndex) => UseReflectionToGetType(typeIndex);
 
             return _typeTable[typeIndex] ?? UseReflectionToGetTypeLocal(typeIndex);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
@@ -939,10 +939,6 @@ namespace System.Resources
         // This allows us to delay-initialize the Type[].  This might be a
         // good startup time savings, since we might have to load assemblies
         // and initialize Reflection.
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "UseReflectionToGetType will get trimmed out when AllowCustomResourceTypes is set to false. " +
-            "When set to true, we will already throw a warning for this feature switch, so we suppress this one in order for" +
-            "the user to only get one error.")]
         private Type FindType(int typeIndex)
         {
             if (!AllowCustomResourceTypes)
@@ -955,7 +951,16 @@ namespace System.Resources
                 throw new BadImageFormatException(SR.BadImageFormat_InvalidType);
             }
 
-            return _typeTable[typeIndex] ?? UseReflectionToGetType(typeIndex);
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+                Justification = "UseReflectionToGetType will get trimmed out when AllowCustomResourceTypes is set to false. " +
+                "When set to true, we will already throw a warning for this feature switch, so we suppress this one in order for" +
+                "the user to only get one error.")]
+            Type UseReflectionToGetTypeLocal(int typeIndex)
+            {
+                return UseReflectionToGetType(typeIndex);
+            }
+
+            return _typeTable[typeIndex] ?? UseReflectionToGetTypeLocal(typeIndex);
         }
 
         [RequiresUnreferencedCode("The CustomResourceTypesSupport feature switch has been enabled for this app which is being trimmed. " +

--- a/src/libraries/System.Private.CoreLib/src/System/Type.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.Helpers.cs
@@ -373,17 +373,18 @@ namespace System
             Justification = "The GetInterfaces technically requires all interfaces to be preserved" +
                 "But this method only compares the result against the passed in ifaceType." +
                 "So if ifaceType exists, then trimming should have kept it implemented on any type.")]
-        // IL2075 is produced due to the BaseType not returning annotated value and used in effectively this.BaseType.GetInterfaces()
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
-            Justification = "The GetInterfaces technically requires all interfaces to be preserved" +
-                "But this method only compares the result against the passed in ifaceType." +
-                "So if ifaceType exists, then trimming should have kept it implemented on any type.")]
         internal bool ImplementInterface(Type ifaceType)
         {
             Type? t = this;
             while (t != null)
             {
+                // IL2075 is produced due to the BaseType not returning annotated value and used in effectively this.BaseType.GetInterfaces()
+                // The GetInterfaces technically requires all interfaces to be preserved
+                // But this method only compares the result against the passed in ifaceType.
+                // So if ifaceType exists, then trimming should have kept it implemented on any type.
+#pragma warning disable IL2075
                 Type[] interfaces = t.GetInterfaces();
+#pragma warning restore IL2075
                 if (interfaces != null)
                 {
                     for (int i = 0; i < interfaces.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/Type.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.Helpers.cs
@@ -382,6 +382,7 @@ namespace System
                 // The GetInterfaces technically requires all interfaces to be preserved
                 // But this method only compares the result against the passed in ifaceType.
                 // So if ifaceType exists, then trimming should have kept it implemented on any type.
+                // The warning is currently analyzer only.
 #pragma warning disable IL2075
                 Type[] interfaces = t.GetInterfaces();
 #pragma warning restore IL2075

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -683,7 +683,7 @@ namespace System.Runtime.Serialization.Json
                 if (isArray)
                 {
                     Debug.Assert(growingCollection != null);
-                    MethodInfo ensureArraySizeMethod = MakeGenericMethod(XmlFormatGeneratorStatics.EnsureArraySizeMethod, itemType);
+                    MethodInfo ensureArraySizeMethod = XmlFormatGeneratorStatics.EnsureArraySizeMethod.MakeGenericMethod(itemType);
                     _ilg.Call(null, ensureArraySizeMethod, growingCollection, i);
                     _ilg.Stloc(growingCollection);
                     _ilg.StoreArrayElement(growingCollection, i, value);
@@ -702,7 +702,7 @@ namespace System.Runtime.Serialization.Json
                 _ilg.EndFor();
                 if (isArray)
                 {
-                    MethodInfo trimArraySizeMethod = MakeGenericMethod(XmlFormatGeneratorStatics.TrimArraySizeMethod, itemType);
+                    MethodInfo trimArraySizeMethod = XmlFormatGeneratorStatics.TrimArraySizeMethod.MakeGenericMethod(itemType);
                     _ilg.Call(null, trimArraySizeMethod, growingCollection, i);
                     _ilg.Stloc(_objectLocal);
                     _ilg.Call(_contextArg, XmlFormatGeneratorStatics.AddNewObjectWithIdMethod, objectId, _objectLocal);
@@ -719,10 +719,6 @@ namespace System.Runtime.Serialization.Json
                 {
                     _ilg.EndIf();
                 }
-
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
-                Justification = "The call to MakeGenericMethod is safe due to the fact that EnsureArraySizeMethod and TrimArraySizeMethod are not annotated.")]
-                static MethodInfo MakeGenericMethod(MethodInfo method, Type itemType) => method.MakeGenericMethod(itemType);
             }
 
             [RequiresDynamicCode(DataContract.SerializerAOTWarning)]

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
@@ -348,10 +348,10 @@ namespace System.Runtime.Serialization.Json
                             break;
                         case CollectionKind.GenericCollection:
                         case CollectionKind.GenericList:
-                            incrementCollectionCountMethod = MakeIncrementCollectionCountGenericMethod(collectionContract.ItemType);
+                            incrementCollectionCountMethod = XmlFormatGeneratorStatics.IncrementCollectionCountGenericMethod.MakeGenericMethod(collectionContract.ItemType);
                             break;
                         case CollectionKind.GenericDictionary:
-                            incrementCollectionCountMethod = MakeIncrementCollectionCountGenericMethod(Globals.TypeOfKeyValuePair.MakeGenericType(collectionContract.ItemType.GetGenericArguments()));
+                            incrementCollectionCountMethod = XmlFormatGeneratorStatics.IncrementCollectionCountGenericMethod.MakeGenericMethod(Globals.TypeOfKeyValuePair.MakeGenericType(collectionContract.ItemType.GetGenericArguments()));
                             break;
                     }
                     if (incrementCollectionCountMethod != null)
@@ -501,10 +501,6 @@ namespace System.Runtime.Serialization.Json
                         _ilg.EndIf();
                     }
                 }
-
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
-                Justification = "The call to MakeGenericMethod is safe due to the fact that IncrementCollectionCountGeneric is not annotated.")]
-                static MethodInfo MakeIncrementCollectionCountGenericMethod(Type itemType) => XmlFormatGeneratorStatics.IncrementCollectionCountGenericMethod.MakeGenericMethod(itemType);
             }
 
             [RequiresDynamicCode(DataContract.SerializerAOTWarning)]

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/PrimitiveDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/PrimitiveDataContract.cs
@@ -675,10 +675,6 @@ namespace System.Runtime.Serialization.DataContracts
 
     internal sealed class DateTimeDataContract : PrimitiveDataContract
     {
-        [UnconditionalSuppressMessage ("ReflectionAnalysis", "IL2118",
-            Justification = "DAM on the first parameter of the PrimitiveDataContract constructor references methods of DateTime, " +
-                            "which has a compiler-generated local function LowGranularityNonCachedFallback that calls PInvokes " +
-                            "which are considered potentially dangerous. Data contract serialization will not access this local function.")]
         public DateTimeDataContract() : base(typeof(DateTime), DictionaryGlobals.DateTimeLocalName, DictionaryGlobals.SchemaNamespace)
         {
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -494,10 +494,6 @@ namespace System.Xml.Serialization
             "token"
         };
 
-        [UnconditionalSuppressMessage ("ReflectionAnalysis", "IL2118",
-            Justification = "DAM on AddPrimitive references methods of DateTime, which has a compiler-generated local function " +
-                            "LowGranularityNonCachedFallback that calls PInvokes which are considered potentially dangerous. " +
-                            "XML serialization will not access this local function.")]
         static TypeScope()
         {
             AddPrimitive(typeof(string), "string", "String", TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.CanBeTextValue | TypeFlags.Reference | TypeFlags.HasDefaultConstructor);
@@ -593,10 +589,6 @@ namespace System.Xml.Serialization
             return false;
         }
 
-        [UnconditionalSuppressMessage ("ReflectionAnalysis", "IL2118",
-            Justification = "DAM on AddPrimitive references methods of DateTime, which has a compiler-generated local function " +
-                            "LowGranularityNonCachedFallback that calls PInvokes which are considered potentially dangerous. " +
-                            "XML serialization will not access this local function.")]
         private static void AddSoapEncodedTypes(string ns)
         {
             AddSoapEncodedPrimitive(typeof(string), "normalizedString", ns, "String", new XmlQualifiedName("normalizedString", XmlSchema.Namespace), TypeFlags.AmbiguousDataType | TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.Reference | TypeFlags.HasDefaultConstructor);

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -164,8 +164,6 @@ namespace System.Reflection
             // Unconditionally generates a new proxy type derived from 'baseType' and implements 'interfaceType'
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2062:UnrecognizedReflectionPattern",
                 Justification = "interfaceType is annotated as preserve All members, so any Types returned from GetInterfaces should be preserved as well once https://github.com/mono/linker/issues/1731 is fixed.")]
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
-                Justification = "interfaceType is annotated as preserve All members, so any Types returned from GetInterfaces should be preserved as well once https://github.com/mono/linker/issues/1731 is fixed.")]
             private GeneratedTypeInfo GenerateProxyType(
                 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type baseType,
                 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type interfaceType)
@@ -203,7 +201,10 @@ namespace System.Reflection
                 ProxyBuilder pb = CreateProxy("generatedProxy", baseType);
 
                 foreach (Type t in interfaceType.GetInterfaces())
+                    // interfaceType is annotated as preserve All members, so any Types returned from GetInterfaces should be preserved as well once https://github.com/mono/linker/issues/1731 is fixed.
+#pragma warning disable IL2072
                     pb.AddInterfaceImpl(t);
+#pragma warning restore IL2072
 
                 pb.AddInterfaceImpl(interfaceType);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableConverterFactory.cs
@@ -15,13 +15,10 @@ namespace System.Text.Json.Serialization
     [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
     internal sealed class IAsyncEnumerableConverterFactory : JsonConverterFactory
     {
-        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         public IAsyncEnumerableConverterFactory() { }
 
         public override bool CanConvert(Type typeToConvert) => GetAsyncEnumerableInterface(typeToConvert) is not null;
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "The ctor is marked RequiresUnreferencedCode.")]
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             Type? asyncEnumerableInterface = GetAsyncEnumerableInterface(typeToConvert);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         public override Action<TCollection, object?> CreateAddMethodDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TCollection>()
             => s_cache.GetOrAdd((nameof(CreateAddMethodDelegate), typeof(TCollection), null),
-        static (_) => s_sourceAccessor.CreateAddMethodDelegate<TCollection>());
+                static (_) => s_sourceAccessor.CreateAddMethodDelegate<TCollection>());
 
         public override Func<object>? CreateConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType)
             => s_cache.GetOrAdd((nameof(CreateConstructor), classType, null),

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionEmitCachingMemberAccessor.cs
@@ -19,9 +19,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         public override Action<TCollection, object?> CreateAddMethodDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TCollection>()
             => s_cache.GetOrAdd((nameof(CreateAddMethodDelegate), typeof(TCollection), null),
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:UnrecognizedReflectionPattern",
-                    Justification = "Parent method annotation does not flow to lambda method, cf. https://github.com/dotnet/roslyn/issues/46646")]
-                static (_) => s_sourceAccessor.CreateAddMethodDelegate<TCollection>());
+        static (_) => s_sourceAccessor.CreateAddMethodDelegate<TCollection>());
 
         public override Func<object>? CreateConstructor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type classType)
             => s_cache.GetOrAdd((nameof(CreateConstructor), classType, null),
@@ -40,20 +38,12 @@ namespace System.Text.Json.Serialization.Metadata
         [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
         public override Func<IEnumerable<KeyValuePair<TKey, TValue>>, TCollection> CreateImmutableDictionaryCreateRangeDelegate<TCollection, TKey, TValue>()
             => s_cache.GetOrAdd((nameof(CreateImmutableDictionaryCreateRangeDelegate), typeof((TCollection, TKey, TValue)), null),
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                    Justification = "Parent method annotation does not flow to lambda method, cf. https://github.com/dotnet/roslyn/issues/46646")]
-#pragma warning disable IL2026 // The suppression doesn't work for the trim analyzer: https://github.com/dotnet/roslyn/issues/59746
                 static (_) => s_sourceAccessor.CreateImmutableDictionaryCreateRangeDelegate<TCollection, TKey, TValue>());
-#pragma warning restore IL2026
 
         [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
         public override Func<IEnumerable<TElement>, TCollection> CreateImmutableEnumerableCreateRangeDelegate<TCollection, TElement>()
             => s_cache.GetOrAdd((nameof(CreateImmutableEnumerableCreateRangeDelegate), typeof((TCollection, TElement)), null),
-                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-                    Justification = "Parent method annotation does not flow to lambda method, cf. https://github.com/dotnet/roslyn/issues/46646")]
-#pragma warning disable IL2026 // The suppression doesn't work for the trim analyzer: https://github.com/dotnet/roslyn/issues/59746
                 static (_) => s_sourceAccessor.CreateImmutableEnumerableCreateRangeDelegate<TCollection, TElement>());
-#pragma warning restore IL2026
 
         public override Func<object[], T>? CreateParameterizedConstructor<T>(ConstructorInfo constructor)
             => s_cache.GetOrAdd((nameof(CreateParameterizedConstructor), typeof(T), constructor), static key => s_sourceAccessor.CreateParameterizedConstructor<T>((ConstructorInfo)key.member!));

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
@@ -47,7 +47,6 @@ internal sealed class DtcProxyShimFactory
         object? pvConfigPararms,
         [MarshalAs(UnmanagedType.Interface)] out ITransactionDispenser ppvObject);
 
-    [UnconditionalSuppressMessage("Trimming", "IL2050", Justification = "Leave me alone")]
     public void ConnectToProxy(
         string? nodeName,
         Guid resourceManagerIdentifier,
@@ -63,7 +62,7 @@ internal sealed class DtcProxyShimFactory
 
         lock (_proxyInitLock)
         {
-            DtcGetTransactionManagerExW(nodeName, null, Guids.IID_ITransactionDispenser_Guid, 0, null, out ITransactionDispenser? localDispenser);
+            DtcGetTransactionManagerExWLocal(nodeName, null, Guids.IID_ITransactionDispenser_Guid, 0, null, out ITransactionDispenser? localDispenser);
 
             // Check to make sure the node name matches.
             if (nodeName is not null)
@@ -117,6 +116,12 @@ internal sealed class DtcProxyShimFactory
             resourceManagerShim = rmShim;
             _transactionDispenser = localDispenser;
             whereabouts = tmpWhereabouts;
+
+            [UnconditionalSuppressMessage("Trimming", "IL2050", Justification = "Leave me alone")]
+            static void DtcGetTransactionManagerExWLocal(string? pszHost, string? pszTmName, in Guid riid, int grfOptions, object? pvConfigPararms, out ITransactionDispenser ppvObject)
+            {
+                DtcGetTransactionManagerExW(pszHost, pszTmName, riid, grfOptions, pvConfigPararms, out ppvObject);
+            }
         }
     }
 

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
@@ -117,7 +117,8 @@ internal sealed class DtcProxyShimFactory
             _transactionDispenser = localDispenser;
             whereabouts = tmpWhereabouts;
 
-            [UnconditionalSuppressMessage("Trimming", "IL2050", Justification = "Leave me alone")]
+            [UnconditionalSuppressMessage("Trimming", "IL2050",
+                Justification = "The PInvoke has object/interface typed parameters which are potentially trim incompatible, but in this case they're OK")]
             static void DtcGetTransactionManagerExWLocal(string? pszHost, string? pszTmName, in Guid riid, int grfOptions, object? pvConfigPararms, out ITransactionDispenser ppvObject)
             {
                 DtcGetTransactionManagerExW(pszHost, pszTmName, riid, grfOptions, pvConfigPararms, out ppvObject);

--- a/src/libraries/sfx.proj
+++ b/src/libraries/sfx.proj
@@ -48,8 +48,6 @@
 
     <PropertyGroup>
       <SharedFrameworkILLinkArgs>$(ILLinkArgs)</SharedFrameworkILLinkArgs>
-      <!-- Unnecessary suppressions - disable for now since we didn't clean the runtime yet -->
-      <SharedFrameworkILLinkArgs>$(ILLinkArgs) --nowarn IL2121</SharedFrameworkILLinkArgs>
       <!-- update debug symbols -->
       <SharedFrameworkILLinkArgs>$(SharedFrameworkILLinkArgs) -b true</SharedFrameworkILLinkArgs>
       <SharedFrameworkILLinkArgs Condition="'@(SharedFrameworkSuppressionsXml)' != ''" >$(SharedFrameworkILLinkArgs) --link-attributes &quot;@(SharedFrameworkSuppressionsXml->'%(FullPath)', '&quot; --link-attributes &quot;')&quot;</SharedFrameworkILLinkArgs>

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/DerivedTypes.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/DerivedTypes.Mono.cs
@@ -230,8 +230,6 @@ namespace System.Reflection.Emit
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
-            Justification = "Linker doesn't recognize always throwing method. https://github.com/mono/linker/issues/2025")]
         public override Type GetInterface(string name, bool ignoreCase)
         {
             throw new NotSupportedException(SR.NotSupported_NonReflectedType);

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
@@ -148,8 +148,6 @@ namespace System.Reflection.Emit
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
-            Justification = "Linker doesn't recognize always throwing method. https://github.com/mono/linker/issues/2025")]
         public override Type GetInterface(string name, bool ignoreCase)
         {
             throw not_supported();

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
@@ -248,8 +248,6 @@ namespace System.Reflection.Emit
             num_types++;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
-            Justification = "Reflection.Emit is not subject to trimming")]
         private TypeBuilder DefineType(string name, TypeAttributes attr, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? parent, Type[]? interfaces, PackingSize packingSize, int typesize)
         {
             ArgumentNullException.ThrowIfNull(name, "fullname");

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -959,6 +959,7 @@ namespace System.Reflection.Emit
         public override EventInfo[] GetEvents()
         {
             const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
+            // Suppression can be removed after https://github.com/dotnet/linker/issues/2673 is resolved.
 #pragma warning disable IL2085
             return GetEvents(DefaultBindingFlags);
 #pragma warning restore IL2085

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -956,12 +956,12 @@ namespace System.Reflection.Emit
 
         /* Needed to keep signature compatibility with MS.NET */
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
-            Justification = "Linker doesn't recognize GetEvents(BindingFlags.Public) but this is what the body is doing")]
         public override EventInfo[] GetEvents()
         {
             const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
+#pragma warning disable IL2085
             return GetEvents(DefaultBindingFlags);
+#pragma warning restore IL2085
         }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -445,8 +445,6 @@ namespace System.Reflection.Emit
         //stuff that throws
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2063:UnrecognizedReflectionPattern",
-            Justification = "Linker doesn't recognize always throwing method. https://github.com/mono/linker/issues/2025")]
         public override Type GetInterface(string name, bool ignoreCase)
         {
             throw new NotSupportedException();

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -362,8 +362,6 @@ namespace System.Reflection
          * The idea behind this optimization is to use a pair of delegates to simulate the same effect of doing a reflection call.
          * The first delegate cast the this argument to the right type and the second does points to the target method.
          */
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:UnrecognizedReflectionPattern",
-            Justification = "MethodInfo used with MakeGenericMethod doesn't have DynamicallyAccessedMembers generic parameters")]
         [DynamicDependency("GetterAdapterFrame`2")]
         [DynamicDependency("StaticGetterAdapterFrame`1")]
         private static GetterAdapter CreateGetterDelegate(MethodInfo method)


### PR DESCRIPTION
Removed suppressions identified as redundant by the linker  (https://github.com/dotnet/linker/pull/2922).

\cc @vitek-karas 