### PR TITLE
Fix issues 73653, 73679, 73692

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1230,7 +1230,7 @@ public:
 
     uint8_t* get_next_marked();
 
-    ~mark_queue_t();
+    void verify_empty();
 };
 
 //class definition of the internal class


### PR DESCRIPTION
There are really just two issues:

- verify_region_to_generation_map needs to skip read only segments as they are not represented in the region to generation map.

- it's bad to check for an empty mark queue in the destructor - thus move that check from the destructor to a normal method, and add a call to that method at the end of the mark phase.

#73653, #73679, #73692