### PR TITLE
Reset current_no_gc_region_info after leaving no gc region implicitly

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -20643,6 +20643,8 @@ BOOL gc_heap::should_proceed_with_gc()
             // The no_gc mode was already in progress yet we triggered another GC,
             // this effectively exits the no_gc mode.
             restore_data_for_no_gc();
+            
+            memset (&current_no_gc_region_info, 0, sizeof (current_no_gc_region_info));
         }
         else
             return should_proceed_for_no_gc();


### PR DESCRIPTION
It appears to me that we missed this place where we should reset the `current_no_gc_region_info.started` flag when we leave a `NoGCRegion`.