### PR TITLE
[mono] Disable JIT/Methodical/Coverage/copy_prop_byref_to_native_int.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2480,6 +2480,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Coverage/b39946/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/Coverage/copy_prop_byref_to_native_int/**">
+            <Issue>https://github.com/dotnet/runtime/issues/69832</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_487699/DevDiv_487699/**">
             <Issue>https://github.com/dotnet/runtime/issues/54393</Issue>
         </ExcludeList>


### PR DESCRIPTION
Re: https://github.com/dotnet/runtime/issues/69832.