### PR TITLE
Switch to using ReadOnlySpan/SpanMarshaller for some generated p/invokes

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
@@ -19,11 +19,8 @@ internal static partial class Interop
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpDigestReset")]
         internal static partial int EvpDigestReset(SafeEvpMdCtxHandle ctx, IntPtr type);
 
-        internal static int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ReadOnlySpan<byte> d, int cnt) =>
-            EvpDigestUpdate(ctx, ref MemoryMarshal.GetReference(d), cnt);
-
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpDigestUpdate")]
-        private static partial int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ref byte d, int cnt);
+        internal static partial int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ReadOnlySpan<byte> d, int cnt);
 
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpDigestFinalEx")]
         internal static partial int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Hmac.cs
@@ -19,11 +19,8 @@ internal static partial class Interop
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_HmacReset")]
         internal static partial int HmacReset(SafeHmacCtxHandle ctx);
 
-        internal static int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len) =>
-            HmacUpdate(ctx, ref MemoryMarshal.GetReference(data), len);
-
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
-        private static partial int HmacUpdate(SafeHmacCtxHandle ctx, ref byte data, int len);
+        internal static partial int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len);
 
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
         internal static partial int HmacFinal(SafeHmacCtxHandle ctx, ref byte data, ref int len);

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -43,70 +43,36 @@ internal static partial class Interop
             out SafeCFDataHandle pDataOut,
             out SafeCFErrorHandle pErrorOut);
 
-        private static int RsaEncryptOaep(
-            SafeSecKeyRefHandle publicKey,
-            ReadOnlySpan<byte> pbData,
-            int cbData,
-            PAL_HashAlgorithm mgfAlgorithm,
-            out SafeCFDataHandle pEncryptedOut,
-            out SafeCFErrorHandle pErrorOut) =>
-            RsaEncryptOaep(publicKey, ref MemoryMarshal.GetReference(pbData), cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
-
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptOaep")]
         private static partial int RsaEncryptOaep(
             SafeSecKeyRefHandle publicKey,
-            ref byte pbData,
+            ReadOnlySpan<byte> pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
-
-        private static int RsaEncryptPkcs(
-            SafeSecKeyRefHandle publicKey,
-            ReadOnlySpan<byte> pbData,
-            int cbData,
-            out SafeCFDataHandle pEncryptedOut,
-            out SafeCFErrorHandle pErrorOut) =>
-            RsaEncryptPkcs(publicKey, ref MemoryMarshal.GetReference(pbData), cbData, out pEncryptedOut, out pErrorOut);
 
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptPkcs")]
         private static partial int RsaEncryptPkcs(
             SafeSecKeyRefHandle publicKey,
-            ref byte pbData,
+            ReadOnlySpan<byte> pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
-
-        private static int RsaDecryptOaep(
-            SafeSecKeyRefHandle publicKey,
-            ReadOnlySpan<byte> pbData,
-            int cbData,
-            PAL_HashAlgorithm mgfAlgorithm,
-            out SafeCFDataHandle pEncryptedOut,
-            out SafeCFErrorHandle pErrorOut) =>
-            RsaDecryptOaep(publicKey, ref MemoryMarshal.GetReference(pbData), cbData, mgfAlgorithm, out pEncryptedOut, out pErrorOut);
 
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptOaep")]
         private static partial int RsaDecryptOaep(
             SafeSecKeyRefHandle publicKey,
-            ref byte pbData,
+            ReadOnlySpan<byte> pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);
 
-        private static int RsaDecryptPkcs(
-            SafeSecKeyRefHandle publicKey,
-            ReadOnlySpan<byte> pbData,
-            int cbData,
-            out SafeCFDataHandle pEncryptedOut,
-            out SafeCFErrorHandle pErrorOut) =>
-            RsaDecryptPkcs(publicKey, ref MemoryMarshal.GetReference(pbData), cbData, out pEncryptedOut, out pErrorOut);
-
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptPkcs")]
         private static partial int RsaDecryptPkcs(
             SafeSecKeyRefHandle publicKey,
-            ref byte pbData,
+            ReadOnlySpan<byte> pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
             out SafeCFErrorHandle pErrorOut);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
@@ -19,11 +19,8 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestReset")]
         internal static partial int EvpDigestReset(SafeEvpMdCtxHandle ctx, IntPtr type);
 
-        internal static int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ReadOnlySpan<byte> d, int cnt) =>
-            EvpDigestUpdate(ctx, ref MemoryMarshal.GetReference(d), cnt);
-
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestUpdate")]
-        private static partial int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ref byte d, int cnt);
+        internal static partial int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, ReadOnlySpan<byte> d, int cnt);
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestFinalEx")]
         internal static partial int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
@@ -19,11 +19,8 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacReset")]
         internal static partial int HmacReset(SafeHmacCtxHandle ctx);
 
