### PR TITLE
Revert "Generic attributes handling in CustomAttributeDecoder"

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/CustomAttributeDecoder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/CustomAttributeDecoder.cs
@@ -22,7 +22,6 @@ namespace System.Reflection.Metadata.Ecma335
         public CustomAttributeValue<TType> DecodeValue(EntityHandle constructor, BlobHandle value)
         {
             BlobHandle signature;
-            BlobHandle attributeOwningTypeSpec = default;
             switch (constructor.Kind)
             {
                 case HandleKind.MethodDefinition:
@@ -33,13 +32,6 @@ namespace System.Reflection.Metadata.Ecma335
                 case HandleKind.MemberReference:
                     MemberReference reference = _reader.GetMemberReference((MemberReferenceHandle)constructor);
                     signature = reference.Signature;
-
-                    // If this is a generic attribute, we'll need its instantiation to decode the signatures
-                    if (reference.Parent.Kind == HandleKind.TypeSpecification)
-                    {
-                        TypeSpecification genericOwner = _reader.GetTypeSpecification((TypeSpecificationHandle)reference.Parent);
-                        attributeOwningTypeSpec = genericOwner.Signature;
-                    }
                     break;
 
                 default:
@@ -68,38 +60,12 @@ namespace System.Reflection.Metadata.Ecma335
                 throw new BadImageFormatException();
             }
 
-            BlobReader genericContextReader = default;
-            if (!attributeOwningTypeSpec.IsNil)
-            {
-                // If this is a generic attribute, grab the instantiation arguments so that we can
-                // interpret the constructor signature, should it refer to the generic context.
-                genericContextReader = _reader.GetBlobReader(attributeOwningTypeSpec);
-                if (genericContextReader.ReadSignatureTypeCode() == SignatureTypeCode.GenericTypeInstance)
-                {
-                    int kind = genericContextReader.ReadCompressedInteger();
-                    if (kind != (int)SignatureTypeKind.Class && kind != (int)SignatureTypeKind.ValueType)
-                    {
-                        throw new BadImageFormatException();
-                    }
-
-                    genericContextReader.ReadTypeHandle();
-
-                    // At this point, the reader points to the "GenArgCount Type Type*" part of the signature.
-                }
-                else
-                {
-                    // Some other invalid TypeSpec. Don't accidentally allow resolving generic parameters
-                    // from the constructor signature into a broken blob.
-                    genericContextReader = default;
-                }
-            }
-
-            ImmutableArray<CustomAttributeTypedArgument<TType>> fixedArguments = DecodeFixedArguments(ref signatureReader, ref valueReader, parameterCount, genericContextReader);
+            ImmutableArray<CustomAttributeTypedArgument<TType>> fixedArguments = DecodeFixedArguments(ref signatureReader, ref valueReader, parameterCount);
             ImmutableArray<CustomAttributeNamedArgument<TType>> namedArguments = DecodeNamedArguments(ref valueReader);
             return new CustomAttributeValue<TType>(fixedArguments, namedArguments);
         }
 
