### PR TITLE
[wasm] Trigger all the AOT library tests when relevant paths have

### DIFF
--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -7,7 +7,7 @@ parameters:
   nameSuffix: ''
   platforms: []
   runAOT: false 
-  runSmokeOnlyArg: ''
+  tryRunSmokeOnly: true
   shouldContinueOnError: false
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
       extraBuildArgs: /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=${{ parameters.buildAOTOnHelix }} /p:RunAOTCompilation=${{ parameters.runAOT }} ${{ parameters.extraBuildArgs }}
       extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true ${{ parameters.extraHelixArgs }}
       alwaysRun: ${{ parameters.alwaysRun }}
-      runSmokeOnlyArg: $(_runSmokeTestsOnlyArg)
+      tryRunSmokeOnly: true
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
         - normal
@@ -42,7 +42,7 @@ jobs:
       extraBuildArgs: /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=${{ parameters.buildAOTOnHelix }} /p:RunAOTCompilation=${{ parameters.runAOT }} ${{ parameters.extraBuildArgs }}
       extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true ${{ parameters.extraHelixArgs }}
       alwaysRun: ${{ parameters.alwaysRun }}
-      runSmokeOnlyArg: $(_runSmokeTestsOnlyArg)
+      tryRunSmokeOnly: true
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
         - WasmTestOnBrowser

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -5,7 +5,7 @@ parameters:
   isExtraPlatformsBuild: false
   nameSuffix: ''
   platforms: []
-  runSmokeOnlyArg: ''
+  tryRunSmokeOnly: false
   scenarios: ['normal']
   shouldContinueOnError: false
 
@@ -32,11 +32,18 @@ jobs:
         value: ${{ parameters.alwaysRun }}
       - name: allWasmContainsChange
         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'] ]
+      - name: _tryRunSmokeOnlyArg
+        value: ${{ parameters.tryRunSmokeOnly }}
+      - name: _runSmokeOnlyToUse
+        $[ if and(
+                ne(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
+                eq(variables['_tryRunSmokeOnlyArg'], true)) ]:
+          value: $(_runSmokeTestsOnlyArg)
     jobParameters:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       testGroup: innerloop
       nameSuffix: LibraryTests${{ parameters.nameSuffix }}
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs) ${{ parameters.runSmokeOnlyArg }} ${{ parameters.extraBuildArgs }}
+      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs) $(_runSmokeOnlyToUse) ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 240
       # always run for runtime-wasm builds (triggered manually)
       # Always run for rolling builds
@@ -52,5 +59,5 @@ jobs:
       extraStepsParameters:
         creator: dotnet-bot
         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-        extraHelixArguments: /p:BrowserHost=$(_hostedOs) ${{ parameters.runSmokeOnlyArg }} ${{ parameters.extraHelixArgs }}
+        extraHelixArguments: /p:BrowserHost=$(_hostedOs) $(_runSmokeOnlyToUse) ${{ parameters.extraHelixArgs }}
         scenarios: ${{ parameters.scenarios }}

--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -76,7 +76,7 @@ jobs:
     platforms:
       - Browser_wasm_win
     nameSuffix: _AOT
-    runSmokeOnlyArg: $(_runSmokeTestsOnlyArg)
+    tryRunSmokeOnly: true
     runAOT: true
     alwaysRun: ${{ variables.isRollingBuild }}
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -372,7 +372,7 @@ jobs:
       - Browser_wasm
     nameSuffix: _EAT
     runAOT: false
-    runSmokeOnlyArg: $(_runSmokeTestsOnlyArg)
+    tryRunSmokeOnly: true
     alwaysRun: ${{ variables.isRollingBuild }}
 
 # AOT Library tests
@@ -382,7 +382,7 @@ jobs:
       - Browser_wasm
     nameSuffix: _AOT
     runAOT: true
-    runSmokeOnlyArg: $(_runSmokeTestsOnlyArg)
+    tryRunSmokeOnly: true
     alwaysRun: ${{ variables.isRollingBuild }}
 
 - template: /eng/pipelines/common/templates/wasm-build-tests.yml


### PR DESCRIPTION
.. changes. This is used to trigger aot tests for changed paths like
`src/mono/wasm/runtime`. In such a case, all the AOT library tests will
run, and not just the smoke tests.