### PR TITLE
Replace BUILDING_INBOX_LIBRARY conditional with NETCOREAPP

### DIFF
--- a/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
+++ b/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
@@ -112,7 +112,7 @@ namespace System.Text.Json
             return _rentedBuffer.AsSpan(_index);
         }
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
         internal ValueTask WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
         {
             return destination.WriteAsync(WrittenMemory, cancellationToken);

--- a/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json
                 return name;
             }
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             return string.Create(name.Length, name, (chars, name) =>
             {
                 name

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -18,9 +18,6 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
-    <!-- For the inbox library (that is shipping with the product), this should always be true. -->
-    <!-- BUILDING_INBOX_LIBRARY is only false when building the netstandard compatible NuGet package. -->
-    <DefineConstants Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
     <NoWarn Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETCoreApp'">$(NoWarn);nullable</NoWarn>
   </PropertyGroup>
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -817,7 +817,7 @@ namespace System.Text.Json
         }
 
         private static async
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             ValueTask<ArraySegment<byte>>
 #else
             Task<ArraySegment<byte>>
@@ -855,7 +855,7 @@ namespace System.Text.Json
                     Debug.Assert(rented.Length >= JsonConstants.Utf8Bom.Length);
 
                     lastRead = await stream.ReadAsync(
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                         rented.AsMemory(written, utf8BomLength - written),
 #else
                         rented,
@@ -886,7 +886,7 @@ namespace System.Text.Json
                     }
 
                     lastRead = await stream.ReadAsync(
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                         rented.AsMemory(written),
 #else
                         rented,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json
             return reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
         }
 
-#if !BUILDING_INBOX_LIBRARY
+#if !NETCOREAPP
         /// <summary>
         /// Returns <see langword="true"/> if <paramref name="value"/> is a valid Unicode scalar
         /// value, i.e., is in [ U+0000..U+D7FF ], inclusive; or [ U+E000..U+10FFFF ], inclusive.
@@ -124,7 +124,7 @@ namespace System.Text.Json
 
         public static bool IsFinite(double value)
         {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             return double.IsFinite(value);
 #else
             return !(double.IsNaN(value) || double.IsInfinity(value));
@@ -133,7 +133,7 @@ namespace System.Text.Json
 
         public static bool IsFinite(float value)
         {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             return float.IsFinite(value);
 #else
             return !(float.IsNaN(value) || float.IsInfinity(value));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Unescaping.cs
@@ -210,7 +210,7 @@ namespace System.Text.Json
         {
             try
             {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                 return s_utf8Encoding.GetString(utf8Unescaped);
 #else
                 if (utf8Unescaped.IsEmpty)
@@ -241,7 +241,7 @@ namespace System.Text.Json
         {
             try
             {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                 return s_utf8Encoding.GetChars(utf8Unescaped, destination);
 #else
                 if (utf8Unescaped.IsEmpty)
@@ -279,7 +279,7 @@ namespace System.Text.Json
         {
             try
             {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                 s_utf8Encoding.GetCharCount(utf8Buffer);
 #else
                 if (utf8Buffer.IsEmpty)
@@ -310,7 +310,7 @@ namespace System.Text.Json
         {
             try
             {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                 return s_utf8Encoding.GetByteCount(text);
 #else
                 if (text.IsEmpty)
@@ -341,7 +341,7 @@ namespace System.Text.Json
         {
             try
             {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                 return s_utf8Encoding.GetBytes(text, dest);
 #else
                 if (text.IsEmpty)
@@ -372,7 +372,7 @@ namespace System.Text.Json
 
         internal static string GetTextFromUtf8(ReadOnlySpan<byte> utf8Text)
         {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             return s_utf8Encoding.GetString(utf8Text);
 #else
             if (utf8Text.IsEmpty)
@@ -521,7 +521,7 @@ namespace System.Text.Json
                                 + JsonConstants.UnicodePlane01StartValue;
                         }
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                         var rune = new Rune(scalar);
                         bool success = rune.TryEncodeToUtf8(destination.Slice(written), out int bytesWritten);
 #else
@@ -594,7 +594,7 @@ namespace System.Text.Json
             return false;
         }
 
-#if !BUILDING_INBOX_LIBRARY
+#if !NETCOREAPP
         /// <summary>
         /// Copies the UTF-8 code unit representation of this scalar to an output buffer.
         /// The buffer must be large enough to hold the required number of <see cref="byte"/>s.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
@@ -93,7 +93,7 @@ namespace System.Text.Json.Serialization
 
         public static bool IsNonGenericStackOrQueue(this Type type)
         {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             // Optimize for linking scenarios where mscorlib is trimmed out.
             const string stackTypeName = "System.Collections.Stack, System.Collections.NonGeneric";
             const string queueTypeName = "System.Collections.Queue, System.Collections.NonGeneric";

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization.Converters
         public override void Write(Utf8JsonWriter writer, char value, JsonSerializerOptions options)
         {
             writer.WriteStringValue(
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                 MemoryMarshal.CreateSpan(ref value, 1)
 #else
                 value.ToString()
@@ -45,7 +45,7 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, char value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
         {
             writer.WritePropertyName(
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                 MemoryMarshal.CreateSpan(ref value, 1)
 #else
                 value.ToString()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -298,7 +298,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 // todo: optimize implementation here by leveraging https://github.com/dotnet/runtime/issues/934.
                 string[] enumValues = value.Split(
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                     ValueSeparator
 #else
                     new string[] { ValueSeparator }, StringSplitOptions.None

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class VersionConverter : JsonConverter<Version>
     {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
         private const int MinimumVersionLength = 3; // 0.0
 
         private const int MaximumVersionLength = 43; // 2147483647.2147483647.2147483647.2147483647
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowInvalidOperationException_ExpectedString(reader.TokenType);
             }
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             if (!JsonHelpers.IsInRangeInclusive(reader.ValueLength, MinimumVersionLength, MaximumEscapedVersionLength))
             {
                 ThrowHelper.ThrowFormatException(DataType.TimeSpan);
@@ -68,7 +68,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, Version value, JsonSerializerOptions options)
         {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             Span<char> span = stackalloc char[MaximumVersionLength];
             bool formattedSuccessfully = value.TryFormat(span, out int charsWritten);
             Debug.Assert(formattedSuccessfully && charsWritten >= MinimumVersionLength);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -982,7 +982,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         private static bool IsByRefLike(Type type)
         {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             return type.IsByRefLike;
 #else
             if (!type.IsValueType)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
@@ -49,7 +49,7 @@ namespace System.Text.Json.Serialization
             do
             {
                 int bytesRead = await utf8Json.ReadAsync(
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                     bufferState._buffer.AsMemory(bufferState._count),
 #else
                     bufferState._buffer, bufferState._count, bufferState._buffer.Length - bufferState._count,
@@ -80,7 +80,7 @@ namespace System.Text.Json.Serialization
             do
             {
                 int bytesRead = utf8Json.Read(
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                     _buffer.AsSpan(_count));
 #else
                     _buffer, _count, _buffer.Length - _count);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -359,7 +359,7 @@ namespace System.Text.Json
             string message = ex.Message;
 
             // Insert the "Path" portion before "LineNumber" and "BytePositionInLine".
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             int iPos = message.AsSpan().LastIndexOf(" LineNumber: ");
 #else
             int iPos = message.LastIndexOf(" LineNumber: ", StringComparison.InvariantCulture);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -6,7 +6,7 @@ using System.Buffers.Text;
 using System.Diagnostics;
 using System.Text.Encodings.Web;
 
-#if !BUILDING_INBOX_LIBRARY
+#if !NETCOREAPP
 using System.Runtime.CompilerServices;
 #endif
 
@@ -43,7 +43,7 @@ namespace System.Text.Json
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+00F0..U+00FF
         };
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
         private const string HexFormatString = "X4";
 #endif
 
@@ -291,7 +291,7 @@ namespace System.Text.Json
                     break;
                 default:
                     destination[written++] = 'u';
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                     int intChar = value;
                     intChar.TryFormat(destination.Slice(written), out int charsWritten, HexFormatString);
                     Debug.Assert(charsWritten == 4);
@@ -303,7 +303,7 @@ namespace System.Text.Json
             }
         }
 
-#if !BUILDING_INBOX_LIBRARY
+#if !NETCOREAPP
         private static int WriteHex(int value, Span<char> destination, int written)
         {
             destination[written++] = HexConverter.ToCharUpper(value >> 12);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
@@ -106,7 +106,7 @@ namespace System.Text.Json
             // the .NET Core 3.0 logic of forwarding to the UTF16 formatter and transcoding it back to UTF8,
             // with some additional changes to remove dependencies on Span APIs which don't exist downlevel.
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             return Utf8Formatter.TryFormat(value, destination, out bytesWritten);
 #else
             string utf16Text = value.ToString(JsonConstants.DoubleFormatString, CultureInfo.InvariantCulture);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
@@ -106,7 +106,7 @@ namespace System.Text.Json
             // the .NET Core 3.0 logic of forwarding to the UTF16 formatter and transcoding it back to UTF8,
             // with some additional changes to remove dependencies on Span APIs which don't exist downlevel.
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             return Utf8Formatter.TryFormat(value, destination, out bytesWritten);
 #else
             string utf16Text = value.ToString(JsonConstants.SingleFormatString, CultureInfo.InvariantCulture);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-#if !BUILDING_INBOX_LIBRARY
+#if !NETCOREAPP
 using System.Runtime.InteropServices;
 #endif
 
@@ -275,7 +275,7 @@ namespace System.Text.Json
                     _arrayBufferWriter.Advance(BytesPending);
                     BytesPending = 0;
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                     _stream.Write(_arrayBufferWriter.WrittenSpan);
 #else
                     Debug.Assert(_arrayBufferWriter.WrittenMemory.Length == _arrayBufferWriter.WrittenCount);
@@ -389,7 +389,7 @@ namespace System.Text.Json
                     _arrayBufferWriter.Advance(BytesPending);
                     BytesPending = 0;
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
                     await _stream.WriteAsync(_arrayBufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
 #else
                     Debug.Assert(_arrayBufferWriter.WrittenMemory.Length == _arrayBufferWriter.WrittenCount);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonTestHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonTestHelper.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json
 {
     internal static partial class JsonTestHelper
     {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
         public const string DoubleFormatString = null;
         public const string SingleFormatString = null;
 #else

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Dynamic.Sample.Tests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Dynamic.Sample.Tests.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.IsType<JsonDynamicNumber>(obj);
 
             double dbl = (double)obj;
-#if !BUILDING_INBOX_LIBRARY
+#if !NETCOREAPP
             string temp = dbl.ToString(System.Globalization.CultureInfo.InvariantCulture);
             // The reader uses "G17" format which causes temp to be 4.2000000000000002 in this case.
             dbl = double.Parse(temp, System.Globalization.CultureInfo.InvariantCulture);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
@@ -392,7 +392,7 @@ namespace System.Text.Json.Serialization.Tests
 
         private static int SingleToInt32Bits(float value)
         {
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             return BitConverter.SingleToInt32Bits(value);
 #else
             return Unsafe.As<float, int>(ref value);
@@ -464,7 +464,7 @@ namespace System.Text.Json.Serialization.Tests
             string json;
             char fillChar = 'x';
 
-#if BUILDING_INBOX_LIBRARY
+#if NETCOREAPP
             json = string.Create(stringLength, fillChar, (chars, fillChar) =>
             {
                 chars.Fill(fillChar);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -16,11 +16,6 @@
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --timeout=1800</WasmXHarnessArgs>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
-  <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
-  <PropertyGroup>
-    <DefineConstants Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
     <HighAotMemoryUsageAssembly Include="System.Text.Json.Tests.dll" />
   </ItemGroup>


### PR DESCRIPTION
The `BUILDING_INBOX_LIBRARY` compile conditional has been a synonym for `NETCOREAPP` for quite a while now. This PR removes the conditional altogether replacing it with `NETCOREAPP` for better consistency.