### PR TITLE
Rename RateLimiter Acquire methods

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
+++ b/src/libraries/System.Threading.RateLimiting/ref/System.Threading.RateLimiting.cs
@@ -10,18 +10,18 @@ namespace System.Threading.RateLimiting
     {
         public ConcurrencyLimiter(System.Threading.RateLimiting.ConcurrencyLimiterOptions options) { }
         public override System.TimeSpan? IdleDuration { get { throw null; } }
-        protected override System.Threading.RateLimiting.RateLimitLease AcquireCore(int permitCount) { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> AcquireAsyncCore(int permitCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected override System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int permitCount) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public override int GetAvailablePermits() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class ConcurrencyLimiterOptions
     {
         public ConcurrencyLimiterOptions() { }
-        public int PermitLimit { get { throw null; } set { throw null; } }
-        public int QueueLimit { get { throw null; } set { throw null; } }
-        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } set { throw null; } }
+        public int PermitLimit { get { throw null; } set { } }
+        public int QueueLimit { get { throw null; } set { } }
+        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } set { } }
     }
     public sealed partial class FixedWindowRateLimiter : System.Threading.RateLimiting.ReplenishingRateLimiter
     {
@@ -29,21 +29,21 @@ namespace System.Threading.RateLimiting
         public override System.TimeSpan? IdleDuration { get { throw null; } }
         public override bool IsAutoReplenishing { get { throw null; } }
         public override System.TimeSpan ReplenishmentPeriod { get { throw null; } }
-        protected override System.Threading.RateLimiting.RateLimitLease AcquireCore(int requestCount) { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> AcquireAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected override System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int requestCount) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public override int GetAvailablePermits() { throw null; }
         public override bool TryReplenish() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class FixedWindowRateLimiterOptions
     {
         public FixedWindowRateLimiterOptions() { }
-        public bool AutoReplenishment { get { throw null; } set { throw null; } }
-        public int PermitLimit { get { throw null; } set { throw null; } }
-        public int QueueLimit { get { throw null; } set { throw null; } }
-        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } set { throw null; } }
-        public System.TimeSpan Window { get { throw null; } set { throw null; } }
+        public bool AutoReplenishment { get { throw null; } set { } }
+        public int PermitLimit { get { throw null; } set { } }
+        public int QueueLimit { get { throw null; } set { } }
+        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } set { } }
+        public System.TimeSpan Window { get { throw null; } set { } }
     }
     public static partial class MetadataName
     {
@@ -70,16 +70,16 @@ namespace System.Threading.RateLimiting
     public abstract partial class PartitionedRateLimiter<TResource> : System.IAsyncDisposable, System.IDisposable
     {
         protected PartitionedRateLimiter() { }
-        public System.Threading.RateLimiting.RateLimitLease Acquire(TResource resource, int permitCount = 1) { throw null; }
-        protected abstract System.Threading.RateLimiting.RateLimitLease AcquireCore(TResource resource, int permitCount);
+        public System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> AcquireAsync(TResource resource, int permitCount = 1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected abstract System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, System.Threading.CancellationToken cancellationToken);
+        public System.Threading.RateLimiting.RateLimitLease AttemptAcquire(TResource resource, int permitCount = 1) { throw null; }
+        protected abstract System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(TResource resource, int permitCount);
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public abstract int GetAvailablePermits(TResource resource);
         public System.Threading.RateLimiting.PartitionedRateLimiter<TOuter> TranslateKey<TOuter>(System.Func<TOuter, TResource> keyAdapter) { throw null; }
-        public System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsync(TResource resource, int permitCount = 1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        protected abstract System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(TResource resource, int permitCount, System.Threading.CancellationToken cancellationToken);
     }
     public enum QueueProcessingOrder
     {
@@ -90,15 +90,15 @@ namespace System.Threading.RateLimiting
     {
         protected RateLimiter() { }
         public abstract System.TimeSpan? IdleDuration { get; }
-        public System.Threading.RateLimiting.RateLimitLease Acquire(int permitCount = 1) { throw null; }
-        protected abstract System.Threading.RateLimiting.RateLimitLease AcquireCore(int permitCount);
+        public System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> AcquireAsync(int permitCount = 1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected abstract System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> AcquireAsyncCore(int permitCount, System.Threading.CancellationToken cancellationToken);
+        public System.Threading.RateLimiting.RateLimitLease AttemptAcquire(int permitCount = 1) { throw null; }
+        protected abstract System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int permitCount);
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public abstract int GetAvailablePermits();
-        public System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsync(int permitCount = 1, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        protected abstract System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, System.Threading.CancellationToken cancellationToken);
     }
     public abstract partial class RateLimitLease : System.IDisposable
     {
@@ -142,22 +142,22 @@ namespace System.Threading.RateLimiting
         public override System.TimeSpan? IdleDuration { get { throw null; } }
         public override bool IsAutoReplenishing { get { throw null; } }
         public override System.TimeSpan ReplenishmentPeriod { get { throw null; } }
-        protected override System.Threading.RateLimiting.RateLimitLease AcquireCore(int requestCount) { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> AcquireAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected override System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int requestCount) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public override int GetAvailablePermits() { throw null; }
         public override bool TryReplenish() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int requestCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class SlidingWindowRateLimiterOptions
     {
         public SlidingWindowRateLimiterOptions() { }
-        public bool AutoReplenishment { get { throw null; } set { throw null; } }
-        public int PermitLimit { get { throw null; } set { throw null; } }
-        public int QueueLimit { get { throw null; } set { throw null; } }
-        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } set { throw null; } }
-        public int SegmentsPerWindow { get { throw null; } set { throw null; } }
-        public System.TimeSpan Window { get { throw null; } set { throw null; } }
+        public bool AutoReplenishment { get { throw null; } set { } }
+        public int PermitLimit { get { throw null; } set { } }
+        public int QueueLimit { get { throw null; } set { } }
+        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } set { } }
+        public int SegmentsPerWindow { get { throw null; } set { } }
+        public System.TimeSpan Window { get { throw null; } set { } }
     }
     public sealed partial class TokenBucketRateLimiter : System.Threading.RateLimiting.ReplenishingRateLimiter
     {
@@ -165,21 +165,21 @@ namespace System.Threading.RateLimiting
         public override System.TimeSpan? IdleDuration { get { throw null; } }
         public override bool IsAutoReplenishing { get { throw null; } }
         public override System.TimeSpan ReplenishmentPeriod { get { throw null; } }
-        protected override System.Threading.RateLimiting.RateLimitLease AcquireCore(int tokenCount) { throw null; }
+        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> AcquireAsyncCore(int tokenCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected override System.Threading.RateLimiting.RateLimitLease AttemptAcquireCore(int tokenCount) { throw null; }
         protected override void Dispose(bool disposing) { }
         protected override System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public override int GetAvailablePermits() { throw null; }
         public override bool TryReplenish() { throw null; }
-        protected override System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease> WaitAndAcquireAsyncCore(int tokenCount, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class TokenBucketRateLimiterOptions
     {
         public TokenBucketRateLimiterOptions() { }
-        public bool AutoReplenishment { get { throw null; } set { throw null; } }
-        public int QueueLimit { get { throw null; } set { throw null; } }
-        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } set { throw null; } }
-        public System.TimeSpan ReplenishmentPeriod { get { throw null; } set { throw null; } }
-        public int TokenLimit { get { throw null; } set { throw null; } }
-        public int TokensPerPeriod { get { throw null; } set { throw null; } }
+        public bool AutoReplenishment { get { throw null; } set { } }
+        public int QueueLimit { get { throw null; } set { } }
+        public System.Threading.RateLimiting.QueueProcessingOrder QueueProcessingOrder { get { throw null; } set { } }
+        public System.TimeSpan ReplenishmentPeriod { get { throw null; } set { } }
+        public int TokenLimit { get { throw null; } set { } }
+        public int TokensPerPeriod { get { throw null; } set { } }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
@@ -40,7 +40,7 @@ namespace System.Threading.RateLimiting
             return lowestPermitCount;
         }
 
-        protected override RateLimitLease AcquireCore(TResource resource, int permitCount)
+        protected override RateLimitLease AttemptAcquireCore(TResource resource, int permitCount)
         {
             ThrowIfDisposed();
             RateLimitLease[]? leases = null;
@@ -50,7 +50,7 @@ namespace System.Threading.RateLimiting
                 Exception? exception = null;
                 try
                 {
-                    lease = _limiters[i].Acquire(resource, permitCount);
+                    lease = _limiters[i].AttemptAcquire(resource, permitCount);
                 }
                 catch (Exception ex)
                 {
@@ -66,7 +66,7 @@ namespace System.Threading.RateLimiting
             return new CombinedRateLimitLease(leases!);
         }
 
-        protected override async ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
+        protected override async ValueTask<RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             RateLimitLease[]? leases = null;
@@ -76,7 +76,7 @@ namespace System.Threading.RateLimiting
                 Exception? exception = null;
                 try
                 {
-                    lease = await _limiters[i].WaitAndAcquireAsync(resource, permitCount, cancellationToken).ConfigureAwait(false);
+                    lease = await _limiters[i].AcquireAsync(resource, permitCount, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiter.cs
@@ -65,7 +65,7 @@ namespace System.Threading.RateLimiting
         public override int GetAvailablePermits() => _permitCount;
 
         /// <inheritdoc/>
-        protected override RateLimitLease AcquireCore(int permitCount)
+        protected override RateLimitLease AttemptAcquireCore(int permitCount)
         {
             // These amounts of resources can never be acquired
             if (permitCount > _options.PermitLimit)
@@ -97,7 +97,7 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken = default)
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken = default)
         {
             // These amounts of resources can never be acquired
             if (permitCount > _options.PermitLimit)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ConcurrencyLimiterOptions.cs
@@ -15,7 +15,7 @@ namespace System.Threading.RateLimiting
         public int PermitLimit { get; set; }
 
         /// <summary>
-        /// Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
+        /// Determines the behaviour of <see cref="RateLimiter.AcquireAsync"/> when not enough resources can be leased.
         /// </summary>
         /// <value>
         /// <see cref="QueueProcessingOrder.OldestFirst"/> by default.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -70,14 +70,14 @@ namespace System.Threading.RateLimiting
             return GetRateLimiter(resource).GetAvailablePermits();
         }
 
-        protected override RateLimitLease AcquireCore(TResource resource, int permitCount)
+        protected override RateLimitLease AttemptAcquireCore(TResource resource, int permitCount)
         {
-            return GetRateLimiter(resource).Acquire(permitCount);
+            return GetRateLimiter(resource).AttemptAcquire(permitCount);
         }
 
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
         {
-            return GetRateLimiter(resource).WaitAndAcquireAsync(permitCount, cancellationToken);
+            return GetRateLimiter(resource).AcquireAsync(permitCount, cancellationToken);
         }
 
         private RateLimiter GetRateLimiter(TResource resource)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -84,7 +84,7 @@ namespace System.Threading.RateLimiting
         public override int GetAvailablePermits() => _requestCount;
 
         /// <inheritdoc/>
-        protected override RateLimitLease AcquireCore(int requestCount)
+        protected override RateLimitLease AttemptAcquireCore(int requestCount)
         {
             // These amounts of resources can never be acquired
             // Raises a PermitLimitExceeded ArgumentOutOFRangeException
@@ -118,7 +118,7 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int requestCount, CancellationToken cancellationToken = default)
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int requestCount, CancellationToken cancellationToken = default)
         {
             // These amounts of resources can never be acquired
             if (requestCount > _options.PermitLimit)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
@@ -30,7 +30,7 @@ namespace System.Threading.RateLimiting
         public int PermitLimit { get; set; }
 
         /// <summary>
-        /// Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
+        /// Determines the behaviour of <see cref="RateLimiter.AcquireAsync"/> when not enough resources can be leased.
         /// </summary>
         /// <value>
         /// <see cref="QueueProcessingOrder.OldestFirst"/> by default.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/NoopLimiter.cs
@@ -18,9 +18,9 @@ namespace System.Threading.RateLimiting
 
         public override int GetAvailablePermits() => int.MaxValue;
 
-        protected override RateLimitLease AcquireCore(int permitCount) => _lease;
+        protected override RateLimitLease AttemptAcquireCore(int permitCount) => _lease;
 
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
             => new ValueTask<RateLimitLease>(_lease);
 
         private sealed class NoopLease : RateLimitLease

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.T.cs
@@ -27,23 +27,23 @@ namespace System.Threading.RateLimiting
         /// <param name="permitCount">Number of permits to try and acquire.</param>
         /// <returns>A successful or failed lease.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public RateLimitLease Acquire(TResource resource, int permitCount = 1)
+        public RateLimitLease AttemptAcquire(TResource resource, int permitCount = 1)
         {
             if (permitCount < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(permitCount));
             }
 
-            return AcquireCore(resource, permitCount);
+            return AttemptAcquireCore(resource, permitCount);
         }
 
         /// <summary>
-        /// Method that <see cref="PartitionedRateLimiter{TResource}"/> implementations implement for <see cref="Acquire"/>.
+        /// Method that <see cref="PartitionedRateLimiter{TResource}"/> implementations implement for <see cref="AttemptAcquire"/>.
         /// </summary>
         /// <param name="resource">The resource to limit.</param>
         /// <param name="permitCount">Number of permits to try and acquire.</param>
         /// <returns></returns>
-        protected abstract RateLimitLease AcquireCore(TResource resource, int permitCount);
+        protected abstract RateLimitLease AttemptAcquireCore(TResource resource, int permitCount);
 
         /// <summary>
         /// Wait until the requested permits are available or permits can no longer be acquired.
@@ -56,7 +56,7 @@ namespace System.Threading.RateLimiting
         /// <param name="cancellationToken">Optional token to allow canceling a queued request for permits.</param>
         /// <returns>A task that completes when the requested permits are acquired or when the requested permits are denied.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public ValueTask<RateLimitLease> WaitAndAcquireAsync(TResource resource, int permitCount = 1, CancellationToken cancellationToken = default)
+        public ValueTask<RateLimitLease> AcquireAsync(TResource resource, int permitCount = 1, CancellationToken cancellationToken = default)
         {
             if (permitCount < 0)
             {
@@ -68,17 +68,17 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(Task.FromCanceled<RateLimitLease>(cancellationToken));
             }
 
-            return WaitAndAcquireAsyncCore(resource, permitCount, cancellationToken);
+            return AcquireAsyncCore(resource, permitCount, cancellationToken);
         }
 
         /// <summary>
-        /// Method that <see cref="PartitionedRateLimiter{TResource}"/> implementations implement for <see cref="WaitAndAcquireAsync"/>.
+        /// Method that <see cref="PartitionedRateLimiter{TResource}"/> implementations implement for <see cref="AcquireAsync"/>.
         /// </summary>
         /// <param name="resource">The resource to limit.</param>
         /// <param name="permitCount">Number of permits to try and acquire.</param>
         /// <param name="cancellationToken">Optional token to allow canceling a queued request for permits.</param>
         /// <returns>A task that completes when the requested permits are acquired or when the requested permits are denied.</returns>
-        protected abstract ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken);
+        protected abstract ValueTask<RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken);
 
         /// <summary>
         /// Dispose method for implementations to write.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/QueueProcessingOrder.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/QueueProcessingOrder.cs
