### PR TITLE
run CET pipeline on a schedule.

### DIFF
--- a/eng/pipelines/runtime-cet.yml
+++ b/eng/pipelines/runtime-cet.yml
@@ -1,6 +1,14 @@
 
 trigger: none
 
+schedules:
+- cron: "0 11 * * 1,3"
+  displayName: Every Monday and Wednesday at 3:00 AM (UTC-8:00)
+  branches:
+    include:
+    - main
+  always: true
+
 pr:
   branches:
     include:


### PR DESCRIPTION
Schedule CET job Mon/Wed each week. Once we have a few successful runs we could enable outerloop for it. 