### PR TITLE
Handle the case when pid replacement is not needed

### DIFF
--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -259,7 +259,7 @@
 #define STRESS_LOG_GC_STACK
 #endif //_DEBUG
 
-void AppendPid(LPCWSTR logFilename, LPWSTR fileName, size_t fileNameLength);
+LPCWSTR ReplacePid(LPCWSTR logFilename, LPWSTR fileName, size_t fileNameLength);
 
 class ThreadStressLog;
 

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -143,7 +143,7 @@ void StressLog::Leave(CRITSEC_COOKIE) {
     DecCantAllocCount();
 }
 
-void AppendPid(LPCWSTR logFilename, LPWSTR fileName, size_t fileNameLength)
+LPCWSTR ReplacePid(LPCWSTR logFilename, LPWSTR fileName, size_t fileNameLength)
 {
     // if the string "{pid}" occurs in the logFilename,
     // replace it by the PID of our process
@@ -164,6 +164,11 @@ void AppendPid(LPCWSTR logFilename, LPWSTR fileName, size_t fileNameLength)
 
         // append the rest of the filename
         wcscat_s(fileName, fileNameLength, logFilename + pidInx + wcslen(pidLit));
+        return fileName;
+    }
+    else
+    {
+        return logFilename;
     }
 }
 
@@ -176,9 +181,9 @@ static LPVOID CreateMemoryMappedFile(LPWSTR logFilename, size_t maxBytesTotal)
     }
 
     WCHAR fileName[MAX_PATH];
-    AppendPid(logFilename, fileName, MAX_PATH);
+    LPCWSTR logFilenameReplaced = ReplacePid(logFilename, fileName, MAX_PATH);
 
-    HandleHolder hFile = WszCreateFile(fileName,
+    HandleHolder hFile = WszCreateFile(logFilenameReplaced,
         GENERIC_READ | GENERIC_WRITE,
         FILE_SHARE_READ,
         NULL,                 // default security descriptor

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -284,8 +284,8 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
 
             // Writing an empty file to indicate completion
             WCHAR outputPath[MAX_PATH];
-            AppendPid(GENAWARE_COMPLETION_FILE_NAME, outputPath, MAX_PATH);
-            fclose(_wfopen(outputPath, W("w+")));
+            LPCWSTR outputPathReplaced = ReplacePid(GENAWARE_COMPLETION_FILE_NAME, outputPath, MAX_PATH);
+            fclose(_wfopen(outputPathReplaced, W("w+")));
         }
 
         if (!bPriorityBoosted)

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1696,8 +1696,8 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGene
                 EX_TRY
                 {
                     WCHAR outputPath[MAX_PATH];
-                    AppendPid(GENAWARE_DUMP_FILE_NAME, outputPath, MAX_PATH);
-                    GenerateDump (outputPath, 2, GenerateDumpFlagsNone, nullptr, 0);
+                    LPCWSTR outputPathReplaced = ReplacePid(GENAWARE_DUMP_FILE_NAME, outputPath, MAX_PATH);
+                    GenerateDump (outputPathReplaced, 2, GenerateDumpFlagsNone, nullptr, 0);
                 }
                 EX_CATCH {}
                 EX_END_CATCH(SwallowAllExceptions);

--- a/src/coreclr/vm/genanalysis.cpp
+++ b/src/coreclr/vm/genanalysis.cpp
@@ -77,7 +77,7 @@ bool gcGenAnalysisDump = false;
 /* static */ void GenAnalysis::EnableGenerationalAwareSession()
 {
     WCHAR outputPath[MAX_PATH];
-    AppendPid(GENAWARE_TRACE_FILE_NAME, outputPath, MAX_PATH);
+    LPCWSTR outputPathReplaced = ReplacePid(GENAWARE_TRACE_FILE_NAME, outputPath, MAX_PATH);
 
     NewArrayHolder<COR_PRF_EVENTPIPE_PROVIDER_CONFIG> pProviders;
     int providerCnt = 1;
@@ -94,7 +94,7 @@ bool gcGenAnalysisDump = false;
 
     EventPipeProviderConfigurationAdapter configAdapter(pProviders, providerCnt);
     gcGenAnalysisEventPipeSessionId = EventPipeAdapter::Enable(
-        outputPath,
+        outputPathReplaced,
         gcGenAnalysisBufferMB,
         configAdapter,
         EP_SESSION_TYPE_FILE,


### PR DESCRIPTION
Fixing a case I missed in #70764. In case `{pid}` is not found in the file name, the existing code would use an uninitialized buffer, which is not good.