### PR TITLE
Disambiguate calli thunks based on full calling conventions

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/TypeLoaderExceptionHelper.cs
@@ -88,6 +88,14 @@ namespace Internal.Runtime
                     return SR.InvalidProgram_Vararg;
                 case ExceptionStringID.InvalidProgramCallVirtFinalize:
                     return SR.InvalidProgram_CallVirtFinalize;
+                case ExceptionStringID.InvalidProgramNonStaticMethod:
+                    return SR.InvalidProgram_NonStaticMethod;
+                case ExceptionStringID.InvalidProgramGenericMethod:
+                    return SR.InvalidProgram_GenericMethod;
+                case ExceptionStringID.InvalidProgramNonBlittableTypes:
+                    return SR.InvalidProgram_NonBlittableTypes;
+                case ExceptionStringID.InvalidProgramMultipleCallConv:
+                    return SR.InvalidProgram_MultipleCallConv;
                 case ExceptionStringID.MissingField:
                     return SR.EE_MissingField;
                 case ExceptionStringID.MissingMethod:

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -12,7 +12,6 @@ namespace Internal.TypeSystem
     public enum MethodSignatureFlags
     {
         None = 0x0000,
-        // TODO: Generic, etc.
 
         UnmanagedCallingConventionMask       = 0x000F,
         UnmanagedCallingConventionCdecl      = 0x0001,
@@ -203,7 +202,6 @@ namespace Internal.TypeSystem
 
         private bool Equals(MethodSignature otherSignature, bool allowCovariantReturn)
         {
-            // TODO: Generics, etc.
             if (this._flags != otherSignature._flags)
                 return false;
 
@@ -249,12 +247,15 @@ namespace Internal.TypeSystem
 
                 for (int i = 0; i < this._embeddedSignatureData.Length; i++)
                 {
-                    if (this._embeddedSignatureData[i].index != otherSignature._embeddedSignatureData[i].index)
+                    ref EmbeddedSignatureData thisData = ref this._embeddedSignatureData[i];
+                    ref EmbeddedSignatureData otherData = ref otherSignature._embeddedSignatureData[i];
+
+                    if (thisData.index != otherData.index ||
+                        thisData.kind != otherData.kind ||
+                        thisData.type != otherData.type)
+                    {
                         return false;
-                    if (this._embeddedSignatureData[i].kind != otherSignature._embeddedSignatureData[i].kind)
-                        return false;
-                    if (this._embeddedSignatureData[i].type != otherSignature._embeddedSignatureData[i].type)
-                        return false;
+                    }
                 }
 
                 return true;
@@ -314,7 +315,7 @@ namespace Internal.TypeSystem
         private int _genericParameterCount;
         private TypeDesc _returnType;
         private TypeDesc[] _parameters;
-        private EmbeddedSignatureData[] _customModifiers;
+        private EmbeddedSignatureData[] _embeddedSignatureData;
 
         public MethodSignatureBuilder(MethodSignature template)
         {
@@ -324,7 +325,7 @@ namespace Internal.TypeSystem
             _genericParameterCount = template._genericParameterCount;
             _returnType = template._returnType;
             _parameters = template._parameters;
-            _customModifiers = template._embeddedSignatureData;
+            _embeddedSignatureData = template._embeddedSignatureData;
         }
 
         public MethodSignatureFlags Flags
@@ -371,15 +372,21 @@ namespace Internal.TypeSystem
             }
         }
 
+        public void SetEmbeddedSignatureData(EmbeddedSignatureData[] embeddedSignatureData)
+        {
+            _embeddedSignatureData = embeddedSignatureData;
+        }
+
         public MethodSignature ToSignature()
         {
             if (_template == null ||
                 _flags != _template._flags ||
                 _genericParameterCount != _template._genericParameterCount ||
                 _returnType != _template._returnType ||
-                _parameters != _template._parameters)
+                _parameters != _template._parameters ||
+                _embeddedSignatureData != _template._embeddedSignatureData)
             {
-                _template = new MethodSignature(_flags, _genericParameterCount, _returnType, _parameters, _customModifiers);
+                _template = new MethodSignature(_flags, _genericParameterCount, _returnType, _parameters, _embeddedSignatureData);
             }
 
             return _template;

--- a/src/coreclr/tools/Common/TypeSystem/Common/Properties/Resources.resx
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Properties/Resources.resx
@@ -156,9 +156,6 @@
   <data name="InvalidProgramCallVirtFinalize" xml:space="preserve">
     <value>Callvirt of '{0}' not supported</value>
   </data>
