### PR TITLE
Do not throw ObjectDisposeException from Socket.EndXyz methods

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2248,11 +2248,7 @@ namespace System.Net.Sockets
         public IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback? requestCallback, object? state) =>
             TaskToApm.Begin(ConnectAsync(addresses, port), requestCallback, state);
 
-        public void EndConnect(IAsyncResult asyncResult)
-        {
-            ThrowIfDisposed();
-            TaskToApm.End(asyncResult);
-        }
+        public void EndConnect(IAsyncResult asyncResult) => TaskToApm.End(asyncResult);
 
         public IAsyncResult BeginDisconnect(bool reuseSocket, AsyncCallback? callback, object? state) =>
             TaskToApm.Begin(DisconnectAsync(reuseSocket).AsTask(), callback, state);
@@ -2278,12 +2274,7 @@ namespace System.Net.Sockets
             _localEndPoint = null;
         }
 
-        public void EndDisconnect(IAsyncResult asyncResult)
-        {
-            ThrowIfDisposed();
-            TaskToApm.End(asyncResult);
-        }
-
+        public void EndDisconnect(IAsyncResult asyncResult) => TaskToApm.End(asyncResult);
 
         public IAsyncResult BeginSend(byte[] buffer, int offset, int size, SocketFlags socketFlags, AsyncCallback? callback, object? state)
         {
@@ -2331,12 +2322,7 @@ namespace System.Net.Sockets
             return TaskToApm.Begin(t, callback, state);
         }
 
-        public int EndSend(IAsyncResult asyncResult)
-        {
-            ThrowIfDisposed();
-
-            return TaskToApm.End<int>(asyncResult);
-        }
+        public int EndSend(IAsyncResult asyncResult) => TaskToApm.End<int>(asyncResult);
 
         public int EndSend(IAsyncResult asyncResult, out SocketError errorCode) =>
             EndSendReceive(asyncResult, out errorCode);
@@ -2360,13 +2346,7 @@ namespace System.Net.Sockets
             return TaskToApm.Begin(SendFileAsync(fileName, preBuffer, postBuffer, flags).AsTask(), callback, state);
         }
 
-        public void EndSendFile(IAsyncResult asyncResult)
-        {
-            ThrowIfDisposed();
-            ArgumentNullException.ThrowIfNull(asyncResult);
-
-            TaskToApm.End(asyncResult);
-        }
+        public void EndSendFile(IAsyncResult asyncResult) => TaskToApm.End(asyncResult);
 
         public IAsyncResult BeginSendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP, AsyncCallback? callback, object? state)
         {
@@ -2378,11 +2358,7 @@ namespace System.Net.Sockets
             return TaskToApm.Begin(t, callback, state);
         }
 
-        public int EndSendTo(IAsyncResult asyncResult)
-        {
-            ThrowIfDisposed();
-            return TaskToApm.End<int>(asyncResult);
-        }
+        public int EndSendTo(IAsyncResult asyncResult) => TaskToApm.End<int>(asyncResult);
 
         public IAsyncResult BeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, AsyncCallback? callback, object? state)
         {
@@ -2428,22 +2404,18 @@ namespace System.Net.Sockets
             return TaskToApm.Begin(t, callback, state);
         }
 
-        public int EndReceive(IAsyncResult asyncResult)
-        {
-            ThrowIfDisposed();
-            return TaskToApm.End<int>(asyncResult);
-        }
+        public int EndReceive(IAsyncResult asyncResult) => TaskToApm.End<int>(asyncResult);
 
         public int EndReceive(IAsyncResult asyncResult, out SocketError errorCode) =>
             EndSendReceive(asyncResult, out errorCode);
 
