### PR TITLE
port SpanHelpers.IndexOfAny(ref byte, byte, byte, int) to Vector128/256

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -808,7 +808,7 @@ namespace System
             nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
             nuint lengthToExamine = (nuint)(uint)length;
 
-            if (Sse2.IsSupported || AdvSimd.Arm64.IsSupported)
+            if (Vector128.IsHardwareAccelerated)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 nint vectorDiff = (nint)length - Vector128<byte>.Count;
@@ -924,10 +924,10 @@ namespace System
             // the end and forwards, which may overlap on an earlier compare.
 
             // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (Sse2.IsSupported)
+            if (Vector128.IsHardwareAccelerated)
             {
-                int matches;
-                if (Avx2.IsSupported)
+                uint matches;
+                if (Vector256.IsHardwareAccelerated)
                 {
                     Vector256<byte> search;
                     // Guard as we may only have a valid size for Vector128; when we will move to the Sse2
@@ -943,13 +943,10 @@ namespace System
                         // First time this checks again against 0, however we will move into final compare if it fails.
                         while (lengthToExamine > offset)
                         {
-                            search = LoadVector256(ref searchSpace, offset);
+                            search = Vector256.LoadUnsafe(ref searchSpace, offset);
                             // Bitwise Or to combine the flagged matches for the second value to our match flags
-                            matches = Avx2.MoveMask(
-                                            Avx2.Or(
-                                                Avx2.CompareEqual(values0, search),
-                                                Avx2.CompareEqual(values1, search)));
-                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search)).ExtractMostSignificantBits();
+                            // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
                             if (matches == 0)
                             {
@@ -962,13 +959,10 @@ namespace System
                         }
 
                         // Move to Vector length from end for final compare
-                        search = LoadVector256(ref searchSpace, lengthToExamine);
+                        search = Vector256.LoadUnsafe(ref searchSpace, lengthToExamine);
                         offset = lengthToExamine;
                         // Same as method as above
-                        matches = Avx2.MoveMask(
-                                    Avx2.Or(
-                                        Avx2.CompareEqual(values0, search),
-                                        Avx2.CompareEqual(values1, search)));
+                        matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search)).ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // None matched
@@ -980,6 +974,7 @@ namespace System
                 }
 
                 // Initial size check was done on method entry.
+                Vector128<byte> compareResult;
                 Debug.Assert(length >= Vector128<byte>.Count);
                 {
                     Vector128<byte> search;
@@ -988,88 +983,38 @@ namespace System
                     // First time this checks against 0 and we will move into final compare if it fails.
                     while (lengthToExamine > offset)
                     {
-                        search = LoadVector128(ref searchSpace, offset);
+                        search = Vector128.LoadUnsafe(ref searchSpace, offset);
 
-                        matches = Sse2.MoveMask(
-                            Sse2.Or(
-                                Sse2.CompareEqual(values0, search),
-                                Sse2.CompareEqual(values1, search))
-                            .AsByte());
-                        // Note that MoveMask has converted the equal vector elements into a set of bit flags,
-                        // So the bit position in 'matches' corresponds to the element offset.
-                        if (matches == 0)
+                        compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search);
+
+                        if (compareResult == Vector128<byte>.Zero)
                         {
                             // None matched
                             offset += (nuint)Vector128<byte>.Count;
                             continue;
                         }
 
+                        matches = compareResult.ExtractMostSignificantBits();
                         goto IntrinsicsMatch;
                     }
                     // Move to Vector length from end for final compare
-                    search = LoadVector128(ref searchSpace, lengthToExamine);
+                    search = Vector128.LoadUnsafe(ref searchSpace, lengthToExamine);
                     offset = lengthToExamine;
                     // Same as method as above
-                    matches = Sse2.MoveMask(
-                        Sse2.Or(
-                            Sse2.CompareEqual(values0, search),
-                            Sse2.CompareEqual(values1, search)));
-                    if (matches == 0)
+                    compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search);
+
+                    if (compareResult == Vector128<byte>.Zero)
                     {
                         // None matched
                         goto NotFound;
                     }
+
+                    matches = compareResult.ExtractMostSignificantBits();
                 }
 
             IntrinsicsMatch:
                 // Find bitflag offset of first difference and add to current offset
                 offset += (nuint)BitOperations.TrailingZeroCount(matches);
-                goto Found;
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                Vector128<byte> search;
-                Vector128<byte> matches;
-                Vector128<byte> values0 = Vector128.Create(value0);
-                Vector128<byte> values1 = Vector128.Create(value1);
-                // First time this checks against 0 and we will move into final compare if it fails.
-                while (lengthToExamine > offset)
-                {
-                    search = LoadVector128(ref searchSpace, offset);
-
-                    matches = AdvSimd.Or(
-                            AdvSimd.CompareEqual(values0, search),
-                            AdvSimd.CompareEqual(values1, search));
-
-                    if (matches == Vector128<byte>.Zero)
-                    {
-                        offset += (nuint)Vector128<byte>.Count;
-                        continue;
-                    }
-
-                    // Find bitflag offset of first match and add to current offset
-                    offset += FindFirstMatchedLane(matches);
-
-                    goto Found;
-                }
-
-                // Move to Vector length from end for final compare
-                search = LoadVector128(ref searchSpace, lengthToExamine);
-                offset = lengthToExamine;
-                // Same as method as above
-                matches = AdvSimd.Or(
-                        AdvSimd.CompareEqual(values0, search),
-                        AdvSimd.CompareEqual(values1, search));
-
-                if (matches == Vector128<byte>.Zero)
-                {
-                    // None matched
-                    goto NotFound;
-                }
-
-                // Find bitflag offset of first match and add to current offset
-                offset += FindFirstMatchedLane(matches);
-
                 goto Found;
             }
             else if (Vector.IsHardwareAccelerated)


### PR DESCRIPTION
### x64

On par.

<details>


```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=Windows 10 (10.0.18363.2212/1909/November2019Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=7.0.100-rc.1.22403.8
  [Host]     : .NET 7.0.0 (7.0.22.40210), X64 RyuJIT AVX2

LaunchCount=9
```

|              Method |             Toolchain | Size |     Mean | Ratio |
|-------------------- |---------------------- |----- |---------:|------:|
| IndexOfAnyTwoValues |       \PR\corerun.exe |  512 | 17.51 ns |  1.00 |
| IndexOfAnyTwoValues | \baseline\corerun.exe |  512 | 17.43 ns |  1.00 |

</details>


### arm64

BDN is reporting less than a nanosecond difference, which maps to 4%. On arm64 I don't have the tool that would allow me to verify whether it's caused by an alginment or codegen change.

<details>


```ini
BenchmarkDotNet=v0.13.1.1828-nightly, OS=ubuntu 20.04
Unknown processor
.NET SDK=7.0.100-rc.1.22403.8
  [Host]     : .NET 7.0.0 (7.0.22.40210), Arm64 RyuJIT AdvSIMD
  
LaunchCount=9
```
|              Method |      Toolchain | Size |     Mean | Ratio |
|-------------------- |--------------- |----- |---------:|------:|
| IndexOfAnyTwoValues |    /PR/corerun |  512 | 37.37 ns |  1.04 |
| IndexOfAnyTwoValues |  /main/corerun |  512 | 36.12 ns |  1.00 |

</details>

contributes to #64451