### PR TITLE
No end stream on ws connect and flush every message

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -168,8 +168,6 @@ namespace System.Net.Http
 
         internal bool WasRedirected() => (_sendStatus & MessageIsRedirect) != 0;
 
-        internal bool IsWebSocketH2Request() => _version.Major == 2 && Method == HttpMethod.Connect && HasHeaders && string.Equals(Headers.Protocol, "websocket", StringComparison.OrdinalIgnoreCase);
-
         internal bool IsExtendedConnectRequest => Method == HttpMethod.Connect && _headers?.Protocol != null;
 
         #region IDisposable Members

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -170,6 +170,8 @@ namespace System.Net.Http
 
         internal bool IsWebSocketH2Request() => _version.Major == 2 && Method == HttpMethod.Connect && HasHeaders && string.Equals(Headers.Protocol, "websocket", StringComparison.OrdinalIgnoreCase);
 
+        internal bool IsExtendedConnectRequest => Method == HttpMethod.Connect && _headers?.Protocol != null;
+
         #region IDisposable Members
 
         protected virtual void Dispose(bool disposing)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1600,7 +1600,7 @@ namespace System.Net.Http
                 // Start the write.  This serializes access to write to the connection, and ensures that HEADERS
                 // and CONTINUATION frames stay together, as they must do. We use the lock as well to ensure new
                 // streams are created and started in order.