@@ -4,16 +4,16 @@
 namespace System.Threading.RateLimiting
 {
     /// <summary>
-    /// Controls the behavior of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
+    /// Controls the behavior of <see cref="RateLimiter.AcquireAsync"/> when not enough resources can be leased.
     /// </summary>
     public enum QueueProcessingOrder
     {
         /// <summary>
-        /// Lease the oldest queued <see cref="RateLimiter.WaitAndAcquireAsync"/> call.
+        /// Lease the oldest queued <see cref="RateLimiter.AcquireAsync"/> call.
         /// </summary>
         OldestFirst,
         /// <summary>
-        /// Lease the newest queued <see cref="RateLimiter.WaitAndAcquireAsync"/> call.
+        /// Lease the newest queued <see cref="RateLimiter.AcquireAsync"/> call.
         /// </summary>
         NewestFirst
     }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimitPartition.cs
@@ -41,7 +41,7 @@ namespace System.Threading.RateLimiting
 
         /// <summary>
         /// Defines a partition that will not have a rate limiter.
-        /// This means any calls to <see cref="PartitionedRateLimiter{TResource}.Acquire(TResource, int)"/> or <see cref="PartitionedRateLimiter{TResource}.WaitAndAcquireAsync(TResource, int, CancellationToken)"/> will always succeed for the given <paramref name="partitionKey"/>.
+        /// This means any calls to <see cref="PartitionedRateLimiter{TResource}.AttemptAcquire(TResource, int)"/> or <see cref="PartitionedRateLimiter{TResource}.AcquireAsync(TResource, int, CancellationToken)"/> will always succeed for the given <paramref name="partitionKey"/>.
         /// </summary>
         /// <typeparam name="TKey">The type to distinguish partitions with.</typeparam>
         /// <param name="partitionKey">The specific key for this partition.</param>

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
@@ -34,22 +34,22 @@ namespace System.Threading.RateLimiting
         /// <param name="permitCount">Number of permits to try and acquire.</param>
         /// <returns>A successful or failed lease.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public RateLimitLease Acquire(int permitCount = 1)
+        public RateLimitLease AttemptAcquire(int permitCount = 1)
         {
             if (permitCount < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(permitCount));
             }
 
-            return AcquireCore(permitCount);
+            return AttemptAcquireCore(permitCount);
         }
 
         /// <summary>
-        /// Method that <see cref="RateLimiter"/> implementations implement for <see cref="Acquire"/>.
+        /// Method that <see cref="RateLimiter"/> implementations implement for <see cref="AttemptAcquire"/>.
         /// </summary>
         /// <param name="permitCount">Number of permits to try and acquire.</param>
         /// <returns></returns>
-        protected abstract RateLimitLease AcquireCore(int permitCount);
+        protected abstract RateLimitLease AttemptAcquireCore(int permitCount);
 
         /// <summary>
         /// Wait until the requested permits are available or permits can no longer be acquired.
@@ -61,7 +61,7 @@ namespace System.Threading.RateLimiting
         /// <param name="cancellationToken">Optional token to allow canceling a queued request for permits.</param>
         /// <returns>A task that completes when the requested permits are acquired or when the requested permits are denied.</returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public ValueTask<RateLimitLease> WaitAndAcquireAsync(int permitCount = 1, CancellationToken cancellationToken = default)
+        public ValueTask<RateLimitLease> AcquireAsync(int permitCount = 1, CancellationToken cancellationToken = default)
         {
             if (permitCount < 0)
             {
@@ -73,16 +73,16 @@ namespace System.Threading.RateLimiting
                 return new ValueTask<RateLimitLease>(Task.FromCanceled<RateLimitLease>(cancellationToken));
             }
 
-            return WaitAndAcquireAsyncCore(permitCount, cancellationToken);
+            return AcquireAsyncCore(permitCount, cancellationToken);
         }
 
         /// <summary>
-        /// Method that <see cref="RateLimiter"/> implementations implement for <see cref="WaitAndAcquireAsync"/>.
+        /// Method that <see cref="RateLimiter"/> implementations implement for <see cref="AcquireAsync"/>.
         /// </summary>
         /// <param name="permitCount">Number of permits to try and acquire.</param>
         /// <param name="cancellationToken">Optional token to allow canceling a queued request for permits.</param>
         /// <returns>A task that completes when the requested permits are acquired or when the requested permits are denied.</returns>
-        protected abstract ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken);
+        protected abstract ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken);
 
         /// <summary>
         /// Dispose method for implementations to write.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -92,7 +92,7 @@ namespace System.Threading.RateLimiting
         public override int GetAvailablePermits() => _requestCount;
 
         /// <inheritdoc/>
-        protected override RateLimitLease AcquireCore(int requestCount)
+        protected override RateLimitLease AttemptAcquireCore(int requestCount)
         {
             // These amounts of resources can never be acquired
             if (requestCount > _options.PermitLimit)
@@ -124,7 +124,7 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int requestCount, CancellationToken cancellationToken = default)
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int requestCount, CancellationToken cancellationToken = default)
         {
             // These amounts of resources can never be acquired
             if (requestCount > _options.PermitLimit)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
@@ -36,7 +36,7 @@ namespace System.Threading.RateLimiting
         public int PermitLimit { get; set; }
 
         /// <summary>
-        /// Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
+        /// Determines the behaviour of <see cref="RateLimiter.AcquireAsync"/> when not enough resources can be leased.
         /// </summary>
         /// <value>
         /// <see cref="QueueProcessingOrder.OldestFirst"/> by default.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -86,7 +86,7 @@ namespace System.Threading.RateLimiting
         public override int GetAvailablePermits() => _tokenCount;
 
         /// <inheritdoc/>
-        protected override RateLimitLease AcquireCore(int tokenCount)
+        protected override RateLimitLease AttemptAcquireCore(int tokenCount)
         {
             // These amounts of resources can never be acquired
             if (tokenCount > _options.TokenLimit)
@@ -117,7 +117,7 @@ namespace System.Threading.RateLimiting
         }
 
         /// <inheritdoc/>
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int tokenCount, CancellationToken cancellationToken = default)
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int tokenCount, CancellationToken cancellationToken = default)
         {
             // These amounts of resources can never be acquired
             if (tokenCount > _options.TokenLimit)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
@@ -36,7 +36,7 @@ namespace System.Threading.RateLimiting
         public int TokenLimit { get; set; }
 
         /// <summary>
-        /// Determines the behaviour of <see cref="RateLimiter.WaitAndAcquireAsync"/> when not enough resources can be leased.
+        /// Determines the behaviour of <see cref="RateLimiter.AcquireAsync"/> when not enough resources can be leased.
         /// </summary>
         /// <value>
         /// <see cref="QueueProcessingOrder.OldestFirst"/> by default.

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TranslatingLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TranslatingLimiter.cs
@@ -29,18 +29,18 @@ namespace System.Threading.RateLimiting
             return _innerRateLimiter.GetAvailablePermits(key);
         }
 
