### PR TITLE
Remove non-determinism from R2R field access

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1713,12 +1713,7 @@ namespace Internal.JitInterface
                 _compilation.TypeSystemContext.EnsureLoadableType(owningClass);
 #endif
 
-#if READYTORUN
-                if (recordToken)
-                {
-                    _compilation.NodeFactory.Resolver.AddModuleTokenForField(field, HandleToModuleToken(ref pResolvedToken));
-                }
-#else
+#if !READYTORUN
                 _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _additionalDependencies, _compilation.NodeFactory, (MethodIL)methodIL, field);
 #endif
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly MethodWithToken _methodArgument;
 
-        private readonly FieldDesc _fieldArgument;
+        private readonly FieldWithToken _fieldArgument;
 
         private readonly GenericContext _methodContext;
 
@@ -31,7 +31,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ReadyToRunFixupKind fixupKind,
             TypeDesc typeArgument,
             MethodWithToken methodArgument,
-            FieldDesc fieldArgument,
+            FieldWithToken fieldArgument,
             GenericContext methodContext)
         {
             Debug.Assert(typeArgument != null || methodArgument != null || fieldArgument != null);
@@ -64,7 +64,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
             else if (_fieldArgument != null)
             {
-                targetModule = factory.SignatureContext.GetTargetModule(_fieldArgument);
+                targetModule = _fieldArgument.Token.Module;
             }
             else
             {
@@ -173,7 +173,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
             if (_fieldArgument != null)
             {
-                sb.Append(nameMangler.GetMangledFieldName(_fieldArgument));
+                _fieldArgument.AppendMangledName(nameMangler, sb);
             }
             sb.Append(" (");
             _methodContext.AppendMangledName(nameMangler, sb);
@@ -210,7 +210,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (otherNode._fieldArgument == null)
                     return 1;
 
-                result = comparer.Compare(_fieldArgument, otherNode._fieldArgument);
+                result = _fieldArgument.CompareTo(otherNode._fieldArgument, comparer);
                 if (result != 0)
                     return result;
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -530,23 +530,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
         }
 
-        public void EmitFieldSignature(FieldDesc field, SignatureContext context)
+        public void EmitFieldSignature(FieldWithToken field, SignatureContext context)
         {
             uint fieldSigFlags = 0;
-            TypeDesc canonOwnerType = field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
             TypeDesc ownerType = null;
-            if (canonOwnerType.HasInstantiation)
+            if (field.OwningTypeNotDerivedFromToken)
             {
-                ownerType = field.OwningType;
+                ownerType = field.Field.OwningType;
                 fieldSigFlags |= (uint)ReadyToRunFieldSigFlags.READYTORUN_FIELD_SIG_OwnerType;
             }
-            if (canonOwnerType != field.OwningType)
-            {
-                // Convert field to canonical form as this is what the field - module token lookup stores
-                field = field.Context.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)canonOwnerType);
-            }
 
-            ModuleToken fieldToken = context.GetModuleTokenForField(field);
+            ModuleToken fieldToken = field.Token;
             switch (fieldToken.TokenType)
             {
                 case CorTokenType.mdtMemberRef:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
@@ -66,11 +66,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return LocalContext;
         }
 
-        public IEcmaModule GetTargetModule(FieldDesc field)
-        {
-            return GetModuleTokenForField(field).Module;
-        }
-
         public IEcmaModule GetTargetModule(MethodDesc method)
         {
             return GetModuleTokenForMethod(method).Module;
@@ -84,11 +79,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public ModuleToken GetModuleTokenForMethod(MethodDesc method)
         {
             return Resolver.GetModuleTokenForMethod(method, throwIfNotFound: false, allowDynamicallyCreatedReference: false);
-        }
-
-        public ModuleToken GetModuleTokenForField(FieldDesc field, bool throwIfNotFound = true)
-        {
-            return Resolver.GetModuleTokenForField(field, throwIfNotFound);
         }
 
         public bool Equals(SignatureContext other)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -622,9 +622,9 @@ namespace ILCompiler.DependencyAnalysis
             {
                 typeArgument = methodWithToken.Method.OwningType;
             }
-            else if (helperArgument is FieldDesc fieldDesc)
+            else if (helperArgument is FieldWithToken fieldWithToken)
             {
-                typeArgument = fieldDesc.OwningType;
+                typeArgument = fieldWithToken.Field.OwningType;
             }
             else
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -65,7 +65,7 @@ namespace ILCompiler.DependencyAnalysis
                     new ReadyToRunInstructionSetSupportSignature(key));
             });
 
