### PR TITLE
Use PtrToStringUTF8 instead of PtrToStringAnsi on Unix

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Environment.NativeAot.Unix.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Environment.NativeAot.Unix.cs
@@ -24,7 +24,7 @@ namespace System
 
             if (s_environment == null)
             {
-                return Marshal.PtrToStringAnsi(Interop.Sys.GetEnv(variable));
+                return Marshal.PtrToStringUTF8(Interop.Sys.GetEnv(variable));
             }
 
             lock (s_environment)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Unix.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.NativeAot.Unix.cs
@@ -17,7 +17,7 @@ namespace System.Runtime.InteropServices
             IntPtr ret = Interop.Sys.LoadLibrary(libraryName);
             if (ret == IntPtr.Zero)
             {
-                string? message = Marshal.PtrToStringAnsi(Interop.Sys.GetLoadLibraryError());
+                string? message = Marshal.PtrToStringUTF8(Interop.Sys.GetLoadLibraryError());
                 errorTracker.TrackErrorMessage(message);
             }
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3392,14 +3392,14 @@ namespace Internal.JitInterface
 
         private bool logMsg(uint level, byte* fmt, IntPtr args)
         {
-            // Console.WriteLine(Marshal.PtrToStringAnsi((IntPtr)fmt));
+            // Console.WriteLine(Marshal.PtrToStringUTF8((IntPtr)fmt));
             return false;
         }
 
         private int doAssert(byte* szFile, int iLine, byte* szExpr)
         {
-            Logger.LogMessage(Marshal.PtrToStringAnsi((IntPtr)szFile) + ":" + iLine);
-            Logger.LogMessage(Marshal.PtrToStringAnsi((IntPtr)szExpr));
+            Logger.LogMessage(Marshal.PtrToStringUTF8((IntPtr)szFile) + ":" + iLine);
+            Logger.LogMessage(Marshal.PtrToStringUTF8((IntPtr)szExpr));
 
             return 1;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Disassembler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Disassembler.cs
@@ -107,7 +107,7 @@ namespace ILCompiler
                     size = DumpInstruction(_handle, (ulong)offset, (IntPtr)pByte, bytes.Length - offset);
                 }
 
-                instruction = Marshal.PtrToStringAnsi(GetOutputBuffer());
+                instruction = Marshal.PtrToStringUTF8(GetOutputBuffer());
                 ClearOutputBuffer();
                 return size;
             }

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -51,7 +51,7 @@ namespace R2RDump
                 instrSize = DumpInstruction(Disasm, new IntPtr(rtf.StartAddress + rtfOffset), ptr, new IntPtr(rtf.Size));
             }
             IntPtr pBuffer = GetOutputBuffer();
-            instr = Marshal.PtrToStringAnsi(pBuffer);
+            instr = Marshal.PtrToStringUTF8(pBuffer);
             ClearOutputBuffer();
             return instrSize;
         }

--- a/src/installer/tests/TestUtils/SymbolicLinking.cs
+++ b/src/installer/tests/TestUtils/SymbolicLinking.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 if (symlink(targetFileName, symbolicLinkName) == -1)
                 {
                     int errno = Marshal.GetLastWin32Error();
-                    errorMessage = Marshal.PtrToStringAnsi(strerror(errno))!;
+                    errorMessage = Marshal.PtrToStringUTF8(strerror(errno))!;
                     return false;
                 }
             }

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Err.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Err.cs
@@ -34,7 +34,7 @@ internal static partial class Interop
             fixed (byte* buf = &buffer[0])
             {
                 ErrErrorStringN(error, buf, buffer.Length);
-                return Marshal.PtrToStringAnsi((IntPtr)buf)!;
+                return Marshal.PtrToStringUTF8((IntPtr)buf)!;
             }
         }
 

--- a/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.cs
+++ b/src/libraries/Common/src/Interop/FreeBSD/Interop.Process.cs
@@ -123,7 +123,7 @@ internal static partial class Interop
                 // Get the process information for the specified pid
                 info = new ProcessInfo();
 
-                info.ProcessName = Marshal.PtrToStringAnsi((IntPtr)kinfo->ki_comm)!;
+                info.ProcessName = Marshal.PtrToStringUTF8((IntPtr)kinfo->ki_comm)!;
                 info.BasePriority = kinfo->ki_nice;
                 info.VirtualBytes = (long)kinfo->ki_size;
                 info.WorkingSet = kinfo->ki_rssize;

--- a/src/libraries/Common/src/Interop/Unix/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Errors.cs
@@ -179,7 +179,7 @@ internal static partial class Interop
                 message = buffer;
             }
 
