### PR TITLE
[Android] Disable failing JIT.Directed test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3703,6 +3703,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/CheckProjects/CheckProjects/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XUnitTestBinBase)/JIT/Directed/aliasing_retbuf/*">
+            <Issue>https://github.com/dotnet/runtime/issues/73539</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XUnitTestBinBase)/JIT/Directed/callconv/ThisCall/ThisCallTest/*">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
A new test was added in #73059 and it is failing on Android. I'm disabling the test for now so that it doesn't add noise to the rolling build.

Ref #73539