### PR TITLE
avoid string concatenation in case when there are no Extended Strings

### DIFF
--- a/src/libraries/System.Console/src/System/TermInfo.Database.cs
+++ b/src/libraries/System.Console/src/System/TermInfo.Database.cs
@@ -34,7 +34,7 @@ internal static partial class TermInfo
         private readonly int _sizeOfInt;
 
         /// <summary>Extended / user-defined entries in the terminfo database.</summary>
-        private readonly Dictionary<string, string> _extendedStrings;
+        private readonly Dictionary<string, string>? _extendedStrings;
 
         /// <summary>Initializes the database instance.</summary>
         /// <param name="term">The name of the terminal.</param>
@@ -75,11 +75,13 @@ internal static partial class TermInfo
             // (Note that the extended section also includes other Booleans and numbers, but we don't
             // have any need for those now, so we don't parse them.)
             int extendedBeginning = RoundUpToEven(StringsTableOffset + _stringTableNumBytes);
-            _extendedStrings = ParseExtendedStrings(data, extendedBeginning, _readAs32Bit) ?? new Dictionary<string, string>();
+            _extendedStrings = ParseExtendedStrings(data, extendedBeginning, _readAs32Bit);
         }
 
         /// <summary>The name of the associated terminfo, if any.</summary>
         public string Term { get { return _term; } }
+
+        internal bool HasExtendedStrings => _extendedStrings is not null;
 
         /// <summary>The offset into data where the names section begins.</summary>
         private const int NamesOffset = 12; // comes right after the header, which is always 12 bytes
@@ -133,9 +135,7 @@ internal static partial class TermInfo
             Debug.Assert(name != null);
 
             string? value;
-            return _extendedStrings.TryGetValue(name, out value) ?
-                value :
-                null;
+            return _extendedStrings is not null && _extendedStrings.TryGetValue(name, out value) ? value : null;
         }
 
         /// <summary>Gets a number from the numbers section by the number's well-known index.</summary>

--- a/src/libraries/System.Console/src/System/TerminalFormatStrings.cs
+++ b/src/libraries/System.Console/src/System/TerminalFormatStrings.cs
@@ -231,11 +231,14 @@ internal sealed class TerminalFormatStrings
 
     private void AddPrefixKey(TermInfo.Database db, string extendedNamePrefix, ConsoleKey key)
     {
-        AddKey(db, extendedNamePrefix + "3", key, shift: false, alt: true,  control: false);
-        AddKey(db, extendedNamePrefix + "4", key, shift: true,  alt: true,  control: false);
-        AddKey(db, extendedNamePrefix + "5", key, shift: false, alt: false, control: true);
-        AddKey(db, extendedNamePrefix + "6", key, shift: true,  alt: false, control: true);
-        AddKey(db, extendedNamePrefix + "7", key, shift: false, alt: false, control: true);
+        if (db.HasExtendedStrings) // avoid string concatenation in case when there are no Extended Strings (typical scenario)
+        {
+            AddKey(db, extendedNamePrefix + "3", key, shift: false, alt: true,  control: false);
+            AddKey(db, extendedNamePrefix + "4", key, shift: true,  alt: true,  control: false);
+            AddKey(db, extendedNamePrefix + "5", key, shift: false, alt: false, control: true);
+            AddKey(db, extendedNamePrefix + "6", key, shift: true,  alt: false, control: true);
+            AddKey(db, extendedNamePrefix + "7", key, shift: false, alt: false, control: true);
+        }
     }
 
     private void AddKey(TermInfo.Database db, string extendedName, ConsoleKey key, bool shift, bool alt, bool control)


### PR DESCRIPTION
When working on the `Console.ReadKey` rewrite I've noticed that most TermInfo files don't define Extended Strings and that we can avoid allocating extended name strings in such cases.

https://github.com/dotnet/runtime/blob/1e7e914a6ec0a84dac9b9596fd646c37339afc4d/src/libraries/System.Console/src/System/TerminalFormatStrings.cs#L147-L155

https://github.com/dotnet/runtime/blob/1e7e914a6ec0a84dac9b9596fd646c37339afc4d/src/libraries/System.Console/src/System/TerminalFormatStrings.cs#L234-L238

this should save 45 string and once dictionary allocations for typical console read initialization code path