### PR TITLE
Update dotnet/msquic ref to release/7.0

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,7 +4,7 @@
       <Uri>https://github.com/dotnet/icu</Uri>
       <Sha>d65ae2e51ad292901e89d06b31d31d7038c30c0f</Sha>
     </Dependency>
-    <Dependency Name="System.Net.MsQuic.Transport" Version="7.0.0-alpha.1.22371.1">
+    <Dependency Name="System.Net.MsQuic.Transport" Version="7.0.0-alpha.1.22406.1">
       <Uri>https://github.com/dotnet/msquic</Uri>
       <Sha>dc012a715ceb9b5d5258f2fda77520586af5a36a</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,7 +6,7 @@
     </Dependency>
     <Dependency Name="System.Net.MsQuic.Transport" Version="7.0.0-alpha.1.22371.1">
       <Uri>https://github.com/dotnet/msquic</Uri>
-      <Sha>620c3a5e7982c143ba8eb3d0f0d902f55359e905</Sha>
+      <Sha>dc012a715ceb9b5d5258f2fda77520586af5a36a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-rc.1.22368.1">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -173,7 +173,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>7.0.0-rc.1.22375.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <SystemNetMsQuicTransportVersion>7.0.0-alpha.1.22371.1</SystemNetMsQuicTransportVersion>
+    <SystemNetMsQuicTransportVersion>7.0.0-alpha.1.22406.1</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.22376.4</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.22376.4</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>


### PR DESCRIPTION
This PR makes the build use MsQuic packages intended for the 7.0.0 release.

Note that this change may get overwritten by the maestro bot, so we will need to change its config as well.