-            _fieldAddressCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
+            _fieldAddressCache = new NodeCache<FieldWithToken, ISymbolNode>(key =>
             {
                 return new DelayLoadHelperImport(
                     _codegenNodeFactory,
@@ -75,7 +75,7 @@ namespace ILCompiler.DependencyAnalysis
                 );
             });
 
-            _fieldOffsetCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
+            _fieldOffsetCache = new NodeCache<FieldWithToken, ISymbolNode>(key =>
             {
                 return new PrecodeHelperImport(
                     _codegenNodeFactory,
@@ -91,7 +91,7 @@ namespace ILCompiler.DependencyAnalysis
                 );
             });
 
-            _checkFieldOffsetCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
+            _checkFieldOffsetCache = new NodeCache<FieldWithToken, ISymbolNode>(key =>
             {
                 return new PrecodeHelperImport(
                     _codegenNodeFactory,
@@ -241,7 +241,7 @@ namespace ILCompiler.DependencyAnalysis
                     return CreateMethodHandleHelper((MethodWithToken)key.Target);
 
                 case ReadyToRunHelperId.FieldHandle:
-                    return CreateFieldHandleHelper((FieldDesc)key.Target);
+                    return CreateFieldHandleHelper((FieldWithToken)key.Target);
 
                 case ReadyToRunHelperId.CctorTrigger:
                     return CreateCctorTrigger((TypeDesc)key.Target);
@@ -361,7 +361,7 @@ namespace ILCompiler.DependencyAnalysis
                     isInstantiatingStub: useInstantiatingStub));
         }
 
-        private ISymbolNode CreateFieldHandleHelper(FieldDesc field)
+        private ISymbolNode CreateFieldHandleHelper(FieldWithToken field)
         {
             return new PrecodeHelperImport(
                 _codegenNodeFactory,
@@ -395,25 +395,25 @@ namespace ILCompiler.DependencyAnalysis
                     isInstantiatingStub: true));
         }
 
-        private NodeCache<FieldDesc, ISymbolNode> _fieldAddressCache;
+        private NodeCache<FieldWithToken, ISymbolNode> _fieldAddressCache;
 
-        public ISymbolNode FieldAddress(FieldDesc fieldDesc)
+        public ISymbolNode FieldAddress(FieldWithToken fieldWithToken)
         {
-            return _fieldAddressCache.GetOrAdd(fieldDesc);
+            return _fieldAddressCache.GetOrAdd(fieldWithToken);
         }
 
-        private NodeCache<FieldDesc, ISymbolNode> _fieldOffsetCache;
+        private NodeCache<FieldWithToken, ISymbolNode> _fieldOffsetCache;
 
-        public ISymbolNode FieldOffset(FieldDesc fieldDesc)
+        public ISymbolNode FieldOffset(FieldWithToken fieldWithToken)
         {
-            return _fieldOffsetCache.GetOrAdd(fieldDesc);
+            return _fieldOffsetCache.GetOrAdd(fieldWithToken);
         }
 
-        private NodeCache<FieldDesc, ISymbolNode> _checkFieldOffsetCache;
+        private NodeCache<FieldWithToken, ISymbolNode> _checkFieldOffsetCache;
 
-        public ISymbolNode CheckFieldOffset(FieldDesc fieldDesc)
+        public ISymbolNode CheckFieldOffset(FieldWithToken fieldWithToken)
         {
-            return _checkFieldOffsetCache.GetOrAdd(fieldDesc);
+            return _checkFieldOffsetCache.GetOrAdd(fieldWithToken);
         }
 
         private NodeCache<TypeDesc, ISymbolNode> _fieldBaseOffsetCache;