-            return Marshal.PtrToStringAnsi((IntPtr)message)!;
+            return Marshal.PtrToStringUTF8((IntPtr)message)!;
         }
 
 #if SERIAL_PORTS

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetCwd.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetCwd.cs
@@ -54,7 +54,7 @@ internal static partial class Interop
             // If it returned non-null, the null-terminated path is in the buffer
             if (result != null)
             {
-                return Marshal.PtrToStringAnsi((IntPtr)ptr);
+                return Marshal.PtrToStringUTF8((IntPtr)ptr);
             }
 
             // Otherwise, if it failed due to the buffer being too small, return null;

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetDomainName.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetDomainName.cs
@@ -31,8 +31,7 @@ internal static partial class Interop
                 throw new InvalidOperationException($"{nameof(GetDomainName)}: {err}");
             }
 
-            // Marshal.PtrToStringAnsi uses UTF8 on Unix.
-            return Marshal.PtrToStringAnsi((IntPtr)name)!;
+            return Marshal.PtrToStringUTF8((IntPtr)name)!;
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetHostName.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetHostName.cs
@@ -33,7 +33,7 @@ internal static partial class Interop
             // If the hostname is truncated, it is unspecified whether the returned buffer includes a terminating null byte.
             name[ArrLength - 1] = 0;
 
-            return Marshal.PtrToStringAnsi((IntPtr)name)!;
+            return Marshal.PtrToStringUTF8((IntPtr)name)!;
         }
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
@@ -67,7 +67,7 @@ internal static partial class Interop
             if (error == 0)
             {
                 Debug.Assert(passwd.Name != null);
-                username = Marshal.PtrToStringAnsi((IntPtr)passwd.Name);
+                username = Marshal.PtrToStringUTF8((IntPtr)passwd.Name);
                 return true;
             }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MountPoints.FormatInfo.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MountPoints.FormatInfo.cs
@@ -60,7 +60,7 @@ internal static partial class Interop
                 // Check if we have a numeric answer or string
                 format = numericFormat != -1 ?
                     Enum.GetName(typeof(UnixFileSystemTypes), numericFormat) ?? string.Empty :
-                    Marshal.PtrToStringAnsi((IntPtr)formatBuffer)!;
+                    Marshal.PtrToStringUTF8((IntPtr)formatBuffer)!;
                 type = GetDriveType(format);
             }
             else

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MountPoints.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MountPoints.cs
@@ -27,7 +27,7 @@ internal static partial class Interop
                     {
                         Array.Resize(ref found, count * 2);
                     }
-                    found[count++] = Marshal.PtrToStringAnsi((IntPtr)name)!;
+                    found[count++] = Marshal.PtrToStringUTF8((IntPtr)name)!;
                 });
             }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssApiException.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssApiException.cs
@@ -79,7 +79,7 @@ internal static partial class Interop
                     Interop.NetSecurityNative.Status displayCallStatus = isMinor ?
                         DisplayMinorStatus(out minStat, status, ref displayBuffer):
                         DisplayMajorStatus(out minStat, status, ref displayBuffer);
-                    return (Status.GSS_S_COMPLETE != displayCallStatus) ? null : Marshal.PtrToStringAnsi(displayBuffer._data);
+                    return (Status.GSS_S_COMPLETE != displayCallStatus) ? null : Marshal.PtrToStringUTF8(displayBuffer._data);
                 }
                 finally
                 {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -73,7 +73,7 @@ internal static partial class Interop
 
             if (bytesNeeded < StackCapacity)
             {
-                return Marshal.PtrToStringAnsi((IntPtr)bufStack, bytesNeeded);
+                return Marshal.PtrToStringUTF8((IntPtr)bufStack, bytesNeeded);
             }
 
             // bytesNeeded does not count the \0 which will be written on the end (based on OpenSSL 1.0.1f),
@@ -99,7 +99,7 @@ internal static partial class Interop
                     throw new CryptographicException();
                 }
 
-                return Marshal.PtrToStringAnsi((IntPtr)buf, bytesNeeded);
+                return Marshal.PtrToStringUTF8((IntPtr)buf, bytesNeeded);
             }
         }
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -73,13 +73,13 @@ internal static partial class Interop
             byte usedDefault;
             IntPtr ptr = GetX509RootStorePath_private(&usedDefault);
             defaultPath = (usedDefault != 0);