-        protected override RateLimitLease AcquireCore(TResource resource, int permitCount)
+        protected override RateLimitLease AttemptAcquireCore(TResource resource, int permitCount)
         {
             ThrowIfDispose();
             TInner key = _keyAdapter(resource);
-            return _innerRateLimiter.Acquire(key, permitCount);
+            return _innerRateLimiter.AttemptAcquire(key, permitCount);
         }
 
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
         {
             ThrowIfDispose();
             TInner key = _keyAdapter(resource);
-            return _innerRateLimiter.WaitAndAcquireAsync(key, permitCount, cancellationToken);
+            return _innerRateLimiter.AcquireAsync(key, permitCount, cancellationToken);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/BaseRateLimiterTests.cs
@@ -60,25 +60,25 @@ namespace System.Threading.RateLimiting.Test
         public abstract void AcquireZero_WithoutAvailability();
 
         [Fact]
-        public abstract Task WaitAndAcquireAsyncZero_WithAvailability();
+        public abstract Task AcquireAsyncZero_WithAvailability();
 
         [Fact]
-        public abstract Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability();
+        public abstract Task AcquireAsyncZero_WithoutAvailabilityWaitsForAvailability();
 
         [Fact]
         public abstract Task CanDequeueMultipleResourcesAtOnce();
 
         [Fact]
-        public abstract Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst();
+        public abstract Task CanAcquireResourcesWithAcquireAsyncWithQueuedItemsIfNewestFirst();
 
         [Fact]
-        public abstract Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst();
+        public abstract Task CannotAcquireResourcesWithAcquireAsyncWithQueuedItemsIfOldestFirst();
 
         [Fact]
-        public abstract Task CanCancelWaitAndAcquireAsyncAfterQueuing();
+        public abstract Task CanCancelAcquireAsyncAfterQueuing();
 
         [Fact]
-        public abstract Task CanCancelWaitAndAcquireAsyncBeforeQueuing();
+        public abstract Task CanCancelAcquireAsyncBeforeQueuing();
 
         [Fact]
         public abstract Task CanFillQueueWithNewestFirstAfterCancelingQueuedRequestWithAnotherQueuedRequest();

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -53,8 +53,8 @@ namespace System.Threading.RateLimiting.Tests
             chainedLimiter.Dispose();
 
             Assert.Throws<ObjectDisposedException>(() => chainedLimiter.GetAvailablePermits(""));
-            Assert.Throws<ObjectDisposedException>(() => chainedLimiter.Acquire(""));
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
+            Assert.Throws<ObjectDisposedException>(() => chainedLimiter.AttemptAcquire(""));
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.AcquireAsync(""));
         }
 
         [Fact]
@@ -85,8 +85,8 @@ namespace System.Threading.RateLimiting.Tests
             await chainedLimiter.DisposeAsync();
 
             Assert.Throws<ObjectDisposedException>(() => chainedLimiter.GetAvailablePermits(""));
-            Assert.Throws<ObjectDisposedException>(() => chainedLimiter.Acquire(""));
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
+            Assert.Throws<ObjectDisposedException>(() => chainedLimiter.AttemptAcquire(""));
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await chainedLimiter.AcquireAsync(""));
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
-            using var lease = chainedLimiter.Acquire("");
+            using var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.True(lease.IsAcquired);
             Assert.Single(limiterFactory.Limiters);
@@ -164,7 +164,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncWorksWithSingleLimiter()
+        public async Task AcquireAsyncWorksWithSingleLimiter()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
@@ -173,12 +173,12 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
-            using var lease = await chainedLimiter.WaitAndAcquireAsync("");
+            using var lease = await chainedLimiter.AcquireAsync("");
 
             Assert.True(lease.IsAcquired);
             Assert.Single(limiterFactory.Limiters);
             Assert.Equal(1, limiterFactory.Limiters[0].Key);
-            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAndAcquireAsyncCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.AcquireAsyncCallCount);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            using var lease = chainedLimiter.Acquire("");
+            using var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiterFactory.Limiters.Count);
@@ -206,7 +206,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncWorksWithMultipleLimiters()
+        public async Task AcquireAsyncWorksWithMultipleLimiters()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
@@ -219,14 +219,14 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            using var lease = await chainedLimiter.WaitAndAcquireAsync("");
+            using var lease = await chainedLimiter.AcquireAsync("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiterFactory.Limiters.Count);
             Assert.Equal(1, limiterFactory.Limiters[0].Key);
-            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.WaitAndAcquireAsyncCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[0].Limiter.AcquireAsyncCallCount);
             Assert.Equal(2, limiterFactory.Limiters[1].Key);
-            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.WaitAndAcquireAsyncCallCount);
+            Assert.Equal(1, limiterFactory.Limiters[1].Limiter.AcquireAsyncCallCount);
         }
 
         [Fact]
@@ -254,7 +254,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter1.GetAvailablePermits());
@@ -266,7 +266,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncLeaseCorrectlyDisposesWithMultipleLimiters()
+        public async Task AcquireAsyncLeaseCorrectlyDisposesWithMultipleLimiters()
         {
             var concurrencyLimiter1 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -290,7 +290,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            var lease = await chainedLimiter.WaitAndAcquireAsync("");
+            var lease = await chainedLimiter.AcquireAsync("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter1.GetAvailablePermits());
@@ -316,7 +316,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
@@ -326,7 +326,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncLeaseCorrectlyDisposesWithSingleLimiter()
+        public async Task AcquireAsyncLeaseCorrectlyDisposesWithSingleLimiter()
         {
             var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -340,7 +340,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
-            var lease = await chainedLimiter.WaitAndAcquireAsync("");
+            var lease = await chainedLimiter.AcquireAsync("");
 
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
@@ -369,10 +369,10 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             // Acquire the only permit on the ConcurrencyLimiter so the chained limiter fails when calling acquire
-            var concurrencyLease = concurrencyLimiter.Acquire();
+            var concurrencyLease = concurrencyLimiter.AttemptAcquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            using var lease = chainedLimiter.Acquire("");
+            using var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.False(lease.IsAcquired);
             Assert.Single(limiterFactory.Limiters);
@@ -381,7 +381,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncFailsWhenOneLimiterDoesNotHaveEnoughResources()
+        public async Task AcquireAsyncFailsWhenOneLimiterDoesNotHaveEnoughResources()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
@@ -400,10 +400,10 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             // Acquire the only permit on the ConcurrencyLimiter so the chained limiter fails when calling acquire
-            var concurrencyLease = await concurrencyLimiter.WaitAndAcquireAsync();
+            var concurrencyLease = await concurrencyLimiter.AcquireAsync();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            using var lease = chainedLimiter.Acquire("");
+            using var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.False(lease.IsAcquired);
             Assert.Single(limiterFactory.Limiters);
@@ -436,17 +436,17 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             // Acquire the only permit on the ConcurrencyLimiter so the chained limiter fails when calling acquire
-            var concurrencyLease = concurrencyLimiter2.Acquire();
+            var concurrencyLease = concurrencyLimiter2.AttemptAcquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            using var lease = chainedLimiter.Acquire("");
+            using var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.False(lease.IsAcquired);
             Assert.Equal(1, concurrencyLimiter1.GetAvailablePermits());
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncFailsAndReleasesAcquiredResources()
+        public async Task AcquireAsyncFailsAndReleasesAcquiredResources()
         {
             using var concurrencyLimiter1 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -470,10 +470,10 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             // Acquire the only permit on the ConcurrencyLimiter so the chained limiter fails when calling acquire
-            var concurrencyLease = await concurrencyLimiter2.WaitAndAcquireAsync();
+            var concurrencyLease = await concurrencyLimiter2.AcquireAsync();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            using var lease = chainedLimiter.Acquire("");
+            using var lease = chainedLimiter.AttemptAcquire("");
 
             Assert.False(lease.IsAcquired);
             Assert.Equal(1, concurrencyLimiter1.GetAvailablePermits());
@@ -498,12 +498,12 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            Assert.Throws<NotImplementedException>(() => chainedLimiter.Acquire(""));
+            Assert.Throws<NotImplementedException>(() => chainedLimiter.AttemptAcquire(""));
             Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncThrowsAndReleasesAcquiredResources()
+        public async Task AcquireAsyncThrowsAndReleasesAcquiredResources()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -521,7 +521,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
+            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.AcquireAsync(""));
             Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
         }
 
@@ -534,11 +534,11 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1);
-            Assert.Throws<NotImplementedException>(() => chainedLimiter.Acquire(""));
+            Assert.Throws<NotImplementedException>(() => chainedLimiter.AttemptAcquire(""));
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncThrows_SingleLimiter()
+        public async Task AcquireAsyncThrows_SingleLimiter()
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
@@ -546,7 +546,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1);
-            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
+            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.AcquireAsync(""));
         }
 
         internal sealed class ThrowDisposeLease : RateLimitLease
@@ -571,23 +571,23 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AttemptAcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
-            var lease = concurrencyLimiter.Acquire();
+            var lease = concurrencyLimiter.AttemptAcquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            var ex = Assert.Throws<AggregateException>(() => chainedLimiter.Acquire(""));
+            var ex = Assert.Throws<AggregateException>(() => chainedLimiter.AttemptAcquire(""));
             Assert.Single(ex.InnerExceptions);
             Assert.IsType<NotImplementedException>(ex.InnerException);
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncFailsDisposeThrows()
+        public async Task AcquireAsyncFailsDisposeThrows()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -597,17 +597,17 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AttemptAcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
-            var lease = await concurrencyLimiter.WaitAndAcquireAsync();
+            var lease = await concurrencyLimiter.AcquireAsync();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            var ex = Assert.Throws<AggregateException>(() => chainedLimiter.Acquire(""));
+            var ex = Assert.Throws<AggregateException>(() => chainedLimiter.AttemptAcquire(""));
             Assert.Single(ex.InnerExceptions);
             Assert.IsType<NotImplementedException>(ex.InnerException);
         }
@@ -623,28 +623,28 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AttemptAcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AttemptAcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
-            var lease = concurrencyLimiter.Acquire();
+            var lease = concurrencyLimiter.AttemptAcquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
-            var ex = Assert.Throws<AggregateException>(() => chainedLimiter.Acquire(""));
+            var ex = Assert.Throws<AggregateException>(() => chainedLimiter.AttemptAcquire(""));
             Assert.Equal(2, ex.InnerExceptions.Count);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[0]);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[1]);
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncFailsDisposeThrowsMultipleLimitersThrow()
+        public async Task AcquireAsyncFailsDisposeThrowsMultipleLimitersThrow()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -654,21 +654,21 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 return RateLimitPartition.Get(1, key => concurrencyLimiter);
             });
 
-            var lease = concurrencyLimiter.Acquire();
+            var lease = concurrencyLimiter.AttemptAcquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
-            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
+            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await chainedLimiter.AcquireAsync(""));
             Assert.Equal(2, ex.InnerExceptions.Count);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[0]);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[1]);