-        private int EndSendReceive(IAsyncResult asyncResult, out SocketError errorCode)
+        private static int EndSendReceive(IAsyncResult asyncResult, out SocketError errorCode)
         {
-            ThrowIfDisposed();
-
             if (TaskToApm.GetTask(asyncResult) is not Task<int> ti)
             {
-                throw new ArgumentException(null, nameof(asyncResult));
+                throw asyncResult is null ?
+                    new ArgumentNullException(nameof(asyncResult)) :
+                    new ArgumentException(null, nameof(asyncResult));
             }
 
             if (!ti.IsCompleted)
@@ -2485,7 +2457,6 @@ namespace System.Net.Sockets
 
         public int EndReceiveMessageFrom(IAsyncResult asyncResult, ref SocketFlags socketFlags, ref EndPoint endPoint, out IPPacketInformation ipPacketInformation)
         {
-            ThrowIfDisposed();
             ArgumentNullException.ThrowIfNull(endPoint);
             if (!CanTryAddressFamily(endPoint.AddressFamily))
             {
@@ -2522,8 +2493,6 @@ namespace System.Net.Sockets
 
         public int EndReceiveFrom(IAsyncResult asyncResult, ref EndPoint endPoint)
         {
-            ThrowIfDisposed();
-
             ArgumentNullException.ThrowIfNull(endPoint);
             if (!CanTryAddressFamily(endPoint.AddressFamily))
             {
@@ -2541,11 +2510,7 @@ namespace System.Net.Sockets
         public IAsyncResult BeginAccept(AsyncCallback? callback, object? state) =>
             TaskToApm.Begin(AcceptAsync(), callback, state);
 
-        public Socket EndAccept(IAsyncResult asyncResult)
-        {
-            ThrowIfDisposed();
-            return TaskToApm.End<Socket>(asyncResult);
-        }
+        public Socket EndAccept(IAsyncResult asyncResult) => TaskToApm.End<Socket>(asyncResult);
 
         // This method provides support for legacy BeginAccept methods that take a "receiveSize" argument and
         // allow data to be received as part of the accept operation.
@@ -2599,7 +2564,6 @@ namespace System.Net.Sockets
 
         public Socket EndAccept(out byte[] buffer, out int bytesTransferred, IAsyncResult asyncResult)
         {
-            ThrowIfDisposed();
             Socket s;
             (s, buffer, bytesTransferred) = TaskToApm.End<(Socket, byte[], int)>(asyncResult);
             return s;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -2413,9 +2413,8 @@ namespace System.Net.Sockets
         {
             if (TaskToApm.GetTask(asyncResult) is not Task<int> ti)
             {
-                throw asyncResult is null ?
-                    new ArgumentNullException(nameof(asyncResult)) :
-                    new ArgumentException(null, nameof(asyncResult));
+                ArgumentNullException.ThrowIfNull(asyncResult);
+                throw new ArgumentException(null, nameof(asyncResult));
             }
 
             if (!ti.IsCompleted)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -323,7 +323,7 @@ namespace System.Net.Sockets.Tests
                 await disposeTask;
 
                 SocketError? localSocketError = null;
-                bool disposedException = false;
+
                 try
                 {
                     await acceptTask;
@@ -332,17 +332,8 @@ namespace System.Net.Sockets.Tests
                 {
                     localSocketError = se.SocketErrorCode;
                 }
-                catch (ObjectDisposedException)
-                {
-                    disposedException = true;
-                }
 
-                if (UsesApm)
-                {
-                    Assert.Null(localSocketError);
-                    Assert.True(disposedException);
-                }
-                else if (UsesSync)
+                if (UsesSync)
                 {
                     Assert.Equal(SocketError.Interrupted, localSocketError);
                 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -393,7 +393,7 @@ namespace System.Net.Sockets.Tests
                 socket.Listen(10);
 
                 bool unobservedThrown = false;
-                TaskScheduler.UnobservedTaskException += OnUnobservedException;
+                TaskScheduler.UnobservedTaskException += (_, __) => unobservedThrown = true;
 
                 await Task.Run(() =>
                 {
@@ -401,7 +401,7 @@ namespace System.Net.Sockets.Tests
                     {
                         try
                         {
-                            var accepted = socket.EndAccept(asyncResult);
+                            socket.EndAccept(asyncResult);
                         }
                         catch
                         {
@@ -423,11 +423,6 @@ namespace System.Net.Sockets.Tests
                 GC.WaitForPendingFinalizers();
 
                 Assert.False(unobservedThrown);
-
-                void OnUnobservedException(object sender, UnobservedTaskExceptionEventArgs? args)
-                {
-                    unobservedThrown = true;
-                }
             }).Dispose();   
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -415,8 +415,10 @@ namespace System.Net.Sockets.Tests
                 // Close the socket aborting Accept
                 socket.Dispose();
 
-                // Give chance for the unobserved exception to propagate. For some reason both waiting and enforcing Finalization is needed for this.
+                // Wait for the internal AcceptAsync Task to complete with the exception.
                 await Task.Delay(30);
+
+                // Ensure that the internal TaskExceptionHolder is finalized and the exception published to UnobservedTaskException.
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -171,12 +171,7 @@ namespace System.Net.Sockets.Tests
                     disposedException = true;
                 }
 
-                if (UsesApm)
-                {
-                    Assert.Null(localSocketError);
-                    Assert.True(disposedException);
-                }
-                else if (UsesSync)
+                if (UsesSync)
                 {
                     Assert.True(disposedException || localSocketError == SocketError.NotSocket, $"{disposedException} {localSocketError}");
                 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
@@ -627,9 +627,16 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void EndConnect_Throws_ObjectDisposed()
+        public void EndConnect_Throws_SocketException()
         {
-            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndConnect(null));
+            using Socket notListening = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            notListening.BindToAnonymousPort(IPAddress.Loopback);
+
+            Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var iar = socket.BeginConnect(notListening.LocalEndPoint, null, null);
+            socket.Dispose();
+
+            Assert.Throws<SocketException>(() => socket.EndConnect(iar));
         }
 
         [Fact]
@@ -657,22 +664,9 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void EndSend_Throws_ObjectDisposedException()
-        {
-            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndSend(null));
-        }
-
-        [Fact]
         public void BeginSendTo_Throws_ObjectDisposedException()
         {
             Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginSendTo(s_buffer, 0, s_buffer.Length, SocketFlags.None, new IPEndPoint(IPAddress.Loopback, 1), TheAsyncCallback, null));
-        }
-
-        [Fact]
-        public void EndSendTo_Throws_ObjectDisposedException()
-        {
-            // Behavior difference: EndSendTo_Throws_ObjectDisposed
-            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndSendTo(null));
         }
 
         [Fact]
@@ -700,9 +694,17 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void EndReceive_Throws_ObjectDisposedException()
+        public void EndReceive_Throws_SocketException()
         {
-            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndReceive(null));
+            (Socket a, Socket b) = SocketTestExtensions.CreateConnectedSocketPair();
+
+            using (b)
+            {
+                var iar = a.BeginReceive(new byte[1], 0, 1, SocketFlags.None, null, null);
+                a.Dispose();
+
+                Assert.Throws<SocketException>(() => a.EndReceive(iar));
+            }
         }
 
         [Fact]
@@ -713,10 +715,16 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void EndReceiveFrom_Throws_ObjectDisposedException()
+        public void EndReceiveFrom_Throws_SocketException()
         {
-            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
-            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndReceiveFrom(null, ref remote));
+            (Socket sender, Socket receiver, EndPoint senderEp) = CreateUdpSocketPair();
+
+            using (sender)
+            {
+                var iar = receiver.BeginReceiveFrom(new byte[1], 0, 1, SocketFlags.None, ref senderEp, null, null);
+                receiver.Dispose();
+                Assert.Throws<SocketException>(() => receiver.EndReceiveFrom(iar, ref senderEp));
+            }
         }
 
         [Fact]
@@ -726,25 +734,49 @@ namespace System.Net.Sockets.Tests
             Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginReceiveMessageFrom(s_buffer, 0, s_buffer.Length, SocketFlags.None, ref remote, TheAsyncCallback, null));
         }
 
-        [Fact]
-        public void EndReceiveMessageFrom_Throws_ObjectDisposedException()
+        private static (Socket a, Socket b, IPEndPoint aEndPoint) CreateUdpSocketPair()
         {
-            SocketFlags flags = SocketFlags.None;
-            EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
-            IPPacketInformation packetInfo;
-            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndReceiveMessageFrom(null, ref flags, ref remote, out packetInfo));
+            Socket a = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            int port = a.BindToAnonymousPort(IPAddress.Loopback);
+            IPEndPoint aEndPoint = new IPEndPoint(IPAddress.Loopback, port);
+            Socket b = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            b.BindToAnonymousPort(IPAddress.Loopback);
+            return (a, b, aEndPoint);
         }
 
         [Fact]
-        public void BeginAccept_Throws_ObjectDisposed()
+        public void EndReceiveMessageFrom_Throws_SocketException()
+        {
+            (Socket sender, Socket receiver, EndPoint senderEp) = CreateUdpSocketPair();
+
+            using (sender)
+            {
+                var iar = receiver.BeginReceiveMessageFrom(new byte[1], 0, 1, SocketFlags.None, ref senderEp, null, null);
+                receiver.Dispose();
+
+                SocketFlags flags = SocketFlags.None;
+                EndPoint remote = new IPEndPoint(IPAddress.Loopback, 1);
+                IPPacketInformation packetInfo;
+                Assert.Throws<SocketException>(() => receiver.EndReceiveMessageFrom(iar, ref flags, ref remote, out packetInfo));
+            }
+        }
+
+        [Fact]
+        public void BeginAccept_Throws_ObjectDisposedException()
         {
             Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().BeginAccept(TheAsyncCallback, null));
         }
 
         [Fact]
-        public void EndAccept_Throws_ObjectDisposed()
+        public void EndAccept_Throws_SocketException()
         {
-            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().EndAccept(null));
+            Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.BindToAnonymousPort(IPAddress.Loopback);
+            listener.Listen();
+            var iar = listener.BeginAccept(null, null);
+            listener.Dispose();
+
+            Assert.Throws<SocketException>(() => listener.EndAccept(iar));
         }
 
         [Fact]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
