### PR TITLE
Suppress downgrade failure

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -90,9 +90,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>13b342360ba81ca3fdf911fda985dc8420d51627</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22408.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22410.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>13b342360ba81ca3fdf911fda985dc8420d51627</Sha>
+      <Sha>fd9941799bb6983a7d00ed72682378b46a45f396</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="7.0.0-beta.22408.3">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.22408.3</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22408.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>7.0.0-beta.22408.3</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>7.0.0-beta.22408.3</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>7.0.0-beta.22410.3</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>7.0.0-beta.22408.3</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksTargetFrameworkVersion>7.0.0-beta.22408.3</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>7.0.0-beta.22408.3</MicrosoftDotNetBuildTasksTemplatingVersion>


### PR DESCRIPTION
Update Microsoft.DotNet.Build.Tasks.Installers to pick up https://github.com/dotnet/arcade/pull/10339

Fixes https://github.com/dotnet/aspnetcore/issues/42764

Allows installation of earlier version of ASP.Net Hosting bundle package when newer runtime is installed on the machine.