### PR TITLE
Cleanup to lsra inspired by #73424

### DIFF
--- a/src/coreclr/jit/jitstd/list.h
+++ b/src/coreclr/jit/jitstd/list.h
@@ -59,7 +59,6 @@ public:
         bool operator==(const const_iterator& it) const;
         bool operator!=(const const_iterator& it) const;
         const T& operator*() const;
-        const T* operator&() const;
         const T* operator->() const;
         operator const T*() const;
 
@@ -85,7 +84,6 @@ public:
         bool operator==(const iterator& it);
         bool operator!=(const iterator& it);
         T& operator*();
-        T* operator&();
         T* operator->();
         operator T*();
 
@@ -115,7 +113,6 @@ public:
         bool operator==(const const_reverse_iterator& it) const;
         bool operator!=(const const_reverse_iterator& it) const;
         const T& operator*() const;
-        const T* operator&() const;
         const T* operator->() const;
         operator const T*() const;
 
@@ -142,7 +139,6 @@ public:
         bool operator==(const reverse_iterator& it);
         bool operator!=(const reverse_iterator& it);
         T& operator*();
-        T* operator&();
         T* operator->();
         operator T*();
         friend class list<T, Allocator>::const_reverse_iterator;
@@ -971,12 +967,6 @@ T& list<T, Allocator>::iterator::operator*()
 }
 
 template <typename T, typename Allocator>
-T* list<T, Allocator>::iterator::operator&()
-{
-    return &(m_pNode->m_value);
-}
-
-template <typename T, typename Allocator>
 T* list<T, Allocator>::iterator::operator->()
 {
     return &(m_pNode->m_value);
@@ -1063,12 +1053,6 @@ const T& list<T, Allocator>::const_iterator::operator*() const
 }
 
 template <typename T, typename Allocator>
