### PR TITLE
Fix missing case for function pointer signatures in Crossgen2

### DIFF
--- a/src/coreclr/tools/Common/Internal/Runtime/CorConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/CorConstants.cs
@@ -95,36 +95,4 @@ namespace Internal.CorConstants
         mdtName = 0x71000000,
         mdtBaseType = 0x72000000,
     }
-
-    [Flags]
-    public enum CorUnmanagedCallingConvention
-    {
-        IMAGE_CEE_UNMANAGED_CALLCONV_C = 0x1,
-        IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL = 0x2,
-        IMAGE_CEE_UNMANAGED_CALLCONV_THISCALL = 0x3,
-        IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL = 0x4,
-    }
-
-    [Flags]
-    public enum CorCallingConvention
-    {
-        IMAGE_CEE_CS_CALLCONV_DEFAULT = 0x0,
-        IMAGE_CEE_CS_CALLCONV_C = (int)CorUnmanagedCallingConvention.IMAGE_CEE_UNMANAGED_CALLCONV_C,
-        IMAGE_CEE_CS_CALLCONV_STDCALL = (int)CorUnmanagedCallingConvention.IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL,
-        IMAGE_CEE_CS_CALLCONV_THISCALL = (int)CorUnmanagedCallingConvention.IMAGE_CEE_UNMANAGED_CALLCONV_THISCALL,
-        IMAGE_CEE_CS_CALLCONV_FASTCALL = (int)CorUnmanagedCallingConvention.IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL,
-        IMAGE_CEE_CS_CALLCONV_VARARG = 0x5,
-        IMAGE_CEE_CS_CALLCONV_FIELD = 0x6,
-        IMAGE_CEE_CS_CALLCONV_LOCAL_SIG = 0x7,
-        IMAGE_CEE_CS_CALLCONV_PROPERTY = 0x8,
-        IMAGE_CEE_CS_CALLCONV_UNMANAGED = 0x9,  // Unmanaged calling convention encoded as modopts
-        IMAGE_CEE_CS_CALLCONV_GENERICINST = 0xa,  // generic method instantiation
-        IMAGE_CEE_CS_CALLCONV_NATIVEVARARG = 0xb,  // used ONLY for 64bit vararg PInvoke calls
-        IMAGE_CEE_CS_CALLCONV_MAX = 0xc,  // first invalid calling convention
-
-        IMAGE_CEE_CS_CALLCONV_MASK = 0x0f,  // Calling convention is bottom 4 bits
-        IMAGE_CEE_CS_CALLCONV_HASTHIS = 0x20,  // Top bit indicates a 'this' parameter
-        IMAGE_CEE_CS_CALLCONV_EXPLICITTHIS = 0x40,  // This parameter is explicitly in the signature
-        IMAGE_CEE_CS_CALLCONV_GENERIC = 0x10,  // Generic method sig with explicit number of type arguments (precedes ordinary parameter count)
-    }
 }

--- a/src/coreclr/tools/Common/Internal/Runtime/CorConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/CorConstants.cs
@@ -95,4 +95,36 @@ namespace Internal.CorConstants
         mdtName = 0x71000000,
         mdtBaseType = 0x72000000,
     }