@@ -685,21 +685,21 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AttemptAcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AttemptAcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 return RateLimitPartition.Get(1, key => new NotImplementedLimiter());
             });
 
-            var lease = concurrencyLimiter.Acquire();
+            var lease = concurrencyLimiter.AttemptAcquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
-            var ex = Assert.Throws<AggregateException>(() => chainedLimiter.Acquire(""));
+            var ex = Assert.Throws<AggregateException>(() => chainedLimiter.AttemptAcquire(""));
             Assert.Equal(3, ex.InnerExceptions.Count);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[0]);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[1]);
@@ -707,7 +707,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncThrowsDisposeThrowsMultipleLimitersThrow()
+        public async Task AcquireAsyncThrowsDisposeThrowsMultipleLimitersThrow()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -717,21 +717,21 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter3 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
                 return RateLimitPartition.Get(1, key => new NotImplementedLimiter());
             });
 
-            var lease = concurrencyLimiter.Acquire();
+            var lease = concurrencyLimiter.AttemptAcquire();
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2, limiter3);
-            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
+            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await chainedLimiter.AcquireAsync(""));
             Assert.Equal(3, ex.InnerExceptions.Count);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[0]);
             Assert.IsType<NotImplementedException>(ex.InnerExceptions[1]);
@@ -749,7 +749,7 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireCoreImpl = _ => new ThrowDisposeLease() });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AttemptAcquireCoreImpl = _ => new ThrowDisposeLease() });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
@@ -757,7 +757,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
             var ex = Assert.Throws<AggregateException>(() => lease.Dispose());
@@ -768,7 +768,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncSucceedsDisposeThrowsAndReleasesResources()
+        public async Task AcquireAsyncSucceedsDisposeThrowsAndReleasesResources()
         {
             using var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -778,7 +778,7 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
-                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
+                return RateLimitPartition.Get(1, key => new CustomizableLimiter() { AcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(new ThrowDisposeLease()) });
             });
             using var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
@@ -786,7 +786,7 @@ namespace System.Threading.RateLimiting.Tests
             });
 
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
-            var lease = await chainedLimiter.WaitAndAcquireAsync("");
+            var lease = await chainedLimiter.AcquireAsync("");
             Assert.True(lease.IsAcquired);
             Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
             var ex = Assert.Throws<AggregateException>(() => lease.Dispose());
@@ -821,7 +821,7 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = chainedLimiter.Acquire("", 3);
+            var lease = chainedLimiter.AttemptAcquire("", 3);
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, concurrencyLimiter1.GetAvailablePermits());
             Assert.Equal(0, concurrencyLimiter2.GetAvailablePermits());
@@ -832,7 +832,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncForwardsCorrectPermitCount()
+        public async Task AcquireAsyncForwardsCorrectPermitCount()
         {
             using var concurrencyLimiter1 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -856,7 +856,7 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = await chainedLimiter.WaitAndAcquireAsync("", 3);
+            var lease = await chainedLimiter.AcquireAsync("", 3);
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, concurrencyLimiter1.GetAvailablePermits());
             Assert.Equal(0, concurrencyLimiter2.GetAvailablePermits());
@@ -888,7 +888,7 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = chainedLimiter.Acquire("1");
+            var lease = chainedLimiter.AttemptAcquire("1");
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiterFactory.Limiters.Count);
             Assert.Equal(1, limiterFactory.Limiters[0].Key);
@@ -896,7 +896,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncForwardsCorrectResource()
+        public async Task AcquireAsyncForwardsCorrectResource()
         {
             var limiterFactory = new TrackingRateLimiterFactory<int>();
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
@@ -917,7 +917,7 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = await chainedLimiter.WaitAndAcquireAsync("1");
+            var lease = await chainedLimiter.AcquireAsync("1");
             Assert.True(lease.IsAcquired);
             Assert.Equal(2, limiterFactory.Limiters.Count);
             Assert.Equal(1, limiterFactory.Limiters[0].Key);
@@ -925,7 +925,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncCanBeCanceled()
+        public async Task AcquireAsyncCanBeCanceled()
         {
             using var limiter = PartitionedRateLimiter.Create<string, int>(resource =>
             {
@@ -938,18 +938,18 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter);
 
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var task = chainedLimiter.WaitAndAcquireAsync("", 1, cts.Token);
+            var task = chainedLimiter.AcquireAsync("", 1, cts.Token);
 
             cts.Cancel();
              await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncCanceledReleasesAcquiredResources()
+        public async Task AcquireAsyncCanceledReleasesAcquiredResources()
         {
             var concurrencyLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -972,12 +972,12 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
             Assert.True(lease.IsAcquired);
             Assert.Equal(1, concurrencyLimiter.GetAvailablePermits());
 
             var cts = new CancellationTokenSource();
-            var task = chainedLimiter.WaitAndAcquireAsync("", 1, cts.Token);
+            var task = chainedLimiter.AcquireAsync("", 1, cts.Token);
 
             Assert.Equal(0, concurrencyLimiter.GetAvailablePermits());
             cts.Cancel();
@@ -986,7 +986,7 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public async Task WaitAndAcquireAsyncWaitsForResourcesBeforeCallingNextLimiter()
+        public async Task AcquireAsyncWaitsForResourcesBeforeCallingNextLimiter()
         {
             using var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
             {
@@ -1010,10 +1010,10 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
             Assert.True(lease.IsAcquired);
 
-            var task = chainedLimiter.WaitAndAcquireAsync("");
+            var task = chainedLimiter.AcquireAsync("");
             Assert.False(task.IsCompleted);
 
             lease.Dispose();
@@ -1042,16 +1042,16 @@ namespace System.Threading.RateLimiting.Tests
             {
                 Assert.True(disposeCalled);
             };
-            customizableLimiter1.AcquireCoreImpl = _ => customizableLease1;
+            customizableLimiter1.AttemptAcquireCoreImpl = _ => customizableLease1;
 
             var customizableLease2 = new CustomizableLease();
             customizableLease2.DisposeImpl = _ =>
             {
                 disposeCalled = true;
             };
-            customizableLimiter2.AcquireCoreImpl = _ => customizableLease2;
+            customizableLimiter2.AttemptAcquireCoreImpl = _ => customizableLease2;
 
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
             Assert.True(lease.IsAcquired);
 
             lease.Dispose();
@@ -1082,20 +1082,20 @@ namespace System.Threading.RateLimiting.Tests
             {
                 Assert.True(disposeCalled);
             };
-            customizableLimiter1.AcquireCoreImpl = _ => customizableLease1;
+            customizableLimiter1.AttemptAcquireCoreImpl = _ => customizableLease1;
 
             var customizableLease2 = new CustomizableLease();
             customizableLease2.DisposeImpl = _ =>
             {
                 disposeCalled = true;
             };
-            customizableLimiter2.AcquireCoreImpl = _ => customizableLease2;
+            customizableLimiter2.AttemptAcquireCoreImpl = _ => customizableLease2;
 
-            Assert.Throws<NotImplementedException>(() => chainedLimiter.Acquire(""));
+            Assert.Throws<NotImplementedException>(() => chainedLimiter.AttemptAcquire(""));
         }
 
         [Fact]
-        public async Task LeasesAreDisposedInReverseOrderWhenWaitAndAcquireAsyncThrows()
+        public async Task LeasesAreDisposedInReverseOrderWhenAcquireAsyncThrows()
         {
             var customizableLimiter1 = new CustomizableLimiter();
             var customizableLimiter2 = new CustomizableLimiter();
@@ -1119,23 +1119,23 @@ namespace System.Threading.RateLimiting.Tests
             {
                 Assert.True(disposeCalled);
             };
-            customizableLimiter1.WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(customizableLease1);
+            customizableLimiter1.AcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(customizableLease1);
 
             var customizableLease2 = new CustomizableLease();
             customizableLease2.DisposeImpl = _ =>
             {
                 disposeCalled = true;
             };
-            customizableLimiter2.WaitAndAcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(customizableLease2);
+            customizableLimiter2.AcquireAsyncCoreImpl = (_, _) => new ValueTask<RateLimitLease>(customizableLease2);
 
-            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.WaitAndAcquireAsync(""));
+            await Assert.ThrowsAsync<NotImplementedException>(async () => await chainedLimiter.AcquireAsync(""));
         }
 
         [Fact]
         public void MetadataIsCombined()
         {
             var customizableLimiter1 = new CustomizableLimiter();
-            customizableLimiter1.AcquireCoreImpl = _ => new CustomizableLease()
+            customizableLimiter1.AttemptAcquireCoreImpl = _ => new CustomizableLease()
             {
                 MetadataNamesImpl = () =>
                 {
@@ -1158,7 +1158,7 @@ namespace System.Threading.RateLimiting.Tests
                 }
             };
             var customizableLimiter2 = new CustomizableLimiter();
-            customizableLimiter2.AcquireCoreImpl = _ => new CustomizableLease()
+            customizableLimiter2.AttemptAcquireCoreImpl = _ => new CustomizableLease()
             {
                 MetadataNamesImpl = () =>
                 {
@@ -1190,7 +1190,7 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
 
             var metaDataNames = lease.MetadataNames.ToArray();
             Assert.Equal(4, metaDataNames.Length);
@@ -1213,7 +1213,7 @@ namespace System.Threading.RateLimiting.Tests
         public void DuplicateMetadataUsesFirstOne()
         {
             var customizableLimiter1 = new CustomizableLimiter();
-            customizableLimiter1.AcquireCoreImpl = _ => new CustomizableLease()
+            customizableLimiter1.AttemptAcquireCoreImpl = _ => new CustomizableLease()
             {
                 MetadataNamesImpl = () =>
                 {
@@ -1236,7 +1236,7 @@ namespace System.Threading.RateLimiting.Tests
                 }
             };
             var customizableLimiter2 = new CustomizableLimiter();
-            customizableLimiter2.AcquireCoreImpl = _ => new CustomizableLease()
+            customizableLimiter2.AttemptAcquireCoreImpl = _ => new CustomizableLease()
             {
                 MetadataNamesImpl = () =>
                 {
@@ -1269,7 +1269,7 @@ namespace System.Threading.RateLimiting.Tests
             });
             using var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
 
-            var lease = chainedLimiter.Acquire("");
+            var lease = chainedLimiter.AttemptAcquire("");
 
             var metadataNames = lease.MetadataNames.ToArray();
             Assert.Equal(3, metadataNames.Length);

--- a/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ConcurrencyLimiterTests.cs
@@ -34,14 +34,14 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire();
+            var lease = limiter.AttemptAcquire();
 
             Assert.True(lease.IsAcquired);
-            Assert.False(limiter.Acquire().IsAcquired);
+            Assert.False(limiter.AttemptAcquire().IsAcquired);
 
             lease.Dispose();
 
-            Assert.True(limiter.Acquire().IsAcquired);
+            Assert.True(limiter.AttemptAcquire().IsAcquired);
         }
 
         [Fact]
@@ -53,10 +53,10 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            var lease = await limiter.WaitAndAcquireAsync();
+            var lease = await limiter.AcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync();
+            var wait = limiter.AcquireAsync();
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -73,11 +73,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 2
             });
-            var lease = await limiter.WaitAndAcquireAsync();
+            var lease = await limiter.AcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAndAcquireAsync();
-            var wait2 = limiter.WaitAndAcquireAsync();
+            var wait1 = limiter.AcquireAsync();
+            var wait2 = limiter.AcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -102,11 +102,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 3
             });
-            var lease = await limiter.WaitAndAcquireAsync(2);
+            var lease = await limiter.AcquireAsync(2);
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAndAcquireAsync(2);
-            var wait2 = limiter.WaitAndAcquireAsync();
+            var wait1 = limiter.AcquireAsync(2);
+            var wait2 = limiter.AcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -132,10 +132,10 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            using var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            using var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(1);
+            var failedLease = await limiter.AcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
         }
 
@@ -148,11 +148,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             var lease1 = await wait;
             Assert.False(lease1.IsAcquired);
             Assert.False(wait2.IsCompleted);
@@ -172,15 +172,15 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 2
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait2.IsCompleted);
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             var lease1 = await wait;
             var lease2 = await wait2;
             Assert.False(lease1.IsAcquired);
@@ -202,14 +202,14 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var lease1 = await limiter.WaitAndAcquireAsync(2);
+            var lease1 = await limiter.AcquireAsync(2);
             Assert.False(lease1.IsAcquired);
 
             lease.Dispose();
@@ -226,14 +226,14 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = int.MaxValue
             });
