### PR TITLE
Make public EventBookmark's constructor and BookmarkText property

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
@@ -179,10 +179,9 @@ namespace System.Diagnostics
 }
 namespace System.Diagnostics.Eventing.Reader
 {
-    public sealed class EventBookmark
+    public partial class EventBookmark
     {
-        public EventBookmark(string bookmarkText) { }
-        public string BookmarkText { get { throw null; } }
+        internal EventBookmark() { }
     }
     public sealed partial class EventKeyword
     {

--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
@@ -179,9 +179,10 @@ namespace System.Diagnostics
 }
 namespace System.Diagnostics.Eventing.Reader
 {
-    public partial class EventBookmark
+    public sealed class EventBookmark
     {
-        internal EventBookmark() { }
+        public EventBookmark(string bookmarkText) { }
+        public string BookmarkText { get { throw null; } }
     }
     public sealed partial class EventKeyword
     {

--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="System.Diagnostics.EventLog.cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
     <Compile Include="System.Diagnostics.EventLog.netframework.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <Compile Include="System.Diagnostics.EventLog.netcoreapp.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">

--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.netcoreapp.cs
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.netcoreapp.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the https://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Diagnostics.Eventing.Reader
+{
+    public sealed partial class EventBookmark
+    {
+        public EventBookmark(string bookmarkText) { }
+        public string BookmarkText { get { throw null; } }
+    }
+}

--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.netcoreapp.cs
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.netcoreapp.cs
@@ -8,7 +8,7 @@ namespace System.Diagnostics.Eventing.Reader
 {
     public sealed partial class EventBookmark
     {
-        public EventBookmark(string bookmarkText) { }
-        public string BookmarkText { get { throw null; } }
+        public EventBookmark(string bookmarkXml) { }
+        public string BookmarkXml { get { throw null; } }
     }
 }

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventBookmark.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventBookmark.cs
@@ -20,17 +20,17 @@ namespace System.Diagnostics.Eventing.Reader
         /// <summary>
         /// Creates a bookmark that identifies an event in a channel.
         /// </summary>
-        /// <param name="bookmarkText">An XML string that represents the bookmark.</param>
-        public EventBookmark(string bookmarkText)
+        /// <param name="bookmarkXml">An XML string that represents the bookmark.</param>
+        public EventBookmark(string bookmarkXml)
         {
-            ArgumentNullException.ThrowIfNull(bookmarkText);
+            ArgumentNullException.ThrowIfNull(bookmarkXml);
 
-            BookmarkText = bookmarkText;
+            BookmarkXml = bookmarkXml;
         }
 
         /// <summary>
         /// Gets the XML string that represents the bookmark.
         /// </summary>
-        public string BookmarkText { get; }
+        public string BookmarkXml { get; }
     }
 }

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventBookmark.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventBookmark.cs
@@ -17,6 +17,10 @@ namespace System.Diagnostics.Eventing.Reader
     /// </summary>
     public sealed class EventBookmark
     {
+        /// <summary>
+        /// Creates a bookmark that identifies an event in a channel.
+        /// </summary>
+        /// <param name="bookmarkText">An XML string that represents the bookmark.</param>
         public EventBookmark(string bookmarkText)
         {
             ArgumentNullException.ThrowIfNull(bookmarkText);
@@ -24,6 +28,9 @@ namespace System.Diagnostics.Eventing.Reader
             BookmarkText = bookmarkText;
         }
 
+        /// <summary>
+        /// Gets the XML string that represents the bookmark.
+        /// </summary>
         public string BookmarkText { get; }
     }
 }

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventBookmark.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventBookmark.cs
@@ -15,15 +15,15 @@ namespace System.Diagnostics.Eventing.Reader
     /// well as marks the location in the result set of the EventReader
     /// that the event instance was obtained from.
     /// </summary>
-    public class EventBookmark
+    public sealed class EventBookmark
     {
-        internal EventBookmark(string bookmarkText)
+        public EventBookmark(string bookmarkText)
         {
             ArgumentNullException.ThrowIfNull(bookmarkText);
 
             BookmarkText = bookmarkText;
         }
 
-        internal string BookmarkText { get; }
+        public string BookmarkText { get; }
     }
 }

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/EventLogRecord.cs
@@ -406,7 +406,7 @@ namespace System.Diagnostics.Eventing.Reader
         {
             if (bookmark == null)
                 return EventLogHandle.Zero;
-            EventLogHandle handle = NativeWrapper.EvtCreateBookmark(bookmark.BookmarkText);
+            EventLogHandle handle = NativeWrapper.EvtCreateBookmark(bookmark.BookmarkXml);
             return handle;
         }
     }

--- a/src/libraries/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -23,6 +23,7 @@
     <Compile Include="System\Diagnostics\Reader\EventLogSessionTests.cs" />
     <Compile Include="System\Diagnostics\Reader\EventLogWatcherTests.cs" />
     <Compile Include="System\Diagnostics\Reader\ProviderMetadataTests.cs" />
+    <Compile Include="System\Diagnostics\Reader\EventBookmarkTests.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="EventLogMessagesTests.cs" />

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventBookmarkTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventBookmarkTests.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
+using System.Diagnostics.Tests;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public class EventBookmarkTests
+    {
+        [Fact]
+        public void Ctor_NullBookmarkText_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EventBookmark(null));
+        }
+
+        [Fact]
+        public void Create_ValidXml_ReturnsEventBookmark()
+        {
+            string bookmarkXml = $"<BookmarkList><Bookmark Channel=\"Application\" RecordId=\"2022\" IsCurrent=\"True\"/></BookmarkList>";
+            var createdBookmark = new EventBookmark(bookmarkXml);
+
+            Assert.Equal(bookmarkXml, createdBookmark.BookmarkText);
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventBookmarkTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventBookmarkTests.cs
@@ -23,10 +23,10 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void Create_ValidXml_ReturnsEventBookmark()
         {
-            string bookmarkXml = $"<BookmarkList><Bookmark Channel=\"Application\" RecordId=\"2022\" IsCurrent=\"True\"/></BookmarkList>";
+            const string bookmarkXml = "<BookmarkList><Bookmark Channel=\"Application\" RecordId=\"2022\" IsCurrent=\"True\"/></BookmarkList>";
             var createdBookmark = new EventBookmark(bookmarkXml);
 
-            Assert.Equal(bookmarkXml, createdBookmark.BookmarkText);
+            Assert.Equal(bookmarkXml, createdBookmark.BookmarkXml);
         }
     }
 }


### PR DESCRIPTION
Follows https://github.com/dotnet/runtime/issues/49866, this PR makes the constructor of `System.Diagnostic.Eventing.Reader.EventBookmark` and its `BookmarkText` property public.