### PR TITLE
[release/6.0] Fix #70391

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -5790,6 +5790,7 @@ static genTreeOps genTreeOpsIllegalAsVNFunc[] = {GT_IND, // When we do heap memo
                                                  GT_OBJ,      // May reference heap memory.
                                                  GT_BLK,      // May reference heap memory.
                                                  GT_INIT_VAL, // Not strictly a pass-through.
+                                                 GT_LEA,      // Needs to encode scale/offset. .NET7+ has no LEA in HIR.
 
                                                  // These control-flow operations need no values.
                                                  GT_JTRUE, GT_RETURN, GT_SWITCH, GT_RETFILT, GT_CKFINITE};


### PR DESCRIPTION
Fix .NET 6 customer-reported silent bad codegen issue #70391.

Fix issue with multiple LEA addresses used for Vector code. Value
Numbering treated multiple LEA identically, ignoring offset and
scale. Fix by creating a new, unique Value Number for all LEA, by
marking LEA nodes as "illegal" as a VNFunc.

Fixed in .NET 7 with #69992. This is a conservative, smaller
fix for .NET 6.

No SPMI asm diffs.

Verified with this repro (fail before, pass afterwards) from #64375:
```
using System;
using System.Numerics;
using System.Runtime.CompilerServices;

internal class Program
{
    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
    public static void Main()
    {
        Matrix4x4 id = Matrix4x4.Identity;

        Action a = () => { var _ = id; };

        Console.WriteLine(
            Vector3.Cross(
                new Vector3(id.M11, id.M12, id.M13),
                new Vector3(id.M21, id.M22, id.M23)).Z);
    }
}
```
(pass means prints `1`)

## Customer Impact

Fixes customer-reported issue in .NET 6.

Fixes silent bad code generation when using certain type of addresses to Vector initializers.

## Testing

SuperPMI asm diffs; manual testing of reduced test case.

## Risk

Low
