### PR TITLE
Fix interleaved heap RW commit failure handling

### DIFF
--- a/src/coreclr/utilcode/loaderheap.cpp
+++ b/src/coreclr/utilcode/loaderheap.cpp
@@ -1304,14 +1304,17 @@ BOOL UnlockedLoaderHeap::GetMoreCommittedPages(size_t dwMinSize)
         void *pData = ExecutableAllocator::Instance()->Commit(m_pPtrToEndOfCommittedRegion, dwSizeToCommitPart, IsExecutable());
         if (pData == NULL)
         {
-            _ASSERTE(!"Unable to commit a loaderheap page");
             return FALSE;
         }
 
         if (IsInterleaved())
         {
             // Commit a data page after the code page
-            ExecutableAllocator::Instance()->Commit(m_pPtrToEndOfCommittedRegion + dwSizeToCommitPart, dwSizeToCommitPart, FALSE);
+            void* pDataRW = ExecutableAllocator::Instance()->Commit(m_pPtrToEndOfCommittedRegion + dwSizeToCommitPart, dwSizeToCommitPart, FALSE);
+            if (pDataRW == NULL)
+            {
+                return FALSE;
+            }
 
             ExecutableWriterHolder<BYTE> codePageWriterHolder((BYTE*)pData, GetOsPageSize());
             m_codePageGenerator(codePageWriterHolder.GetRW(), (BYTE*)pData);


### PR DESCRIPTION
We were not checking the result of the `ExecutableAllocator::Commit` call
for mapping the RW page in the case of interleaved heaps. I've seen a
failure in the CI that seems to be caused by this - when we succeeded
committing the RX page, but failed to commit the related RW page, we
have then crashed when trying to initialize the precode stubs data.

This change adds the check to fix the problem. This causes the
`LoaderHeap` allocation to fail as expected in such case.

Close #71624