### PR TITLE
[mono][jit] Don't memset memory in increments lower than word size

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/String.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/String.Mono.cs
@@ -45,16 +45,27 @@ namespace System
                 }
                 return;
             }
-            if (val != 0)
+#if TARGET_64BIT
+            const int word_size = 8;
+            long word_val;
+#else
+            const int word_size = 4;
+            int word_val;
+#endif
+            word_val = val;
+            if (word_val != 0)
             {
-                val |= (val << 8);
-                val |= (val << 16);
+                word_val |= (word_val << 8);
+                word_val |= (word_val << 16);
+#if TARGET_64BIT
+                word_val |= (word_val << 32);
+#endif
             }
-            // align to 4
-            int rest = (int)dest & 3;
+            // align to word_size
+            int rest = (int)dest & (word_size - 1);
             if (rest != 0)
             {
-                rest = 4 - rest;
+                rest = word_size - rest;
                 len -= rest;
                 do
                 {
@@ -63,20 +74,30 @@ namespace System
                     --rest;
                 } while (rest != 0);
             }
+
             while (len >= 16)
             {
-                ((int*)dest)[0] = val;
-                ((int*)dest)[1] = val;
-                ((int*)dest)[2] = val;
-                ((int*)dest)[3] = val;
+#if TARGET_64BIT
+                ((long*)dest)[0] = word_val;
+                ((long*)dest)[1] = word_val;
+#else
+                ((int*)dest)[0] = word_val;
+                ((int*)dest)[1] = word_val;
+                ((int*)dest)[2] = word_val;
+                ((int*)dest)[3] = word_val;
+#endif
                 dest += 16;
                 len -= 16;
             }
-            while (len >= 4)
+            while (len >= word_size)
             {
-                ((int*)dest)[0] = val;
-                dest += 4;
-                len -= 4;
+#if TARGET_64BIT
+                ((long*)dest)[0] = word_val;
+#else
+                ((int*)dest)[0] = word_val;
+#endif
+                dest += word_size;
+                len -= word_size;
             }
             // tail bytes
             while (len > 0)


### PR DESCRIPTION
If we memset a vt containing references, then, in order for preemptive GC and concurrent GC to work, writing to reference slots must happen atomically, otherwise GC might encounter a garbage ref.

Also speeds up memset by about 15% for smaller valuetypes hitting this path on 64bit. More for extra large valuetypes.

Fixes https://github.com/dotnet/runtime/issues/58828