### PR TITLE
Support void* to UIntPtr parameter conversion for Invoked method

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -217,13 +217,7 @@ namespace System
 
         private static Exception ConvertPointerIfPossible(object srcObject, EETypePtr dstEEType, CheckArgumentSemantics semantics, out object dstPtr)
         {
-            if (srcObject is IntPtr)
-            {
-                dstPtr = srcObject;
-                return null;
-            }
-
-            if (srcObject is UIntPtr)
+            if (srcObject is IntPtr or UIntPtr)
             {
                 dstPtr = srcObject;
                 return null;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -108,7 +108,7 @@ namespace System
 
             if (dstEEType.IsPointer)
             {
-                Exception exception = ConvertPointerIfPossible(srcObject, dstEEType, semantics, out object dstIntPtr);
+                Exception exception = ConvertPointerIfPossible(srcObject, dstEEType, semantics, out object dstPtr);
                 if (exception != null)
                 {
                     dstObject = null;
@@ -215,17 +215,17 @@ namespace System
             return null;
         }
 
-        private static Exception ConvertPointerIfPossible(object srcObject, EETypePtr dstEEType, CheckArgumentSemantics semantics, out object dstIntPtr)
+        private static Exception ConvertPointerIfPossible(object srcObject, EETypePtr dstEEType, CheckArgumentSemantics semantics, out object dstPtr)
         {
-            if (srcObject is IntPtr srcIntPtr)
+            if (srcObject is IntPtr)
             {
-                dstIntPtr = srcIntPtr;
+                dstPtr = srcObject;
                 return null;
             }
 
-            if (srcObject is UIntPtr srcUIntPtr)
+            if (srcObject is UIntPtr)
             {
-                dstIntPtr = srcUIntPtr;
+                dstPtr = srcUIntPtr;
                 return null;
             }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -114,7 +114,7 @@ namespace System
                     dstObject = null;
                     return exception;
                 }
-                dstObject = dstIntPtr;
+                dstObject = dstPtr;
                 return null;
             }
 
@@ -225,7 +225,7 @@ namespace System
 
             if (srcObject is UIntPtr)
             {
-                dstPtr = srcUIntPtr;
+                dstPtr = srcObject;
                 return null;
             }
 
@@ -233,12 +233,12 @@ namespace System
             {
                 if (dstEEType == typeof(void*).TypeHandle.ToEETypePtr() || RuntimeImports.AreTypesAssignable(pSourceType: srcPointer.GetPointerType().TypeHandle.ToEETypePtr(), pTargetType: dstEEType))
                 {
-                    dstIntPtr = srcPointer.GetPointerValue();
+                    dstPtr = srcPointer.GetPointerValue();
                     return null;
                 }
             }
 
-            dstIntPtr = IntPtr.Zero;
+            dstPtr = null;
             return CreateChangeTypeException(srcObject.GetEETypePtr(), dstEEType, semantics);
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -108,7 +108,7 @@ namespace System
 
             if (dstEEType.IsPointer)
             {
-                Exception exception = ConvertPointerIfPossible(srcObject, dstEEType, semantics, out IntPtr dstIntPtr);
+                Exception exception = ConvertPointerIfPossible(srcObject, dstEEType, semantics, out object dstIntPtr);
                 if (exception != null)
                 {
                     dstObject = null;
@@ -215,11 +215,17 @@ namespace System
             return null;
         }
 
-        private static Exception ConvertPointerIfPossible(object srcObject, EETypePtr dstEEType, CheckArgumentSemantics semantics, out IntPtr dstIntPtr)
+        private static Exception ConvertPointerIfPossible(object srcObject, EETypePtr dstEEType, CheckArgumentSemantics semantics, out object dstIntPtr)
         {
             if (srcObject is IntPtr srcIntPtr)
             {
                 dstIntPtr = srcIntPtr;
+                return null;
+            }
+
+            if (srcObject is UIntPtr srcUIntPtr)
+            {
+                dstIntPtr = srcUIntPtr;
                 return null;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
@@ -112,13 +112,7 @@ namespace System.Reflection
 
         private static bool TryConvertPointer(object srcObject, [NotNullWhen(true)] out object? dstPtr)
         {
-            if (srcObject is IntPtr)
-            {
-                dstPtr = srcObject;
-                return true;
-            }
-
-            if (srcObject is UIntPtr)
+            if (srcObject is IntPtr or UIntPtr)
             {
                 dstPtr = srcObject;
                 return true;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
@@ -4,6 +4,7 @@
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection
 {
@@ -16,7 +17,7 @@ namespace System.Reflection
 
             if (dstType.IsPointer)
             {
-                if (TryConvertPointer(srcObject, out object dstPtr))
+                if (TryConvertPointer(srcObject, out object? dstPtr))
                 {
                     return dstPtr;
                 }
@@ -109,7 +110,7 @@ namespace System.Reflection
             return dstObject;
         }
 
-        private static bool TryConvertPointer(object srcObject, out object dstPtr)
+        private static bool TryConvertPointer(object srcObject, [NotNullWhen(true)] out object? dstPtr)
         {
             if (srcObject is IntPtr)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
@@ -16,14 +16,9 @@ namespace System.Reflection
 
             if (dstType.IsPointer)
             {
-                if (TryConvertIntPtr(srcObject, out IntPtr dstIntPtr))
+                if (TryConvertPointer(srcObject, out object dstIntPtr))
                 {
                     return dstIntPtr;
-                }
-
-                if (TryConvertUIntPtr(srcObject, out UIntPtr dstUIntPtr))
-                {
-                    return dstUIntPtr;
                 }
 
                 Debug.Fail($"Unexpected CorElementType: {dstElementType}. Not a valid widening target.");
@@ -114,7 +109,7 @@ namespace System.Reflection
             return dstObject;
         }
 
-        private static bool TryConvertIntPtr(object srcObject, out IntPtr dstIntPtr)
+        private static bool TryConvertPointer(object srcObject, out object dstIntPtr)
         {
             if (srcObject is IntPtr srcIntPtr)
             {
@@ -122,22 +117,16 @@ namespace System.Reflection
                 return true;
             }
 
-            dstIntPtr = IntPtr.Zero;
-            return false;
-        }
-
-        private static bool TryConvertUIntPtr(object srcObject, out UIntPtr dstIntPtr)
-        {
-            if (srcObject is UIntPtr srcIntPtr)
+            if (srcObject is UIntPtr srcUIntPtr)
             {
-                dstIntPtr = srcIntPtr;
+                dstIntPtr = srcUIntPtr;
                 return true;
             }
 
-            // The source pointer should already have been converted to an UntPtr.
+            // The source pointer should already have been converted to an IntPtr or UntPtr.
             Debug.Assert(srcObject is not Pointer);
 
-            dstIntPtr = UIntPtr.Zero;
+            dstIntPtr = IntPtr.Zero;
             return false;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
@@ -16,9 +16,14 @@ namespace System.Reflection
 
             if (dstType.IsPointer)
             {
-                if (TryConvertPointer(srcObject, out IntPtr dstIntPtr))
+                if (TryConvertIntPtr(srcObject, out IntPtr dstIntPtr))
                 {
                     return dstIntPtr;
+                }
+
+                if (TryConvertUIntPtr(srcObject, out UIntPtr dstUIntPtr))
+                {
+                    return dstUIntPtr;
                 }
 
                 Debug.Fail($"Unexpected CorElementType: {dstElementType}. Not a valid widening target.");
@@ -109,7 +114,7 @@ namespace System.Reflection
             return dstObject;
         }
 
-        private static bool TryConvertPointer(object srcObject, out IntPtr dstIntPtr)
+        private static bool TryConvertIntPtr(object srcObject, out IntPtr dstIntPtr)
         {
             if (srcObject is IntPtr srcIntPtr)
             {
@@ -117,10 +122,22 @@ namespace System.Reflection
                 return true;
             }
 
-            // The source pointer should already have been converted to an IntPtr.
+            dstIntPtr = IntPtr.Zero;
+            return false;
+        }
+
+        private static bool TryConvertUIntPtr(object srcObject, out UIntPtr dstIntPtr)
+        {
+            if (srcObject is UIntPtr srcIntPtr)
+            {
+                dstIntPtr = srcIntPtr;
+                return true;
+            }
+
+            // The source pointer should already have been converted to an UntPtr.
             Debug.Assert(srcObject is not Pointer);
 
-            dstIntPtr = IntPtr.Zero;
+            dstIntPtr = UIntPtr.Zero;
             return false;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
@@ -16,9 +16,9 @@ namespace System.Reflection
 
             if (dstType.IsPointer)
             {
-                if (TryConvertPointer(srcObject, out object dstIntPtr))
+                if (TryConvertPointer(srcObject, out object dstPtr))
                 {
-                    return dstIntPtr;
+                    return dstPtr;
                 }
 
                 Debug.Fail($"Unexpected CorElementType: {dstElementType}. Not a valid widening target.");
@@ -109,24 +109,24 @@ namespace System.Reflection
             return dstObject;
         }
 
-        private static bool TryConvertPointer(object srcObject, out object dstIntPtr)
+        private static bool TryConvertPointer(object srcObject, out object dstPtr)
         {
-            if (srcObject is IntPtr srcIntPtr)
+            if (srcObject is IntPtr)
             {
-                dstIntPtr = srcIntPtr;
+                dstPtr = srcObject;
                 return true;
             }
 
-            if (srcObject is UIntPtr srcUIntPtr)
+            if (srcObject is UIntPtr)
             {
-                dstIntPtr = srcUIntPtr;
+                dstPtr = srcObject;
                 return true;
             }
 
-            // The source pointer should already have been converted to an IntPtr or UntPtr.
+            // The source pointer should already have been converted to an IntPtr.
             Debug.Assert(srcObject is not Pointer);
 
-            dstIntPtr = IntPtr.Zero;
+            dstPtr = null;
             return false;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBase.cs
@@ -241,7 +241,7 @@ namespace System.Reflection
                     Debug.Assert(arg != null);
                     Debug.Assert(
                         arg.GetType() == sigType ||
-                        (sigType.IsPointer && arg.GetType() == typeof(IntPtr)) ||
+                        (sigType.IsPointer && (arg.GetType() == typeof(IntPtr) || arg.GetType() == typeof(UIntPtr))) ||
                         (sigType.IsByRef && arg.GetType() == RuntimeTypeHandle.GetElementType(sigType)) ||
                         ((sigType.IsEnum || arg.GetType().IsEnum) && RuntimeType.GetUnderlyingType((RuntimeType)arg.GetType()) == RuntimeType.GetUnderlyingType(sigType)));
 #endif

--- a/src/libraries/System.Runtime/tests/System/Reflection/PointerTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/PointerTests.cs
@@ -233,8 +233,8 @@ namespace System.Reflection.Tests
             };
 
         [Theory]
-        [MemberData(nameof(Pointers))]
-        public void UIntPtrMethodParameter(int value)
+        [MemberData(nameof(PointersUInt))]
+        public void UIntPtrMethodParameter(uint value)
         {
             var obj = new PointerHolder();
             MethodInfo method = typeof(PointerHolder).GetMethod(nameof(PointerHolder.MethodWithVoidPointer));

--- a/src/libraries/System.Runtime/tests/System/Reflection/PointerTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/PointerTests.cs
@@ -29,6 +29,8 @@ namespace System.Reflection.Tests
         {
             return Pointer.Box((byte*)expected, typeof(byte*));
         }
+
+        public static void MethodWithVoidPointer(void* vp) { }
     }
 
     unsafe delegate void MethodDelegate(byte* ptr, int expected);
@@ -218,6 +220,25 @@ namespace System.Reflection.Tests
             var obj = new PointerHolder();
             MethodInfo method = typeof(PointerHolder).GetMethod("Method");
             method.Invoke(obj, new object[] { (IntPtr)value, value });
+        }
+
+        public static IEnumerable<object[]> PointersUInt =>
+            new[]
+            {
+                new object[] { UIntPtr.Zero },
+                new object[] { 0 },
+                new object[] { 1 },
+                new object[] { uint.MinValue },
+                new object[] { uint.MaxValue },
+            };
+
+        [Theory]
+        [MemberData(nameof(Pointers))]
+        public void UIntPtrMethodParameter(int value)
+        {
+            var obj = new PointerHolder();
+            MethodInfo method = typeof(PointerHolder).GetMethod(nameof(PointerHolder.MethodWithVoidPointer));
+            method.Invoke(obj, new object[] { (UIntPtr)value });
         }
 
         [Theory]

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -4652,7 +4652,7 @@ invoke_span_extract_argument (MonoSpanOfObjects *params_span, int i, MonoType *t
 				if (arg == NULL) {
 					result = NULL;
 				} else {
-					g_assert (arg->vtable->klass == mono_defaults.int_class);
+					g_assert (arg->vtable->klass == mono_defaults.int_class || arg->vtable->klass == mono_defaults.uint_class);
 					result = ((MonoIntPtr*)arg)->m_value;
 				}
 				break;


### PR DESCRIPTION
There automatic type conversion takes place from Pointer (*) types to IntPtr but not for UIntPtr (throws `NotSupportedException`). Whenever possible it should be able to convert to UintPtr too

Fixes https://github.com/dotnet/runtime/issues/7430