### PR TITLE
Fix JSON source gen to work with public context and public types with internal properties

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -1041,6 +1041,11 @@ namespace System.Text.Json.SourceGeneration
                                 }
 
                                 spec = GetPropertyGenerationSpec(propertyInfo, isVirtual, generationMode);
+                                if (!spec.IsPublic && !propertyInfo.PropertyType.IsPublic)
+                                {
+                                    continue;
+                                }
+
                                 CacheMemberHelper(propertyInfo.GetDiagnosticLocation());
                             }
 
@@ -1052,6 +1057,11 @@ namespace System.Text.Json.SourceGeneration
                                 }
 
                                 spec = GetPropertyGenerationSpec(fieldInfo, isVirtual: false, generationMode);
+                                if (!spec.IsPublic && !fieldInfo.FieldType.IsPublic)
+                                {
+                                    continue;
+                                }
+
                                 CacheMemberHelper(fieldInfo.GetDiagnosticLocation());
                             }
 

--- a/src/libraries/System.Text.Json/gen/Reflection/RoslynExtensions.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/RoslynExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
@@ -9,7 +10,8 @@ namespace System.Text.Json.Reflection
 {
     internal static class RoslynExtensions
     {
-        public static Type AsType(this ITypeSymbol typeSymbol, MetadataLoadContextInternal metadataLoadContext)
+        [return: NotNullIfNotNull("typeSymbol")]
+        public static Type? AsType(this ITypeSymbol? typeSymbol, MetadataLoadContextInternal metadataLoadContext)
         {
             if (typeSymbol == null)
             {

--- a/src/libraries/System.Text.Json/gen/Reflection/TypeWrapper.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/TypeWrapper.cs
@@ -109,7 +109,7 @@ namespace System.Text.Json.Reflection
             }
         }
 
-        public override Type BaseType => _typeSymbol.BaseType!.AsType(_metadataLoadContext);
+        public override Type BaseType => _typeSymbol.BaseType.AsType(_metadataLoadContext);
 
         public override Type DeclaringType => _typeSymbol.ContainingType?.ConstructedFrom.AsType(_metadataLoadContext);
 
@@ -499,9 +499,29 @@ namespace System.Text.Json.Reflection
                     _typeAttributes |= TypeAttributes.Interface;
                 }
 
-                if (_typeSymbol.ContainingType != null && _typeSymbol.DeclaredAccessibility == Accessibility.Private)
+                bool isNested = _typeSymbol.ContainingType != null;
+
+                switch (_typeSymbol.DeclaredAccessibility)
                 {
-                    _typeAttributes |= TypeAttributes.NestedPrivate;
+                    case Accessibility.NotApplicable:
+                    case Accessibility.Private:
+                        _typeAttributes |= isNested ? TypeAttributes.NestedPrivate : TypeAttributes.NotPublic;
+                        break;
+                    case Accessibility.ProtectedAndInternal:
+                        _typeAttributes |= isNested ? TypeAttributes.NestedFamANDAssem : TypeAttributes.NotPublic;
+                        break;
+                    case Accessibility.Protected:
+                        _typeAttributes |= isNested ? TypeAttributes.NestedFamily : TypeAttributes.NotPublic;
+                        break;
+                    case Accessibility.Internal:
+                        _typeAttributes |= isNested ? TypeAttributes.NestedAssembly : TypeAttributes.NotPublic;
+                        break;
+                    case Accessibility.ProtectedOrInternal:
+                        _typeAttributes |= isNested ? TypeAttributes.NestedFamORAssem : TypeAttributes.NotPublic;
+                        break;
+                    case Accessibility.Public:
+                        _typeAttributes |= isNested ? TypeAttributes.NestedPublic : TypeAttributes.Public;
+                        break;
                 }
             }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
@@ -117,6 +117,9 @@ namespace System.Text.Json.SourceGeneration.Tests
     internal partial class DictionaryTypeContext : JsonSerializerContext { }
 
     [JsonSerializable(typeof(JsonMessage))]
+    [JsonSerializable(typeof(PublicClassWithDifferentAccessibilitiesProperties))]
+    [JsonSerializable(typeof(JsonConverter))]
+    [JsonSerializable(typeof(JsonSerializerOptions))]
     public partial class PublicContext : JsonSerializerContext { }
 
     [JsonSerializable(typeof(JsonMessage))]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyVisibilityTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Text.Json.Serialization.Tests;
 using System.Threading.Tasks;
 using Xunit;
