### PR TITLE
Avoid url string allocation in WebProxy.IsMatchInBypassList

### DIFF
--- a/src/libraries/System.Net.WebProxy/src/System.Net.WebProxy.csproj
+++ b/src/libraries/System.Net.WebProxy/src/System.Net.WebProxy.csproj
@@ -10,6 +10,7 @@
     <Compile Condition="'$(TargetPlatformIdentifier)' != 'Browser'" Include="System\Net\WebProxy.NonBrowser.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Memory" />
     <Reference Include="System.Net.NameResolution" />
     <Reference Include="System.Net.NetworkInformation" />
     <Reference Include="System.Net.Primitives" />

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
@@ -160,9 +160,9 @@ namespace System.Net
             {
                 bool isDefaultPort = input.IsDefaultPort;
                 int lengthRequired = input.Scheme.Length + 3 + input.Host.Length;
-                if (isDefaultPort)
+                if (!isDefaultPort)
                 {
-                    lengthRequired += 1 + 10; // 1 for ':' and 10 for max formatted length of a uint
+                    lengthRequired += 1 + 5; // 1 for ':' and 5 for max formatted length of a port (16 bit value)
                 }
 
                 int charsWritten;


### PR DESCRIPTION
Use new the Regex.IsMatch(span) overload to avoid allocating a new string on each call. On its own this won't move the needle much, but once https://github.com/dotnet/runtime/pull/73803 is in, IsMatchInBypassList will be allocation-free for all reasonable input Uris (and we could change it to use ArrayPool in the future if we found hosts that were frequently longer than this).

cc: @dotnet/ncl, @joperezr, @onehourlate