### PR TITLE
[NativeAOT] Follow up changes for the suspension loop routine.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/StackFrameIterator.cpp
+++ b/src/coreclr/nativeaot/Runtime/StackFrameIterator.cpp
@@ -95,7 +95,7 @@ GVAL_IMPL_INIT(PTR_VOID, g_RhpRethrow2Addr, PointerToRhpRethrow2);
 StackFrameIterator::StackFrameIterator(Thread * pThreadToWalk, PInvokeTransitionFrame* pInitialTransitionFrame)
 {
     STRESS_LOG0(LF_STACKWALK, LL_INFO10000, "----Init---- [ GC ]\n");
-    ASSERT(!pThreadToWalk->DangerousCrossThreadIsHijacked());
+    ASSERT(!pThreadToWalk->IsHijacked());
 
     if (pInitialTransitionFrame == INTERRUPTED_THREAD_MARKER)
     {
@@ -1463,7 +1463,7 @@ UnwindOutOfCurrentManagedFrame:
     else
     {
         // if the thread is safe to walk, it better not have a hijack in place.
-        ASSERT((ThreadStore::GetCurrentThread() == m_pThread) || !m_pThread->DangerousCrossThreadIsHijacked());
+        ASSERT(!m_pThread->IsHijacked());
 
         SetControlPC(dac_cast<PTR_VOID>(*(m_RegDisplay.GetAddrOfIP())));
 

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -136,6 +136,12 @@ public:
 #ifdef FEATURE_GC_STRESS
         TSF_IsRandSeedSet       = 0x00000040,       // set to indicate the random number generator for GCStress was inited
 #endif // FEATURE_GC_STRESS
+
+#ifdef FEATURE_SUSPEND_REDIRECTION
+        TSF_Redirected = 0x00000080,                // Set to indicate the thread is redirected and will inevitably
+                                                    // suspend once resumed.
+                                                    // As an optimization, if we see this flag, we skip hijacking.
+#endif //FEATURE_SUSPEND_REDIRECTION
     };
 private:
 

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -138,9 +138,9 @@ public:
 #endif // FEATURE_GC_STRESS
 
 #ifdef FEATURE_SUSPEND_REDIRECTION
-        TSF_Redirected = 0x00000080,                // Set to indicate the thread is redirected and will inevitably
+        TSF_Redirected          = 0x00000080,       // Set to indicate the thread is redirected and will inevitably
                                                     // suspend once resumed.
-                                                    // As an optimization, if we see this flag, we skip hijacking.
+                                                    // If we see this flag, we skip hijacking as an optimization.
 #endif //FEATURE_SUSPEND_REDIRECTION
     };
 private:
@@ -203,13 +203,11 @@ public:
 
     void                Hijack();
     void                Unhijack();
+    bool                IsHijacked();
+
 #ifdef FEATURE_GC_STRESS
     static void         HijackForGcStress(PAL_LIMITED_CONTEXT * pSuspendCtx);
 #endif // FEATURE_GC_STRESS
-    bool                IsHijacked();
-    void *              GetHijackedReturnAddress();
-    void *              GetUnhijackedReturnAddress(void** ppvReturnAddressLocation);
-    bool                DangerousCrossThreadIsHijacked();
 
     bool                IsSuppressGcStressSet();
     void                SetSuppressGcStress();
@@ -236,7 +234,7 @@ public:
 #endif // DACCESS_COMPILE
 #ifdef FEATURE_GC_STRESS
     void                SetRandomSeed(uint32_t seed);
-    uint32_t              NextRand();
+    uint32_t            NextRand();
     bool                IsRandInited();
 #endif // FEATURE_GC_STRESS
     PTR_ExInfo          GetCurExInfo();

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -212,6 +212,10 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
     // set the global trap for pinvoke leave and return
     RhpTrapThreads |= (uint32_t)TrapThreadsFlags::TrapThreads;
 
+    LARGE_INTEGER li;
+    PalQueryPerformanceCounter(&li);
+    int64_t startTicks = li.QuadPart;
+
     // Our lock-free algorithm depends on flushing write buffers of all processors running RH code.  The
     // reason for this is that we essentially implement Dekker's algorithm, which requires write ordering.
     PalFlushProcessWriteBuffers();
@@ -270,6 +274,15 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
     // preemptive mode.
     PalFlushProcessWriteBuffers();
 #endif //TARGET_ARM || TARGET_ARM64
+
+    PalQueryPerformanceFrequency(&li);
+    int64_t ticksPerSecond = li.QuadPart;
+
+    PalQueryPerformanceCounter(&li);
+    int64_t endTicks = li.QuadPart;
+    int64_t usecTotal = (endTicks - startTicks) * 1000000 / ticksPerSecond;
+
+    printf("@: %i \n", (int)usecTotal);
 }
 
 void ThreadStore::ResumeAllThreads(bool waitForGCEvent)

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -196,6 +196,35 @@ void ThreadStore::UnlockThreadStore()
     m_Lock.ReleaseReadLock();
 }
 
