### PR TITLE
Refactor input bubble checks to work in non-composite scenarios

### DIFF
--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -1093,6 +1093,11 @@ public:
         return &m_crstLoaderAllocatorReferences;
     }
 
+    void AssertLoadLockHeld()
+    {
+        _ASSERTE(m_FileLoadLock.HasLock());
+    }
+
 protected:
 
     //****************************************************************************************

--- a/src/coreclr/vm/assemblybinder.cpp
+++ b/src/coreclr/vm/assemblybinder.cpp
@@ -38,27 +38,125 @@ NativeImage* AssemblyBinder::LoadNativeImage(Module* componentModule, LPCUTF8 na
     bool isNewNativeImage;
     NativeImage* nativeImage = NativeImage::Open(componentModule, nativeImageName, binder, moduleLoaderAllocator, &isNewNativeImage);
 
-    if (isNewNativeImage && nativeImage != nullptr)
-    {
-        m_nativeImages.Append(nativeImage);
+    return nativeImage;
+}
 
-        for (COUNT_T assemblyIndex = 0; assemblyIndex < m_loadedAssemblies.GetCount(); assemblyIndex++)
+#ifdef FEATURE_READYTORUN
+void AssemblyBinder::DeclareDependencyOnMvid(LPCUTF8 simpleName, GUID mvid, LPCUTF8 requestingAssemblyName)
+{
+    // If the table is empty, then we didn't fill it with all the loaded assemblies as they were loaded. Record this detail, and fix after adding the dependency
+    bool addAllLoadedModules = false;
+    if (m_assemblySimpleNameMvidCheckHash.GetCount() == 0)
+    {
+        addAllLoadedModules = true;
+    }
+
+    SimpleNameToExpectedMVIDAndRequiringAssembly* foundElem = (SimpleNameToExpectedMVIDAndRequiringAssembly*)m_assemblySimpleNameMvidCheckHash.LookupPtr(simpleName);
+    if (foundElem == NULL)
+    {
+        SimpleNameToExpectedMVIDAndRequiringAssembly newElem(simpleName, mvid, requestingAssemblyName);
+        m_assemblySimpleNameMvidCheckHash.Add(newElem);
+    }
+    else
+    {
+        // Elem already exists. Determine if the existing elem is another one with the same mvid, in which case just record that a dependency is in play.
+        // If the existing elem has a different mvid, fail.
+        if (IsEqualGUID(mvid, foundElem->Mvid))
         {
-            nativeImage->CheckAssemblyMvid(m_loadedAssemblies[assemblyIndex]);
+            // Mvid matches exactly.
+            if (foundElem->RequiredAssemblySimpleName == NULL)
+                foundElem->RequiredAssemblySimpleName = requestingAssemblyName;
+        }
+        else
+        {
+            static const size_t MVID_TEXT_LENGTH = 39;
+            WCHAR assemblyMvidText[MVID_TEXT_LENGTH];
+            StringFromGUID2(foundElem->Mvid, assemblyMvidText, MVID_TEXT_LENGTH);
+
+            WCHAR componentMvidText[MVID_TEXT_LENGTH];
+            StringFromGUID2(mvid, componentMvidText, MVID_TEXT_LENGTH);
+
+            SString message;
+            message.Printf(W("MVID mismatch between loaded assembly '%s' (MVID = %s) and an assembly with the same simple name embedded in the native image '%s' (MVID = %s)"),
+                SString(SString::Utf8, simpleName).GetUnicode(),
+                assemblyMvidText,
+                SString(SString::Utf8, requestingAssemblyName).GetUnicode(),
+                componentMvidText);
+
+            EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_FAILFAST, message.GetUnicode());
         }
     }
 
-    return nativeImage;
+    if (addAllLoadedModules)
+    {
+        for (COUNT_T assemblyIndex = 0; assemblyIndex < m_loadedAssemblies.GetCount(); assemblyIndex++)
+        {
+           DeclareLoadedAssembly(m_loadedAssemblies[assemblyIndex]);
+        }
+    }
 }
