### PR TITLE
Avoid integer overflow on ARM machine with 8G of memory

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1229,7 +1229,7 @@ uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted)
         return 0;
     }
 
-    return pages * pageSize;
+    return (uint64_t)pages * (uint64_t)pageSize;
 #elif HAVE_SYSCTL
     int mib[3];
     mib[0] = CTL_HW;

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -338,10 +338,10 @@ GlobalMemoryStatusEx(
 
     // Get the physical memory size
 #if HAVE_SYSCONF && HAVE__SC_PHYS_PAGES
-    int64_t physical_memory;
+    uint64_t physical_memory;
 
     // Get the Physical memory size
-    physical_memory = ((int64_t)sysconf( _SC_PHYS_PAGES )) * ((int64_t) sysconf( _SC_PAGE_SIZE ));
+    physical_memory = ((uint64_t)sysconf( _SC_PHYS_PAGES )) * ((uint64_t) sysconf( _SC_PAGE_SIZE ));
     lpBuffer->ullTotalPhys = (DWORDLONG)physical_memory;
     fRetVal = TRUE;
 #elif HAVE_SYSCTL

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -341,7 +341,7 @@ GlobalMemoryStatusEx(
     int64_t physical_memory;
 
     // Get the Physical memory size
-    physical_memory = sysconf( _SC_PHYS_PAGES ) * sysconf( _SC_PAGE_SIZE );
+    physical_memory = ((int64_t)sysconf( _SC_PHYS_PAGES )) * ((int64_t) sysconf( _SC_PAGE_SIZE ));
     lpBuffer->ullTotalPhys = (DWORDLONG)physical_memory;
     fRetVal = TRUE;
 #elif HAVE_SYSCTL


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/65466

On Raspberry Pi 4 model d03114, there is 8G of physical memory.

If we install the ARM dotnet SDK and run an application there, `GetGCMemoryInfo.TotalAvailableMemoryBytes` would return a negative number, and that is because we are hitting an integer overflow with the multiplication in this change.

Note that `sysconf` returns a `long` and that is a signed 32-bit number on ARM.

I confirmed that the negative value no longer repros on that machine, and it reports a number close to 8G.