### PR TITLE
Apply some obvious rich debug info optimizations

### DIFF
--- a/src/coreclr/inc/eventtracebase.h
+++ b/src/coreclr/inc/eventtracebase.h
@@ -690,7 +690,11 @@ class CrstBase;
 class BulkTypeEventLogger;
 class TypeHandle;
 class Thread;
-
+template<typename ELEMENT, typename TRAITS>
+class SetSHash;
+template<typename ELEMENT>
+class PtrSetSHashTraits;
+typedef SetSHash<MethodDesc*, PtrSetSHashTraits<MethodDesc*>> MethodDescSet;
 
 // All ETW helpers must be a part of this namespace
 // We have auto-generated macros to directly fire the events
@@ -903,8 +907,8 @@ namespace ETW
         static VOID SendEventsForNgenMethods(Module *pModule, DWORD dwEventOptions);
         static VOID SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
         static VOID SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, PCODE pNativeCodeStartAddress, DWORD nativeCodeId, ReJITID ilCodeId);
-        static VOID SendMethodRichDebugInfo(MethodDesc * pMethodDesc, PCODE pNativeCodeStartAddress, DWORD nativeCodeId, ReJITID ilCodeId);
-        static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, PCODE pNativeCodeStartAddress = 0, PrepareCodeConfig *pConfig = NULL);
+        static VOID SendMethodRichDebugInfo(MethodDesc * pMethodDesc, PCODE pNativeCodeStartAddress, DWORD nativeCodeId, ReJITID ilCodeId, MethodDescSet* sentMethodDetailsSet);
+        static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, PCODE pNativeCodeStartAddress = 0, PrepareCodeConfig *pConfig = NULL, MethodDescSet* sentMethodDetailsSet = NULL);
         static VOID SendHelperEvent(ULONGLONG ullHelperStartAddress, ULONG ulHelperSize, LPCWSTR pHelperName);
     public:
         typedef union _MethodStructs
@@ -937,6 +941,7 @@ namespace ETW
         static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature);
         static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig);
         static VOID SendMethodDetailsEvent(MethodDesc *pMethodDesc);
+        static VOID SendNonDuplicateMethodDetailsEvent(MethodDesc* pMethodDesc, MethodDescSet* set);
         static VOID StubInitialized(ULONGLONG ullHelperStartAddress, LPCWSTR pHelperName);
         static VOID StubsInitialized(PVOID *pHelperStartAddress, PVOID *pHelperNames, LONG ulNoOfHelpers);
         static VOID MethodRestored(MethodDesc * pMethodDesc);

--- a/src/coreclr/inc/nibblestream.h
+++ b/src/coreclr/inc/nibblestream.h
@@ -159,6 +159,22 @@ public:
         WriteEncodedU32(dw);
     };
 
+    void WriteUnencodedU32(uint32_t x)
+    {
+        CONTRACTL
+        {
+            THROWS;
+            GC_NOTRIGGER;
+        }
+        CONTRACTL_END;
+
+        for (int i = 0; i < 8; i++)
+        {
+            WriteNibble(static_cast<NIBBLE>(x & 0b1111));
+            x >>= 4;
+        }
+    }
+
 protected:
     NIBBLE m_PendingNibble;     // Pending value, not yet written out.
     bool m_fPending;
@@ -286,6 +302,18 @@ public:
         DWORD dw = ReadEncodedU32();
         int x = dw >> 1;
         return (dw & 1) ? (-x) : (x);
+    }
+
+    DWORD ReadUnencodedU32()
+    {
+        DWORD result = 0;
+
+        for (int i = 0; i < 8; i++)
+        {
+            result |= ReadNibble() << (i * 4);
+        }
+
+        return result;
     }
 
 protected:

--- a/src/coreclr/inc/nibblestream.h
+++ b/src/coreclr/inc/nibblestream.h
@@ -310,7 +310,7 @@ public:
 
         for (int i = 0; i < 8; i++)
         {
-            result |= ReadNibble() << (i * 4);
+            result |= static_cast<DWORD>(ReadNibble()) << (i * 4);
         }
 
         return result;

--- a/src/coreclr/inc/nibblestream.h
+++ b/src/coreclr/inc/nibblestream.h
@@ -306,6 +306,14 @@ public:
 
     DWORD ReadUnencodedU32()
     {
+        CONTRACTL
+        {
+            THROWS;
+            GC_NOTRIGGER;
+            SUPPORTS_DAC;
+        }
+        CONTRACTL_END;
+
         DWORD result = 0;
 
         for (int i = 0; i < 8; i++)

--- a/src/coreclr/vm/debuginfostore.cpp
+++ b/src/coreclr/vm/debuginfostore.cpp
@@ -113,6 +113,20 @@ public:
 #endif
     }
 
