### PR TITLE
Fix issue where calculation of valuetypeshapecharacteristic on Arm64 does not match native runtime

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -255,7 +255,8 @@ namespace ILCompiler
 
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
-            if (type.Context.Target.Architecture == TargetArchitecture.ARM64)
+            if (type.Context.Target.Architecture == TargetArchitecture.ARM64 &&
+                type.Instantiation[0].IsPrimitiveNumeric)
             {
                 return type.InstanceFieldSize.AsInt switch
                 {

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -227,9 +227,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953/*">
             <Issue>https://github.com/dotnet/runtime/issues/67870</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Generics/GenericsTest/*">
-            <Issue>https://github.com/dotnet/runtime/issues/60036</Issue>
-        </ExcludeList>
         <!-- Arm64 does not support Vector256 -->
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/HardwareIntrinsics/General/Vector256/**">
             <Issue>https://github.com/dotnet/runtime/issues/60154</Issue>


### PR DESCRIPTION
- We didn't check to make sure that the type of the Vector<T> was a primitive numeric as the runtime does
- Re-enable test

Fixes #60036