### PR TITLE
Fix missing symbols for `singlefilehost`

### DIFF
--- a/eng/native/naming.props
+++ b/eng/native/naming.props
@@ -36,10 +36,4 @@
     <AdditionalSymbolPackageExcludes Condition="'$(LibSuffix)' != ''" Include="%2A%2A\%2A.a;%2A%2A\%2A$(LibSuffix)" />
   </ItemGroup>
 
-  <!-- arcade is using long name for this property; 'SymbolFileExtension'.
-       remove this property group when arcade is updated with short name (SymbolsSuffix). -->
-  <PropertyGroup>
-    <SymbolFileExtension>$(SymbolsSuffix)</SymbolFileExtension>
-  </PropertyGroup>
-
 </Project>

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -45,9 +45,12 @@
     Outputs="$(SingleFileHostDestinationPath);$(SingleFileHostSymbolsDestinationPath)"
     DependsOnTargets="ResolveProjectReferences"
     Condition="'$(RuntimeFlavor)' != 'Mono'">
-    <Copy SourceFiles="$(SingleFileHostPath);$(SingleFileHostSymbolsPath)" DestinationFiles="$(SingleFileHostDestinationPath);$(SingleFileHostSymbolsDestinationPath)" />
+    <Copy SourceFiles="$(SingleFileHostPath)" DestinationFiles="$(SingleFileHostDestinationPath)" />
     <Exec Condition="'$(TargetOS)' == 'windows'"
           Command="&quot;$(DotNetTool)&quot; exec @(InjectResourceTool) --bin &quot;$(DacPath)&quot; --image &quot;$(SingleFileHostDestinationPath)&quot; --name MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER" />
+
+    <!-- Copy symbols if they exist. We may not have separate symbols if they were not stripped from the native binary itself. -->
+    <Copy SourceFiles="$(SingleFileHostSymbolsPath)" DestinationFiles="$(SingleFileHostSymbolsDestinationPath)" Condition="Exists('$(SingleFileHostSymbolsPath)')" />
   </Target>
 
   <Target Name="PrepareSingleFileHostWithEmbeddedDac"

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -18,10 +18,18 @@
   <Target Name="PrepareSingleFileHostWithEmbeddedDacPrereqs">
     <PropertyGroup>
       <SingleFileHostPath>$(CoreCLRArtifactsPath)/corehost/singlefilehost$(ExeSuffix)</SingleFileHostPath>
-      <SingleFileHostSymbolsPath>$(CoreCLRArtifactsPath)/corehost/PDB/singlefilehost$(SymbolsSuffix)</SingleFileHostSymbolsPath>
       <DacPath>$(CoreCLRArtifactsPath)/mscordaccore$(LibSuffix)</DacPath>
       <SingleFileHostDestinationPath>$(DotNetHostBinDir)/singlefilehost$(ExeSuffix)</SingleFileHostDestinationPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetOS)' == 'windows'">
+      <!-- Symbols for Windows are in a PDB subdirectory -->
+      <SingleFileHostSymbolsPath>$(CoreCLRArtifactsPath)/corehost/PDB/singlefilehost$(SymbolsSuffix)</SingleFileHostSymbolsPath>
       <SingleFileHostSymbolsDestinationPath>$(DotNetHostBinDir)/PDB/singlefilehost$(SymbolsSuffix)</SingleFileHostSymbolsDestinationPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetOS)' != 'windows'">
+      <!-- Symbols for non-Windows are next to the binary -->
+      <SingleFileHostSymbolsPath>$(CoreCLRArtifactsPath)/corehost/singlefilehost$(SymbolsSuffix)</SingleFileHostSymbolsPath>
+      <SingleFileHostSymbolsDestinationPath>$(DotNetHostBinDir)/singlefilehost$(SymbolsSuffix)</SingleFileHostSymbolsDestinationPath>
     </PropertyGroup>
   </Target>
 
@@ -37,11 +45,11 @@
     Outputs="$(SingleFileHostDestinationPath);$(SingleFileHostSymbolsDestinationPath)"
     DependsOnTargets="ResolveProjectReferences"
     Condition="'$(RuntimeFlavor)' != 'Mono'">
-    <Copy SourceFiles="$(SingleFileHostPath);$(SingleFileHostSymbolsPath)" DestinationFiles="$(SingleFileHostDestinationPath);$(SingleFileHostSymbolsPath)" />
+    <Copy SourceFiles="$(SingleFileHostPath);$(SingleFileHostSymbolsPath)" DestinationFiles="$(SingleFileHostDestinationPath);$(SingleFileHostSymbolsDestinationPath)" />
     <Exec Condition="'$(TargetOS)' == 'windows'"
           Command="&quot;$(DotNetTool)&quot; exec @(InjectResourceTool) --bin &quot;$(DacPath)&quot; --image &quot;$(SingleFileHostDestinationPath)&quot; --name MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER" />
   </Target>
-  
+
   <Target Name="PrepareSingleFileHostWithEmbeddedDac"
           DependsOnTargets="PrepareSingleFileHostWithEmbeddedDacPrereqs;PrepareSingleFileHostWithEmbeddedDacCore"
           AfterTargets="Build"/>


### PR DESCRIPTION
The symbol packages were missing symbols for `singlefilehost` because they weren't being copied to the expected location, resulting in `singlefilehost.dbg/pdb` not being published. This updates the `PrepareSingleFileHostWithEmbeddedDacCore` target to copy the symbol file from and to the expected locations (PDB sudbirectory for Windows, next to the binary for non-Windows).

Fixes https://github.com/dotnet/runtime/issues/71735