### PR TITLE
Disable gcstress on osx-x64

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -18,7 +18,8 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - OSX_arm64
-    - OSX_x64
+    # See https://github.com/dotnet/runtime/issues/71931
+    # - OSX_x64
     - windows_x64
     - windows_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
@@ -43,7 +44,8 @@ jobs:
     - Linux_x64
     - Linux_arm64
     - OSX_arm64
-    - OSX_x64
+    # See https://github.com/dotnet/runtime/issues/71931
+    # - OSX_x64
     - windows_x64
     - windows_arm64
     jobParameters:


### PR DESCRIPTION
Disable gcstress leg for osx-x64 until https://github.com/dotnet/runtime/issues/71931 is fixed.