### PR TITLE
[release/6.0] Reset current_no_gc_region_info after leaving no gc region implicitly

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -19988,6 +19988,8 @@ BOOL gc_heap::should_proceed_with_gc()
             // The no_gc mode was already in progress yet we triggered another GC,
             // this effectively exits the no_gc mode.
             restore_data_for_no_gc();
+            
+            memset (&current_no_gc_region_info, 0, sizeof (current_no_gc_region_info));
         }
         else
             return should_proceed_for_no_gc();


### PR DESCRIPTION
Backport https://github.com/dotnet/runtime/pull/73602.

## Customer Impact
Customers reported occasional `System.InvalidOperationException` with message `The NoGCRegion mode was already in progress` when calling `GC.TryStartNoGCRegion`. This is preventing them from using this optimization and impacting their cold start latencies.

## Testing
Customers have tried the fix on .NET 6 overnight and reported the exception never appears again. Meanwhile, there is an unpatched machine and observed 72 exceptions of the same type in the same time interval, proving this does fix the bug.

## Risk
Low. This only impact customer using `TryStartNoGCRegion`, and this is the right thing to do.