@@ -204,18 +204,10 @@ namespace System.Net.Sockets.Tests
                 if (closeOrDispose) socket.Close();
                 else socket.Dispose();
 
-                if (DisposeDuringOperationResultsInDisposedException)
-                {
-                    await Assert.ThrowsAsync<ObjectDisposedException>(() => receiveTask)
+                SocketException ex = await Assert.ThrowsAsync<SocketException>(() => receiveTask)
                         .WaitAsync(CancellationTestTimeout);
-                }
-                else
-                {
-                    SocketException ex = await Assert.ThrowsAsync<SocketException>(() => receiveTask)
-                        .WaitAsync(CancellationTestTimeout);
-                    SocketError expectedError = UsesSync ? SocketError.Interrupted : SocketError.OperationAborted;
-                    Assert.Equal(expectedError, ex.SocketErrorCode);
-                }
+                SocketError expectedError = UsesSync ? SocketError.Interrupted : SocketError.OperationAborted;
+                Assert.Equal(expectedError, ex.SocketErrorCode);
             }
         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -208,16 +208,9 @@ namespace System.Net.Sockets.Tests
                 if (closeOrDispose) socket.Close();
                 else socket.Dispose();
 
-                if (DisposeDuringOperationResultsInDisposedException)
-                {
-                    await Assert.ThrowsAsync<ObjectDisposedException>(() => receiveTask).WaitAsync(CancellationTestTimeout);
-                }
-                else
-                {
-                    SocketException ex = await Assert.ThrowsAsync<SocketException>(() => receiveTask).WaitAsync(CancellationTestTimeout);
-                    SocketError expectedError = UsesSync ? SocketError.Interrupted : SocketError.OperationAborted;
-                    Assert.Equal(expectedError, ex.SocketErrorCode);
-                }
+                SocketException ex = await Assert.ThrowsAsync<SocketException>(() => receiveTask).WaitAsync(CancellationTestTimeout);
+                SocketError expectedError = UsesSync ? SocketError.Interrupted : SocketError.OperationAborted;
+                Assert.Equal(expectedError, ex.SocketErrorCode);
             }
         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -268,7 +268,7 @@ namespace System.Net.Sockets.Tests
                     await disposeTask;
 
                     SocketError? localSocketError = null;
