### PR TITLE
Fail JsonTypeInfo.CreateObject setting when not supported by converter.

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -650,6 +650,9 @@
   <data name="InvalidJsonTypeInfoOperationForKind" xml:space="preserve">
     <value>Invalid JsonTypeInfo operation for JsonTypeInfoKind '{0}'.</value>
   </data>
+  <data name="CreateObjectConverterNotCompatible" xml:space="preserve">
+    <value>The converter for type '{0}' does not support setting 'CreateObject' delegates.</value>
+  </data>
   <data name="CombineOneOfResolversIsNull" xml:space="preserve">
     <value>One of the provided resolvers is null.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
@@ -15,6 +15,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override bool HandleNull => _sourceConverter.HandleNull;
         internal override ConverterStrategy ConverterStrategy => _sourceConverter.ConverterStrategy;
+        internal override bool SupportsCreateObjectDelegate => _sourceConverter.SupportsCreateObjectDelegate;
 
         internal CastingConverter(JsonConverter<TSource> sourceConverter) : base(initialize: false)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json.Serialization.Converters
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             state.Current.ReturnValue = new List<TElement>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
@@ -27,6 +27,7 @@ namespace System.Text.Json.Serialization.Converters
             ((BufferedAsyncEnumerable)state.Current.ReturnValue!)._buffer.Add(value);
         }
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             state.Current.ReturnValue = new BufferedAsyncEnumerable();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
@@ -22,6 +22,7 @@ namespace System.Text.Json.Serialization.Converters
             ((List<object?>)state.Current.ReturnValue!).Add(value);
         }
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             if (!_isDeserializable)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableOfTConverter.cs
@@ -20,6 +20,7 @@ namespace System.Text.Json.Serialization.Converters
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             if (!_isDeserializable)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfTKeyTValueConverter.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json.Serialization.Converters
             ((Dictionary<TKey, TValue>)state.Current.ReturnValue!)[key] = value;
         }
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state)
         {
             if (!_isDeserializable)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
@@ -19,6 +19,7 @@ namespace System.Text.Json.Serialization.Converters
 
         internal sealed override bool CanHaveMetadata => false;
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected sealed override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state)
         {
             state.Current.ReturnValue = new Dictionary<TKey, TValue>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json.Serialization.Converters
 
         internal sealed override bool CanHaveMetadata => false;
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected sealed override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             state.Current.ReturnValue = new List<TElement>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -14,6 +14,7 @@ namespace System.Text.Json.Serialization
     /// </summary>
     internal abstract class JsonCollectionConverter<TCollection, TElement> : JsonResumableConverter<TCollection>
     {
+        internal override bool SupportsCreateObjectDelegate => true;
         internal sealed override ConverterStrategy ConverterStrategy => ConverterStrategy.Enumerable;
         internal override Type ElementType => typeof(TElement);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -12,6 +12,7 @@ namespace System.Text.Json.Serialization
     /// </summary>
     internal abstract class JsonDictionaryConverter<TDictionary> : JsonResumableConverter<TDictionary>
     {
+        internal override bool SupportsCreateObjectDelegate => true;
         internal sealed override ConverterStrategy ConverterStrategy => ConverterStrategy.Dictionary;
 
         protected internal abstract bool OnWriteResume(Utf8JsonWriter writer, TDictionary dictionary, JsonSerializerOptions options, ref WriteStack state);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpListConverter.cs
@@ -25,6 +25,7 @@ namespace System.Text.Json.Serialization.Converters
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             state.Current.ReturnValue = new List<TElement>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpMapConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpMapConverter.cs
@@ -28,6 +28,7 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override bool CanHaveMetadata => false;
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state)
         {
             state.Current.ReturnValue = new List<Tuple<TKey, TValue>>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpSetConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpSetConverter.cs
@@ -25,6 +25,7 @@ namespace System.Text.Json.Serialization.Converters
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }
 
+        internal override bool SupportsCreateObjectDelegate => false;
         protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             state.Current.ReturnValue = new List<TElement>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json.Serialization.Converters
         internal override Type? ElementType => Converter.ElementType;
 
         internal override bool ConstructorIsParameterized => Converter.ConstructorIsParameterized;
-
+        internal override bool SupportsCreateObjectDelegate => Converter.SupportsCreateObjectDelegate;
         internal override bool CanHaveMetadata => Converter.CanHaveMetadata;
 
         public JsonMetadataServicesConverter(Func<JsonConverter<T>> converterCreator, ConverterStrategy converterStrategy)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -15,6 +15,7 @@ namespace System.Text.Json.Serialization.Converters
     internal class ObjectDefaultConverter<T> : JsonObjectConverter<T> where T : notnull
     {
         internal override bool CanHaveMetadata => true;
+        internal override bool SupportsCreateObjectDelegate => true;
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, [MaybeNullWhen(false)] out T value)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -25,6 +25,8 @@ namespace System.Text.Json.Serialization
 
         internal abstract ConverterStrategy ConverterStrategy { get; }
 
+        internal virtual bool SupportsCreateObjectDelegate => false;
+
         /// <summary>
         /// Can direct Read or Write methods be called (for performance).
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -25,6 +25,12 @@ namespace System.Text.Json.Serialization
 
         internal abstract ConverterStrategy ConverterStrategy { get; }
 
+        /// <summary>
+        /// Indicates that the converter can consume the <see cref="JsonTypeInfo.CreateObject"/> delegate.
+        /// Needed because certain collection converters cannot support arbitrary delegates.
+        /// TODO remove once https://github.com/dotnet/runtime/pull/73395/ and
+        /// https://github.com/dotnet/runtime/issues/71944 have been addressed.
+        /// </summary>
         internal virtual bool SupportsCreateObjectDelegate => false;
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -125,19 +125,6 @@ namespace System.Text.Json.Serialization
         // Whether a type (ConverterStrategy.Object) is deserialized using a parameterized constructor.
         internal virtual bool ConstructorIsParameterized { get; }
 
-        /// <summary>
-        ///  For reflection-based metadata generation, indicates whether the
-        ///  converter avails of default constructors when deserializing types.
-        /// </summary>
-        internal bool UsesDefaultConstructor =>
-            ConverterStrategy switch
-            {
-                ConverterStrategy.Object => !ConstructorIsParameterized && this is not ObjectConverter,
-                ConverterStrategy.Enumerable or
-                ConverterStrategy.Dictionary => true,
-                _ => false
-            };
-
         internal ConstructorInfo? ConstructorInfo { get; set; }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -57,6 +57,13 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKind(Kind);
             }
 
+            if (!Converter.SupportsCreateObjectDelegate)
+            {
+                Debug.Assert(_createObject is null);
+                Debug.Assert(_typedCreateObject == null);
+                ThrowHelper.ThrowInvalidOperationException_CreateObjectConverterNotCompatible(Type);
+            }
+
             Func<object>? untypedCreateObject;
             Func<T>? typedCreateObject;
 
@@ -79,6 +86,18 @@ namespace System.Text.Json.Serialization.Metadata
 
             _createObject = untypedCreateObject;
             _typedCreateObject = typedCreateObject;
+        }
+
+        private protected void SetCreateObjectIfCompatible(Delegate? createObject)
+        {
+            Debug.Assert(!IsConfigured);
+
+            // Guard against the reflection resolver/source generator attempting to pass
+            // a CreateObject delegate to converters/metadata that do not support it.
+            if (Converter.SupportsCreateObjectDelegate && !Converter.ConstructorIsParameterized)
+            {
+                SetCreateObject(createObject);
+            }
         }
 
         internal JsonTypeInfo(JsonConverter converter, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -31,11 +31,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             Func<object>? createObject = Options.MemberAccessorStrategy.CreateConstructor(typeof(T));
-            if (converter.UsesDefaultConstructor)
-            {
-                SetCreateObject(createObject);
-            }
-
+            SetCreateObjectIfCompatible(createObject);
             CreateObjectForExtensionDataProperty = createObject;
 
             // Plug in any converter configuration -- should be run last.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -39,7 +39,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
             else
             {
-                SetCreateObject(objectInfo.ObjectCreator);
+                SetCreateObjectIfCompatible(objectInfo.ObjectCreator);
                 CreateObjectForExtensionDataProperty = ((JsonTypeInfo)this).CreateObject;
             }
 
@@ -76,7 +76,7 @@ namespace System.Text.Json.Serialization.Metadata
             SerializeHandler = collectionInfo.SerializeHandler;
             CreateObjectWithArgs = createObjectWithArgs;
             AddMethodDelegate = addFunc;
-            CreateObject = collectionInfo.ObjectCreator;
+            SetCreateObjectIfCompatible(collectionInfo.ObjectCreator);
             PopulatePolymorphismMetadata();
             MapInterfaceTypesToCallbacks();
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -351,6 +351,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_CreateObjectConverterNotCompatible(Type type)
+        {
+            throw new InvalidOperationException(SR.Format(SR.CreateObjectConverterNotCompatible, type));
+        }
+
+        [DoesNotReturn]
         public static void ReThrowWithPath(ref ReadStack state, JsonReaderException ex)
         {
             Debug.Assert(ex.Path == null);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization.Metadata;
@@ -443,6 +445,62 @@ namespace System.Text.Json.Serialization.Tests
                     Assert.IsType<InvalidOperationException>(exception.InnerException);
                 }
             }
