### PR TITLE
Add `scoped` keyword where needed on interpolated string handlers

### DIFF
--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -358,8 +358,8 @@ namespace System
             public TryWriteInterpolatedStringHandler(int literalLength, int formattedCount, System.Span<char> destination, out bool shouldAppend) { throw null; }
             public TryWriteInterpolatedStringHandler(int literalLength, int formattedCount, System.Span<char> destination, IFormatProvider? provider, out bool shouldAppend) { throw null; }
             public bool AppendLiteral(string value) { throw null; }
-            public bool AppendFormatted(System.ReadOnlySpan<char> value) { throw null; }
-            public bool AppendFormatted(System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { throw null; }
+            public bool AppendFormatted(scoped System.ReadOnlySpan<char> value) { throw null; }
+            public bool AppendFormatted(scoped System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { throw null; }
             public bool AppendFormatted<T>(T value) { throw null; }
             public bool AppendFormatted<T>(T value, string? format) { throw null; }
             public bool AppendFormatted<T>(T value, int alignment) { throw null; }

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -2701,7 +2701,7 @@ namespace System
             #region AppendFormatted ReadOnlySpan<char>
             /// <summary>Writes the specified character span to the handler.</summary>
             /// <param name="value">The span to write.</param>
-            public bool AppendFormatted(ReadOnlySpan<char> value)
+            public bool AppendFormatted(scoped ReadOnlySpan<char> value)
             {
                 // Fast path for when the value fits in the current buffer
                 if (value.TryCopyTo(_destination.Slice(_pos)))
@@ -2717,7 +2717,7 @@ namespace System
             /// <param name="value">The span to write.</param>
             /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
             /// <param name="format">The format string.</param>
-            public bool AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
+            public bool AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null)
             {
                 bool leftAlign = false;
                 if (alignment < 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -411,7 +411,7 @@ namespace System.Runtime.CompilerServices
         #region AppendFormatted ReadOnlySpan<char>
         /// <summary>Writes the specified character span to the handler.</summary>
         /// <param name="value">The span to write.</param>
-        public void AppendFormatted(ReadOnlySpan<char> value)
+        public void AppendFormatted(scoped ReadOnlySpan<char> value)
         {
             // Fast path for when the value fits in the current buffer
             if (value.TryCopyTo(_chars.Slice(_pos)))
@@ -428,7 +428,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="value">The span to write.</param>
         /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
         /// <param name="format">The format string.</param>
-        public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
+        public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null)
         {
             bool leftAlign = false;
             if (alignment < 0)
@@ -621,7 +621,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Fallback for <see cref="AppendFormatted(ReadOnlySpan{char})"/> for when not enough space exists in the current buffer.</summary>
         /// <param name="value">The span to write.</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void GrowThenCopySpan(ReadOnlySpan<char> value)
+        private void GrowThenCopySpan(scoped ReadOnlySpan<char> value)
         {
             Grow(value.Length);
             value.CopyTo(_chars.Slice(_pos));

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12249,8 +12249,8 @@ namespace System.Runtime.CompilerServices
         public DefaultInterpolatedStringHandler(int literalLength, int formattedCount, System.IFormatProvider? provider) { throw null; }
         public DefaultInterpolatedStringHandler(int literalLength, int formattedCount, System.IFormatProvider? provider, System.Span<char> initialBuffer) { throw null; }
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) { }
-        public void AppendFormatted(System.ReadOnlySpan<char> value) { }
-        public void AppendFormatted(System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { }
+        public void AppendFormatted(scoped System.ReadOnlySpan<char> value) { }
+        public void AppendFormatted(scoped System.ReadOnlySpan<char> value, int alignment = 0, string? format = null) { }
         public void AppendFormatted(string? value) { }
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) { }
         public void AppendFormatted<T>(T value) { }


### PR DESCRIPTION
Only two `ref struct` handlers are in dotnet/runtime:
* DefaultInterpolatedStringHandler
* MemoryExtensions.TryWriteInterpolatedStringHandler

each of them only have two overloads of AppendFormatted that took
a `ref struct` (always ReadOnlySpan<char>).

DefaultInterpolatedStringHandler does have a Span parameter in a ctor,
but that one does escape to the instance, so `scoped` isn't correct there.

Fixes #73642