### PR TITLE
Fix Android x86 Debug build of pal_ifaddrs.c

### DIFF
--- a/src/native/libs/System.Native/pal_ifaddrs.c
+++ b/src/native/libs/System.Native/pal_ifaddrs.c
@@ -312,7 +312,7 @@ static struct ifaddrs *get_link_info(struct nlmsghdr *message)
                 break;
 
             case IFLA_BROADCAST:
-                LOG_DEBUG("   interface broadcast (%lu bytes)\n", RTA_PAYLOAD(attribute));
+                LOG_DEBUG("   interface broadcast (%zu bytes)\n", RTA_PAYLOAD(attribute));
                 if (fill_ll_address(&sa, net_interface, RTA_DATA(attribute), RTA_PAYLOAD(attribute)) < 0) {
                     goto error;
                 }
@@ -320,7 +320,7 @@ static struct ifaddrs *get_link_info(struct nlmsghdr *message)
                 break;
 
             case IFLA_ADDRESS:
-                LOG_DEBUG("   interface address (%lu bytes)\n", RTA_PAYLOAD(attribute));
+                LOG_DEBUG("   interface address (%zu bytes)\n", RTA_PAYLOAD(attribute));
                 if (fill_ll_address(&sa, net_interface, RTA_DATA(attribute), RTA_PAYLOAD(attribute)) < 0) {
                     goto error;
                 }


### PR DESCRIPTION
It was failing with

```
pal_ifaddrs.c(315,67): error GBA20CE26: format specifies type 'unsigned long' but the argument has type 'unsigned int' [-Werror,-Wformat]
```

/cc @simonrozsival 