-            var lease = limiter.Acquire(int.MaxValue);
+            var lease = limiter.AttemptAcquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAndAcquireAsync(3);
+            var wait = limiter.AcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(int.MaxValue);
+            var wait2 = limiter.AcquireAsync(int.MaxValue);
             Assert.False(wait2.IsCompleted);
 
             var lease1 = await wait;
@@ -253,17 +253,17 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(1);
+            var failedLease = await limiter.AcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
 
             lease.Dispose();
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAndAcquireAsync(1);
+            wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -280,7 +280,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => limiter.Acquire(2));
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => limiter.AttemptAcquire(2));
             Assert.Equal("permitCount", ex.ParamName);
         }
 
@@ -293,7 +293,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(2));
+            var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.AcquireAsync(2));
             Assert.Equal("permitCount", ex.ParamName);
         }
 
@@ -306,7 +306,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.Acquire(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.AttemptAcquire(-1));
         }
 
         [Fact]
@@ -318,7 +318,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(-1));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.AcquireAsync(-1));
         }
 
         [Fact]
@@ -331,7 +331,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueLimit = 1
             });
 
-            using var lease = limiter.Acquire(0);
+            using var lease = limiter.AttemptAcquire(0);
             Assert.True(lease.IsAcquired);
         }
 
@@ -344,16 +344,16 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var lease2 = limiter.Acquire(0);
+            var lease2 = limiter.AttemptAcquire(0);
             Assert.False(lease2.IsAcquired);
             lease2.Dispose();
         }
 
         [Fact]
-        public override async Task WaitAndAcquireAsyncZero_WithAvailability()
+        public override async Task AcquireAsyncZero_WithAvailability()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -362,12 +362,12 @@ namespace System.Threading.RateLimiting.Test
                 QueueLimit = 1
             });
 
-            using var lease = await limiter.WaitAndAcquireAsync(0);
+            using var lease = await limiter.AcquireAsync(0);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
+        public override async Task AcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -375,10 +375,10 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 1
             });
-            var lease = await limiter.WaitAndAcquireAsync(1);
+            var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(0);
+            var wait = limiter.AcquireAsync(0);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -395,11 +395,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 2
             });
-            using var lease = await limiter.WaitAndAcquireAsync(2);
+            using var lease = await limiter.AcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -412,7 +412,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst()
+        public override async Task CanAcquireResourcesWithAcquireAsyncWithQueuedItemsIfNewestFirst()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -420,12 +420,12 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 3
             });
-            using var lease = await limiter.WaitAndAcquireAsync(1);
+            using var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(2);
+            var wait1 = limiter.AcquireAsync(2);
             Assert.False(wait1.IsCompleted);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             var lease2 = await wait2;
             Assert.True(lease2.IsAcquired);
 
@@ -439,7 +439,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst()
+        public override async Task CannotAcquireResourcesWithAcquireAsyncWithQueuedItemsIfOldestFirst()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -447,11 +447,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 3
             });
-            using var lease = await limiter.WaitAndAcquireAsync(1);
+            using var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(2);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait1 = limiter.AcquireAsync(2);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -475,12 +475,12 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 3
             });
-            using var lease = await limiter.WaitAndAcquireAsync(1);
+            using var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(2);
+            var wait1 = limiter.AcquireAsync(2);
             Assert.False(wait1.IsCompleted);
-            var lease2 = limiter.Acquire(1);
+            var lease2 = limiter.AttemptAcquire(1);
             Assert.True(lease2.IsAcquired);
 
             lease.Dispose();
@@ -501,12 +501,12 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 3
             });
-            using var lease = await limiter.WaitAndAcquireAsync(1);
+            using var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(2);
+            var wait1 = limiter.AcquireAsync(2);
             Assert.False(wait1.IsCompleted);
-            var lease2 = limiter.Acquire(1);
+            var lease2 = limiter.AttemptAcquire(1);
             Assert.False(lease2.IsAcquired);
 
             lease.Dispose();
@@ -516,7 +516,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAndAcquireAsyncAfterQueuing()
+        public override async Task CanCancelAcquireAsyncAfterQueuing()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -524,11 +524,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -540,7 +540,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAndAcquireAsyncBeforeQueuing()
+        public override async Task CanCancelAcquireAsyncBeforeQueuing()
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
@@ -548,13 +548,13 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAndAcquireAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.AcquireAsync(1, cts.Token).AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
@@ -571,17 +571,17 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            wait = limiter.WaitAndAcquireAsync(1);
+            wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -598,21 +598,21 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                 QueueLimit = 2
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             // Add another item to queue, will be completed as failed later when we queue another item
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             // will be kicked by wait3 because we're using NewestFirst
@@ -634,11 +634,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -657,7 +657,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.False(lease.TryGetMetadata(MetadataName.ReasonPhrase.Name, out _));
         }
 
@@ -670,7 +670,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.Collection(lease.MetadataNames, metadataName => Assert.Equal(metadataName, MetadataName.ReasonPhrase.Name));
         }
 
@@ -683,11 +683,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 3
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
 
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
-            var wait3 = limiter.WaitAndAcquireAsync(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
+            var wait3 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -704,8 +704,8 @@ namespace System.Threading.RateLimiting.Test
             lease.Dispose();
 
             // Throws after disposal
-            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
+            Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire(1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.AcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -717,11 +717,11 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 3
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
 
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
-            var wait3 = limiter.WaitAndAcquireAsync(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
+            var wait3 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -738,8 +738,8 @@ namespace System.Threading.RateLimiting.Test
             lease.Dispose();
 
             // Throws after disposal
-            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
+            Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire(1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.AcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -751,9 +751,9 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(2);
+            var failedLease = await limiter.AcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.ReasonPhrase.Name, out var metadata));
             Assert.Equal("Queue limit reached", metadata);
@@ -772,7 +772,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.Null(limiter.IdleDuration);
         }
 
@@ -800,7 +800,7 @@ namespace System.Threading.RateLimiting.Test
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 1
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             lease.Dispose();
             Assert.NotNull(limiter.IdleDuration);
         }

--- a/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
@@ -20,16 +20,16 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire();
+            var lease = limiter.AttemptAcquire();
 
             Assert.True(lease.IsAcquired);
-            Assert.False(limiter.Acquire().IsAcquired);
+            Assert.False(limiter.AttemptAcquire().IsAcquired);
 
             lease.Dispose();
-            Assert.False(limiter.Acquire().IsAcquired);
+            Assert.False(limiter.AttemptAcquire().IsAcquired);
             Assert.True(limiter.TryReplenish());
 
-            Assert.True(limiter.Acquire().IsAcquired);
+            Assert.True(limiter.AttemptAcquire().IsAcquired);
         }
 
         [Fact]
@@ -76,10 +76,10 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = await limiter.WaitAndAcquireAsync();
+            using var lease = await limiter.AcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync();
+            var wait = limiter.AcquireAsync();
             Assert.False(wait.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
@@ -98,11 +98,11 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = await limiter.WaitAndAcquireAsync();
+            var lease = await limiter.AcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAndAcquireAsync();
-            var wait2 = limiter.WaitAndAcquireAsync();
+            var wait1 = limiter.AcquireAsync();
+            var wait2 = limiter.AcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -133,11 +133,11 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = await limiter.WaitAndAcquireAsync(2);
+            var lease = await limiter.AcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(2);
-            var wait2 = limiter.WaitAndAcquireAsync();
+            var wait1 = limiter.AcquireAsync(2);
+            var wait2 = limiter.AcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -168,10 +168,10 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            using var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(1);
+            var failedLease = await limiter.AcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var timeSpan));
             Assert.Equal(TimeSpan.Zero, timeSpan);
@@ -188,11 +188,11 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             var lease1 = await wait;
             Assert.False(lease1.IsAcquired);
             Assert.False(wait2.IsCompleted);
@@ -214,15 +214,15 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait2.IsCompleted);
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             var lease1 = await wait;
             var lease2 = await wait2;
             Assert.False(lease1.IsAcquired);
@@ -246,14 +246,14 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var lease1 = await limiter.WaitAndAcquireAsync(2);
+            var lease1 = await limiter.AcquireAsync(2);
             Assert.False(lease1.IsAcquired);
 
             limiter.TryReplenish();
@@ -273,17 +273,17 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(1);
+            var failedLease = await limiter.AcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
 
             limiter.TryReplenish();
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAndAcquireAsync(1);
+            wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -302,14 +302,14 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(int.MaxValue);
+            var lease = limiter.AttemptAcquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAndAcquireAsync(3);
+            var wait = limiter.AcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(int.MaxValue);
+            var wait2 = limiter.AcquireAsync(int.MaxValue);
             Assert.False(wait2.IsCompleted);
 
             var lease1 = await wait;
@@ -331,7 +331,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.Acquire(2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.AttemptAcquire(2));
         }
 
         [Fact]
@@ -345,7 +345,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(2));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.AcquireAsync(2));
         }
 
         [Fact]
@@ -359,7 +359,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.Acquire(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.AttemptAcquire(-1));
         }
 
         [Fact]
@@ -373,7 +373,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(-1));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.AcquireAsync(-1));
         }
 
         [Fact]
@@ -388,7 +388,7 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = limiter.Acquire(0);
+            using var lease = limiter.AttemptAcquire(0);
             Assert.True(lease.IsAcquired);
         }
 
