### PR TITLE
port SpanHelpers.IndexOf(ref byte, byte, int) to Vector128/256

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -442,7 +442,7 @@ namespace System
             nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
             nuint lengthToExamine = (nuint)(uint)length;
 
-            if (Sse2.IsSupported || AdvSimd.Arm64.IsSupported)
+            if (Vector128.IsHardwareAccelerated)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
@@ -508,10 +508,10 @@ namespace System
                 offset += 1;
             }
 
-            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true; and remain length is greater than Vector length.
+            // We get past SequentialScan only if IsHardwareAccelerated is true; and remain length is greater than Vector length.
             // However, we still have the redundant check to allow the JIT to see that the code is unreachable and eliminate it when the platform does not
             // have hardware accelerated. After processing Vector lengths we return to SequentialScan to finish any remaining.
-            if (Avx2.IsSupported)
+            if (Vector256.IsHardwareAccelerated)
             {
                 if (offset < (nuint)(uint)length)
                 {
@@ -522,10 +522,10 @@ namespace System
                         // Start with a check on Vector128 to align to Vector256, before moving to processing Vector256.
                         // This ensures we do not fault across memory pages while searching for an end of string.
                         Vector128<byte> values = Vector128.Create(value);
-                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+                        Vector128<byte> search = Vector128.LoadUnsafe(ref searchSpace, offset);
 
                         // Same method as below
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values, search));
+                        uint matches = Vector128.Equals(values, search).ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -544,8 +544,8 @@ namespace System
                         Vector256<byte> values = Vector256.Create(value);
                         do
                         {
-                            Vector256<byte> search = LoadVector256(ref searchSpace, offset);
-                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values, search));
+                            Vector256<byte> search = Vector256.LoadUnsafe(ref searchSpace, offset);
+                            uint matches = Vector256.Equals(values, search).ExtractMostSignificantBits();
                             // Note that MoveMask has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
                             if (matches == 0)
@@ -564,10 +564,10 @@ namespace System
                     if (lengthToExamine > offset)
                     {
                         Vector128<byte> values = Vector128.Create(value);
-                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+                        Vector128<byte> search = Vector128.LoadUnsafe(ref searchSpace, offset);
 
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values, search));
+                        uint matches = Vector128.Equals(values, search).ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -587,7 +587,7 @@ namespace System
                     }
                 }
             }
-            else if (Sse2.IsSupported)
+            else if (Vector128.IsHardwareAccelerated)
             {
                 if (offset < (nuint)(uint)length)
                 {
@@ -596,10 +596,10 @@ namespace System
                     Vector128<byte> values = Vector128.Create(value);
                     while (lengthToExamine > offset)
                     {
-                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+                        Vector128<byte> search = Vector128.LoadUnsafe(ref searchSpace, offset);
 
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values, search));
+                        uint matches = Vector128.Equals(values, search).ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -609,34 +609,6 @@ namespace System
 
                         // Find bitflag offset of first match and add to current offset
                         return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
-                    }
-
-                    if (offset < (nuint)(uint)length)
-                    {
-                        lengthToExamine = ((nuint)(uint)length - offset);
-                        goto SequentialScan;
-                    }
-                }
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                if (offset < (nuint)(uint)length)
-                {
-                    lengthToExamine = GetByteVector128SpanLength(offset, length);
-
-                    Vector128<byte> values = Vector128.Create(value);
-                    while (lengthToExamine > offset)
-                    {
-                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
-                        Vector128<byte> compareResult = AdvSimd.CompareEqual(values, search);
-
-                        if (compareResult == Vector128<byte>.Zero)
-                        {
-                            offset += (nuint)Vector128<byte>.Count;
-                            continue;
-                        }
-
-                        return (int)(offset + FindFirstMatchedLane(compareResult));
                     }
 
                     if (offset < (nuint)(uint)length)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -599,8 +599,8 @@ namespace System
                         Vector128<byte> search = Vector128.LoadUnsafe(ref searchSpace, offset);
 
                         // Same method as above
-                        uint matches = Vector128.Equals(values, search).ExtractMostSignificantBits();
-                        if (matches == 0)
+                        Vector128<byte> compareResult = Vector128.Equals(values, search);
+                        if (compareResult == Vector128<byte>.Zero)
                         {
                             // Zero flags set so no matches
                             offset += (nuint)Vector128<byte>.Count;
@@ -608,6 +608,7 @@ namespace System
                         }
 
                         // Find bitflag offset of first match and add to current offset
+                        uint matches = compareResult.ExtractMostSignificantBits();
                         return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
                     }
 


### PR DESCRIPTION
## x64

10% improvement for AVX2, no re regressions for AVX and no HI.

<details>

```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=Windows 11 (10.0.22000.795/21H2)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT AVX2
  Job-BJEYEU : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-KDQZPU : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX2
```

|       Method |        Job |             Toolchain | Size |     Mean | Ratio |
|------------- |----------- |---------------------- |----- |---------:|------:|
| IndexOfValue | Job-BJEYEU |       \PR\corerun.exe |  512 | 6.896 ns |  0.89 |
| IndexOfValue | Job-KDQZPU | \baseline\corerun.exe |  512 | 7.740 ns |  1.00 |


```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=Windows 11 (10.0.22000.795/21H2)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT AVX2
  Job-SUXHIF : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX
  Job-KVLSYC : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX

EnvironmentVariables=COMPlus_EnableAVX2=0
```

|       Method |        Job |             Toolchain | Size |     Mean | Ratio |
|------------- |----------- |---------------------- |----- |---------:|------:|
| IndexOfValue | Job-JAXEOB |       \PR\corerun.exe |  512 | 9.438 ns |  1.00 |
| IndexOfValue | Job-JLYYUT | \baseline\corerun.exe |  512 | 9.466 ns |  1.00 |


```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=Windows 11 (10.0.22000.795/21H2)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT AVX2
  Job-KLMBAP : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT
  Job-KSWPBM : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT

EnvironmentVariables=COMPlus_EnableHWIntrinsic=0
```

|       Method |        Job |             Toolchain | Size |     Mean | Ratio |
|------------- |----------- |---------------------- |----- |---------:|------:|
| IndexOfValue | Job-KLMBAP |       \PR\corerun.exe |  512 | 35.78 ns |  1.01 |
| IndexOfValue | Job-KSWPBM | \baseline\corerun.exe |  512 | 35.35 ns |  1.00 |

</details>

## arm64

The initial implementation got x2 perf hit, but after I've moved the call to `ExtractMostSignificantBits` to be performed only when a match is found, the perf is on par (see the second commit). 

BDN reports half a nanosecond difference, which translates to 2-3% and I think that we should just ignore it (it's within the range of error).

<details>

```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=ubuntu 20.04
Unknown processor
.NET SDK=7.0.100-rc.1.22403.8
  [Host]     : .NET 7.0.0 (7.0.22.40210), Arm64 RyuJIT AdvSIMD
  Job-SUFTPF : .NET 7.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD
  Job-WFBVQA : .NET 7.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD
```

|       Method |        Job |      Toolchain | Size |     Mean | Ratio |
|------------- |----------- |--------------- |----- |---------:|------:|
| IndexOfValue | Job-SUFTPF |    /PR/corerun |  512 | 20.06 ns |  0.97 |
| IndexOfValue | Job-WFBVQA |  /main/corerun |  512 | 20.78 ns |  1.00 |

</details>

contributes to #64451