### PR TITLE
Disable newly added TraceSource.Config.Tests on NativeAOT

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -512,6 +512,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.TraceSource\tests\System.Diagnostics.TraceSource.Config.Tests\System.Diagnostics.TraceSource.Config.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Dynamic.Runtime\tests\System.Dynamic.Runtime.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Formats.Cbor\tests\System.Formats.Cbor.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Queryable\tests\System.Linq.Queryable.Tests.csproj" />


### PR DESCRIPTION
Likely a single file related issue. Not sure how ConfigurationManager grabs the config files, but probably Assembly.Location. Will need to look at that.

```
[FAIL] System.Diagnostics.TraceSourceConfigTests.ConfigurationTests.ConfigWithEvents_RuntimeListener
System.Configuration.ConfigurationErrorsException : Could not create System.Diagnostics.SourceSwitch.
   at System.Diagnostics.TraceUtils.GetRuntimeObject(String, Type, String) + 0x5b8
   at System.Diagnostics.TraceConfiguration.<InitializingTraceSource>g__CreateSwitch|3_0(String, String, TraceConfiguration.<>c__DisplayClass3_0&) + 0x44
   at System.Diagnostics.TraceConfiguration.InitializingTraceSource(Object, InitializingTraceSourceEventArgs) + 0x208
   at System.Diagnostics.TraceSource.Config!<BaseAddress>+0xf7b98c
   at System.Diagnostics.TraceSource.OnInitializing(InitializingTraceSourceEventArgs) + 0x3c
   at System.Diagnostics.TraceSource.Initialize() + 0x78
   at System.Diagnostics.TraceSourceConfigTests.ConfigurationTests.ConfigWithEvents_RuntimeListener() + 0x94
   at System.Diagnostics.TraceSource.Config!<BaseAddress>+0x10bcbe4
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) + 0xd8
```