-                await PerformWriteAsync(totalSize, (thisRef: this, http2Stream, headerBytes, endStream: (request.Content == null && !http2Stream.ConnectProtocolEstablished), mustFlush), static (s, writeBuffer) =>
+                await PerformWriteAsync(totalSize, (thisRef: this, http2Stream, headerBytes, endStream: (request.Content == null && !request.IsWebSocketH2Request()), mustFlush ), static (s, writeBuffer) =>
                 {
                     if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.http2Stream.StreamId, $"Started writing. Total header bytes={s.headerBytes.Length}");
 
@@ -1962,7 +1962,7 @@ namespace System.Net.Http
             try
             {
                 // Send request headers
-                bool shouldExpectContinue = request.Content != null && request.HasHeaders && request.Headers.ExpectContinue == true;
+                bool shouldExpectContinue = (request.Content != null && request.HasHeaders && request.Headers.ExpectContinue == true) || request.IsWebSocketH2Request();
                 Http2Stream http2Stream = await SendHeadersAsync(request, cancellationToken, mustFlush: shouldExpectContinue).ConfigureAwait(false);
 
                 bool duplex = request.Content != null && request.Content.AllowDuplex;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1600,7 +1600,7 @@ namespace System.Net.Http
                 // Start the write.  This serializes access to write to the connection, and ensures that HEADERS
                 // and CONTINUATION frames stay together, as they must do. We use the lock as well to ensure new
                 // streams are created and started in order.
-                await PerformWriteAsync(totalSize, (thisRef: this, http2Stream, headerBytes, endStream: (request.Content == null && !request.IsWebSocketH2Request()), mustFlush ), static (s, writeBuffer) =>
+                await PerformWriteAsync(totalSize, (thisRef: this, http2Stream, headerBytes, endStream: (request.Content == null && !request.IsWebSocketH2Request()), mustFlush), static (s, writeBuffer) =>
                 {
                     if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.http2Stream.StreamId, $"Started writing. Total header bytes={s.headerBytes.Length}");
 
@@ -1962,8 +1962,8 @@ namespace System.Net.Http
             try
             {
                 // Send request headers
-                bool shouldExpectContinue = (request.Content != null && request.HasHeaders && request.Headers.ExpectContinue == true) || request.IsWebSocketH2Request();
-                Http2Stream http2Stream = await SendHeadersAsync(request, cancellationToken, mustFlush: shouldExpectContinue).ConfigureAwait(false);
+                bool shouldExpectContinue = (request.Content != null && request.HasHeaders && request.Headers.ExpectContinue == true);
+                Http2Stream http2Stream = await SendHeadersAsync(request, cancellationToken, mustFlush: shouldExpectContinue || request.IsWebSocketH2Request()).ConfigureAwait(false);
 
                 bool duplex = request.Content != null && request.Content.AllowDuplex;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1600,7 +1600,7 @@ namespace System.Net.Http
                 // Start the write.  This serializes access to write to the connection, and ensures that HEADERS
                 // and CONTINUATION frames stay together, as they must do. We use the lock as well to ensure new
                 // streams are created and started in order.
-                await PerformWriteAsync(totalSize, (thisRef: this, http2Stream, headerBytes, endStream: (request.Content == null && !request.IsWebSocketH2Request()), mustFlush), static (s, writeBuffer) =>
+                await PerformWriteAsync(totalSize, (thisRef: this, http2Stream, headerBytes, endStream: (request.Content == null && !request.IsExtendedConnectRequest), mustFlush), static (s, writeBuffer) =>
                 {
                     if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.http2Stream.StreamId, $"Started writing. Total header bytes={s.headerBytes.Length}");
 
@@ -1963,7 +1963,7 @@ namespace System.Net.Http
             {
                 // Send request headers
                 bool shouldExpectContinue = (request.Content != null && request.HasHeaders && request.Headers.ExpectContinue == true);
-                Http2Stream http2Stream = await SendHeadersAsync(request, cancellationToken, mustFlush: shouldExpectContinue || request.IsWebSocketH2Request()).ConfigureAwait(false);
+                Http2Stream http2Stream = await SendHeadersAsync(request, cancellationToken, mustFlush: shouldExpectContinue || request.IsExtendedConnectRequest).ConfigureAwait(false);
 
                 bool duplex = request.Content != null && request.Content.AllowDuplex;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -108,7 +108,7 @@ namespace System.Net.Http
                 if (_request.Content == null)
                 {
                     _requestCompletionState = StreamCompletionState.Completed;
-                    if (_request.IsWebSocketH2Request())
+                    if (_request.IsExtendedConnectRequest)
                     {
                         _requestBodyCancellationSource = new CancellationTokenSource();
                     }
@@ -637,7 +637,7 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        if (statusCode == 200 && _response.RequestMessage!.IsWebSocketH2Request())
+                        if (statusCode == 200 && _response.RequestMessage!.IsExtendedConnectRequest)
                         {
                             ConnectProtocolEstablished = true;
                         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1018,7 +1018,7 @@ namespace System.Net.Http
                     // Use HTTP/3 if possible.
                     if (IsHttp3Supported() && // guard to enable trimming HTTP/3 support
                         _http3Enabled &&
-                        !request.IsWebSocketH2Request() &&
+                        !request.IsExtendedConnectRequest &&
                         (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)))
                     {
                         Debug.Assert(async);
@@ -1047,7 +1047,7 @@ namespace System.Net.Http
                             Debug.Assert(connection is not null || !_http2Enabled);
                             if (connection is not null)
                             {
-                                if (request.IsWebSocketH2Request())
+                                if (request.IsExtendedConnectRequest)
                                 {
                                     await connection.InitialSettingsReceived.WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
                                     if (!connection.IsConnectEnabled)
@@ -1120,7 +1120,7 @@ namespace System.Net.Http
                     if (request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
                     {
                         HttpRequestException exception = new HttpRequestException(SR.Format(SR.net_http_requested_version_server_refused, request.Version, request.VersionPolicy), e);
-                        if (request.IsWebSocketH2Request())
+                        if (request.IsExtendedConnectRequest)
                         {
                             exception.Data["HTTP2_ENABLED"] = false;
                         }

--- a/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.Http2.cs
@@ -57,6 +57,9 @@ namespace System.Net.WebSockets.Client.Tests
                 // send status 200 OK to establish websocket
                 await connection.SendResponseHeadersAsync(streamId, endStream: false).ConfigureAwait(false);
 
+                WebSocket websocket = WebSocket.CreateFromStream(connection.Stream, isServer: true, null, Timeout.InfiniteTimeSpan);
+                Assert.Equal(WebSocketState.Open, websocket.State);
+
                 // send reply
                 byte binaryMessageType = 2;
                 var prefix = new byte[] { binaryMessageType, (byte)serverMessage.Length };
@@ -96,6 +99,9 @@ namespace System.Net.WebSockets.Client.Tests
                 (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
                 // send status 200 OK to establish websocket
                 await connection.SendResponseHeadersAsync(streamId, endStream: false).ConfigureAwait(false);
+
+                WebSocket websocket = WebSocket.CreateFromStream(connection.Stream, isServer: true, null, Timeout.InfiniteTimeSpan);
+                Assert.Equal(WebSocketState.Open, websocket.State);
 
                 // send reply
                 byte binaryMessageType = 2;

--- a/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.Http2.cs
@@ -57,9 +57,6 @@ namespace System.Net.WebSockets.Client.Tests
                 // send status 200 OK to establish websocket
                 await connection.SendResponseHeadersAsync(streamId, endStream: false).ConfigureAwait(false);
 
-                WebSocket websocket = WebSocket.CreateFromStream(connection.Stream, isServer: true, null, Timeout.InfiniteTimeSpan);
-                Assert.Equal(WebSocketState.Open, websocket.State);
-
                 // send reply
                 byte binaryMessageType = 2;
                 var prefix = new byte[] { binaryMessageType, (byte)serverMessage.Length };
@@ -99,9 +96,6 @@ namespace System.Net.WebSockets.Client.Tests
                 (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
                 // send status 200 OK to establish websocket
                 await connection.SendResponseHeadersAsync(streamId, endStream: false).ConfigureAwait(false);
-
-                WebSocket websocket = WebSocket.CreateFromStream(connection.Stream, isServer: true, null, Timeout.InfiniteTimeSpan);
-                Assert.Equal(WebSocketState.Open, websocket.State);
 
                 // send reply
                 byte binaryMessageType = 2;

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -411,7 +411,6 @@ namespace System.Net.WebSockets
             // If we get here, the cancellation token is not cancelable so we don't have to worry about it,
             // and we own the semaphore, so we don't need to asynchronously wait for it.
             ValueTask writeTask = default;
-            Task flushTask;
             bool releaseSendBufferAndSemaphore = true;
             try
             {
@@ -424,11 +423,9 @@ namespace System.Net.WebSockets
                 // the task, and we're done.
                 if (writeTask.IsCompleted)
                 {
-                    flushTask = _stream.FlushAsync();
-                    if (flushTask.IsCompleted)
-                    {
-                        return writeTask;
-                    }
+                    writeTask.GetAwaiter().GetResult();
+                    writeTask = new ValueTask(_stream.FlushAsync());
+                    return writeTask;
                 }
 
                 // Up until this point, if an exception occurred (such as when accessing _stream or when

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -432,6 +432,7 @@ namespace System.Net.WebSockets
                     }
                     else
                     {
+                        releaseSendBufferAndSemaphore = false;
                         return WaitForWriteTaskAsync(flushTask, false);
                     }
                 }

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -433,7 +433,7 @@ namespace System.Net.WebSockets
                     else
                     {
                         releaseSendBufferAndSemaphore = false;
-                        return WaitForWriteTaskAsync(flushTask, false);
+                        return WaitForWriteTaskAsync(flushTask, shouldFlush: false);
                     }
                 }
 
@@ -458,7 +458,7 @@ namespace System.Net.WebSockets
                 }
             }
 
-            return WaitForWriteTaskAsync(writeTask, true);
+            return WaitForWriteTaskAsync(writeTask, shouldFlush: true);
         }
 
         private async ValueTask WaitForWriteTaskAsync(ValueTask writeTask, bool shouldFlush)

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -411,7 +411,6 @@ namespace System.Net.WebSockets
             // If we get here, the cancellation token is not cancelable so we don't have to worry about it,
             // and we own the semaphore, so we don't need to asynchronously wait for it.
             ValueTask writeTask = default;
-            ValueTask flushTask;
             bool releaseSendBufferAndSemaphore = true;
             try
             {
@@ -425,7 +424,7 @@ namespace System.Net.WebSockets
                 if (writeTask.IsCompleted)
                 {
                     writeTask.GetAwaiter().GetResult();
-                    flushTask = new ValueTask(_stream.FlushAsync());
+                    ValueTask flushTask = new ValueTask(_stream.FlushAsync());
                     if (flushTask.IsCompleted)
                     {
                         return flushTask;

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTestStream.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTestStream.cs
@@ -206,7 +206,7 @@ namespace System.Net.WebSockets.Tests
             Write(buffer.Span);
         }
 
-        public override void Flush() => throw new NotSupportedException();
+        public override void Flush() { }
 
         public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 


### PR DESCRIPTION
The second attempt to fix #72301

End stream should not be sent on the connect request, but it should be flushed instead.
Also, for web sockets we should flush every message immediately.

To test the change, I run all existing tests for 1.1 against local Kestrel server with WS over HTTP/2 support. All tests passed except CloseStatusDescription checks - it seems to be changed on the server side. Now server adds "Server received" and status at the beginning