### PR TITLE
66163 fatal error xml serializer immutable array

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
@@ -303,6 +303,11 @@ namespace System.Xml.Serialization
                           CodeGenerator.InstanceBindingFlags,
                           Type.EmptyTypes
                           )!;
+                    // ICollection is not a value type, and ICollection::get_Count is a virtual method. So Call() here
+                    // will do a 'callvirt'. If we are working with a value type, box it before calling.
+                    Debug.Assert(ICollection_get_Count.IsVirtual && !ICollection_get_Count.DeclaringType!.IsValueType);
+                    if (varType.IsValueType)
+                        Box(varType);
                     Call(ICollection_get_Count);
                 }
                 Blt(forState.BeginLabel);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SourceInfo.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/SourceInfo.cs
@@ -103,7 +103,7 @@ namespace System.Xml.Serialization
                 }
                 else
                 {
-                    ILG.Load(varA);
+                    ILG.LoadAddress(varA);
                     ILG.Load(varIA);
                     MethodInfo get_Item = varType.GetMethod(
                         "get_Item",

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -2881,7 +2881,8 @@ namespace System.Xml.Serialization
                 )!;
             ilg.Ldarg(0);
             ilg.Call(XmlSerializationReader_ReadNull);
-            ilg.IfNot();
+            ilg.IfNot();    // if (!ReadNull()) { // EnterScope
+            ilg.EnterScope();
 
             MemberMapping memberMapping = new MemberMapping();
             memberMapping.Elements = arrayMapping.Elements;
@@ -2976,11 +2977,14 @@ namespace System.Xml.Serialization
 
             if (isNullable)
             {
-                ilg.Else();
+                ilg.ExitScope();    // if(!ReadNull()) { ExitScope
+                ilg.Else();         // } else { EnterScope
+                ilg.EnterScope();
                 member.IsNullable = true;
                 WriteMemberBegin(members);
                 WriteMemberEnd(members);
             }
+            ilg.ExitScope();    // if(!ReadNull())/else ExitScope
             ilg.EndIf();
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -2176,7 +2176,7 @@ namespace System.Xml.Serialization
                         }
                         else
                         {
-                            if (member.IsList && !member.Mapping.ReadOnly && member.Mapping.TypeDesc.IsNullable)
+                            if (member.IsList && !member.Mapping.ReadOnly) //&& member.Mapping.TypeDesc.IsNullable) // nullable or not, we are likely to assign null in the next step if we don't do this initialization. So just do this.
                             {
                                 // we need to new the Collections and ArrayLists
                                 ILGenLoad(member.Source, typeof(object));

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -197,6 +197,11 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         Assert.Equal((string)x[1], (string)y[1]);
     }
 
+// ROC and Immutable types are not types from 'SerializableAssembly.dll', so they were not included in the
+// pregenerated serializers for the sgen tests. We could wrap them in a type that does exist there...
+// but I think the RO/Immutable story is wonky enough and RefEmit vs Reflection is near enough on the
+// horizon that it's not worth the trouble.
+#if !XMLSERIALIZERGENERATORTESTS
     [Fact]
     public static void Xml_ReadOnlyCollection()
     {
@@ -287,6 +292,7 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         yield return new object[] { typeof(ImmutableDictionary<string, int>), new Dictionary<string, int>() { { "one", 1 } }.ToImmutableDictionary(), typeof(NotSupportedException), null, null, "is not supported because it implements IDictionary." };
 #endif
     }
+#endif  // !XMLSERIALIZERGENERATORTESTS
 
     [Fact]
     public static void Xml_EnumAsRoot()


### PR DESCRIPTION
Fixes #66163

This does not add full support for 'Immutable' collections a la some feature requests. But it does stop XmlSerializer from crashing with fatal EE exceptions when faced with an 'Immutable' collection.