### PR TITLE
Rename ObsoletedInOSPlatform attribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
@@ -219,7 +219,7 @@
     <type fullname="System.Runtime.Versioning.UnsupportedOSPlatformAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
-    <type fullname="System.Runtime.Versioning.ObsoletedInOSPlatformAttribute">
+    <type fullname="System.Runtime.Versioning.ObsoletedOSPlatformAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
     <type fullname="System.Runtime.Versioning.RequiresPreviewFeaturesAttribute">

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs
@@ -132,12 +132,12 @@ namespace System.Runtime.Versioning
 #else
     internal
 #endif
-        sealed class ObsoletedInOSPlatformAttribute : OSPlatformAttribute
+        sealed class ObsoletedOSPlatformAttribute : OSPlatformAttribute
     {
-        public ObsoletedInOSPlatformAttribute(string platformName) : base(platformName)
+        public ObsoletedOSPlatformAttribute(string platformName) : base(platformName)
         {
         }
-        public ObsoletedInOSPlatformAttribute(string platformName, string? message) : base(platformName)
+        public ObsoletedOSPlatformAttribute(string platformName, string? message) : base(platformName)
         {
             Message = message;
         }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13366,10 +13366,10 @@ namespace System.Runtime.Versioning
         public override string ToString() { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Enum | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
-    public sealed partial class ObsoletedInOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
+    public sealed partial class ObsoletedOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
     {
-        public ObsoletedInOSPlatformAttribute(string platformName) : base(platformName) { }
-        public ObsoletedInOSPlatformAttribute(string platformName, string? message) : base(platformName) { }
+        public ObsoletedOSPlatformAttribute(string platformName) : base(platformName) { }
+        public ObsoletedOSPlatformAttribute(string platformName, string? message) : base(platformName) { }
         public string? Message { get { throw null; } }
         public string? Url { get { throw null; } set {} }
     }

--- a/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/Versioning/OSPlatformAttributeTests.cs
@@ -58,9 +58,9 @@ namespace System.Runtime.Versioning.Tests
         [InlineData("Windows8.0")]
         [InlineData("Android4.1")]
         [InlineData("")]
-        public void TestObsoletedInOSPlatformAttribute(string platformName)
+        public void TestObsoletedOSPlatformAttribute(string platformName)
         {
-            var tpa = new ObsoletedInOSPlatformAttribute(platformName);
+            var tpa = new ObsoletedOSPlatformAttribute(platformName);
 
             Assert.Equal(platformName, tpa.PlatformName);
         }
@@ -69,9 +69,9 @@ namespace System.Runtime.Versioning.Tests
         [InlineData("Windows8.0", "Message in a bottle")]
         [InlineData("Android4.1", "Message on a pigeon")]
         [InlineData("", null)]
-        public void TestObsoletedInOSPlatformAttributeWithMessage(string platformName, string? message)
+        public void TestObsoletedOSPlatformAttributeWithMessage(string platformName, string? message)
         {
-            var tpa = new ObsoletedInOSPlatformAttribute(platformName, message);
+            var tpa = new ObsoletedOSPlatformAttribute(platformName, message);
 
             Assert.Equal(platformName, tpa.PlatformName);
             Assert.Equal(message, tpa.Message);


### PR DESCRIPTION
We [decided](https://github.com/dotnet/runtime/issues/72970#issuecomment-1203138551) to rename `ObsoletedInOSPlatformAttribute` into `ObsoletedOSPlatformAttribute` to match with other platform names

Fixes https://github.com/dotnet/runtime/issues/72970

CC @rolfbjarne @jeffhandley 