@@ -403,16 +403,16 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var lease2 = limiter.Acquire(0);
+            var lease2 = limiter.AttemptAcquire(0);
             Assert.False(lease2.IsAcquired);
             lease2.Dispose();
         }
 
         [Fact]
-        public override async Task WaitAndAcquireAsyncZero_WithAvailability()
+        public override async Task AcquireAsyncZero_WithAvailability()
         {
             var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
             {
@@ -423,12 +423,12 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = await limiter.WaitAndAcquireAsync(0);
+            using var lease = await limiter.AcquireAsync(0);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
+        public override async Task AcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
         {
             var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
             {
@@ -438,10 +438,10 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = await limiter.WaitAndAcquireAsync(1);
+            var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(0);
+            var wait = limiter.AcquireAsync(0);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -461,11 +461,11 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            using var lease = await limiter.WaitAndAcquireAsync(2);
+            using var lease = await limiter.AcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -479,7 +479,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAndAcquireAsyncAfterQueuing()
+        public override async Task CanCancelAcquireAsyncAfterQueuing()
         {
             var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
             {
@@ -489,11 +489,11 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -506,7 +506,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAndAcquireAsyncBeforeQueuing()
+        public override async Task CanCancelAcquireAsyncBeforeQueuing()
         {
             var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
             {
@@ -516,13 +516,13 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAndAcquireAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.AcquireAsync(1, cts.Token).AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
@@ -542,17 +542,17 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            wait = limiter.WaitAndAcquireAsync(1);
+            wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -571,7 +571,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.False(lease.TryGetMetadata(MetadataName.RetryAfter, out _));
         }
 
@@ -586,7 +586,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.Collection(lease.MetadataNames, metadataName => Assert.Equal(metadataName, MetadataName.RetryAfter.Name));
         }
 
@@ -601,10 +601,10 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
-            var wait3 = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
+            var wait3 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -619,8 +619,8 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(lease.IsAcquired);
 
             // Throws after disposal
-            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
+            Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire(1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.AcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -634,10 +634,10 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
-            var wait3 = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
+            var wait3 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -652,8 +652,8 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(lease.IsAcquired);
 
             // Throws after disposal
-            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
+            Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire(1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.AcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -669,9 +669,9 @@ namespace System.Threading.RateLimiting.Test
             };
             var limiter = new FixedWindowRateLimiter(options);
 
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(2);
+            var failedLease = await limiter.AcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter.Name, out var metadata));
             var metaDataTime = Assert.IsType<TimeSpan>(metadata);
@@ -695,12 +695,12 @@ namespace System.Threading.RateLimiting.Test
             };
             var limiter = new FixedWindowRateLimiter(options);
 
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
             // Queue item which changes the retry after time for failed items
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(2);
+            var failedLease = await limiter.AcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.Window.Ticks, typedMetadata.Ticks);
@@ -720,9 +720,9 @@ namespace System.Threading.RateLimiting.Test
             };
             var limiter = new FixedWindowRateLimiter(options);
 
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(3);
+            var failedLease = await limiter.AcquireAsync(3);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.Window.Ticks, typedMetadata.Ticks);
@@ -756,14 +756,14 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = true
             });
             Assert.Equal(2, limiter.GetAvailablePermits());
-            limiter.Acquire(2);
+            limiter.AttemptAcquire(2);
 
-            var lease = await limiter.WaitAndAcquireAsync(1);
+            var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst()
+        public override async Task CanAcquireResourcesWithAcquireAsyncWithQueuedItemsIfNewestFirst()
         {
             var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
             {
@@ -774,14 +774,14 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             Assert.Equal(1, limiter.GetAvailablePermits());
-            lease = await limiter.WaitAndAcquireAsync(1);
+            lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
 
@@ -792,7 +792,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst()
+        public override async Task CannotAcquireResourcesWithAcquireAsyncWithQueuedItemsIfOldestFirst()
         {
             var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
             {
@@ -803,11 +803,11 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(2);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -835,13 +835,13 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
-            lease = limiter.Acquire(1);
+            lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
 
@@ -863,13 +863,13 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
-            lease = limiter.Acquire(1);
+            lease = limiter.AttemptAcquire(1);
             Assert.False(lease.IsAcquired);
 
             limiter.TryReplenish();
@@ -889,7 +889,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.FromMilliseconds(2),
                 AutoReplenishment = false
             });
-            limiter.Acquire(1);
+            limiter.AttemptAcquire(1);
             Assert.Null(limiter.IdleDuration);
         }
 
@@ -921,7 +921,7 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            limiter.Acquire(1);
+            limiter.AttemptAcquire(1);
             limiter.TryReplenish();
             Assert.NotNull(limiter.IdleDuration);
         }
@@ -965,14 +965,14 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             // Add another item to queue, will be completed as failed later when we queue another item
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             cts.Cancel();
@@ -981,7 +981,7 @@ namespace System.Threading.RateLimiting.Test
 
             lease.Dispose();
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             // will be kicked by wait3 because we're using NewestFirst
@@ -1004,11 +1004,11 @@ namespace System.Threading.RateLimiting.Test
                 Window = TimeSpan.Zero,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());

--- a/src/libraries/System.Threading.RateLimiting/tests/Infrastructure/Utils.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/Infrastructure/Utils.cs
@@ -43,8 +43,8 @@ namespace System.Threading.RateLimiting.Tests
     internal sealed class NotImplementedPartitionedRateLimiter<T> : PartitionedRateLimiter<T>
     {
         public override int GetAvailablePermits(T resource) => throw new NotImplementedException();
-        protected override RateLimitLease AcquireCore(T resource, int permitCount) => throw new NotImplementedException();
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(T resource, int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
+        protected override RateLimitLease AttemptAcquireCore(T resource, int permitCount) => throw new NotImplementedException();
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(T resource, int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 
     internal sealed class TrackingRateLimiter : RateLimiter
@@ -57,7 +57,7 @@ namespace System.Threading.RateLimiting.Tests
 
         public int GetAvailablePermitsCallCount => _getAvailablePermitsCallCount;
         public int AcquireCallCount => _acquireCallCount;
-        public int WaitAndAcquireAsyncCallCount => _waitAsyncCallCount;
+        public int AcquireAsyncCallCount => _waitAsyncCallCount;
         public int DisposeCallCount => _disposeCallCount;
         public int DisposeAsyncCallCount => _disposeAsyncCallCount;
 
@@ -69,13 +69,13 @@ namespace System.Threading.RateLimiting.Tests
             return 1;
         }
 
-        protected override RateLimitLease AcquireCore(int permitCount)
+        protected override RateLimitLease AttemptAcquireCore(int permitCount)
         {
             Interlocked.Increment(ref _acquireCallCount);
             return new Lease();
         }
 
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref _waitAsyncCallCount);
             return new ValueTask<RateLimitLease>(new Lease());
@@ -143,8 +143,8 @@ namespace System.Threading.RateLimiting.Tests
         public override TimeSpan? IdleDuration => throw new NotImplementedException();
 
         public override int GetAvailablePermits() => throw new NotImplementedException();
-        protected override RateLimitLease AcquireCore(int permitCount) => throw new NotImplementedException();
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
+        protected override RateLimitLease AttemptAcquireCore(int permitCount) => throw new NotImplementedException();
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 
     internal sealed class CustomizableLimiter : RateLimiter
@@ -155,11 +155,11 @@ namespace System.Threading.RateLimiting.Tests
         public Func<int> GetAvailablePermitsImpl { get; set; } = () => throw new NotImplementedException();
         public override int GetAvailablePermits() => GetAvailablePermitsImpl();
 
-        public Func<int, RateLimitLease> AcquireCoreImpl { get; set; } = _ => new Lease();
-        protected override RateLimitLease AcquireCore(int permitCount) => AcquireCoreImpl(permitCount);
+        public Func<int, RateLimitLease> AttemptAcquireCoreImpl { get; set; } = _ => new Lease();
+        protected override RateLimitLease AttemptAcquireCore(int permitCount) => AttemptAcquireCoreImpl(permitCount);
 
-        public Func<int, CancellationToken, ValueTask<RateLimitLease>> WaitAndAcquireAsyncCoreImpl { get; set; } = (_, _) => new ValueTask<RateLimitLease>(new Lease());
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => WaitAndAcquireAsyncCoreImpl(permitCount, cancellationToken);
+        public Func<int, CancellationToken, ValueTask<RateLimitLease>> AcquireAsyncCoreImpl { get; set; } = (_, _) => new ValueTask<RateLimitLease>(new Lease());
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => AcquireAsyncCoreImpl(permitCount, cancellationToken);
 
         public Action<bool> DisposeImpl { get; set; } = _ => { };
         protected override void Dispose(bool disposing) => DisposeImpl(disposing);
@@ -185,11 +185,11 @@ namespace System.Threading.RateLimiting.Tests
         public Func<int> GetAvailablePermitsImpl { get; set; } = () => throw new NotImplementedException();
         public override int GetAvailablePermits() => GetAvailablePermitsImpl();
 
-        public Func<int, RateLimitLease> AcquireCoreImpl { get; set; } = _ => new Lease();
-        protected override RateLimitLease AcquireCore(int permitCount) => AcquireCoreImpl(permitCount);
+        public Func<int, RateLimitLease> AttemptAcquireCoreImpl { get; set; } = _ => new Lease();
+        protected override RateLimitLease AttemptAcquireCore(int permitCount) => AttemptAcquireCoreImpl(permitCount);
 
-        public Func<int, CancellationToken, ValueTask<RateLimitLease>> WaitAndAcquireAsyncCoreImpl { get; set; } = (_, _) => new ValueTask<RateLimitLease>(new Lease());
-        protected override ValueTask<RateLimitLease> WaitAndAcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => WaitAndAcquireAsyncCoreImpl(permitCount, cancellationToken);
+        public Func<int, CancellationToken, ValueTask<RateLimitLease>> AcquireAsyncCoreImpl { get; set; } = (_, _) => new ValueTask<RateLimitLease>(new Lease());
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken) => AcquireAsyncCoreImpl(permitCount, cancellationToken);
 
         public Func<ValueTask> DisposeAsyncCoreImpl { get; set; } = () => default;
         protected override ValueTask DisposeAsyncCore() => DisposeAsyncCoreImpl();

--- a/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/RateLimiterPartitionTests.cs
@@ -54,14 +54,14 @@ namespace System.Threading.RateLimiting.Tests
 
             // How do we test an internal implementation of a limiter that doesn't limit? Just try some stuff that normal limiters would probably block on and see if it works.
             var available = limiter.GetAvailablePermits();
-            var lease = limiter.Acquire(int.MaxValue);
+            var lease = limiter.AttemptAcquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
             Assert.Equal(available, limiter.GetAvailablePermits());
 
-            lease = limiter.Acquire(int.MaxValue);
+            lease = limiter.AttemptAcquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(int.MaxValue);
+            var wait = limiter.AcquireAsync(int.MaxValue);
             Assert.True(wait.IsCompletedSuccessfully);
             lease = await wait;
             Assert.True(lease.IsAcquired);

