### PR TITLE
Fix handling of no metadata type

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionDomain.cs
@@ -207,7 +207,7 @@ namespace Internal.Reflection.Core.Execution
             }
             else
             {
-                Debug.Assert(ExecutionEnvironment.IsReflectionBlocked(typeHandle));
+                Debug.Assert(ExecutionEnvironment.IsReflectionBlocked(typeHandle) || RuntimeAugments.MightBeUnconstructedType(typeHandle));
                 return RuntimeBlockedTypeInfo.GetRuntimeBlockedTypeInfo(typeHandle, isGenericTypeDefinition);
             }
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -152,6 +152,14 @@ namespace Internal.Runtime.Augments
             return Array.NewMultiDimArray(typeHandleForArrayType.ToEETypePtr(), pImmutableLengths, lengths.Length);
         }
 
+        public static unsafe bool MightBeUnconstructedType(RuntimeTypeHandle type)
+        {
+            // If there are no vtable slots the type is likely an unconstructed type.
+            // But could also be an interface with no virtuals. We can't distinguish those.
+            Debug.Assert(MethodTable.Of<object>()->NumVtableSlots != 0);
+            return CreateEETypePtr(type).ToPointer()->NumVtableSlots == 0;
+        }
+
         public static IntPtr GetAllocateObjectHelperForType(RuntimeTypeHandle type)
         {
             return RuntimeImports.RhGetRuntimeHelperForType(CreateEETypePtr(type), RuntimeHelperKind.AllocateObject);

--- a/src/tests/nativeaot/SmokeTests/DeadCodeElimination/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/DeadCodeElimination/DeadCodeElimination.cs
@@ -19,6 +19,7 @@ class Program
         TestUnusedDefaultInterfaceMethod.Run();
         TestArrayElementTypeOperations.Run();
         TestStaticVirtualMethodOptimizations.Run();
+        TestTypeEquals.Run();
 
         return 100;
     }
@@ -308,6 +309,24 @@ class Program
 
             ThrowIfNotPresent(typeof(TestStaticVirtualMethodOptimizations), nameof(Marker1));
             ThrowIfPresent(typeof(TestStaticVirtualMethodOptimizations), nameof(Marker2));
+        }
+    }
+
+    class TestTypeEquals
+    {
+        sealed class Never { }
+
+        static Type s_type = null;
+
+        public static void Run()
+        {
+            // This was asserting the BCL because Never would not have reflection metadata
+            // despite the typeof
+            Console.WriteLine(s_type == typeof(Never));
+
+#if !DEBUG
+            ThrowIfPresent(typeof(TestTypeEquals), nameof(Never));
+#endif
         }
     }
 


### PR DESCRIPTION
Turns out we do have one situation where a MethodTable would have no metadata - when it's the unconstructed MethodTable. User code doesn't see them.

Cc @dotnet/ilc-contrib 