### PR TITLE
ILASM - Roundtrip fix for 'poison' and 'hugeSimpleExpr1'

### DIFF
--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -30,9 +30,9 @@ WARNING:   When setting properties based on their current state (for example:
   -->
 
   <PropertyGroup>
-    <_IlasmSwitches Condition="'$(DebugType)' == 'Full'">$(_IlasmSwitches) -DEBUG</_IlasmSwitches>
-    <_IlasmSwitches Condition="'$(DebugType)' == 'Impl'">$(_IlasmSwitches) -DEBUG=IMPL</_IlasmSwitches>
-    <_IlasmSwitches Condition="'$(DebugType)' == 'PdbOnly'">$(_IlasmSwitches) -DEBUG=OPT</_IlasmSwitches>
+    <_IlasmSwitches Condition="'$(DebugType)' == 'Full' and '$(Optimize)' != 'True'">$(_IlasmSwitches) -DEBUG</_IlasmSwitches>
+    <_IlasmSwitches Condition="'$(DebugType)' == 'Impl' and '$(Optimize)' != 'True'">$(_IlasmSwitches) -DEBUG=IMPL</_IlasmSwitches>
+    <_IlasmSwitches Condition="'$(DebugType)' == 'PdbOnly' and '$(Optimize)' != 'True'">$(_IlasmSwitches) -DEBUG</_IlasmSwitches>
   </PropertyGroup>
 
   <Target Name="GetIlasmRoundTripBashScript"


### PR DESCRIPTION
Should resolve: https://github.com/dotnet/runtime/issues/73545

Ran the tests manually and they both pass:
```
Time [secs] | Total | Passed | Failed | Skipped | Assembly Execution Summary
============================================================================
      4.275 |     1 |      1 |      0 |       0 | JIT.Directed.XUnitWrapper.dll
     68.222 |     1 |      1 |      0 |       0 | JIT.jit64.XUnitWrapper.dll
----------------------------------------------------------------------------
     72.497 |     2 |      2 |      0 |       0 | (total)
```

**Description**
We added ILASM debug switches for roundtrip testing, but it wasn't totally correct as `-DEBUG=OPT` will create an assembly that tells the JIT that it is not debuggable code - this is why the poison test was still failing.

For `hugeSimpleExpr1` - this was failing because it was producing debuggable code that caused the JIT to stackoverflow, not due to recursion, just simply because the JIT created 50,000 tmp locals... The corresponding `.csproj` marks the assembly as optimized but producing a FullPdb. So, we change the ILASM switches for roundtrip testing to account for the `Optimize` flag being set by `.csproj`.

**Acceptance Criteria**
- [ ] CI Passes