### PR TITLE
Adding documentation explaining case-insensitive behavior across engines

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GeneratedRegexAttribute.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GeneratedRegexAttribute.cs
@@ -9,15 +9,18 @@ namespace System.Text.RegularExpressions;
 
 /// <summary>Instructs the System.Text.RegularExpressions source generator to generate an implementation of the specified regular expression.</summary>
 /// <remarks>
+/// <para>
 /// The generator associated with this attribute only supports C#.  It only supplies an implementation when applied to static, partial, parameterless, non-generic methods that
 /// are typed to return <see cref="Regex"/>.
-///
-/// When the regex supports case-insensitive matches (either by passing <see cref="RegexOptions.IgnoreCase"/> or using the inline `(?i)` switch in the pattern) the regex
-/// engines will use an internal casing table to transform the passed in pattern into a case-sensitive equivalent one. For example, given the pattern `abc` our engines
-/// will transform it to `[Aa][Bb][Cc]`. The equivalences found on this internal casing table can change over time, for example in the case new characters are added to
-/// a new version of Unicode. When using the source generator's engine, this transformation happens at compile time, which means that the casing table used to find the
-/// equivalences will be depending on the target framework at compile time. This differs from the rest of our engines, which will make the transformation at runtime, meaning
-/// it will always use the most current casing table for the current runtime.
+/// </para>
+/// <para>
+/// When the <see cref="Regex"/> supports case-insensitive matches (either by passing <see cref="RegexOptions.IgnoreCase"/> or using the inline `(?i)` switch in the pattern) the regex
+/// engines will use an internal casing table to transform the passed in pattern into an equivalent case-sensitive one. For example, given the pattern `abc`, the engines
+/// will transform it to the equivalent pattern `[Aa][Bb][Cc]`. The equivalences found in this internal casing table can change over time, for example in the case new characters are added to
+/// a new version of Unicode. When using the source generator, this transformation happens at compile time, which means the casing table used to find the
+/// equivalences will depend on the target framework at compile time. This differs from the rest of the <see cref="Regex"/> engines, which perform this transformation at run-time, meaning
+/// they will always use casing table for the current runtime.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public sealed class GeneratedRegexAttribute : Attribute

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GeneratedRegexAttribute.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GeneratedRegexAttribute.cs
@@ -17,7 +17,7 @@ namespace System.Text.RegularExpressions;
 /// will transform it to `[Aa][Bb][Cc]`. The equivalences found on this internal casing table can change over time, for example in the case new characters are added to
 /// a new version of Unicode. When using the source generator's engine, this transformation happens at compile time, which means that the casing table used to find the
 /// equivalences will be depending on the target framework at compile time. This differs from the rest of our engines, which will make the transformation at runtime, meaning
-/// it will always use the most current casing table for the current runtime. This discrepancy is explained further here: https://github.com/dotnet/runtime/issues/70214
+/// it will always use the most current casing table for the current runtime.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public sealed class GeneratedRegexAttribute : Attribute

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GeneratedRegexAttribute.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GeneratedRegexAttribute.cs
@@ -8,7 +8,17 @@ using System.Threading;
 namespace System.Text.RegularExpressions;
 
 /// <summary>Instructs the System.Text.RegularExpressions source generator to generate an implementation of the specified regular expression.</summary>
-/// <remarks>The generator associated with this attribute only supports C#.  It only supplies an implementation when applied to static, partial, parameterless, non-generic methods that are typed to return <see cref="Regex"/>.</remarks>
+/// <remarks>
+/// The generator associated with this attribute only supports C#.  It only supplies an implementation when applied to static, partial, parameterless, non-generic methods that
+/// are typed to return <see cref="Regex"/>.
+///
+/// When the regex supports case-insensitive matches (either by passing <see cref="RegexOptions.IgnoreCase"/> or using the inline `(?i)` switch in the pattern) the regex
+/// engines will use an internal casing table to transform the passed in pattern into a case-sensitive equivalent one. For example, given the pattern `abc` our engines
+/// will transform it to `[Aa][Bb][Cc]`. The equivalences found on this internal casing table can change over time, for example in the case new characters are added to
+/// a new version of Unicode. When using the source generator's engine, this transformation happens at compile time, which means that the casing table used to find the
+/// equivalences will be depending on the target framework at compile time. This differs from the rest of our engines, which will make the transformation at runtime, meaning
+/// it will always use the most current casing table for the current runtime. This discrepancy is explained further here: https://github.com/dotnet/runtime/issues/70214
+/// </remarks>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public sealed class GeneratedRegexAttribute : Attribute
 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/70214

Adding some documentation on GeneratedRegex to point out the case-insensitivity behavior differences vs other engines.

cc: @GrabYourPitchforks @tarekgh @stephentoub to make sure the description in the docs make sense.