@@ -502,7 +502,7 @@ namespace ILCompiler.DependencyAnalysis
             public readonly ReadyToRunFixupKind FixupKind;
             public readonly TypeDesc TypeArgument;
             public readonly MethodWithToken MethodArgument;
-            public readonly FieldDesc FieldArgument;
+            public readonly FieldWithToken FieldArgument;
             public readonly GenericContext MethodContext;
 
             public GenericLookupKey(
@@ -510,7 +510,7 @@ namespace ILCompiler.DependencyAnalysis
                 ReadyToRunFixupKind fixupKind,
                 TypeDesc typeArgument,
                 MethodWithToken methodArgument,
-                FieldDesc fieldArgument,
+                FieldWithToken fieldArgument,
                 GenericContext methodContext)
             {
                 LookupKind = lookupKind;
@@ -603,7 +603,7 @@ namespace ILCompiler.DependencyAnalysis
                     return GenericLookupFieldHelper(
                         runtimeLookupKind,
                         ReadyToRunFixupKind.FieldHandle,
-                        (FieldDesc)helperArgument,
+                        (FieldWithToken)helperArgument,
                         methodContext);
 
                 default:
@@ -638,7 +638,7 @@ namespace ILCompiler.DependencyAnalysis
         private ISymbolNode GenericLookupFieldHelper(
             CORINFO_RUNTIME_LOOKUP_KIND runtimeLookupKind,
             ReadyToRunFixupKind fixupKind,
-            FieldDesc fieldArgument,
+            FieldWithToken fieldArgument,
             GenericContext methodContext)
         {
             GenericLookupKey key = new GenericLookupKey(runtimeLookupKind, fixupKind, typeArgument: null, methodArgument: null, fieldArgument: fieldArgument, methodContext);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/RuntimeDeterminedTypeHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/RuntimeDeterminedTypeHelper.cs
@@ -146,6 +146,15 @@ namespace ILCompiler
                 RuntimeDeterminedTypeHelper.Equals(field1.FieldType, field2.FieldType);
         }
 
+        public static bool Equals(FieldWithToken field1, FieldWithToken field2)
+        {
+            if (field1 == null || field2 == null)
+            {
+                return field1 == null && field2 == null;
+            }
+            return RuntimeDeterminedTypeHelper.Equals(field1.Field, field2.Field);
+        }
+
         public static int GetHashCode(Instantiation instantiation)
         {
             int hashcode = unchecked(instantiation.Length << 24);
@@ -197,6 +206,15 @@ namespace ILCompiler
                 return 0;
             }
             return unchecked(GetHashCode(field.OwningType) + 97 * GetHashCode(field.FieldType) + 31 * field.Name.GetHashCode());
+        }
+
+        public static int GetHashCode(FieldWithToken field)
+        {
+            if (field == null)
+            {
+                return 0;
+            }
+            return GetHashCode(field.Field);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -736,6 +736,10 @@ namespace Internal.JitInterface
                             MethodDesc sharedMethod = methodIL.OwningMethod.GetSharedRuntimeFormMethodTarget();
                             helperArg = new MethodWithToken(methodDesc, HandleToModuleToken(ref pResolvedToken), constrainedType, unboxing: false, context: sharedMethod);
                         }
+                        else if (helperArg is FieldDesc fieldDesc)
+                        {
+                            helperArg = new FieldWithToken(fieldDesc, HandleToModuleToken(ref pResolvedToken));
+                        }
 
                         GenericContext methodContext = new GenericContext(entityFromContext(pResolvedToken.tokenContext));
                         ISymbolNode helper = _compilation.SymbolNodeFactory.GenericLookupHelper(

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -37,6 +37,82 @@ namespace Internal.JitInterface
         public string Message { get; }
     }
 