-        private ImmutableArray<CustomAttributeTypedArgument<TType>> DecodeFixedArguments(ref BlobReader signatureReader, ref BlobReader valueReader, int count, BlobReader genericContextReader)
+        private ImmutableArray<CustomAttributeTypedArgument<TType>> DecodeFixedArguments(ref BlobReader signatureReader, ref BlobReader valueReader, int count)
         {
             if (count == 0)
             {
@@ -110,7 +76,7 @@ namespace System.Reflection.Metadata.Ecma335
 
             for (int i = 0; i < count; i++)
             {
-                ArgumentTypeInfo info = DecodeFixedArgumentType(ref signatureReader, genericContextReader);
+                ArgumentTypeInfo info = DecodeFixedArgumentType(ref signatureReader);
                 arguments.Add(DecodeArgument(ref valueReader, info));
             }
 
@@ -158,7 +124,7 @@ namespace System.Reflection.Metadata.Ecma335
         // better perf-wise, but even more important is that we can't actually reason about
         // a method signature with opaque TType values without adding some unnecessary chatter
         // with the provider.
-        private ArgumentTypeInfo DecodeFixedArgumentType(ref BlobReader signatureReader, BlobReader genericContextReader, bool isElementType = false)
+        private ArgumentTypeInfo DecodeFixedArgumentType(ref BlobReader signatureReader, bool isElementType = false)
         {
             SignatureTypeCode signatureTypeCode = signatureReader.ReadSignatureTypeCode();
 
@@ -204,32 +170,11 @@ namespace System.Reflection.Metadata.Ecma335
                         throw new BadImageFormatException();
                     }
 
-                    var elementInfo = DecodeFixedArgumentType(ref signatureReader, genericContextReader, isElementType: true);
+                    var elementInfo = DecodeFixedArgumentType(ref signatureReader, isElementType: true);
                     info.ElementType = elementInfo.Type;
                     info.ElementTypeCode = elementInfo.TypeCode;
                     info.Type = _provider.GetSZArrayType(info.ElementType);
                     break;
-
-                case SignatureTypeCode.GenericTypeParameter:
-                    if (genericContextReader.Length == 0)
-                    {
-                        throw new BadImageFormatException();
-                    }
-
-                    int parameterIndex = signatureReader.ReadCompressedInteger();
-                    int numGenericParameters = genericContextReader.ReadCompressedInteger();
-                    if (parameterIndex >= numGenericParameters)
-                    {
-                        throw new BadImageFormatException();
-                    }
-
-                    while (parameterIndex > 0)
-                    {
-                        SkipType(ref genericContextReader);
-                        parameterIndex--;
-                    }
-
-                    return DecodeFixedArgumentType(ref genericContextReader, default, isElementType);
 
                 default:
                     throw new BadImageFormatException();
@@ -418,95 +363,5 @@ namespace System.Reflection.Metadata.Ecma335
                 HandleKind.TypeReference => _provider.GetTypeFromReference(_reader, (TypeReferenceHandle)handle, 0),
                 _ => throw new BadImageFormatException(SR.NotTypeDefOrRefHandle),
             };
-
-        private static void SkipType(ref BlobReader blobReader)
-        {
-            int typeCode = blobReader.ReadCompressedInteger();
-
-            switch (typeCode)
-            {
-                case (int)SignatureTypeCode.Boolean:
-                case (int)SignatureTypeCode.Char:
-                case (int)SignatureTypeCode.SByte:
-                case (int)SignatureTypeCode.Byte:
-                case (int)SignatureTypeCode.Int16:
-                case (int)SignatureTypeCode.UInt16:
-                case (int)SignatureTypeCode.Int32:
-                case (int)SignatureTypeCode.UInt32:
-                case (int)SignatureTypeCode.Int64:
-                case (int)SignatureTypeCode.UInt64:
-                case (int)SignatureTypeCode.Single:
-                case (int)SignatureTypeCode.Double:
-                case (int)SignatureTypeCode.IntPtr:
-                case (int)SignatureTypeCode.UIntPtr:
-                case (int)SignatureTypeCode.Object:
-                case (int)SignatureTypeCode.String:
-                case (int)SignatureTypeCode.Void:
-                case (int)SignatureTypeCode.TypedReference:
-                    return;
-
-                case (int)SignatureTypeCode.Pointer:
-                case (int)SignatureTypeCode.ByReference:
-                case (int)SignatureTypeCode.Pinned:
-                case (int)SignatureTypeCode.SZArray:
-                    SkipType(ref blobReader);
-                    return;
-
-                case (int)SignatureTypeCode.FunctionPointer:
-                    SignatureHeader header = blobReader.ReadSignatureHeader();
-                    if (header.IsGeneric)
-                    {
-                        blobReader.ReadCompressedInteger(); // arity
-                    }
-
-                    int paramCount = blobReader.ReadCompressedInteger();
-                    SkipType(ref blobReader);
-                    for (int i = 0; i < paramCount; i++)
-                        SkipType(ref blobReader);
-                    return;
-
-                case (int)SignatureTypeCode.Array:
-                    SkipType(ref blobReader);
-                    blobReader.ReadCompressedInteger(); // rank
-                    int boundsCount = blobReader.ReadCompressedInteger();
-                    for (int i = 0; i < boundsCount; i++)
-                    {
-                        blobReader.ReadCompressedInteger();
-                    }
-                    int lowerBoundsCount = blobReader.ReadCompressedInteger();
-                    for (int i = 0; i < lowerBoundsCount; i++)
-                    {
-                        blobReader.ReadCompressedSignedInteger();
-                    }
-                    return;
-
-                case (int)SignatureTypeCode.RequiredModifier:
-                case (int)SignatureTypeCode.OptionalModifier:
-                    blobReader.ReadTypeHandle();
-                    SkipType(ref blobReader);
-                    return;
-
-                case (int)SignatureTypeCode.GenericTypeInstance:
-                    SkipType(ref blobReader);
-                    int count = blobReader.ReadCompressedInteger();
-                    for (int i = 0; i < count; i++)
-                    {
-                        SkipType(ref blobReader);
-                    }
-                    return;
-
-                case (int)SignatureTypeCode.GenericTypeParameter:
-                    blobReader.ReadCompressedInteger();
-                    return;
-
-                case (int)SignatureTypeKind.Class:
-                case (int)SignatureTypeKind.ValueType:
-                    SkipType(ref blobReader);
-                    break;
-
-                default:
-                    throw new BadImageFormatException();
-            }
-        }
     }
 }

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Reflection.Metadata.Tests;
@@ -12,7 +11,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
 {
     public class CustomAttributeDecoderTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles), nameof(PlatformDetection.IsMonoRuntime))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/60579", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void TestCustomAttributeDecoder()
         {
@@ -22,6 +21,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
                 MetadataReader reader = peReader.GetMetadataReader();
                 var provider = new CustomAttributeTypeProvider();
                 TypeDefinitionHandle typeDefHandle = TestMetadataResolver.FindTestType(reader, typeof(HasAttributes));
+
 
                 int i = 0;
                 foreach (CustomAttributeHandle attributeHandle in reader.GetCustomAttributes(typeDefHandle))
@@ -75,273 +75,15 @@ namespace System.Reflection.Metadata.Decoding.Tests
                             break;
 
                         default:
-                            // TODO: https://github.com/dotnet/runtime/issues/73593
-                            // This method only tests first 3 attriubtes because the complete test 'TestCustomAttributeDecoderUsingReflection' fails on mono
-                            // Leaving this hard coded test only for mono, until the issue fixed on mono
+                            // TODO: https://github.com/dotnet/runtime/issues/16552
+                            // The other cases are missing corresponding assertions. This needs some refactoring to
+                            // be data-driven. A better approach would probably be to generically compare reflection
+                            // CustomAttributeData to S.R.M CustomAttributeValue for every test attribute applied.
                             break;
                     }
                 }
             }
         }
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73593", TestRuntimes.Mono)]
-        public void TestCustomAttributeDecoderUsingReflection()
-        {
-            Type type = typeof(HasAttributes);
-            using (FileStream stream = File.OpenRead(AssemblyPathHelper.GetAssemblyLocation(type.GetTypeInfo().Assembly)))
-            using (PEReader peReader = new PEReader(stream))
-            {
-                MetadataReader reader = peReader.GetMetadataReader();
-                CustomAttributeTypeProvider provider = new CustomAttributeTypeProvider();
-                TypeDefinitionHandle typeDefHandle = TestMetadataResolver.FindTestType(reader, type);
-
-                IList<CustomAttributeData> attributes = type.GetCustomAttributesData();
-
-                int i = 0;
-                foreach (CustomAttributeHandle attributeHandle in reader.GetCustomAttributes(typeDefHandle))
-                {
-                    CustomAttribute attribute = reader.GetCustomAttribute(attributeHandle);
-                    CustomAttributeValue<string> value = attribute.DecodeValue(provider);
-                    CustomAttributeData reflectionAttribute = attributes[i++];
-
-                    Assert.Equal(reflectionAttribute.ConstructorArguments.Count, value.FixedArguments.Length);
-                    Assert.Equal(reflectionAttribute.NamedArguments.Count, value.NamedArguments.Length);
-
-                    int j = 0;
-                    foreach (CustomAttributeTypedArgument<string> arguments in value.FixedArguments)
-                    {
-                        Type t = reflectionAttribute.ConstructorArguments[j].ArgumentType;
-                        Assert.Equal(TypeToString(t), arguments.Type);
-                        if (t.IsArray && arguments.Value is not null)
-                        {   
-                            ImmutableArray<CustomAttributeTypedArgument<string>> array = (ImmutableArray<CustomAttributeTypedArgument<string>>)(arguments.Value);
-                            IList<CustomAttributeTypedArgument> refArray = (IList<CustomAttributeTypedArgument>)reflectionAttribute.ConstructorArguments[j].Value;
-                            int k = 0;
-                            foreach (CustomAttributeTypedArgument<string> element in array)
-                            {
-                                if (refArray[k].ArgumentType.IsArray)
-                                {
-                                    ImmutableArray<CustomAttributeTypedArgument<string>> innerArray = (ImmutableArray<CustomAttributeTypedArgument<string>>)(element.Value);
-                                    IList<CustomAttributeTypedArgument> refInnerArray = (IList<CustomAttributeTypedArgument>)refArray[k].Value;
-                                    int a = 0;
-                                    foreach (CustomAttributeTypedArgument<string> el in innerArray)
-                                    {
-                                        if (refInnerArray[a].Value?.ToString() != el.Value?.ToString())
-                                        {
-                                            Assert.Equal(refInnerArray[a].Value, el.Value);
-                                        }
-                                        a++;
-                                    }
-                                }
-                                else if (refArray[k].Value?.ToString() != element.Value?.ToString())
-                                {
-                                    if (refArray[k].ArgumentType == typeof(Type)) // TODO: check if it is expected
-                                    {
-                                        Assert.Contains(refArray[k].Value.ToString(), element.Value.ToString());
-                                    }
-                                    else
-                                    {
-                                        Assert.Equal(refArray[k].Value, element.Value);
-                                    }
-                                }
-                                k++;
-                            }
-                        }
-                        else if (reflectionAttribute.ConstructorArguments[j].Value?.ToString() != arguments.Value?.ToString())
-                        {
-                            if (reflectionAttribute.ConstructorArguments[j].ArgumentType == typeof(Type))
-                            {
-                                Assert.Contains(reflectionAttribute.ConstructorArguments[j].Value.ToString(), arguments.Value.ToString());
-                            }
-                            else
-                            {
-                                Assert.Equal(reflectionAttribute.ConstructorArguments[j].Value, arguments.Value);
-                            }
-                        }
-                        j++;
-                    }
-                    j = 0;
-                    foreach (CustomAttributeNamedArgument<string> arguments in value.NamedArguments)
-                    {
-                        Type t = reflectionAttribute.NamedArguments[j].TypedValue.ArgumentType;
-                        Assert.Equal(TypeToString(t), arguments.Type);
-                        if (t.IsArray && arguments.Value is not null)
-                        {
-                            ImmutableArray<CustomAttributeTypedArgument<string>> array = (ImmutableArray<CustomAttributeTypedArgument<string>>)(arguments.Value);
-                            IList<CustomAttributeTypedArgument> refArray = (IList<CustomAttributeTypedArgument>)reflectionAttribute.NamedArguments[j].TypedValue.Value;
-                            int k = 0;
-                            foreach (CustomAttributeTypedArgument<string> element in array)
-                            {
-                                if (refArray[k].Value?.ToString() != element.Value?.ToString())
-                                {
-                                    Assert.Equal(refArray[k].Value, element.Value);
-                                }
-                                k++;
-                            }
-                        }
-                        else if (reflectionAttribute.NamedArguments[j].TypedValue.Value?.ToString() != arguments.Value?.ToString())
-                        {
-                            if (reflectionAttribute.NamedArguments[j].TypedValue.ArgumentType == typeof(Type)) // typeof operator used for named parameter, like [Test(TypeField = typeof(string))], check if it is expected
-                            {
-                                Assert.Contains(reflectionAttribute.NamedArguments[j].TypedValue.Value.ToString(), arguments.Value.ToString());
-                            }
-                            else
-                            {
-                                Assert.Equal(reflectionAttribute.NamedArguments[j].TypedValue.Value, arguments.Value);
-                            }
-                        }
-                        j++;
-                    }
-                }
-            }
-        }
-
-#if NETCOREAPP // Generic attribute is not supported on .NET Framework.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60579", TestPlatforms.iOS | TestPlatforms.tvOS)]
-        public void TestCustomAttributeDecoderGenericUsingReflection()
-        {
-            Type type = typeof(HasGenericAttributes);
-            using (FileStream stream = File.OpenRead(AssemblyPathHelper.GetAssemblyLocation(type.GetTypeInfo().Assembly)))
-            using (PEReader peReader = new PEReader(stream))
-            {
-                MetadataReader reader = peReader.GetMetadataReader();
-                CustomAttributeTypeProvider provider = new CustomAttributeTypeProvider();
-                TypeDefinitionHandle typeDefHandle = TestMetadataResolver.FindTestType(reader, type);
-
-                IList<CustomAttributeData> attributes= type.GetCustomAttributesData();
-
-                int i = 0;
-                foreach (CustomAttributeHandle attributeHandle in reader.GetCustomAttributes(typeDefHandle))
-                {
-                    CustomAttribute attribute = reader.GetCustomAttribute(attributeHandle);
-                    CustomAttributeValue<string> value = attribute.DecodeValue(provider);
-                    CustomAttributeData reflectionAttribute = attributes[i++];
-
-                    Assert.Equal(reflectionAttribute.ConstructorArguments.Count, value.FixedArguments.Length);
-                    Assert.Equal(reflectionAttribute.NamedArguments.Count, value.NamedArguments.Length);
-
-                    int j = 0;
-                    foreach (CustomAttributeTypedArgument<string> arguments in value.FixedArguments)
-                    {
-                        Assert.Equal(TypeToString(reflectionAttribute.ConstructorArguments[j].ArgumentType), arguments.Type);
-                        if (reflectionAttribute.ConstructorArguments[j].Value.ToString() != arguments.Value.ToString())
-                        {
-                            Assert.Equal(reflectionAttribute.ConstructorArguments[j].Value, arguments.Value);
-                        }
-                        j++;
-                    }
-                    j = 0;
-                    foreach (CustomAttributeNamedArgument<string> arguments in value.NamedArguments)
-                    {
-                        Assert.Equal(TypeToString(reflectionAttribute.NamedArguments[j].TypedValue.ArgumentType), arguments.Type);
-                        if (reflectionAttribute.NamedArguments[j].TypedValue.Value.ToString() != arguments.Value.ToString())
-                        {
-                            Assert.Equal(reflectionAttribute.NamedArguments[j].TypedValue.Value, arguments.Value);
-                        }
-                        j++;
-                    }
-                }
-            }
-        }
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60579", TestPlatforms.iOS | TestPlatforms.tvOS)]
-        public void TestCustomAttributeDecoderGenericArray()
-        {
-            Type type = typeof(HasGenericArrayAttributes);
-            using (FileStream stream = File.OpenRead(AssemblyPathHelper.GetAssemblyLocation(type.GetTypeInfo().Assembly)))
-            using (PEReader peReader = new PEReader(stream))
-            {
-                MetadataReader reader = peReader.GetMetadataReader();
-                CustomAttributeTypeProvider provider = new CustomAttributeTypeProvider();
-                TypeDefinitionHandle typeDefHandle = TestMetadataResolver.FindTestType(reader, type);
-
-                IList<CustomAttributeData> attributes = type.GetCustomAttributesData();
-
-                foreach (CustomAttributeHandle attributeHandle in reader.GetCustomAttributes(typeDefHandle))
-                {
-                    CustomAttribute attribute = reader.GetCustomAttribute(attributeHandle);
-                    CustomAttributeValue<string> value = attribute.DecodeValue(provider);
-
-                    if (value.FixedArguments.Length == 2)
-                    {
-                        Assert.Equal(2, value.FixedArguments.Length);
-                        ImmutableArray<CustomAttributeTypedArgument<string>> array1 = (ImmutableArray<CustomAttributeTypedArgument<string>>)(value.FixedArguments[0].Value);
-                        Assert.Equal("int32[]", value.FixedArguments[0].Type);
-                        Assert.Equal(1, array1[0].Value);
-                        Assert.Equal(3, array1[2].Value);
-                        ImmutableArray<CustomAttributeTypedArgument<string>> array2 = (ImmutableArray<CustomAttributeTypedArgument<string>>)(value.FixedArguments[1].Value);
-                        Assert.Equal("uint8[]", value.FixedArguments[1].Type);
-                        Assert.Equal((byte)4, array2[0].Value);
-                        Assert.Equal((byte)5, array2[1].Value);
-
-                        Assert.Empty(value.NamedArguments);
-                    }
-                    else
-                    {
-                        Assert.Equal(1, value.FixedArguments.Length);
-
-                        Assert.Equal("uint8", value.FixedArguments[0].Type);
-                        Assert.Equal((byte)1, value.FixedArguments[0].Value);
-
-                        Assert.Equal(2, value.NamedArguments.Length);
-
-                        Assert.Equal("uint8", value.NamedArguments[0].Type);
-                        Assert.Equal((byte)2, value.NamedArguments[0].Value);
-
-                        ImmutableArray<CustomAttributeTypedArgument<string>> array = (ImmutableArray<CustomAttributeTypedArgument<string>>)(value.NamedArguments[1].Value);
-                        Assert.Equal("uint8[]", value.NamedArguments[1].Type);
-                        Assert.Equal((byte)3, array[0].Value);
-                    }
-                }
-            }
-        }
-
-        [GenericAttribute<bool>]
-        [GenericAttribute<string>("Hello")]
-        [GenericAttribute<int>(12)]
-        [GenericAttribute<string>("Hello", 12, TProperty = "Bye")]
-        [GenericAttribute<byte>(1, TProperty = 2)]
-        [GenericAttribute2<bool, int>(true, 13)]
-        // [GenericAttribute<MyEnum>(MyEnum.Property)] TODO: https://github.com/dotnet/runtime/issues/16552
-        [GenericAttribute<Type>(typeof(HasAttributes))]
-        [GenericAttribute<Type>(TProperty = typeof(HasAttributes))]
-        public class HasGenericAttributes { }
-
-        [GenericAttribute2<int[], byte[]>(new int[] { 1, 2, 3 }, new byte[] { 4, 5 })]
-        [GenericAttribute<byte>(1, TProperty = 2, TArrayProperty = new byte[] { 3, 4 })]
-        public class HasGenericArrayAttributes { }
-
-        [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
-        internal class GenericAttribute<T> : Attribute
-        {
-            public GenericAttribute() { }
-            public GenericAttribute(T value)
-            {
-                Field = value;
-            }
-            public GenericAttribute(T value, int count)
-            {
-                Field = value;
-            }
-            public T TProperty { get; set; }
-            public T[] TArrayProperty { get; set; }
-            public T Field;
-        }
-
-        [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
-        internal class GenericAttribute2<K, V> : Attribute
-        {
-            public GenericAttribute2() { }
-            public GenericAttribute2(K key) { }
-            public GenericAttribute2(K key, V value) { }
-            public K Key { get; set; }
-            public V Value { get; set; }
-            public K[] ArrayProperty { get; set; }
-        }
-#endif
 
         // no arguments
         [Test]
@@ -378,17 +120,17 @@ namespace System.Reflection.Metadata.Decoding.Tests
         [Test(true)]
         [Test(false)]
         [Test(typeof(string))]
-        /* [Test(SByteEnum.Value)] // The FullName is (System.Reflection.Metadata.Decoding.Tests.CustomAttributeDecoderTests+SByteEnum) 
-        [Test(Int16Enum.Value)] // but some enums '+' is replaced with '/' and causing inconsistency
-        [Test(Int32Enum.Value)] // Updaated https://github.com/dotnet/runtime/issues/16552 to resolve this scenario later
+        [Test(SByteEnum.Value)]
+        [Test(Int16Enum.Value)]
+        [Test(Int32Enum.Value)]
         [Test(Int64Enum.Value)]
         [Test(ByteEnum.Value)]
         [Test(UInt16Enum.Value)]
         [Test(UInt32Enum.Value)]
-        [Test(UInt64Enum.Value)]*/
+        [Test(UInt64Enum.Value)]
         [Test(new string[] { })]
         [Test(new string[] { "x", "y", "z", null })]
-        // [Test(new Int32Enum[] { Int32Enum.Value })] TODO: https://github.com/dotnet/runtime/issues/16552
+        [Test(new Int32Enum[] { Int32Enum.Value })]
 
         // same single fixed arguments as above, typed as object
         [Test((object)("string"))]
@@ -434,7 +176,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
             (uint)4,
             true,
             false,
-            typeof(string), // check if the produced value is expected
+            typeof(string),
             SByteEnum.Value,
             Int16Enum.Value,
             Int32Enum.Value,
@@ -475,7 +217,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
         [Test(UInt64EnumField = UInt64Enum.Value)]
         [Test(new string[] { })]
         [Test(new string[] { "x", "y", "z", null })]
-        // [Test(new Int32Enum[] { Int32Enum.Value })] TODO: https://github.com/dotnet/runtime/issues/16552
+        [Test(new Int32Enum[] { Int32Enum.Value })]
 
         // null named arguments
         [Test(ObjectField = null)]
@@ -591,83 +333,6 @@ namespace System.Reflection.Metadata.Decoding.Tests
             public UInt64Enum[] UInt64EnumArrayProperty { get; set; }
         }
 
-        private string TypeToString(Type type)
-        {
-            if (type == typeof(Type))
-                return $"[{MetadataReaderTestHelpers.RuntimeAssemblyName}]System.Type";
-
-            if (type.IsArray)
-            {
-                if (type.GetElementType().IsEnum)
-                {
-                    Type el = type.GetElementType();
-                    return type.FullName;
-                }
-                return GetPrimitiveType(type.GetElementType()) + "[]";
-            }
-
-            if (type.IsEnum)
-                return type.FullName;
-
-            return GetPrimitiveType(type);
-        }
-
-        private static string GetPrimitiveType(Type type)
-        {
-            switch (Type.GetTypeCode(type))
-            {
-                case TypeCode.Boolean:
-                    return "bool";
-
-                case TypeCode.Byte:
-                    return "uint8";
-
-                case TypeCode.Char:
-                    return "char";
-
-                case TypeCode.Double:
-                    return "float64";
-
-                case TypeCode.Int16:
-                    return "int16";
-
-                case TypeCode.Int32:
-                    return "int32";
-
-                case TypeCode.Int64:
-                    return "int64";
-
-                case TypeCode.Object:
-                    return "object";
-
-                case TypeCode.SByte:
-                    return "int8";
-
-                case TypeCode.Single:
-                    return "float32";
-
-                case TypeCode.String:
-                    return "string";
-
-                case TypeCode.UInt16:
-                    return "uint16";
-
-                case TypeCode.UInt32:
-                    return "uint32";
-
-                case TypeCode.UInt64:
-                    return "uint64";
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(type));
-            }
-        }
-
-        public enum MyEnum
-        {
-            Ctor,
-            Property
-        }
 
         private class CustomAttributeTypeProvider : DisassemblingTypeProvider, ICustomAttributeTypeProvider<string>
         {
@@ -714,9 +379,6 @@ namespace System.Reflection.Metadata.Decoding.Tests
 
                 if (runtimeType == typeof(UInt64Enum))
                     return PrimitiveTypeCode.UInt64;
-
-                if (runtimeType == typeof(MyEnum))
-                    return PrimitiveTypeCode.Byte;
 
                 throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
Reverts dotnet/runtime#72561

The merge causing failures on rolling build and https://github.com/dotnet/runtime/pull/73410