### PR TITLE
Condition ExternalConsoleManipulation_RegistrationRemoved_UnregisterSucceeds on RemoteExecutor.IsSupported

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Windows.cs
@@ -29,7 +29,7 @@ namespace System.Tests
 
         private static IEnumerable<PosixSignal> SupportedPosixSignals => new[] { PosixSignal.SIGINT, PosixSignal.SIGQUIT, PosixSignal.SIGTERM, PosixSignal.SIGHUP };
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void ExternalConsoleManipulation_RegistrationRemoved_UnregisterSucceeds()
         {
             RemoteExecutor.Invoke(() =>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/73145