### PR TITLE
Initialize main thread to MTA by default in NativeAOT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -77,7 +77,7 @@ namespace Internal.IL.Stubs.StartupCode
                     codeStream.Emit(ILOpcode.call, emitter.NewToken(method));
                 }
             }
-            
+
             MetadataType startup = Context.GetOptionalHelperType("StartupCodeHelpers");
 
             // Initialize command line args if the class library supports this
@@ -110,8 +110,9 @@ namespace Internal.IL.Stubs.StartupCode
                     codeStream.EmitLdc((int)System.Threading.ApartmentState.STA);
                     codeStream.Emit(ILOpcode.call, emitter.NewToken(initApartmentState));
                 }
-                if (_mainMethod.WrappedMethod.HasCustomAttribute("System", "MTAThreadAttribute"))
+                else
                 {
+                    // Initialize to MTA by default
                     codeStream.EmitLdc((int)System.Threading.ApartmentState.MTA);
                     codeStream.Emit(ILOpcode.call, emitter.NewToken(initApartmentState));
                 }


### PR DESCRIPTION
Initialize the main thread to MTA by default instead of only when `MTAThreadAttribute` is used. This is what we do in coreclr and is our [documented behaviour](https://docs.microsoft.com/dotnet/api/system.threading.thread.setapartmentstate#remarks).

cc @jkoritzinsky @jkotas 