### PR TITLE
[Android][iOS] Enable HttpClientHandler.DangerousAcceptAnyServerCertificateValidator when using native handlers

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -738,16 +738,9 @@ namespace System.Net.Http
         {
             get
             {
-                if (IsNativeHandlerEnabled)
-                {
-                    throw new PlatformNotSupportedException();
-                }
-                else
-                {
-                    return Volatile.Read(ref s_dangerousAcceptAnyServerCertificateValidator) ??
-                    Interlocked.CompareExchange(ref s_dangerousAcceptAnyServerCertificateValidator, delegate { return true; }, null) ??
-                    s_dangerousAcceptAnyServerCertificateValidator;
-                }
+                return Volatile.Read(ref s_dangerousAcceptAnyServerCertificateValidator) ??
+                Interlocked.CompareExchange(ref s_dangerousAcceptAnyServerCertificateValidator, delegate { return true; }, null) ??
+                s_dangerousAcceptAnyServerCertificateValidator;
             }
         }
 


### PR DESCRIPTION
The static `HttpClientHandler.DangerousAcceptAnyServerCertificateValidator` getter throws PNSE when the native HTTP handler is enabled because Xamarin.Android's `AndroidMessageHandler` and Xamarin.iOS `NSUrlSessionHandler` didn't use to have support for the `ServerCertificateCustomValidationCallback`.

We already implemented the Android part in .NET 6 and support in the iOS implementation is WIP and we should be able to implement it in time for .NET 7. IMO it's safe to remove the exception in the getter in .NET 7.

Closes #68898