### PR TITLE
[Test] Lower the Kerberos principal expiration time

### DIFF
--- a/src/libraries/Common/tests/System/Net/Security/Kerberos/FakeKerberosPrincipal.cs
+++ b/src/libraries/Common/tests/System/Net/Security/Kerberos/FakeKerberosPrincipal.cs
@@ -19,7 +19,7 @@ class FakeKerberosPrincipal : IKerberosPrincipal
         this.Type = type;
         this.PrincipalName = principalName;
         this.Realm = realm;
-        this.Expires = DateTimeOffset.UtcNow.AddMonths(9999);
+        this.Expires = DateTimeOffset.UtcNow.AddMonths(1);
         this._password = password;
     }
 

--- a/src/libraries/Common/tests/System/Net/Security/Kerberos/KerberosExecutor.cs
+++ b/src/libraries/Common/tests/System/Net/Security/Kerberos/KerberosExecutor.cs
@@ -29,9 +29,7 @@ public class KerberosExecutor : IDisposable
     private readonly ITestOutputHelper _testOutputHelper;
 
     public static bool IsSupported { get; } =
-        RemoteExecutor.IsSupported && (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()) &&
-        // ARM32 is cursed (https://github.com/dotnet/runtime/issues/73343)
-        !PlatformDetection.IsArmProcess;
+        RemoteExecutor.IsSupported && (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS());
     public const string DefaultAdminPassword = "PLACEHOLDERadmin.";
 
     public const string DefaultUserPassword = "PLACEHOLDERcorrect20";


### PR DESCRIPTION
KRB5/GSSAPI on Arm32 is unable to handle dates far in the future. We don't use the credentials long-term so the expiration could be almost arbitrarily short.

Fixes #73343