### PR TITLE
Temporarily remove Windows.11.Arm64.Open queue from runtime-extra-platforms

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -184,7 +184,8 @@ jobs:
     # windows arm64
     - ${{ if eq(parameters.platform, 'windows_arm64') }}:
       - Windows.10.Arm64.Open
-      - Windows.11.Arm64.Open
+      # TODO: Uncomment once there is HW deployed to service Win11 ARM64 queue
+      # - Windows.11.Arm64.Open
 
     # WebAssembly
     - ${{ if eq(parameters.platform, 'Browser_wasm') }}:


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/73713 added Windows.11.Arm64.Open runs to check MsQuic functionality there, but currently, there is no HW servicing the queue and the ci job timeouts. This PR temporarily suspends runs on the queue until appropriate HW is deployed to helix.

cc. @wfurt.