--- a/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
@@ -21,17 +21,17 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire();
+            var lease = limiter.AttemptAcquire();
 
             Assert.True(lease.IsAcquired);
-            Assert.False(limiter.Acquire().IsAcquired);
+            Assert.False(limiter.AttemptAcquire().IsAcquired);
 
             lease.Dispose();
-            Assert.False(limiter.Acquire().IsAcquired);
+            Assert.False(limiter.AttemptAcquire().IsAcquired);
             Assert.True(limiter.TryReplenish());
             Assert.True(limiter.TryReplenish());
 
-            Assert.True(limiter.Acquire().IsAcquired);
+            Assert.True(limiter.AttemptAcquire().IsAcquired);
         }
 
         [Fact]
@@ -92,17 +92,17 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = await limiter.WaitAndAcquireAsync();
+            using var lease = await limiter.AcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
 
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(2);
+            var wait2 = limiter.AcquireAsync(2);
             Assert.False(wait2.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
@@ -126,22 +126,22 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = await limiter.WaitAndAcquireAsync(2);
+            using var lease = await limiter.AcquireAsync(2);
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync(3);
+            var wait = limiter.AcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
 
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(2);
+            var wait2 = limiter.AcquireAsync(2);
             Assert.True(wait2.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
@@ -163,11 +163,11 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = await limiter.WaitAndAcquireAsync(2);
+            var lease = await limiter.AcquireAsync(2);
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAndAcquireAsync();
-            var wait2 = limiter.WaitAndAcquireAsync(2);
+            var wait1 = limiter.AcquireAsync();
+            var wait2 = limiter.AcquireAsync(2);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -203,11 +203,11 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = await limiter.WaitAndAcquireAsync(2);
+            var lease = await limiter.AcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(2);
-            var wait2 = limiter.WaitAndAcquireAsync();
+            var wait1 = limiter.AcquireAsync(2);
+            var wait2 = limiter.AcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -242,10 +242,10 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            using var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(1);
+            var failedLease = await limiter.AcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
         }
 
@@ -261,11 +261,11 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             var lease1 = await wait;
             Assert.False(lease1.IsAcquired);
             Assert.False(wait2.IsCompleted);
@@ -289,15 +289,15 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait2.IsCompleted);
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             var lease1 = await wait;
             var lease2 = await wait2;
             Assert.False(lease1.IsAcquired);
@@ -323,14 +323,14 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var lease1 = await limiter.WaitAndAcquireAsync(2);
+            var lease1 = await limiter.AcquireAsync(2);
             Assert.False(lease1.IsAcquired);
 
             limiter.TryReplenish();
@@ -352,10 +352,10 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 3,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var lease = limiter.AttemptAcquire(2);
+            var wait = limiter.AcquireAsync(2);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(2);
+            var failedLease = await limiter.AcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
 
             limiter.TryReplenish();
@@ -366,7 +366,7 @@ namespace System.Threading.RateLimiting.Test
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAndAcquireAsync(2);
+            wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -389,14 +389,14 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(int.MaxValue);
+            var lease = limiter.AttemptAcquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAndAcquireAsync(3);
+            var wait = limiter.AcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(int.MaxValue);
+            var wait2 = limiter.AcquireAsync(int.MaxValue);
             Assert.False(wait2.IsCompleted);
 
             var lease1 = await wait;
@@ -420,7 +420,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = false
             });
-            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.Acquire(2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.AttemptAcquire(2));
         }
 
         [Fact]
@@ -435,7 +435,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = false
             });
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(2));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.AcquireAsync(2));
         }
 
         [Fact]
@@ -450,7 +450,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = false
             });
-            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.Acquire(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.AttemptAcquire(-1));
         }
 
         [Fact]
@@ -465,7 +465,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = false
             });
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(-1));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.AcquireAsync(-1));
         }
 
         [Fact]
@@ -481,7 +481,7 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = limiter.Acquire(0);
+            using var lease = limiter.AttemptAcquire(0);
             Assert.True(lease.IsAcquired);
         }
 
@@ -497,16 +497,16 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var lease2 = limiter.Acquire(0);
+            var lease2 = limiter.AttemptAcquire(0);
             Assert.False(lease2.IsAcquired);
             lease2.Dispose();
         }
 
         [Fact]
-        public override async Task WaitAndAcquireAsyncZero_WithAvailability()
+        public override async Task AcquireAsyncZero_WithAvailability()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
             {
@@ -518,12 +518,12 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = await limiter.WaitAndAcquireAsync(0);
+            using var lease = await limiter.AcquireAsync(0);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
+        public override async Task AcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
             {
@@ -534,10 +534,10 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = await limiter.WaitAndAcquireAsync(1);
+            var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(0);
+            var wait = limiter.AcquireAsync(0);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -559,11 +559,11 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            using var lease = await limiter.WaitAndAcquireAsync(2);
+            using var lease = await limiter.AcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -578,7 +578,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAndAcquireAsyncAfterQueuing()
+        public override async Task CanCancelAcquireAsyncAfterQueuing()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
             {
@@ -589,11 +589,11 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -606,7 +606,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAndAcquireAsyncBeforeQueuing()
+        public override async Task CanCancelAcquireAsyncBeforeQueuing()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
             {
@@ -617,13 +617,13 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAndAcquireAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.AcquireAsync(1, cts.Token).AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
@@ -644,17 +644,17 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            wait = limiter.WaitAndAcquireAsync(1);
+            wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -677,7 +677,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.False(lease.TryGetMetadata(MetadataName.RetryAfter, out _));
         }
 
@@ -693,7 +693,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.Collection(lease.MetadataNames, metadataName => Assert.Equal(metadataName, MetadataName.RetryAfter.Name));
         }
 
@@ -709,10 +709,10 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
-            var wait3 = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
+            var wait3 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -727,8 +727,8 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(lease.IsAcquired);
 
             // Throws after disposal
-            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
+            Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire(1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.AcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -743,10 +743,10 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
-            var wait3 = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
+            var wait3 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -761,8 +761,8 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(lease.IsAcquired);
 
             // Throws after disposal
-            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
+            Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire(1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.AcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -795,14 +795,14 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = true
             });
             Assert.Equal(2, limiter.GetAvailablePermits());
-            limiter.Acquire(2);
+            limiter.AttemptAcquire(2);
 
-            var lease = await limiter.WaitAndAcquireAsync(1);
+            var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst()
+        public override async Task CanAcquireResourcesWithAcquireAsyncWithQueuedItemsIfNewestFirst()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
             {
@@ -814,14 +814,14 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             Assert.Equal(1, limiter.GetAvailablePermits());
-            lease = await limiter.WaitAndAcquireAsync(1);
+            lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
 
@@ -836,7 +836,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst()
+        public override async Task CannotAcquireResourcesWithAcquireAsyncWithQueuedItemsIfOldestFirst()
         {
             var limiter = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
             {
@@ -848,11 +848,11 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(3);
+            var lease = limiter.AttemptAcquire(3);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
-            var wait2 = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
+            var wait2 = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -886,13 +886,13 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
-            lease = limiter.Acquire(1);
+            lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
 
@@ -916,13 +916,13 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
-            lease = limiter.Acquire(1);
+            lease = limiter.AttemptAcquire(1);
             Assert.False(lease.IsAcquired);
 
             limiter.TryReplenish();
@@ -944,7 +944,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 1,
                 AutoReplenishment = false
             });
-            limiter.Acquire(1);
+            limiter.AttemptAcquire(1);
             Assert.Null(limiter.IdleDuration);
         }
 
@@ -978,7 +978,7 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            limiter.Acquire(1);
+            limiter.AttemptAcquire(1);
             limiter.TryReplenish();
             limiter.TryReplenish();
             Assert.NotNull(limiter.IdleDuration);
@@ -1026,14 +1026,14 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             // Add another item to queue, will be completed as failed later when we queue another item
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             cts.Cancel();
@@ -1043,7 +1043,7 @@ namespace System.Threading.RateLimiting.Test
             lease.Dispose();
             limiter.TryReplenish();
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             // will be kicked by wait3 because we're using NewestFirst
@@ -1067,11 +1067,11 @@ namespace System.Threading.RateLimiting.Test
                 SegmentsPerWindow = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -21,16 +21,16 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire();
+            var lease = limiter.AttemptAcquire();
 
             Assert.True(lease.IsAcquired);
-            Assert.False(limiter.Acquire().IsAcquired);
+            Assert.False(limiter.AttemptAcquire().IsAcquired);
 
             lease.Dispose();
-            Assert.False(limiter.Acquire().IsAcquired);
+            Assert.False(limiter.AttemptAcquire().IsAcquired);
             Assert.True(limiter.TryReplenish());
 
-            Assert.True(limiter.Acquire().IsAcquired);
+            Assert.True(limiter.AttemptAcquire().IsAcquired);
         }
 
         [Fact]
@@ -91,10 +91,10 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = await limiter.WaitAndAcquireAsync();
+            using var lease = await limiter.AcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync();
+            var wait = limiter.AcquireAsync();
             Assert.False(wait.IsCompleted);
 
             Assert.True(limiter.TryReplenish());
@@ -114,11 +114,11 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = await limiter.WaitAndAcquireAsync();
+            var lease = await limiter.AcquireAsync();
 
             Assert.True(lease.IsAcquired);
-            var wait1 = limiter.WaitAndAcquireAsync();
-            var wait2 = limiter.WaitAndAcquireAsync();
+            var wait1 = limiter.AcquireAsync();
+            var wait2 = limiter.AcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -150,11 +150,11 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = await limiter.WaitAndAcquireAsync(2);
+            var lease = await limiter.AcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(2);
-            var wait2 = limiter.WaitAndAcquireAsync();
+            var wait1 = limiter.AcquireAsync(2);
+            var wait2 = limiter.AcquireAsync();
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -187,10 +187,10 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            using var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(1);
+            var failedLease = await limiter.AcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var timeSpan));
             Assert.Equal(TimeSpan.Zero, timeSpan);
@@ -208,11 +208,11 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             var lease1 = await wait;
             Assert.False(lease1.IsAcquired);
             Assert.False(wait2.IsCompleted);
@@ -235,15 +235,15 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait2.IsCompleted);
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             var lease1 = await wait;
             var lease2 = await wait2;
             Assert.False(lease1.IsAcquired);
@@ -269,14 +269,14 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var lease1 = await limiter.WaitAndAcquireAsync(2);
+            var lease1 = await limiter.AcquireAsync(2);
             Assert.False(lease1.IsAcquired);
 
             limiter.TryReplenish();
@@ -297,17 +297,17 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait = limiter.AcquireAsync(1);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(1);
+            var failedLease = await limiter.AcquireAsync(1);
             Assert.False(failedLease.IsAcquired);
 
             limiter.TryReplenish();
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAndAcquireAsync(1);
+            wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -327,14 +327,14 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = int.MaxValue,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(int.MaxValue);
+            var lease = limiter.AttemptAcquire(int.MaxValue);
             Assert.True(lease.IsAcquired);
 
             // Fill queue
