### PR TITLE
Repoint urls in docs

### DIFF
--- a/docs/design/coreclr/profiling/Profiler Attach on CoreCLR.md
+++ b/docs/design/coreclr/profiling/Profiler Attach on CoreCLR.md
@@ -19,7 +19,7 @@ This method returns a status HR following the usual convention, 0 (S_OK) means a
 
 ## What if you can't run managed code in your trigger process?
 
-If you are unable to run managed code as part of your trigger process, it is still possible to request a profiler attach. The spec for the diagnostics port is located [here](https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md).
+If you are unable to run managed code as part of your trigger process, it is still possible to request a profiler attach. The spec for the diagnostics port is located [here](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md).
 
 You will have to do the following (according to the above spec):
 1) Open the appropriate channel - domain socket on Linux and a named pipe on Windows

--- a/docs/design/features/additional-deps.md
+++ b/docs/design/features/additional-deps.md
@@ -3,9 +3,9 @@
 ## Summary
 This document describes current (2.0) and proposed (2.1) behavior for "light-up" scenarios regarding additional-deps functionality. The proposed behavior resolves the following issues:
 
-https://github.com/dotnet/core-setup/issues/3889
+https://github.com/dotnet/runtime/issues/3093
 
-https://github.com/dotnet/core-setup/issues/3884
+https://github.com/dotnet/runtime/issues/3091
 
 The `deps.json` file format specifies assets including managed assemblies, resource assemblies and native libraries to load.
 

--- a/docs/design/features/native-hosting.md
+++ b/docs/design/features/native-hosting.md
@@ -306,7 +306,7 @@ Returns the value of a runtime property specified by its name.
 
 Trying to get a property which doesn't exist is an error and will return an appropriate error code.
 
-We're proposing a fix in `hostpolicy` which will make sure that there are no duplicates possible after initialization (see [dotnet/core-setup#5529](https://github.com/dotnet/core-setup/issues/5529)). With that `hostfxr_get_runtime_property_value` will work always (as there can only be one value).
+We're proposing a fix in `hostpolicy` which will make sure that there are no duplicates possible after initialization (see [dotnet/runtime#3514](https://github.com/dotnet/runtime/issues/3514)). With that `hostfxr_get_runtime_property_value` will work always (as there can only be one value).
 
 
 ``` C

--- a/docs/project/linux-performance-tracing.md
+++ b/docs/project/linux-performance-tracing.md
@@ -275,5 +275,5 @@ dotnet-trace collect --process-id <PID>
 The resulting trace can be viewed in [PerfView](https://aka.ms/perfview) on Windows. Alternatively on Linux/macOS, it can be viewed on [SpeedScope](https://speedscope.app) if you convert the trace format to speedscope by passing `--format speedscope` argument when collecting the trace.
 
 ## More Information ##
-To read more about how to use dotnet-trace, please refer to the [dotnet-trace documentation](https://github.com/dotnet/diagnostics/blob/master/documentation/dotnet-trace-instructions.md).
+To read more about how to use dotnet-trace, please refer to the [dotnet-trace documentation](https://github.com/dotnet/diagnostics/blob/main/documentation/dotnet-trace-instructions.md).
 

--- a/docs/workflow/debugging/coreclr/debugging.md
+++ b/docs/workflow/debugging/coreclr/debugging.md
@@ -87,14 +87,14 @@ When there's source code change in coreclr, invoke the 'Install' command again t
 
 ### Using SOS with windbg or cdb on Windows ###
 
-See the SOS installation instructions [here](https://github.com/dotnet/diagnostics/blob/master/documentation/installing-sos-windows-instructions.md).
+See the SOS installation instructions [here](https://github.com/dotnet/diagnostics/blob/main/documentation/installing-sos-windows-instructions.md).
 
-For more information on SOS commands click [here](https://github.com/dotnet/diagnostics/blob/master/documentation/sos-debugging-extension-windows.md).
+For more information on SOS commands click [here](https://github.com/dotnet/diagnostics/blob/main/documentation/sos-debugging-extension-windows.md).
 
 Debugging CoreCLR on Linux and macOS
 ====================================
 
-See the SOS installation instructions [here](https://github.com/dotnet/diagnostics/blob/master/documentation/installing-sos-instructions.md). After SOS is installed, it will automatically be loaded by lldb.
+See the SOS installation instructions [here](https://github.com/dotnet/diagnostics/blob/main/documentation/installing-sos-instructions.md). After SOS is installed, it will automatically be loaded by lldb.
 
 Only lldb is supported by SOS. Gdb can be used to debug the coreclr code but with no SOS support.
 
@@ -113,7 +113,7 @@ See https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-sos for info
 
 ### Debugging core dumps with lldb
 
-See this [link](https://github.com/dotnet/diagnostics/blob/master/documentation/debugging-coredump.md) in the diagnostics repo.
+See this [link](https://github.com/dotnet/diagnostics/blob/main/documentation/debugging-coredump.md) in the diagnostics repo.
 
 Disabling Managed Attach/Debugging
 ==================================

--- a/docs/workflow/debugging/libraries/unix-instructions.md
+++ b/docs/workflow/debugging/libraries/unix-instructions.md
@@ -15,7 +15,7 @@ It is also possible to debug .NET crash dumps using lldb and SOS. In order to do
 - The crash dump file.
 - On Linux, there is an utility called `createdump` (see [doc](../../../design/coreclr/botr/xplat-minidump-generation.md "doc")) that can be setup to generate core dumps when a managed app throws an unhandled exception or faults.'
 
-There are instructions for installing lldb and SOS [here](https://github.com/dotnet/diagnostics/blob/master/documentation/sos.md).
+There are instructions for installing lldb and SOS [here](https://github.com/dotnet/diagnostics/blob/main/documentation/sos.md).
 
 Once you have everything listed above, you are ready to start debugging. You need to specify an extra parameter to lldb in order for it to correctly resolve the symbols for libcoreclr.so. Use a command like this:
 
@@ -29,7 +29,7 @@ lldb-3.9 -O "settings set target.exec-search-paths <runtime-path>" --core <core-
 
 lldb should start debugging successfully at this point. You should see stacktraces with resolved symbols for libcoreclr.so. At this point you can begin using SOS commands provided you've set it up as described in the links.
 
-Also see this [link](https://github.com/dotnet/diagnostics/blob/master/documentation/debugging-coredump.md) in the diagnostics repo.
+Also see this [link](https://github.com/dotnet/diagnostics/blob/main/documentation/debugging-coredump.md) in the diagnostics repo.
 
 ##### Example
 

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -329,7 +329,7 @@ jobs:
   - ${{ if ne(parameters.container, '') }}:
     # Builds don't set user ID, so files might be owned by root and unable to be cleaned up by AzDO.
     # Clean up the build dirs ourselves in another Docker container to avoid failures.
-    # Using hosted agents is tracked by https://github.com/dotnet/core-setup/issues/4997
+    # Using hosted agents is tracked by https://github.com/dotnet/runtime/issues/3416
     - script: |
         set -x
         docker run --rm \

--- a/eng/testing/debug-dump-template.md
+++ b/eng/testing/debug-dump-template.md
@@ -112,7 +112,7 @@ Now you can debug with WinDbg or `dotnet-dump` as if it was a Windows dump. See 
 
 ## ... and you want to debug with LLDB
 
-Install or update LLDB if necessary ([instructions here](https://github.com/dotnet/diagnostics/blob/master/documentation/lldb/linux-instructions.md))
+Install or update LLDB if necessary ([instructions here](https://github.com/dotnet/diagnostics/blob/main/documentation/lldb/linux-instructions.md))
 
 Load the dump:
 ```sh
@@ -151,4 +151,4 @@ will start generating native Mach-O core files. dotnet-dump and ClrMD are still 
 ---
 # Other Helpful Information
 