-                    bool disposedException = false;
+
                     try
                     {
                         await socketOperation;
@@ -277,17 +277,8 @@ namespace System.Net.Sockets.Tests
                     {
                         localSocketError = se.SocketErrorCode;
                     }
-                    catch (ObjectDisposedException)
-                    {
-                        disposedException = true;
-                    }
 
-                    if (UsesApm)
-                    {
-                        Assert.Null(localSocketError);
-                        Assert.True(disposedException);
-                    }
-                    else if (UsesSync)
+                    if (UsesSync)
                     {
                         Assert.Equal(SocketError.ConnectionAborted, localSocketError);
                     }
@@ -454,7 +445,6 @@ namespace System.Net.Sockets.Tests
             s.Dispose();
             Assert.Throws<ObjectDisposedException>(() => s.BeginSendFile(null, null, null));
             Assert.Throws<ObjectDisposedException>(() => s.BeginSendFile(null, null, null, TransmitFileOptions.UseDefaultWorkerThread, null, null));
-            Assert.Throws<ObjectDisposedException>(() => s.EndSendFile(null));
         }
 
         [Fact]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -959,6 +959,10 @@ namespace System.Net.Sockets.Tests
                 {
                     localSocketError = se.SocketErrorCode;
                 }
+                catch (ObjectDisposedException)
+                {
+                    Assert.Fail("Dispose happened before he operation, retry.");
+                }
 
                 if (UsesSync)
                 {
@@ -1039,6 +1043,10 @@ namespace System.Net.Sockets.Tests
                     catch (SocketException se)
                     {
                         localSocketError = se.SocketErrorCode;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        Assert.Fail("Dispose happened before he operation, retry.");
                     }
 
                     if (UsesSync)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -961,7 +961,7 @@ namespace System.Net.Sockets.Tests
                 }
                 catch (ObjectDisposedException)
                 {
-                    Assert.Fail("Dispose happened before he operation, retry.");
+                    Assert.Fail("Dispose happened before the operation, retry.");
                 }
 
                 if (UsesSync)
