### PR TITLE
MonoAOTCompiler.cs: fix regression in caching, which breaks incremental

### DIFF
--- a/src/tasks/Common/FileCache.cs
+++ b/src/tasks/Common/FileCache.cs
@@ -29,7 +29,7 @@ internal sealed class FileCache
             return;
         }
 
-        //Enabled = true;
+        Enabled = true;
         if (File.Exists(cacheFilePath))
         {
             _oldCache = (CompilerCache?)JsonSerializer.Deserialize(File.ReadAllText(cacheFilePath),


### PR DESCRIPTION
.. builds.

https://github.com/dotnet/runtime/pull/72394 disabled the cache always,
even when it was intended to be used. This reverses that change.

This shows up as a Wasm.Build.Tests failure:
```
Wasm.Build.NativeRebuild.Tests.SimpleSourceChangeRebuildTest.SimpleStringChangeInSource(buildArgs: BuildArgs { ProjectName = placeholder, Config = Release, AOT = True, ProjectFileContents = placeholder, ExtraBuildArgs =  }, nativeRelink: False, invariant: False, host: Chrome, id: "kfqswgdd.hbi") [FAIL]
      CompareStat failed:
      [Expected unchanged file: System.Private.CoreLib.dll.bc]
         old: FileStat { Exists = True, LastWriteTimeUtc = 8/4/2022 9:01:26 PM, Length = 16570448, FullPath = /datadisks/disk1/work/AEEC0971/w/AF8A095A/e/kfqswgdd.hbi/obj/Release/net7.0/browser-wasm/wasm/for-publish/System.Private.CoreLib.dll.bc }
         new: FileStat { Exists = True, LastWriteTimeUtc = 8/4/2022 9:02:39 PM, Length = 16570448, FullPath = /datadisks/disk1/work/AEEC0971/w/AF8A095A/e/kfqswgdd.hbi/obj/Release/net7.0/browser-wasm/wasm/for-publish/System.Private.CoreLib.dll.bc }
```

Fixes https://github.com/dotnet/runtime/issues/73419