### PR TITLE
Re-enable System.IO.Pipes.Tests on iOS-based platforms

### DIFF
--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -30,7 +30,7 @@ namespace System.IO.Pipes
         private static readonly char[] s_invalidPathNameChars = Path.GetInvalidPathChars();
 
         /// <summary>Prefix to prepend to all pipe names.</summary>
-        private static readonly string s_pipePrefix = Path.Combine(Path.GetTempPath(), (RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))) ? "" : "CoreFxPipe_");
+        private static readonly string s_pipePrefix = Path.Combine(Path.GetTempPath(), (RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))) ? "x" : "CoreFxPipe_");
 
         public override int Read(byte[] buffer, int offset, int count)
         {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -30,7 +30,7 @@ namespace System.IO.Pipes
         private static readonly char[] s_invalidPathNameChars = Path.GetInvalidPathChars();
 
         /// <summary>Prefix to prepend to all pipe names.</summary>
-        private static readonly string s_pipePrefix = Path.Combine(Path.GetTempPath(), "CoreFxPipe_");
+        private static readonly string s_pipePrefix = Path.Combine(Path.GetTempPath(), (RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))) ? "" : "CoreFxPipe_");
 
         public override int Read(byte[] buffer, int offset, int count)
         {

--- a/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -556,7 +556,6 @@ namespace System.IO.Tests
         [InlineData(1, true)]
         [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51390", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task ReadAsync_Canceled_ThrowsException(int method, bool precanceled)
         {
             Func<StreamReader, CancellationToken, Task<int>> func = method switch
@@ -566,7 +565,7 @@ namespace System.IO.Tests
                 _ => throw new Exception("unknown mode")
             };
 
-            string pipeName = Guid.NewGuid().ToString("N");
+            string pipeName = "x";
             using (var serverStream = new NamedPipeServerStream(pipeName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous))
             using (var clientStream = new NamedPipeClientStream(".", pipeName, PipeDirection.In, PipeOptions.Asynchronous))
             {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -329,11 +329,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator') and '$(RunDisablediOSTests)' != 'true'">
-    <!-- https://github.com/dotnet/runtime/issues/51335 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' != 'true'">
   </ItemGroup>
 


### PR DESCRIPTION
This seems fixed by a pipe name shortening at some point in the past

Closes: #51335