### PR TITLE
Fix performance regression introduced in object deserialization

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -216,6 +216,20 @@ namespace System.Text.Json.Serialization
             bool isContinuation = state.IsContinuation;
             bool success;
 
+            if (
+#if NETCOREAPP
+                !typeof(T).IsValueType &&
+#endif
+                CanBePolymorphic)
+            {
+                // Special case object converters since they don't
+                // require the expensive ReadStack.Push()/Pop() operations.
+                Debug.Assert(this is ObjectConverter);
+                success = OnTryRead(ref reader, typeToConvert, options, ref state, out value);
+                Debug.Assert(success);
+                return true;
+            }
+
 #if DEBUG
             // DEBUG: ensure push/pop operations preserve stack integrity
             JsonTypeInfo originalJsonTypeInfo = state.Current.JsonTypeInfo;


### PR DESCRIPTION
Special cases deserialization for the built-in object converter so that it avoids making expensive `ReadStack.Push()/Pop()` calls.

|                   Method |        Job |                                                                                                          Toolchain |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | MannWhitney(3%) |  Gen 0 |  Gen 1 | Allocated | Alloc Ratio |
|------------------------- |----------- |------------------------------------------------------------------------------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|---------------- |-------:|-------:|----------:|------------:|
| DeserializeFromUtf8Bytes | Job-QKIRBU |  main | 43.18 us | 0.768 us | 0.681 us | 43.27 us | 41.77 us | 43.88 us |  1.00 |            Base | 4.0761 | 0.8492 |  40.36 KB |        1.00 |
| DeserializeFromUtf8Bytes | Job-XPCOIK | PR | 35.05 us | 0.570 us | 0.476 us | 35.04 us | 33.94 us | 35.92 us |  0.81 |          Faster | 4.0367 | 0.9744 |  39.93 KB |        0.99 |

Fixes performance regression introduced by https://github.com/dotnet/runtime/pull/65748. Fix #66341.