### PR TITLE
Fix generation of .ni.pdb symbols

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/OutputInfoBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/OutputInfoBuilder.cs
@@ -183,24 +183,22 @@ namespace ILCompiler.PEWriter
         {
             DebugNameFormatter nameFormatter = new DebugNameFormatter();
             TypeNameFormatter typeNameFormatter = new TypeString();
-            HashSet<MethodDesc> emittedMethods = new HashSet<MethodDesc>();
             foreach (KeyValuePair<ISymbolDefinitionNode, MethodWithGCInfo> symbolMethodPair in _methodSymbolMap)
             {
-                EcmaMethod ecmaMethod = symbolMethodPair.Value.Method.GetTypicalMethodDefinition() as EcmaMethod;
-                if (ecmaMethod != null && emittedMethods.Add(ecmaMethod))
+                MethodInfo methodInfo = new MethodInfo();
+                if (symbolMethodPair.Value.Method.GetTypicalMethodDefinition() is EcmaMethod ecmaMethod)
                 {
-                    MethodInfo methodInfo = new MethodInfo();
                     methodInfo.MethodToken = (uint)MetadataTokens.GetToken(ecmaMethod.Handle);
                     methodInfo.AssemblyName = ecmaMethod.Module.Assembly.GetName().Name;
-                    methodInfo.Name = FormatMethodName(symbolMethodPair.Value.Method, typeNameFormatter);
-                    OutputNode node = _nodeSymbolMap[symbolMethodPair.Key];
-                    Section section = _sections[node.SectionIndex];
-                    methodInfo.HotRVA = (uint)(section.RVAWhenPlaced + node.Offset);
-                    methodInfo.HotLength = (uint)node.Length;
-                    methodInfo.ColdRVA = 0;
-                    methodInfo.ColdLength = 0;
-                    yield return methodInfo;
                 }
+                methodInfo.Name = FormatMethodName(symbolMethodPair.Value.Method, typeNameFormatter);
+                OutputNode node = _nodeSymbolMap[symbolMethodPair.Key];
+                Section section = _sections[node.SectionIndex];
+                methodInfo.HotRVA = (uint)(section.RVAWhenPlaced + node.Offset);
+                methodInfo.HotLength = (uint)node.Length;
+                methodInfo.ColdRVA = 0;
+                methodInfo.ColdLength = 0;
+                yield return methodInfo;
             }
         }
 


### PR DESCRIPTION
At present, we emit a symbol for at most one instantiation of each generic method.  For instance, `System.Private.CoreLib.ni.pdb` misses about 27% of the ReadyToRun methods.  This fix removes that restriction. Since CodeView does not store the length of a symbol, we cannot leave any gaps and have to report every method.

Fixes #72578. @dotnet/crossgen-contrib 