### PR TITLE
Implement IXmlTextWriterInitializer on the async writer wrapper.

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
@@ -11,17 +11,17 @@ using System.Threading.Tasks;
 
 namespace System.Xml
 {
-    internal sealed class XmlDictionaryAsyncCheckWriter : XmlDictionaryWriter
+    internal sealed class XmlDictionaryAsyncCheckWriter<T> : XmlDictionaryWriter, IXmlTextWriterInitializer where T : XmlDictionaryWriter, IXmlTextWriterInitializer
     {
-        private readonly XmlDictionaryWriter _coreWriter;
+        private readonly T _coreWriter;
         private Task? _lastTask;
 
-        public XmlDictionaryAsyncCheckWriter(XmlDictionaryWriter writer)
+        public XmlDictionaryAsyncCheckWriter(T writer)
         {
             _coreWriter = writer;
         }
 
-        internal XmlDictionaryWriter CoreWriter
+        internal T CoreWriter
         {
             get
             {
@@ -693,6 +693,12 @@ namespace System.Xml
         {
             CheckAsync();
             CoreWriter.Dispose();
+        }
+
+        public void SetOutput(Stream stream, Encoding encoding, bool ownsStream)
+        {
+            CheckAsync();
+            CoreWriter.SetOutput(stream, encoding, ownsStream);
         }
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
@@ -11,17 +11,19 @@ using System.Threading.Tasks;
 
 namespace System.Xml
 {
-    internal sealed class XmlDictionaryAsyncCheckWriter<T> : XmlDictionaryWriter, IXmlTextWriterInitializer where T : XmlDictionaryWriter, IXmlTextWriterInitializer
+    internal sealed class XmlDictionaryAsyncCheckWriter : XmlDictionaryWriter, IXmlTextWriterInitializer
     {
-        private readonly T _coreWriter;
+        private readonly XmlDictionaryWriter _coreWriter;
+        private readonly IXmlTextWriterInitializer? _initializer;
         private Task? _lastTask;
 
-        public XmlDictionaryAsyncCheckWriter(T writer)
+        public XmlDictionaryAsyncCheckWriter(XmlDictionaryWriter writer)
         {
             _coreWriter = writer;
+            _initializer = writer as IXmlTextWriterInitializer;
         }
 
-        internal T CoreWriter
+        internal XmlDictionaryWriter CoreWriter
         {
             get
             {
@@ -697,8 +699,11 @@ namespace System.Xml
 
         public void SetOutput(Stream stream, Encoding encoding, bool ownsStream)
         {
+            if (_initializer == null)
+                return;
+
             CheckAsync();
-            CoreWriter.SetOutput(stream, encoding, ownsStream);
+            _initializer.SetOutput(stream, encoding, ownsStream);
         }
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -14,13 +15,12 @@ namespace System.Xml
     internal sealed class XmlDictionaryAsyncCheckWriter : XmlDictionaryWriter, IXmlTextWriterInitializer
     {
         private readonly XmlDictionaryWriter _coreWriter;
-        private readonly IXmlTextWriterInitializer? _initializer;
         private Task? _lastTask;
 
         public XmlDictionaryAsyncCheckWriter(XmlDictionaryWriter writer)
         {
+            Debug.Assert(writer is IXmlTextWriterInitializer);
             _coreWriter = writer;
-            _initializer = writer as IXmlTextWriterInitializer;
         }
 
         internal XmlDictionaryWriter CoreWriter
@@ -699,11 +699,11 @@ namespace System.Xml
 
         public void SetOutput(Stream stream, Encoding encoding, bool ownsStream)
         {
-            if (_initializer == null)
-                return;
-
-            CheckAsync();
-            _initializer.SetOutput(stream, encoding, ownsStream);
+            if (CoreWriter is IXmlTextWriterInitializer initializer)
+            {
+                CheckAsync();
+                initializer.SetOutput(stream, encoding, ownsStream);
+            }
         }
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
@@ -54,7 +54,7 @@ namespace System.Xml
         {
             XmlUTF8TextWriter writer = new XmlUTF8TextWriter();
             writer.SetOutput(stream, encoding, ownsStream);
-            var asyncWriter = new XmlDictionaryAsyncCheckWriter<XmlUTF8TextWriter>(writer);
+            var asyncWriter = new XmlDictionaryAsyncCheckWriter(writer);
             return asyncWriter;
         }
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
@@ -54,7 +54,7 @@ namespace System.Xml
         {
             XmlUTF8TextWriter writer = new XmlUTF8TextWriter();
             writer.SetOutput(stream, encoding, ownsStream);
-            var asyncWriter = new XmlDictionaryAsyncCheckWriter(writer);
+            var asyncWriter = new XmlDictionaryAsyncCheckWriter<XmlUTF8TextWriter>(writer);
             return asyncWriter;
         }
 


### PR DESCRIPTION
Fixes #66045

I had an alternate solution that does not use generics and type restrictions. These parts are all internal, so it's really 6 or a half dozen.