@@ -1046,7 +1046,7 @@ namespace System.Net.Sockets.Tests
                     }
                     catch (ObjectDisposedException)
                     {
-                        Assert.Fail("Dispose happened before he operation, retry.");
+                        Assert.Fail("Dispose happened before the operation, retry.");
                     }
 
                     if (UsesSync)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -815,17 +815,10 @@ namespace System.Net.Sockets.Tests
 
                     client.Dispose();
 
-                    if (DisposeDuringOperationResultsInDisposedException)
-                    {
-                        await Assert.ThrowsAsync<ObjectDisposedException>(() => receiveTask);
-                    }
-                    else
-                    {
-                        var se = await Assert.ThrowsAsync<SocketException>(() => receiveTask);
-                        Assert.True(
-                            se.SocketErrorCode == SocketError.OperationAborted || se.SocketErrorCode == SocketError.ConnectionAborted,
-                            $"Expected {nameof(SocketError.OperationAborted)} or {nameof(SocketError.ConnectionAborted)}, got {se.SocketErrorCode}");
-                    }
+                    var se = await Assert.ThrowsAsync<SocketException>(() => receiveTask);
+                    Assert.True(
+                        se.SocketErrorCode == SocketError.OperationAborted || se.SocketErrorCode == SocketError.ConnectionAborted,
+                        $"Expected {nameof(SocketError.OperationAborted)} or {nameof(SocketError.ConnectionAborted)}, got {se.SocketErrorCode}");
                 }
             }
         }
