### PR TITLE
Respect the Keep-Alive response header on HTTP/1.1 as well

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -236,6 +236,8 @@ namespace System.Net.Http
 
         private bool CheckKeepAliveTimeoutExceeded()
         {
+            // We intentionally honor the Keep-Alive timeout on all HTTP/1.X versions, not just 1.0. This is to maximize compat with
+            // servers that use a lower idle timeout than the client, but give us a hint in the form of a Keep-Alive timeout parameter.
             // If _keepAliveTimeoutSeconds is 0, no timeout has been set.
             return _keepAliveTimeoutSeconds != 0 &&
                 GetIdleTicks(Environment.TickCount64) >= _keepAliveTimeoutSeconds * 1000;
@@ -1122,6 +1124,8 @@ namespace System.Net.Http
 
                 if (descriptor.Equals(KnownHeaders.KeepAlive))
                 {
+                    // We are intentionally going against RFC to honor the Keep-Alive header even if
+                    // we haven't received a Keep-Alive connection token to maximize compat with servers.
                     connection.ProcessKeepAliveHeader(headerValue);
                 }
 
@@ -1140,6 +1144,7 @@ namespace System.Net.Http
             {
                 foreach (NameValueHeaderValue nameValue in parsedValues)
                 {
+                    // The HTTP/1.1 spec does not define any parameters for the Keep-Alive header, so we are using the de facto standard ones - timeout and max.
                     if (string.Equals(nameValue.Name, "timeout", StringComparison.OrdinalIgnoreCase))
                     {
                         if (!string.IsNullOrEmpty(nameValue.Value) &&

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
@@ -44,7 +44,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses Task.Delay")]
         [Fact]
-        public async Task Http10ResponseWithKeepAliveTimeout_ConnectionRecycledAfterTimeout()
+        public async Task Http1ResponseWithKeepAliveTimeout_ConnectionRecycledAfterTimeout()
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
@@ -60,7 +60,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await connection.WriteStringAsync("HTTP/1.0 200 OK\r\nKeep-Alive: timeout=1\r\nContent-Length: 1\r\n\r\n1");
+                    await connection.WriteStringAsync("HTTP/1.1 200 OK\r\nKeep-Alive: timeout=1\r\nContent-Length: 1\r\n\r\n1");
                     connection.CompleteRequestProcessing();
 
                     await Assert.ThrowsAnyAsync<Exception>(() => connection.ReadRequestDataAsync());
@@ -74,6 +74,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("timeout=1000", true)]
         [InlineData("timeout=30", true)]
         [InlineData("timeout=0", false)]
+        [InlineData("timeout=1", false)]
         [InlineData("foo, bar=baz, timeout=30", true)]
         [InlineData("foo, bar=baz, timeout=0", false)]
         [InlineData("timeout=-1", true)]
@@ -86,7 +87,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("timeout=30, max=0", false)]
         [InlineData("timeout=0, max=1", false)]
         [InlineData("timeout=0, max=0", false)]
-        public async Task Http10ResponseWithKeepAlive_ConnectionNotReusedForShortTimeoutOrMax0(string keepAlive, bool shouldReuseConnection)
+        public async Task Http1ResponseWithKeepAlive_ConnectionNotReusedForShortTimeoutOrMax0(string keepAlive, bool shouldReuseConnection)
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
@@ -100,7 +101,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await connection.WriteStringAsync($"HTTP/1.0 200 OK\r\nKeep-Alive: {keepAlive}\r\nContent-Length: 1\r\n\r\n1");
+                    await connection.WriteStringAsync($"HTTP/1.{Random.Shared.Next(10)} 200 OK\r\nKeep-Alive: {keepAlive}\r\nContent-Length: 1\r\n\r\n1");
                     connection.CompleteRequestProcessing();
 
                     if (shouldReuseConnection)
@@ -117,33 +118,6 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.AcceptConnectionSendResponseAndCloseAsync();
                 }
-            });
-        }
-
-        [Theory]
-        [InlineData("timeout=1")]
-        [InlineData("timeout=0")]
-        [InlineData("max=1")]
-        [InlineData("max=0")]
-        public async Task Http11ResponseWithKeepAlive_KeepAliveIsIgnored(string keepAlive)
-        {
-            await LoopbackServer.CreateClientAndServerAsync(async uri =>
-            {
-                using HttpClient client = CreateHttpClient();
-
-                await client.GetAsync(uri);
-                await client.GetAsync(uri);
-            },
-            async server =>
-            {
-                await server.AcceptConnectionAsync(async connection =>
-                {
-                    await connection.ReadRequestDataAsync();
-                    await connection.WriteStringAsync($"HTTP/1.1 200 OK\r\nKeep-Alive: {keepAlive}\r\nContent-Length: 1\r\n\r\n1");
-                    connection.CompleteRequestProcessing();
-
-                    await connection.HandleRequestAsync();
-                });
             });
         }
     }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http1KeepAlive.cs
@@ -60,7 +60,7 @@ namespace System.Net.Http.Functional.Tests
                 await server.AcceptConnectionAsync(async connection =>
                 {
                     await connection.ReadRequestDataAsync();
-                    await connection.WriteStringAsync("HTTP/1.1 200 OK\r\nKeep-Alive: timeout=1\r\nContent-Length: 1\r\n\r\n1");
+                    await connection.WriteStringAsync("HTTP/1.1 200 OK\r\nKeep-Alive: timeout=2\r\nContent-Length: 1\r\n\r\n1");
                     connection.CompleteRequestProcessing();
 
                     await Assert.ThrowsAnyAsync<Exception>(() => connection.ReadRequestDataAsync());


### PR DESCRIPTION
Followup after #73020
Contributes to #72958

This changes #73020 to apply to all 1.x responses, not just 1.0.

It also brings back the 1 second offset (discussed at https://github.com/dotnet/runtime/pull/73020#discussion_r934542368) we apply to the timeout to avoid reusing the connection as it's about to time out.
An example from a real service closing the connection right as we've sent the request right about 5 seconds after the last one:

![tempsnip2](https://user-images.githubusercontent.com/25307628/183503516-154ad872-db28-42ff-8594-b296e755f7a4.png)

With these changes, an internal service I was testing with experiences no more "Connection reset by peer" request failures.

cc: @halter73 