### PR TITLE
Workload promotion

### DIFF
--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -209,20 +209,12 @@
         Exclude="@(DownloadedSymbolNupkgFile)" />
 
       <!--
-        Workloads VS insertion artifacts produced by src/workloads/workloads.csproj.
-        Manually dedupe the file set for publishing since we have duplicates files in separate
-        feature band folders and Distinct() works on the actual Include value.
+        Workloads VS insertion artifacts produced by src/workloads/workloads.csproj. Only grab
+        the zip artifacts as they're grouped by SDK feature band which correlates with specific VS versions.
       -->
-      <_WorkloadsVSInsertionFile
-        Include="
-          $(DownloadDirectory)*\workloads-vs\**\*.msi;
-          $(DownloadDirectory)*\workloads-vs\**\*.json" />
-      <__WorkloadsVSInsertionFile Include="%(_WorkloadsVSInsertionFile.Filename)%(Extension)" ActualPath="%(FullPath)" />
-      <___WorkloadsVSInsertionFile Include="@(__WorkloadsVSInsertionFile->Distinct())" />
-      <WorkloadsVSInsertionFile Include="%(___WorkloadsVSInsertionFile.ActualPath)" />
       <WorkloadsVSInsertionFile
         Include="
-          $(DownloadDirectory)**\Workloads.VSDrop*.zip" />
+          $(DownloadDirectory)*\workloads-vs\**\*.zip"/>
 
       <!--
         Runtime packages associated with some identity packages. Need to exclude "runtime.native.*"

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -18,6 +18,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
     <WorkloadIntermediateOutputPath>$(ArtifactsObjDir)workloads/</WorkloadIntermediateOutputPath>
+    <VSTemp>$(WorkloadIntermediateOutputPath)VS/</VSTemp>
     <WorkloadOutputPath>$(ArtifactsBinDir)workloads/</WorkloadOutputPath>
     <WorkloadOutputPath Condition="'$(workloadArtifactsPath)' != ''">$(workloadArtifactsPath)/</WorkloadOutputPath>
     <PackageSource>$(ArtifactsShippingPackagesDir)</PackageSource>
@@ -112,7 +113,7 @@
     </CreateVisualStudioWorkload>
 
     <!-- Build all the SWIX projects. This requires full framework MSBuild-->
-    <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VisualStudioSetupInsertionPath)%(SwixProjects.SdkFeatureBand)" />
+    <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VSTemp)%(SwixProjects.SdkFeatureBand)" />
 
     <!-- Create payload package for VSDROP creation -->
     <ItemGroup>
@@ -120,7 +121,8 @@
     </ItemGroup>
     
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" />
-    <ZipDirectory Overwrite="true" DestinationFile="$(WorkloadOutputPath)Workloads.VSDrop.%(SdkFeatureBand.Identity).$(PackageVersion).zip" SourceDirectory="$(VisualStudioSetupInsertionPath)%(SdkFeatureBand.Identity)"/>
+    <MakeDir Directories="$(VisualStudioSetupInsertionPath)" />
+    <ZipDirectory Overwrite="true" DestinationFile="$(VisualStudioSetupInsertionPath)Workloads.VSDrop.%(SdkFeatureBand.Identity).$(PackageVersion).zip" SourceDirectory="$(VSTemp)%(SdkFeatureBand.Identity)"/>
 
     <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
     <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -120,7 +120,7 @@
     </ItemGroup>
     
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" />
-    <ZipDirectory Overwrite="true" DestinationFile="$(ArtifactsNonShippingPackagesDir)Workloads.VSDrop.%(SdkFeatureBand.Identity).$(PackageVersion).zip" SourceDirectory="$(VisualStudioSetupInsertionPath)%(SdkFeatureBand.Identity)"/>
+    <ZipDirectory Overwrite="true" DestinationFile="$(WorkloadOutputPath)Workloads.VSDrop.%(SdkFeatureBand.Identity).$(PackageVersion).zip" SourceDirectory="$(VisualStudioSetupInsertionPath)%(SdkFeatureBand.Identity)"/>
 
     <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
     <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />


### PR DESCRIPTION
This PR fixes up the build promotion issue around duplicate aka.ms links where some of the new zips used for VSDROP are causing duplicate files. It's also cleaning up published artifacts for VS.

We previously published the individual MSIs + JSON manifests for VS. Since we now group these by SDK feature bands in zip files, we only need to publish the zips. The zips were also duplicated in two artifacts folders so we'd download the zip from workloads and workloads-vs.