### PR TITLE
[mini] Fix the bounds check in GET_BBLOCK

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -467,9 +467,9 @@ mini_set_inline_failure (MonoCompile *cfg, const char *msg)
 } while (0)
 
 #define GET_BBLOCK(cfg,tblock,ip) do { \
+		if ((ip) >= end || (ip) < header->code) { UNVERIFIED; }	\
 		(tblock) = cfg->cil_offset_to_bb [(ip) - cfg->cil_start]; \
 		if (!(tblock)) { \
-			if ((ip) >= end || (ip) < header->code) UNVERIFIED; \
 			NEW_BBLOCK (cfg, (tblock)); \
 			(tblock)->cil_code = (ip); \
 			ADD_BBLOCK (cfg, (tblock)); \


### PR DESCRIPTION
If the target IP is out of bounds, but `cfg->cil_offset_to_bb` has some non-zero data before or after it, then `tblock` will be some non-NULL pointer that we will treat as a good basic block.

Related to https://github.com/dotnet/runtime/issues/73474 (but doesn't fix the underlying issue there - it will just make the whole offending method throw a BadImageFormatException when it's called)

This may have some performance overhead for the mono JIT.