-  <data name="InvalidProgramUnmanagedCallersOnly" xml:space="preserve">
-    <value>UnmanagedCallersOnly method '{0}' cannot be called from managed code</value>
-  </data>
   <data name="InvalidProgramCallAbstractMethod" xml:space="preserve">
     <value>Direct call to abstract method '{0}' not allowed</value>
   </data>

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.Mangling.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.Mangling.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
+
 using Internal.TypeSystem;
 
 namespace Internal.IL.Stubs
@@ -20,7 +22,16 @@ namespace Internal.IL.Stubs
         {
             get
             {
-                return RuntimeMarshallingEnabled ? "CalliWithRuntimeMarshalling" : "Calli";
+                string prefix = RuntimeMarshallingEnabled ? "CalliWithRuntimeMarshalling" : "Calli";
+
+                // The target signature is expected to be normalized as MethodSignatureFlags.UnmanagedCallingConvention
+                Debug.Assert((_targetSignature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) == MethodSignatureFlags.UnmanagedCallingConvention);
+
+                // Append calling convention details to the prefix
+                if (_targetSignature.HasEmbeddedSignatureData)
+                    prefix += _targetSignature.GetStandaloneMethodSignatureCallingConventions().ToString("x");
+
+                return prefix;
             }
         }
     }

--- a/src/coreclr/tools/Common/TypeSystem/Interop/InteropStateManager.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/InteropStateManager.cs
@@ -188,7 +188,11 @@ namespace Internal.TypeSystem
 
         public MethodDesc GetPInvokeCalliStub(MethodSignature signature, ModuleDesc moduleContext)
         {
-            return _pInvokeCalliHashtable.GetOrCreateValue(new CalliMarshallingMethodThunkKey(signature, MarshalHelpers.IsRuntimeMarshallingEnabled(moduleContext)));
+            // Normalize calling convention details on the signature
+            var normalizedSignatureBuilder = new MethodSignatureBuilder(signature);
+            normalizedSignatureBuilder.Flags = (signature.Flags & MethodSignatureFlags.Static) | MethodSignatureFlags.UnmanagedCallingConvention;
+            normalizedSignatureBuilder.SetEmbeddedSignatureData(signature.GetStandaloneMethodSignatureCallingConventions().EncodeAsEmbeddedSignatureData(moduleContext.Context));
+            return _pInvokeCalliHashtable.GetOrCreateValue(new CalliMarshallingMethodThunkKey(normalizedSignatureBuilder.ToSignature(), MarshalHelpers.IsRuntimeMarshallingEnabled(moduleContext)));
         }
 
         private class NativeStructTypeHashtable : LockFreeReaderHashtable<MetadataType, NativeStructType>

