### PR TITLE
Add Directory.CreateTempSubdirectory

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -46,6 +46,14 @@ internal static partial class Interop
     }
 
     /// <summary>
+    /// Throws an exception using the last error info (errno).
+    /// </summary>
+    internal static void ThrowExceptionForLastError()
+    {
+        ThrowExceptionForIoErrno(Sys.GetLastErrorInfo(), path: null, isDirectory: false);
+    }
+
+    /// <summary>
     /// Validates the result of system call that returns greater than or equal to 0 on success
     /// and less than 0 on failure, with errno set to the error code.
     /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.

--- a/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -46,9 +46,9 @@ internal static partial class Interop
     }
 
     /// <summary>
-    /// Throws an exception using the last error info (errno).
+    /// Throws an IOException using the last error info (errno).
     /// </summary>
-    internal static void ThrowExceptionForLastError()
+    internal static void ThrowIOExceptionForLastError()
     {
         ThrowExceptionForIoErrno(Sys.GetLastErrorInfo(), path: null, isDirectory: false);
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MkdTemp.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MkdTemp.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_MkdTemp", SetLastError = true)]
-        internal static unsafe partial byte* MkdTemp(byte[] template);
+        internal static unsafe partial byte* MkdTemp(byte* template);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MkdTemp.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MkdTemp.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_MkdTemp", SetLastError = true)]
+        internal static unsafe partial byte* MkdTemp(byte[] template);
+    }
+}

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MksTemps.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MksTemps.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_MksTemps", SetLastError = true)]
-        internal static partial IntPtr MksTemps(
-            byte[] template,
+        internal static unsafe partial IntPtr MksTemps(
+            byte* template,
             int suffixlen);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateDirectory.cs
@@ -14,15 +14,15 @@ internal static partial class Interop
         /// </summary>
         [LibraryImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static partial bool CreateDirectoryPrivate(
+        private static unsafe partial bool CreateDirectoryPrivate(
             string path,
-            ref SECURITY_ATTRIBUTES lpSecurityAttributes);
+            SECURITY_ATTRIBUTES* lpSecurityAttributes);
 
-        internal static bool CreateDirectory(string path, ref SECURITY_ATTRIBUTES lpSecurityAttributes)
+        internal static unsafe bool CreateDirectory(string path, SECURITY_ATTRIBUTES* lpSecurityAttributes)
         {
             // We always want to add for CreateDirectory to get around the legacy 248 character limitation
             path = PathInternal.EnsureExtendedPrefix(path);
-            return CreateDirectoryPrivate(path, ref lpSecurityAttributes);
+            return CreateDirectoryPrivate(path, lpSecurityAttributes);
         }
     }
 }

--- a/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
@@ -88,7 +88,7 @@ namespace System.IO
                     string name = stackDir[stackDir.Count - 1];
                     stackDir.RemoveAt(stackDir.Count - 1);
 