+
+    [Flags]
+    public enum CorUnmanagedCallingConvention
+    {
+        IMAGE_CEE_UNMANAGED_CALLCONV_C = 0x1,
+        IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL = 0x2,
+        IMAGE_CEE_UNMANAGED_CALLCONV_THISCALL = 0x3,
+        IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL = 0x4,
+    }
+
+    [Flags]
+    public enum CorCallingConvention
+    {
+        IMAGE_CEE_CS_CALLCONV_DEFAULT = 0x0,
+        IMAGE_CEE_CS_CALLCONV_C = (int)CorUnmanagedCallingConvention.IMAGE_CEE_UNMANAGED_CALLCONV_C,
+        IMAGE_CEE_CS_CALLCONV_STDCALL = (int)CorUnmanagedCallingConvention.IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL,
+        IMAGE_CEE_CS_CALLCONV_THISCALL = (int)CorUnmanagedCallingConvention.IMAGE_CEE_UNMANAGED_CALLCONV_THISCALL,
+        IMAGE_CEE_CS_CALLCONV_FASTCALL = (int)CorUnmanagedCallingConvention.IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL,
+        IMAGE_CEE_CS_CALLCONV_VARARG = 0x5,
+        IMAGE_CEE_CS_CALLCONV_FIELD = 0x6,
+        IMAGE_CEE_CS_CALLCONV_LOCAL_SIG = 0x7,
+        IMAGE_CEE_CS_CALLCONV_PROPERTY = 0x8,
+        IMAGE_CEE_CS_CALLCONV_UNMANAGED = 0x9,  // Unmanaged calling convention encoded as modopts
+        IMAGE_CEE_CS_CALLCONV_GENERICINST = 0xa,  // generic method instantiation
+        IMAGE_CEE_CS_CALLCONV_NATIVEVARARG = 0xb,  // used ONLY for 64bit vararg PInvoke calls
+        IMAGE_CEE_CS_CALLCONV_MAX = 0xc,  // first invalid calling convention
+
+        IMAGE_CEE_CS_CALLCONV_MASK = 0x0f,  // Calling convention is bottom 4 bits
+        IMAGE_CEE_CS_CALLCONV_HASTHIS = 0x20,  // Top bit indicates a 'this' parameter
+        IMAGE_CEE_CS_CALLCONV_EXPLICITTHIS = 0x40,  // This parameter is explicitly in the signature
+        IMAGE_CEE_CS_CALLCONV_GENERIC = 0x10,  // Generic method sig with explicit number of type arguments (precedes ordinary parameter count)
+    }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -372,24 +372,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private void EmitFunctionPointerTypeSignature(FunctionPointerType type, SignatureContext context)
         {
-            CorCallingConvention callingConvention = (type.Signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) switch
-            {
-                MethodSignatureFlags.None => CorCallingConvention.IMAGE_CEE_CS_CALLCONV_DEFAULT,
-                MethodSignatureFlags.UnmanagedCallingConventionCdecl => CorCallingConvention.IMAGE_CEE_CS_CALLCONV_C,
-                MethodSignatureFlags.UnmanagedCallingConventionStdCall => CorCallingConvention.IMAGE_CEE_CS_CALLCONV_STDCALL,
-                MethodSignatureFlags.UnmanagedCallingConventionThisCall => CorCallingConvention.IMAGE_CEE_CS_CALLCONV_THISCALL,
-                MethodSignatureFlags.CallingConventionVarargs => CorCallingConvention.IMAGE_CEE_CS_CALLCONV_VARARG,
-                MethodSignatureFlags.UnmanagedCallingConvention => CorCallingConvention.IMAGE_CEE_CS_CALLCONV_UNMANAGED,
-                _ => throw new NotSupportedException()
-            };
-
-            if ((type.Signature.Flags & MethodSignatureFlags.Static) == 0)
-            {
-                callingConvention |= CorCallingConvention.IMAGE_CEE_CS_CALLCONV_HASTHIS | CorCallingConvention.IMAGE_CEE_CS_CALLCONV_EXPLICITTHIS;
-            }
+            SignatureCallingConvention callingConvention = (SignatureCallingConvention)(type.Signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask);
+            SignatureAttributes callingConventionAttributes = ((type.Signature.Flags & MethodSignatureFlags.Static) != 0 ? SignatureAttributes.None : SignatureAttributes.Instance);
 
             EmitElementType(CorElementType.ELEMENT_TYPE_FNPTR);
-            EmitUInt((byte)callingConvention);
+            EmitUInt((uint)((byte)callingConvention | (byte)callingConventionAttributes));
             EmitUInt((uint)type.Signature.Length);
 
             EmitTypeSignature(type.Signature.ReturnType, context);

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -925,9 +925,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/Arm/AdvSimd.Arm64/AdvSimd.Arm64_Part2_r/*">
             <Issue>https://github.com/dotnet/runtime/issues/63856</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ValueNumbering/TypeTestFolding/*">
-            <Issue>https://github.com/dotnet/runtime/issues/72822</Issue>
-        </ExcludeList>
     </ItemGroup>
 
       <!-- NativeAOT specific -->


### PR DESCRIPTION
As Andy Ayers conjectured in the issue #72822 and I confirmed,
Crossgen2 signature emitter was missing the code path for
emitting function pointer signatures. This change fixes this
deficiency. The change also removes the issues.targets exclusion
of the affected test that Andy originally merged in to mitigate
the issue.

Thanks

Tomas

P.S. Even though MethodSignatureFlags more or less corresponds
to CoreCLR runtime calling convention, I have ignored this fact
and implemented an explicit conversion as I find it cleaner, please
let me know if you think otherwise. I would also appreciate
double-checking of the logic around Static vs. HASTHIS as I'm not
completely sure about the exact interpretation of this runtime flag.

/cc @dotnet/crossgen-contrib 

Fixes: https://github.com/dotnet/runtime/issues/72822