### PR TITLE
Copy default value back when Missing.Value is provided as argument

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
@@ -312,7 +312,7 @@ namespace System.Reflection
             {
                 StackAllocedArguments argStorage = default;
                 Span<object?> copyOfParameters = new(ref argStorage._arg0, 1);
-                object?[] parameters = new object?[] { parameter };
+                ReadOnlySpan<object?> parameters = new(in parameter);
                 Span<ParameterCopyBackAction> shouldCopyBackParameters = new(ref argStorage._copyBack0, 1);
 
                 StackAllocatedByRefs byrefStorage = default;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.CoreCLR.cs
@@ -312,7 +312,7 @@ namespace System.Reflection
             {
                 StackAllocedArguments argStorage = default;
                 Span<object?> copyOfParameters = new(ref argStorage._arg0, 1);
-                ReadOnlySpan<object?> parameters = new(in parameter);
+                object?[] parameters = new object?[] { parameter };
                 Span<ParameterCopyBackAction> shouldCopyBackParameters = new(ref argStorage._copyBack0, 1);
 
                 StackAllocatedByRefs byrefStorage = default;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3623,7 +3623,7 @@ namespace System
             }
 
             bool isValueType;
-            CheckValueStatus result = TryChangeType(ref value, out copyBack, out isValueType);
+            CheckValueStatus result = TryChangeType(ref value, ref copyBack, out isValueType);
             if (result == CheckValueStatus.Success)
             {
                 return isValueType;
@@ -3653,7 +3653,7 @@ namespace System
                         return IsValueType; // Note the call to IsValueType, not the variable.
                     }
 
-                    result = TryChangeType(ref value, out copyBack, out isValueType);
+                    result = TryChangeType(ref value, ref copyBack, out isValueType);
                     if (result == CheckValueStatus.Success)
                     {
                         return isValueType;
@@ -3675,7 +3675,7 @@ namespace System
 
         private CheckValueStatus TryChangeType(
             ref object? value,
-            out ParameterCopyBackAction copyBack,
+            ref ParameterCopyBackAction copyBack,
             out bool isValueType)
         {
             RuntimeType? sigElementType;
@@ -3731,7 +3731,6 @@ namespace System
 
             if (value == null)
             {
-                copyBack = ParameterCopyBackAction.None;
                 isValueType = RuntimeTypeHandle.IsValueType(this);
                 if (!isValueType)
                 {
@@ -3762,7 +3761,6 @@ namespace System
                 if (!CanValueSpecialCast(srcType, this))
                 {
                     isValueType = false;
-                    copyBack = ParameterCopyBackAction.None;
                     return CheckValueStatus.ArgumentException;
                 }
 
@@ -3781,12 +3779,10 @@ namespace System
                 }
 
                 isValueType = true;
-                copyBack = ParameterCopyBackAction.None;
                 return CheckValueStatus.Success;
             }
 
             isValueType = false;
-            copyBack = ParameterCopyBackAction.None;
             return CheckValueStatus.ArgumentException;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -204,7 +204,6 @@ namespace System.Reflection
                         {
                             // Fast path when the default value's type matches the signature type.
                             isValueType = RuntimeTypeHandle.IsValueType(sigType);
-                            copyBackArg = ParameterCopyBackAction.Copy;
                         }
                         else
                         {
@@ -217,12 +216,12 @@ namespace System.Reflection
                                 {
                                     arg = Enum.ToObject(argumentType, arg);
                                 }
-
-                                copyBackArg = ParameterCopyBackAction.CopyNullable;
                             }
 
                             isValueType = sigType.CheckValue(ref arg, ref copyBackArg, binder, culture, invokeAttr);
                         }
+
+                        copyBackArg = sigType.IsNullableOfT ? ParameterCopyBackAction.CopyNullable : ParameterCopyBackAction.Copy;
                     }
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -204,6 +204,7 @@ namespace System.Reflection
                         {
                             // Fast path when the default value's type matches the signature type.
                             isValueType = RuntimeTypeHandle.IsValueType(sigType);
+                            copyBackArg = ParameterCopyBackAction.Copy;
                         }
                         else
                         {
@@ -216,6 +217,8 @@ namespace System.Reflection
                                 {
                                     arg = Enum.ToObject(argumentType, arg);
                                 }
+
+                                copyBackArg = ParameterCopyBackAction.CopyNullable;
                             }
 
                             isValueType = sigType.CheckValue(ref arg, ref copyBackArg, binder, culture, invokeAttr);

--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -763,11 +763,17 @@ namespace System.Reflection.Tests
             Assert.Throws<ArgumentException>(() => method.Invoke(null, new object?[] { Type.Missing }));
         }
 
+        public static IEnumerable<object[]> MethodNameAndArgumetns()
+        {
+            yield return new object[] { nameof(Sample.DefaultString), "Hello", "Hi" };
+            yield return new object[] { nameof(Sample.DefaultNullString), null, "Hi" };
+            yield return new object[] { nameof(Sample.DefaultNullableInt), 3, 5 };
+            yield return new object[] { nameof(Sample.DefaultNullableEnum), YesNo.Yes, YesNo.No };
+        }
+
         [Theory]
