### PR TITLE
port SpanHelpers.IndexOf(ref char, char, int) to Vector128/256

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -526,7 +526,7 @@ namespace System
             {
                 // Input isn't char aligned, we won't be able to align it to a Vector
             }
-            else if (Sse2.IsSupported || AdvSimd.Arm64.IsSupported)
+            else if (Vector128.IsHardwareAccelerated)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 // Needs to be double length to allow us to align the data first.
@@ -575,13 +575,14 @@ namespace System
                 lengthToExamine--;
             }
 
-            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true. However, we still have the redundant check to allow
+            // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
             // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
-            if (Avx2.IsSupported)
+            if (Vector256.IsHardwareAccelerated)
             {
                 if (offset < length)
                 {
                     Debug.Assert(length - offset >= Vector128<ushort>.Count);
+                    ref ushort ushortSearchSpace = ref Unsafe.As<char, ushort>(ref searchSpace);
                     if (((nint)Unsafe.AsPointer(ref Unsafe.Add(ref searchSpace, (nint)offset)) & (nint)(Vector256<byte>.Count - 1)) != 0)
                     {
                         // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
@@ -600,10 +601,10 @@ namespace System
                         // the misalignment that may occur after; to we default to giving the GC a free hand to relocate and
                         // its up to the caller whether they are operating over fixed data.
                         Vector128<ushort> values = Vector128.Create((ushort)value);
-                        Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+                        Vector128<ushort> search = Vector128.LoadUnsafe(ref ushortSearchSpace, (nuint)offset);
 
                         // Same method as below
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values, search).AsByte());
+                        uint matches = Vector128.Equals(values, search).AsByte().ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -624,8 +625,8 @@ namespace System
                         {
                             Debug.Assert(lengthToExamine >= Vector256<ushort>.Count);
 
-                            Vector256<ushort> search = LoadVector256(ref searchSpace, offset);
-                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values, search).AsByte());
+                            Vector256<ushort> search = Vector256.LoadUnsafe(ref ushortSearchSpace, (nuint)offset);
+                            uint matches = Vector256.Equals(values, search).AsByte().ExtractMostSignificantBits();
                             // Note that MoveMask has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
                             if (matches == 0)
@@ -648,10 +649,10 @@ namespace System
                         Debug.Assert(lengthToExamine >= Vector128<ushort>.Count);
 
                         Vector128<ushort> values = Vector128.Create((ushort)value);
-                        Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+                        Vector128<ushort> search = Vector128.LoadUnsafe(ref ushortSearchSpace, (nuint)offset);
 
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values, search).AsByte());
+                        uint matches = Vector128.Equals(values, search).AsByte().ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -673,11 +674,12 @@ namespace System
                     }
                 }
             }
