### PR TITLE
Propagate BBF_HAS_MDARRAYREF to new blocks when copying IR

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -583,6 +583,13 @@ enum BasicBlockFlags : unsigned __int64
 
     BBF_SPLIT_GAINED = BBF_DONT_REMOVE | BBF_HAS_JMP | BBF_BACKWARD_JUMP | BBF_HAS_IDX_LEN | BBF_HAS_MD_IDX_LEN | BBF_PROF_WEIGHT | \
                        BBF_HAS_NEWOBJ | BBF_KEEP_BBJ_ALWAYS | BBF_CLONED_FINALLY_END | BBF_HAS_NULLCHECK | BBF_HAS_HISTOGRAM_PROFILE | BBF_HAS_MDARRAYREF,
+
+    // Flags that must be propagated to a new block if code is copied from a block to a new block. These are flags that
+    // limit processing of a block if the code in question doesn't exist. This is conservative; we might not
+    // have actually copied one of these type of tree nodes, but if we only copy a portion of the block's statements,
+    // we don't know (unless we actually pay close attention during the copy).
+
+    BBF_COPY_PROPAGATE = BBF_HAS_NEWOBJ | BBF_HAS_NULLCHECK | BBF_HAS_IDX_LEN | BBF_HAS_MD_IDX_LEN | BBF_HAS_MDARRAYREF,
 };
 
 inline constexpr BasicBlockFlags operator ~(BasicBlockFlags a)

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4125,7 +4125,7 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
     gtReverseCond(condTree);
 
     // We need to update the following flags of the bJump block if they were set in the bDest block
-    bJump->bbFlags |= (bDest->bbFlags & (BBF_HAS_NEWOBJ | BBF_HAS_NULLCHECK | BBF_HAS_IDX_LEN | BBF_HAS_MD_IDX_LEN));
+    bJump->bbFlags |= bDest->bbFlags & BBF_COPY_PROPAGATE;
 
     bJump->bbJumpKind = BBJ_COND;
     bJump->bbJumpDest = bDest->bbNext;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -261,11 +261,11 @@ GenTree* Lowering::LowerNode(GenTree* node)
 #endif // TARGET_XARCH
 
         case GT_ARR_ELEM:
-            assert(!comp->opts.compJitEarlyExpandMDArrays);
+            noway_assert(!comp->opts.compJitEarlyExpandMDArrays);
             return LowerArrElem(node->AsArrElem());
 
         case GT_ARR_OFFSET:
-            assert(!comp->opts.compJitEarlyExpandMDArrays);
+            noway_assert(!comp->opts.compJitEarlyExpandMDArrays);
             ContainCheckArrOffset(node->AsArrOffs());
             break;
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5018,13 +5018,8 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
 
     assert(foundCondTree);
 
-    // Flag the block that received the copy as potentially having an array/vtable
-    // reference, nullcheck, object allocation if the block copied from did;
-    // this is a conservative guess.
-    if (auto copyFlags = bTest->bbFlags & (BBF_HAS_IDX_LEN | BBF_HAS_MD_IDX_LEN | BBF_HAS_NULLCHECK | BBF_HAS_NEWOBJ))
-    {
-        bNewCond->bbFlags |= copyFlags;
-    }
+    // Flag the block that received the copy as potentially having various constructs.
+    bNewCond->bbFlags |= bTest->bbFlags & BBF_COPY_PROPAGATE;
 
     bNewCond->bbJumpDest = bTest->bbNext;
     bNewCond->inheritWeight(block);
@@ -6341,7 +6336,7 @@ void Compiler::optPerformHoistExpr(GenTree* origExpr, BasicBlock* exprBb, unsign
     compCurBB = preHead;
     hoist     = fgMorphTree(hoist);
 
-    preHead->bbFlags |= (exprBb->bbFlags & (BBF_HAS_IDX_LEN | BBF_HAS_MD_IDX_LEN | BBF_HAS_NULLCHECK));
+    preHead->bbFlags |= exprBb->bbFlags & BBF_COPY_PROPAGATE;
 
     Statement* hoistStmt = gtNewStmt(hoist);
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72768/Runtime_72768.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72768/Runtime_72768.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Adapted from:
+// Fuzzlyn v1.5 on 2022-07-24 15:28:54
+// Run on X86 Windows
+// Seed: 9097970668016732717
+// Reduced from 177.2 KiB to 1.0 KiB in 00:04:15
+// Hits JIT assert in Release:
+// Assertion failed '!comp->opts.compJitEarlyExpandMDArrays' in 'Program:Main(Fuzzlyn.ExecutionServer.IRuntime)' during 'Lowering nodeinfo' (IL size 111; hash 0xade6b36b; FullOpts)
+// 
+//     File: D:\a\_work\1\s\src\coreclr\jit\lower.cpp Line: 264
+// 
+public class Program
+{
+    public static int PASS = 100;
+    public static int FAIL = 0;
+    public static IRuntime s_rt;
+    public static bool s_1;
+    public static bool[, ] s_12;
+    public static int s_22;
+    public static byte[] s_27;
+    public static ushort s_33;
+    public static bool s_43;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Test()
+    {
+        try
+        {
+            try
+            {
+            }
+            finally
+            {
+                if (s_12[0, 0])
+                {
+                    int vr3 = s_22;
+                }
+            }
+        }
+        finally
+        {
+            if (s_1)
+            {
+                ushort vr4 = s_33--;
+                s_rt.WriteLine(vr4);
+            }
+            else
+            {
+                byte vr5 = s_27[0];
+                s_rt.WriteLine(vr5);
+            }
+
+            bool vr6 = s_43;
+            s_rt.WriteLine(vr6);
+        }
+    }
+
+    public static int Main()
+    {
+        try
+        {
+            Test();
+        }
+        catch (NullReferenceException)
+        {
+            // This is expected
+        }
+        catch (Exception)
+        {
+            return FAIL;
+        }
+
+        return PASS;
+    }
+}
+
+public interface IRuntime
+{
+    void WriteLine<T>(T value);
+}
+
+public class Runtime : IRuntime
+{
+    public void WriteLine<T>(T value) => System.Console.WriteLine(value);
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72768/Runtime_72768.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72768/Runtime_72768.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Several block flags are used to indicate the presence of certain IR nodes
to avoid visiting blocks unnecessarily. To make this work, though, these
flags must be added to new blocks when code is copied from one block to
another. Add `BBF_HAS_MDARRAYREF` to the set of flags that need such
copying, and define and use `BBF_COPY_PROPAGATE` as the set of such flags.

Add a Fuzzlyn-derived unit test.

Fixes #72768