### PR TITLE
JIT: Fix alignment insertion assuming only emitForceNewIG can create new IGs

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -5189,32 +5189,13 @@ void emitter::emitCheckAlignFitInCurIG(unsigned nAlignInstr)
 //
 void emitter::emitLoopAlign(unsigned paddingBytes, bool isFirstAlign DEBUG_ARG(bool isPlacedBehindJmp))
 {
-    // Determine if 'align' instruction about to be generated will
-    // fall in current IG or next.
-    bool alignInstrInNewIG = emitForceNewIG;
-
-    if (!alignInstrInNewIG)
-    {
-        // If align fits in current IG, then mark that it contains alignment
-        // instruction in the end.
-        emitCurIG->igFlags |= IGF_HAS_ALIGN;
-    }
-
-    /* Insert a pseudo-instruction to ensure that we align
-       the next instruction properly */
+    // Insert a pseudo-instruction to ensure that we align
+    // the next instruction properly
     instrDescAlign* id = emitNewInstrAlign();
 
-    if (alignInstrInNewIG)
-    {
-        // Mark this IG has alignment in the end, so during emitter we can check the instruction count
-        // heuristics of all IGs that follows this IG that participate in a loop.
-        emitCurIG->igFlags |= IGF_HAS_ALIGN;
-    }
-    else
-    {
-        // Otherwise, make sure it was already marked such.
-        assert(emitCurIG->endsWithAlignInstr());
-    }
+    // Mark this IG has alignment in the end, so during emitter we can check the instruction count
+    // heuristics of all IGs that follows this IG that participate in a loop.
+    emitCurIG->igFlags |= IGF_HAS_ALIGN;
 
 #if defined(TARGET_XARCH)
     assert(paddingBytes <= MAX_ENCODED_SIZE);


### PR DESCRIPTION
Issue I noticed over in #73365.
`emitNewInstrAlign` can create new IGs for other reasons than `emitForceNewIG`, e.g. if the current IG cannot fit another `instrDesc` or if we have reached the limit on the number of instructions in the current IG (255).