### PR TITLE
Make sure thread is initialized for COM before registering test class factory

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/Common/CommonTypes.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/Common/CommonTypes.Windows.cs
@@ -58,6 +58,10 @@ namespace System.Runtime.InteropServices.Tests.Common
         [ModuleInitializer]
         internal static unsafe void RegisterInProcCOMServer()
         {
+            // Make sure we are initialized for COM before registering
+            if (Thread.CurrentThread.GetApartmentState() == ApartmentState.Unknown)
+                Thread.CurrentThread.SetApartmentState(ApartmentState.MTA);
+
             var clsid = new Guid(ComObjectFactory.CLSID);
             const int CLSCTX_INPROC_SERVER = 1;
             const int REGCLS_MULTIPLEUSE = 1;


### PR DESCRIPTION
The call to `CoRegisterClassObject` will fail with `CO_E_NOTINITIALIZED` if the thread hasn't been initialized for COM. Check and default to MTA if it hasn't been initialized.