### PR TITLE
shortcut string replace if oldvalue is longer than count

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1869,7 +1869,7 @@ namespace System.Text
 
             if (oldValue.Length > count)
             {
-                return;
+                return this;
             }
 
             newValue ??= string.Empty;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1867,6 +1867,11 @@ namespace System.Text
             }
             ArgumentException.ThrowIfNullOrEmpty(oldValue);
 
+            if (oldValue.Length > count)
+            {
+                return;
+            }
+
             newValue ??= string.Empty;
 
             Span<int> replacements = stackalloc int[5]; // A list of replacement positions in a chunk to apply


### PR DESCRIPTION
thoughts on this small optimization? or do i have my understanding incorrect?

given `StringBuilder.Replace` knows the max characters range to replace, is it safe to early exit if the `oldValue.Length`  is greater than that range `count`?
