### PR TITLE
Fix handling of empty iterations in Regex lazy loops

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -3309,7 +3309,7 @@ namespace System.Text.RegularExpressions.Generator
                         writer.WriteLine("// If the iteration successfully matched zero-length input, record that an empty iteration was seen.");
                         using (EmitBlock(writer, $"if (pos == {startingPos})"))
                         {
-                            writer.WriteLine($"{sawEmpty} = 1 /* true */;");
+                            writer.WriteLine($"{sawEmpty} = 1; // true");
                         }
                         writer.WriteLine();
                     }
@@ -3355,9 +3355,16 @@ namespace System.Text.RegularExpressions.Generator
                         {
                             // The child has backtracking constructs.  If we have no successful iterations previously processed, just bail.
                             // If we do have successful iterations previously processed, however, we need to backtrack back into the last one.
-                            writer.WriteLine($"// If the lazy loop has matched any iterations, backtrack into the last one.");
                             using (EmitBlock(writer, $"if ({iterationCount} > 0)"))
                             {
+                                writer.WriteLine($"// The lazy loop matched at least one iteration; backtrack into the last one.");
+                                if (iterationMayBeEmpty)
+                                {
+                                    // If we saw empty, it must have been in the most recent iteration, as we wouldn't have
+                                    // allowed additional iterations after one that was empty.  Thus, we reset it back to
+                                    // false prior to backtracking / undoing that iteration.
+                                    writer.WriteLine($"{sawEmpty} = 0; // false");
+                                }
                                 Goto(doneLabel);
                             }
                             writer.WriteLine();
@@ -3417,6 +3424,7 @@ namespace System.Text.RegularExpressions.Generator
                     {
                         FinishEmitBlock clause;
 
+                        writer.WriteLine();
                         if (maxIterations == int.MaxValue)
                         {
                             // If the last iteration matched empty, backtrack.
@@ -3440,6 +3448,13 @@ namespace System.Text.RegularExpressions.Generator
 
                         using (clause)
                         {
+                            if (iterationMayBeEmpty)
+                            {
+                                // If we saw empty, it must have been in the most recent iteration, as we wouldn't have
+                                // allowed additional iterations after one that was empty.  Thus, we reset it back to
+                                // false prior to backtracking / undoing that iteration.
+                                writer.WriteLine($"{sawEmpty} = 0; // false");
+                            }
                             Goto(doneLabel);
                         }
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -3950,20 +3950,24 @@ namespace System.Text.RegularExpressions
 
                     if (iterationMayBeEmpty)
                     {
-                        // if (sawEmpty == 0) goto body;
+                        // if (sawEmpty != 0)
+                        // {
+                        //     sawEmpty = 0;
+                        //     goto doneLabel;
+                        // }
+                        Label sawEmptyZero = DefineLabel();
                         Ldloc(sawEmpty!);
                         Ldc(0);
-                        BeqFar(body);
+                        Beq(sawEmptyZero);
 
                         // We saw empty, and it must have been in the most recent iteration, as we wouldn't have
                         // allowed additional iterations after one that was empty.  Thus, we reset it back to
                         // false prior to backtracking / undoing that iteration.
-                        // sawEmpty = 0;
                         Ldc(0);
                         Stloc(sawEmpty!);
 
-                        // goto doneLabel;
                         BrFar(doneLabel);
+                        MarkLabel(sawEmptyZero);
                     }
 
                     if (maxIterations != int.MaxValue)

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -590,6 +590,14 @@ namespace System.Text.RegularExpressions.Tests
             }
             yield return ("[^a-z0-9]etag|[^a-z0-9]digest", "this string has .digest as a substring", RegexOptions.None, 16, 7, true, ".digest");
             yield return (@"(\w+|\d+)a+[ab]+", "123123aa", RegexOptions.None, 0, 8, true, "123123aa");
+            foreach (string aOptional in new[] { "(a|)", "(|a)", "(a?)", "(a??)" })
+            {
+                yield return (@$"^{aOptional}{{0,2}}?b", "aab", RegexOptions.None, 0, 3, true, "aab");
+                yield return (@$"^{aOptional}{{0,2}}b", "aab", RegexOptions.None, 0, 3, true, "aab");
+                yield return (@$"^{aOptional}{{1,2}}?b", "aab", RegexOptions.None, 0, 3, true, "aab");
+                yield return (@$"^{aOptional}{{1,2}}b", "aab", RegexOptions.None, 0, 3, true, "aab");
+                yield return (@$"^{aOptional}{{2}}b", "aab", RegexOptions.None, 0, 3, true, "aab");
+            }
             if (!RegexHelpers.IsNonBacktracking(engine))
             {
                 yield return ("(?(dog2))", "dog2", RegexOptions.None, 0, 4, true, string.Empty);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -596,6 +596,7 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@$"^{aOptional}{{0,2}}b", "aab", RegexOptions.None, 0, 3, true, "aab");
                 yield return (@$"^{aOptional}{{1,2}}?b", "aab", RegexOptions.None, 0, 3, true, "aab");
                 yield return (@$"^{aOptional}{{1,2}}b", "aab", RegexOptions.None, 0, 3, true, "aab");
+                yield return (@$"^{aOptional}{{1,2}}?b", "aaab", RegexOptions.None, 0, 4, false, "");
                 yield return (@$"^{aOptional}{{2}}b", "aab", RegexOptions.None, 0, 3, true, "aab");
             }
             if (!RegexHelpers.IsNonBacktracking(engine))


### PR DESCRIPTION
The semantics of regex lazy loops requires avoiding additional iterations if the last iteration was empty; otherwise, you can end up in an infinite loop matching empty over and over.  We have a bool that tracks whether the last iteration was empty so that we can avoid another iteration if it was, but if/when we backtrack into that iteration, we're failing to reset it.

@joperezr, please double-check my reasoning explained in the comments. :)  Also, if you have an opportunity to run this commit against all of the new tests you're adding, that'd be appreciated.

Fixes https://github.com/dotnet/runtime/issues/73209