-            return Marshal.PtrToStringAnsi(ptr);
+            return Marshal.PtrToStringUTF8(ptr);
         }
 
         internal static unsafe string? GetX509RootStoreFile()
         {
             byte unused;
-            return Marshal.PtrToStringAnsi(GetX509RootStoreFile_private(&unused));
+            return Marshal.PtrToStringUTF8(GetX509RootStoreFile_private(&unused));
         }
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStorePath")]

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -37,7 +37,7 @@ internal static partial class Interop
             fixed (byte* buf = &buffer[0])
             {
                 ErrErrorStringN(error, buf, buffer.Length);
-                ret = Marshal.PtrToStringAnsi((IntPtr)buf)!;
+                ret = Marshal.PtrToStringUTF8((IntPtr)buf)!;
             }
 
             ArrayPool<byte>.Shared.Return(buffer);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -872,7 +872,7 @@ internal static partial class Interop
             // Capture last error to be consistent with CreateOpenSslCryptographicException
             ulong errorVal = Crypto.ErrPeekLastError();
             Crypto.ErrClearError();
-            string msg = SR.Format(message, Marshal.PtrToStringAnsi(Crypto.ErrReasonErrorString(errorVal)));
+            string msg = SR.Format(message, Marshal.PtrToStringUTF8(Crypto.ErrReasonErrorString(errorVal)));
             return new SslException(msg, (int)errorVal);
         }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -282,7 +282,7 @@ internal static partial class Interop
 
         internal static string? GetOpenSslCipherSuiteName(SafeSslHandle ssl, TlsCipherSuite cipherSuite, out bool isTls12OrLower)
         {
-            string? ret = Marshal.PtrToStringAnsi(GetOpenSslCipherSuiteName(ssl, (int)cipherSuite, out int isTls12OrLowerInt));
+            string? ret = Marshal.PtrToStringUTF8(GetOpenSslCipherSuiteName(ssl, (int)cipherSuite, out int isTls12OrLowerInt));
             isTls12OrLower = isTls12OrLowerInt != 0;
             return ret;
         }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Win32.SafeHandles
                 return false;
             }
 
-            string? targetName = Marshal.PtrToStringAnsi(namePtr);
+            string? targetName = Marshal.PtrToStringUTF8(namePtr);
             Debug.Assert(targetName != null);
 
             if (!string.IsNullOrEmpty(targetName))
@@ -162,7 +162,7 @@ namespace Microsoft.Win32.SafeHandles
         {
             Debug.Assert(_sslSessions != null);
 
-            string? targetName = Marshal.PtrToStringAnsi(namePtr);
+            string? targetName = Marshal.PtrToStringUTF8(namePtr);
             Debug.Assert(targetName != null);
 
             if (_sslSessions != null && targetName != null)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -243,7 +243,7 @@ internal static partial class Interop
 
         internal static string GetX509VerifyCertErrorString(int n)
         {
-            return Marshal.PtrToStringAnsi(X509VerifyCertErrorString(n))!;
+            return Marshal.PtrToStringUTF8(X509VerifyCertErrorString(n))!;
         }
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCertErrorString")]

--- a/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
@@ -365,7 +365,7 @@ namespace System.IO.Compression
             }
 
             // This can work even after XxflateEnd().