-            else if (Sse2.IsSupported)
+            else if (Vector128.IsHardwareAccelerated)
             {
                 if (offset < length)
                 {
                     Debug.Assert(length - offset >= Vector128<ushort>.Count);
+                    ref ushort ushortSearchSpace = ref Unsafe.As<char, ushort>(ref searchSpace);
 
                     lengthToExamine = GetCharVector128SpanLength(offset, length);
                     if (lengthToExamine > 0)
@@ -687,11 +689,11 @@ namespace System
                         {
                             Debug.Assert(lengthToExamine >= Vector128<ushort>.Count);
 
-                            Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+                            Vector128<ushort> search = Vector128.LoadUnsafe(ref ushortSearchSpace, (uint)offset);
 
                             // Same method as above
-                            int matches = Sse2.MoveMask(Sse2.CompareEqual(values, search).AsByte());
-                            if (matches == 0)
+                            Vector128<ushort> compareResult = Vector128.Equals(values, search);
+                            if (compareResult == Vector128<ushort>.Zero)
                             {
                                 // Zero flags set so no matches
                                 offset += Vector128<ushort>.Count;
@@ -701,42 +703,8 @@ namespace System
 
                             // Find bitflag offset of first match and add to current offset,
                             // flags are in bytes so divide for chars
+                            uint matches = compareResult.AsByte().ExtractMostSignificantBits();
                             return (int)(offset + ((uint)BitOperations.TrailingZeroCount(matches) / sizeof(char)));
-                        } while (lengthToExamine > 0);
-                    }
-
-                    if (offset < length)
-                    {
-                        lengthToExamine = length - offset;
-                        goto SequentialScan;
-                    }
-                }
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                if (offset < length)
-                {
-                    Debug.Assert(length - offset >= Vector128<ushort>.Count);
-
-                    lengthToExamine = GetCharVector128SpanLength(offset, length);
-                    if (lengthToExamine > 0)
-                    {
-                        Vector128<ushort> values = Vector128.Create((ushort)value);
-                        do
-                        {
-                            Debug.Assert(lengthToExamine >= Vector128<ushort>.Count);
-
-                            Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
-                            Vector128<ushort> compareResult = AdvSimd.CompareEqual(values, search);
-
-                            if (compareResult == Vector128<ushort>.Zero)
-                            {
-                                offset += Vector128<ushort>.Count;
-                                lengthToExamine -= Vector128<ushort>.Count;
-                                continue;
-                            }
-
-                            return (int)(offset + FindFirstMatchedLane(compareResult));
                         } while (lengthToExamine > 0);
                     }
 


### PR DESCRIPTION
## x64

**Update:** The performance has not regressed, we can observe gains for both AMD and Intel, but I am afraid that they are caused by code alignment changes.

<details>

```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=Windows 11 (10.0.22000.795/21H2)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT AVX2
  Job-JFJYAP : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-ONLITS : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX2
```

|       Method |             Toolchain | Size |      Mean | Ratio |
|------------- |---------------------- |----- |----------:|------:|
| IndexOfValue |       \PR\corerun.exe |  512 |  9.984 ns |  0.74 |
| IndexOfValue | \baseline\corerun.exe |  512 | 13.563 ns |  1.00 |

```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=Windows 10 (10.0.18363.2212/1909/November2019Update/19H2)                                                                         
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores                                                                                                  
.NET SDK=7.0.100-rc.1.22403.8                                                                                                                                              
  [Host]     : .NET 7.0.0 (7.0.22.40210), X64 RyuJIT AVX2                                                                                                                  
  Job-AKDWNL : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX2                                                                                                                
  Job-LOZHUC : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX2                                                                                                                
                                                                                                                                                                           
LaunchCount=9                                                                               
```
                                                                                                                                                                           
|       Method |             Toolchain | Size |     Mean | Ratio | 
|------------- |---------------------- |----- |---------:|------:| 
| IndexOfValue |       \PR\corerun.exe |  512 | 12.30 ns |  0.92 | 
| IndexOfValue | \baseline\corerun.exe |  512 | 13.34 ns |  1.00 | 

```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=Windows 11 (10.0.22000.795/21H2)
AMD Ryzen Threadripper PRO 3945WX 12-Cores, 1 CPU, 24 logical and 12 physical cores
.NET SDK=7.0.100-preview.6.22352.1
  [Host]     : .NET 7.0.0 (7.0.22.32404), X64 RyuJIT AVX2
  Job-KVCIYU : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX
  Job-QAYATX : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT AVX

EnvironmentVariables=COMPlus_EnableAVX2=0
```

|       Method |             Toolchain | Size |     Mean | Ratio |
|------------- |---------------------- |----- |---------:|------:|
| IndexOfValue |       \PR\corerun.exe |  512 | 15.58 ns |  0.95 |
| IndexOfValue | \baseline\corerun.exe |  512 | 16.38 ns |  1.00 |

</details>

## arm64

Perf on par.

<details>

```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=ubuntu 20.04
Unknown processor
.NET SDK=7.0.100-rc.1.22403.8
  [Host]     : .NET 7.0.0 (7.0.22.40210), Arm64 RyuJIT AdvSIMD
  Job-BEMTXA : .NET 7.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD
  Job-MKFBYT : .NET 7.0.0 (42.42.42.42424), Arm64 RyuJIT AdvSIMD
```

|       Method |      Toolchain | Size |     Mean | Ratio |
|------------- |--------------- |----- |---------:|------:|
| IndexOfValue |    /PR/corerun |  512 | 43.13 ns |  1.00 |
| IndexOfValue |  /main/corerun |  512 | 43.10 ns |  1.00 |

</details>

contributes to https://github.com/dotnet/runtime/issues/64451