### PR TITLE
Don't excessively generate default constructors

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -61,8 +61,10 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             // Keep track of the default constructor map dependency for this type if it has a default constructor
+            // We only do this for reflection blocked types because dataflow analysis is responsible for
+            // generating default constructors for Activator.CreateInstance in other cases.
             MethodDesc defaultCtor = closestDefType.GetDefaultConstructor();
-            if (defaultCtor != null)
+            if (defaultCtor != null && factory.MetadataManager.IsReflectionBlocked(defaultCtor))
             {
                 dependencyList.Add(new DependencyListEntry(
                     factory.CanonicalEntrypoint(defaultCtor),

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -82,11 +82,13 @@ namespace ILCompiler.DependencyAnalysis
             factory.InteropStubManager.AddInterestingInteropConstructedTypeDependencies(ref dependencyList, factory, _type);
 
             // Keep track of the default constructor map dependency for this type if it has a default constructor
+            // We only do this for reflection blocked types because dataflow analysis is responsible for
+            // generating default constructors for Activator.CreateInstance in other cases.
             MethodDesc defaultCtor = closestDefType.GetDefaultConstructor();
-            if (defaultCtor != null)
+            if (defaultCtor != null && factory.MetadataManager.IsReflectionBlocked(defaultCtor))
             {
                 dependencyList.Add(new DependencyListEntry(
-                    factory.CanonicalEntrypoint(defaultCtor), 
+                    factory.CanonicalEntrypoint(defaultCtor),
                     "DefaultConstructorNode"));
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DefaultConstructorMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DefaultConstructorMapNode.cs
@@ -64,6 +64,15 @@ namespace ILCompiler.DependencyAnalysis
                 if (defaultCtor == null)
                     continue;
 
+                // We only place default constructors of reflection-blocked types in this table.
+                // At runtime, the type loader will search both this table and the invoke map
+                // for default constructor info. If the ctor is reflectable, we would have
+                // expected dataflow analysis to ensure there's a reflectable method for it.
+                // If we don't find a reflectable method for the ctor of a non-blocked type
+                // there would have to be a dataflow analysis warning.
+                if (!factory.MetadataManager.IsReflectionBlocked(defaultCtor))
+                    continue;
+
                 defaultCtor = defaultCtor.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
                 ISymbolNode typeNode = factory.NecessaryTypeSymbol(type);


### PR DESCRIPTION
Fixes #68660.

This is a piece of logic that originates from .NET Native. We didn't have a hard stance on `Activator.CreateInstance<T>` at that time, so we took a conservative approach of always generating the default constructors for all types that have type handle.

Since we now do static analysis and warn if `Activator` is used with something we couldn't analyze. We can trim more.

I would delete the whole table and logic, but I'm not sure if we can't still hit a problem when `CreateInstance<T>` is used with a reflection blocked type - this would affect private reflection within CoreLib (we don't think about reflection when doing `new T()`, so this can happen). With reflection blocking even if dataflow figures out that `BlockedFromReflectionType..ctor` should be reflectable, we won't reflection enable it.

We really should just get rid of reflection blocking (#72570). Then all of this can go away.

Cc @dotnet/ilc-contrib 