+    public class FieldWithToken : IEquatable<FieldWithToken>
+    {
+        public readonly FieldDesc Field;
+        public readonly ModuleToken Token;
+        public readonly bool OwningTypeNotDerivedFromToken;
+
+        public FieldWithToken(FieldDesc field, ModuleToken token)
+        {
+            Field = field;
+            Token = token;
+            if (token.TokenType == CorTokenType.mdtMemberRef)
+            {
+                var memberRef = token.MetadataReader.GetMemberReference((MemberReferenceHandle)token.Handle);
+                switch (memberRef.Parent.Kind)
+                {
+                case HandleKind.TypeDefinition:
+                case HandleKind.TypeReference:
+                case HandleKind.TypeSpecification:
+                    OwningTypeNotDerivedFromToken = token.Module.GetType(memberRef.Parent) != field.OwningType;
+                    break;
+
+                default:
+                    break;
+                }
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is FieldWithToken fieldWithToken &&
+                Equals(fieldWithToken);
+        }
+
+        public override int GetHashCode()
+        {
+            return Field.GetHashCode() ^ unchecked(17 * Token.GetHashCode());
+        }
+
+        public bool Equals(FieldWithToken fieldWithToken)
+        {
+            if (fieldWithToken == null)
+                return false;
+
+            return Field == fieldWithToken.Field && Token.Equals(fieldWithToken.Token);
+        }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.GetMangledFieldName(Field));
+            sb.Append("; ");
+            sb.Append(Token.ToString());
+        }
+
+        public override string ToString()
+        {
+            StringBuilder debuggingName = new StringBuilder();
+            debuggingName.Append(Field.ToString());
+
+            debuggingName.Append("; ");
+            debuggingName.Append(Token.ToString());
+
+            return debuggingName.ToString();
+        }
+
+        public int CompareTo(FieldWithToken other, TypeSystemComparer comparer)
+        {
+            int result;
+
+            result = comparer.Compare(Field, other.Field);
+            if (result != 0)
+                return result;
+
+            return Token.CompareTo(other.Token);
+        }
+    }
+
     public class MethodWithToken
     {
         public readonly MethodDesc Method;
@@ -1041,6 +1117,12 @@ namespace Internal.JitInterface
             return true;
         }
 
+        private FieldWithToken ComputeFieldWithToken(FieldDesc field, ref CORINFO_RESOLVED_TOKEN pResolvedToken)
+        {
+            ModuleToken token = HandleToModuleToken(ref pResolvedToken);
+            return new FieldWithToken(field, token);
+        }
+
         private MethodWithToken ComputeMethodWithToken(MethodDesc method, ref CORINFO_RESOLVED_TOKEN pResolvedToken, TypeDesc constrainedType, bool unboxing)
         {
             ModuleToken token = HandleToModuleToken(ref pResolvedToken, method, out object context, ref constrainedType);
@@ -1416,7 +1498,7 @@ namespace Internal.JitInterface
                     if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout && (fieldOffset <= FieldFixupSignature.MaxCheckableOffset))
                     {
                         // ENCODE_CHECK_FIELD_OFFSET
-                        AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                        AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
                     }
                 }
                 else
@@ -1457,7 +1539,7 @@ namespace Internal.JitInterface
 
                         // Static fields outside of the version bubble need to be accessed using the ENCODE_FIELD_ADDRESS
                         // helper in accordance with ZapInfo::getFieldInfo in CoreCLR.
-                        pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.FieldAddress(field));
+                        pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.FieldAddress(ComputeFieldWithToken(field, ref pResolvedToken)));
 
                         pResult->helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_STATIC_BASE;
 
