### PR TITLE
Describe PGO kind in JitDisasm

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1880,7 +1880,30 @@ void CodeGen::genGenerateMachineCode()
 
         if (compiler->fgHaveProfileData())
         {
-            printf("; with PGO: edge weights are %s, and fgCalledCount is " FMT_WT "\n",
+            const char* pgoKind;
+            switch (compiler->fgPgoSource)
+            {
+                case ICorJitInfo::PgoSource::Static:
+                    pgoKind = "Static";
+                    break;
+                case ICorJitInfo::PgoSource::Dynamic:
+                    pgoKind = "Dynamic";
+                    break;
+                case ICorJitInfo::PgoSource::Blend:
+                    pgoKind = "Blend";
+                    break;
+                case ICorJitInfo::PgoSource::Text:
+                    pgoKind = "Text";
+                    break;
+                case ICorJitInfo::PgoSource::Sampling:
+                    pgoKind = "Sampling";
+                    break;
+                default:
+                    pgoKind = "Unknown";
+                    break;
+            }
+
+            printf("; with %s PGO: edge weights are %s, and fgCalledCount is " FMT_WT "\n", pgoKind,
                    compiler->fgHaveValidEdgeWeights ? "valid" : "invalid", compiler->fgCalledCount);
         }
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1893,10 +1893,10 @@ void CodeGen::genGenerateMachineCode()
                     pgoKind = "Blend";
                     break;
                 case ICorJitInfo::PgoSource::Text:
-                    pgoKind = "Text";
+                    pgoKind = "Textual";
                     break;
                 case ICorJitInfo::PgoSource::Sampling:
-                    pgoKind = "Sampling";
+                    pgoKind = "Sample-based";
                     break;
                 default:
                     pgoKind = "Unknown";


### PR DESCRIPTION
@AndyAyersMS you asked to leave a mark in JitDisasm whether PGO is Static or Dynamic. With this PR it's now:
```
; Assembly listing for method Program:Foo(Program):int
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; Tier-1 compilation
; optimized code
; optimized using profile data
; rsp based frame
; partially interruptible
; with Dynamic PGO: edge weights are valid, and fgCalledCount is 50
; 0 inlinees with PGO data; 1 single block inlinees; 0 inlinees without PGO data

... asm
```
And since JitDisasm will be available in Release this is how users will be able to diagnose whether Dynamic PGO was kicked in or not