### PR TITLE
Revert "Disable GetGCMemoryInfo on arm (#73477)"

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -81,7 +81,6 @@
 
     <!-- Arm32 All OS -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TargetArchitecture)' == 'arm' or '$(AltJitArch)' == 'arm') and '$(RuntimeFlavor)' == 'coreclr' ">
-
         <ExcludeList Include="$(XunitTestBinBase)/CoreMangLib/cti/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
@@ -108,9 +107,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetAllocatedBytesForCurrentThread/*">
             <Issue>https://github.com/dotnet/runtime/issues/</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetGCMemoryInfo/**">
-            <Issue>https://github.com/dotnet/runtime/issues/73247</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Features/HeapExpansion/bestfit-finalize/*">
             <Issue>times out</Issue>


### PR DESCRIPTION
Fixes #73247

This reverts commit 9865cc7a89a4a613a47986b8268a10bc37adbd65.
We believe the problematic change has been reverted so the test can be re-enabled.