-                    r = Interop.Kernel32.CreateDirectory(name, ref secAttrs);
+                    r = Interop.Kernel32.CreateDirectory(name, &secAttrs);
                     if (!r && (firstError == 0))
                     {
                         int currentError = Marshal.GetLastWin32Error();

--- a/src/libraries/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Unix.cs
@@ -16,6 +16,7 @@ namespace System.IO
         internal const char PathSeparator = ':';
         internal const string DirectorySeparatorCharAsString = "/";
         internal const string ParentDirectoryPrefix = @"../";
+        internal const string DirectorySeparators = DirectorySeparatorCharAsString;
 
         internal static int GetRootLength(ReadOnlySpan<char> path)
         {

--- a/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
@@ -54,6 +54,7 @@ namespace System.IO
         internal const string UncNTPathPrefix = @"\??\UNC\";
         internal const string DevicePathPrefix = @"\\.\";
         internal const string ParentDirectoryPrefix = @"..\";
+        internal const string DirectorySeparators = @"\/";
 
         internal const int MaxShortPath = 260;
         internal const int MaxShortDirectoryPath = 248;

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/DisposableFileSystem.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/DisposableFileSystem.cs
@@ -14,9 +14,13 @@ namespace Microsoft.Extensions.Configuration.Test
 
         public DisposableFileSystem()
         {
-            RootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            CreateFolder("");
-            DirectoryInfo = new DirectoryInfo(RootPath);
+#if NETCOREAPP
+            DirectoryInfo = Directory.CreateTempSubdirectory();
+#else
+            DirectoryInfo = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+            DirectoryInfo.Create();
+#endif
+            RootPath = DirectoryInfo.FullName;
         }
 
         public string RootPath { get; }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/TestUtility/DisposableFileSystem.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/TestUtility/DisposableFileSystem.cs
@@ -10,9 +10,13 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests.TestUtility
     {
         public DisposableFileSystem()
         {
-            RootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(RootPath);
-            DirectoryInfo = new DirectoryInfo(RootPath);
+#if NETCOREAPP
+            DirectoryInfo = Directory.CreateTempSubdirectory();
+#else
+            DirectoryInfo = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+            DirectoryInfo.Create();
+#endif
+            RootPath = DirectoryInfo.FullName;
         }
 
         public string RootPath { get; }

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/TempFileCollectionTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/TempFileCollectionTests.cs
@@ -277,8 +277,13 @@ namespace System.CodeDom.Tests
         {
             if (s_tempDirectory == null)
             {
+#if NETCOREAPP
+                string tempDirectory = Directory.CreateTempSubdirectory().FullName;
+#else
                 string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 Directory.CreateDirectory(tempDirectory);
+#endif
+
                 s_tempDirectory = tempDirectory;
             }
             return s_tempDirectory;

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogDebuggerProxyTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogDebuggerProxyTests.cs
@@ -164,9 +164,7 @@ namespace System.ComponentModel.Composition.Primitives
 
         private string GetTemporaryDirectory(string location = null)
         {
-            string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(tempDirectory);
-            return tempDirectory;
+            return Directory.CreateTempSubdirectory().FullName;
         }
     }
 
@@ -193,16 +191,12 @@ namespace System.ComponentModel.Composition.Primitives
 
         public static string GetNewTemporaryDirectory()
         {
-            string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(tempDirectory);
-            return tempDirectory;
+            return Directory.CreateTempSubdirectory().FullName;
         }
 
         public static string GetTemporaryDirectory()
         {
-            string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(tempDirectory);
-            return tempDirectory;
+            return Directory.CreateTempSubdirectory().FullName;
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateTempSubdirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateTempSubdirectory.cs
@@ -63,7 +63,7 @@ namespace System.IO.Tests
                 DirectoryInfo tempPathWithUnicode = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + "\u00F6"));
                 tempPathWithUnicode.Create();
                 
-                string tempEnvVar = OperatingSystem.IsWindows() ? "TEMP" : "TMPDIR";
+                string tempEnvVar = OperatingSystem.IsWindows() ? "TMP" : "TMPDIR";
                 Environment.SetEnvironmentVariable(tempEnvVar, tempPathWithUnicode.FullName);
                 
                 try
@@ -100,8 +100,7 @@ namespace System.IO.Tests
         [MemberData(nameof(InvalidPrefixData))]
         public void CreateTempSubdirectoryThrowsWithPrefixContainingDirectorySeparator(string prefix)
         {
-            ArgumentException e = Assert.Throws<ArgumentException>(() => Directory.CreateTempSubdirectory(prefix));
-            Assert.Equal("prefix", e.ParamName);
+            AssertExtensions.Throws<ArgumentException>("prefix", () => Directory.CreateTempSubdirectory(prefix));
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateTempSubdirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateTempSubdirectory.cs
@@ -31,12 +31,14 @@ namespace System.IO.Tests
             {
                 Assert.True(tmpDir.Exists);
                 Assert.Equal(-1, tmpDir.FullName.IndexOfAny(Path.GetInvalidPathChars()));
-                Assert.Empty(Directory.GetFiles(tmpDir.FullName));
+                Assert.Empty(Directory.GetFileSystemEntries(tmpDir.FullName));
                 Assert.Equal(Path.TrimEndingDirectorySeparator(Path.GetTempPath()), tmpDir.Parent.FullName);
 
                 if (!string.IsNullOrEmpty(prefix))
                 {
                     Assert.StartsWith(prefix, tmpDir.Name);
+                    int expectedNameLength = prefix.Length + (OperatingSystem.IsWindows() ? 12 : 6);
+                    Assert.Equal(expectedNameLength, tmpDir.Name.Length);
                 }
 
                 // Ensure a file can be written to the directory

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateTempSubdirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateTempSubdirectory.cs
@@ -42,6 +42,12 @@ namespace System.IO.Tests
                     Assert.Equal(expectedNameLength, tmpDir.Name.Length);
                 }
 
+                if (!OperatingSystem.IsWindows())
+                {
+                    UnixFileMode userRWX = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+                    Assert.Equal(userRWX, tmpDir.UnixFileMode);
+                }
+
                 // Ensure a file can be written to the directory
                 string tempFile = Path.Combine(tmpDir.FullName, "newFile");
                 using (FileStream fs = File.Create(tempFile, bufferSize: 1024, FileOptions.DeleteOnClose))

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateTempSubdirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateTempSubdirectory.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class Directory_CreateTempSubdirectory : FileSystemTest
+    {
+        public static TheoryData<string> CreateTempSubdirectoryData
+        {
+            get
+            {
+                var result = new TheoryData<string>() { null, "", "myDir", "my.Dir" };
+                if (!OperatingSystem.IsWindows())
+                {
+                    // ensure we can use backslashes on Unix since that isn't a directory separator
+                    result.Add(@"my\File");
+                    result.Add(@"\");
+                }
+                return result;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateTempSubdirectoryData))]
+        public void CreateTempSubdirectory(string prefix)
+        {
+            DirectoryInfo tmpDir = Directory.CreateTempSubdirectory(prefix);
+            try
+            {
+                Assert.True(tmpDir.Exists);
+                Assert.Equal(-1, tmpDir.FullName.IndexOfAny(Path.GetInvalidPathChars()));
+                Assert.Empty(Directory.GetFiles(tmpDir.FullName));
+                Assert.Equal(Path.TrimEndingDirectorySeparator(Path.GetTempPath()), tmpDir.Parent.FullName);
+
+                if (!string.IsNullOrEmpty(prefix))
+                {
+                    Assert.StartsWith(prefix, tmpDir.Name);
+                }
+
+                // Ensure a file can be written to the directory
+                string tempFile = Path.Combine(tmpDir.FullName, "newFile");
+                using (FileStream fs = File.Create(tempFile, bufferSize: 1024, FileOptions.DeleteOnClose))
+                {
+                    Assert.Equal(0, fs.Length);
+                }
+            }
+            finally
+            {
+                tmpDir.Delete(recursive: true);
+            }
+        }
+
+        public static TheoryData<string> InvalidPrefixData
+        {
+            get
+            {
+                var result = new TheoryData<string>() { "/", "myDir/", "my/Dir" };
+                if (OperatingSystem.IsWindows())
+                {
+                    result.Add(@"\");
+                    result.Add(@"myDir\");
+                    result.Add(@"my\Dir");
+                }
+                return result;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidPrefixData))]
+        public void CreateTempSubdirectoryThrowsWithPrefixContainingDirectorySeparator(string prefix)
+        {
+            ArgumentException e = Assert.Throws<ArgumentException>(() => Directory.CreateTempSubdirectory(prefix));
+            Assert.Equal("prefix", e.ParamName);
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -19,6 +19,7 @@
     <Compile Include="Base\SymbolicLinks\BaseSymbolicLinks.cs" />
     <Compile Include="Base\SymbolicLinks\BaseSymbolicLinks.FileSystem.cs" />
     <Compile Include="Base\SymbolicLinks\BaseSymbolicLinks.FileSystemInfo.cs" />
+    <Compile Include="Directory\CreateTempSubdirectory.cs" />
     <Compile Include="Directory\EnumerableTests.cs" />
     <Compile Include="Directory\SymbolicLinks.cs" />
     <Compile Include="DirectoryInfo\SymbolicLinks.cs" />

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2710,6 +2710,9 @@
   <data name="IO_UnknownFileName" xml:space="preserve">
     <value>[Unknown]</value>
   </data>
+  <data name="IO_MaxAttemptsReached" xml:space="preserve">
+    <value>Unable to complete the operation after the maximum number of attempts.</value>
+  </data>
   <data name="Lazy_CreateValue_NoParameterlessCtorForT" xml:space="preserve">
     <value>The lazily-initialized type does not have a public, parameterless constructor.</value>
   </data>
@@ -3987,5 +3990,8 @@
   </data>
   <data name="FileNotFound_AssemblyNotFound" xml:space="preserve">
     <value>Cannot load assembly '{0}'. No metadata found for this assembly.</value>
+  </data>
+  <data name="Argument_DirectorySeparatorInvalid" xml:space="preserve">
+    <value>The value may not contain directory separator characters.</value>
   </data>
 </root>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2093,6 +2093,9 @@
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MkDir.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.MkDir.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MkdTemp.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.MkdTemp.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MksTemps.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.MksTemps.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Unix.cs
@@ -8,8 +8,6 @@ namespace System.IO
 {
     public static partial class Directory
     {
-        private static readonly char[] s_directorySeparators = new char[] { Path.DirectorySeparatorChar };
-
         private static DirectoryInfo CreateDirectoryCore(string path, UnixFileMode unixCreateMode)
         {
             ArgumentException.ThrowIfNullOrEmpty(path);
@@ -41,7 +39,7 @@ namespace System.IO
             }
 
             // 'name' is now the name of the directory
-            Debug.Assert(name[name.Length - 1] == '\0');
+            Debug.Assert(name[^1] == '\0');
             return Encoding.UTF8.GetString(name, 0, name.Length - 1); // trim off the trailing '\0'
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Unix.cs
@@ -47,7 +47,7 @@ namespace System.IO
             {
                 if (Interop.Sys.MkdTemp(pPath) is null)
                 {
-                    Interop.CheckIo(-1);
+                    Interop.ThrowExceptionForLastError();
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Unix.cs
@@ -1,10 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Text;
+
 namespace System.IO
 {
     public static partial class Directory
     {
+        private static readonly char[] s_directorySeparators = new char[] { Path.DirectorySeparatorChar };
+
         private static DirectoryInfo CreateDirectoryCore(string path, UnixFileMode unixCreateMode)
         {
             ArgumentException.ThrowIfNullOrEmpty(path);
@@ -19,6 +24,25 @@ namespace System.IO
             FileSystem.CreateDirectory(fullPath, unixCreateMode);
 
             return new DirectoryInfo(path, fullPath, isNormalized: true);
+        }
+
+        private static unsafe string CreateTempSubdirectoryCore(string? prefix)
+        {
+            // mkdtemp takes a char* and overwrites the XXXXXX with six characters
+            // that'll result in a unique file name.
+            string template = $"{Path.GetTempPath()}{prefix}XXXXXX\0";
+            byte[] name = Encoding.UTF8.GetBytes(template);
+
+            // Create the temp directory.
+            byte* result = Interop.Sys.MkdTemp(name);
+            if (result == null)
+            {
+                Interop.CheckIo(-1);
+            }
+
+            // 'name' is now the name of the directory
+            Debug.Assert(name[name.Length - 1] == '\0');
+            return Encoding.UTF8.GetString(name, 0, name.Length - 1); // trim off the trailing '\0'
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Unix.cs
@@ -47,7 +47,7 @@ namespace System.IO
             {
                 if (Interop.Sys.MkdTemp(pPath) is null)
                 {
-                    Interop.ThrowExceptionForLastError();
+                    Interop.ThrowIOExceptionForLastError();
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Windows.cs
@@ -35,6 +35,7 @@ namespace System.IO
             int attempts = 0;
             while (attempts < MaxAttempts)
             {
+                // simulate a call to Path.GetRandomFileName() without allocating an intermediate string
                 Interop.GetRandomBytes(pKey, RandomKeyLength);
                 Path.Populate83FileNameFromRandomBytes(pKey, RandomKeyLength, builder.RawChars.Slice(builder.Length, RandomFileNameLength));
                 builder.Length += RandomFileNameLength;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Windows.cs
@@ -8,8 +8,6 @@ namespace System.IO
 {
     public static partial class Directory
     {
-        private static readonly char[] s_directorySeparators = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
-
         private static DirectoryInfo CreateDirectoryCore(string path, UnixFileMode unixCreateMode)
             => throw new PlatformNotSupportedException(SR.PlatformNotSupported_UnixFileMode);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Windows.cs
@@ -1,11 +1,68 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
+using System.Text;
+
 namespace System.IO
 {
     public static partial class Directory
     {
+        private static readonly char[] s_directorySeparators = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
         private static DirectoryInfo CreateDirectoryCore(string path, UnixFileMode unixCreateMode)
             => throw new PlatformNotSupportedException(SR.PlatformNotSupported_UnixFileMode);
+
+        private static unsafe string CreateTempSubdirectoryCore(string? prefix)
+        {
+            ValueStringBuilder builder = new ValueStringBuilder(stackalloc char[PathInternal.MaxShortPath]);
+            Path.GetTempPath(ref builder);
+
+            // ensure the base TEMP directory exists
+            CreateDirectory(PathHelper.Normalize(ref builder));
+
+            builder.Append(prefix);
+
+            const int RandomFileNameLength = 12; // 12 == 8 + 1 (for period) + 3
+            int initialTempPathLength = builder.Length;
+            builder.EnsureCapacity(initialTempPathLength + RandomFileNameLength);
+
+            // For generating random file names
+            // 8 random bytes provides 12 chars in our encoding for the 8.3 name.
+            const int RandomKeyLength = 8;
+            byte* pKey = stackalloc byte[RandomKeyLength];
+
+            // to avoid an infinite loop, only try as many as GetTempFileNameW will create
+            const int MaxAttempts = ushort.MaxValue;
+            int attempts = 0;
+            while (attempts < MaxAttempts)
+            {
+                Interop.GetRandomBytes(pKey, RandomKeyLength);
+                Path.Populate83FileNameFromRandomBytes(pKey, RandomKeyLength, builder.RawChars.Slice(builder.Length, RandomFileNameLength));
+                builder.Length += RandomFileNameLength;
+
+                string path = PathHelper.Normalize(ref builder);
+
+                bool directoryCreated = Interop.Kernel32.CreateDirectory(path, null);
+                if (!directoryCreated)
+                {
+                    // in the off-chance that the directory already exists, try again
+                    int error = Marshal.GetLastWin32Error();
+                    if (error == Interop.Errors.ERROR_ALREADY_EXISTS)
+                    {
+                        builder.Length = initialTempPathLength;
+                        attempts++;
+                        continue;
+                    }
+
+                    throw Win32Marshal.GetExceptionForWin32Error(error, path);
+                }
+
+                builder.Dispose();
+                return path;
+            }
+
+            throw new IOException(SR.IO_MaxAttemptsReached);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
@@ -70,7 +70,7 @@ namespace System.IO
 
         private static void EnsureNoDirectorySeparators(string? value, [CallerArgumentExpression("value")] string? paramName = null)
         {
-            if (!string.IsNullOrEmpty(value) && value.IndexOfAny(s_directorySeparators) != -1)
+            if (value is not null && value.AsSpan().IndexOfAny(PathInternal.DirectorySeparators) >= 0)
             {
                 throw new ArgumentException(SR.Argument_DirectorySeparatorInvalid, paramName);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Enumeration;
+using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 
 namespace System.IO
@@ -51,6 +52,29 @@ namespace System.IO
         [UnsupportedOSPlatform("windows")]
         public static DirectoryInfo CreateDirectory(string path, UnixFileMode unixCreateMode)
             => CreateDirectoryCore(path, unixCreateMode);
+
+        /// <summary>
+        /// Creates a uniquely-named, empty directory in the current user's temporary directory.
+        /// </summary>
+        /// <param name="prefix">An optional string to add to the beginning of the subdirectory name.</param>
+        /// <returns>An object that represents the directory that was created.</returns>
+        /// <exception cref="ArgumentException"><paramref name="prefix" /> contains a directory separator.</exception>
+        /// <exception cref="IOException">A new directory cannot be created.</exception>
+        public static unsafe DirectoryInfo CreateTempSubdirectory(string? prefix = null)
+        {
+            EnsureNoDirectorySeparators(prefix);
+
+            string path = CreateTempSubdirectoryCore(prefix);
+            return new DirectoryInfo(path, isNormalized: true);
+        }
+
+        private static void EnsureNoDirectorySeparators(string? value, [CallerArgumentExpression("value")] string? paramName = null)
+        {
+            if (!string.IsNullOrEmpty(value) && value.IndexOfAny(s_directorySeparators) != -1)
+            {
+                throw new ArgumentException(SR.Argument_DirectorySeparatorInvalid, paramName);
+            }
+        }
 
         // Tests if the given path refers to an existing DirectoryInfo on disk.
         public static bool Exists([NotNullWhen(true)] string? path)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
@@ -151,7 +151,7 @@ namespace System.IO
             return path;
         }
 
-        private static void GetTempPath(ref ValueStringBuilder builder)
+        internal static void GetTempPath(ref ValueStringBuilder builder)
         {
             uint result;
             while ((result = Interop.Kernel32.GetTempPathW(builder.Capacity, ref builder.GetPinnableReference())) > builder.Capacity)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -818,7 +818,7 @@ namespace System.IO
 
         private static ReadOnlySpan<byte> Base32Char => "abcdefghijklmnopqrstuvwxyz012345"u8;
 
-        private static unsafe void Populate83FileNameFromRandomBytes(byte* bytes, int byteCount, Span<char> chars)
+        internal static unsafe void Populate83FileNameFromRandomBytes(byte* bytes, int byteCount, Span<char> chars)
         {
             // This method requires bytes of length 8 and chars of length 12.
             Debug.Assert(bytes != null);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PosixSignalRegistration.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PosixSignalRegistration.Unix.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices
         {
             if (!Interop.Sys.InitializeTerminalAndSignalHandling())
             {
-                Interop.CheckIo(-1);
+                Interop.ThrowExceptionForLastError();
             }
 
             Interop.Sys.SetPosixSignalHandler(&OnPosixSignal);
@@ -44,7 +44,7 @@ namespace System.Runtime.InteropServices
                 if (tokens.Count == 0 &&
                     !Interop.Sys.EnablePosixSignalHandling(signo))
                 {
-                    Interop.CheckIo(-1);
+                    Interop.ThrowExceptionForLastError();
                 }
 
                 tokens.Add(token);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PosixSignalRegistration.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PosixSignalRegistration.Unix.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices
         {
             if (!Interop.Sys.InitializeTerminalAndSignalHandling())
             {
-                Interop.ThrowExceptionForLastError();
+                Interop.ThrowIOExceptionForLastError();
             }
 
             Interop.Sys.SetPosixSignalHandler(&OnPosixSignal);
@@ -44,7 +44,7 @@ namespace System.Runtime.InteropServices
                 if (tokens.Count == 0 &&
                     !Interop.Sys.EnablePosixSignalHandling(signo))
                 {
-                    Interop.ThrowExceptionForLastError();
+                    Interop.ThrowIOExceptionForLastError();
                 }
 
                 tokens.Add(token);

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.RemoteExecutor;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
@@ -203,7 +204,7 @@ namespace System.IO.Tests
                 DirectoryInfo tempPathWithUnicode = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + "\u00F6"));
                 tempPathWithUnicode.Create();
 
-                string tempEnvVar = OperatingSystem.IsWindows() ? "TEMP" : "TMPDIR";
+                string tempEnvVar = OperatingSystem.IsWindows() ? "TMP" : "TMPDIR";
                 Environment.SetEnvironmentVariable(tempEnvVar, tempPathWithUnicode.FullName);
                 
                 try

--- a/src/libraries/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
@@ -38,10 +38,7 @@ namespace System.Runtime.Loader.Tests
             var assemblyFilename = "System.Runtime.Loader.Noop.Assembly.dll";
 
             // Form the dynamic path that would not collide if another instance of this test is running.
-            s_loadFromPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-
-            // Create the folder
-            Directory.CreateDirectory(s_loadFromPath);
+            s_loadFromPath = Directory.CreateTempSubdirectory().FullName;
 
             var targetPath = Path.Combine(s_loadFromPath, assemblyFilename);
 

--- a/src/libraries/System.Runtime.Loader/tests/ResourceAssemblyLoadContext.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ResourceAssemblyLoadContext.cs
@@ -42,10 +42,7 @@ namespace System.Runtime.Loader.Tests
                 // This custom load context will extract that resource and store it at the %temp% path at runtime.
                 // This prevents the corerun from adding the test assembly to the TPA list.
                 // Once loaded it is not possible to unload the assembly, therefore it cannot be deleted.
-                var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-
-                // Create the folder since it will not exist already
-                Directory.CreateDirectory(tempPath);
+                var tempPath = Directory.CreateTempSubdirectory().FullName;
 
                 string path = Path.Combine(tempPath, assembly);
                 using (FileStream output = File.OpenWrite(path))

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9379,6 +9379,7 @@ namespace System.IO
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
         public static System.IO.DirectoryInfo CreateDirectory(string path, System.IO.UnixFileMode unixCreateMode) { throw null; }
         public static System.IO.FileSystemInfo CreateSymbolicLink(string path, string pathToTarget) { throw null; }
+        public static System.IO.DirectoryInfo CreateTempSubdirectory(string? prefix = null) { throw null; }
         public static void Delete(string path) { }
         public static void Delete(string path, bool recursive) { }
         public static System.Collections.Generic.IEnumerable<string> EnumerateDirectories(string path) { throw null; }

--- a/src/native/libs/System.Native/entrypoints.c
+++ b/src/native/libs/System.Native/entrypoints.c
@@ -86,6 +86,7 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_MkNod)
     DllImportEntry(SystemNative_GetDeviceIdentifiers)
     DllImportEntry(SystemNative_MkFifo)
+    DllImportEntry(SystemNative_MkdTemp)
     DllImportEntry(SystemNative_MksTemps)
     DllImportEntry(SystemNative_MMap)
     DllImportEntry(SystemNative_MUnmap)

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -794,6 +794,13 @@ int32_t SystemNative_MkFifo(const char* pathName, uint32_t mode)
     return result;
 }
 
+char* SystemNative_MkdTemp(char* pathTemplate)
+{
+    char* result = NULL;
+    while ((result = mkdtemp(pathTemplate)) == NULL && errno == EINTR);
+    return result;
+}
+
 intptr_t SystemNative_MksTemps(char* pathTemplate, int32_t suffixLength)
 {
     intptr_t result;

--- a/src/native/libs/System.Native/pal_io.h
+++ b/src/native/libs/System.Native/pal_io.h
@@ -562,6 +562,14 @@ PALEXPORT int32_t SystemNative_MkNod(const char* pathName, uint32_t mode, uint32
 PALEXPORT int32_t SystemNative_MkFifo(const char* pathName, uint32_t mode);
 
 /**
+ * Creates a directory name that adheres to the specified template, creates the directory on disk with
+ * 0700 permissions, and returns the directory name.
+ *
+ * Returns returns a pointer to the modified template string on success; otherwise, returns NULL and errno is set.
+ */
+PALEXPORT char* SystemNative_MkdTemp(char* pathTemplate);
+
+/**
  * Creates a file name that adheres to the specified template, creates the file on disk with
  * 0600 permissions, and returns an open r/w File Descriptor on the file.
  *

--- a/src/native/libs/System.Native/pal_io.h
+++ b/src/native/libs/System.Native/pal_io.h
@@ -565,7 +565,7 @@ PALEXPORT int32_t SystemNative_MkFifo(const char* pathName, uint32_t mode);
  * Creates a directory name that adheres to the specified template, creates the directory on disk with
  * 0700 permissions, and returns the directory name.
  *
- * Returns returns a pointer to the modified template string on success; otherwise, returns NULL and errno is set.
+ * Returns a pointer to the modified template string on success; otherwise, returns NULL and errno is set.
  */
 PALEXPORT char* SystemNative_MkdTemp(char* pathTemplate);
 


### PR DESCRIPTION
CreateTempSubdirectory will create a new uniquely named directory under the temp directory. This allows applications to write temporary files in a co-located directory.

Contributes to #72881

Note: I've decided not to implement the full approved API in #72881 because of the feedback on the File API. That will be added in a future PR.