### PR TITLE
Add release branches to jitrollingbuild.yml

### DIFF
--- a/eng/pipelines/coreclr/jitrollingbuild.yml
+++ b/eng/pipelines/coreclr/jitrollingbuild.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
     - main
+    - release/*.*
   paths:
     include:
     - src/coreclr/jit/*


### PR DESCRIPTION
I've just realized that I did not finish https://github.com/dotnet/runtime/pull/61597

let's publish checked JITs for release branches too so then we can get a matching clrjit for any dotnet/installer sdk

