### PR TITLE
Disable SendMailAsync_CanBeCanceled_CancellationToken for more runs

### DIFF
--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -458,7 +458,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72818", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/73447", TestPlatforms.AnyUnix)]
         public async Task SendMailAsync_CanBeCanceled_CancellationToken()
         {
             using var server = new LoopbackSmtpServer();


### PR DESCRIPTION
SendMailAsync_CanBeCanceled_CancellationToken is failing also on CoreCLR and on OSX - tracked by #73447