-const T* list<T, Allocator>::const_iterator::operator&() const
-{
-    return &(m_pNode->m_value);
-}
-
-template <typename T, typename Allocator>
 const T* list<T, Allocator>::const_iterator::operator->() const
 {
     return &(m_pNode->m_value);
@@ -1145,12 +1129,6 @@ template <typename T, typename Allocator>
 T& list<T, Allocator>::reverse_iterator::operator*()
 {
     return m_pNode->m_value;
-}
-
-template <typename T, typename Allocator>
-T* list<T, Allocator>::reverse_iterator::operator&()
-{
-    return &(m_pNode->m_value);
 }
 
 template <typename T, typename Allocator>
@@ -1234,12 +1212,6 @@ template <typename T, typename Allocator>
 const T& list<T, Allocator>::const_reverse_iterator::operator*() const
 {
     return m_pNode->m_value;
-}
-
-template <typename T, typename Allocator>
-const T* list<T, Allocator>::const_reverse_iterator::operator&() const
-{
-    return &(m_pNode->m_value);
 }
 
 template <typename T, typename Allocator>

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -9537,15 +9537,10 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
         if (mode == LSRA_DUMP_REFPOS)
         {
             bool printedBlockHeader = false;
+            bool continueLoop       = true;
             // We should find the boundary RefPositions in the order of exposed uses, dummy defs, and the blocks
-            for (; currentRefPosition != refPositions.end(); ++currentRefPosition)
+            for (; currentRefPosition != refPositions.end() && continueLoop; ++currentRefPosition)
             {
-                if (currentRefPosition->refType != RefTypeExpUse && currentRefPosition->refType != RefTypeDummyDef &&
-                    !(currentRefPosition->refType == RefTypeBB && !printedBlockHeader))
-                {
-                    break;
-                }
-
                 Interval* interval = nullptr;
                 if (currentRefPosition->isIntervalRef())
                 {
@@ -9564,12 +9559,17 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
                         printf("  Dummy def of V%02u at #%d\n", interval->varNum, currentRefPosition->rpNum);
                         break;
                     case RefTypeBB:
+                        if (printedBlockHeader)
+                        {
+                            continueLoop = false;
+                            break;
+                        }
                         block->dspBlockHeader(compiler);
                         printedBlockHeader = true;
                         printf("=====\n");
                         break;
                     default:
-                        printf("Unexpected RefPosition type at #%d\n", currentRefPosition->rpNum);
+                        continueLoop = false;
                         break;
                 }
             }
@@ -9624,11 +9624,10 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
                 // and combining the fixed regs with their associated def or use
                 bool         killPrinted        = false;
                 RefPosition* lastFixedRegRefPos = nullptr;
-                for (; currentRefPosition != refPositions.end(); ++currentRefPosition)
+                bool         continueLoop       = true;
+                for (; currentRefPosition != refPositions.end() && continueLoop; ++currentRefPosition)
                 {
-                    if (!(currentRefPosition->refType == RefTypeUse || currentRefPosition->refType == RefTypeFixedReg ||
-                          currentRefPosition->refType == RefTypeKill || currentRefPosition->refType == RefTypeDef) ||
-                        !(currentRefPosition->nodeLocation == tree->gtSeqNum ||
+                    if (!(currentRefPosition->nodeLocation == tree->gtSeqNum ||
                           currentRefPosition->nodeLocation == tree->gtSeqNum + 1))
                     {
                         break;
@@ -9711,7 +9710,7 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
                             lastFixedRegRefPos = currentRefPosition;
                             break;
                         default:
-                            printf("Unexpected RefPosition type at #%d\n", currentRefPosition->rpNum);
+                            continueLoop = false;
                             break;
                     }
                 }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2171,10 +2171,8 @@ void LinearScan::checkLastUses(BasicBlock* block)
     VARSET_TP computedLive(VarSetOps::MakeCopy(compiler, block->bbLiveOut));
 
     bool                       foundDiff       = false;
-    RefPositionReverseIterator reverseIterator = refPositions.rbegin();
-    RefPosition*               currentRefPosition;
-    for (currentRefPosition = &reverseIterator; currentRefPosition->refType != RefTypeBB;
-         reverseIterator++, currentRefPosition = &reverseIterator)
+    RefPositionReverseIterator currentRefPosition = refPositions.rbegin();
+    for (; currentRefPosition->refType != RefTypeBB; currentRefPosition++)
     {
         // We should never see ParamDefs or ZeroInits within a basic block.
         assert(currentRefPosition->refType != RefTypeParamDef && currentRefPosition->refType != RefTypeZeroInit);
@@ -2233,7 +2231,7 @@ void LinearScan::checkLastUses(BasicBlock* block)
             }
         }
 
-        assert(reverseIterator != refPositions.rend());
+        assert(currentRefPosition != refPositions.rend());
     }
 
     VARSET_TP liveInNotComputedLive(VarSetOps::Diff(compiler, block->bbLiveIn, computedLive));
@@ -9478,8 +9476,7 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
     // currentRefPosition is not used for LSRA_DUMP_PRE
     // We keep separate iterators for defs, so that we can print them
     // on the lhs of the dump
-    RefPositionIterator refPosIterator     = refPositions.begin();
-    RefPosition*        currentRefPosition = &refPosIterator;
+    RefPositionIterator currentRefPosition = refPositions.begin();
 
     switch (mode)
     {
@@ -9500,9 +9497,8 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
     if (mode != LSRA_DUMP_PRE)
     {
         printf("Incoming Parameters: ");
-        for (; refPosIterator != refPositions.end(); ++refPosIterator)
+        for (; currentRefPosition != refPositions.end(); ++currentRefPosition)
         {
-            currentRefPosition = &refPosIterator;
             if (currentRefPosition->refType == RefTypeBB)
             {
                 break;
@@ -9547,9 +9543,8 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
         {
             bool printedBlockHeader = false;
             // We should find the boundary RefPositions in the order of exposed uses, dummy defs, and the blocks
-            for (; refPosIterator != refPositions.end(); ++refPosIterator)
+            for (; currentRefPosition != refPositions.end(); ++currentRefPosition)
             {
-                currentRefPosition = &refPosIterator;
                 if (currentRefPosition->refType != RefTypeExpUse && currentRefPosition->refType != RefTypeDummyDef &&
                     !(currentRefPosition->refType == RefTypeBB && !printedBlockHeader))
                 {
@@ -9634,9 +9629,8 @@ void LinearScan::TupleStyleDump(LsraTupleDumpMode mode)
                 // and combining the fixed regs with their associated def or use
                 bool         killPrinted        = false;
                 RefPosition* lastFixedRegRefPos = nullptr;
-                for (; refPosIterator != refPositions.end(); ++refPosIterator)
+                for (; currentRefPosition != refPositions.end(); ++currentRefPosition)
                 {
-                    currentRefPosition = &refPosIterator;
                     if (!(currentRefPosition->refType == RefTypeUse || currentRefPosition->refType == RefTypeFixedReg ||
                           currentRefPosition->refType == RefTypeKill || currentRefPosition->refType == RefTypeDef) ||
                         !(currentRefPosition->nodeLocation == tree->gtSeqNum ||
@@ -10399,46 +10393,45 @@ void LinearScan::verifyFinalAllocation()
     BasicBlock*  currentBlock                = nullptr;
     GenTree*     firstBlockEndResolutionNode = nullptr;
     LsraLocation currentLocation             = MinLocation;
-    for (RefPosition& refPosition : refPositions)
+    for (RefPosition& currentRefPosition : refPositions)
     {
-        RefPosition* currentRefPosition = &refPosition;
         Interval*    interval           = nullptr;
         RegRecord*   regRecord          = nullptr;
         regNumber    regNum             = REG_NA;
-        activeRefPosition               = currentRefPosition;
+        activeRefPosition               = &currentRefPosition;
 
-        if (currentRefPosition->refType != RefTypeBB)
+        if (currentRefPosition.refType != RefTypeBB)
         {
-            if (currentRefPosition->IsPhysRegRef())
+            if (currentRefPosition.IsPhysRegRef())
             {
-                regRecord                    = currentRefPosition->getReg();
-                regRecord->recentRefPosition = currentRefPosition;
+                regRecord                    = currentRefPosition.getReg();
+                regRecord->recentRefPosition = &currentRefPosition;
                 regNum                       = regRecord->regNum;
             }
-            else if (currentRefPosition->isIntervalRef())
+            else if (currentRefPosition.isIntervalRef())
             {
-                interval                    = currentRefPosition->getInterval();
-                interval->recentRefPosition = currentRefPosition;
-                if (currentRefPosition->registerAssignment != RBM_NONE)
+                interval                    = currentRefPosition.getInterval();
+                interval->recentRefPosition = &currentRefPosition;
+                if (currentRefPosition.registerAssignment != RBM_NONE)
                 {
-                    if (!genMaxOneBit(currentRefPosition->registerAssignment))
+                    if (!genMaxOneBit(currentRefPosition.registerAssignment))
                     {
-                        assert(currentRefPosition->refType == RefTypeExpUse ||
-                               currentRefPosition->refType == RefTypeDummyDef);
+                        assert(currentRefPosition.refType == RefTypeExpUse ||
+                               currentRefPosition.refType == RefTypeDummyDef);
                     }
                     else
                     {
-                        regNum    = currentRefPosition->assignedReg();
+                        regNum    = currentRefPosition.assignedReg();
                         regRecord = getRegisterRecord(regNum);
                     }
                 }
             }
         }
 
-        LsraLocation newLocation = currentRefPosition->nodeLocation;
+        LsraLocation newLocation = currentRefPosition.nodeLocation;
         currentLocation          = newLocation;
 
-        switch (currentRefPosition->refType)
+        switch (currentRefPosition.refType)
         {
             case RefTypeBB:
             {
@@ -10522,7 +10515,7 @@ void LinearScan::verifyFinalAllocation()
 
                     if (VERBOSE)
                     {
-                        dumpRefPositionShort(currentRefPosition, currentBlock);
+                        dumpRefPositionShort(&currentRefPosition, currentBlock);
                         dumpRegRecords();
                     }
 
@@ -10587,7 +10580,7 @@ void LinearScan::verifyFinalAllocation()
                     dumpLsraAllocationEvent(LSRA_EVENT_SPECIAL_PUTARG, interval, regNum);
                     break;
                 }
-                if (currentRefPosition->reload)
+                if (currentRefPosition.reload)
                 {
                     interval->isActive = true;
                     assert(regNum != REG_NA);
@@ -10602,7 +10595,7 @@ void LinearScan::verifyFinalAllocation()
                     if (interval->physReg != REG_NA)
                     {
                         // then unassign it if no new register was assigned to the RefTypeDef
-                        if (RefTypeIsDef(currentRefPosition->refType))
+                        if (RefTypeIsDef(currentRefPosition.refType))
                         {
                             assert(interval->assignedReg != nullptr);
                             if (interval->assignedReg->assignedInterval == interval)
@@ -10616,14 +10609,14 @@ void LinearScan::verifyFinalAllocation()
 
                     dumpLsraAllocationEvent(LSRA_EVENT_NO_REG_ALLOCATED, interval);
                 }
-                else if (RefTypeIsDef(currentRefPosition->refType))
+                else if (RefTypeIsDef(currentRefPosition.refType))
                 {
                     interval->isActive = true;
 
                     if (VERBOSE)
                     {
-                        if (interval->isConstant && (currentRefPosition->treeNode != nullptr) &&
-                            currentRefPosition->treeNode->IsReuseRegVal())
+                        if (interval->isConstant && (currentRefPosition.treeNode != nullptr) &&
+                            currentRefPosition.treeNode->IsReuseRegVal())
                         {
                             dumpLsraAllocationEvent(LSRA_EVENT_REUSE_REG, nullptr, regRecord->regNum, currentBlock);
                         }
@@ -10633,11 +10626,11 @@ void LinearScan::verifyFinalAllocation()
                         }
                     }
                 }
-                else if (currentRefPosition->copyReg)
+                else if (currentRefPosition.copyReg)
                 {
                     dumpLsraAllocationEvent(LSRA_EVENT_COPY_REG, interval, regRecord->regNum, currentBlock);
                 }
-                else if (currentRefPosition->moveReg)
+                else if (currentRefPosition.moveReg)
                 {
                     assert(interval->assignedReg != nullptr);
                     interval->assignedReg->assignedInterval = nullptr;
@@ -10654,13 +10647,13 @@ void LinearScan::verifyFinalAllocation()
                 {
                     dumpLsraAllocationEvent(LSRA_EVENT_KEPT_ALLOCATION, nullptr, regRecord->regNum, currentBlock);
                 }
-                if (currentRefPosition->lastUse || (currentRefPosition->spillAfter && !currentRefPosition->writeThru))
+                if (currentRefPosition.lastUse || (currentRefPosition.spillAfter && !currentRefPosition.writeThru))
                 {
                     interval->isActive = false;
                 }
                 if (regNum != REG_NA)
                 {
-                    if (currentRefPosition->spillAfter)
+                    if (currentRefPosition.spillAfter)
                     {
                         if (VERBOSE)
                         {
@@ -10668,14 +10661,14 @@ void LinearScan::verifyFinalAllocation()
                             // is the homeReg of the interval not the reg currently assigned
                             // to refPos.
                             regNumber spillReg = regNum;
-                            if (currentRefPosition->copyReg)
+                            if (currentRefPosition.copyReg)
                             {
                                 assert(interval != nullptr);
                                 spillReg = interval->physReg;
                             }
                             dumpRegRecords();
                             dumpEmptyRefPosition();
-                            if (currentRefPosition->writeThru)
+                            if (currentRefPosition.writeThru)
                             {
                                 printf("WThru    %-4s ", getRegName(spillReg));
                             }
@@ -10685,13 +10678,13 @@ void LinearScan::verifyFinalAllocation()
                             }
                         }
                     }
-                    else if (currentRefPosition->copyReg)
+                    else if (currentRefPosition.copyReg)
                     {
                         regRecord->assignedInterval = interval;
                     }
                     else
                     {
-                        if (RefTypeIsDef(currentRefPosition->refType))
+                        if (RefTypeIsDef(currentRefPosition.refType))
                         {
                             // Interval was assigned to a different register.
                             // Clear the assigned interval of current register.
@@ -10711,7 +10704,7 @@ void LinearScan::verifyFinalAllocation()
                 // However, we will assert that, at resolution time, no registers contain GC refs.
                 {
                     DBEXEC(VERBOSE, printf("           "));
-                    regMaskTP candidateRegs = currentRefPosition->registerAssignment;
+                    regMaskTP candidateRegs = currentRefPosition.registerAssignment;
                     while (candidateRegs != RBM_NONE)
                     {
                         regMaskTP nextRegBit = genFindLowestBit(candidateRegs);
@@ -10727,32 +10720,32 @@ void LinearScan::verifyFinalAllocation()
             case RefTypeExpUse:
             case RefTypeDummyDef:
                 // Do nothing; these will be handled by the RefTypeBB.
-                DBEXEC(VERBOSE, dumpRefPositionShort(currentRefPosition, currentBlock));
+                DBEXEC(VERBOSE, dumpRefPositionShort(&currentRefPosition, currentBlock));
                 DBEXEC(VERBOSE, printf("              "));
                 break;
 
             case RefTypeInvalid:
-                // for these 'currentRefPosition->refType' values, No action to take
+                // for these 'currentRefPosition.refType' values, No action to take
                 break;
         }
 
-        if (currentRefPosition->refType != RefTypeBB)
+        if (currentRefPosition.refType != RefTypeBB)
         {
             DBEXEC(VERBOSE, dumpRegRecords());
             if (interval != nullptr)
             {
-                if (currentRefPosition->copyReg)
+                if (currentRefPosition.copyReg)
                 {
                     assert(interval->physReg != regNum);
                     regRecord->assignedInterval = nullptr;
                     assert(interval->assignedReg != nullptr);
                     regRecord = interval->assignedReg;
                 }
-                if (currentRefPosition->spillAfter || currentRefPosition->lastUse)
+                if (currentRefPosition.spillAfter || currentRefPosition.lastUse)
                 {
-                    assert(!currentRefPosition->spillAfter || currentRefPosition->IsActualRef());
+                    assert(!currentRefPosition.spillAfter || currentRefPosition.IsActualRef());
 
-                    if (RefTypeIsDef(currentRefPosition->refType))
+                    if (RefTypeIsDef(currentRefPosition.refType))
                     {
                         // If an interval got assigned to a different register (while the different
                         // register got spilled), then clear the assigned interval of current register.
@@ -10771,12 +10764,12 @@ void LinearScan::verifyFinalAllocation()
                         regRecord->assignedInterval = nullptr;
                     }
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-                    else if (interval->isUpperVector && !currentRefPosition->RegOptional())
+                    else if (interval->isUpperVector && !currentRefPosition.RegOptional())
                     {
                         // These only require a register if they are not RegOptional, and their lclVar
                         // interval is living in a register and not already partially spilled.
-                        if ((currentRefPosition->refType == RefTypeUpperVectorSave) ||
-                            (currentRefPosition->refType == RefTypeUpperVectorRestore))
+                        if ((currentRefPosition.refType == RefTypeUpperVectorSave) ||
+                            (currentRefPosition.refType == RefTypeUpperVectorRestore))
                         {
                             Interval* lclVarInterval = interval->relatedInterval;
                             assert((lclVarInterval->physReg == REG_NA) || lclVarInterval->isPartiallySpilled);
@@ -10785,7 +10778,7 @@ void LinearScan::verifyFinalAllocation()
 #endif
                     else
                     {
-                        assert(currentRefPosition->RegOptional());
+                        assert(currentRefPosition.RegOptional());
                     }
                 }
             }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2170,7 +2170,7 @@ void LinearScan::checkLastUses(BasicBlock* block)
 
     VARSET_TP computedLive(VarSetOps::MakeCopy(compiler, block->bbLiveOut));
 
-    bool                       foundDiff       = false;
+    bool                       foundDiff          = false;
     RefPositionReverseIterator currentRefPosition = refPositions.rbegin();
     for (; currentRefPosition->refType != RefTypeBB; currentRefPosition++)
     {
@@ -4607,7 +4607,7 @@ void LinearScan::allocateRegisters()
 
     for (RefPosition& currentRefPosition : refPositions)
     {
-        RefPosition* nextRefPosition    = currentRefPosition.nextRefPosition;
+        RefPosition* nextRefPosition = currentRefPosition.nextRefPosition;
 
         // TODO: Can we combine this with the freeing of registers below? It might
         // mess with the dump, since this was previously being done before the call below
@@ -5198,7 +5198,7 @@ void LinearScan::allocateRegisters()
 
                 if (keepAssignment == false)
                 {
-                    RegRecord* physRegRecord               = getRegisterRecord(currentInterval->physReg);
+                    RegRecord* physRegRecord              = getRegisterRecord(currentInterval->physReg);
                     currentRefPosition.registerAssignment = allRegs(currentInterval->registerType);
                     currentRefPosition.isFixedRegRef      = false;
                     unassignPhysRegNoSpill(physRegRecord);
@@ -5239,7 +5239,7 @@ void LinearScan::allocateRegisters()
                     clearConstantReg(assignedRegister, currentInterval->registerType);
                 }
                 currentRefPosition.moveReg = true;
-                assignedRegister            = REG_NA;
+                assignedRegister           = REG_NA;
                 currentRefPosition.registerAssignment &= ~assignedRegBit;
                 setIntervalAsSplit(currentInterval);
                 INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_MOVE_REG, currentInterval, assignedRegister));
@@ -5402,7 +5402,7 @@ void LinearScan::allocateRegisters()
                 INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_REG_ALLOCATED, currentInterval));
                 currentRefPosition.registerAssignment = RBM_NONE;
                 currentRefPosition.reload             = false;
-                currentInterval->isActive              = false;
+                currentInterval->isActive             = false;
                 setIntervalAsSpilled(currentInterval);
             }
 #ifdef DEBUG
@@ -10389,10 +10389,10 @@ void LinearScan::verifyFinalAllocation()
     LsraLocation currentLocation             = MinLocation;
     for (RefPosition& currentRefPosition : refPositions)
     {
-        Interval*    interval           = nullptr;
-        RegRecord*   regRecord          = nullptr;
-        regNumber    regNum             = REG_NA;
-        activeRefPosition               = &currentRefPosition;
+        Interval*  interval  = nullptr;
+        RegRecord* regRecord = nullptr;
+        regNumber  regNum    = REG_NA;
+        activeRefPosition    = &currentRefPosition;
 
         if (currentRefPosition.refType != RefTypeBB)
         {


### PR DESCRIPTION
Inspired by comments ([here](https://github.com/dotnet/runtime/pull/73424#discussion_r939068635) and [here](
https://github.com/dotnet/runtime/pull/73424#discussion_r939090204))

- Remove `RefPosition* currentRefPosition = &reverseIterator` as it creates two variables that are essentially the same, especially since the iterator has operators like `->`.  In fact, I had to spend a bit of time verifying that there weren't any updates to one but not the other in the code.  (And actually #73424 did slightly impact this relationship since it moved the assignment from the loop iteration step to the loop body, but I don't believe that this mattered.)
I renamed the "iterator" variable to the "position" name to reduce textual churn in the code.  This didn't work as well for the range-based loops since they yield -references- to the underlying object so a bunch of C++ punctuation changes.
- Break apart two complicated `for` conditions and remove duplication between the condition and the loop body.  Search for `continueLoop` to see them.
 - Delete list's `operator&` on each iterator since they are no longer used and not part of normal iterators.