### PR TITLE
Fixes for Overlapped tests

### DIFF
--- a/src/libraries/System.Threading.Overlapped/tests/OverlappedTests.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/OverlappedTests.cs
@@ -60,9 +60,7 @@ public static partial class OverlappedTests
         Assert.Equal(1, obj.OffsetLow);
     }
 
-    [Fact]
-    [ActiveIssue("https://github.com/mono/mono/issues/15311", TestRuntimes.Mono)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/73422", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
     public static void PropertyTest3()
     {
         IAsyncResult asyncResult = new Task(() => Console.WriteLine("this is a dummy task"));

--- a/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_AllocateNativeOverlappedTests.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_AllocateNativeOverlappedTests.cs
@@ -80,13 +80,12 @@ public partial class ThreadPoolBoundHandleTests
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/73421", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
     public unsafe void AllocateNativeOverlapped_NonBlittableTypeAsPinData_Throws()
     {
         using (ThreadPoolBoundHandle handle = CreateThreadPoolBoundHandle())
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => handle.AllocateNativeOverlapped((_, __, ___) => { }, new object(), new NonBlittableType() { s = "foo" }));
-            AssertExtensions.Throws<ArgumentException>(null, () => handle.UnsafeAllocateNativeOverlapped((_, __, ___) => { }, new object(), new NonBlittableType() { s = "foo" }));
+            Assert.Throws<ArgumentException>(() => handle.AllocateNativeOverlapped((_, __, ___) => { }, new object(), new NonBlittableType() { s = "foo" }));
+            Assert.Throws<ArgumentException>(() => handle.UnsafeAllocateNativeOverlapped((_, __, ___) => { }, new object(), new NonBlittableType() { s = "foo" }));
         }
     }
 
@@ -130,7 +129,6 @@ public partial class ThreadPoolBoundHandleTests
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/73421", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
     public unsafe void AllocateNativeOverlapped_ObjectArrayWithNonBlittableTypeAsPinData_Throws()
     {
         var array = new object[]
@@ -141,8 +139,8 @@ public partial class ThreadPoolBoundHandleTests
 
         using (ThreadPoolBoundHandle handle = CreateThreadPoolBoundHandle())
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => handle.AllocateNativeOverlapped((_, __, ___) => { }, new object(), array));
-            AssertExtensions.Throws<ArgumentException>(null, () => handle.UnsafeAllocateNativeOverlapped((_, __, ___) => { }, new object(), array));
+            Assert.Throws<ArgumentException>(() => handle.AllocateNativeOverlapped((_, __, ___) => { }, new object(), array));
+            Assert.Throws<ArgumentException>(() => handle.UnsafeAllocateNativeOverlapped((_, __, ___) => { }, new object(), array));
         }
     }
 

--- a/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_PreAllocatedOverlappedTests.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_PreAllocatedOverlappedTests.cs
@@ -43,11 +43,10 @@ public partial class ThreadPoolBoundHandleTests
 
     [Fact]
     [ActiveIssue("https://github.com/mono/mono/issues/15313", TestRuntimes.Mono)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/73421", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
     public unsafe void PreAllocatedOverlapped_NonBlittableTypeAsPinData_Throws()
     {
-        AssertExtensions.Throws<ArgumentException>(null, () => new PreAllocatedOverlapped((_, __, ___) => { }, new object(), new NonBlittableType() { s = "foo" }));
-        AssertExtensions.Throws<ArgumentException>(null, () => PreAllocatedOverlapped.UnsafeCreate((_, __, ___) => { }, new object(), new NonBlittableType() { s = "foo" }));
+        Assert.Throws<ArgumentException>(() => new PreAllocatedOverlapped((_, __, ___) => { }, new object(), new NonBlittableType() { s = "foo" }));
+        Assert.Throws<ArgumentException>(() => PreAllocatedOverlapped.UnsafeCreate((_, __, ___) => { }, new object(), new NonBlittableType() { s = "foo" }));
 
         // Make sure the PreAllocatedOverlapped finalizer does the right thing in the case where the .ctor failed.
         GC.Collect();
@@ -76,7 +75,6 @@ public partial class ThreadPoolBoundHandleTests
 
     [Fact]
     [ActiveIssue("https://github.com/mono/mono/issues/15313", TestRuntimes.Mono)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/73421", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
     public unsafe void PreAllocatedOverlapped_ObjectArrayWithNonBlittableTypeAsPinData_Throws()
     {
         var array = new object[]
@@ -85,8 +83,8 @@ public partial class ThreadPoolBoundHandleTests
             new byte[5],
         };
 
-        AssertExtensions.Throws<ArgumentException>(null, () => new PreAllocatedOverlapped((_, __, ___) => { }, new object(), array));
-        AssertExtensions.Throws<ArgumentException>(null, () => PreAllocatedOverlapped.UnsafeCreate((_, __, ___) => { }, new object(), array));
+        Assert.Throws<ArgumentException>(() => new PreAllocatedOverlapped((_, __, ___) => { }, new object(), array));
+        Assert.Throws<ArgumentException>(() => PreAllocatedOverlapped.UnsafeCreate((_, __, ___) => { }, new object(), array));
 
         // Make sure the PreAllocatedOverlapped finalizer does the right thing in the case where the .ctor failed.
         GC.Collect();


### PR DESCRIPTION
- Disable test that is testing 64-bit incompatible API on 64-bit platforms
- Relax ArgumentException argument name validation. The name of the argument that test was expecting did not match the actual name of the method argument since the ArgumentException originates several layers deep into the implementation.

Fixes https://github.com/dotnet/runtime/issues/73421
Fixes https://github.com/dotnet/runtime/issues/73422
Fixes https://github.com/mono/mono/issues/15311