### PR TITLE
Ensure methods on different instantiations are reflectable

### DIFF
--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -62,6 +62,7 @@ internal static class ReflectionTest
         TestInvokeMethodMetadata.Run();
         TestVTableOfNullableUnderlyingTypes.Run();
         TestInterfaceLists.Run();
+        TestMethodConsistency.Run();
 
         //
         // Mostly functionality tests
@@ -2018,6 +2019,25 @@ internal static class ReflectionTest
             }
 
             throw new Exception();
+        }
+    }
+
+    class TestMethodConsistency
+    {
+        class MyGenericType<T>
+        {
+            public static string MyMethod() => typeof(T).Name;
+        }
+
+        struct Atom { }
+
+        public static void Run()
+        {
+            object returned = Grab<Atom>().Invoke(null, null);
+            if ((string)returned != nameof(Atom))
+                throw new Exception();
+
+            static MethodInfo Grab<T>() => typeof(MyGenericType<T>).GetMethod(nameof(MyGenericType<T>.MyMethod));
         }
     }
 


### PR DESCRIPTION
This is something I noticed among the failures in #73547.

See the regression test - since it doesn't trigger AOT or trimming warnings, it needs to "just work". What we need to do to fix this is to force generation of code on things that have a type handle (i.e. the type is reflection-visible) and reflection visible method definitions. We would previously fail at the `Invoke` step since no method body was generated for this instantiation.

This is a size regression - it's 4 kB on a hello world - but we need it for correctness.

Cc @dotnet/ilc-contrib 