### PR TITLE
[mono][jit] Don't inflate Mono.ValueTuple with byrefs

### DIFF
--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -1246,6 +1246,16 @@ get_wrapper_shared_vtype (MonoType *t)
 	}
 	g_assert (tuple_class);
 
+	for (int i = 0; i < findex; i++) {
+		if (m_type_is_byref (args [i])) {
+#if TARGET_SIZEOF_VOID_P == 8
+			args [i] = m_class_get_byval_arg (mono_defaults.int_class);
+#else
+			args [i] = m_class_get_byval_arg (mono_defaults.int32_class);
+#endif
+		}
+	}
+
 	memset (&ctx, 0, sizeof (ctx));
 	ctx.class_inst = mono_metadata_get_generic_inst (findex, args);
 


### PR DESCRIPTION
Mono.ValueTuple's must have the same layout as the original vtype. Use normal IntPtr for ref fields. This also allows sharing of more signatures. Before this change the behavior was dubious when sharing valuetypes with ref fields (like Span). The value tuple class was inflated with byref types and it ended up having byref fields, even though it is not byreflike, resulting in failure during class loading.

Fixes https://github.com/dotnet/runtime/issues/72635