### PR TITLE
Fix ASAN mismatch

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -6109,7 +6109,7 @@ ClrDataAccess::GetMethodNativeMap(MethodDesc* methodDesc,
 
     // Bounds info.
     ULONG32 countMapCopy;
-    NewHolder<ICorDebugInfo::OffsetMapping> mapCopy(NULL);
+    NewArrayHolder<ICorDebugInfo::OffsetMapping> mapCopy(NULL);
 
     BOOL success = DebugInfoManager::GetBoundariesAndVars(
         request,

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -185,7 +185,7 @@ void DeleteDbiMemory(void* p)
     }
     else
     {
-        ::delete (BYTE*)p;
+        ::delete [] (BYTE*)p;
     }
 }
 


### PR DESCRIPTION
ASAN alloc-dealloc mismatch is detected during dump creation.
Detection happens on `.NET 6` but the code is the same with `main` branch.
