### PR TITLE
Stop including runtime-specific symbols in non-runtime-specific packages

### DIFF
--- a/src/coreclr/.nuget/Directory.Build.targets
+++ b/src/coreclr/.nuget/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\Directory.Build.targets" />
-  
+
   <PropertyGroup>
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <NativeWithSymbolFile Include="@(NativeBinary)">
+      <NativeWithSymbolFile Include="@(NativeBinary)" Condition="'$(PackageTargetRuntime)'!=''">
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       </NativeWithSymbolFile>
       <NativeWithSymbolFile Include="@(ArchitectureSpecificToolFile)">

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -136,17 +136,13 @@
   <!--
     Finds symbol files and injects them into the package build.
   -->
-
-  <!--
-    Finds symbol files and injects them into the package build.
-  -->
   <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
     <ItemGroup Condition="'$(SymbolsSuffix)' != ''">
       <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolsSuffix)"/>
     </ItemGroup>
 
     <ItemGroup>
-      <NativeWithSymbolFile Include="@(NativeBinary)">
+      <NativeWithSymbolFile Include="@(NativeBinary)" Condition="'$(PackageTargetRuntime)'!=''">
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       </NativeWithSymbolFile>
       <NativeWithSymbolFile Include="@(ArchitectureSpecificToolFile)">


### PR DESCRIPTION
We were incorrectly adding runtime-specific native symbols to the non-runtime-specific packages. This change conditions the inclusion on `PackageTargetRuntime` being non-empty, such that they should only be included in the runtime-specific packages.

This reduces the size of the IntermediateArtifacts that we upload/download in official builds by about 900MB.