-* [How to debug a Linux core dump with SOS](https://github.com/dotnet/diagnostics/blob/master/documentation/debugging-coredump.md)
+* [How to debug a Linux core dump with SOS](https://github.com/dotnet/diagnostics/blob/main/documentation/debugging-coredump.md)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1544,7 +1544,7 @@ namespace System.Reflection
         {
             Type[] pcas = new Type[]
             {
-                // See https://github.com/dotnet/coreclr/blob/master/src/md/compiler/custattr_emit.cpp
+                // See https://github.com/dotnet/runtime/blob/main/src/coreclr/md/compiler/custattr_emit.cpp
                 typeof(FieldOffsetAttribute), // field
                 typeof(SerializableAttribute), // class, struct, enum, delegate
                 typeof(MarshalAsAttribute), // parameter, field, return-value

--- a/src/coreclr/inc/gcdecoder.cpp
+++ b/src/coreclr/inc/gcdecoder.cpp
@@ -15,7 +15,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // ******************************************************************************
 // WARNING!!!: This code is also used by SOS in the diagnostics repo. Should be
 // updated in a backwards and forwards compatible way.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcdecoder.cpp
+// See: https://github.com/dotnet/diagnostics/blob/main/src/shared/inc/gcdecoder.cpp
 // ******************************************************************************
 
 #ifdef TARGET_X86

--- a/src/coreclr/inc/gcinfo.h
+++ b/src/coreclr/inc/gcinfo.h
@@ -4,7 +4,7 @@
 // ******************************************************************************
 // WARNING!!!: These values are used by SOS in the diagnostics repo. Values should
 // added or removed in a backwards and forwards compatible way.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcinfo.h
+// See: https://github.com/dotnet/diagnostics/blob/main/src/shared/inc/gcinfo.h
 // ******************************************************************************
 
 /*****************************************************************************/

--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -10,7 +10,7 @@
 // ******************************************************************************
 // WARNING!!!: These values are used by SOS in the diagnostics repo. Values should
 // added or removed in a backwards and forwards compatible way.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcinfodecoder.h
+// See: https://github.com/dotnet/diagnostics/blob/main/src/shared/inc/gcinfodecoder.h
 // ******************************************************************************
 
 #ifndef _GC_INFO_DECODER_

--- a/src/coreclr/inc/gcinfodumper.h
+++ b/src/coreclr/inc/gcinfodumper.h
@@ -10,7 +10,7 @@
 // *****************************************************************************
 // WARNING!!!: These values and code are also used by SOS in the diagnostics
 // repo. Should updated in a backwards and forwards compatible way.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcinfodumper.h
+// See: https://github.com/dotnet/diagnostics/blob/main/src/shared/inc/gcinfodumper.h
 // *****************************************************************************
 
 //

--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -12,7 +12,7 @@
 // *****************************************************************************
 // WARNING!!!: These values and code are also used by SOS in the diagnostics
 // repo. Should updated in a backwards and forwards compatible way.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcinfotypes.h
+// See: https://github.com/dotnet/diagnostics/blob/main/src/shared/inc/gcinfotypes.h
 // *****************************************************************************
 
 #define PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED

--- a/src/coreclr/inc/predeftlsslot.h
+++ b/src/coreclr/inc/predeftlsslot.h
@@ -9,7 +9,7 @@
 // ******************************************************************************
 // WARNING!!!: These enums are used by SOS in the diagnostics repo. Values should
 // added or removed in a backwards and forwards compatible way.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/predeftlsslot.h
+// See: https://github.com/dotnet/diagnostics/blob/main/src/shared/inc/predeftlsslot.h
 // ******************************************************************************
 
 // The historic location of ThreadType slot kept for compatibility with SOS

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -19,8 +19,8 @@
 // ******************************************************************************
 // WARNING!!!: These classes are used by SOS in the diagnostics repo. Values should
 // added or removed in a backwards and forwards compatible way.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/stresslog.h
-// Parser: https://github.com/dotnet/diagnostics/blob/master/src/SOS/Strike/stressLogDump.cpp
+// See: https://github.com/dotnet/diagnostics/blob/main/src/shared/inc/stresslog.h
+// Parser: https://github.com/dotnet/diagnostics/blob/main/src/SOS/Strike/stressLogDump.cpp
 // ******************************************************************************
 
 /*************************************************************************************/

--- a/src/coreclr/inc/tls.h
+++ b/src/coreclr/inc/tls.h
@@ -9,7 +9,7 @@
 
 // **************************************************************************************
 // WARNING!!!: These values are used by SOS in the diagnostics repo and need to the same.
-// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/tls.h
+// See: https://github.com/dotnet/diagnostics/blob/main/src/shared/inc/tls.h
 // **************************************************************************************
 
 #ifndef __tls_h__

--- a/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
+++ b/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
@@ -35,7 +35,7 @@ struct ReadyToRunHeader
 // of the enum and deprecated sections should not be removed to preserve ID stability.
 //
 // Eventually this will be reconciled with ReadyToRunSectionType from
-// https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h
+// https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/readytorun.h
 //
 enum class ReadyToRunSectionType
 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Activator.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Activator.NativeAot.cs
@@ -118,7 +118,7 @@ namespace System
         [RequiresUnreferencedCode("Type and its constructor could be removed")]
         public static ObjectHandle CreateInstance(string assemblyName, string typeName)
         {
-            throw new PlatformNotSupportedException(); // https://github.com/dotnet/corefx/issues/30845
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/runtime/issues/26701
         }
 
         [RequiresUnreferencedCode("Type and its constructor could be removed")]
@@ -131,13 +131,13 @@ namespace System
                                                   CultureInfo? culture,
                                                   object?[]? activationAttributes)
         {
-            throw new PlatformNotSupportedException(); // https://github.com/dotnet/corefx/issues/30845
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/runtime/issues/26701
         }
 
         [RequiresUnreferencedCode("Type and its constructor could be removed")]
         public static ObjectHandle CreateInstance(string assemblyName, string typeName, object?[]? activationAttributes)
         {
-            throw new PlatformNotSupportedException(); // https://github.com/dotnet/corefx/issues/30845
+            throw new PlatformNotSupportedException(); // https://github.com/dotnet/runtime/issues/26701
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
@@ -377,7 +377,7 @@ namespace System.Threading
             t_comState &= ~ComState.InitializedByUs;
         }
 
-        // TODO: https://github.com/dotnet/corefx/issues/20766
+        // TODO: https://github.com/dotnet/runtime/issues/22161
         public void DisableComObjectEagerCleanup() { }
 
         private static Thread InitializeExistingThreadPoolThread()

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -41,7 +41,7 @@ namespace Internal.Runtime
     // of the enum and deprecated sections should not be removed to preserve ID stability.
     //
     // This list should be kept in sync with the runtime version at
-    // https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h
+    // https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/readytorun.h
     //
     public enum ReadyToRunSectionType
     {

--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -174,7 +174,7 @@ namespace Internal.ReadyToRunConstants
 
     //
     // Intrinsics and helpers
-    // Keep in sync with https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h
+    // Keep in sync with https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/readytorun.h
     //
 
     [Flags]

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugInfoTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugInfoTableNode.cs
@@ -15,49 +15,49 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     /// <summary>
     /// DebugInfoTableNode emits the data structures required to support managed code debugging
-    /// for ready to run code. See https://github.com/dotnet/coreclr/blob/master/src/inc/cordebuginfo.h
-    /// for the types this information is based on. We store two tables of information in an 
+    /// for ready to run code. See https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/cordebuginfo.h
+    /// for the types this information is based on. We store two tables of information in an
     /// image:
-    /// 
+    ///
     /// Location Information
     ///
-    ///     In order to provide source line debugging, generated ready-to-run code is mapped 
+    ///     In order to provide source line debugging, generated ready-to-run code is mapped
     ///     back to the original IL instruction. This maps to OffsetMapping in cordebuginfo.h.
-    ///     
+    ///
     ///     A row in the table looks like this:
-    ///     
+    ///
     ///     Native offset | IL Offset | Flags
-    ///     
-    ///     Native offset starts at 0 for the beginning of a method. The rows are stored in 
+    ///
+    ///     Native offset starts at 0 for the beginning of a method. The rows are stored in
     ///     ascending order of offset and use a delta encoding. That is, each successive row
     ///     stores the difference between the previous native offset and the new one to save
     ///     encoding space.
-    ///     
-    ///     Flags stores values useful to the debugger. For example, if the offset is a 
-    ///     call site, or the stack is empty at that point. These are used for edit and 
+    ///
+    ///     Flags stores values useful to the debugger. For example, if the offset is a
+    ///     call site, or the stack is empty at that point. These are used for edit and
     ///     continue. It maps to SourceTypes in cordebuginfo.h.
-    ///     
+    ///
     /// Variable Information
-    /// 
-    ///     The debugger needs to know, for a given native code range, where the memory 
+    ///
+    ///     The debugger needs to know, for a given native code range, where the memory
     ///     backing each variable is stored. That can be in a register, on the stack, or maybe
-    ///     even split between a combination of registers and the stack. This maps to 
+    ///     even split between a combination of registers and the stack. This maps to
     ///     NativeVarInfo in cordebuginfo.h.
-    ///     
+    ///
     ///     A row in the table looks like this:
-    ///     
+    ///
     ///     Start Offset | End Offset | Variable Number | Location
-    ///     
+    ///
     ///     Start Offset and End Offset are offsets within the generated native code and are
     ///     used to capture the range of instructions during which the variable is stored
     ///     in the same location.
-    ///     
+    ///
     ///     Variable Number is the index of each variable in the original IL code.
-    ///     
+    ///
     ///     Location is a variant data structure specifying what memory is backing the variable
     ///     for a given native code range. This is a specific register, or a stack offset. This
     ///     maps to VarLoc in cordebuginfo.h.
-    ///     
+    ///
     /// </summary>
     public class DebugInfoTableNode : HeaderTableNode
     {
@@ -83,11 +83,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             section.Place(vertexArray);
 
             Dictionary<byte[], BlobVertex> blobCache = new Dictionary<byte[], BlobVertex>(ByteArrayComparer.Instance);
-            
+
             foreach (MethodWithGCInfo method in factory.EnumerateCompiledMethods())
             {
                 MemoryStream methodDebugBlob = new MemoryStream();
-                
+
                 byte[] bounds = method.DebugLocInfos;
                 byte[] vars = method.DebugVarInfos;
 
@@ -167,7 +167,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 writer.WriteUInt((uint)(nativeVarInfo.varNumber - (int)ILNum.MAX_ILNUM));
 
                 VarLocType varLocType = nativeVarInfo.varLoc.LocationType;
-                
+
                 writer.WriteUInt((uint)varLocType);
 
                 switch (varLocType)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHashCode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHashCode.cs
@@ -17,7 +17,7 @@ namespace ILCompiler
     public static class ReadyToRunHashCode
     {
         /// <summary>
-        /// CoreCLR <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/typehashingalgorithms.h#L15">ComputeNameHashCode</a>
+        /// CoreCLR <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/typehashingalgorithms.h#L14">ComputeNameHashCode</a>
         /// </summary>
         /// <param name="name">Name string to hash</param>
         public static int NameHashCode(string name)
@@ -53,7 +53,7 @@ namespace ILCompiler
 
         /// <summary>
         /// Calculate hash code for a namespace - name combination.
-        /// CoreCLR 2-parameter <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/typehashingalgorithms.h#L42">ComputeNameHashCode</a>
+        /// CoreCLR 2-parameter <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/typehashingalgorithms.h#L41">ComputeNameHashCode</a>
         /// DIFFERENT FROM NATIVEAOT: NativeAOT hashes the full name as one string ("namespace.name"),
         /// as the full name is already available. In CoreCLR we normally only have separate
         /// strings for namespace and name, thus we hash them separately.
@@ -66,7 +66,7 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// CoreCLR 3-parameter <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/versionresilienthashcode.cpp#L9">GetVersionResilientTypeHashCode</a>
+        /// CoreCLR 3-parameter <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/versionresilienthashcode.cpp#L9">GetVersionResilientTypeHashCode</a>
         /// </summary>
         /// <param name="type">Type to hash</param>
         public static int TypeTableHashCode(DefType type)
@@ -82,7 +82,7 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// CoreCLR 1-parameter <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/versionresilienthashcode.cpp#L76">GetVersionResilientTypeHashCode</a>
+        /// CoreCLR 1-parameter <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/versionresilienthashcode.cpp#L109">GetVersionResilientTypeHashCode</a>
         /// </summary>
         /// <param name="type">Type to hash</param>
         public static int TypeHashCode(TypeDesc type)
@@ -124,7 +124,7 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// CoreCLR <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/typehashingalgorithms.h#L80">ComputeNestedTypeHashCode</a>
+        /// CoreCLR <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/typehashingalgorithms.h#L79">ComputeNestedTypeHashCode</a>
         /// </summary>
         /// <param name="enclosingTypeHashcode">Hash code of the enclosing type</param>
         /// <param name="nestedTypeNameHash">Hash code of the nested type name</param>
@@ -134,7 +134,7 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// CoreCLR <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/typehashingalgorithms.h#L52">ComputeArrayTypeHashCode</a>
+        /// CoreCLR <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/typehashingalgorithms.h#L51">ComputeArrayTypeHashCode</a>
         /// </summary>
         /// <param name="elementTypeHashcode">Hash code representing the array element type</param>
         /// <param name="rank">Array rank</param>
@@ -152,7 +152,7 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// CoreCLR <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/typehashingalgorithms.h#L66">ComputePointerTypeHashCode</a>
+        /// CoreCLR <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/typehashingalgorithms.h#L65">ComputePointerTypeHashCode</a>
         /// </summary>
         /// <param name="pointeeTypeHashcode">Hash code of the pointee type</param>
         private static int PointerTypeHashCode(int pointeeTypeHashcode)
@@ -161,7 +161,7 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// CoreCLR <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/typehashingalgorithms.h#L73">ComputeByrefTypeHashCode</a>
+        /// CoreCLR <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/typehashingalgorithms.h#L72">ComputeByrefTypeHashCode</a>
         /// </summary>
         /// <param name="parameterTypeHashCode">Hash code representing the parameter type</param>
         private static int ByrefTypeHashCode(int parameterTypeHashcode)
@@ -170,7 +170,7 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// CoreCLR <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/typehashingalgorithms.h#L88">ComputeGenericInstanceHashCode</a>
+        /// CoreCLR <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/typehashingalgorithms.h#L87">ComputeGenericInstanceHashCode</a>
         /// </summary>
         /// <param name="hashcode">Base hash code</param>
         /// <param name="instantiation">Instantiation to include in the hash</param>
@@ -185,7 +185,7 @@ namespace ILCompiler
         }
 
         /// <summary>
-        /// CoreCLR <a href="https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/vm/versionresilienthashcode.cpp#L129">GetVersionResilientMethodHashCode</a>
+        /// CoreCLR <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/versionresilienthashcode.cpp#L161">GetVersionResilientMethodHashCode</a>
         /// </summary>
         /// <param name="method">Method to hash</param>
         public static int MethodHashCode(MethodDesc method)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -157,7 +157,7 @@ namespace ILCompiler
                     if (typeDef.GetGenericParameters().Count != 0)
                     {
                         // Generic types are exempt from the static field layout algorithm, see
-                        // <a href="https://github.com/dotnet/coreclr/blob/659af58047a949ed50d11101708538d2e87f2568/src/vm/ceeload.cpp#L2049">this check</a>.
+                        // <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/ceeload.cpp#L931">this check</a>.
                         continue;
                     }
 
@@ -172,7 +172,7 @@ namespace ILCompiler
                         if ((fieldDef.Attributes & (FieldAttributes.Static | FieldAttributes.Literal)) == FieldAttributes.Static)
                         {
                             // Static RVA fields are included when approximating offsets and sizes for the module field layout, see
-                            // <a href="https://github.com/dotnet/coreclr/blob/659af58047a949ed50d11101708538d2e87f2568/src/vm/ceeload.cpp#L2057">this loop</a>.
+                            // <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/ceeload.cpp#L939">this loop</a>.
 
                             int index = (IsFieldThreadStatic(in fieldDef, module.MetadataReader) ? StaticIndex.ThreadLocal : StaticIndex.Regular);
                             int alignment;
@@ -271,7 +271,7 @@ namespace ILCompiler
                     if (moduleLayout && fieldType.GetTypeDefinition() is EcmaType ecmaType && ecmaType.EcmaModule != module)
                     {
                         // Allocate pessimistic non-GC area for cross-module fields as that's what CoreCLR does
-                        // <a href="https://github.com/dotnet/coreclr/blob/659af58047a949ed50d11101708538d2e87f2568/src/vm/ceeload.cpp#L2124">here</a>
+                        // <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/ceeload.cpp#L1006">here</a>
                         alignment = TargetDetails.MaximumPrimitiveSize;
                         size = TargetDetails.MaximumPrimitiveSize;
                         isGcBoxedField = true;
@@ -372,7 +372,7 @@ namespace ILCompiler
                         if (moduleLayout && fieldDesc.FieldType.GetTypeDefinition() is EcmaType ecmaType && ecmaType.EcmaModule != module)
                         {
                             // Allocate pessimistic non-GC area for cross-module fields as that's what CoreCLR does
-                            // <a href="https://github.com/dotnet/coreclr/blob/659af58047a949ed50d11101708538d2e87f2568/src/vm/ceeload.cpp#L2124">here</a>
+                            // <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/ceeload.cpp#L1006">here</a>
                             alignment = TargetDetails.MaximumPrimitiveSize;
                             size = TargetDetails.MaximumPrimitiveSize;
                             isGcBoxedField = true;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1543,7 +1543,7 @@ namespace Internal.JitInterface
 
             // This formula roughly corresponds to CoreCLR CEEInfo::resolveToken when calling GetMethodDescFromMethodSpec
             // (that always winds up by calling FindOrCreateAssociatedMethodDesc) at
-            // https://github.com/dotnet/coreclr/blob/57a6eb69b3d6005962ad2ae48db18dff268aff56/src/vm/jitinterface.cpp#L1141
+            // https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/jitinterface.cpp#L1054
             // Its basic meaning is that shared generic methods always need instantiating
             // stubs as the shared generic code needs the method dictionary parameter that cannot
             // be provided by other means.
@@ -1624,7 +1624,7 @@ namespace Internal.JitInterface
 
                     // This check for introducing an instantiation stub comes from the logic in
                     // MethodTable::TryResolveConstraintMethodApprox at
-                    // https://github.com/dotnet/coreclr/blob/57a6eb69b3d6005962ad2ae48db18dff268aff56/src/vm/methodtable.cpp#L10062
+                    // https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/methodtable.cpp#L8628
                     // Its meaning is that, for direct method calls on value types, instantiating
                     // stubs are always needed in the presence of generic arguments as the generic
                     // dictionary cannot be passed through "this->method table".

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
     public class GcInfo : BaseGcInfo
     {
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcinfodecoder.h">src/inc/gcinfodecoder.h</a> GcInfoHeaderFlags
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfodecoder.h">src/inc/gcinfodecoder.h</a> GcInfoHeaderFlags
         /// </summary>
         private enum GcInfoHeaderFlags
         {
@@ -84,7 +84,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         public GcInfo() { }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/gcinfodecoder.cpp">GcInfoDecoder::GcInfoDecoder</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcInfoDecoder::GcInfoDecoder</a>
         /// </summary>
         public GcInfo(byte[] image, int offset, Machine machine, ushort majorVersion)
         {
@@ -305,7 +305,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/gcinfodecoder.cpp">GcInfoDecoder::GcInfoDecoder</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcInfoDecoder::GcInfoDecoder</a>
         /// </summary>
         private void ParseHeaderFlags(byte[] image, ref int bitOffset)
         {
@@ -347,7 +347,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         }
 
         /// <summary>
-        /// based on beginning of <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/gcinfodecoder.cpp">GcInfoDecoder::EnumerateLiveSlots</a>
+        /// based on beginning of <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcInfoDecoder::EnumerateLiveSlots</a>
         /// </summary>
         private List<InterruptibleRange> EnumerateInterruptibleRanges(byte[] image, int interruptibleRangeDelta1EncBase, int interruptibleRangeDelta2EncBase, ref int bitOffset)
         {
@@ -484,7 +484,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         }
 
         /// <summary>
-        /// based on end of <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/gcinfodecoder.cpp">GcInfoDecoder::EnumerateLiveSlots and GcInfoEncoder::Build</a>
+        /// based on end of <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcInfoDecoder::EnumerateLiveSlots and GcInfoEncoder::Build</a>
         /// </summary>
         private Dictionary<int, List<BaseGcTransition>> GetTransitions(byte[] image, ref int bitOffset)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
@@ -96,7 +96,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         public GcSlotTable() { }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/gcinfodecoder.cpp">GcSlotDecoder::DecodeSlotTable</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/gcinfodecoder.cpp">GcSlotDecoder::DecodeSlotTable</a>
         /// </summary>
         public GcSlotTable(byte[] image, Machine machine, GcInfoTypes gcInfoTypes, ref int bitOffset)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/Registers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/Registers.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun.Amd64
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/gcdumpnonx86.cpp">src\gcdump\gcdumpnonx86.cpp</a> GetRegName
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/gcdumpnonx86.cpp">src\gcdump\gcdumpnonx86.cpp</a> GetRegName
     /// </summary>
     public enum Registers
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun.Amd64
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_OP_CODES
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_OP_CODES
     /// </summary>
     public enum UnwindOpCodes
     {
@@ -27,7 +27,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
     }
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_OP_CODES
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_OP_CODES
     /// </summary>
     public enum UnwindFlags
     {
@@ -38,7 +38,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
     }
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_CODE
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_CODE
     /// </summary>
     public class UnwindCode
     {
@@ -150,7 +150,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
     }
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_INFO
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_INFO
     /// </summary>
     public class UnwindInfo : BaseUnwindInfo
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         public UnwindCode() { }
 
         /// <summary>
-        /// Unwinde code parsing is based on <a href="https://github.com/dotnet/coreclr/blob/master/src/jit/unwindamd64.cpp">src\jit\unwindamd64.cpp</a> DumpUnwindInfo
+        /// Unwinde code parsing is based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/jit/unwindamd64.cpp">src\jit\unwindamd64.cpp</a> DumpUnwindInfo
         /// </summary>
         public UnwindCode(byte[] image, ref int frameOffset, ref int offset)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm/Registers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm/Registers.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun.Arm
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/jit/unwindarm.cpp">src/jit/unwindarm.cpp</a> mapRegNumToDwarfReg
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/jit/unwindarm.cpp">src/jit/unwindarm.cpp</a> mapRegNumToDwarfReg
     /// </summary>
     public enum Registers
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm/UnwindInfo.cs
@@ -56,7 +56,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm
     }
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/jit/unwindarm.cpp">src/jit/unwindarm.cpp</a> DumpUnwindInfo
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/jit/unwindarm.cpp">src/jit/unwindarm.cpp</a> DumpUnwindInfo
     /// </summary>
     public class UnwindInfo : BaseUnwindInfo
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm64/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Arm64/UnwindInfo.cs
@@ -57,7 +57,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Arm64
     }
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/jit/unwindarm.cpp">src/jit/unwindarm.cpp</a> DumpUnwindInfo
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/jit/unwindarm.cpp">src/jit/unwindarm.cpp</a> DumpUnwindInfo
     /// </summary>
     public class UnwindInfo : BaseUnwindInfo
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
@@ -12,7 +12,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 {
     /// <summary>
     /// Represents the debug information for a single method in the ready-to-run image.
-    /// See <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/cordebuginfo.h">src\inc\cordebuginfo.h</a> for
+    /// See <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/cordebuginfo.h">src\inc\cordebuginfo.h</a> for
     /// the fundamental types this is based on.
     /// </summary>
     public class DebugInfo

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/EHInfo.cs
@@ -33,7 +33,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// <summary>
     /// This class represents a single exception handling clause. It basically corresponds
     /// to IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT in
-    /// <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/cordebuginfo.h">src\inc\corhdr.h</a>.
+    /// <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/cordebuginfo.h">src\inc\corhdr.h</a>.
     /// </summary>
     public class EHClause
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a> infoHdrAdjustConstants
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a> infoHdrAdjustConstants
     /// </summary>
     enum InfoHdrAdjustConstants
     {
@@ -26,7 +26,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
     /// <summary>
     /// Enum to define codes that are used to incrementally adjust the InfoHdr structure.
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a> infoHdrAdjustConstants
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a> infoHdrAdjustConstants
     /// </summary>
     enum InfoHdrAdjust
     {
@@ -68,7 +68,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     };
 
     /// <summary>
-    /// based on macros defined in <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a>
+    /// based on macros defined in <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a>
     /// </summary>
     public class GcInfoTypes
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeArray.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeArray.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/nativeformatreader.h">NativeFormat::NativeArray</a>
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/nativeformatreader.h">NativeFormat::NativeArray</a>
     /// </summary>
     public class NativeArray
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeHashtable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeHashtable.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/nativeformatreader.h">NativeFormat::NativeParser</a>
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/nativeformatreader.h">NativeFormat::NativeParser</a>
     /// </summary>
     public struct NativeParser
     {
@@ -80,7 +80,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     }
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/nativeformatreader.h">NativeFormat::NativeHashtable</a>
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/nativeformatreader.h">NativeFormat::NativeHashtable</a>
     /// </summary>
     public struct NativeHashtable
     {
@@ -241,7 +241,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     }
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/nativeformatreader.h">NativeFormat::NativeHashtable</a>
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/nativeformatreader.h">NativeFormat::NativeHashtable</a>
     /// </summary>
     public struct NativeCuckooFilter
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeReader.cs
@@ -128,7 +128,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         // <summary>
         /// Decode variable length numbers
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcinfodecoder.h">src\inc\gcinfodecoder.h</a> DecodeVarLengthUnsigned
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfodecoder.h">src\inc\gcinfodecoder.h</a> DecodeVarLengthUnsigned
         /// </summary>
         /// <param name="image">PE image</param>
         /// <param name="len">Number of bits to read</param>
@@ -153,7 +153,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         // <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcinfodecoder.h">src\inc\gcinfodecoder.h</a> DecodeVarLengthSigned
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfodecoder.h">src\inc\gcinfodecoder.h</a> DecodeVarLengthSigned
         /// </summary>
         public static int DecodeVarLengthSigned(byte[] image, int len, ref int bitOffset)
         {
@@ -175,7 +175,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         // <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/nativeformatreader.h">src\vm\nativeformatreader.h</a> DecodeUnsigned
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/nativeformatreader.h">src\vm\nativeformatreader.h</a> DecodeUnsigned
         /// </summary>
         public static uint DecodeUnsigned(byte[] image, uint offset, ref uint pValue)
         {
@@ -234,7 +234,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         // <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/vm/nativeformatreader.h">src\vm\nativeformatreader.h</a> DecodeSigned
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/nativeformatreader.h">src\vm\nativeformatreader.h</a> DecodeSigned
         /// </summary>
         public static uint DecodeSigned(byte[] image, uint offset, ref int pValue)
         {
@@ -320,7 +320,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeUnsigned
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeUnsigned
         /// </summary>
         public static uint DecodeUnsignedGc(byte[] image, ref int start)
         {
@@ -338,7 +338,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeSigned
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeSigned
         /// </summary>
         public static int DecodeSignedGc(byte[] image, ref int start)
         {
@@ -360,7 +360,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeUDelta
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeUDelta
         /// </summary>
         public static uint DecodeUDelta(byte[] image, ref int start, uint lastValue)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunHeader.cs
@@ -88,7 +88,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h">src/inc/readytorun.h</a> READYTORUN_HEADER
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/readytorun.h">src/inc/readytorun.h</a> READYTORUN_HEADER
     /// </summary>
     public class ReadyToRunHeader : ReadyToRunCoreHeader
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunImportSection.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunImportSection.cs
@@ -10,7 +10,7 @@ using Internal.ReadyToRunConstants;
 namespace ILCompiler.Reflection.ReadyToRun
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/readytorun.h">src/inc/readytorun.h</a> READYTORUN_IMPORT_SECTION
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/readytorun.h">src/inc/readytorun.h</a> READYTORUN_IMPORT_SECTION
     /// </summary>
     public struct ReadyToRunImportSection
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -21,7 +21,7 @@ using Debug = System.Diagnostics.Debug;
 namespace ILCompiler.Reflection.ReadyToRun
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/pedecoder.h">src/inc/pedecoder.h</a> IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/pedecoder.h">src/inc/pedecoder.h</a> IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE
     /// </summary>
     public enum OperatingSystem
     {
@@ -1388,7 +1388,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         /// <summary>
         /// Reads the method entrypoint from the offset. Used for non-generic methods
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/debug/daccess/nidump.cpp">NativeImageDumper::DumpReadyToRunMethods</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/debug/daccess/nidump.cpp">NativeImageDumper::DumpReadyToRunMethods</a>
         /// </summary>
         private void GetRuntimeFunctionIndexFromOffset(int offset, out int runtimeFunctionIndex, out int? fixupOffset)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -544,7 +544,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         /// <summary>
         /// Read a single unsigned 32-bit in from the signature stream. Adapted from CorSigUncompressData,
-        /// <a href="">https://github.com/dotnet/coreclr/blob/master/src/inc/cor.h</a>.
+        /// <a href="">https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/cor.h</a>.
         /// </summary>
         /// <param name="data"></param>
         public uint ReadUInt()
@@ -574,7 +574,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// Read a signed integer from the signature stream. Signed integer is basically encoded
         /// as an unsigned integer after converting it to the unsigned number 2 * abs(x) + (x &gt;= 0 ? 0 : 1).
-        /// Adapted from CorSigUncompressSignedInt, <a href="">https://github.com/dotnet/coreclr/blob/master/src/inc/cor.h</a>.
+        /// Adapted from CorSigUncompressSignedInt, <a href="">https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/cor.h</a>.
         /// </summary>
         public int ReadInt()
         {
@@ -619,7 +619,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         /// <summary>
         /// Read a single element type from the signature stream. Adapted from CorSigUncompressElementType,
-        /// <a href="">https://github.com/dotnet/coreclr/blob/master/src/inc/cor.h</a>.
+        /// <a href="">https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/cor.h</a>.
         /// </summary>
         /// <returns></returns>
         public CorElementType ReadElementType()

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/CallPattern.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/CallPattern.cs
@@ -11,7 +11,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
     {
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeCallPattern
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> decodeCallPattern
         /// </summary>
         public static void DecodeCallPattern(uint pattern, out uint argCnt, out uint regMask, out uint argMask, out uint codeDelta)
         {
@@ -24,12 +24,12 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> callCommonDelta
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> callCommonDelta
         /// </summary>
         public static uint[] callCommonDelta = { 6, 8, 10, 12 };
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> callPatternTable
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> callPatternTable
         /// </summary>
         private static uint[] callPatternTable =
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcInfo.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         public GcInfo() { }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
         public GcInfo(byte[] image, int offset, Machine machine, ushort majorVersion)
         {
@@ -95,7 +95,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
         private void GetTransitionsFullyInterruptible(byte[] image, ref int offset)
         {
@@ -197,7 +197,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
         private void GetTransitionsEbpFrame(byte[] image, ref int offset)
         {
@@ -340,7 +340,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
         private void SaveCallTransition(byte[] image, ref int offset, uint val, uint curOffs, uint callRegMask, bool callPndTab, uint callPndTabCnt, uint callPndMask, uint lastSkip, ref uint imask)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcSlotTable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/GcSlotTable.cs
@@ -122,7 +122,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
         private void DecodeUntracked(byte[] image, InfoHdrSmall header, ref int offset)
         {
@@ -163,7 +163,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpGCTable</a>
         /// </summary>
         private void DecodeFrameVariableLifetimeTable(byte[] image, InfoHdrSmall header, ref int offset)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/InfoHdr.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun.x86
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a> InfoHdrSmall
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a> InfoHdrSmall
     /// </summary>
     public struct InfoHdrSmall
     {
@@ -161,7 +161,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         private const uint YES = HAS_VARPTR;
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a> GetInfoHdr
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcinfotypes.h">src\inc\gcinfotypes.h</a> GetInfoHdr
         /// </summary>
         public static InfoHdrSmall GetInfoHdr(byte encoding)
         {
@@ -170,7 +170,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
 
         /// <summary>
         /// Initialize the GcInfo header
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> DecodeHeader and <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">GCDump::DumpInfoHdr</a>
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> DecodeHeader and <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">GCDump::DumpInfoHdr</a>
         /// </summary>
         public static InfoHdrSmall DecodeHeader(byte[] image, ref int offset, int codeLength)
         {
@@ -378,7 +378,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
         }
 
         /// <summary>
-        /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> infoHdrShortcut
+        /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/gcdecoder.cpp">src\inc\gcdecoder.cpp</a> infoHdrShortcut
         /// </summary>
         private static InfoHdrSmall[] _infoHdrShortcut = {
             new InfoHdrSmall(  0,  1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0          ),  //    1139  00

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/Registers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/Registers.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun.x86
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">src\gcdump\i386\gcdumpx86.cpp</a> RegName
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">src\gcdump\i386\gcdumpx86.cpp</a> RegName
     /// </summary>
     public enum Registers
     {
@@ -23,7 +23,7 @@ namespace ILCompiler.Reflection.ReadyToRun.x86
     };
 
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/gcdump/i386/gcdumpx86.cpp">src\gcdump\i386\gcdumpx86.cpp</a> CalleeSavedRegName
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/gcdump/i386/gcdumpx86.cpp">src\gcdump\i386\gcdumpx86.cpp</a> CalleeSavedRegName
     /// </summary>
     public enum CalleeSavedRegisters
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/x86/UnwindInfo.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace ILCompiler.Reflection.ReadyToRun.x86
 {
     /// <summary>
-    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_INFO
+    /// based on <a href="https://github.com/dotnet/runtime/blob/main/src/coreclr/inc/win64unwind.h">src\inc\win64unwind.h</a> _UNWIND_INFO
     /// </summary>
     public class UnwindInfo : BaseUnwindInfo
     {

--- a/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
+++ b/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
@@ -9,7 +9,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <Serviceable>true</Serviceable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- Managed API isn't completely documented yet. TODO: https://github.com/dotnet/core-setup/issues/5108 -->
+    <!-- Managed API isn't completely documented yet. TODO: https://github.com/dotnet/runtime/issues/3450 -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Historically, the key for the managed projects is the AspNetCore key Arcade carries. -->

--- a/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
+++ b/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
@@ -9,7 +9,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <Serviceable>true</Serviceable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- Managed API isn't completely documented yet. TODO: https://github.com/dotnet/runtime/issues/3450 -->
+    <!-- Managed API isn't completely documented yet. TODO: https://github.com/dotnet/runtime/issues/43872 -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Historically, the key for the managed projects is the AspNetCore key Arcade carries. -->

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <!--
-    See https://github.com/dotnet/core-setup/issues/7846. Cross-arch MSI installers are needed for
+    See https://github.com/dotnet/runtime/issues/3746. Cross-arch MSI installers are needed for
     C++/CLI project system support.
   -->
   <ItemGroup>
@@ -68,7 +68,7 @@
     user's machine before use. We have a signing validation exception for Visual Studio insertion's
     signature validation. However, the exceptions are based on the file IDs, which are not stable
     because product version is in the path. We need to force these IDs to be stable by modifying
-    the WiX source file. https://github.com/dotnet/core-setup/issues/7327
+    the WiX source file. https://github.com/dotnet/runtime/issues/3694
   -->
   <ItemGroup>
     <HeatOutputFileElementToStabilize Include="native\apphost.exe" ReplacementId="apphosttemplateapphostexe" />

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining("Hello World");
         }
 
-        // https://github.com/dotnet/core-setup/issues/6914
+        // https://github.com/dotnet/runtime/issues/3654
         [Fact(Skip = "The 3.0 SDK copies NuGet references to the output by default now for executable projects, so this no longer fails.")]
         public void Muxer_Exec_activation_of_Build_Output_Portable_DLL_with_DepsJson_Local_and_RuntimeConfig_Remote_Without_AdditionalProbingPath_Fails()
         {
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Should().Fail();
         }
 
-        // https://github.com/dotnet/core-setup/issues/6914
+        // https://github.com/dotnet/runtime/issues/3654
         [Fact(Skip = "The 3.0 SDK copies NuGet references to the output by default now for executable projects, so this no longer fails.")]
         public void Muxer_Exec_activation_of_Build_Output_Portable_DLL_with_DepsJson_Local_and_RuntimeConfig_Remote_With_AdditionalProbingPath_Succeeds()
         {
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .And.HaveStdOutContaining("Hello World");
         }
 
-        // https://github.com/dotnet/core-setup/issues/6914
+        // https://github.com/dotnet/runtime/issues/3654
         [Fact(Skip = "The 3.0 SDK copies NuGet references to the output by default now for executable projects, so the additional probing path is no longer needed.")]
         public void Muxer_Activation_With_Templated_AdditionalProbingPath_Succeeds()
         {

--- a/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
+++ b/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
                 "Microsoft.NETCore.App.Ref"))
             {
                 // Allow no targeting pack in case this is a servicing build.
-                // This condition should be tightened: https://github.com/dotnet/core-setup/issues/8830
+                // This condition should be tightened: https://github.com/dotnet/runtime/issues/3836
                 if (tester == null)
                 {
                     return;

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextWriter.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/DependencyContextWriter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.DependencyModel
             ThrowHelper.ThrowIfNull(context);
             ThrowHelper.ThrowIfNull(stream);
 
-            // Custom encoder is required to fix https://github.com/dotnet/core-setup/issues/7137
+            // Custom encoder is required to fix https://github.com/dotnet/runtime/issues/3678
             // Since the JSON is only written to a file that is read by the SDK (and not transmitted over the wire),
             // it is safe to skip escaping certain characters in this scenario
             // (that would otherwise be escaped, by default, as part of defense-in-depth, such as +).

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextJsonWriterTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextJsonWriterTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                                         "package",
                                         "PackageName",
                                         "1.2.3",
-                                        "HASH+/==", // verify that '+' and '/' is not getting escaped to workaround bug in older xunit https://github.com/dotnet/core-setup/issues/7137
+                                        "HASH+/==", // verify that '+' and '/' is not getting escaped to workaround bug in older xunit https://github.com/dotnet/runtime/issues/3678
                                         new [] {"Banana.dll"},
                                         new [] {
                                             new Dependency("Fruits.Abstract.dll","2.0.0")

--- a/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.ConcurrentAccessDetection.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.ConcurrentAccessDetection.cs
@@ -84,7 +84,7 @@ namespace Generic.Dictionary
         }
     }
 
-    // We use a custom type instead of string because string use optimized comparer https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs#L79
+    // We use a custom type instead of string because string use optimized comparer https://github.com/dotnet/runtime/blob/2594ec1bfb3d8a82815691a80cc4a23b5a281b2e/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs#L44
     // We want to test case with _comparer = null
     public class DummyRefType
     {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -208,7 +208,7 @@ namespace System.Diagnostics
         /// <see cref="Start"/> is called by appending suffix to Parent.Id
         /// or ParentId; Activity has no Id until it started
         /// <para/>
-        /// See <see href="https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/> for more details
+        /// See <see href="https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/> for more details
         /// </summary>
         /// <example>
         /// Id looks like '|a000b421-5d183ab6.1.8e2d4c28_1.':<para />
@@ -246,7 +246,7 @@ namespace System.Diagnostics
         /// from the parent).   This accessor fetches the parent ID if it exists at all.
         /// Note this can be null if this is a root Activity (it has no parent)
         /// <para/>
-        /// See <see href="https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/> for more details
+        /// See <see href="https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/> for more details
         /// </summary>
         public string? ParentId
         {
@@ -1757,7 +1757,7 @@ namespace System.Diagnostics
     public enum ActivityIdFormat
     {
         Unknown = 0,      // ID format is not known.
-        Hierarchical = 1, //|XXXX.XX.X_X ... see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format
+        Hierarchical = 1, //|XXXX.XX.X_X ... see https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format
         W3C = 2,          // 00-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXX-XX see https://w3c.github.io/trace-context/
     };
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -279,7 +279,7 @@ namespace System.Diagnostics
         /// Root Id is substring from Activity.Id (or ParentId) between '|' (or beginning) and first '.'.
         /// Filtering by root Id allows to find all Activities involved in operation processing.
         /// RootId may be null if Activity has neither ParentId nor Id.
-        /// See <see href="https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/> for more details
+        /// See <see href="https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/> for more details
         /// </summary>
         public string? RootId
         {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -23,7 +23,7 @@ namespace System.Diagnostics
     /// will fire for every live DiagnosticListener in the appdomain (past or present).
     ///
     /// Please See the DiagnosticSource Users Guide
-    /// https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
+    /// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
     /// for instructions on its use.
     /// </summary>
     public partial class DiagnosticListener : DiagnosticSource, IObservable<KeyValuePair<string, object?>>, IDisposable

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics
     /// (which can also write object), but is intended to log complex objects that can't be serialized.
     ///
     /// Please See the DiagnosticSource Users Guide
-    /// https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
+    /// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md
     /// for instructions on its use.
     /// </summary>
     public abstract partial class DiagnosticSource

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics.Tracing
     /// <summary>
     /// Provides the ability to collect statistics through EventSource
     ///
-    /// See https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md
+    /// See https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md
     /// for a tutorial guide.
     ///
     /// See https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestEventCounter.cs

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
@@ -298,7 +298,7 @@ namespace System.Reflection.Metadata.Ecma335
         /// <param name="value">Document name.</param>
         /// <returns>
         /// Handle to the added or existing document name blob
-        /// (see https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md#DocumentNameBlob).
+        /// (see https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md#DocumentNameBlob).
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
         public BlobHandle GetOrAddDocumentName(string value)

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/Ecma/EcmaCustomAttributeHelpers.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/Ecma/EcmaCustomAttributeHelpers.cs
@@ -172,7 +172,7 @@ namespace System.Reflection.TypeLoading.Ecma
         //
         // Logic ported from ParseNativeTypeInfo()
         //
-        // https://github.com/dotnet/coreclr/blob/ab9b4511180d1dfde09d1480c29a7bbacf3587dd/src/vm/mlinfo.cpp#L512
+        // https://github.com/dotnet/runtime/blob/b908ecf514f32c7ba7d59ecc28fa3fdd64a10a1a/src/coreclr/vm/mlinfo.cpp#L469
         //
         public static MarshalAsAttribute ToMarshalAsAttribute(this BlobHandle blobHandle, EcmaModule module)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Transcoding.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Transcoding.cs
@@ -29,7 +29,7 @@ namespace System.Text.Json
         {
             //
             //
-            // KEEP THIS IMPLEMENTATION IN SYNC WITH https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs#L841
+            // KEEP THIS IMPLEMENTATION IN SYNC WITH https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs#L845
             //
             //
             fixed (byte* chars = &MemoryMarshal.GetReference(utf16Source))

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -95,7 +95,7 @@ namespace System.Reflection
             }
         }
 
-        // Copied from https://github.com/dotnet/coreclr/blob/7a24a538cd265993e5864179f51781398c28ecdf/src/System.Private.CoreLib/src/System/RtType.cs#L2022
+        // Copied from https://github.com/dotnet/runtime/blob/2594ec1bfb3d8a82815691a80cc4a23b5a281b2e/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs#L2058
         private static BindingFlags FilterPreCalculate(bool isPublic, bool isInherited, bool isStatic)
         {
             BindingFlags bindingFlags = isPublic ? BindingFlags.Public : BindingFlags.NonPublic;

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -857,7 +857,7 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	}
 
 	// Looking up corlib resources here can cause an infinite loop
-	// See: https://github.com/dotnet/coreclr/blob/0a762eb2f3a299489c459da1ddeb69e042008f07/src/vm/appdomain.cpp#L5178-L5239
+	// See: https://github.com/dotnet/runtime/blob/753d12facef5aa9d7926e3e284bfb40b7197f016/src/coreclr/vm/appdomain.cpp#L3518-L3572
 	if (!(strcmp (aname->name, MONO_ASSEMBLY_CORLIB_RESOURCE_NAME) == 0 && is_satellite) && postload) {
 		reference = mono_assembly_invoke_search_hook_internal (alc, requesting, aname, TRUE);
 		if (reference) {

--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -780,7 +780,7 @@ compare_guid (guint8* guid1, guint8* guid2)
 }
 
 // for parent_type see HasCustomDebugInformation table at
-// https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/specs/PortablePdb-Metadata.md
+// https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md
 static const char*
 lookup_custom_debug_information (MonoImage* image, guint32 token, uint8_t parent_type, guint8* guid)
 {

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -233,7 +233,7 @@ ves_icall_System_Array_SetValueRelaxedImpl (MonoArrayHandle arr, MonoObjectHandl
 	array_set_value_impl (arr, value, pos, FALSE, FALSE, error);
 }
 
-// Copied from CoreCLR: https://github.com/dotnet/coreclr/blob/d3e39bc2f81e3dbf9e4b96347f62b49d8700336c/src/vm/invokeutil.cpp#L33
+// Copied from CoreCLR: https://github.com/dotnet/runtime/blob/402aa8584ed18792d6bc6ed1869f7c31b38f8139/src/coreclr/vm/invokeutil.cpp#L31
 #define PT_Primitive          0x01000000
 
 static const guint32 primitive_conversions [] = {
@@ -253,7 +253,7 @@ static const guint32 primitive_conversions [] = {
 	PT_Primitive | 0x2000,	// MONO_TYPE_R8   (W = R8)
 };
 
-// Copied from CoreCLR: https://github.com/dotnet/coreclr/blob/030a3ea9b8dbeae89c90d34441d4d9a1cf4a7de6/src/vm/invokeutil.h#L176
+// Copied from CoreCLR: https://github.com/dotnet/runtime/blob/402aa8584ed18792d6bc6ed1869f7c31b38f8139/src/coreclr/vm/invokeutil.h#L119
 static
 gboolean can_primitive_widen (MonoTypeEnum src_type, MonoTypeEnum dest_type)
 {
@@ -263,7 +263,7 @@ gboolean can_primitive_widen (MonoTypeEnum src_type, MonoTypeEnum dest_type)
 	return ((1 << dest_type) & primitive_conversions [src_type]) != 0;
 }
 
-// Copied from CoreCLR: https://github.com/dotnet/coreclr/blob/eafa8648ebee92de1380278b15cd5c2b6ef11218/src/vm/array.cpp#L1406
+// Copied from CoreCLR: https://github.com/dotnet/runtime/blob/402aa8584ed18792d6bc6ed1869f7c31b38f8139/src/coreclr/vm/array.cpp#L1312
 static MonoTypeEnum
 get_normalized_integral_array_element_type (MonoTypeEnum elementType)
 {

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -5482,7 +5482,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 #ifdef TARGET_WIN32
 			// Redundant REX byte indicates a tailcall to the native unwinder. It means nothing to the processor.
-			// https://github.com/dotnet/coreclr/blob/966dabb5bb3c4bf1ea885e1e8dc6528e8c64dc4f/src/unwinder/amd64/unwinder_amd64.cpp#L1394
+			// https://github.com/dotnet/runtime/blob/384dceb4547d3aa240107dc3fbd4abc4387ced70/src/coreclr/unwinder/amd64/unwinder_amd64.cpp#L1390
 			// FIXME This should be jmp rip+32 for AOT direct to same assembly.
 			// FIXME This should be jmp [rip+32] for AOT direct to not-same assembly (through data).
 			// FIXME This should be jmp [rip+32] for JIT direct -- patch data instead of code.

--- a/src/mono/mono/utils/mono-dl.c
+++ b/src/mono/mono/utils/mono-dl.c
@@ -158,7 +158,7 @@ static const char *
 fix_libc_name (const char *name)
 {
 	if (name != NULL && strcmp (name, "libc") == 0) {
-		// Taken from CoreCLR: https://github.com/dotnet/coreclr/blob/6b0dab793260d36e35d66c82678c63046828d01b/src/pal/src/loader/module.cpp#L568-L576
+		// Taken from CoreCLR: https://github.com/dotnet/runtime/blob/732b7434a2ff453048c1647262c00bc8b7652112/src/coreclr/pal/src/loader/module.cpp#L569-L577
 #if defined (HOST_DARWIN)
 		return "/usr/lib/libc.dylib";
 #elif defined (__FreeBSD__)

--- a/src/mono/mono/utils/mono-proclib.c
+++ b/src/mono/mono/utils/mono-proclib.c
@@ -145,7 +145,7 @@ mono_cpu_count (void)
  * [2] https://lists.01.org/pipermail/powertop/2012-September/000433.html
  * [3] https://android.googlesource.com/platform/libcore/+/750dc634e56c58d1d04f6a138734ac2b772900b5%5E1..750dc634e56c58d1d04f6a138734ac2b772900b5/
  * [4] https://bugs.openjdk.java.net/browse/JDK-6515172
- * [5] https://github.com/dotnet/coreclr/blob/7058273693db2555f127ce16e6b0c5b40fb04867/src/pal/src/misc/sysinfo.cpp#L148
+ * [5] https://github.com/dotnet/runtime/blob/732b7434a2ff453048c1647262c00bc8b7652112/src/coreclr/pal/src/misc/sysinfo.cpp#L126
  */
 
 #if defined (_SC_NPROCESSORS_CONF) && defined (HAVE_SYSCONF)

--- a/src/mono/mono/utils/mono-time.c
+++ b/src/mono/mono/utils/mono-time.c
@@ -114,7 +114,7 @@ MONO_RESTORE_WARNING
 #include <time.h>
 
 /* Returns the number of milliseconds from boot time: this should be monotonic */
-/* Adapted from CoreCLR: https://github.com/dotnet/coreclr/blob/66d2738ea96fcce753dec1370e79a0c78f7b6adb/src/pal/src/misc/time.cpp */
+/* Adapted from CoreCLR: https://github.com/dotnet/runtime/blob/402aa8584ed18792d6bc6ed1869f7c31b38f8139/src/coreclr/pal/src/misc/time.cpp */
 gint64
 mono_msec_boottime (void)
 {

--- a/src/mono/mono/utils/mono-utils-debug.c
+++ b/src/mono/mono/utils/mono-utils-debug.c
@@ -41,7 +41,7 @@ static gboolean
 mono_is_usermode_native_debugger_present_slow (void)
 // PAL_IsDebuggerPresent
 // based closely on with some local cleanup:
-//   https://github.com/dotnet/coreclr/blob/master/src/pal/src/init/pal.cpp
+//   https://github.com/dotnet/runtime/blob/main/src/coreclr/pal/src/init/pal.cpp
 //   https://raw.githubusercontent.com/dotnet/coreclr/f1c9dac3e2db2397e01cd2da3e8aaa4f81a80013/src/pal/src/init/pal.cpp
 {
 #if defined (__APPLE__)

--- a/src/native/corehost/hostmisc/longfile.windows.cpp
+++ b/src/native/corehost/hostmisc/longfile.windows.cpp
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-//The logic in this file was ported from https://github.com/dotnet/coreclr/blob/54891e0650e69f08832f75a40dc102efc6115d38/src/utilcode/longfilepathwrappers.cpp
+//The logic in this file was ported from https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/utilcode/longfilepathwrappers.cpp
 //Please reflect any change here into the above file too!
 #include "pal.h"
 #include "trace.h"
@@ -33,7 +33,7 @@ bool ShouldNormalizeWorker(const pal::string_t& path)
 
 //For longpath names on windows, if the paths are normalized they are always prefixed with
 //extended syntax, Windows does not do any more normalizations on this string and uses it as is
-//So we should ensure that there are NO adjacent DirectorySeparatorChar 
+//So we should ensure that there are NO adjacent DirectorySeparatorChar
 bool AssertRepeatingDirSeparator(const pal::string_t& path)
 {
     if (path.empty())

--- a/src/native/eventpipe/ds-process-protocol.c
+++ b/src/native/eventpipe/ds-process-protocol.c
@@ -91,7 +91,7 @@ static
 uint16_t
 process_info_payload_get_size (DiagnosticsProcessInfoPayload *payload)
 {
-	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md
 	// for definition of serialization format
 
 	// uint64_t ProcessId;  -> 8 bytes
@@ -137,7 +137,7 @@ process_info_payload_flatten (
 	EP_ASSERT (size != NULL);
 	EP_ASSERT (process_info_payload_get_size (process_info) == *size);
 
-	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md
 	// for definition of serialization format
 
 	bool success = true;
@@ -205,7 +205,7 @@ static
 uint16_t
 process_info_2_payload_get_size (DiagnosticsProcessInfo2Payload *payload)
 {
-	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md
 	// for definition of serialization format
 
 	// uint64_t ProcessId;  -> 8 bytes
@@ -261,7 +261,7 @@ process_info_2_payload_flatten (
 	EP_ASSERT (size != NULL);
 	EP_ASSERT (process_info_2_payload_get_size (process_info) == *size);
 
-	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md
 	// for definition of serialization format
 
 	bool success = true;
@@ -388,7 +388,7 @@ env_info_payload_flatten (
 	EP_ASSERT (size != NULL);
 	EP_ASSERT (env_info_payload_get_size (env_info) == *size);
 
-	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md
 	// for definition of serialization format
 
 	bool success = true;
@@ -420,7 +420,7 @@ env_info_stream_env_block (
 	EP_ASSERT (payload != NULL);
 	EP_ASSERT (stream != NULL);
 
-	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+	// see IPC spec @ https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md
 	// for definition of serialization format
 
 	bool success = true;

--- a/src/native/eventpipe/ds-process-protocol.h
+++ b/src/native/eventpipe/ds-process-protocol.h
@@ -119,7 +119,7 @@ struct _DiagnosticsEnvironmentInfoPayload_Internal {
 #endif
 	// The environment is sent back as an optional continuation stream of data.
 	// It is encoded in the typical length-prefixed array format as defined in
-	// the Diagnostics IPC Spec: https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+	// the Diagnostics IPC Spec: https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md
 	uint32_t incoming_bytes;
 	uint16_t future;
 	ep_rt_env_array_utf16_t env_array;

--- a/src/tests/JIT/HardwareIntrinsics/X86/General/VectorArgs.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/General/VectorArgs.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
-// This test case is ported from S.N.Vector counterpart 
-// https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorArgs.cs
+// This test case is ported from S.N.Vector counterpart
+// https://github.com/dotnet/runtime/blob/main/src/tests/JIT/SIMD/VectorUnused.cs
 
 using System;
 using System.Runtime.Intrinsics;

--- a/src/tests/JIT/HardwareIntrinsics/X86/General/VectorArray.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/General/VectorArray.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
-// This test case is ported from S.N.Vector counterpart 
-// https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorArray.cs
+// This test case is ported from S.N.Vector counterpart
+// https://github.com/dotnet/runtime/blob/main/src/tests/JIT/SIMD/VectorArray.cs
 
 using System;
 using System.Numerics;

--- a/src/tests/JIT/HardwareIntrinsics/X86/General/VectorRet.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/General/VectorRet.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
-// This test case is ported from S.N.Vector counterpart 
-// https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorReturn.cs
+// This test case is ported from S.N.Vector counterpart
+// https://github.com/dotnet/runtime/blob/main/src/tests/JIT/SIMD/VectorReturn.cs
 
 using System;
 using System.Runtime.Intrinsics;

--- a/src/tests/JIT/HardwareIntrinsics/X86/General/VectorUnused.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86/General/VectorUnused.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 
-// This test case is ported from S.N.Vector counterpart 
-// https://github.com/dotnet/coreclr/blob/master/tests/src/JIT/SIMD/VectorUnused.cs
+// This test case is ported from S.N.Vector counterpart
+// https://github.com/dotnet/runtime/blob/main/src/tests/JIT/SIMD/VectorUnused.cs
 
 using System;
 using System.Runtime.Intrinsics;

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/GitHub21379.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/GitHub21379.cs
@@ -80,7 +80,7 @@ public class GitHub21379
             // Basic: forward SZArray
             BinarySearch_Array(array, index, length, value, (IComparer)comparer, expected);
         }
-            
+
         if (index == 0 && length == array.Length)
         {
             if (isDefaultComparer)

--- a/src/tests/sizeondisk/sodbench/THIRD-PARTY-NOTICES.TXT
+++ b/src/tests/sizeondisk/sodbench/THIRD-PARTY-NOTICES.TXT
@@ -22,4 +22,4 @@ Content: https://stackoverflow.com/a/769713
 Question author: Bob The Janitor -- https://stackoverflow.com/users/55102/bob-the-janitor
 Answer author: harp -- https://stackoverflow.com/users/4525/harpo
 
-Use: https://github.com/dotnet/coreclr/blob/a9074bce5e3814db67dbec1c56f477202164d162/tests/src/sizeondisk/sodbench/SoDBench.cs#L738
+Use: https://github.com/dotnet/runtime/blob/4893732ba881a4fb9023af1d6d4e64bb2a6eddbc/src/tests/sizeondisk/sodbench/SoDBench.cs#L735


### PR DESCRIPTION
## Summary
Closes #73682
Repoint urls in docs and xmldocs from those that point to archived repos as dotnet/corefx, dotnet/coreclr, dotnet/core-setup so that they point to runtime repo. I also changed urls that point to file in dotnet/diagnostics repo that were moved, and urls that use obsolete default branch name.  
In cases when commit hashes were used as part of url I used most recent commit hash.

## Notes
* I've left links in [FreeBSD building instructions](https://github.com/dotnet/runtime/blob/main/docs/workflow/building/coreclr/freebsd-instructions.md) in place since patching them requires some knowledge about building coreclr and corefx that I don't have.
* I also didn't change docs that point to corefxlab repo, even though it's archived I couldn't find those docs in dotnet/runtime and dotnet/designs repos
https://github.com/dotnet/runtime/blob/384dceb4547d3aa240107dc3fbd4abc4387ced70/docs/coding-guidelines/api-guidelines/System.Memory.md?plain=1#L7-L8
* Also i didn't repoint urls to PRs since it looks like they didn't move to dotnet/runtime
* Also it seems there are some tests that use "obsolete" issue id as part of their filename like [this one](https://github.com/dotnet/runtime/blob/main/src/tests/nativeaot/SmokeTests/DynamicGenerics/GitHub21379.cs), i ignored such files.
* https://github.com/dotnet/coreclr/blob/master/src/zap/ referenced in https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs#L1391 https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs#L552 https://github.com/dotnet/runtime/blob/753d12facef5aa9d7926e3e284bfb40b7197f016/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs#L173 isn't present in runtime repo so references are left as is

* https://github.com/dotnet/runtime/blob/753d12facef5aa9d7926e3e284bfb40b7197f016/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/NativeReader.cs#L296 references code in https://github.com/dotnet/runtime/blob/main/src/coreclr/debug/daccess/nidump.cpp that isn't present there.

* https://github.com/dotnet/runtime/blob/b908ecf514f32c7ba7d59ecc28fa3fdd64a10a1a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/SignatureDecoder.cs#L315 references removed code it seems, the most close thing i could find is [here](https://github.com/dotnet/runtime/blob/b908ecf514f32c7ba7d59ecc28fa3fdd64a10a1a/src/coreclr/utilcode/util.cpp#L1752), it handles the same case, but logic isn't the same i suppose

* https://github.com/dotnet/runtime/blob/14be2a080974c454bed200dbdaa3fd1293ee530a/docs/project/garbage-collector-guidelines.md?plain=1#L42 references project in dotnet/coreclr which is no longer available