### PR TITLE
ILASM - Fixing ILASM roundtrip issue with `vararg` calling convention

### DIFF
--- a/src/coreclr/inc/corhlprpriv.cpp
+++ b/src/coreclr/inc/corhlprpriv.cpp
@@ -110,17 +110,21 @@ HRESULT _CountBytesOfOneArg(
     switch (ulElementType)
     {
         case ELEMENT_TYPE_GENERICINST:
-            CHECK_REMAINDER;
             // skip over generic type
+            CHECK_REMAINDER;
+            cb = cbTotalMax - cbTotal;
             IfFailGo( _CountBytesOfOneArg(&pbSig[cbTotal], &cb) );
             cbTotal += cb;
 
             // skip over number of parameters
+            CHECK_REMAINDER;
             cbTotal += CorSigUncompressData(&pbSig[cbTotal], &cArg);
 
             // loop through type parameters
             for (cArgsIndex = 0; cArgsIndex < cArg; cArgsIndex++)
             {
+                CHECK_REMAINDER;
+                cb = cbTotalMax - cbTotal;
                 IfFailGo( _CountBytesOfOneArg(&pbSig[cbTotal], &cb) );
                 cbTotal += cb;
             }

--- a/src/coreclr/inc/corhlprpriv.cpp
+++ b/src/coreclr/inc/corhlprpriv.cpp
@@ -109,6 +109,23 @@ HRESULT _CountBytesOfOneArg(
     }
     switch (ulElementType)
     {
+        case ELEMENT_TYPE_GENERICINST:
+            CHECK_REMAINDER;
+            // skip over generic type
+            IfFailGo( _CountBytesOfOneArg(&pbSig[cbTotal], &cb) );
+            cbTotal += cb;
+
+            // skip over number of parameters
+            cbTotal += CorSigUncompressData(&pbSig[cbTotal], &cArg);
+
+            // loop through type parameters
+            for (cArgsIndex = 0; cArgsIndex < cArg; cArgsIndex++)
+            {
+                IfFailGo( _CountBytesOfOneArg(&pbSig[cbTotal], &cb) );
+                cbTotal += cb;
+            }
+            break;
+
         case ELEMENT_TYPE_SZARRAY:
         case 0x1e /* obsolete */:
             // skip over base type


### PR DESCRIPTION
Should resolve: https://github.com/dotnet/runtime/issues/72759

**Description**

ILASM was failing to emit the correct callsite signature for a method with a `vararg` calling convention if one of the parameters was generic instantiation of a type.

In `ResolveLocalMemberRefs`, it seems we lost some information when getting the fixed signature for `vararg` callconv and it creates a bad signature for the new member reference.

There are two solutions:

1. Remove special handling for `vararg` callconv in `ResolveLocalMemberRefs` as we already have the correct signature from `m_LocalMethodRefDList`.
2. Fix `CountBytesOfOneArg` to handle `ELEMENT_TYPE_GENERICINST` as described by @jakobbotsch 

The PR is now using solution number 2.

I manually tested this and it resolves the issue reported. I also tried this scenario:
ClassLibrary1.dll
```csharp
using System.Runtime.Intrinsics;

namespace ClassLibrary1
{
    public class Class1
    {
        public static int paramLength(Vector128<int> arg, __arglist)
        {
            ArgIterator iterator = new ArgIterator(__arglist);
            return iterator.GetRemainingCount();
        }
    }
}
```
vararg_test.exe
```csharp
using ClassLibrary1;
using System.Runtime.Intrinsics;

Console.WriteLine(Class1.paramLength(Vector128<int>.AllBitsSet, __arglist(1, 2)));
```
This scenario works with the PR changes, so this gives me confidence in the change as this is across assembly boundaries.

**Acceptance Criteria**
- [x] No additional ilasm roundtrip failures in CI