### PR TITLE
Throw if MethodDesc::GetName() returns null

### DIFF
--- a/src/coreclr/vm/memberload.cpp
+++ b/src/coreclr/vm/memberload.cpp
@@ -1118,7 +1118,6 @@ MemberLoader::FindMethod(
     for (; it.IsValid(); it.Prev())
     {
         MethodDesc *pCurDeclMD = it.GetDeclMethodDesc();
-        LPCUTF8 pCurDeclMDName = NULL;
 #ifdef _DEBUG
         MethodTable *pCurDeclMT = pCurDeclMD->GetMethodTable();
         CONSISTENCY_CHECK(!pMT->IsInterface() || pCurDeclMT == pMT->GetCanonicalMethodTable());
@@ -1133,8 +1132,7 @@ MemberLoader::FindMethod(
             ||
             (pCurDeclMD->MightHaveName(targetNameHash)
             // This is done last since it is the most expensive of the IF statement.
-            && (pCurDeclMDName = pCurDeclMD->GetName()) != NULL
-            && StrCompFunc(pszName, pCurDeclMDName) == 0)
+            && StrCompFunc(pszName, pCurDeclMD->GetNameThrowing()) == 0)
            )
         {
             if (CompareMethodSigWithCorrectSubstitution(pSignature, cSignature, pModule, pCurDeclMD, pDefSubst, pMT))

--- a/src/coreclr/vm/memberload.cpp
+++ b/src/coreclr/vm/memberload.cpp
@@ -1118,6 +1118,7 @@ MemberLoader::FindMethod(
     for (; it.IsValid(); it.Prev())
     {
         MethodDesc *pCurDeclMD = it.GetDeclMethodDesc();
+        LPCUTF8 pCurDeclMDName = NULL;
 #ifdef _DEBUG
         MethodTable *pCurDeclMT = pCurDeclMD->GetMethodTable();
         CONSISTENCY_CHECK(!pMT->IsInterface() || pCurDeclMT == pMT->GetCanonicalMethodTable());
@@ -1132,7 +1133,8 @@ MemberLoader::FindMethod(
             ||
             (pCurDeclMD->MightHaveName(targetNameHash)
             // This is done last since it is the most expensive of the IF statement.
-            && StrCompFunc(pszName, pCurDeclMD->GetName()) == 0)
+            && (pCurDeclMDName = pCurDeclMD->GetName()) != NULL
+            && StrCompFunc(pszName, pCurDeclMDName) == 0)
            )
         {
             if (CompareMethodSigWithCorrectSubstitution(pSignature, cSignature, pModule, pCurDeclMD, pDefSubst, pMT))

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -218,7 +218,7 @@ BaseDomain *MethodDesc::GetDomain()
         FORBID_FAULT;
         SUPPORTS_DAC;
     }
-    CONTRACTL_END
+    CONTRACTL_END;
 
     return AppDomain::GetCurrentDomain();
 }
@@ -241,6 +241,24 @@ LoaderAllocator * MethodDesc::GetDomainSpecificLoaderAllocator()
 
 #endif //!DACCESS_COMPILE
 
+
+//*******************************************************************************
+LPCUTF8 MethodDesc::GetNameThrowing()
+{
+    CONTRACTL
+    {
+        THROWS;
+    }
+    CONTRACTL_END;
+
+    LPCUTF8 result = GetName();
+    if (result == NULL)
+    {
+        ThrowHR(COR_E_BADIMAGEFORMAT, BFA_METADATA_CORRUPT);
+    }
+    return result;
+}
+
 //*******************************************************************************
 LPCUTF8 MethodDesc::GetName(USHORT slot)
 {
@@ -260,7 +278,8 @@ LPCUTF8 MethodDesc::GetName()
         GC_NOTRIGGER;
         FORBID_FAULT;
         SUPPORTS_DAC;
-    }CONTRACTL_END;
+    }
+    CONTRACTL_END;
 
     if (IsArray())
     {

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -323,6 +323,8 @@ public:
 
     LPCUTF8 GetName(USHORT slot);
 
+    LPCUTF8 GetNameThrowing();
+
     BOOL MightHaveName(ULONG nameHashValue);
 
     FORCEINLINE LPCUTF8 GetNameOnNonArrayClass()


### PR DESCRIPTION
`sigsegv` occurs due to null argument to strcmp().
This patch simply checks if argument is null before calling strcmp()

```cpp
bt full
#0  __GI_raise (sig=11) at /usr/src/debug/glibc-2.30/signal/../sysdeps/unix/sysv/linux/raise.c:50
set = {__val = {0, 2, 3183135240, 0, 3000022036, 3183135136, 3183135288, 3183135508, 3053334176, 0, 3045877323, 4222451713, 3183135240, 3183135240, 3183135240, 3183135240, 3183135242, 3183135255, 3183135240, 3183135255, 0 <repeats 12 times>}}
pid = <optimized out>
tid = <optimized out>
ret = <optimized out>
#1  0xaee89bcc in invoke_previous_action (action=<optimized out>, code=<optimized out>, siginfo=<optimized out>, context=<optimized out>, signalRestarts=255) at /usr/src/debug/coreclr-3.1.3/src/pal/src/exception/signal.cpp:299
No locals.
#2  sigsegv_handler (code=11, siginfo=0xb2ccbc88, context=0xb2ccbd08) at /usr/src/debug/coreclr-3.1.3/src/pal/src/exception/signal.cpp:501
No locals.
#3  <signal handler called>
No locals.

#4  __GI_strcmp (p1=<optimized out>, p2=<optimized out>) at /usr/src/debug/glibc-2.30/string/strcmp.c:39
s1 = 0xa612ad06 "vocGetSoundMode"
s2 = <optimized out>
c1 = 65 'A'
c2 = <optimized out>
#5  0xaebeaff6 in MemberLoader::FindMethod (pMT=0x5b95b30, pszName=0xa612ad05 "AvocGetSoundMode", pSignature=0xa61493a3 "", cSignature=10, pModule=<optimized out>, flags=<optimized out>, pDefSubst=<optimized out>) at /usr/src/debug/coreclr-3.1.3/src/vm/memberload.cpp:1120
pCurDeclMD = 0x5b414f4
StrCompFunc = 0xb5ff3a08 <__GI_strcmp>
targetName = {<SBuffer> = {m_size = 17, m_allocation = 17, m_flags = 17, {m_buffer = 0xa612ad05 "AvocGetSoundMode", m_asStr = 0xa612ad05 u"癁捯敇却畯摮潍敤䄀潶卣瑥潓湵䵤摯e畓瑢瑩敬潍敤刀獥畯捲䝥浡䵥摯e癁捯敇䝴浡䵥摯e癁捯敓䝴浡䵥摯e慧敭潍敤䄀潶䍣敨正潃潬呲湯䵥摯e癁捯敇䍴汯牯潔敮潍敤䄀潶卣瑥潃潬呲湯䵥摯e敒潳牵散楐瑣牵䵥摯e癁捯敓側捩畴敲潍敤䤀䵳癯湩䵧摯e敳彴畳瑢瑩敬潈䵨摯e敧彴扳䵴摯e敇䵴摯e敓䵴摯e癁捯桃捥卫畯摮潍敤祂潍敤䄀潶䍣敨正楐瑣牵䵥摯䉥䵹摯e捖湯䭦祥潎敤挀摯e癁捯敇䕴捺污瑓瑡獵祂浐摯e潮敤䄀潶䅣摵潩潓湵䵤摯敥䄀潶䝣浡䵥"...}}, static MINIMUM_GUESS = 20, static s_EmptyBuffer = <same as static member of an already seen type>, static s_ACP = 65001, static s_Empty = 0xaf0bd6bc <s_EmptySpace>}
targetNameHash = <optimized out>
it = <optimized out>
pParentMT = <optimized out>
#6  0xaebeaaa4 in MemberLoader::GetDescFromMemberRef (pModule=0xa7782b24, MemberRef=167772781, ppMD=<optimized out>, ppFD=<optimized out>, pTypeContext=<optimized out>, strictMetadataChecks=<optimized out>, ppTH=<optimized out>, actualTypeRequired=<optimized out>, ppTypeSig=<optimized out>, pcbTypeSig=<optimized out>) at /usr/src/debug/coreclr-3.1.3/src/vm/memberload.cpp:404
sigSubst = {m_pModule = 0xa7782b24, m_sigInst = {<SigParser> = {m_ptr = 0x0, m_dwLen = 0}, <No data fields>}, m_pNext = 0x0}
pMD = <optimized out>
fIsMethod = <optimized out>
parent = <optimized out>
pInternalImport = <optimized out>
pTypeSig = <optimized out>
cTypeSig = <optimized out>
pMT = 0x5b95b30
pSig = 0xb5ff3a08 <__GI_strcmp> "\001\060\320\344\001 \321", <incomplete sequence \344>
cSig = <optimized out>
szMember = 0x0
typeHnd = {{m_asTAddr = 96033584, m_asPtr = 0x5b95b30, m_asMT = 0x5b95b30, m_asTypeDesc = 0x5b95b30, m_asArrayTypeDesc = 0x5b95b30, m_asParamTypeDesc = 0x5b95b30, m_asTypeVarTypeDesc = 0x5b95b30, m_asFnPtrTypeDesc = 0x5b95b30}}
pDatum = <optimized out>
fIsField = <optimized out>
#7  0xaec09fca in ExternalMethodFixupWorker (pTransitionBlock=<optimized out>, pIndirection=<optimized out>, sectionIndex=<optimized out>, pModule=0xa7782b24) at /usr/src/debug/coreclr-3.1.3/src/vm/prestub.cpp:2479
pFD = <optimized out>
MemberRef = 0
typeContext = <optimized out>
pSignatures = <optimized out>
th = <optimized out>
__gcHolder = <optimized out>
kind = <optimized out>
pNativeImage = <optimized out>
rva = <optimized out>
pImportSection = <optimized out>
index = <optimized out>
pBlob = <optimized out>
pInfoModule = <optimized out>
pMD = <optimized out>
slot = 0
pMT = <optimized out>
__pException = <optimized out>
CURRENT_THREAD = <optimized out>
__fExceptionCatched = false
__pUnCException = <optimized out>
__pThread = <optimized out>
__pUnCEntryFrame = <optimized out>
CURRENT_THREAD = <optimized out>
frame = <optimized out>
CURRENT_THREAD_AVAILABLE = true
exCopy = <optimized out>
__pThread = <optimized out>
pEMFrame = <optimized out>
hasCaughtException = false
ex = <optimized out>
__dwLastError = <optimized out>
pCode = 0
#8  0xaece4ac8 in DelayLoad_MethodCall_FakeProlog () at /usr/src/debug/coreclr-3.1.3/src/pal/inc/unixasmmacrosarm.inc:1654
No locals.
#9  0xa60e3f3e in ?? ()
No symbol table info available.
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```

```asm
6: x/10i __GI_strcmp
0xb5ff3a08 <__GI_strcmp>:	ldrb	r3, [r0], #1
=> 0xb5ff3a0c <__GI_strcmp+4>:	ldrb	r2, [r1], #1
0xb5ff3a10 <__GI_strcmp+8>:	cmp	r3, #0
0xb5ff3a14 <__GI_strcmp+12>:	beq	0xb5ff3a28 <__GI_strcmp+32>
0xb5ff3a18 <__GI_strcmp+16>:	cmp	r3, r2
0xb5ff3a1c <__GI_strcmp+20>:	beq	0xb5ff3a08 <__GI_strcmp>
0xb5ff3a20 <__GI_strcmp+24>:	sub	r0, r3, r2
0xb5ff3a24 <__GI_strcmp+28>:	bx	lr
0xb5ff3a28 <__GI_strcmp+32>:	rsb	r0, r2, #0
0xb5ff3a2c <__GI_strcmp+36>:	bx	lr
```

```asm
info registers
r0             0xa612ad06          2786241798
r1             0x0                 0
r2             0xb5ff3a08          3053402632
r3             0x41                65
r4             0xb5ff3a08          3053402632
r5             0x0                 0
r6             0xa612ad05          2786241797
r7             0xbdbaaa00          3183127040
r8             0xaf0bbd28          2936782120
r9             0x5b414f4           95687924
r10            0xa7782b24          2809670436
r11            0x5b95b30           96033584
r12            0x11c               284
sp             0xbdbaa990          0xbdbaa990
lr             0xaebeaff7          -1363234825
pc             0xb5ff3a0c          0xb5ff3a0c <__GI_strcmp+4>
cpsr           0x60000010          1610612752
fpscr          0x20000010          536870928
```