### PR TITLE
Make OCSP Stapling tests more reliable and more diagnosable

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -211,11 +212,31 @@ namespace System.Net.Security.Tests
                 keySize: 2048,
                 extensions: TestHelper.BuildTlsServerCertExtensions(serverName));
 
+            X509Certificate2 issuerCert = intermediateAuthority.CloneIssuerCert();
+            X509Certificate2 rootCert = rootAuthority.CloneIssuerCert();
+
             SslClientAuthenticationOptions clientOpts = new SslClientAuthenticationOptions
             {
                 TargetHost = serverName,
                 RemoteCertificateValidationCallback = CertificateValidationCallback,
-                CertificateRevocationCheckMode = revocationMode,
+                CertificateChainPolicy = new X509ChainPolicy
+                {
+                    RevocationMode = revocationMode,
+                    TrustMode = X509ChainTrustMode.CustomRootTrust,
+
+                    // The offline test will not know about revocation for the intermediate,
+                    // so change the policy to only check the end certificate.
+                    RevocationFlag = X509RevocationFlag.EndCertificateOnly,
+
+                    ExtraStore =
+                    {
+                        issuerCert,
+                    },
+                    CustomTrustStore =
+                    {
+                        rootCert,
+                    },
+                },
             };
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -231,7 +252,8 @@ namespace System.Net.Security.Tests
             using (rootAuthority)
             using (intermediateAuthority)
             using (serverCert)
-            using (X509Certificate2 issuerCert = intermediateAuthority.CloneIssuerCert())
+            using (issuerCert)
+            using (rootCert)
             await using (SslStream tlsClient = new SslStream(clientStream))
             await using (SslStream tlsServer = new SslStream(serverStream))
             {
@@ -300,20 +322,6 @@ namespace System.Net.Security.Tests
                 Assert.NotNull(certificate);
                 Assert.NotNull(chain);
 
-                sslPolicyErrors &= ~SslPolicyErrors.RemoteCertificateChainErrors;
-
-                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                chain.ChainPolicy.CustomTrustStore.Add(chain.ChainElements[^1].Certificate);
-
-                // The offline test will not know about revocation for the intermediate,
-                // so change the policy to only check the end certificate.
-                chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EndCertificateOnly;
-
-                if (!chain.Build((X509Certificate2)certificate))
-                {
-                    sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
-                }
-
                 if (chain.ChainPolicy.RevocationMode == X509RevocationMode.NoCheck)
                 {
                     X509ChainStatusFlags chainFlags = 0;
@@ -335,9 +343,8 @@ namespace System.Net.Security.Tests
                     // process, because there's no OCSP data.
                     Assert.Equal(SslPolicyErrors.RemoteCertificateChainErrors, sslPolicyErrors);
 
-                    Assert.Contains(
-                        chain.ChainElements[0].ChainElementStatus,
-                        cs => cs.Status == X509ChainStatusFlags.RevocationStatusUnknown);
+                    X509ChainStatusFlags[] flags = chain.ChainElements[0].ChainElementStatus.Select(cs => cs.Status).ToArray();
+                    Assert.Contains(X509ChainStatusFlags.RevocationStatusUnknown, flags);
                 }
                 else
                 {
@@ -345,9 +352,8 @@ namespace System.Net.Security.Tests
                     // say the chain isn't happy.
                     Assert.Equal(SslPolicyErrors.RemoteCertificateChainErrors, sslPolicyErrors);
 
-                    Assert.Contains(
-                        chain.ChainElements[0].ChainElementStatus,
-                        cs => cs.Status == X509ChainStatusFlags.Revoked);
+                    X509ChainStatusFlags[] flags = chain.ChainElements[0].ChainElementStatus.Select(cs => cs.Status).ToArray();
+                    Assert.Contains(X509ChainStatusFlags.Revoked, flags);
                 }
 
                 return true;


### PR DESCRIPTION
Utilize the new CertificateChainPolicy option to avoid the second chain build,
and remove the need for an AIA fetch of the intermediate.

Also changes the use of Assert.Contains with a predicate to first build an array and use a simpler variant, so it pretty-prints failures better.