@@ -1470,7 +1552,7 @@ namespace Internal.JitInterface
                         if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout && (fieldOffset <= FieldFixupSignature.MaxCheckableOffset))
                         {
                             // ENCODE_CHECK_FIELD_OFFSET
-                            AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                            AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
                         }
 
                         pResult->fieldLookup = CreateConstLookupToSymbol(
@@ -1493,7 +1575,7 @@ namespace Internal.JitInterface
             pResult->accessAllowed = CorInfoIsAccessAllowedResult.CORINFO_ACCESS_ALLOWED;
             pResult->offset = fieldOffset;
 
-            EncodeFieldBaseOffset(field, pResult, callerMethod);
+            EncodeFieldBaseOffset(field, ref pResolvedToken, pResult, callerMethod);
 
             // TODO: We need to implement access checks for fields and methods.  See JitInterface.cpp in mrtjit
             //       and STS::AccessCheck::CanAccess.
@@ -2407,7 +2489,7 @@ namespace Internal.JitInterface
                     case CorInfoGenericHandleType.CORINFO_HANDLETYPE_FIELD:
                         symbolNode = _compilation.SymbolNodeFactory.CreateReadyToRunHelper(
                             ReadyToRunHelperId.FieldHandle,
-                            HandleToObject(pResolvedToken.hField));
+                            ComputeFieldWithToken(HandleToObject(pResolvedToken.hField), ref pResolvedToken));
                         break;
 
                     default:
@@ -2455,7 +2537,7 @@ namespace Internal.JitInterface
             }
         }
 
-        private void EncodeFieldBaseOffset(FieldDesc field, CORINFO_FIELD_INFO* pResult, MethodDesc callerMethod)
+        private void EncodeFieldBaseOffset(FieldDesc field, ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_FIELD_INFO* pResult, MethodDesc callerMethod)
         {
             TypeDesc pMT = field.OwningType;
 
@@ -2471,7 +2553,7 @@ namespace Internal.JitInterface
                     if (pResult->offset > FieldFixupSignature.MaxCheckableOffset)
                         throw new RequiresRuntimeJitException(callerMethod.ToString() + " -> " + field.ToString());
 
-                    AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                    AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
                     // No-op other than generating the check field offset fixup
                 }
                 else
@@ -2481,7 +2563,7 @@ namespace Internal.JitInterface
                     // ENCODE_FIELD_OFFSET
                     pResult->offset = 0;
                     pResult->fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INSTANCE_WITH_BASE;
-                    pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.FieldOffset(field));
+                    pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.FieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
                 }
             }
             else if (pMT.IsValueType)
@@ -2490,7 +2572,7 @@ namespace Internal.JitInterface
                 {
                     // ENCODE_CHECK_FIELD_OFFSET
                     if (_compilation.CompilationModuleGroup.VersionsWithType(field.OwningType)) // Only verify versions with types
-                        AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                        AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
                 }
                 // ENCODE_NONE
             }
@@ -2500,14 +2582,14 @@ namespace Internal.JitInterface
                 {
                     // ENCODE_CHECK_FIELD_OFFSET
                     if (_compilation.CompilationModuleGroup.VersionsWithType(field.OwningType)) // Only verify versions with types
-                        AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                        AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
                 }
                 // ENCODE_NONE
             }
             else if (TypeCannotUseBasePlusOffsetEncoding(pMT.BaseType as MetadataType))
             {
                 // ENCODE_CHECK_FIELD_OFFSET
-                AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
                 // No-op other than generating the check field offset fixup
             }
             else
@@ -2518,7 +2600,7 @@ namespace Internal.JitInterface
                 {
                     // ENCODE_CHECK_FIELD_OFFSET
                     if (_compilation.CompilationModuleGroup.VersionsWithType(field.OwningType)) // Only verify versions with types
-                        AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                        AddPrecodeFixup(_compilation.SymbolNodeFactory.CheckFieldOffset(ComputeFieldWithToken(field, ref pResolvedToken)));
                 }
 
                 // ENCODE_FIELD_BASE_OFFSET


### PR DESCRIPTION
- Remove all trace of storing off the field token in a compiler non-deterministic manner
 - Notably, remove the _fieldToRefTokens field from ModuleTokenResolver, and remove the ability of that class to resolve tokens for fields
- Add a new concept called FieldWithToken modeled after MethodWithToken
- Plumb through the various dependency analysis structures as needed

Fixes #73403