+
+void AssemblyBinder::DeclareLoadedAssembly(Assembly* loadedAssembly)
+{
+    // If table is empty, then no mvid dependencies have been declared, so we don't need to record this information
+    if (m_assemblySimpleNameMvidCheckHash.GetCount() == 0)
+        return;
+
+    GUID mvid;
+    loadedAssembly->GetMDImport()->GetScopeProps(NULL, &mvid);
+
+    LPCUTF8 simpleName = loadedAssembly->GetSimpleName();
+
+    SimpleNameToExpectedMVIDAndRequiringAssembly* foundElem = (SimpleNameToExpectedMVIDAndRequiringAssembly*)m_assemblySimpleNameMvidCheckHash.LookupPtr(simpleName);
+    if (foundElem == NULL)
+    {
+        SimpleNameToExpectedMVIDAndRequiringAssembly newElem(simpleName, mvid, NULL);
+        m_assemblySimpleNameMvidCheckHash.Add(newElem);
+    }
+    else
+    {
+        // Elem already exists. Determine if the existing elem is another one with the same mvid, in which case do nothing. Everything is fine here.
+        // If the existing elem has a different mvid, but isn't a dependency on exact mvid elem, then set the mvid to all 0.
+        // If the existing elem has a different mvid, and is a dependency on exact mvid elem, then we've hit a fatal error.
+        if (IsEqualGUID(mvid, foundElem->Mvid))
+        {
+            // Mvid matches exactly.
+        }
+        else if (foundElem->RequiredAssemblySimpleName == NULL)
+        {
+            // Another loaded assembly, set the stored Mvid to all zeroes to indicate that it isn't a unique mvid
+            memset(&foundElem->Mvid, 0, sizeof(GUID));
+        }
+        else
+        {
+            static const size_t MVID_TEXT_LENGTH = 39;
+            WCHAR assemblyMvidText[MVID_TEXT_LENGTH];
+            StringFromGUID2(mvid, assemblyMvidText, MVID_TEXT_LENGTH);
+
+            WCHAR componentMvidText[MVID_TEXT_LENGTH];
+            StringFromGUID2(foundElem->Mvid, componentMvidText, MVID_TEXT_LENGTH);
+
+            SString message;
+            message.Printf(W("MVID mismatch between loaded assembly '%s' (MVID = %s) and an assembly with the same simple name embedded in the native image '%s' (MVID = %s)"),
+                SString(SString::Utf8, simpleName).GetUnicode(),
+                assemblyMvidText,
+                SString(SString::Utf8, foundElem->RequiredAssemblySimpleName).GetUnicode(),
+                componentMvidText);
+
+            EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_FAILFAST, message.GetUnicode());
+        }
+    }
+}
+#endif // FEATURE_READYTORUN
 
 void AssemblyBinder::AddLoadedAssembly(Assembly* loadedAssembly)
 {
     BaseDomain::LoadLockHolder lock(AppDomain::GetCurrentDomain());
     m_loadedAssemblies.Append(loadedAssembly);
-    for (COUNT_T nativeImageIndex = 0; nativeImageIndex < m_nativeImages.GetCount(); nativeImageIndex++)
-    {
-        m_nativeImages[nativeImageIndex]->CheckAssemblyMvid(loadedAssembly);
-    }
+
+#ifdef FEATURE_READYTORUN
+    DeclareLoadedAssembly(loadedAssembly);
+#endif // FEATURE_READYTORUN
 }
 
 void AssemblyBinder::GetNameForDiagnosticsFromManagedALC(INT_PTR managedALC, /* out */ SString& alcName)

--- a/src/coreclr/vm/assemblybinder.h
+++ b/src/coreclr/vm/assemblybinder.h
@@ -55,14 +55,74 @@ public:
     static void GetNameForDiagnosticsFromManagedALC(INT_PTR managedALC, /* out */ SString& alcName);
     static void GetNameForDiagnosticsFromSpec(AssemblySpec* spec, /*out*/ SString& alcName);
 
