### PR TITLE
Disable useless warnings

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/MethodMemoryMap.cs
+++ b/src/coreclr/tools/dotnet-pgo/MethodMemoryMap.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 MethodDesc method = null;
                 try
                 {
-                    method = idParser.ResolveMethodID(e.MethodID);
+                    method = idParser.ResolveMethodID(e.MethodID, out _);
                 }
                 catch
                 {
@@ -98,7 +98,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 MethodDesc method = null;
                 try
                 {
-                    method = idParser.ResolveMethodID(e.MethodID, throwIfNotFound: false);
+                    method = idParser.ResolveMethodID(e.MethodID, out _, throwIfNotFound: false);
                 }
                 catch
                 {
@@ -271,7 +271,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
             void AddSubTree(InlineContext ctx)
             {
-                MethodDesc md = idParser.ResolveMethodID((long)ctx.MethodID, false);
+                MethodDesc md = idParser.ResolveMethodID((long)ctx.MethodID, out _, false);
                 byOrdinal.Add(ctx.Ordinal, (ctx, md));
 
                 foreach (var child in ctx.Inlinees)

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1416,7 +1416,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         bool failedDueToNonloadableModule = false;
                         try
                         {
-                             method = idParser.ResolveMethodID(e.MethodID, out failedDueToNonloadableModule, commandLineOptions.VerboseWarnings);
+                            method = idParser.ResolveMethodID(e.MethodID, out failedDueToNonloadableModule, commandLineOptions.VerboseWarnings);
                         }
                         catch (Exception exception)
                         {

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
             try
             {
-                type = _idParser.ResolveTypeHandle(input, false);
+                bool unusedNonLoadableModule = false;
+                type = _idParser.ResolveTypeHandle(input, ref unusedNonLoadableModule, false);
             }
             catch
             { }
@@ -94,7 +95,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
             try
             {
-                method = _idParser.ResolveMethodID(input, false);
+                method = _idParser.ResolveMethodID(input, out _, false);
             }
             catch
             { }
@@ -1284,7 +1285,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     ModuleDesc loadedModule = idParser.ResolveModuleID(e.ModuleID, false);
                     if (loadedModule == null)
                     {
-                        PrintWarning($"Unable to find loaded module {e.ModuleILFileName} to verify match");
+                        if (!idParser.IsDynamicModuleID(e.ModuleID))
+                            PrintWarning($"Unable to find loaded module {e.ModuleILFileName} to verify match");
                         continue;
                     }
 
@@ -1365,9 +1367,10 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         }
                         MethodDesc method = null;
                         string extraWarningText = null;
+                        bool failedDueToNonloadableModule = false;
                         try
                         {
-                            method = idParser.ResolveMethodID(e.MethodID, commandLineOptions.VerboseWarnings);
+                            method = idParser.ResolveMethodID(e.MethodID, out failedDueToNonloadableModule, commandLineOptions.VerboseWarnings);
                         }
                         catch (Exception exception)
                         {
@@ -1376,7 +1379,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                         if (method == null)
                         {
-                            if ((e.MethodNamespace == "dynamicClass") || !commandLineOptions.Warnings)
+                            if ((e.MethodNamespace == "dynamicClass") || failedDueToNonloadableModule || !commandLineOptions.Warnings)
                                 continue;
 
                             PrintWarning($"Unable to parse {methodNameFromEventDirectly} when looking up R2R methods");
@@ -1410,9 +1413,10 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                         MethodDesc method = null;
                         string extraWarningText = null;
+                        bool failedDueToNonloadableModule = false;
                         try
                         {
-                            method = idParser.ResolveMethodID(e.MethodID, commandLineOptions.VerboseWarnings);
+                             method = idParser.ResolveMethodID(e.MethodID, out failedDueToNonloadableModule, commandLineOptions.VerboseWarnings);
                         }
                         catch (Exception exception)
                         {
@@ -1421,7 +1425,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                         if (method == null)
                         {
-                            if ((e.MethodNamespace == "dynamicClass") || !commandLineOptions.Warnings)
+                            if ((e.MethodNamespace == "dynamicClass") || failedDueToNonloadableModule || !commandLineOptions.Warnings)
                                 continue;
 
                             PrintWarning($"Unable to parse {methodNameFromEventDirectly}");
@@ -1549,7 +1553,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     MethodDesc method = null;
                     try
                     {
-                        method = idParser.ResolveMethodID(methodID, commandLineOptions.VerboseWarnings);
+                        method = idParser.ResolveMethodID(methodID, out _, commandLineOptions.VerboseWarnings);
                     }
                     catch (Exception)
                     {

--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -93,15 +93,17 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
         class ModuleDescInfo
         {
-            public ModuleDescInfo(long id, string assemblyName)
+            public ModuleDescInfo(long id, string assemblyName, bool isDynamic)
             {
                 ID = id;
                 AssemblyName = assemblyName;
+                IsDynamic = isDynamic;
             }
 
             public readonly long ID;
             public ModuleDesc Module;
             public readonly string AssemblyName;
+            public readonly bool IsDynamic;
         }
 
         private readonly Dictionary<long, MethodDescInfo> _methods = new Dictionary<long, MethodDescInfo>();
@@ -223,10 +225,13 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
             Dictionary<long, int> assemblyToCLRInstanceIDMap = new Dictionary<long, int>();
             Dictionary<long, string> assemblyToFullyQualifiedAssemblyName = new Dictionary<long, string>();
+            Dictionary<long, bool> assemblyToIsDynamic = new Dictionary<long, bool>();
+
             foreach (var assemblyLoadTrace in _traceProcess.EventsInProcess.ByEventType<AssemblyLoadUnloadTraceData>())
             {
                 assemblyToCLRInstanceIDMap[assemblyLoadTrace.AssemblyID] = assemblyLoadTrace.ClrInstanceID;
                 assemblyToFullyQualifiedAssemblyName[assemblyLoadTrace.AssemblyID] = assemblyLoadTrace.FullyQualifiedAssemblyName;
+                assemblyToIsDynamic[assemblyLoadTrace.AssemblyID] = ((assemblyLoadTrace.AssemblyFlags & Tracing.Parsers.Clr.AssemblyFlags.Dynamic) == Tracing.Parsers.Clr.AssemblyFlags.Dynamic);
             }
 
             foreach (var moduleFile in _traceProcess.LoadedModules)
@@ -242,7 +247,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     if (clrInstanceIDModule != _clrInstanceID)
                         continue;
 
-                    var currentInfo = new ModuleDescInfo(managedModule.ModuleID, assemblyToFullyQualifiedAssemblyName[managedModule.AssemblyID]);
+                    var currentInfo = new ModuleDescInfo(managedModule.ModuleID, assemblyToFullyQualifiedAssemblyName[managedModule.AssemblyID], assemblyToIsDynamic[managedModule.AssemblyID]);
                     if (!_modules.ContainsKey(managedModule.ModuleID))
                         _modules.Add(managedModule.ModuleID, currentInfo);
                 }
@@ -255,7 +260,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             // Fill in all the types
             foreach (var entry in _types)
             {
-                ResolveTypeHandle(entry.Key, false);
+                bool nonLoadableModule = false;
+                ResolveTypeHandle(entry.Key, ref nonLoadableModule, false);
             }
         }
 
@@ -278,6 +284,13 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     if (minfo.Module != null)
                         return minfo.Module;
 
+                    if (minfo.IsDynamic)
+                    {
+                        if (throwIfNotFound)
+                            throw new Exception("Attempt to load dynamic module in pgo processing logic");
+                        return null;
+                    }
+
                     minfo.Module = _context.ResolveAssembly(new AssemblyName(minfo.AssemblyName), throwIfNotFound);
                     return minfo.Module;
                 }
@@ -290,7 +303,23 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
         }
 
-        public TypeDesc ResolveTypeHandle(long handle, bool throwIfNotFound = true)
+        public bool IsDynamicModuleID(long handle)
+        {
+            lock (_lock)
+            {
+                ModuleDescInfo minfo;
+                if (_modules.TryGetValue(handle, out minfo))
+                {
+                    return minfo.IsDynamic;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        public TypeDesc ResolveTypeHandle(long handle, ref bool dependsOnKnownNonLoadableType, bool throwIfNotFound = true)
         {
             lock(_lock)
             {
@@ -307,7 +336,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             throw new Exception("Bad format for BulkType");
                         }
 
-                        TypeDesc elementType = ResolveTypeHandle((long)tinfo.TypeValue.TypeParameters[0], throwIfNotFound);
+                        TypeDesc elementType = ResolveTypeHandle((long)tinfo.TypeValue.TypeParameters[0], ref dependsOnKnownNonLoadableType, throwIfNotFound);
                         if (elementType == null)
                             return null;
 
@@ -328,7 +357,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             throw new Exception("Bad format for BulkType");
                         }
 
-                        TypeDesc elementType = ResolveTypeHandle((long)tinfo.TypeValue.TypeParameters[0], throwIfNotFound);
+                        TypeDesc elementType = ResolveTypeHandle((long)tinfo.TypeValue.TypeParameters[0], ref dependsOnKnownNonLoadableType, throwIfNotFound);
                         if (elementType == null)
                             return null;
 
@@ -341,7 +370,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             throw new Exception("Bad format for BulkType");
                         }
 
-                        TypeDesc elementType = ResolveTypeHandle((long)tinfo.TypeValue.TypeParameters[0], throwIfNotFound);
+                        TypeDesc elementType = ResolveTypeHandle((long)tinfo.TypeValue.TypeParameters[0], ref dependsOnKnownNonLoadableType, throwIfNotFound);
                         if (elementType == null)
                             return null;
 
@@ -356,7 +385,12 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         // Must be class type or instantiated type.
                         ModuleDesc module = ResolveModuleID((long)tinfo.TypeValue.ModuleID, throwIfNotFound);
                         if (module == null)
+                        {
+                            if (this.IsDynamicModuleID((long)tinfo.TypeValue.ModuleID))
+                                dependsOnKnownNonLoadableType = true;
+
                             return null;
+                        }
 
                         EcmaModule ecmaModule = module as EcmaModule;
                         if (ecmaModule == null)
@@ -384,7 +418,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             TypeDesc[] instantiation = new TypeDesc[tinfo.TypeValue.TypeParameters.Length];
                             for (int i = 0; i < instantiation.Length; i++)
                             {
-                                instantiation[i] = ResolveTypeHandle((long)tinfo.TypeValue.TypeParameters[i], throwIfNotFound);
+                                instantiation[i] = ResolveTypeHandle((long)tinfo.TypeValue.TypeParameters[i], ref dependsOnKnownNonLoadableType, throwIfNotFound);
                                 if (instantiation[i] == null)
                                     return null;
                             }
@@ -419,8 +453,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
         }
 
-        public MethodDesc ResolveMethodID(long handle, bool throwIfNotFound = true)
+        public MethodDesc ResolveMethodID(long handle, out bool nonLoadableModuleInvolvedInMethod, bool throwIfNotFound = true)
         {
+            nonLoadableModuleInvolvedInMethod = false;
             lock (_lock)
             {
                 MethodDescInfo minfo;
@@ -429,7 +464,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     if (minfo.Method != null)
                         return minfo.Method;
 
-                    TypeDesc owningType = ResolveTypeHandle(minfo.MethodDetailsTraceData.TypeID, throwIfNotFound);
+                    TypeDesc owningType = ResolveTypeHandle(minfo.MethodDetailsTraceData.TypeID, ref nonLoadableModuleInvolvedInMethod, throwIfNotFound);
                     if (owningType == null)
                         return null;
 
@@ -482,7 +517,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         TypeDesc[] instantiation = new TypeDesc[minfo.MethodDetailsTraceData.TypeParameters.Length];
                         for (int i = 0; i < instantiation.Length; i++)
                         {
-                            instantiation[i] = ResolveTypeHandle((long)minfo.MethodDetailsTraceData.TypeParameters[i], throwIfNotFound);
+                            instantiation[i] = ResolveTypeHandle((long)minfo.MethodDetailsTraceData.TypeParameters[i], ref nonLoadableModuleInvolvedInMethod, throwIfNotFound);
                             if (instantiation[i] == null)
                                 return null;
                         }


### PR DESCRIPTION
- Detect use of dynamic modules in PGO data processing and skip them instead of generating useless, non-actionable warnings
- Infrastructure currently used only for dynamic modules, but could be extended in the future to provide a means to ignore assemblies based on the set of assemblies specified on the commandline.

Fixes #68000