+        }
+
+        [Theory]
+        [InlineData(typeof(ICollection<int>), typeof(List<int>), false)]
+        [InlineData(typeof(IList), typeof(List<int>), false)]
+        [InlineData(typeof(IList<int>), typeof(List<int>), false)]
+        [InlineData(typeof(List<int>), typeof(List<int>), false)]
+        [InlineData(typeof(ISet<int>), typeof(HashSet<int>), false)]
+        [InlineData(typeof(Queue<int>), typeof(Queue<int>), false)]
+        [InlineData(typeof(Stack<int>), typeof(Stack<int>), false)]
+        [InlineData(typeof(IDictionary), typeof(Hashtable), true)]
+        [InlineData(typeof(IDictionary<string, int>), typeof(ConcurrentDictionary<string, int>), true)]
+        public static void JsonTypeInfo_CreateObject_SupportedCollection(Type collectionType, Type runtimeType, bool isDictionary)
+        {
+            bool isDelegateInvoked = false;
+
+            var options = new JsonSerializerOptions
+            {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver
+                {
+                    Modifiers =
+                    {
+                        jsonTypeInfo =>
+                        {
+                            if (jsonTypeInfo.Type == collectionType)
+                            {
+                                jsonTypeInfo.CreateObject = () =>
+                                {
+                                    isDelegateInvoked = true;
+                                    return Activator.CreateInstance(runtimeType);
+                                };
+                            }
+                        }
+                    }
+                }
+            };
+
+            string json = isDictionary ? "{}" : "[]";
+            object result = JsonSerializer.Deserialize(json, collectionType, options);
+            Assert.IsType(runtimeType, result);
+            Assert.True(isDelegateInvoked);
+        }
+
+        [Theory]
+        [InlineData(typeof(int[]))]
+        [InlineData(typeof(ImmutableArray<int>))]
+        [InlineData(typeof(IEnumerable))]
+        [InlineData(typeof(IEnumerable<int>))]
+        [InlineData(typeof(IAsyncEnumerable<int>))]
+        [InlineData(typeof(IReadOnlyDictionary<string, int>))]
+        [InlineData(typeof(ImmutableDictionary<string, int>))]
+        public static void JsonTypeInfo_CreateObject_UnsupportedCollection_ThrowsInvalidOperationException(Type collectionType)
+        {
+            var options = new JsonSerializerOptions();
+            JsonTypeInfo jsonTypeInfo = JsonTypeInfo.CreateJsonTypeInfo(collectionType, options);
+            Assert.Throws<InvalidOperationException>(() => jsonTypeInfo.CreateObject = () => new object());
         }
 
         [Theory]


### PR DESCRIPTION
Contributes to #73382.