### PR TITLE
[wasm] fix IMPORTS and flat API in createDotnetRuntime callback parameter

### DIFF
--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -34,7 +34,7 @@ if (ENVIRONMENT_IS_NODE) {
 let __dotnet_exportedAPI = __dotnet_runtime.__initializeImportsAndExports(
     { isGlobal:false, isNode:ENVIRONMENT_IS_NODE, isWorker:ENVIRONMENT_IS_WORKER, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, isPThread:${isPThread}, quit_, ExitStatus, requirePromise:__dotnet_replacements.requirePromise },
     { mono:MONO, binding:BINDING, internal:INTERNAL, module:Module, marshaled_imports: IMPORTS },
-    __dotnet_replacements);
+    __dotnet_replacements, __callbackAPI);
 updateGlobalBufferAndViews = __dotnet_replacements.updateGlobalBufferAndViews;
 var fetch = __dotnet_replacements.fetch;
 _scriptDir = __dirname = scriptDirectory = __dotnet_replacements.scriptDirectory;

--- a/src/mono/wasm/runtime/es6/dotnet.es6.pre.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.pre.js
@@ -2,9 +2,10 @@ const MONO = {}, BINDING = {}, INTERNAL = {}, IMPORTS = {};
 let ENVIRONMENT_IS_GLOBAL = false;
 var require = require || undefined;
 var __dirname = __dirname || '';
+var __callbackAPI = { MONO, BINDING, INTERNAL, IMPORTS };
 if (typeof createDotnetRuntime === "function") {
-    Module = { ready: Module.ready };
-    const extension = createDotnetRuntime({ MONO, BINDING, INTERNAL, Module, IMPORTS })
+    __callbackAPI.Module = Module = { ready: Module.ready };
+    const extension = createDotnetRuntime(__callbackAPI)
     if (extension.ready) {
         throw new Error("MONO_WASM: Module.ready couldn't be redefined.")
     }
@@ -13,7 +14,7 @@ if (typeof createDotnetRuntime === "function") {
     if (!createDotnetRuntime.locateFile) createDotnetRuntime.locateFile = createDotnetRuntime.__locateFile = (path) => scriptDirectory + path;
 }
 else if (typeof createDotnetRuntime === "object") {
-    Module = { ready: Module.ready, __undefinedConfig: Object.keys(createDotnetRuntime).length === 1 };
+    __callbackAPI.Module = Module = { ready: Module.ready, __undefinedConfig: Object.keys(createDotnetRuntime).length === 1 };
     Object.assign(Module, createDotnetRuntime);
     createDotnetRuntime = Module;
     if (!createDotnetRuntime.locateFile) createDotnetRuntime.locateFile = createDotnetRuntime.__locateFile = (path) => scriptDirectory + path;

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -32,6 +32,7 @@ function initializeImportsAndExports(
     imports: EarlyImports,
     exports: EarlyExports,
     replacements: EarlyReplacements,
+    callbackAPI: any
 ): DotnetPublicAPI {
     const module = exports.module as DotnetModule;
     const globalThisAny = globalThis as any;
@@ -60,6 +61,7 @@ function initializeImportsAndExports(
         },
         ...API,
     };
+    Object.assign(callbackAPI, API);
     if (exports.module.__undefinedConfig) {
         module.disableDotnet6Compatibility = true;
         module.configSrc = "./mono-config.json";

--- a/src/mono/wasm/runtime/imports.ts
+++ b/src/mono/wasm/runtime/imports.ts
@@ -25,6 +25,7 @@ export function set_imports_exports(
     exports: EarlyExports,
 ): void {
     INTERNAL = exports.internal;
+    IMPORTS = exports.marshaled_imports;
     Module = exports.module;
 
     ENVIRONMENT_IS_NODE = imports.isNode;


### PR DESCRIPTION
- add flat APIs to createDotnetRuntime callback parameter
- assign IMPORTS instance