### PR TITLE
Improve IndexOf(char, OrdinalIgnoreCase)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -60,11 +60,27 @@ namespace System
                     return IndexOf(value);
 
                 case StringComparison.OrdinalIgnoreCase:
-                    return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.OrdinalIgnoreCase);
+                    return IndexOfCharOrdinalIgnoreCase(value);
 
                 default:
                     throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
+        }
+
+        private int IndexOfCharOrdinalIgnoreCase(char value)
+        {
+            if (!char.IsAscii(value))
+            {
+                return CompareInfo.Invariant.IndexOf(this, value, CompareOptions.OrdinalIgnoreCase);
+            }
+
+            if (char.IsAsciiLetter(value))
+            {
+                char valueUc = (char)(value | 0x20);
+                char valueLc = (char)(value & ~0x20);
+                return SpanHelpers.IndexOfAny(ref _firstChar, valueLc, valueUc, Length);
+            }
+            return SpanHelpers.IndexOf(ref _firstChar, value, Length);
         }
 
         public unsafe int IndexOf(char value, int startIndex, int count)

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -80,6 +80,7 @@ namespace System
                 char valueLc = (char)(value & ~0x20);
                 return SpanHelpers.IndexOfAny(ref _firstChar, valueLc, valueUc, Length);
             }
+
             return SpanHelpers.IndexOf(ref _firstChar, value, Length);
         }
 


### PR DESCRIPTION
A similar trick is used for `IndexOf(string, OrdinalIgnoreCase)` see [here](https://github.com/dotnet/runtime/blob/e43e31527db9f1a2dde3095a1651279b272c8c09/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs#L256-L261).

Benchmark:
```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Benchmarks).Assembly).Run(args);

public class Benchmarks
{
    const string TestStr =
        ".NET Runtime uses third-party libraries or other resources that may be" +
        " distributed under licenses different than the.NET Runtime software.";

    [Benchmark]
    public int IndexOfDash() => TestStr.IndexOf('-', StringComparison.OrdinalIgnoreCase);

    [Benchmark]
    public int IndexOfL() => TestStr.IndexOf('L', StringComparison.OrdinalIgnoreCase);

    [Benchmark]
    public int IndexOfZ() => TestStr.IndexOf('z', StringComparison.OrdinalIgnoreCase);
}
```

|      Method |        Job |                   Toolchain |      Mean | Ratio |
|------------ |----------- |---------------------------- |----------:|------:|
| IndexOfDash | Job-GBURIF | \Core_Root_base\corerun.exe | 16.125 ns |  1.00 |
| IndexOfDash | Job-DLWGWE |      \Core_Root\corerun.exe |  7.084 ns |  0.44 |
|             |            |                             |           |       |
|    IndexOfL | Job-GBURIF | \Core_Root_base\corerun.exe | 14.907 ns |  1.00 |
|    IndexOfL | Job-DLWGWE |      \Core_Root\corerun.exe |  5.630 ns |  0.38 |
|             |            |                             |           |       |
|    IndexOfZ | Job-GBURIF | \Core_Root_base\corerun.exe | 16.809 ns |  1.00 |
|    IndexOfZ | Job-DLWGWE |      \Core_Root\corerun.exe |  8.337 ns |  0.50 |