### PR TITLE
Fix aka.ms links in build promotion for VSDROP

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -120,7 +120,7 @@
     </ItemGroup>
     
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" />
-    <ZipDirectory Overwrite="true" DestinationFile="$(ArtifactsNonShippingPackagesDir)Workloads.VSDrop.%(SdkFeatureBand.Identity).zip" SourceDirectory="$(VisualStudioSetupInsertionPath)%(SdkFeatureBand.Identity)"/>
+    <ZipDirectory Overwrite="true" DestinationFile="$(ArtifactsNonShippingPackagesDir)Workloads.VSDrop.%(SdkFeatureBand.Identity).$(PackageVersion).zip" SourceDirectory="$(VisualStudioSetupInsertionPath)%(SdkFeatureBand.Identity)"/>
 
     <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
     <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />


### PR DESCRIPTION
Build promotion is failing because the zip artifacts don't appear unique to maestro.