### PR TITLE
Make Ibc support opt-in instead of enabled by default

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileDataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileDataManager.cs
@@ -37,6 +37,7 @@ namespace ILCompiler
                                   CompilerTypeSystemContext context,
                                   ReadyToRunCompilationModuleGroupBase compilationGroup,
                                   bool embedPgoDataInR2RImage,
+                                  bool parseIbcData,
                                   Func<MethodDesc, bool> canBeIncludedInCurrentCompilation)
         {
             EmbedPgoDataInR2RImage = embedPgoDataInR2RImage;
@@ -74,13 +75,19 @@ namespace ILCompiler
                 }
             }
 
+            if (parseIbcData)
             {
                 // Parse Ibc data
                 foreach (var module in inputModules)
                 {
                     _inputData.Add(_ibcParser.ParseIBCDataFromModule((EcmaModule)module));
-                    _placedProfileMethods.Add(module, new HashSet<MethodDesc>());
                 }
+            }
+
+            // Ensure each module has a hashset of methods available
+            foreach (var module in inputModules)
+            {
+                _placedProfileMethods.Add(module, new HashSet<MethodDesc>());
             }
 
             // Merge all data together

--- a/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
@@ -58,6 +58,7 @@ namespace ILCompiler
         public bool MapCsv;
         public bool PrintReproInstructions;
         public bool Pdb;
+        public bool SupportIbc;
         public string PdbPath;
         public bool PerfMap;
         public string PerfMapPath;
@@ -149,6 +150,7 @@ namespace ILCompiler
                 syntax.DefineOption("systemmodule", ref SystemModule, SR.SystemModuleOverrideOption);
                 syntax.DefineOption("waitfordebugger", ref WaitForDebugger, SR.WaitForDebuggerOption);
                 syntax.DefineOptionList("codegenopt|codegen-options", ref CodegenOptions, SR.CodeGenOptions);
+                syntax.DefineOption("support-ibc", ref SupportIbc, SR.SupportIbc);
                 syntax.DefineOption("resilient", ref Resilient, SR.ResilientOption);
                 syntax.DefineOption("imagebase", ref ImageBase, SR.ImageBase);
 

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -789,6 +789,7 @@ namespace ILCompiler
                         typeSystemContext,
                         compilationGroup,
                         _commandLineOptions.EmbedPgoData,
+                        _commandLineOptions.SupportIbc,
                         crossModuleInlineableCode.Count == 0 ? compilationGroup.VersionsWithMethodBody : compilationGroup.CrossModuleInlineable);
 
                     compilationGroup.ApplyProfileGuidedOptimizationData(profileDataManager, _commandLineOptions.Partial);

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -390,4 +390,7 @@
   <data name="CpuFamilies" xml:space="preserve">
     <value>The following CPU names are predefined groups of instruction sets and can be used in --instruction-set too:</value>
   </data>
+  <data name="SupportIbc" xml:space="preserve">
+    <value>Enable processing of Ibc data embedded in the input assembly.</value>
+  </data>
 </root>


### PR DESCRIPTION
- This support has been a bit of a bug farm, and hasn't provided much value as we have the more capable Mibc support
- Customers which wish to use Ibc support can now enable this support as needed

Fixes #60343