### PR TITLE
JIT: Assign method handle for root inline context in all builds

### DIFF
--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -1247,12 +1247,7 @@ InlineContext* InlineStrategy::NewRoot()
 
     rootContext->m_ILSize = m_Compiler->info.compILCodeSize;
     rootContext->m_Code   = m_Compiler->info.compCode;
-
-#if defined(DEBUG) || defined(INLINE_DATA)
-
     rootContext->m_Callee = m_Compiler->info.compMethodHnd;
-
-#endif // defined(DEBUG) || defined(INLINE_DATA)
 
     return rootContext;
 }


### PR DESCRIPTION
Missed this in a recent change where these handles were made available
in all builds.