+    void DoMethodHandle(CORINFO_METHOD_HANDLE p)
+    {
+        uintptr_t up = reinterpret_cast<uintptr_t>(p);
+        if (sizeof(CORINFO_METHOD_HANDLE) == 4)
+        {
+            m_w.WriteUnencodedU32(static_cast<uint32_t>(up));
+        }
+        else
+        {
+            m_w.WriteUnencodedU32(static_cast<uint32_t>(up));
+            m_w.WriteUnencodedU32(static_cast<uint32_t>(up >> 32));
+        }
+    }
+
 protected:
     NibbleWriter & m_w;
 
@@ -189,6 +203,21 @@ public:
         reg = (ICorDebugInfo::RegNum) m_r.ReadEncodedU32();
     }
 
+    void DoMethodHandle(CORINFO_METHOD_HANDLE& p)
+    {
+        if (sizeof(CORINFO_METHOD_HANDLE) == 4)
+        {
+            uint32_t val = m_r.ReadUnencodedU32();
+            p = reinterpret_cast<CORINFO_METHOD_HANDLE>(static_cast<uintptr_t>(val));
+        }
+        else
+        {
+            uint32_t lo = m_r.ReadUnencodedU32();
+            uint32_t hi = m_r.ReadUnencodedU32();
+            p = reinterpret_cast<CORINFO_METHOD_HANDLE>(uintptr_t(lo) | (uintptr_t(hi) << 32));
+        }
+    }
+
     // For debugging purposes, inject cookies into the Compression.
     void DoCookie(BYTE b)
     {
@@ -217,13 +246,16 @@ static int g_CDI_bMethodTotalCompress   = 0;
 
 static int g_CDI_bVarsTotalUncompress   = 0;
 static int g_CDI_bVarsTotalCompress     = 0;
+
+static int g_CDI_bRichDebugInfoTotalUncompress = 0;
+static int g_CDI_bRichDebugInfoTotalCompress = 0;
 #endif
 
 //-----------------------------------------------------------------------------
 // Serialize Bounds info.
 //-----------------------------------------------------------------------------
 template <class T>
-void DoBounds(
+static void DoBounds(
     T trans, // transfer object.
     ULONG32                       cMap,
     ICorDebugInfo::OffsetMapping *pMap
@@ -267,7 +299,7 @@ void DoBounds(
 
 // Helper to write a compressed Native Var Info
 template<class T>
-void DoNativeVarInfo(
+static void DoNativeVarInfo(
     T trans,
     ICorDebugInfo::NativeVarInfo * pVar
 )
@@ -352,6 +384,56 @@ void DoNativeVarInfo(
 
 
     trans.DoCookie(0xC);
+}
+
+template<typename T>
+static void DoInlineTreeNodes(
+    T trans,
+    ULONG32 cNodes,
+    ICorDebugInfo::InlineTreeNode* nodes)
+{
+    uint32_t lastChildIndex = 0;
+    uint32_t lastSiblingIndex = 0;
+
+    for (uint32_t i = 0; i < cNodes; i++)
+    {
+        ICorDebugInfo::InlineTreeNode* node = &nodes[i];
+
+        trans.DoMethodHandle(node->Method);
+
+        trans.DoEncodedAdjustedU32(node->ILOffset, (DWORD) ICorDebugInfo::MAX_MAPPING_VALUE);
+
+        trans.DoEncodedDeltaU32(node->Child, lastChildIndex);
+        lastChildIndex = node->Child;
+
+        trans.DoEncodedDeltaU32(node->Sibling, lastSiblingIndex);
+        lastSiblingIndex = node->Sibling;
+    }
+}
+
+template<typename T>
+static void DoRichOffsetMappings(
+    T trans,
+    ULONG32 cMappings,
+    ICorDebugInfo::RichOffsetMapping* mappings)
+{
+    // Loop through and transfer each Entry in the Mapping.
+    uint32_t lastNativeOffset = 0;
+    uint32_t lastInlinee = 0;
+    for (uint32_t i = 0; i < cMappings; i++)
+    {
+        ICorDebugInfo::RichOffsetMapping* mapping = &mappings[i];
+
+        trans.DoEncodedDeltaU32(mapping->NativeOffset, lastNativeOffset);
+        lastNativeOffset = mapping->NativeOffset;
+
+        trans.DoEncodedDeltaU32(mapping->Inlinee, lastInlinee);
+        lastInlinee = mapping->Inlinee;
+
+        trans.DoEncodedAdjustedU32(mapping->ILOffset, (DWORD)ICorDebugInfo::MAX_MAPPING_VALUE);
+
+        trans.DoEncodedSourceType(mapping->Source);
+    }
 }
 
 enum EXTRA_DEBUG_INFO_FLAGS
@@ -441,6 +523,41 @@ void CompressDebugInfo::CompressVars(
 #endif
 }
 
+void CompressDebugInfo::CompressRichDebugInfo(
+    IN ULONG32                           cInlineTree,
+    IN ICorDebugInfo::InlineTreeNode*    pInlineTree,
+    IN ULONG32                           cRichOffsetMappings,
+    IN ICorDebugInfo::RichOffsetMapping* pRichOffsetMappings,
+    IN OUT NibbleWriter*                 pWriter)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    _ASSERTE(pWriter != NULL);
+    _ASSERTE((cInlineTree > 0) || (cRichOffsetMappings > 0));
+    pWriter->WriteEncodedU32(cInlineTree);
+    pWriter->WriteEncodedU32(cRichOffsetMappings);
+
+    TransferWriter t(*pWriter);
+    DoInlineTreeNodes(t, cInlineTree, pInlineTree);
+    DoRichOffsetMappings(t, cRichOffsetMappings, pRichOffsetMappings);
+
+    pWriter->Flush();
+
+#ifdef _DEBUG
+    DWORD cbBlob;
+    PVOID pBlob = pWriter->GetBlob(&cbBlob);
+
+    g_CDI_bRichDebugInfoTotalUncompress += 8 + cInlineTree * sizeof(ICorDebugInfo::InlineTreeNode) + cRichOffsetMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
+    g_CDI_bRichDebugInfoTotalCompress   += 4 + cbBlob;
+#endif
+}
+
 PTR_BYTE CompressDebugInfo::CompressBoundariesAndVars(
     IN ICorDebugInfo::OffsetMapping*     pOffsetMapping,
     IN ULONG                             iOffsetMapping,
@@ -477,16 +594,6 @@ PTR_BYTE CompressDebugInfo::CompressBoundariesAndVars(
     _ASSERTE(patchpointInfo == NULL);
 #endif
 
-    DWORD cbRichDebugInfo = 0;
-    if ((iInlineTree > 0) || (iRichOffsetMappings > 0))
-    {
-        // Lengths
-        cbRichDebugInfo += 8;
-        // Data
-        cbRichDebugInfo += iInlineTree * sizeof(ICorDebugInfo::InlineTreeNode);
-        cbRichDebugInfo += iRichOffsetMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
-    }
-
     // Actually do the compression. These will throw on oom.
     NibbleWriter boundsBuffer;
     DWORD cbBounds = 0;
@@ -506,6 +613,15 @@ PTR_BYTE CompressDebugInfo::CompressBoundariesAndVars(
         pVars = varsBuffer.GetBlob(&cbVars);
     }
 
+    NibbleWriter richDebugInfoBuffer;
+    DWORD cbRichDebugInfo = 0;
+    PVOID pRichDebugInfo = NULL;
+    if ((iInlineTree > 0) || (iRichOffsetMappings > 0))
+    {
+        CompressDebugInfo::CompressRichDebugInfo(iInlineTree, pInlineTree, iRichOffsetMappings, pRichOffsetMappings, &richDebugInfoBuffer);
+        pRichDebugInfo = richDebugInfoBuffer.GetBlob(&cbRichDebugInfo);
+    }
+
     // Now write it all out to the buffer in a compact fashion.
     NibbleWriter w;
     w.WriteEncodedU32(cbBounds);
@@ -520,7 +636,7 @@ PTR_BYTE CompressDebugInfo::CompressBoundariesAndVars(
         cbFinalSize += 1;
 
     cbFinalSize += cbPatchpointInfo;
-    cbFinalSize += cbRichDebugInfo;
+    cbFinalSize += S_UINT32(4) + S_UINT32(cbRichDebugInfo);
     cbFinalSize += S_UINT32(cbHeader) + S_UINT32(cbBounds) + S_UINT32(cbVars);
 
     if (cbFinalSize.IsOverflow())
@@ -545,14 +661,10 @@ PTR_BYTE CompressDebugInfo::CompressBoundariesAndVars(
 
     if (cbRichDebugInfo > 0)
     {
-        memcpy(ptr, &iInlineTree, 4);
+        memcpy(ptr, &cbRichDebugInfo, 4);
         ptr += 4;
-        memcpy(ptr, &iRichOffsetMappings, 4);
-        ptr += 4;
-        memcpy(ptr, pInlineTree, iInlineTree * sizeof(ICorDebugInfo::InlineTreeNode));
-        ptr += iInlineTree * sizeof(ICorDebugInfo::InlineTreeNode);
-        memcpy(ptr, pRichOffsetMappings, iRichOffsetMappings * sizeof(ICorDebugInfo::RichOffsetMapping));
-        ptr += iRichOffsetMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
+        memcpy(ptr, pRichDebugInfo, cbRichDebugInfo);
+        ptr += cbRichDebugInfo;
     }
 
     memcpy(ptr, pHeader, cbHeader);
@@ -613,12 +725,9 @@ void CompressDebugInfo::RestoreBoundariesAndVars(
 
         if ((flagByte & EXTRA_DEBUG_INFO_RICH) != 0)
         {
-            UINT32 iInlineTree = *PTR_UINT32(pDebugInfo);
+            UINT32 cbRichDebugInfo = *PTR_UINT32(pDebugInfo);
             pDebugInfo += 4;
-            UINT32 iRichMappings = *PTR_UINT32(pDebugInfo);
-            pDebugInfo += 4;
-            pDebugInfo += iInlineTree * sizeof(ICorDebugInfo::InlineTreeNode);
-            pDebugInfo += iRichMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
+            pDebugInfo += cbRichDebugInfo;
             flagByte &= ~EXTRA_DEBUG_INFO_RICH;
         }
 
@@ -750,26 +859,26 @@ void CompressDebugInfo::RestoreRichDebugInfo(
     }
 #endif
 
-    *pNumInlineTree = *PTR_UINT32(pDebugInfo);
+    UINT32 cbRichDebugInfo = *PTR_UINT32(pDebugInfo);
+    pDebugInfo += 4;
+    NibbleReader r(pDebugInfo, cbRichDebugInfo);
+
+    *pNumInlineTree = r.ReadEncodedU32();
+    *pNumRichMappings = r.ReadEncodedU32();
+
     UINT32 cbInlineTree = *pNumInlineTree * sizeof(ICorDebugInfo::InlineTreeNode);
-    pDebugInfo += 4;
-
-    *pNumRichMappings = *PTR_UINT32(pDebugInfo);
-    UINT32 cbRichOffsetMappings = *pNumRichMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
-    pDebugInfo += 4;
-
     *ppInlineTree = reinterpret_cast<ICorDebugInfo::InlineTreeNode*>(fpNew(pNewData, cbInlineTree));
     if (*ppInlineTree == NULL)
         ThrowOutOfMemory();
 
-    memcpy(*ppInlineTree, PTR_READ(dac_cast<TADDR>(pDebugInfo), cbInlineTree), cbInlineTree);
-    pDebugInfo += cbInlineTree;
-
+    UINT32 cbRichOffsetMappings = *pNumRichMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
     *ppRichMappings = reinterpret_cast<ICorDebugInfo::RichOffsetMapping*>(fpNew(pNewData, cbRichOffsetMappings));
     if (*ppRichMappings == NULL)
         ThrowOutOfMemory();
 
-    memcpy(*ppRichMappings, PTR_READ(dac_cast<TADDR>(pDebugInfo), cbRichOffsetMappings), cbRichOffsetMappings);
+    TransferReader t(r);
+    DoInlineTreeNodes(t, *pNumInlineTree, *ppInlineTree);
+    DoRichOffsetMappings(t, *pNumRichMappings, *ppRichMappings);
 }
 
 #ifdef DACCESS_COMPILE
@@ -800,12 +909,9 @@ void CompressDebugInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags, PTR_BYTE
 
         if ((flagByte & EXTRA_DEBUG_INFO_RICH) != 0)
         {
-            UINT32 iInlineTree = *PTR_UINT32(pDebugInfo);
+            UINT32 cbRichDebugInfo = *PTR_UINT32(pDebugInfo);
             pDebugInfo += 4;
-            UINT32 iRichMappings = *PTR_UINT32(pDebugInfo);
-            pDebugInfo += 4;
-            pDebugInfo += iInlineTree * sizeof(ICorDebugInfo::InlineTreeNode);
-            pDebugInfo += iRichMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
+            pDebugInfo += cbRichDebugInfo;
             flagByte &= ~EXTRA_DEBUG_INFO_RICH;
         }
 

--- a/src/coreclr/vm/debuginfostore.cpp
+++ b/src/coreclr/vm/debuginfostore.cpp
@@ -116,15 +116,13 @@ public:
     void DoMethodHandle(CORINFO_METHOD_HANDLE p)
     {
         uintptr_t up = reinterpret_cast<uintptr_t>(p);
-        if (sizeof(CORINFO_METHOD_HANDLE) == 4)
-        {
-            m_w.WriteUnencodedU32(static_cast<uint32_t>(up));
-        }
-        else
-        {
-            m_w.WriteUnencodedU32(static_cast<uint32_t>(up));
-            m_w.WriteUnencodedU32(static_cast<uint32_t>(up >> 32));
-        }
+
+#ifdef TARGET_64BIT
+        m_w.WriteUnencodedU32(static_cast<uint32_t>(up));
+        m_w.WriteUnencodedU32(static_cast<uint32_t>(up >> 32));
+#else
+        m_w.WriteUnencodedU32(static_cast<uint32_t>(up));
+#endif
     }
 
 protected:
@@ -205,17 +203,14 @@ public:
 
     void DoMethodHandle(CORINFO_METHOD_HANDLE& p)
     {
-        if (sizeof(CORINFO_METHOD_HANDLE) == 4)
-        {
-            uint32_t val = m_r.ReadUnencodedU32();
-            p = reinterpret_cast<CORINFO_METHOD_HANDLE>(static_cast<uintptr_t>(val));
-        }
-        else
-        {
-            uint32_t lo = m_r.ReadUnencodedU32();
-            uint32_t hi = m_r.ReadUnencodedU32();
-            p = reinterpret_cast<CORINFO_METHOD_HANDLE>(uintptr_t(lo) | (uintptr_t(hi) << 32));
-        }
+#ifdef TARGET_64BIT
+        uint32_t lo = m_r.ReadUnencodedU32();
+        uint32_t hi = m_r.ReadUnencodedU32();
+        p = reinterpret_cast<CORINFO_METHOD_HANDLE>(uintptr_t(lo) | (uintptr_t(hi) << 32));
+#else
+        uint32_t val = m_r.ReadUnencodedU32();
+        p = reinterpret_cast<CORINFO_METHOD_HANDLE>(static_cast<uintptr_t>(val));
+#endif
     }
 
     // For debugging purposes, inject cookies into the Compression.

--- a/src/coreclr/vm/debuginfostore.cpp
+++ b/src/coreclr/vm/debuginfostore.cpp
@@ -407,6 +407,7 @@ static void DoInlineTreeNodes(
     ULONG32 cNodes,
     ICorDebugInfo::InlineTreeNode* nodes)
 {
+    uint32_t lastILOffset = static_cast<uint32_t>(ICorDebugInfo::PROLOG);
     uint32_t lastChildIndex = 0;
     uint32_t lastSiblingIndex = 0;
 
@@ -416,7 +417,8 @@ static void DoInlineTreeNodes(
 
         trans.DoMethodHandle(node->Method);
 
-        trans.DoEncodedAdjustedU32(node->ILOffset, (DWORD) ICorDebugInfo::MAX_MAPPING_VALUE);
+        trans.DoEncodedDeltaU32NonMonotonic(node->ILOffset, lastILOffset);
+        lastILOffset = node->ILOffset;
 
         trans.DoEncodedDeltaU32NonMonotonic(node->Child, lastChildIndex);
         lastChildIndex = node->Child;
@@ -435,6 +437,7 @@ static void DoRichOffsetMappings(
     // Loop through and transfer each Entry in the Mapping.
     uint32_t lastNativeOffset = 0;
     uint32_t lastInlinee = 0;
+    uint32_t lastILOffset = static_cast<uint32_t>(ICorDebugInfo::PROLOG);
     for (uint32_t i = 0; i < cMappings; i++)
     {
         ICorDebugInfo::RichOffsetMapping* mapping = &mappings[i];
@@ -445,7 +448,8 @@ static void DoRichOffsetMappings(
         trans.DoEncodedDeltaU32NonMonotonic(mapping->Inlinee, lastInlinee);
         lastInlinee = mapping->Inlinee;
 
-        trans.DoEncodedAdjustedU32(mapping->ILOffset, (DWORD)ICorDebugInfo::MAX_MAPPING_VALUE);
+        trans.DoEncodedDeltaU32NonMonotonic(mapping->ILOffset, lastILOffset);
+        lastILOffset = mapping->ILOffset;
 
         trans.DoEncodedSourceType(mapping->Source);
     }

--- a/src/coreclr/vm/debuginfostore.h
+++ b/src/coreclr/vm/debuginfostore.h
@@ -62,7 +62,6 @@ typedef BYTE* (*FP_IDS_NEW)(void * pData, size_t cBytes);
 //-----------------------------------------------------------------------------
 class CompressDebugInfo
 {
-public:
     // Compress incoming data and write it to the provided NibbleWriter.
     static void CompressBoundaries(
         IN ULONG32                       cMap,
@@ -76,6 +75,14 @@ public:
         IN OUT NibbleWriter * pBuffer
     );
 
+    static void CompressRichDebugInfo(
+        IN ULONG32                           cInlineTree,
+        IN ICorDebugInfo::InlineTreeNode*    pInlineTree,
+        IN ULONG32                           cRichOffsetMappings,
+        IN ICorDebugInfo::RichOffsetMapping* pRichOffsetMappings,
+        IN OUT NibbleWriter*                 pWriter);
+
+public:
     // Stores the result in LoaderHeap
     static PTR_BYTE CompressBoundariesAndVars(
         IN ICorDebugInfo::OffsetMapping * pOffsetMapping,
@@ -91,7 +98,6 @@ public:
         IN LoaderHeap     * pLoaderHeap
     );
 
-public:
     // Uncompress data supplied by Compress functions.
     static void RestoreBoundariesAndVars(
         IN FP_IDS_NEW fpNew, IN void * pNewData,

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -6957,6 +6957,13 @@ VOID ETW::MethodLog::SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWOR
         FireEtwMethodDCEndILToNativeMap_V1(ullMethodIdentifier, nativeCodeId, 0, cMap, rguiILOffset, rguiNativeOffset, GetClrInstanceId(), ilCodeId);
 }
 
+template<typename T>
+static void WriteToBuffer(BYTE** pBuffer, const T& val)
+{
+    memcpy(*pBuffer, &val, sizeof(T));
+    *pBuffer += sizeof(T);
+}
+
 VOID ETW::MethodLog::SendMethodRichDebugInfo(MethodDesc* pMethodDesc, PCODE pNativeCodeStartAddress, DWORD nativeCodeId, ReJITID ilCodeId, MethodDescSet* sentMethodDetailsSet)
 {
     CONTRACTL
@@ -6986,20 +6993,48 @@ VOID ETW::MethodLog::SendMethodRichDebugInfo(MethodDesc* pMethodDesc, PCODE pNat
     ULONG32 numMappings = 0;
     if (DebugInfoManager::GetRichDebugInfo(request, fpNew, NULL, &inlineTree, &numInlineTree, &mappings, &numMappings))
     {
-        unsigned dataSize = 8 + numInlineTree * sizeof(ICorDebugInfo::InlineTreeNode) + numMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
+        static_assert_no_msg((std::is_same<decltype(inlineTree->Method), CORINFO_METHOD_HANDLE>::value));
+        static_assert_no_msg((std::is_same<decltype(inlineTree->ILOffset), uint32_t>::value));
+        static_assert_no_msg((std::is_same<decltype(inlineTree->Child), uint32_t>::value));
+        static_assert_no_msg((std::is_same<decltype(inlineTree->Sibling), uint32_t>::value));
+
+        static_assert_no_msg((std::is_same<decltype(mappings->ILOffset), uint32_t>::value));
+        static_assert_no_msg((std::is_same<decltype(mappings->Inlinee), uint32_t>::value));
+        static_assert_no_msg((std::is_same<decltype(mappings->NativeOffset), uint32_t>::value));
+
+        const uint32_t inlineTreeNodeDataSize =
+            sizeof(CORINFO_METHOD_HANDLE) +
+            sizeof(uint32_t) * 3;
+
+        const uint32_t richOffsetMappingDataSize =
+            sizeof(uint32_t) * 3 +
+            1; // source type
+
+        unsigned dataSize = 8 + numInlineTree * inlineTreeNodeDataSize + numMappings * richOffsetMappingDataSize;
 
         InlineSBuffer<1024> buffer;
         buffer.Preallocate(dataSize);
 
         BYTE* pBuffer = &buffer[0];
-        memcpy(pBuffer, &numInlineTree, 4);
-        pBuffer += 4;
-        memcpy(pBuffer, &numMappings, 4);
-        pBuffer += 4;
-        memcpy(pBuffer, inlineTree, numInlineTree * sizeof(ICorDebugInfo::InlineTreeNode));
-        pBuffer += numInlineTree * sizeof(ICorDebugInfo::InlineTreeNode);
-        memcpy(pBuffer, mappings, numMappings * sizeof(ICorDebugInfo::RichOffsetMapping));
-        pBuffer += numMappings * sizeof(ICorDebugInfo::RichOffsetMapping);
+        WriteToBuffer(&pBuffer, numInlineTree);
+        WriteToBuffer(&pBuffer, numMappings);
+        for (uint32_t i = 0; i < numInlineTree; i++)
+        {
+            WriteToBuffer(&pBuffer, inlineTree[i].Method);
+            WriteToBuffer(&pBuffer, inlineTree[i].ILOffset);
+            WriteToBuffer(&pBuffer, inlineTree[i].Child);
+            WriteToBuffer(&pBuffer, inlineTree[i].Sibling);
+        }
+
+        for (uint32_t i = 0; i < numMappings; i++)
+        {
+            WriteToBuffer(&pBuffer, mappings[i].ILOffset);
+            WriteToBuffer(&pBuffer, mappings[i].Inlinee);
+            WriteToBuffer(&pBuffer, mappings[i].NativeOffset);
+            WriteToBuffer(&pBuffer, static_cast<uint8_t>(mappings[i].Source));
+        }
+
+        _ASSERTE((pBuffer - &buffer[0]) == dataSize);
 
         const uint32_t chunkSize = 40000;
         const uint32_t finalChunkFlag = 0x80000000;
@@ -7111,8 +7146,8 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
     _ASSERTE(pLoaderAllocatorFilter == nullptr || !fGetCodeIds);
 
     // Set of methods for which we already have sent a MethodDetails event.
-    // Only used when sending rich debug info that would other send a lot of
-    // duplicate events.
+    // Only used when sending rich debug info that would otherwise send a lot
+    // of duplicate events.
     MethodDescSet sentMethodDetailsSet;
     MethodDescSet* pSentMethodDetailsSet = fSendRichDebugInfoEvent ? &sentMethodDetailsSet : NULL;
 
@@ -7177,8 +7212,7 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
                     NULL,           // methodSignature
                     codeStart,
                     &config,
-                    pSentMethodDetailsSet
-                    );
+                    pSentMethodDetailsSet);
             }
         }
 

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -6518,6 +6518,11 @@ done:;
 
 VOID ETW::MethodLog::SendNonDuplicateMethodDetailsEvent(MethodDesc* pMethodDesc, MethodDescSet* set)
 {
+    CONTRACTL {
+        THROWS;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+
     if (set == NULL || !set->Contains(pMethodDesc))
     {
         SendMethodDetailsEvent(pMethodDesc);

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -7034,7 +7034,7 @@ VOID ETW::MethodLog::SendMethodRichDebugInfo(MethodDesc* pMethodDesc, PCODE pNat
             WriteToBuffer(&pBuffer, static_cast<uint8_t>(mappings[i].Source));
         }
 
-        _ASSERTE((pBuffer - &buffer[0]) == dataSize);
+        _ASSERTE(static_cast<size_t>(pBuffer - &buffer[0]) == static_cast<size_t>(dataSize));
 
         const uint32_t chunkSize = 40000;
         const uint32_t finalChunkFlag = 0x80000000;

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -4184,7 +4184,6 @@ VOID ETW::EnumerationLog::EndRundown()
                                                                             TRACE_LEVEL_INFORMATION,
                                                                             CLR_RUNDOWNJITTEDMETHODILTONATIVEMAP_KEYWORD);
         BOOL bIsRichDebugInfoEnabled =
-            bIsIlToNativeMapsRundownEnabled &&
             ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_DOTNET_Context, JittedMethodRichDebugInfo);
 
         if(ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_DOTNET_Context,
@@ -5554,7 +5553,7 @@ VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrC
             _ASSERTE(g_pDebugInterface != NULL);
             g_pDebugInterface->InitializeLazyDataIfNecessary();
 
-            ETW::MethodLog::SendMethodRichDebugInfo(pMethodDesc, pNativeCodeStartAddress, pConfig->GetCodeVersion().GetVersionId(), pConfig->GetCodeVersion().GetILCodeVersionId());
+            ETW::MethodLog::SendMethodRichDebugInfo(pMethodDesc, pNativeCodeStartAddress, pConfig->GetCodeVersion().GetVersionId(), pConfig->GetCodeVersion().GetILCodeVersionId(), NULL);
         }
 
     } EX_CATCH { } EX_END_CATCH(SwallowAllExceptions);
@@ -6517,6 +6516,17 @@ done:;
     } EX_CATCH { } EX_END_CATCH(SwallowAllExceptions);
 }
 
+VOID ETW::MethodLog::SendNonDuplicateMethodDetailsEvent(MethodDesc* pMethodDesc, MethodDescSet* set)
+{
+    if (set == NULL || !set->Contains(pMethodDesc))
+    {
+        SendMethodDetailsEvent(pMethodDesc);
+
+        if (set != NULL)
+            set->Add(pMethodDesc);
+    }
+}
+
 /*****************************************************************/
 /* This routine is used to send an ETW event just before a method starts jitting*/
 /*****************************************************************/
@@ -6596,7 +6606,7 @@ VOID ETW::MethodLog::SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *n
 /****************************************************************************/
 /* This routine is used to send a method load/unload or rundown event                              */
 /****************************************************************************/
-VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig)
+VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig, MethodDescSet* sentMethodDetailsSet)
 {
     CONTRACTL {
         THROWS;
@@ -6733,7 +6743,7 @@ VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptio
     szDtraceOutput2 = (PCWSTR)pMethodName;
     szDtraceOutput3 = (PCWSTR)pMethodSignature;
 
-    SendMethodDetailsEvent(pMethodDesc);
+    SendNonDuplicateMethodDetailsEvent(pMethodDesc, sentMethodDetailsSet);
 
     if((dwEventOptions & ETW::EnumerationLog::EnumerationStructs::JitMethodLoad) ||
         (dwEventOptions & ETW::EnumerationLog::EnumerationStructs::NgenMethodLoad))
@@ -6947,7 +6957,7 @@ VOID ETW::MethodLog::SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWOR
         FireEtwMethodDCEndILToNativeMap_V1(ullMethodIdentifier, nativeCodeId, 0, cMap, rguiILOffset, rguiNativeOffset, GetClrInstanceId(), ilCodeId);
 }
 
-VOID ETW::MethodLog::SendMethodRichDebugInfo(MethodDesc* pMethodDesc, PCODE pNativeCodeStartAddress, DWORD nativeCodeId, ReJITID ilCodeId)
+VOID ETW::MethodLog::SendMethodRichDebugInfo(MethodDesc* pMethodDesc, PCODE pNativeCodeStartAddress, DWORD nativeCodeId, ReJITID ilCodeId, MethodDescSet* sentMethodDetailsSet)
 {
     CONTRACTL
     {
@@ -7019,7 +7029,7 @@ VOID ETW::MethodLog::SendMethodRichDebugInfo(MethodDesc* pMethodDesc, PCODE pNat
         {
             MethodDesc* pInlineeMethodDesc = reinterpret_cast<MethodDesc*>(inlineTree[i].Method);
             if (pInlineeMethodDesc != pMethodDesc)
-                SendMethodDetailsEvent(pInlineeMethodDesc);
+                SendNonDuplicateMethodDetailsEvent(pInlineeMethodDesc, sentMethodDetailsSet);
         }
     }
 
@@ -7100,6 +7110,12 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
     _ASSERTE(pLoaderAllocatorFilter == nullptr || pLoaderAllocatorFilter->IsCollectible());
     _ASSERTE(pLoaderAllocatorFilter == nullptr || !fGetCodeIds);
 
+    // Set of methods for which we already have sent a MethodDetails event.
+    // Only used when sending rich debug info that would other send a lot of
+    // duplicate events.
+    MethodDescSet sentMethodDetailsSet;
+    MethodDescSet* pSentMethodDetailsSet = fSendRichDebugInfoEvent ? &sentMethodDetailsSet : NULL;
+
     EEJitManager::CodeHeapIterator heapIterator(pLoaderAllocatorFilter);
     while (heapIterator.Next())
     {
@@ -7160,7 +7176,9 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
                     NULL,           // methodName
                     NULL,           // methodSignature
                     codeStart,
-                    &config);
+                    &config,
+                    pSentMethodDetailsSet
+                    );
             }
         }
 
@@ -7169,7 +7187,7 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
             ETW::MethodLog::SendMethodILToNativeMapEvent(pMD, dwEventOptions, codeStart, nativeCodeVersionId, ilCodeId);
 
         if (fSendRichDebugInfoEvent)
-            ETW::MethodLog::SendMethodRichDebugInfo(pMD, codeStart, nativeCodeVersion.GetVersionId(), ilCodeId);
+            ETW::MethodLog::SendMethodRichDebugInfo(pMD, codeStart, nativeCodeVersion.GetVersionId(), ilCodeId, pSentMethodDetailsSet);
 
         // When we're called to announce unloads, then the methodunload event itself must
         // come after any supplemental events, so that the method unload event is the


### PR DESCRIPTION
When rich debug info is enabled we send MethodDetails events for all inlinees as otherwise no information for those may have been sent (in case they have not been jitted). During rundown this was sending a lot of duplicate events, so use a hash set to avoid this. On Avalonia.ILSpy which has around ~33k methods jitted, we go from ~94k MethodDetails events to ~43k MethodDetails events on rundown.

In addition, compress rich debug info when stored in the runtime. For the above scenario the memory overhead of rich debug info goes from 7 MB -> 2.1 MB.

Also optimize the format we use for the ETW events. While we do not use the same delta compression as the runtime storage, we now avoid sending out padding and also use a smaller type for the offset mappings source type. The average size of a rich debug info ETW event goes from 259 bytes to 219 bytes for the above scenario.

The net result is the following for two rundowns of Avalonia.ILSpy (I clicked around a bit and did a few actions before enabling the rundown. EventID(189) is the rich debug info event)
Before:
![image](https://user-images.githubusercontent.com/7887810/182860458-a7232167-4f2b-4bf2-974a-3eb33812bcc5.png)

After:
![image](https://user-images.githubusercontent.com/7887810/182860632-4d7c9d16-f64e-4931-bb6d-ec20bfce579c.png)


There should not be any effect of this PR except when rich debug info is enabled.

I would like to get this in .NET 7. There is more work to be done here for .NET 8, e.g. by avoiding storing method handles when we can get it based on IL offset, but this fixes the most glaring issues.