-            var wait = limiter.WaitAndAcquireAsync(3);
+            var wait = limiter.AcquireAsync(3);
             Assert.False(wait.IsCompleted);
 
-            var wait2 = limiter.WaitAndAcquireAsync(int.MaxValue);
+            var wait2 = limiter.AcquireAsync(int.MaxValue);
             Assert.False(wait2.IsCompleted);
 
             var lease1 = await wait;
@@ -357,7 +357,7 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.Acquire(2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.AttemptAcquire(2));
         }
 
         [Fact]
@@ -372,7 +372,7 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(2));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.AcquireAsync(2));
         }
 
         [Fact]
@@ -387,7 +387,7 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.Acquire(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => limiter.AttemptAcquire(-1));
         }
 
         [Fact]
@@ -402,7 +402,7 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.WaitAndAcquireAsync(-1));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await limiter.AcquireAsync(-1));
         }
 
         [Fact]
@@ -418,7 +418,7 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = limiter.Acquire(0);
+            using var lease = limiter.AttemptAcquire(0);
             Assert.True(lease.IsAcquired);
         }
 
@@ -434,16 +434,16 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var lease2 = limiter.Acquire(0);
+            var lease2 = limiter.AttemptAcquire(0);
             Assert.False(lease2.IsAcquired);
             lease2.Dispose();
         }
 
         [Fact]
-        public override async Task WaitAndAcquireAsyncZero_WithAvailability()
+        public override async Task AcquireAsyncZero_WithAvailability()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
@@ -455,12 +455,12 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            using var lease = await limiter.WaitAndAcquireAsync(0);
+            using var lease = await limiter.AcquireAsync(0);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task WaitAndAcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
+        public override async Task AcquireAsyncZero_WithoutAvailabilityWaitsForAvailability()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
@@ -471,10 +471,10 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = await limiter.WaitAndAcquireAsync(1);
+            var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(0);
+            var wait = limiter.AcquireAsync(0);
             Assert.False(wait.IsCompleted);
 
             lease.Dispose();
@@ -495,11 +495,11 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 2,
                 AutoReplenishment = false
             });
-            using var lease = await limiter.WaitAndAcquireAsync(2);
+            using var lease = await limiter.AcquireAsync(2);
             Assert.True(lease.IsAcquired);
 
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -513,7 +513,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAndAcquireAsyncAfterQueuing()
+        public override async Task CanCancelAcquireAsyncAfterQueuing()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
@@ -524,11 +524,11 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -552,14 +552,14 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 2,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(2);
+            var lease = limiter.AttemptAcquire(2);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             // Add another item to queue, will be completed as failed later when we queue another item
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             cts.Cancel();
@@ -568,7 +568,7 @@ namespace System.Threading.RateLimiting.Test
 
             lease.Dispose();
 
-            var wait3 = limiter.WaitAndAcquireAsync(2);
+            var wait3 = limiter.AcquireAsync(2);
             Assert.False(wait3.IsCompleted);
 
             // will be kicked by wait3 because we're using NewestFirst
@@ -592,11 +592,11 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
@@ -607,7 +607,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CanCancelWaitAndAcquireAsyncBeforeQueuing()
+        public override async Task CanCancelAcquireAsyncBeforeQueuing()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
@@ -618,13 +618,13 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.WaitAndAcquireAsync(1, cts.Token).AsTask());
+            var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => limiter.AcquireAsync(1, cts.Token).AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
             lease.Dispose();
@@ -645,17 +645,17 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
             var cts = new CancellationTokenSource();
-            var wait = limiter.WaitAndAcquireAsync(1, cts.Token);
+            var wait = limiter.AcquireAsync(1, cts.Token);
 
             cts.Cancel();
             var ex = await Assert.ThrowsAsync<TaskCanceledException>(() => wait.AsTask());
             Assert.Equal(cts.Token, ex.CancellationToken);
 
-            wait = limiter.WaitAndAcquireAsync(1);
+            wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             limiter.TryReplenish();
@@ -675,7 +675,7 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.False(lease.TryGetMetadata(MetadataName.RetryAfter, out _));
         }
 
@@ -691,7 +691,7 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            using var lease = limiter.Acquire(1);
+            using var lease = limiter.AttemptAcquire(1);
             Assert.Collection(lease.MetadataNames, metadataName => Assert.Equal(metadataName, MetadataName.RetryAfter.Name));
         }
 
@@ -707,10 +707,10 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
-            var wait3 = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
+            var wait3 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -725,8 +725,8 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(lease.IsAcquired);
 
             // Throws after disposal
-            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
+            Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire(1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.AcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -741,10 +741,10 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            var lease = limiter.Acquire(1);
-            var wait1 = limiter.WaitAndAcquireAsync(1);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
-            var wait3 = limiter.WaitAndAcquireAsync(1);
+            var lease = limiter.AttemptAcquire(1);
+            var wait1 = limiter.AcquireAsync(1);
+            var wait2 = limiter.AcquireAsync(1);
+            var wait3 = limiter.AcquireAsync(1);
             Assert.False(wait1.IsCompleted);
             Assert.False(wait2.IsCompleted);
             Assert.False(wait3.IsCompleted);
@@ -759,8 +759,8 @@ namespace System.Threading.RateLimiting.Test
             Assert.False(lease.IsAcquired);
 
             // Throws after disposal
-            Assert.Throws<ObjectDisposedException>(() => limiter.Acquire(1));
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.WaitAndAcquireAsync(1).AsTask());
+            Assert.Throws<ObjectDisposedException>(() => limiter.AttemptAcquire(1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => limiter.AcquireAsync(1).AsTask());
         }
 
         [Fact]
@@ -777,9 +777,9 @@ namespace System.Threading.RateLimiting.Test
             };
             var limiter = new TokenBucketRateLimiter(options);
 
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(2);
+            var failedLease = await limiter.AcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter.Name, out var metadata));
             var metaDataTime = Assert.IsType<TimeSpan>(metadata);
@@ -804,12 +804,12 @@ namespace System.Threading.RateLimiting.Test
             };
             var limiter = new TokenBucketRateLimiter(options);
 
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
             // Queue item which changes the retry after time for failed items
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(2);
+            var failedLease = await limiter.AcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.ReplenishmentPeriod.Ticks * 3, typedMetadata.Ticks);
@@ -829,12 +829,12 @@ namespace System.Threading.RateLimiting.Test
             };
             var limiter = new TokenBucketRateLimiter(options);
 
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
             // Queue item which changes the retry after time for failed waits
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(2);
+            var failedLease = await limiter.AcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.ReplenishmentPeriod, typedMetadata);
@@ -854,12 +854,12 @@ namespace System.Threading.RateLimiting.Test
             };
             var limiter = new TokenBucketRateLimiter(options);
 
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
             // Queue item which changes the retry after time for failed items
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(2);
+            var failedLease = await limiter.AcquireAsync(2);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.ReplenishmentPeriod, typedMetadata);
@@ -879,9 +879,9 @@ namespace System.Threading.RateLimiting.Test
             };
             var limiter = new TokenBucketRateLimiter(options);
 
-            using var lease = limiter.Acquire(2);
+            using var lease = limiter.AttemptAcquire(2);
 
-            var failedLease = await limiter.WaitAndAcquireAsync(3);
+            var failedLease = await limiter.AcquireAsync(3);
             Assert.False(failedLease.IsAcquired);
             Assert.True(failedLease.TryGetMetadata(MetadataName.RetryAfter, out var typedMetadata));
             Assert.Equal(options.ReplenishmentPeriod.Ticks * 2, typedMetadata.Ticks);
@@ -899,8 +899,8 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 3,
                 AutoReplenishment = false
             });
-            Assert.True(limiter.Acquire(5).IsAcquired);
-            Assert.False(limiter.Acquire(3).IsAcquired);
+            Assert.True(limiter.AttemptAcquire(5).IsAcquired);
+            Assert.False(limiter.AttemptAcquire(3).IsAcquired);
 
             Assert.Equal(2, limiter.GetAvailablePermits());
             Assert.True(limiter.TryReplenish());
@@ -957,14 +957,14 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = true
             });
             Assert.Equal(2, limiter.GetAvailablePermits());
-            limiter.Acquire(2);
+            limiter.AttemptAcquire(2);
 
-            var lease = await limiter.WaitAndAcquireAsync(1);
+            var lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
         }
 
         [Fact]
-        public override async Task CanAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfNewestFirst()
+        public override async Task CanAcquireResourcesWithAcquireAsyncWithQueuedItemsIfNewestFirst()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
@@ -976,14 +976,14 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
             Assert.Equal(1, limiter.GetAvailablePermits());
-            lease = await limiter.WaitAndAcquireAsync(1);
+            lease = await limiter.AcquireAsync(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
 
@@ -994,7 +994,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public override async Task CannotAcquireResourcesWithWaitAndAcquireAsyncWithQueuedItemsIfOldestFirst()
+        public override async Task CannotAcquireResourcesWithAcquireAsyncWithQueuedItemsIfOldestFirst()
         {
             var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
             {
@@ -1006,11 +1006,11 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
-            var wait2 = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(2);
+            var wait2 = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
             Assert.False(wait2.IsCompleted);
 
@@ -1039,13 +1039,13 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
-            lease = limiter.Acquire(1);
+            lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
             Assert.False(wait.IsCompleted);
 
@@ -1068,13 +1068,13 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(1);
+            var lease = limiter.AttemptAcquire(1);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(2);
+            var wait = limiter.AcquireAsync(2);
             Assert.False(wait.IsCompleted);
 
-            lease = limiter.Acquire(1);
+            lease = limiter.AttemptAcquire(1);
             Assert.False(lease.IsAcquired);
 
             limiter.TryReplenish();
@@ -1098,10 +1098,10 @@ namespace System.Threading.RateLimiting.Test
                 AutoReplenishment = false
             });
 
-            var lease = limiter.Acquire(10);
+            var lease = limiter.AttemptAcquire(10);
             Assert.True(lease.IsAcquired);
 
-            var wait = limiter.WaitAndAcquireAsync(1);
+            var wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             var replenishInternalMethod = typeof(TokenBucketRateLimiter).GetMethod("ReplenishInternal", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance)!;
@@ -1112,7 +1112,7 @@ namespace System.Threading.RateLimiting.Test
             lease = await wait;
             Assert.True(lease.IsAcquired);
 
-            wait = limiter.WaitAndAcquireAsync(1);
+            wait = limiter.AcquireAsync(1);
             Assert.False(wait.IsCompleted);
 
             // Tick 1 millisecond too soon and verify that the queued item wasn't completed
@@ -1137,7 +1137,7 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            limiter.Acquire(1);
+            limiter.AttemptAcquire(1);
             Assert.Null(limiter.IdleDuration);
         }
 
@@ -1171,7 +1171,7 @@ namespace System.Threading.RateLimiting.Test
                 TokensPerPeriod = 1,
                 AutoReplenishment = false
             });
-            limiter.Acquire(1);
+            limiter.AttemptAcquire(1);
             limiter.TryReplenish();
             Assert.NotNull(limiter.IdleDuration);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/71775