### PR TITLE
[release/6.0] Respect the Keep-Alive response header on HTTP/1.0

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1125,7 +1125,7 @@ namespace System.Net.Http
             {
                 string headerValue = connection.GetResponseHeaderValueWithCaching(descriptor, value, valueEncoding);
 
-                if (descriptor.Equals(KnownHeaders.KeepAlive))
+                if (ReferenceEquals(descriptor.KnownHeader, KnownHeaders.KeepAlive))
                 {
                     // We are intentionally going against RFC to honor the Keep-Alive header even if
                     // we haven't received a Keep-Alive connection token to maximize compat with servers.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -236,7 +236,6 @@ namespace System.Net.Http
 
         private bool CheckKeepAliveTimeoutExceeded()
         {
-            // We only honor a Keep-Alive timeout on HTTP/1.0 responses.
             // If _keepAliveTimeoutSeconds is 0, no timeout has been set.
             return _keepAliveTimeoutSeconds != 0 &&
                 GetIdleTicks(Environment.TickCount64) >= _keepAliveTimeoutSeconds * 1000;
@@ -666,11 +665,6 @@ namespace System.Net.Http
                         break;
                     }
                     ParseHeaderNameValue(this, line.Span, response, isFromTrailer: false);
-                }
-
-                if (response.Version.Minor == 0)
-                {
-                    ProcessHttp10KeepAliveHeader(response);
                 }
 
                 if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.ResponseHeadersStop();
@@ -1127,47 +1121,53 @@ namespace System.Net.Http
             }
             else
             {
-                // Request headers returned on the response must be treated as custom headers.
                 string headerValue = connection.GetResponseHeaderValueWithCaching(descriptor, value, valueEncoding);
+
+                if (descriptor.Equals(KnownHeaders.KeepAlive))
+                {
+                    connection.ProcessKeepAliveHeader(headerValue);
+                }
+
+                // Request headers returned on the response must be treated as custom headers.
                 response.Headers.TryAddWithoutValidation(
                     (descriptor.HeaderType & HttpHeaderType.Request) == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor,
                     headerValue);
             }
         }
 
