### PR TITLE
Remove executable bits from generated shared libs

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -83,6 +83,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,-rpath,'$(IlcRPath)'" />
       <LinkerArg Include="-Wl,--build-id=sha1" Condition="'$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-Wl,--as-needed" Condition="'$(TargetOS)' != 'OSX'" />
+      <LinkerArg Include="-Wl,-e0x0" Condition="'$(NativeLib)' == 'Shared' and '$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-pthread" Condition="'$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-lstdc++" />
       <LinkerArg Include="-ldl" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -342,6 +342,9 @@ The .NET Foundation licenses this file to you under the MIT license.
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)lib.rsp" Lines="@(CustomLibArg)" Overwrite="true" Encoding="utf-8" Condition="'$(TargetOS)' == 'windows' and '$(NativeLib)' == 'Static'" />
     <Exec Command="&quot;$(CppLibCreator)&quot; @&quot;$(NativeIntermediateOutputPath)lib.rsp&quot;" Condition="'$(TargetOS)' == 'windows' and '$(NativeLib)' == 'Static'" />
 
+    <!-- remove executable flag -->
+    <Exec Command="chmod 644 &quot;$(NativeBinary)&quot;" Condition="'$(TargetOS)' != 'windows' and '$(NativeLib)' == 'Shared'" />
+
     <!-- strip symbols, see https://github.com/dotnet/runtime/blob/5d3288d/eng/native/functions.cmake#L374 -->
     <Exec Condition="'$(StripSymbols)' == 'true' and '$(TargetOS)' != 'windows' and '$(TargetOS)' != 'OSX'"
       Command="


### PR DESCRIPTION
In the llvm-toolchain installation on debian, there is no executable bit set for shared libraries. This PR adapts that convention in NativeAOT and strips the executable bits from the generated shared libs.

```diff
--- before
+++ after

$ dotnet7 publish -o dist --use-current-runtime -c Release -p:PublishAot=true
$ readelf -e dist/nativelib1.so  | grep Entry
-  Entry point address:               0xcac60
+  Entry point address:               0x0
$ stat -c %a dist/nativelib1.so
- 775
+ 644
```