### PR TITLE
Add missing const qualifier to hosting API implementation

### DIFF
--- a/src/native/corehost/hostpolicy/hostpolicy.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy.cpp
@@ -301,7 +301,7 @@ void trace_hostpolicy_entrypoint_invocation(const pal::string_t& entryPointName)
 // If hostpolicy is already initialized, the library will not be
 // reinitialized.
 //
-SHARED_API int HOSTPOLICY_CALLTYPE corehost_load(host_interface_t* init)
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_load(const host_interface_t* init)
 {
     assert(init != nullptr);
     std::lock_guard<std::mutex> lock{ g_init_lock };

--- a/src/native/corehost/hostpolicy/hostpolicy_init.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_init.cpp
@@ -14,7 +14,7 @@ void make_palstr_arr(size_t argc, const pal::char_t** argv, std::vector<pal::str
     }
 }
 
-bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
+bool hostpolicy_init_t::init(const host_interface_t* input, hostpolicy_init_t* init)
 {
     // Check if there are any breaking changes.
     if (input->version_hi != HOST_INTERFACE_LAYOUT_VERSION_HI)
@@ -46,7 +46,7 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     }
     else
     {
-        trace::error(_X("The size of the data layout used to initialize %s is %zd; expected at least %d"), LIBHOSTPOLICY_NAME, input->version_lo, 
+        trace::error(_X("The size of the data layout used to initialize %s is %zd; expected at least %d"), LIBHOSTPOLICY_NAME, input->version_lo,
             offsetof(host_interface_t, host_mode) + sizeof(input->host_mode));
     }
 
@@ -57,7 +57,7 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     {
         init->tfm = input->tfm;
     }
-    
+
     if (input->version_lo >= offsetof(host_interface_t, fx_ver) + sizeof(input->fx_ver))
     {
         init->additional_deps_serialized = input->additional_deps_serialized;
@@ -138,7 +138,7 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
     return true;
 }
 
-void hostpolicy_init_t::init_host_command(host_interface_t* input, hostpolicy_init_t* init)
+void hostpolicy_init_t::init_host_command(const host_interface_t* input, hostpolicy_init_t* init)
 {
     if (input->version_lo >= offsetof(host_interface_t, host_command) + sizeof(input->host_command))
     {

--- a/src/native/corehost/hostpolicy/hostpolicy_init.h
+++ b/src/native/corehost/hostpolicy/hostpolicy_init.h
@@ -25,9 +25,9 @@ struct hostpolicy_init_t
     pal::string_t host_command;
     host_startup_info_t host_info;
 
-    static bool init(host_interface_t* input, hostpolicy_init_t* init);
+    static bool init(const host_interface_t* input, hostpolicy_init_t* init);
 
-    static void init_host_command(host_interface_t* input, hostpolicy_init_t* init);
+    static void init_host_command(const host_interface_t* input, hostpolicy_init_t* init);
 };
 
 #endif // __HOSTPOLICY_INIT_H__


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/73043

Fixes https://github.com/dotnet/runtime/issues/73402

/cc @vitek-karas @elinor-fung 