### PR TITLE
[Android] Enable ThreadPoolCanPickUpOneOrMoreWorkItemsWhenThreadIsAvailable test

### DIFF
--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -628,7 +628,9 @@ namespace System.Threading.ThreadPools.Tests
                 ThreadPool.QueueUserWorkItem(blockingWorkItem);
             }
 
-            allBlockingWorkItemsStarted.CheckedWait();
+            if (processorCount > 1)
+                allBlockingWorkItemsStarted.CheckedWait();
+
             for (int i = 0; i < processorCount; ++i)
             {
                 ThreadPool.QueueUserWorkItem(testWorkItem);

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -599,7 +599,6 @@ namespace System.Threading.ThreadPools.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/43754", TestPlatforms.Android)]
         public static void ThreadPoolCanPickUpOneOrMoreWorkItemsWhenThreadIsAvailable()
         {
             int processorCount = Environment.ProcessorCount;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/43754