+#ifdef FEATURE_READYTORUN
+    // Must be called under the LoadLock
+    void DeclareDependencyOnMvid(LPCUTF8 simpleName, GUID mvid, LPCUTF8 requestingAssemblyName);
+#endif // FEATURE_READYTORUN
+
 private:
+
+#ifdef FEATURE_READYTORUN
+    // Must be called under the LoadLock
+    void DeclareLoadedAssembly(Assembly* loadedAssembly);
+
+    struct SimpleNameToExpectedMVIDAndRequiringAssembly
+    {
+        LPCUTF8 SimpleName;
+
+        // When an assembly is loaded, this Mvid value will be set to the mvid of the assembly. If there are multiple assemblies
+        // with different mvid's loaded with the same simple name, then the Mvid value will be set to all zeroes.
+        GUID Mvid;
+
+        // If an assembly of this simple name is not yet loaded, but a depedency on an exact mvid is registered, then this field will
+        // be filled in with the simple assembly name of the first assembly loaded with an mvid dependency.
+        LPCUTF8 RequiredAssemblySimpleName;
+
+        SimpleNameToExpectedMVIDAndRequiringAssembly() :
+            SimpleName(NULL),
+            Mvid({0}),
+            RequiredAssemblySimpleName(NULL)
+        {
+            memset(&Mvid, 0, sizeof(GUID));
+        }
+
+        SimpleNameToExpectedMVIDAndRequiringAssembly(LPCUTF8 simpleName, GUID mvid, LPCUTF8 requiredAssemblySimpleName) : 
+            SimpleName(simpleName),
+            Mvid(mvid),
+            RequiredAssemblySimpleName(requiredAssemblySimpleName)
+        {}
+
+        static SimpleNameToExpectedMVIDAndRequiringAssembly GetNull() { return SimpleNameToExpectedMVIDAndRequiringAssembly(); }
+        bool IsNull() const { return SimpleName == NULL; }
+    };
+
+    class SimpleNameWithMvidHashTraits : public NoRemoveSHashTraits< DefaultSHashTraits<SimpleNameToExpectedMVIDAndRequiringAssembly> >
+    {
+    public:
+        typedef LPCUTF8 key_t;
+
+        static SimpleNameToExpectedMVIDAndRequiringAssembly Null() { return SimpleNameToExpectedMVIDAndRequiringAssembly::GetNull(); }
+        static bool IsNull(const SimpleNameToExpectedMVIDAndRequiringAssembly& e) { return e.IsNull(); }
+
+        static LPCUTF8 GetKey(const SimpleNameToExpectedMVIDAndRequiringAssembly& e) { return e.SimpleName; }
+
+        static BOOL Equals(LPCUTF8 a, LPCUTF8 b) { return strcmp(a, b) == 0; } // Use a case senstive comparison here even though
+                                                                            // assembly name matching should be case insensitive. Case insensitive
+                                                                            // comparisons are slow and have throwing scenarios, and this hash table
+                                                                            // provides a best-effort match to prevent problems, not perfection
+
+        static count_t Hash(LPCUTF8 a) { return HashStringA(a); } // As above, this is a case sensitive hash
+    };
+
+    SHash<SimpleNameWithMvidHashTraits> m_assemblySimpleNameMvidCheckHash;
+#endif // FEATURE_READYTORUN
+
     BINDER_SPACE::ApplicationContext m_appContext;
 
     // A GC handle to the managed AssemblyLoadContext.
     // It is a long weak handle for collectible AssemblyLoadContexts and strong handle for non-collectible ones.
     INT_PTR m_ptrManagedAssemblyLoadContext;
 
-    SArray<NativeImage*> m_nativeImages;
     SArray<Assembly*> m_loadedAssemblies;
 };
 

--- a/src/coreclr/vm/assemblybinder.h
+++ b/src/coreclr/vm/assemblybinder.h
@@ -57,7 +57,7 @@ public:
 
 #ifdef FEATURE_READYTORUN
     // Must be called under the LoadLock
