### PR TITLE
Implement thread-local caching for Utf8JsonWriter in JsonSerializer.

### DIFF
--- a/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
+++ b/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
@@ -13,14 +13,17 @@ namespace System.Text.Json
 {
     internal sealed class PooledByteBufferWriter : IBufferWriter<byte>, IDisposable
     {
-        private byte[] _rentedBuffer;
+        // This class allows two possible configurations: if rentedBuffer is not null then
+        // it can be used as an IBufferWriter and holds a buffer that should eventually be
+        // returned to the shared pool. If rentedBuffer is null, then the instance is in a
+        // cleared/disposed state and it must re-rent a buffer before it can be used again.
+        private byte[]? _rentedBuffer;
         private int _index;
 
         private const int MinimumBufferSize = 256;
 
         private PooledByteBufferWriter()
         {
-            _rentedBuffer = null!;
         }
 
         public PooledByteBufferWriter(int initialCapacity)
@@ -79,7 +82,7 @@ namespace System.Text.Json
 
             ClearHelper();
             byte[] toReturn = _rentedBuffer;
-            _rentedBuffer = null!;
+            _rentedBuffer = null;
             ArrayPool<byte>.Shared.Return(toReturn);
         }
 
@@ -102,7 +105,7 @@ namespace System.Text.Json
 
             ClearHelper();
             byte[] toReturn = _rentedBuffer;
-            _rentedBuffer = null!;
+            _rentedBuffer = null;
             ArrayPool<byte>.Shared.Return(toReturn);
         }
 

--- a/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
+++ b/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
@@ -154,11 +154,13 @@ namespace System.Text.Json
 #else
         internal Task WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
         {
+            Debug.Assert(_rentedBuffer != null);
             return destination.WriteAsync(_rentedBuffer, 0, _index, cancellationToken);
         }
 
         internal void WriteToStream(Stream destination)
         {
+            Debug.Assert(_rentedBuffer != null);
             destination.Write(_rentedBuffer, 0, _index);
         }
 #endif

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -130,6 +130,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Serialization\Metadata\JsonTypeInfoKind.cs" />
     <Compile Include="System\Text\Json\Serialization\Metadata\CustomJsonTypeInfoOfT.cs" />
     <Compile Include="System\Text\Json\Serialization\PolymorphicSerializationState.cs" />
+    <Compile Include="System\Text\Json\Writer\Utf8JsonWriterCache.cs" />
     <Compile Include="System\Text\Json\Serialization\ReferenceEqualsWrapper.cs" />
     <Compile Include="System\Text\Json\Serialization\ConverterStrategy.cs" />
     <Compile Include="System\Text\Json\Serialization\ConfigurationList.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs
@@ -126,12 +126,5 @@ namespace System.Text.Json.Nodes
             JsonElement element = JsonElement.ParseValue(utf8Json, documentOptions);
             return JsonNodeConverter.Create(element, nodeOptions);
         }
-
-        internal static JsonNode? FromJsonElement(
-            JsonElement jsonElement,
-            JsonNodeOptions? nodeOptions = null)
-        {
-            return JsonNodeConverter.Create(jsonElement, nodeOptions);
-        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs
@@ -126,5 +126,12 @@ namespace System.Text.Json.Nodes
             JsonElement element = JsonElement.ParseValue(utf8Json, documentOptions);
             return JsonNodeConverter.Create(element, nodeOptions);
         }
