### PR TITLE
Don't generate templates for MdArrays

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -84,7 +84,11 @@ namespace ILCompiler.DependencyAnalysis
                     if (type.IsFunctionPointer)
                         return;
 
-                    dependencies.Add(factory.MaximallyConstructableType(type.ConvertToCanonForm(CanonicalFormKind.Specific)), "Reflection invoke");
+                    TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
+                    if (canonType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                        GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, type.ConvertToCanonForm(CanonicalFormKind.Specific));
+                    else
+                        dependencies.Add(factory.MaximallyConstructableType(canonType), "Reflection invoke");
                 }
             }
 


### PR DESCRIPTION
The compiler was asserting that `__Canon[,]` should not exist. We don't use templates for these because they don't have generic interfaces. They're the same as pointers and byrefs - we can make as many as we want at runtime.