-        [InlineData(nameof(Sample.DefaultString), "Hello", "Hi")]
-        [InlineData(nameof(Sample.DefaultNullableInt), 3, 5)]
-        [InlineData(nameof(Sample.DefaultNullableEnum), YesNo.Yes, YesNo.No)]
-        public static void InvokeCopiesBackMissingParameter(string methodName, object defaultValue, object passingValue)
+        [MemberData(nameof(MethodNameAndArgumetns))]
+        public static void InvokeCopiesBackMissingArgument(string methodName, object defaultValue, object passingValue)
         {
             MethodInfo method = typeof(Sample).GetMethod(methodName);
             object[] args = new object[] { Missing.Value };
@@ -779,6 +785,20 @@ namespace System.Reflection.Tests
 
             Assert.Equal(passingValue, method.Invoke(null, args));
             Assert.Equal(passingValue, args[0]);
+
+            args[0] = null;
+            Assert.Null(method.Invoke(null, args));
+            Assert.Null(args[0]);
+        }
+
+        [Fact]
+        public static void InvokeCopiesBackMissingParameterAndArgument()
+        {
+            MethodInfo method = typeof(Sample).GetMethod(nameof(Sample.DefaultMissing));
+            object[] args = new object[] { Missing.Value };
+
+            Assert.Equal(Missing.Value, method.Invoke(null, args)); // Argument type matches with parameter type, therefore default value null will not copied back
+            Assert.Equal(Missing.Value, args[0]);
 
             args[0] = null;
             Assert.Null(method.Invoke(null, args));
@@ -1109,11 +1129,16 @@ namespace System.Reflection.Tests
         {
             return "";
         }
+
         public static string DefaultString(string value = "Hello") => value;
+
+        public static string DefaultNullString(string value = null) => value;
 
         public static YesNo? DefaultNullableEnum(YesNo? value = YesNo.Yes) => value;
 
         public static int? DefaultNullableInt(int? value = 3) => value;
+
+        public static Missing DefaultMissing(Missing value = null) => value;
     }
 
     public class SampleG<T>

--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -763,6 +763,28 @@ namespace System.Reflection.Tests
             Assert.Throws<ArgumentException>(() => method.Invoke(null, new object?[] { Type.Missing }));
         }
 
+        [Theory]
+        [InlineData(nameof(Sample.DefaultString), "Hello", "Hi")]
+        [InlineData(nameof(Sample.DefaultNullableInt), 3, 5)]
+        [InlineData(nameof(Sample.DefaultNullableEnum), YesNo.Yes, YesNo.No)]
+        public static void InvokeCopiesBackMissingParameter(string methodName, object defaultValue, object passingValue)
+        {
+            MethodInfo method = typeof(Sample).GetMethod(methodName);
+            object[] args = new object[] { Missing.Value };
+
+            Assert.Equal(defaultValue, method.Invoke(null, args));
+            Assert.Equal(defaultValue, args[0]);
+
+            args[0] = passingValue;
+
+            Assert.Equal(passingValue, method.Invoke(null, args));
+            Assert.Equal(passingValue, args[0]);
+
+            args[0] = null;
+            Assert.Null(method.Invoke(null, args));
+            Assert.Null(args[0]);
+        }
+
         [Fact]
         public void ValueTypeMembers_WithOverrides()
         {
@@ -1087,6 +1109,11 @@ namespace System.Reflection.Tests
         {
             return "";
         }
+        public static string DefaultString(string value = "Hello") => value;
+
+        public static YesNo? DefaultNullableEnum(YesNo? value = YesNo.Yes) => value;
+
+        public static int? DefaultNullableInt(int? value = 3) => value;
     }
 
     public class SampleG<T>

--- a/src/libraries/System.Reflection/tests/MethodInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/MethodInfoTests.cs
@@ -797,8 +797,8 @@ namespace System.Reflection.Tests
             MethodInfo method = typeof(Sample).GetMethod(nameof(Sample.DefaultMissing));
             object[] args = new object[] { Missing.Value };
 
-            Assert.Equal(Missing.Value, method.Invoke(null, args)); // Argument type matches with parameter type, therefore default value null will not copied back
-            Assert.Equal(Missing.Value, args[0]);
+            Assert.Null(method.Invoke(null, args));
+            Assert.Null(args[0]);
 
             args[0] = null;
             Assert.Null(method.Invoke(null, args));


### PR DESCRIPTION
Fix [Missing.Value corner-case behavior changes in .NET 7](https://github.com/dotnet/runtime/issues/73106)

In .NET 6 and below all arguments were copied back
https://github.com/dotnet/runtime/blob/510444c8ce032dc611e5e6c2079382921deb63a2/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs#L437-L440

Later in .NET 7 it seems updated to copy only if ByRef are present as mentioned in the comment, this is causing a regression when `Missing.Value` is provides as argument and default value used to written back instead of `Missing.Value`

Fixes https://github.com/dotnet/runtime/issues/73106