--- a/src/coreclr/tools/Common/TypeSystem/Sorting/MethodSignature.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Sorting/MethodSignature.Sorting.cs
@@ -8,15 +8,15 @@ namespace Internal.TypeSystem
     {
         internal int CompareTo(MethodSignature other, TypeSystemComparer comparer)
         {
-            int result = _parameters.Length - other._parameters.Length;
+            int result = _parameters.Length.CompareTo(other._parameters.Length);
             if (result != 0)
                 return result;
 
-            result = (int)_flags - (int)other._flags;
+            result = ((int)_flags).CompareTo((int)other._flags);
             if (result != 0)
                 return result;
 
-            result = _genericParameterCount - other._genericParameterCount;
+            result = _genericParameterCount.CompareTo(other._genericParameterCount);
             if (result != 0)
                 return result;
 
@@ -30,10 +30,35 @@ namespace Internal.TypeSystem
             {
                 result = comparer.Compare(_parameters[i], other._parameters[i]);
                 if (result != 0)
-                    break;
+                    return result;
             }
 
-            return result;
+            if (_embeddedSignatureData == null || other._embeddedSignatureData == null)
+                return (_embeddedSignatureData?.Length ?? 0).CompareTo(other._embeddedSignatureData?.Length ?? 0);
+
+            result = _embeddedSignatureData.Length.CompareTo(other._embeddedSignatureData.Length);
+            if (result != 0)
+                return result;
+
+            for (int i = 0; i < _embeddedSignatureData.Length; i++)
+            {
+                ref EmbeddedSignatureData thisData = ref _embeddedSignatureData[i];
+                ref EmbeddedSignatureData otherData = ref other._embeddedSignatureData[i];
+
+                result = string.CompareOrdinal(thisData.index, otherData.index);
+                if (result != 0)
+                    return result;
+
+                result = ((int)thisData.kind).CompareTo((int)otherData.kind);
+                if (result != 0)
+                    return result;
+
+                result = comparer.Compare(thisData.type, otherData.type);
+                if (result != 0)
+                    return result;
+            }
+
+            return 0;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3929,6 +3929,9 @@
   <data name="InvalidProgram_CallVirtFinalize" xml:space="preserve">
     <value>Object.Finalize() can not be called directly. It is only callable by the runtime.</value>
   </data>
+  <data name="InvalidProgram_MultipleCallConv" xml:space="preserve">
+    <value>Multiple unmanaged calling conventions are specified. Only a single calling convention is supported.</value>
+  </data>
   <data name="Delegate_GarbageCollected" xml:space="preserve">
     <value>The corresponding delegate has been garbage collected. Please make sure the delegate is still referenced by managed code when you are using the marshalled native function pointer.</value>
   </data>

--- a/src/tests/baseservices/callconvs/TestCallingConventions.cs
+++ b/src/tests/baseservices/callconvs/TestCallingConventions.cs
@@ -30,9 +30,7 @@ unsafe class Program
 
         public static string GetFullPath()
         {
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            string directory = Path.GetDirectoryName(assembly.Location);
-            return Path.Combine(directory, GetFileName());
+            return Path.Combine(AppContext.BaseDirectory, GetFileName());
         }
     }
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -941,9 +941,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/DiamondShape/svm_diamondshape_r/*">
             <Issue>https://github.com/dotnet/runtime/issues/72589</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/callconvs/TestCallingConventions/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/153</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/RuntimeConfiguration/TestConfig/*">
             <Issue>Test expects being run with corerun</Issue>
         </ExcludeList>

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
@@ -309,6 +309,12 @@ namespace PInvokeTests
         [DllImport("PInvokeNative", CallingConvention = CallingConvention.StdCall)]
         internal static extern decimal DecimalTest(decimal value);
 
+        [UnmanagedCallersOnly]
+        internal unsafe static void UnmanagedMethod(byte* address, byte value) => *address = value;
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvStdcall)})]
+        internal unsafe static void StdcallMethod(byte* address, byte value) => *address = value;
+
         internal enum MagicEnum
         {
             MagicResult = 42,
@@ -337,6 +343,7 @@ namespace PInvokeTests
             TestWithoutPreserveSig();
             TestForwardDelegateWithUnmanagedCallersOnly();
             TestDecimal();
+            TestDifferentModopts();
 
             return 100;
         }
@@ -1108,6 +1115,37 @@ namespace PInvokeTests
             Console.WriteLine("Testing Forward Delegate with UnmanagedCallersOnly");
             Action a = Marshal.GetDelegateForFunctionPointer<Action>((IntPtr)(void*)(delegate* unmanaged<void>)&UnmanagedCallback);
             a();
+        }
+        
+        public static unsafe void TestDifferentModopts()
+        {
+            byte storage;
+
+            delegate* unmanaged<byte*, byte, void> unmanagedMethod = &UnmanagedMethod;
+
+            var outUnmanagedMethod = (delegate* unmanaged<out byte, byte, void>)unmanagedMethod;
+            outUnmanagedMethod(out storage, 12);
+            ThrowIfNotEquals(storage, 12, "Out unmanaged call failed.");
+
+            var refUnmanagedMethod = (delegate* unmanaged<ref byte, byte, void>)unmanagedMethod;
+            refUnmanagedMethod(ref storage, 34);
+            ThrowIfNotEquals(storage, 34, "Ref unmanaged call failed.");
+
+            delegate* unmanaged[Stdcall]<byte*, byte, void> stdcallMethod = &StdcallMethod;
+
+            var outStdcallMethod = (delegate* unmanaged[Stdcall]<out byte, byte, void>)stdcallMethod;
+            outStdcallMethod(out storage, 12);
+            ThrowIfNotEquals(storage, 12, "Out unmanaged stdcall failed.");
+
+            var refStdcallMethod = (delegate* unmanaged[Stdcall]<ref byte, byte, void>)stdcallMethod;
+            refStdcallMethod(ref storage, 34);
+            ThrowIfNotEquals(storage, 34, "Ref unmanaged stdcall failed.");
+            var refStdcallSuppressTransition = (delegate* unmanaged[Stdcall, SuppressGCTransition]<ref byte, byte, void>)stdcallMethod;
+            if (string.Empty.Length > 0)
+            {
+                // Do not actually call this because the calling convention is wrong. We just check the compiler didn't crash.
+                refStdcallSuppressTransition(ref storage, 56);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes dotnet/runtimelab#153