@@ -324,6 +325,66 @@ namespace System.Text.Json.SourceGeneration.Tests
             // Since this code goes down fast-path, there's no warm up and we hit the reader exception about having no tokens.
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.DeserializeWrapper("", type));
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.SerializeWrapper(Activator.CreateInstance(type), type));
+        }
+
+        [Fact]
+        public static void PublicContexAndTestClassWithPropertiesWithDifferentAccesibilities()
+        {
+            JsonSerializerOptions options = new()
+            {
+                IncludeFields = true,
+            };
+
+            options.AddContext<PublicContext>();
+
+            PublicClassWithDifferentAccessibilitiesProperties obj = new()
+            {
+                PublicProperty = new(),
+                PublicField = new(),
+            };
+
+            string json = JsonSerializer.Serialize(obj, options);
+            Assert.Equal("""{"PublicProperty":{},"PublicField":{}}""", json);
+
+            var deserialized = JsonSerializer.Deserialize<PublicClassWithDifferentAccessibilitiesProperties>(json, options);
+            Assert.NotNull(deserialized.PublicProperty);
+            Assert.NotNull(deserialized.PublicField);
+
+            json = "{}";
+            deserialized = JsonSerializer.Deserialize<PublicClassWithDifferentAccessibilitiesProperties>(json, options);
+            Assert.Null(deserialized.PublicProperty);
+            Assert.Null(deserialized.PublicField);
+        }
+
+        [Fact]
+        public static void PublicContexAndJsonConverter()
+        {
+            JsonConverter obj = JsonMetadataServices.BooleanConverter;
+
+            string json = JsonSerializer.Serialize(obj, PublicContext.Default.Options);
+            Assert.Equal("{}", json);
+
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<JsonConverter>(json, PublicContext.Default.Options));
+        }
+
+        [Fact]
+        public static void PublicContexAndJsonSerializerOptions()
+        {
+            JsonSerializerOptions obj = new()
+            {
+                DefaultBufferSize = 123,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                IncludeFields = true,
+            };
+
+            string json = JsonSerializer.Serialize(obj, PublicContext.Default.Options);
+
+            JsonSerializerOptions deserialized = JsonSerializer.Deserialize<JsonSerializerOptions>(json, PublicContext.Default.Options);
+            Assert.Equal(obj.DefaultBufferSize, deserialized.DefaultBufferSize);
+            Assert.Equal(obj.DefaultIgnoreCondition, deserialized.DefaultIgnoreCondition);
+            Assert.Equal(obj.IncludeFields, deserialized.IncludeFields);
+            Assert.Equal(obj.IgnoreReadOnlyFields, deserialized.IgnoreReadOnlyFields);
+            Assert.Equal(obj.MaxDepth, deserialized.MaxDepth);
         }
 
         [JsonSerializable(typeof(ClassWithNewSlotField))]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
@@ -226,4 +226,53 @@ namespace System.Text.Json.SourceGeneration.Tests
             }
         }
     }
+
+    public class PublicClassWithDifferentAccessibilitiesProperties
+    {
+        public PublicTestClass PublicProperty { get; set; }
+        internal PublicTestClass.InternalNestedClass InternalProperty1 { get; set; }
+        protected ProtectedClass ProtectedProperty1 { get; set; }
+        protected ProtectedInternalClass ProtectedProperty2 { get; set; }
+        internal InternalTestClass InternalProperty2 { get; set; }
+        internal InternalTestClass.PublicClass InternalProperty3 { get; set; }
+        internal InternalTestClass.ProtectedInternalClass InternalProperty4 { get; set; }
+        private InternalTestClass PrivateProperty1 { get; set; }
+        private PrivateClass PrivateProperty2 { get; set; }
+        private PrivateClass2 PrivateProperty3 { get; set; }
+        PrivateClass2 PrivateProperty4 { get; set; }
+        private PrivateProtectedClass PrivateProperty5 { get; set; }
+
+        public PublicTestClass PublicField;
+
+#pragma warning disable CS0414 // The field ... is assigned but its value is never used.
+        internal PublicTestClass.InternalNestedClass InternalField1 = null;
+        protected ProtectedClass ProtectedField1 = null;
+        protected ProtectedInternalClass ProtectedField2 = null;
+        internal InternalTestClass InternalField2 = null;
+        internal InternalTestClass.PublicClass InternalField3 = null;
+        internal InternalTestClass.ProtectedInternalClass InternalField4 = null;
+        private InternalTestClass PrivateField1 = null;
+        private PrivateClass PrivateField2 = null;
+        private PrivateClass2 PrivateField3 = null;
+        PrivateClass2 PrivateField4 = null;
+        private PrivateProtectedClass PrivateField5 = null;
+#pragma warning restore
+
+        private class PrivateClass { }
+        protected class ProtectedClass { }
+        protected internal class ProtectedInternalClass { }
+        private protected class PrivateProtectedClass { }
+        class PrivateClass2 { }
+    }
+
+    internal class InternalTestClass
+    {
+        public class PublicClass { }
+        protected internal class ProtectedInternalClass { }
+    }
+
+    public class PublicTestClass
+    {
+        internal class InternalNestedClass { }
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/73371

See my explanation for root cause here: https://github.com/dotnet/runtime/issues/73371#issuecomment-1208208411

Testing done:
- manually test scenario with locally build nuget package and reported issue
- added couple of tests testing root cause (public context + public class with different types of accessibility options) and serialization of JsonConverter/JsonSerializerOptions