-        private void ProcessHttp10KeepAliveHeader(HttpResponseMessage response)
+        private void ProcessKeepAliveHeader(string keepAlive)
         {
-            if (response.Headers.NonValidated.TryGetValues(KnownHeaders.KeepAlive.Name, out HeaderStringValues keepAliveValues))
-            {
-                string keepAlive = keepAliveValues.ToString();
-                var parsedValues = new ObjectCollection<NameValueHeaderValue>();
+            var parsedValues = new ObjectCollection<NameValueHeaderValue>();
 
-                if (NameValueHeaderValue.GetNameValueListLength(keepAlive, 0, ',', parsedValues) == keepAlive.Length)
+            if (NameValueHeaderValue.GetNameValueListLength(keepAlive, 0, ',', parsedValues) == keepAlive.Length)
+            {
+                foreach (NameValueHeaderValue nameValue in parsedValues)
                 {
-                    foreach (NameValueHeaderValue nameValue in parsedValues)
+                    if (string.Equals(nameValue.Name, "timeout", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (string.Equals(nameValue.Name, "timeout", StringComparison.OrdinalIgnoreCase))
+                        if (!string.IsNullOrEmpty(nameValue.Value) &&
+                            HeaderUtilities.TryParseInt32(nameValue.Value, out int timeout) &&
+                            timeout >= 0)
                         {
-                            if (!string.IsNullOrEmpty(nameValue.Value) &&
-                                HeaderUtilities.TryParseInt32(nameValue.Value, out int timeout) &&
-                                timeout >= 0)
-                            {
-                                if (timeout == 0)
-                                {
-                                    _connectionClose = true;
-                                }
-                                else
-                                {
-                                    _keepAliveTimeoutSeconds = timeout;
-                                }
-                            }
-                        }
-                        else if (string.Equals(nameValue.Name, "max", StringComparison.OrdinalIgnoreCase))
-                        {
-                            if (nameValue.Value == "0")
+                            // Some servers are very strict with closing the connection exactly at the timeout.
+                            // Avoid using the connection if it is about to exceed the timeout to avoid resulting request failures.
+                            const int OffsetSeconds = 1;
+
+                            if (timeout <= OffsetSeconds)
                             {
                                 _connectionClose = true;
                             }
+                            else
+                            {
+                                _keepAliveTimeoutSeconds = timeout - OffsetSeconds;
+                            }
+                        }
+                    }
+                    else if (string.Equals(nameValue.Name, "max", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (nameValue.Value == "0")
+                        {
+                            _connectionClose = true;
                         }
                     }
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -236,6 +236,8 @@ namespace System.Net.Http
 
         private bool CheckKeepAliveTimeoutExceeded()
         {
+            // We intentionally honor the Keep-Alive timeout on all HTTP/1.X versions, not just 1.0. This is to maximize compat with
+            // servers that use a lower idle timeout than the client, but give us a hint in the form of a Keep-Alive timeout parameter.
             // If _keepAliveTimeoutSeconds is 0, no timeout has been set.
             return _keepAliveTimeoutSeconds != 0 &&
                 GetIdleTicks(Environment.TickCount64) >= _keepAliveTimeoutSeconds * 1000;
@@ -1125,6 +1127,8 @@ namespace System.Net.Http
 
                 if (descriptor.Equals(KnownHeaders.KeepAlive))
                 {
+                    // We are intentionally going against RFC to honor the Keep-Alive header even if
+                    // we haven't received a Keep-Alive connection token to maximize compat with servers.
                     connection.ProcessKeepAliveHeader(headerValue);
                 }
 
@@ -1143,6 +1147,7 @@ namespace System.Net.Http
             {
                 foreach (NameValueHeaderValue nameValue in parsedValues)
                 {
+                    // The HTTP/1.1 spec does not define any parameters for the Keep-Alive header, so we are using the de facto standard ones - timeout and max.
                     if (string.Equals(nameValue.Name, "timeout", StringComparison.OrdinalIgnoreCase))
                     {
                         if (!string.IsNullOrEmpty(nameValue.Value) &&

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -2073,7 +2073,7 @@ namespace System.Net.Http
 
                 if (!connection.CheckUsabilityOnScavenge())
                 {
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace($"Scavenging connection. Unexpected data or EOF received.");
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace($"Scavenging connection. Keep-Alive timeout exceeded, unexpected data or EOF received.");
                     return false;
                 }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
@@ -1,0 +1,150 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Test.Common;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    [ConditionalClass(typeof(SocketsHttpHandler), nameof(SocketsHttpHandler.IsSupported))]
+    public sealed class SocketsHttpHandler_Http1KeepAlive_Test : HttpClientHandlerTestBase
+    {
+        public SocketsHttpHandler_Http1KeepAlive_Test(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public async Task Http10Response_ConnectionIsReusedFor10And11()
+        {
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using HttpClient client = CreateHttpClient();
+
+                await client.SendAsync(CreateRequest(HttpMethod.Get, uri, HttpVersion.Version10, exactVersion: true));
+                await client.SendAsync(CreateRequest(HttpMethod.Get, uri, HttpVersion.Version11, exactVersion: true));
+                await client.SendAsync(CreateRequest(HttpMethod.Get, uri, HttpVersion.Version10, exactVersion: true));
+            },
+            server => server.AcceptConnectionAsync(async connection =>
+            {
+                HttpRequestData request = await connection.ReadRequestDataAsync();
+                Assert.Equal(0, request.Version.Minor);
+                await connection.WriteStringAsync("HTTP/1.0 200 OK\r\nContent-Length: 1\r\n\r\n1");
+                connection.CompleteRequestProcessing();
+
+                request = await connection.ReadRequestDataAsync();
+                Assert.Equal(1, request.Version.Minor);
+                await connection.WriteStringAsync("HTTP/1.0 200 OK\r\nContent-Length: 1\r\n\r\n2");
+                connection.CompleteRequestProcessing();
+
+                request = await connection.ReadRequestDataAsync();
+                Assert.Equal(0, request.Version.Minor);
+                await connection.WriteStringAsync("HTTP/1.0 200 OK\r\nContent-Length: 1\r\n\r\n3");
+            }));
+        }
+
+        [OuterLoop("Uses Task.Delay")]
+        [Fact]
+        public async Task Http10ResponseWithKeepAliveTimeout_ConnectionRecycledAfterTimeout()
+        {
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using HttpClient client = CreateHttpClient();
+
+                await client.GetAsync(uri);
+
+                await Task.Delay(2000);
+                await client.GetAsync(uri);
+            },
+            async server =>
+            {
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestDataAsync();
+                    await connection.WriteStringAsync("HTTP/1.0 200 OK\r\nKeep-Alive: timeout=1\r\nContent-Length: 1\r\n\r\n1");
+                    connection.CompleteRequestProcessing();
+
+                    await Assert.ThrowsAnyAsync<Exception>(() => connection.ReadRequestDataAsync());
+                });
+
+                await server.AcceptConnectionSendResponseAndCloseAsync();
+            });
+        }
+
+        [Theory]
+        [InlineData("timeout=1000", true)]
+        [InlineData("timeout=30", true)]
+        [InlineData("timeout=0", false)]
+        [InlineData("foo, bar=baz, timeout=30", true)]
+        [InlineData("foo, bar=baz, timeout=0", false)]
+        [InlineData("timeout=-1", true)]
+        [InlineData("timeout=abc", true)]
+        [InlineData("max=1", true)]
+        [InlineData("max=0", false)]
+        [InlineData("max=-1", true)]
+        [InlineData("max=abc", true)]
+        [InlineData("timeout=30, max=1", true)]
+        [InlineData("timeout=30, max=0", false)]
+        [InlineData("timeout=0, max=1", false)]
+        [InlineData("timeout=0, max=0", false)]
+        public async Task Http10ResponseWithKeepAlive_ConnectionNotReusedForShortTimeoutOrMax0(string keepAlive, bool shouldReuseConnection)
+        {
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using HttpClient client = CreateHttpClient();
+
+                await client.GetAsync(uri);
+                await client.GetAsync(uri);
+            },
+            async server =>
+            {
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestDataAsync();
+                    await connection.WriteStringAsync($"HTTP/1.0 200 OK\r\nKeep-Alive: {keepAlive}\r\nContent-Length: 1\r\n\r\n1");
+                    connection.CompleteRequestProcessing();
+
+                    if (shouldReuseConnection)
+                    {
+                        await connection.HandleRequestAsync();
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAnyAsync<Exception>(() => connection.ReadRequestDataAsync());
+                    }
+                });
+
+                if (!shouldReuseConnection)
+                {
+                    await server.AcceptConnectionSendResponseAndCloseAsync();
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData("timeout=1")]
+        [InlineData("timeout=0")]
+        [InlineData("max=1")]
+        [InlineData("max=0")]
+        public async Task Http11ResponseWithKeepAlive_KeepAliveIsIgnored(string keepAlive)
+        {
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using HttpClient client = CreateHttpClient();
+
+                await client.GetAsync(uri);
+                await client.GetAsync(uri);
+            },
+            async server =>
+            {
+                await server.AcceptConnectionAsync(async connection =>
+                {
+                    await connection.ReadRequestDataAsync();
+                    await connection.WriteStringAsync($"HTTP/1.1 200 OK\r\nKeep-Alive: {keepAlive}\r\nContent-Length: 1\r\n\r\n1");
+                    connection.CompleteRequestProcessing();
+
+                    await connection.HandleRequestAsync();
+                });
+            });
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
@@ -44,7 +44,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses Task.Delay")]
         [Fact]
-        public async Task Http10ResponseWithKeepAliveTimeout_ConnectionRecycledAfterTimeout()
+        public async Task Http1ResponseWithKeepAliveTimeout_ConnectionRecycledAfterTimeout()
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
@@ -60,7 +60,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await connection.WriteStringAsync("HTTP/1.0 200 OK\r\nKeep-Alive: timeout=1\r\nContent-Length: 1\r\n\r\n1");
+                    await connection.WriteStringAsync("HTTP/1.1 200 OK\r\nKeep-Alive: timeout=1\r\nContent-Length: 1\r\n\r\n1");
                     connection.CompleteRequestProcessing();
 
                     await Assert.ThrowsAnyAsync<Exception>(() => connection.ReadRequestDataAsync());
@@ -74,6 +74,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("timeout=1000", true)]
         [InlineData("timeout=30", true)]
         [InlineData("timeout=0", false)]
+        [InlineData("timeout=1", false)]
         [InlineData("foo, bar=baz, timeout=30", true)]
         [InlineData("foo, bar=baz, timeout=0", false)]
         [InlineData("timeout=-1", true)]
@@ -86,7 +87,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("timeout=30, max=0", false)]
         [InlineData("timeout=0, max=1", false)]
         [InlineData("timeout=0, max=0", false)]
-        public async Task Http10ResponseWithKeepAlive_ConnectionNotReusedForShortTimeoutOrMax0(string keepAlive, bool shouldReuseConnection)
+        public async Task Http1ResponseWithKeepAlive_ConnectionNotReusedForShortTimeoutOrMax0(string keepAlive, bool shouldReuseConnection)
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
@@ -100,7 +101,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await connection.WriteStringAsync($"HTTP/1.0 200 OK\r\nKeep-Alive: {keepAlive}\r\nContent-Length: 1\r\n\r\n1");
+                    await connection.WriteStringAsync($"HTTP/1.{Random.Shared.Next(10)} 200 OK\r\nKeep-Alive: {keepAlive}\r\nContent-Length: 1\r\n\r\n1");
                     connection.CompleteRequestProcessing();
 
                     if (shouldReuseConnection)
@@ -117,33 +118,6 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.AcceptConnectionSendResponseAndCloseAsync();
                 }
-            });
-        }
-
-        [Theory]
-        [InlineData("timeout=1")]
-        [InlineData("timeout=0")]
-        [InlineData("max=1")]
-        [InlineData("max=0")]
-        public async Task Http11ResponseWithKeepAlive_KeepAliveIsIgnored(string keepAlive)
-        {
-            await LoopbackServer.CreateClientAndServerAsync(async uri =>
-            {
-                using HttpClient client = CreateHttpClient();
-
-                await client.GetAsync(uri);
-                await client.GetAsync(uri);
-            },
-            async server =>
-            {
-                await server.AcceptConnectionAsync(async connection =>
-                {
-                    await connection.ReadRequestDataAsync();
-                    await connection.WriteStringAsync($"HTTP/1.1 200 OK\r\nKeep-Alive: {keepAlive}\r\nContent-Length: 1\r\n\r\n1");
-                    connection.CompleteRequestProcessing();
-
-                    await connection.HandleRequestAsync();
-                });
             });
         }
     }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