+
+        internal static JsonNode? FromJsonElement(
+            JsonElement jsonElement,
+            JsonNodeOptions? nodeOptions = null)
+        {
+            return JsonNodeConverter.Create(jsonElement, nodeOptions);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -120,25 +120,34 @@ namespace System.Text.Json
         {
             Debug.Assert(jsonTypeInfo.IsConfigured);
 
-            JsonSerializerOptions options = jsonTypeInfo.Options;
+            Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(jsonTypeInfo.Options, out PooledByteBufferWriter output);
 
-            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-
-            WriteCore(writer, value, jsonTypeInfo);
-            return output.WrittenMemory.ToArray();
+            try
+            {
+                WriteCore(writer, value, jsonTypeInfo);
+                return output.WrittenMemory.ToArray();
+            }
+            finally
+            {
+                Utf8JsonWriterCache.ReturnWriterAndBuffer(writer, output);
+            }
         }
 
         private static byte[] WriteBytesAsObject(object? value, JsonTypeInfo jsonTypeInfo)
         {
             Debug.Assert(jsonTypeInfo.IsConfigured);
 
-            JsonSerializerOptions options = jsonTypeInfo.Options;
+            Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(jsonTypeInfo.Options, out PooledByteBufferWriter output);
 
-            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-            WriteCoreAsObject(writer, value, jsonTypeInfo);
-            return output.WrittenMemory.ToArray();
+            try
+            {
+                WriteCoreAsObject(writer, value, jsonTypeInfo);
+                return output.WrittenMemory.ToArray();
+            }
+            finally
+            {
+                Utf8JsonWriterCache.ReturnWriterAndBuffer(writer, output);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Document.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Document.cs
@@ -117,10 +117,17 @@ namespace System.Text.Json
             // For performance, share the same buffer across serialization and deserialization.
             // The PooledByteBufferWriter is cleared and returned when JsonDocument.Dispose() is called.
             PooledByteBufferWriter output = new(options.DefaultBufferSize);
-            using Utf8JsonWriter writer = new(output, options.GetWriterOptions());
+            Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriter(options, output);
 
-            WriteCore(writer, value, jsonTypeInfo);
-            return JsonDocument.ParseRented(output, options.GetDocumentOptions());
+            try
+            {
+                WriteCore(writer, value, jsonTypeInfo);
+                return JsonDocument.ParseRented(output, options.GetDocumentOptions());
+            }
+            finally
+            {
+                Utf8JsonWriterCache.ReturnWriter(writer);
+            }
         }
 
         private static JsonDocument WriteDocumentAsObject(object? value, JsonTypeInfo jsonTypeInfo)
@@ -131,10 +138,17 @@ namespace System.Text.Json
             // For performance, share the same buffer across serialization and deserialization.
             // The PooledByteBufferWriter is cleared and returned when JsonDocument.Dispose() is called.
             PooledByteBufferWriter output = new(options.DefaultBufferSize);
-            using Utf8JsonWriter writer = new(output, options.GetWriterOptions());
+            Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriter(options, output);
 
-            WriteCoreAsObject(writer, value, jsonTypeInfo);
-            return JsonDocument.ParseRented(output, options.GetDocumentOptions());
+            try
+            {
+                WriteCoreAsObject(writer, value, jsonTypeInfo);
+                return JsonDocument.ParseRented(output, options.GetDocumentOptions());
+            }
+            finally
+            {
+                Utf8JsonWriterCache.ReturnWriter(writer);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
@@ -111,29 +111,9 @@ namespace System.Text.Json
         }
 
         private static JsonElement WriteElement<TValue>(in TValue value, JsonTypeInfo<TValue> jsonTypeInfo)
-        {
-            Debug.Assert(jsonTypeInfo.IsConfigured);
-            JsonSerializerOptions options = jsonTypeInfo.Options;
-
-            // For performance, share the same buffer across serialization and deserialization.
-            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-
-            WriteCore(writer, value, jsonTypeInfo);
-            return JsonElement.ParseValue(output.WrittenMemory.Span, options.GetDocumentOptions());
-        }
+            => WriteDocument(value, jsonTypeInfo).RootElement;
 
         private static JsonElement WriteElementAsObject(object? value, JsonTypeInfo jsonTypeInfo)
-        {
-            JsonSerializerOptions options = jsonTypeInfo.Options;
-            Debug.Assert(options != null);
-
-            // For performance, share the same buffer across serialization and deserialization.
-            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-
-            WriteCoreAsObject(writer, value, jsonTypeInfo);
-            return JsonElement.ParseValue(output.WrittenMemory.Span, options.GetDocumentOptions());
-        }
+            => WriteDocumentAsObject(value, jsonTypeInfo).RootElement;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
@@ -113,28 +113,14 @@ namespace System.Text.Json
 
         private static JsonNode? WriteNode<TValue>(in TValue value, JsonTypeInfo<TValue> jsonTypeInfo)
         {
-            Debug.Assert(jsonTypeInfo.IsConfigured);
-            JsonSerializerOptions options = jsonTypeInfo.Options;
-
-            // For performance, share the same buffer across serialization and deserialization.
-            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-
-            WriteCore(writer, value, jsonTypeInfo);
-            return JsonNode.Parse(output.WrittenMemory.Span, options.GetNodeOptions(), options.GetDocumentOptions());
+            JsonDocument jsonDocument = WriteDocument(value, jsonTypeInfo);
+            return JsonNode.FromJsonElement(jsonDocument.RootElement);
         }
 
         private static JsonNode? WriteNodeAsObject(object? value, JsonTypeInfo jsonTypeInfo)
         {
-            Debug.Assert(jsonTypeInfo.IsConfigured);
-            JsonSerializerOptions options = jsonTypeInfo.Options;
-
-            // For performance, share the same buffer across serialization and deserialization.
-            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-
-            WriteCoreAsObject(writer, value, jsonTypeInfo);
-            return JsonNode.Parse(output.WrittenMemory.Span, options.GetNodeOptions(), options.GetDocumentOptions());
+            JsonDocument jsonDocument = WriteDocumentAsObject(value, jsonTypeInfo);
+            return JsonNode.FromJsonElement(jsonDocument.RootElement);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -133,26 +133,34 @@ namespace System.Text.Json
         {
             Debug.Assert(jsonTypeInfo.IsConfigured);
 
-            JsonSerializerOptions options = jsonTypeInfo.Options;
+            Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(jsonTypeInfo.Options, out PooledByteBufferWriter output);
 
-            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-
-            WriteCore(writer, value, jsonTypeInfo);
-            return JsonReaderHelper.TranscodeHelper(output.WrittenMemory.Span);
+            try
+            {
+                WriteCore(writer, value, jsonTypeInfo);
+                return JsonReaderHelper.TranscodeHelper(output.WrittenMemory.Span);
+            }
+            finally
+            {
+                Utf8JsonWriterCache.ReturnWriterAndBuffer(writer, output);
+            }
         }
 
         private static string WriteStringAsObject(object? value, JsonTypeInfo jsonTypeInfo)
         {
             Debug.Assert(jsonTypeInfo.IsConfigured);
 
-            JsonSerializerOptions options = jsonTypeInfo.Options;
+            Utf8JsonWriter writer = Utf8JsonWriterCache.RentWriterAndBuffer(jsonTypeInfo.Options, out PooledByteBufferWriter output);
 
-            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-
-            WriteCoreAsObject(writer, value, jsonTypeInfo);
-            return JsonReaderHelper.TranscodeHelper(output.WrittenMemory.Span);
+            try
+            {
+                WriteCoreAsObject(writer, value, jsonTypeInfo);
+                return JsonReaderHelper.TranscodeHelper(output.WrittenMemory.Span);
+            }
+            finally
+            {
+                Utf8JsonWriterCache.ReturnWriterAndBuffer(writer, output);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -89,6 +89,10 @@ namespace System.Text.Json
         /// </summary>
         public int CurrentDepth => _currentDepth & JsonConstants.RemoveFlagsBitMask;
 
+        private Utf8JsonWriter()
+        {
+        }
+
         /// <summary>
         /// Constructs a new <see cref="Utf8JsonWriter"/> instance with a specified <paramref name="bufferWriter"/>.
         /// </summary>
@@ -225,6 +229,29 @@ namespace System.Text.Json
 
             ResetHelper();
         }
+
+        internal void ResetAllStateForCacheReuse()
+        {
+            ResetHelper();
+
+            _stream = null;
+            _arrayBufferWriter = null;
+            _output = null;
+        }
+
+        internal void Reset(IBufferWriter<byte> bufferWriter, JsonWriterOptions options)
+        {
+            Debug.Assert(_output is null && _stream is null && _arrayBufferWriter is null);
+
+            _output = bufferWriter;
+            _options = options;
+            if (_options.MaxDepth == 0)
+            {
+                _options.MaxDepth = JsonWriterOptions.DefaultMaxDepth; // If max depth is not set, revert to the default depth.
+            }
+        }
+
+        internal static Utf8JsonWriter CreateEmptyInstanceForCaching() => new Utf8JsonWriter();
 
         private void ResetHelper()
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
@@ -11,11 +11,11 @@ namespace System.Text.Json
     internal static class Utf8JsonWriterCache
     {
         [ThreadStatic]
-        private static ThreadLocalState? s_threadLocalState;
+        private static ThreadLocalState? t_threadLocalState;
 
         public static Utf8JsonWriter RentWriterAndBuffer(JsonSerializerOptions options, out PooledByteBufferWriter bufferWriter)
         {
-            ThreadLocalState state = s_threadLocalState ??= new();
+            ThreadLocalState state = t_threadLocalState ??= new();
             Utf8JsonWriter writer;
 
             if (state.RentedWriters++ == 0)
@@ -39,7 +39,7 @@ namespace System.Text.Json
 
         public static Utf8JsonWriter RentWriter(JsonSerializerOptions options, PooledByteBufferWriter bufferWriter)
         {
-            ThreadLocalState state = s_threadLocalState ??= new();
+            ThreadLocalState state = t_threadLocalState ??= new();
             Utf8JsonWriter writer;
 
             if (state.RentedWriters++ == 0)
@@ -59,8 +59,8 @@ namespace System.Text.Json
 
         public static void ReturnWriterAndBuffer(Utf8JsonWriter writer, PooledByteBufferWriter bufferWriter)
         {
-            Debug.Assert(s_threadLocalState != null);
-            ThreadLocalState state = s_threadLocalState;
+            Debug.Assert(t_threadLocalState != null);
+            ThreadLocalState state = t_threadLocalState;
 
             writer.ResetAllStateForCacheReuse();
             bufferWriter.ClearAndReturnBuffers();
@@ -71,8 +71,8 @@ namespace System.Text.Json
 
         public static void ReturnWriter(Utf8JsonWriter writer)
         {
-            Debug.Assert(s_threadLocalState != null);
-            ThreadLocalState state = s_threadLocalState;
+            Debug.Assert(t_threadLocalState != null);
+            ThreadLocalState state = t_threadLocalState;
 
             writer.ResetAllStateForCacheReuse();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Text.Json
+{
+    /// <summary>
+    /// Defines a thread-local cache for JsonSerializer to store reusable Utf8JsonWriter/IBufferWriter instances.
+    /// </summary>
+    internal static class Utf8JsonWriterCache
+    {
+        [ThreadStatic]
+        private static ThreadLocalState? s_threadLocalState;
+
+        public static Utf8JsonWriter RentWriterAndBuffer(JsonSerializerOptions options, out PooledByteBufferWriter bufferWriter)
+        {
+            ThreadLocalState state = s_threadLocalState ??= new();
+            Utf8JsonWriter writer;
+
+            if (state.RentedWriters++ == 0)
+            {
+                // First JsonSerializer call in the stack -- initialize & return the cached instances.
+                bufferWriter = state.BufferWriter;
+                writer = state.Writer;
+
+                bufferWriter.InitializeEmptyInstance(options.DefaultBufferSize);
+                writer.Reset(bufferWriter, options.GetWriterOptions());
+            }
+            else
+            {
+                // We're in a recursive JsonSerializer call -- return fresh instances.
+                bufferWriter = new PooledByteBufferWriter(options.DefaultBufferSize);
+                writer = new Utf8JsonWriter(bufferWriter, options.GetWriterOptions());
+            }
+
+            return writer;
+        }
+
+        public static Utf8JsonWriter RentWriter(JsonSerializerOptions options, PooledByteBufferWriter bufferWriter)
+        {
+            ThreadLocalState state = s_threadLocalState ??= new();
+            Utf8JsonWriter writer;
+
+            if (state.RentedWriters++ == 0)
+            {
+                // First JsonSerializer call in the stack -- initialize & return the cached instance.
+                writer = state.Writer;
+                writer.Reset(bufferWriter, options.GetWriterOptions());
+            }
+            else
+            {
+                // We're in a recursive JsonSerializer call -- return a fresh instance.
+                writer = new Utf8JsonWriter(bufferWriter, options.GetWriterOptions());
+            }
+
+            return writer;
+        }
+
+        public static void ReturnWriterAndBuffer(Utf8JsonWriter writer, PooledByteBufferWriter bufferWriter)
+        {
+            Debug.Assert(s_threadLocalState != null);
+            ThreadLocalState state = s_threadLocalState;
+
+            writer.ResetAllStateForCacheReuse();
+            bufferWriter.ClearAndReturnBuffers();
+
+            int rentedWriters = --state.RentedWriters;
+            Debug.Assert((rentedWriters == 0) == (ReferenceEquals(state.BufferWriter, bufferWriter) && ReferenceEquals(state.Writer, writer)));
+        }
+
+        public static void ReturnWriter(Utf8JsonWriter writer)
+        {
+            Debug.Assert(s_threadLocalState != null);
+            ThreadLocalState state = s_threadLocalState;
+
+            writer.ResetAllStateForCacheReuse();
+
+            int rentedWriters = --state.RentedWriters;
+            Debug.Assert((rentedWriters == 0) == ReferenceEquals(state.Writer, writer));
+        }
+
+        private sealed class ThreadLocalState
+        {
+            public readonly PooledByteBufferWriter BufferWriter;
+            public readonly Utf8JsonWriter Writer;
+            public int RentedWriters;
+
+            public ThreadLocalState()
+            {
+                BufferWriter = PooledByteBufferWriter.CreateEmptyInstanceForCaching();
+                Writer = Utf8JsonWriter.CreateEmptyInstanceForCaching();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Following recommendation in #69889. Records nice improvements in the allocation profile when serializing small-ish values. 

cc @davidfowl 

## [WriteJson&lt;int&gt;](https://github.com/dotnet/performance/blob/e03024567eb5b6c66e51751c08f0ae1f7f3d3059/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WriteJson.cs)

|                  Method |        Job |                                                                                                          Toolchain |      Mean |    Error |   StdDev |    Median |       Min |       Max | Ratio | MannWhitney(3%) | RatioSD |  Gen 0 | Allocated | Alloc Ratio |
|------------------------ |----------- |------------------------------------------------------------------------------------------------------------------- |----------:|---------:|---------:|----------:|----------:|----------:|------:|---------------- |--------:|-------:|----------:|------------:|
|       SerializeToString | Job-PLUXQS | main | 120.17 ns | 2.334 ns | 2.184 ns | 119.68 ns | 116.27 ns | 125.73 ns |  1.00 |            Base |    0.00 | 0.0182 |     184 B |        1.00 |
|       SerializeToString | Job-YSJKRU | PR | 123.69 ns | 2.042 ns | 1.705 ns | 123.15 ns | 120.87 ns | 126.57 ns |  1.03 |            Same |    0.02 | 0.0030 |      32 B |        0.17 |
|                         |            |                                                                                                                    |           |          |          |           |           |           |       |                 |         |        |           |             |
|    SerializeToUtf8Bytes | Job-PLUXQS | main | 105.70 ns | 2.059 ns | 1.826 ns | 106.01 ns | 102.20 ns | 109.37 ns |  1.00 |            Base |    0.00 | 0.0181 |     184 B |        1.00 |
|    SerializeToUtf8Bytes | Job-YSJKRU | PR |  99.58 ns | 2.058 ns | 2.202 ns |  98.58 ns |  97.10 ns | 103.77 ns |  0.94 |          Faster |    0.03 | 0.0028 |      32 B |        0.17 |

## WriteJson&lt;LoginViewModel&gt;

|                  Method |        Job |                                                                                                          Branch|     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | MannWhitney(3%) | RatioSD |  Gen 0 | Allocated | Alloc Ratio |
|------------------------ |----------- |------------------------------------------------------------------------------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|---------------- |--------:|-------:|----------:|------------:|
|       SerializeToString | Job-PLUXQS |  main | 315.8 ns | 10.84 ns | 12.49 ns | 314.0 ns | 294.3 ns | 338.3 ns |  1.00 |            Base |    0.00 | 0.0338 |     344 B |        1.00 |
|       SerializeToString | Job-YSJKRU | PR | 302.3 ns |  4.02 ns |  3.14 ns | 302.8 ns | 293.6 ns | 306.6 ns |  0.98 |            Same |    0.03 | 0.0180 |     192 B |        0.56 |
|                         |            |                                                                                                                    |          |          |          |          |          |          |       |                 |         |        |           |             |
|    SerializeToUtf8Bytes | Job-PLUXQS | main | 278.0 ns |  5.09 ns |  4.52 ns | 279.4 ns | 270.3 ns | 284.2 ns |  1.00 |            Base |    0.00 | 0.0252 |     264 B |        1.00 |
|    SerializeToUtf8Bytes | Job-YSJKRU | PR | 282.4 ns |  5.73 ns |  6.37 ns | 281.5 ns | 273.0 ns | 296.5 ns |  1.02 |            Same |    0.03 | 0.0110 |     112 B |        0.42 |

## WriteJson&lt;Dictionary&lt;string,string&gt;&gt; (Count == 100)

|                  Method |        Job |                                                                                                          Toolchain |     Mean |     Error |    StdDev |   Median |      Min |       Max | Ratio | MannWhitney(3%) | RatioSD |  Gen 0 |  Gen 1 | Allocated | Alloc Ratio |
|------------------------ |----------- |------------------------------------------------------------------------------------------------------------------- |---------:|----------:|----------:|---------:|---------:|----------:|------:|---------------- |--------:|-------:|-------:|----------:|------------:|
|       SerializeToString | Job-PLUXQS | main | 9.233 μs | 0.1798 μs | 0.1594 μs | 9.188 μs | 8.996 μs |  9.466 μs |  1.00 |            Base |    0.00 | 1.1623 | 0.0375 |   12008 B |        1.00 |
|       SerializeToString | Job-YSJKRU | PR | 9.258 μs | 0.2519 μs | 0.2900 μs | 9.243 μs | 8.797 μs |  9.957 μs |  1.00 |            Same |    0.04 | 1.1621 | 0.0363 |   11856 B |        0.99 |
|                         |            |                                                                                                                    |          |           |           |          |          |           |       |                 |         |        |        |           |             |
|    SerializeToUtf8Bytes | Job-PLUXQS | main | 8.349 μs | 0.0805 μs | 0.0673 μs | 8.352 μs | 8.235 μs |  8.448 μs |  1.00 |            Base |    0.00 | 0.5759 |      - |    6096 B |        1.00 |
|    SerializeToUtf8Bytes | Job-YSJKRU | PR | 8.817 μs | 0.4493 μs | 0.5174 μs | 8.516 μs | 8.335 μs | 10.016 μs |  1.08 |            Same |    0.07 | 0.5688 |      - |    5944 B |        0.98 |

Fix #69889.