### PR TITLE
JIT: extend forward sub to local fields

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3639,6 +3639,7 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
             break;
 
         case GT_OBJ:
+        case GT_BLK:
             retVal->ChangeOper(GT_IND);
             FALLTHROUGH;
         case GT_IND:


### PR DESCRIPTION
Optimize cases where we copy a struct and then immedately read just one field
to read from the original struct instead.