### PR TITLE
Wasm.Build.Tests: re-enable building with latest sdk

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -163,7 +163,7 @@
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <!-- Uncomment to set a fixed version, else the latest is used -->
-    <SdkVersionForWorkloadTesting>7.0.100-rc.1.22402.35</SdkVersionForWorkloadTesting>
+    <!--<SdkVersionForWorkloadTesting>7.0.100-rc.1.22402.35</SdkVersionForWorkloadTesting>-->
     <CompilerPlatformTestingVersion>1.1.2-beta1.22205.2</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220721.1</MicrosoftPrivateIntellisenseVersion>


### PR DESCRIPTION
The sdk issue https://github.com/dotnet/sdk/issues/26967 was fixed in
https://github.com/dotnet/sdk/pull/26796 .

Fixes https://github.com/dotnet/runtime/issues/73312 .