### PR TITLE
Fix JSON perf regressions reported by #73242.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -431,12 +431,8 @@ namespace System.Text.Json
             Debug.Assert(queueTypeInfo.IsConfigured);
             JsonSerializerOptions options = queueTypeInfo.Options;
             var bufferState = new ReadBufferState(options.DefaultBufferSize);
-            ReadStack readStack = new ReadStack
-            {
-                SupportContinuation = true
-            };
-
-            readStack.Initialize(queueTypeInfo);
+            ReadStack readStack = default;
+            readStack.Initialize(queueTypeInfo, supportContinuation: true);
 
             var jsonReaderState = new JsonReaderState(options.GetReaderOptions());
 
@@ -475,11 +471,8 @@ namespace System.Text.Json
             Debug.Assert(jsonTypeInfo.IsConfigured);
             JsonSerializerOptions options = jsonTypeInfo.Options;
             var bufferState = new ReadBufferState(options.DefaultBufferSize);
-            ReadStack readStack = new ReadStack
-            {
-                SupportContinuation = true
-            };
-            readStack.Initialize(jsonTypeInfo);
+            ReadStack readStack = default;
+            readStack.Initialize(jsonTypeInfo, supportContinuation: true);
             var jsonReaderState = new JsonReaderState(options.GetReaderOptions());
 
             try
@@ -508,11 +501,8 @@ namespace System.Text.Json
             Debug.Assert(jsonTypeInfo.IsConfigured);
             JsonSerializerOptions options = jsonTypeInfo.Options;
             var bufferState = new ReadBufferState(options.DefaultBufferSize);
-            ReadStack readStack = new ReadStack
-            {
-                SupportContinuation = true
-            };
-            readStack.Initialize(jsonTypeInfo);
+            ReadStack readStack = default;
+            readStack.Initialize(jsonTypeInfo, supportContinuation: true);
             var jsonReaderState = new JsonReaderState(options.GetReaderOptions());
 
             try

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -314,15 +314,10 @@ namespace System.Text.Json
             using (var bufferWriter = new PooledByteBufferWriter(options.DefaultBufferSize))
             using (var writer = new Utf8JsonWriter(bufferWriter, writerOptions))
             {
-                WriteStack state = new WriteStack
-                {
-                    CancellationToken = cancellationToken,
-                    SupportContinuation = true,
-                    SupportAsync = true,
-                };
-
+                WriteStack state = default;
                 jsonTypeInfo = ResolvePolymorphicTypeInfo(value, jsonTypeInfo, out state.IsPolymorphicRootValue);
-                state.Initialize(jsonTypeInfo);
+                state.Initialize(jsonTypeInfo, supportAsync: true, supportContinuation: true);
+                state.CancellationToken = cancellationToken;
 
                 bool isFinalBlock;
 
@@ -395,13 +390,9 @@ namespace System.Text.Json
             using (var bufferWriter = new PooledByteBufferWriter(options.DefaultBufferSize))
             using (var writer = new Utf8JsonWriter(bufferWriter, writerOptions))
             {
-                WriteStack state = new WriteStack
-                {
-                    SupportContinuation = true
-                };
-
+                WriteStack state = default;
                 jsonTypeInfo = ResolvePolymorphicTypeInfo(value, jsonTypeInfo, out state.IsPolymorphicRootValue);
-                state.Initialize(jsonTypeInfo);
+                state.Initialize(jsonTypeInfo, supportContinuation: true, supportAsync: false);
 
                 bool isFinalBlock;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -93,7 +93,7 @@ namespace System.Text.Json
             }
         }
 
-        internal void Initialize(JsonTypeInfo jsonTypeInfo)
+        internal void Initialize(JsonTypeInfo jsonTypeInfo, bool supportContinuation = false)
         {
             JsonSerializerOptions options = jsonTypeInfo.Options;
             if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve)
@@ -106,6 +106,7 @@ namespace System.Text.Json
             Current.JsonPropertyInfo = jsonTypeInfo.PropertyInfoForTypeInfo;
             Current.NumberHandling = Current.JsonPropertyInfo.EffectiveNumberHandling;
             Current.CanContainMetadata = PreserveReferences || jsonTypeInfo.PolymorphicTypeResolver?.UsesTypeDiscriminators == true;
+            SupportContinuation = supportContinuation;
         }
 
         public void Push()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -139,14 +139,17 @@ namespace System.Text.Json
             }
         }
 
-        internal void Initialize(JsonTypeInfo jsonTypeInfo)
+        internal void Initialize(JsonTypeInfo jsonTypeInfo, bool supportContinuation = false, bool supportAsync = false)
         {
+            Debug.Assert(!supportAsync || supportContinuation, "supportAsync must imply supportContinuation");
             Debug.Assert(!IsContinuation);
             Debug.Assert(CurrentDepth == 0);
 
             Current.JsonTypeInfo = jsonTypeInfo;
             Current.JsonPropertyInfo = jsonTypeInfo.PropertyInfoForTypeInfo;
             Current.NumberHandling = Current.JsonPropertyInfo.EffectiveNumberHandling;
+            SupportContinuation = supportContinuation;
+            SupportAsync = supportAsync;
 
             JsonSerializerOptions options = jsonTypeInfo.Options;
             if (options.ReferenceHandlingStrategy != ReferenceHandlingStrategy.None)


### PR DESCRIPTION
I was able to isolate the perf regression to using object initializer syntax in the state structs introduced in #72789. Not sure why, @EgorBo any insights?

Fix #73242.