### PR TITLE
Recoup some of the perf losses in cold start serialization

### DIFF
--- a/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
+++ b/src/libraries/System.Text.Json/src/System/ReflectionExtensions.cs
@@ -91,15 +91,19 @@ namespace System.Text.Json.Reflection
         /// <summary>
         /// Polyfill for BindingFlags.DoNotWrapExceptions
         /// </summary>
-        public static object? InvokeNoWrapExceptions(this MethodInfo methodInfo, object? obj, object?[] parameters)
+        public static object? CreateInstanceNoWrapExceptions(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)] this Type type,
+            Type[] parameterTypes,
+            object?[] parameters)
         {
+            ConstructorInfo ctorInfo = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, parameterTypes, null)!;
 #if NETCOREAPP
-            return methodInfo.Invoke(obj, BindingFlags.DoNotWrapExceptions, null, parameters, null);
+            return ctorInfo.Invoke(BindingFlags.DoNotWrapExceptions, null, parameters, null);
 #else
             object? result = null;
             try
             {
-                result = methodInfo.Invoke(obj, parameters);
+                result = ctorInfo.Invoke(parameters);
             }
             catch (TargetInvocationException ex)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -69,6 +69,22 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException();
         }
 
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        internal virtual JsonTypeInfo CreateReflectionJsonTypeInfo(JsonSerializerOptions options)
+        {
+            Debug.Fail("Should not be reachable.");
+
+            throw new InvalidOperationException();
+        }
+
+        internal virtual JsonTypeInfo CreateCustomJsonTypeInfo(JsonSerializerOptions options)
+        {
+            Debug.Fail("Should not be reachable.");
+
+            throw new InvalidOperationException();
+        }
+
         internal abstract JsonParameterInfo CreateJsonParameterInfo();
 
         internal abstract JsonConverter<TTarget> CreateCastingConverter<TTarget>();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Converters;
 using System.Text.Json.Serialization.Metadata;
 
@@ -66,6 +67,18 @@ namespace System.Text.Json.Serialization
         }
 
         internal override ConverterStrategy ConverterStrategy => ConverterStrategy.Value;
+
+        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        internal sealed override JsonTypeInfo CreateReflectionJsonTypeInfo(JsonSerializerOptions options)
+        {
+            return new ReflectionJsonTypeInfo<T>(this, options);
+        }
+
+        internal sealed override JsonTypeInfo CreateCustomJsonTypeInfo(JsonSerializerOptions options)
+        {
+            return new CustomJsonTypeInfo<T>(this, options);
+        }
 
         internal sealed override JsonParameterInfo CreateJsonParameterInfo()
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/CustomJsonTypeInfoOfT.cs
@@ -1,11 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using System.Text.Json.Serialization.Converters;
 
 namespace System.Text.Json.Serialization.Metadata
 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Text.Json.Reflection;
 using System.Threading;
 
@@ -85,20 +85,26 @@ namespace System.Text.Json.Serialization.Metadata
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         private static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options)
         {
-            s_createReflectionJsonTypeInfoMethodInfo ??= typeof(DefaultJsonTypeInfoResolver).GetMethod(nameof(CreateReflectionJsonTypeInfo), BindingFlags.NonPublic | BindingFlags.Static)!;
-            return (JsonTypeInfo)s_createReflectionJsonTypeInfoMethodInfo.MakeGenericMethod(type)
-                .InvokeNoWrapExceptions(null, new object[] { options })!;
-        }
+            JsonTypeInfo jsonTypeInfo;
+            JsonConverter converter = GetConverterForType(type, options);
 
-        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private static JsonTypeInfo<T> CreateReflectionJsonTypeInfo<T>(JsonSerializerOptions options)
-        {
-            JsonConverter converter = GetConverterForType(typeof(T), options);
-            return new ReflectionJsonTypeInfo<T>(converter, options);
-        }
+            if (converter.TypeToConvert == type)
+            {
+                // For performance, avoid doing a reflection-based instantiation
+                // if the converter type matches that of the declared type.
+                jsonTypeInfo = converter.CreateReflectionJsonTypeInfo(options);
+            }
+            else
+            {
+                Type jsonTypeInfoType = typeof(ReflectionJsonTypeInfo<>).MakeGenericType(type);
+                jsonTypeInfo = (JsonTypeInfo)jsonTypeInfoType.CreateInstanceNoWrapExceptions(
+                    parameterTypes: new Type[] { typeof(JsonConverter), typeof(JsonSerializerOptions) },
+                    parameters: new object[] { converter, options })!;
+            }
 
-        private static MethodInfo? s_createReflectionJsonTypeInfoMethodInfo;
+            Debug.Assert(jsonTypeInfo.Type == type);
+            return jsonTypeInfo;
+        }
 
         /// <summary>
         /// Gets a list of user-defined callbacks that can be used to modify the initial contract.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.Json.Reflection;
 
 namespace System.Text.Json.Serialization.Metadata


### PR DESCRIPTION
Makes the following changes:

* Use `ConstructorInfo` invocations instead of static `MethodInfo` when instantiating generic metadata types. In my measurements this is ~2x faster.
* Delegate `JsonTypeInfo<T>` construction to existing `JsonConverter<T>` instances, where possible.

|             Method |        Job |                                                                                                         Toolchain |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | MannWhitney(3%) | RatioSD |  Gen 0 |  Gen 1 | Allocated | Alloc Ratio |
|------------------- |----------- |------------------------------------------------------------------------------------------------------------------ |---------:|---------:|---------:|---------:|---------:|---------:|------:|---------------- |--------:|-------:|-------:|----------:|------------:|
| NewCustomConverter | Job-GMEIGR | main | 24.35 us | 0.312 us | 0.244 us | 24.37 us | 23.92 us | 24.78 us |  1.00 |            Base |    0.00 | 0.9720 | 0.0972 |   9.74 KB |        1.00 |
| NewCustomConverter | Job-XOBSON | PR | 19.80 us | 0.389 us | 0.400 us | 19.78 us | 19.23 us | 20.45 us |  0.82 |          Faster |    0.02 | 0.7650 | 0.0765 |   7.86 KB |        0.81 |

Fix #73388.