@@ -957,7 +950,7 @@ namespace System.Net.Sockets.Tests
                 await disposeTask;
 
                 SocketError? localSocketError = null;
-                bool disposedException = false;
+
                 try
                 {
                     await receiveTask;
@@ -966,17 +959,8 @@ namespace System.Net.Sockets.Tests
                 {
                     localSocketError = se.SocketErrorCode;
                 }
-                catch (ObjectDisposedException)
-                {
-                    disposedException = true;
-                }
 
-                if (UsesApm)
-                {
-                    Assert.Null(localSocketError);
-                    Assert.True(disposedException);
-                }
-                else if (UsesSync)
+                if (UsesSync)
                 {
                     Assert.Equal(SocketError.Interrupted, localSocketError);
                 }
@@ -1047,7 +1031,6 @@ namespace System.Net.Sockets.Tests
                               .WaitAsync(TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout));
 
                     SocketError? localSocketError = null;
-                    bool disposedException = false;
                     try
                     {
                         await socketOperation
@@ -1057,17 +1040,8 @@ namespace System.Net.Sockets.Tests
                     {
                         localSocketError = se.SocketErrorCode;
                     }
-                    catch (ObjectDisposedException)
-                    {
-                        disposedException = true;
-                    }
 
-                    if (UsesApm)
-                    {
-                        Assert.Null(localSocketError);
-                        Assert.True(disposedException);
-                    }
-                    else if (UsesSync)
+                    if (UsesSync)
                     {
                         Assert.Equal(SocketError.ConnectionAborted, localSocketError);
                     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
@@ -37,7 +37,6 @@ namespace System.Net.Sockets.Tests
         public virtual bool UsesSync => false;
         public virtual bool UsesApm => false;
         public virtual bool UsesEap => false;
-        public virtual bool DisposeDuringOperationResultsInDisposedException => false;
         public virtual bool ConnectAfterDisconnectResultsInInvalidOperationException => false;
         public virtual bool SupportsMultiConnect => true;
         public virtual bool SupportsAcceptIntoExistingSocket => true;
@@ -119,7 +118,6 @@ namespace System.Net.Sockets.Tests
 
     public sealed class SocketHelperApm : SocketHelperBase
     {
-        public override bool DisposeDuringOperationResultsInDisposedException => true;
         public override bool SupportsAcceptReceive => true;
 
         public override Task<Socket> AcceptAsync(Socket s) =>
@@ -453,7 +451,6 @@ namespace System.Net.Sockets.Tests
         public bool UsesSync => _socketHelper.UsesSync;
         public bool UsesApm => _socketHelper.UsesApm;
         public bool UsesEap => _socketHelper.UsesEap;
-        public bool DisposeDuringOperationResultsInDisposedException => _socketHelper.DisposeDuringOperationResultsInDisposedException;
         public bool ConnectAfterDisconnectResultsInInvalidOperationException => _socketHelper.ConnectAfterDisconnectResultsInInvalidOperationException;
         public bool SupportsMultiConnect => _socketHelper.SupportsMultiConnect;
         public bool SupportsAcceptIntoExistingSocket => _socketHelper.SupportsAcceptIntoExistingSocket;


### PR DESCRIPTION
Fixes #61411 and cleans up some null-reference exception handling.

Considering (1) the amount of test changes (2) the fact that we are documenting ODE (3) complaints like #41585, I think it's reasonable to mark this change as breaking.