-            public string GetErrorMessage() => _zStream.msg != ZNullPtr ? Marshal.PtrToStringAnsi(_zStream.msg)! : string.Empty;
+            public string GetErrorMessage() => _zStream.msg != ZNullPtr ? Marshal.PtrToStringUTF8(_zStream.msg)! : string.Empty;
         }
 
         public static ErrorCode CreateZLibStreamForDeflate(out ZLibStreamHandle zLibStreamHandle, CompressionLevel level,

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
@@ -38,7 +38,7 @@ namespace System.Diagnostics
                 // Set the values we have; all the other values don't have meaning or don't exist on OSX
                 Interop.libproc.proc_taskallinfo temp = info.Value;
                 string processName;
-                unsafe { processName = Marshal.PtrToStringAnsi(new IntPtr(temp.pbsd.pbi_comm))!; }
+                unsafe { processName = Marshal.PtrToStringUTF8(new IntPtr(temp.pbsd.pbi_comm))!; }
                 if (!string.IsNullOrEmpty(processNameFilter) && !string.Equals(processName, processNameFilter, StringComparison.OrdinalIgnoreCase))
                 {
                     return null;

--- a/src/libraries/System.IO.Pipes/tests/InteropTest.Unix.cs
+++ b/src/libraries/System.IO.Pipes/tests/InteropTest.Unix.cs
@@ -26,7 +26,7 @@ namespace System.IO.Pipes.Tests
 
             if (result == 0)
             {
-                hostName = Marshal.PtrToStringAnsi((IntPtr)name);
+                hostName = Marshal.PtrToStringUTF8((IntPtr)name);
                 return true;
             }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Unix.cs
@@ -49,7 +49,7 @@ namespace System.Net
             try
             {
                 hostName = !justAddresses && hostEntry.CanonicalName != null
-                    ? Marshal.PtrToStringAnsi((IntPtr)hostEntry.CanonicalName)
+                    ? Marshal.PtrToStringUTF8((IntPtr)hostEntry.CanonicalName)
                     : null;
 
                 IPAddress[] localAddresses;
@@ -105,7 +105,7 @@ namespace System.Net
                         localAliases = new string[numAliases];
                         for (int i = 0; i < localAliases.Length; i++)
                         {
-                            localAliases[i] = Marshal.PtrToStringAnsi((IntPtr)hostEntry.Aliases[i])!;
+                            localAliases[i] = Marshal.PtrToStringUTF8((IntPtr)hostEntry.Aliases[i])!;
                         }
                     }
                 }
@@ -176,7 +176,7 @@ namespace System.Net
 
             socketError = GetSocketErrorForNativeError(error);
             nativeErrorCode = error;
-            return socketError == SocketError.Success ? Marshal.PtrToStringAnsi((IntPtr)buffer) : null;
+            return socketError == SocketError.Success ? Marshal.PtrToStringUTF8((IntPtr)buffer) : null;
         }
 
         public static string GetHostName() => Interop.Sys.GetHostName();

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -93,7 +93,7 @@ namespace System.Net.NetworkInformation
 
                 for (int i = 0; i < interfaceCount; i++)
                 {
-                    var lni = new LinuxNetworkInterface(Marshal.PtrToStringAnsi((IntPtr)nii->Name)!, nii->InterfaceIndex, systemProperties);
+                    var lni = new LinuxNetworkInterface(Marshal.PtrToStringUTF8((IntPtr)nii->Name)!, nii->InterfaceIndex, systemProperties);
                     lni._interfaceType = (NetworkInterfaceType)nii->HardwareType;
                     lni._speed = nii->Speed;
                     lni._operationalStatus = (OperationalStatus)nii->OperationalState;

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.Android.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.Android.cs
@@ -51,7 +51,7 @@ namespace System.Net.NetworkInformation
             var networkInterfaceInfo = (Interop.Sys.NetworkInterfaceInfo*)networkInterfacesPtr;
             for (int i = 0; i < interfaceCount; i++, networkInterfaceInfo++)
             {
-                var name = Marshal.PtrToStringAnsi((IntPtr)networkInterfaceInfo->Name);
+                var name = Marshal.PtrToStringUTF8((IntPtr)networkInterfaceInfo->Name);
                 networkInterfaces[i] = new AndroidNetworkInterface(name!, networkInterfaceInfo);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/PersistedFiles.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/PersistedFiles.Unix.cs
@@ -132,7 +132,7 @@ namespace System.IO
             if (error == 0)
             {
                 Debug.Assert(passwd.HomeDirectory != null);
-                path = Marshal.PtrToStringAnsi((IntPtr)passwd.HomeDirectory);
+                path = Marshal.PtrToStringUTF8((IntPtr)passwd.HomeDirectory);
                 return true;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -236,7 +236,7 @@ namespace System
                 throw new ArgumentException(SR.Arg_InvalidANSIString);
             return newString;
 #else
-            return Encoding.UTF8.GetString(pb, numBytes);
+            return CreateStringFromEncoding(pb, numBytes, Encoding.UTF8);
 #endif
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OidLookup.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OidLookup.OpenSsl.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography
                     Debug.Assert(friendlyNamePtr != IntPtr.Zero, "friendlyNamePtr != IntPtr.Zero");
 
                     // The pointer is to a shared string, so marshalling it out is all that's required.
-                    return Marshal.PtrToStringAnsi(friendlyNamePtr);
+                    return Marshal.PtrToStringUTF8(friendlyNamePtr);
                 case -1: /* OpenSSL internal error */
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 default:

--- a/src/mono/System.Private.CoreLib/src/System/Environment.Unix.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Environment.Unix.Mono.cs
@@ -20,7 +20,7 @@ namespace System
 
             if (s_environment == null)
             {
-                return Marshal.PtrToStringAnsi(Interop.Sys.GetEnv(variable));
+                return Marshal.PtrToStringUTF8(Interop.Sys.GetEnv(variable));
             }
 
             variable = TrimStringOnFirstZero(variable);


### PR DESCRIPTION
Also changed a few places in tools that use Utf8 encoding internally, even on Windows.