-    void DeclareDependencyOnMvid(LPCUTF8 simpleName, GUID mvid, LPCUTF8 requestingAssemblyName);
+    void DeclareDependencyOnMvid(LPCUTF8 simpleName, GUID mvid, bool compositeComponent, LPCUTF8 imageName);
 #endif // FEATURE_READYTORUN
 
 private:
@@ -76,20 +76,24 @@ private:
 
         // If an assembly of this simple name is not yet loaded, but a depedency on an exact mvid is registered, then this field will
         // be filled in with the simple assembly name of the first assembly loaded with an mvid dependency.
-        LPCUTF8 RequiredAssemblySimpleName;
+        LPCUTF8 AssemblyRequirementName;
+
+        // To disambiguate between component images of a composite image and requirements from a non-composite --inputbubble assembly, use this bool
+        bool CompositeComponent;
 
         SimpleNameToExpectedMVIDAndRequiringAssembly() :
             SimpleName(NULL),
             Mvid({0}),
-            RequiredAssemblySimpleName(NULL)
+            AssemblyRequirementName(NULL),
+            CompositeComponent(false)
         {
-            memset(&Mvid, 0, sizeof(GUID));
         }
 
-        SimpleNameToExpectedMVIDAndRequiringAssembly(LPCUTF8 simpleName, GUID mvid, LPCUTF8 requiredAssemblySimpleName) : 
+        SimpleNameToExpectedMVIDAndRequiringAssembly(LPCUTF8 simpleName, GUID mvid, bool compositeComponent, LPCUTF8 AssemblyRequirementName) : 
             SimpleName(simpleName),
             Mvid(mvid),
-            RequiredAssemblySimpleName(requiredAssemblySimpleName)
+            AssemblyRequirementName(AssemblyRequirementName),
+            CompositeComponent(compositeComponent)
         {}
 
         static SimpleNameToExpectedMVIDAndRequiringAssembly GetNull() { return SimpleNameToExpectedMVIDAndRequiringAssembly(); }

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -68,7 +68,6 @@ void NativeImage::Initialize(READYTORUN_HEADER *pHeader, LoaderAllocator *pLoade
 
     m_pReadyToRunInfo = new ReadyToRunInfo(/*pModule*/ NULL, pLoaderAllocator, m_pImageLayout, pHeader, /*compositeImage*/ NULL, pamTracker);
     m_pComponentAssemblies = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ComponentAssemblies);
-    m_pComponentAssemblyMvids = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ManifestAssemblyMvids);
     m_componentAssemblyCount = m_pComponentAssemblies->Size / sizeof(READYTORUN_COMPONENT_ASSEMBLIES_ENTRY);
     
     // Check if the current module's image has native manifest metadata, otherwise the current->GetNativeAssemblyImport() asserts.
@@ -285,56 +284,6 @@ PTR_READYTORUN_CORE_HEADER NativeImage::GetComponentAssemblyHeader(LPCUTF8 simpl
         return (PTR_READYTORUN_CORE_HEADER)&pImageBase[componentAssembly->ReadyToRunCoreHeader.VirtualAddress];
     }
     return NULL;