-        internal static int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len) =>
-            HmacUpdate(ctx, ref MemoryMarshal.GetReference(data), len);
-
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
-        private static partial int HmacUpdate(SafeHmacCtxHandle ctx, ref byte data, int len);
+        internal static partial int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len);
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
         internal static partial int HmacFinal(SafeHmacCtxHandle ctx, ref byte data, ref int len);

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptCreateHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptCreateHash.cs
@@ -11,13 +11,8 @@ internal static partial class Interop
 {
     internal static partial class BCrypt
     {
-        internal static NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ReadOnlySpan<byte> secret, int cbSecret, BCryptCreateHashFlags dwFlags)
-        {
-            return BCryptCreateHash(hAlgorithm, out phHash, pbHashObject, cbHashObject, ref MemoryMarshal.GetReference(secret), cbSecret, dwFlags);
-        }
-
         [LibraryImport(Libraries.BCrypt, StringMarshalling = StringMarshalling.Utf16)]
-        private static partial NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ref byte pbSecret, int cbSecret, BCryptCreateHashFlags dwFlags);
+        internal static partial NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ReadOnlySpan<byte> secret, int cbSecret, BCryptCreateHashFlags dwFlags);
 
         [Flags]
         internal enum BCryptCreateHashFlags : int

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptFinishHash.cs
@@ -9,10 +9,7 @@ internal static partial class Interop
 {
     internal static partial class BCrypt
     {
-        internal static NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, Span<byte> pbOutput, int cbOutput, int dwFlags) =>
-            BCryptFinishHash(hHash, ref MemoryMarshal.GetReference(pbOutput), cbOutput, dwFlags);
-
         [LibraryImport(Libraries.BCrypt)]
-        private static partial NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, ref byte pbOutput, int cbOutput, int dwFlags);
+        internal static partial NTSTATUS BCryptFinishHash(SafeBCryptHashHandle hHash, Span<byte> pbOutput, int cbOutput, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptHashData.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptHashData.cs
@@ -10,10 +10,7 @@ internal static partial class Interop
 {
     internal static partial class BCrypt
     {
-        internal static NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ReadOnlySpan<byte> pbInput, int cbInput, int dwFlags) =>
-            BCryptHashData(hHash, ref MemoryMarshal.GetReference(pbInput), cbInput, dwFlags);
-
         [LibraryImport(Libraries.BCrypt, StringMarshalling = StringMarshalling.Utf16)]
-        private static partial NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ref byte pbInput, int cbInput, int dwFlags);
+        internal static partial NTSTATUS BCryptHashData(SafeBCryptHashHandle hHash, ReadOnlySpan<byte> pbInput, int cbInput, int dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.EncryptDecrypt.cs
@@ -9,16 +9,10 @@ internal static partial class Interop
 {
     internal static partial class NCrypt
     {
-        internal static unsafe ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
-            NCryptEncrypt(hKey, ref MemoryMarshal.GetReference(pbInput), cbInput, pPaddingInfo, ref MemoryMarshal.GetReference(pbOutput), cbOutput, out pcbResult, dwFlags);
+        [LibraryImport(Interop.Libraries.NCrypt)]
+        internal static unsafe partial ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
 
         [LibraryImport(Interop.Libraries.NCrypt)]
-        private static unsafe partial ErrorCode NCryptEncrypt(SafeNCryptKeyHandle hKey, ref byte pbInput, int cbInput, void* pPaddingInfo, ref byte pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
-
-        internal static unsafe ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
-            NCryptDecrypt(hKey, ref MemoryMarshal.GetReference(pbInput), cbInput, pPaddingInfo, ref MemoryMarshal.GetReference(pbOutput), cbOutput, out pcbResult, dwFlags);
-
-        [LibraryImport(Interop.Libraries.NCrypt)]
-        private static unsafe partial ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ref byte pbInput, int cbInput, void* pPaddingInfo, ref byte pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
+        internal static unsafe partial ErrorCode NCryptDecrypt(SafeNCryptKeyHandle hKey, ReadOnlySpan<byte> pbInput, int cbInput, void* pPaddingInfo, Span<byte> pbOutput, int cbOutput, out int pcbResult, AsymmetricPaddingMode dwFlags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.SignVerify.cs
@@ -9,16 +9,10 @@ internal static partial class Interop
 {
     internal static partial class NCrypt
     {
-        internal static unsafe ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, Span<byte> pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags) =>
-            NCryptSignHash(hKey, pPaddingInfo, ref MemoryMarshal.GetReference(pbHashValue), cbHashValue, ref MemoryMarshal.GetReference(pbSignature), cbSignature, out pcbResult, dwFlags);
+        [LibraryImport(Libraries.NCrypt, StringMarshalling = StringMarshalling.Utf16)]
+        internal static unsafe partial ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, Span<byte> pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
 
         [LibraryImport(Libraries.NCrypt, StringMarshalling = StringMarshalling.Utf16)]
-        private static unsafe partial ErrorCode NCryptSignHash(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ref byte pbHashValue, int cbHashValue, ref byte pbSignature, int cbSignature, out int pcbResult, AsymmetricPaddingMode dwFlags);
-
-        internal static unsafe ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, ReadOnlySpan<byte> pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags) =>
-            NCryptVerifySignature(hKey, pPaddingInfo, ref MemoryMarshal.GetReference(pbHashValue), cbHashValue, ref MemoryMarshal.GetReference(pbSignature), cbSignature, dwFlags);
-
-        [LibraryImport(Libraries.NCrypt, StringMarshalling = StringMarshalling.Utf16)]
-        private static unsafe partial ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ref byte pbHashValue, int cbHashValue, ref byte pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
+        internal static unsafe partial ErrorCode NCryptVerifySignature(SafeNCryptKeyHandle hKey, void* pPaddingInfo, ReadOnlySpan<byte> pbHashValue, int cbHashValue, ReadOnlySpan<byte> pbSignature, int cbSignature, AsymmetricPaddingMode dwFlags);
     }
 }


### PR DESCRIPTION
Convert some existing `LibraryImport`s to use `ReadOnlySpan`/`Span` directly. There's definitely more that we could switch over, but this should ensure we have coverage/usage in the runtime on different platforms.