### PR TITLE
Fix `IBinaryInteger.Read***Endian` to accept a `ReadOnlySpan<byte>`.

### DIFF
--- a/src/libraries/Common/tests/System/GenericMathHelpers.cs
+++ b/src/libraries/Common/tests/System/GenericMathHelpers.cs
@@ -33,13 +33,13 @@ namespace System
 
         public static TSelf ReadBigEndian(byte[] source, int startIndex, bool isUnsigned) => TSelf.ReadBigEndian(source, startIndex, isUnsigned);
 
-        public static TSelf ReadBigEndian(Span<byte> source, bool isUnsigned) => TSelf.ReadBigEndian(source, isUnsigned);
+        public static TSelf ReadBigEndian(ReadOnlySpan<byte> source, bool isUnsigned) => TSelf.ReadBigEndian(source, isUnsigned);
 
         public static TSelf ReadLittleEndian(byte[] source, bool isUnsigned) => TSelf.ReadLittleEndian(source, isUnsigned);
 
         public static TSelf ReadLittleEndian(byte[] source, int startIndex, bool isUnsigned) => TSelf.ReadLittleEndian(source, startIndex, isUnsigned);
 
-        public static TSelf ReadLittleEndian(Span<byte> source, bool isUnsigned) => TSelf.ReadLittleEndian(source, isUnsigned);
+        public static TSelf ReadLittleEndian(ReadOnlySpan<byte> source, bool isUnsigned) => TSelf.ReadLittleEndian(source, isUnsigned);
 
         public static TSelf RotateLeft(TSelf value, int rotateAmount) => TSelf.RotateLeft(value, rotateAmount);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/IBinaryInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/IBinaryInteger.cs
@@ -74,7 +74,7 @@ namespace System.Numerics
         /// <param name="isUnsigned"><c>true</c> if <paramref name="source" /> represents an unsigned two's complement number; otherwise, <c>false</c> to indicate it represents a signed two's complement number.</param>
         /// <returns>The value read from <paramref name="source" />.</returns>
         /// <exception cref="OverflowException"><paramref name="source" /> is not representable by <typeparamref name="TSelf" /></exception>
-        static virtual TSelf ReadBigEndian(Span<byte> source, bool isUnsigned)
+        static virtual TSelf ReadBigEndian(ReadOnlySpan<byte> source, bool isUnsigned)
         {
             if (!TSelf.TryReadBigEndian(source, isUnsigned, out TSelf value))
             {
@@ -117,7 +117,7 @@ namespace System.Numerics
         /// <param name="isUnsigned"><c>true</c> if <paramref name="source" /> represents an unsigned two's complement number; otherwise, <c>false</c> to indicate it represents a signed two's complement number.</param>
         /// <returns>The value read from <paramref name="source" />.</returns>
         /// <exception cref="OverflowException"><paramref name="source" /> is not representable by <typeparamref name="TSelf" /></exception>
-        static virtual TSelf ReadLittleEndian(Span<byte> source, bool isUnsigned)
+        static virtual TSelf ReadLittleEndian(ReadOnlySpan<byte> source, bool isUnsigned)
         {
             if (!TSelf.TryReadLittleEndian(source, isUnsigned, out TSelf value))
             {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10239,10 +10239,10 @@ namespace System.Numerics
         static abstract TSelf PopCount(TSelf value);
         static virtual TSelf ReadBigEndian(byte[] source, bool isUnsigned) { throw null; }
         static virtual TSelf ReadBigEndian(byte[] source, int startIndex, bool isUnsigned) { throw null; }
-        static virtual TSelf ReadBigEndian(System.Span<byte> source, bool isUnsigned) { throw null; }
+        static virtual TSelf ReadBigEndian(System.ReadOnlySpan<byte> source, bool isUnsigned) { throw null; }
         static virtual TSelf ReadLittleEndian(byte[] source, bool isUnsigned) { throw null; }
         static virtual TSelf ReadLittleEndian(byte[] source, int startIndex, bool isUnsigned) { throw null; }
-        static virtual TSelf ReadLittleEndian(System.Span<byte> source, bool isUnsigned) { throw null; }
+        static virtual TSelf ReadLittleEndian(System.ReadOnlySpan<byte> source, bool isUnsigned) { throw null; }
         static virtual TSelf RotateLeft(TSelf value, int rotateAmount) { throw null; }
         static virtual TSelf RotateRight(TSelf value, int rotateAmount) { throw null; }
         static abstract TSelf TrailingZeroCount(TSelf value);


### PR DESCRIPTION
In [the approved shape](https://github.com/dotnet/runtime/issues/71902#issuecomment-1182306312) it accepts a `ReadOnlySpan<byte>` but in the initial implementation it accepted a `Span<byte>` by mistake.