-}
-#endif
-
-#ifndef DACCESS_COMPILE
-void NativeImage::CheckAssemblyMvid(Assembly *assembly) const
-{
-    STANDARD_VM_CONTRACT;
-    if (m_pComponentAssemblyMvids == NULL)
-    {
-        return;
-    }
-
-    const AssemblyNameIndex *assemblyNameIndex = m_assemblySimpleNameToIndexMap.LookupPtr(assembly->GetSimpleName());
-    if (assemblyNameIndex == NULL)
-    {
-        return;
-    }
-
-    GUID assemblyMvid;
-    assembly->GetMDImport()->GetScopeProps(NULL, &assemblyMvid);
-
-    const byte *pImageBase = (const BYTE *)m_pImageLayout->GetBase();
-    const GUID *componentMvid = (const GUID *)&pImageBase[m_pComponentAssemblyMvids->VirtualAddress] + assemblyNameIndex->Index;
-    if (IsEqualGUID(*componentMvid, assemblyMvid))
-    {
-        return;
-    }
-
-    GUID emptyGuid  = {0};
-    if (IsEqualGUID(*componentMvid, emptyGuid))
-    {
-        // Empty guid always succeeds, as it isn't used for dependency checks
-        return;
-    }
-
-    static const size_t MVID_TEXT_LENGTH = 39;
-    WCHAR assemblyMvidText[MVID_TEXT_LENGTH];
-    StringFromGUID2(assemblyMvid, assemblyMvidText, MVID_TEXT_LENGTH);
-
-    WCHAR componentMvidText[MVID_TEXT_LENGTH];
-    StringFromGUID2(*componentMvid, componentMvidText, MVID_TEXT_LENGTH);
-
-    SString message;
-    message.Printf(W("MVID mismatch between loaded assembly '%s' (MVID = %s) and an assembly with the same simple name embedded in the native image '%s' (MVID = %s)"),
-        SString(SString::Utf8, assembly->GetSimpleName()).GetUnicode(),
-        assemblyMvidText,
-        SString(SString::Utf8, GetFileName()).GetUnicode(),
-        componentMvidText);
-
-    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_FAILFAST, message.GetUnicode());
 }
 #endif
 

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -66,7 +66,7 @@ void NativeImage::Initialize(READYTORUN_HEADER *pHeader, LoaderAllocator *pLoade
 {
     LoaderHeap *pHeap = pLoaderAllocator->GetHighFrequencyHeap();
 
-    m_pReadyToRunInfo = new ReadyToRunInfo(/*pModule*/ NULL, pLoaderAllocator, m_pImageLayout, pHeader, /*compositeImage*/ NULL, pamTracker);
+    m_pReadyToRunInfo = new ReadyToRunInfo(/*pModule*/ NULL, pLoaderAllocator, m_pImageLayout, pHeader, this, pamTracker);
     m_pComponentAssemblies = m_pReadyToRunInfo->FindSection(ReadyToRunSectionType::ComponentAssemblies);
     m_componentAssemblyCount = m_pComponentAssemblies->Size / sizeof(READYTORUN_COMPONENT_ASSEMBLIES_ENTRY);
     

--- a/src/coreclr/vm/nativeimage.h
+++ b/src/coreclr/vm/nativeimage.h
@@ -88,7 +88,6 @@ private:
     PTR_ModuleBase m_pNativeManifestModule;
     
     IMAGE_DATA_DIRECTORY *m_pComponentAssemblies;
-    IMAGE_DATA_DIRECTORY *m_pComponentAssemblyMvids;
     uint32_t m_componentAssemblyCount;
     uint32_t m_manifestAssemblyCount;
     SHash<AssemblyNameIndexHashTraits> m_assemblySimpleNameToIndexMap;

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -781,7 +781,7 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, LoaderAllocator* pLoaderAllocat
                     LPCSTR assemblyName;
                     IfFailThrow(pNativeMDImport->GetAssemblyRefProps(assemblyRef, NULL, NULL, &assemblyName, NULL, NULL, NULL, NULL));
 
-                    binder->DeclareDependencyOnMvid(assemblyName, *componentMvid, pNativeImage != NULL ? pNativeImage->GetFileName() : NULL, pModule != NULL ? pModule->GetSimpleName() : NULL);
+                    binder->DeclareDependencyOnMvid(assemblyName, *componentMvid, pNativeImage != NULL, pModule != NULL ? pModule->GetSimpleName() : pNativeImage->GetFileName());
                     manifestAssemblyCount++;
                 }
             }


### PR DESCRIPTION
- Input bubble checks for making sure that the input bubble is valid are not currently processed for non-composite scenarios
- Refactor them so that they are not n^2 in cost, and are handled for both composite and non-composite scenarios

Fixes #71131