### PR TITLE
Expand NativeAOT testing platforms

### DIFF
--- a/eng/pipelines/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/runtime-extra-platforms-other.yml
@@ -86,13 +86,12 @@ jobs:
     - windows_arm64
     - Linux_x64
     - Linux_arm64
-    - OSX_x64
     - Linux_musl_x64
     - Linux_musl_arm64
     jobParameters:
       testGroup: innerloop
       isSingleFile: true
-      nameSuffix: NativeAOT_Libs_Passing
+      nameSuffix: NativeAOT_Libs
       buildArgs: -s clr.aot+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:ArchiveTests=true
       timeoutInMinutes: 240
       # extra steps, run tests

--- a/eng/pipelines/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/runtime-extra-platforms-other.yml
@@ -87,7 +87,6 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - Linux_musl_x64
-    - Linux_musl_arm64
     jobParameters:
       testGroup: innerloop
       isSingleFile: true

--- a/eng/pipelines/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/runtime-extra-platforms-other.yml
@@ -86,6 +86,9 @@ jobs:
     - windows_arm64
     - Linux_x64
     - Linux_arm64
+    - OSX_x64
+    - Linux_musl_x64
+    - Linux_musl_arm64
     jobParameters:
       testGroup: innerloop
       isSingleFile: true

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -6,6 +6,9 @@
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
   <ItemGroup>
+    <RdXmlFile Include="default.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/default.rd.xml
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/default.rd.xml
@@ -1,0 +1,15 @@
+<Directives>
+  <Application>
+    <Assembly Name="System.Linq">
+      <!-- called by xUnit in obscure MemberData scenarios  -->
+      <Type Name="System.Linq.Enumerable">
+        <Method Name="Cast" Dynamic="Required All">
+          <GenericArgument Name="System.Net.Security.TlsCipherSuite,System.Net.Security" />
+        </Method>
+        <Method Name="ToArray" Dynamic="Required All">
+          <GenericArgument Name="System.Net.Security.TlsCipherSuite,System.Net.Security" />
+        </Method>
+      </Type>
+    </Assembly>    
+  </Application>
+</Directives>


### PR DESCRIPTION
* We don't officially support x64 Mac because it would look dumb if we don't support ARM64. I would still like to see us testing it to prevent regressions.
* We should ideally support MUSL-based Linux officially (let's see how close we're based on CI).