+// exponential spinwait with an approximate time limit for waiting in microsecond range.
+// when iteration == -1, only usecLimit is used
+void SpinWait(int iteration, int usecLimit)
+{
+    LARGE_INTEGER li;
+    PalQueryPerformanceCounter(&li);
+    int64_t startTicks = li.QuadPart;
+
+    PalQueryPerformanceFrequency(&li);
+    int64_t ticksPerSecond = li.QuadPart;
+    int64_t endTicks = startTicks + (usecLimit * ticksPerSecond) / 1000000;
+
+    int l = min((unsigned)iteration, 30);
+    for (int i = 0; i < l; i++)
+    {
+        for (int j = 0; j < (1 << i); j++)
+        {
+            System_YieldProcessor();
+        }
+
+        PalQueryPerformanceCounter(&li);
+        int64_t currentTicks = li.QuadPart;
+        if (currentTicks > endTicks)
+        {
+            break;
+        }
+    }
+}
+
 void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
 {
     Thread * pThisThread = GetCurrentThreadIfAvailable();
@@ -220,12 +249,16 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
     // reason for this is that we essentially implement Dekker's algorithm, which requires write ordering.
     PalFlushProcessWriteBuffers();
 
-    bool keepWaiting;
-    YieldProcessorNormalizationInfo normalizationInfo;
-    int waitCycles = 1;
-    do
+    int retries = 0;
+    int prevRemaining = 0;
+    int remaining = 0;
+    bool observeOnly = false;
+
+    while(true)
     {
-        keepWaiting = false;
+        prevRemaining = remaining;
+        remaining = 0;
+
         FOREACH_THREAD(pTargetThread)
         {
             if (pTargetThread == pThisThread)
@@ -233,37 +266,42 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
 
             if (!pTargetThread->CacheTransitionFrameForSuspend())
             {
-                // We drive all threads to preemptive mode by hijacking them with return-address hijack.
-                keepWaiting = true;
-                pTargetThread->Hijack();
+                remaining++;
+                if (!observeOnly)
+                {
+                    pTargetThread->Hijack();
+                }
             }
         }
         END_FOREACH_THREAD
 
-        if (keepWaiting)
+        if (!remaining)
+            break;
+
+        // if we see progress or have just done a hijacking pass
+        // do not hijack in the next iteration
+        if (remaining < prevRemaining || !observeOnly)
         {
-            if (PalSwitchToThread() == 0 && g_RhNumberOfProcessors > 1)
-            {
-                // No threads are scheduled on this processor.  Perhaps we're waiting for a thread
-                // that's scheduled on another processor.  If so, let's give it a little time
-                // to make forward progress.
-                // Note that we do not call Sleep, because the minimum granularity of Sleep is much
-                // too long (we probably don't need a 15ms wait here).  Instead, we'll just burn some
-                // cycles.
-    	        // @TODO: need tuning for spin
-                // @TODO: need tuning for this whole loop as well.
-                //        we are likley too aggressive with interruptions which may result in longer pauses.
-                YieldProcessorNormalizedForPreSkylakeCount(normalizationInfo, waitCycles);
-
-                // simplistic linear backoff for now
-                // we could be catching threads in restartable sequences such as LL/SC style interlocked on ARM64
-                // and forcing them to restart.
-                // if interrupt mechanism is fast, eagerness could be hurting our overall progress.
-                waitCycles += 10000;
-            }
+            // 5 usec delay, then check for more progress
+            SpinWait(-1, 5);
+            observeOnly = true;
         }
+        else
+        {
+            SpinWait(retries++, 100);
 
-    } while (keepWaiting);
+            // make sure our spining is not starving other threads, but not too often,
+            // this can cause a 1-15 msec delay, depending on OS, and that is a lot while
+            // very rarely needed, since threads are supposed to be releasing their CPUs
+            if ((retries & 127) == 0)
+            {
+                PalSwitchToThread();
+            }
+
+            observeOnly = false;
+            // printf("RETRY: %i \n", retries);
+        }
+    }
 
 #if defined(TARGET_ARM) || defined(TARGET_ARM64)
     // Flush the store buffers on all CPUs, to ensure that all changes made so far are seen


### PR DESCRIPTION
Last item for https://github.com/dotnet/runtime/issues/67805

Turns out polling, while simpler, works better than CoreCLR-style event handshake, so I am keeping the pure polling style, while making it a bit more robust - added an observe-only pass, set a limit for per-iteration wait, avoid hijacking already redirected threads, etc. Otherwise it is the same algorithm as before.

In CoreCLR implementation, user threads signal an event as they suspend and suspending thread waits on the event with a 1 msec timeout. Porting that here resulted in regressions.
The problem is when we do timeout, and that happens often enough as some threads may not be hijacked on a first try, - that results in 1 msec delay, which is considerable, and on some OSes 15 msec, which is really a lot. 
It is probably amplified by the fact that in NativeAOT synchronous GC polls are relatively rare, unless a thread does a lot of allocations or pinvokes.

We should reconsider using the event pattern in CoreCLR as well. It is questionable if the complexity adds any benefits.