@@ -60,7 +60,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await connection.WriteStringAsync("HTTP/1.1 200 OK\r\nKeep-Alive: timeout=1\r\nContent-Length: 1\r\n\r\n1");
+                    await connection.WriteStringAsync("HTTP/1.1 200 OK\r\nKeep-Alive: timeout=2\r\nContent-Length: 1\r\n\r\n1");
                     connection.CompleteRequestProcessing();
 
                     await Assert.ThrowsAnyAsync<Exception>(() => connection.ReadRequestDataAsync());

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -134,6 +134,7 @@
              Link="Common\System\Net\Http\HttpClientHandlerTest.DefaultProxyCredentials.cs" />
     <Compile Include="HttpClientHandlerTest.AltSvc.cs" />
     <Compile Include="SocketsHttpHandlerTest.Cancellation.cs" />
+    <Compile Include="SocketsHttpHandlerTest.Http1KeepAlive.cs" />
     <Compile Include="SocketsHttpHandlerTest.Http2FlowControl.cs" />
     <Compile Include="SocketsHttpHandlerTest.Http2KeepAlivePing.cs" />
     <Compile Include="HttpClientHandlerTest.Connect.cs" />


### PR DESCRIPTION
Backport of #73020 and #73585
Fixes #72958

## Customer Impact

There is an inherent race in HTTP/1.x between the server closing an idle connection and the client trying to send a request at the same time (#60644). To mitigate this, the server may respond with a `Keep-Alive: timeout=60` header that informs the client of how long it can reuse an idle connection for.
This change makes `SocketsHttpHandler` look for this header and use it to limit the idle timeout of a connection.

As a result, we avoid the race condition and fewer requests fail with a "Connection reset by peer" error.

## Testing

Targeted test cases have been added and the patch was validated by an internal party in production.

## Risk

There is a tradeoff between mitigating the race condition and how long we consider an idle connection usable for.

There is a risk that the user may see more connections being established if they make requests on an interval that falls within a 1-second offset of the server Keep-Alive timeout.
For example, if the server responds with a timeout of 5 seconds and the user has a script pinging the server every 4.5 seconds, every request would create a new connection instead of reusing the existing one.
Users facing such an issue can increase the interval at which they make requests or if possible increase the timeout on the server.