### PR TITLE
Show address offsets in hex

### DIFF
--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -6770,16 +6770,37 @@ void emitter::emitDispInst(instruction ins, insFlags flags)
  *
  *  Display an immediate value
  */
-void emitter::emitDispImm(int imm, bool addComma, bool alwaysHex /* =false */)
+void emitter::emitDispImm(int imm, bool addComma, bool alwaysHex /* =false */, bool isAddrOffset /*= false*/)
 {
     if (!alwaysHex && (imm > -1000) && (imm < 1000))
+    {
         printf("%d", imm);
+    }
     else if ((imm > 0) ||
              (imm == -imm) || // -0x80000000 == 0x80000000. So we don't want to add an extra "-" at the beginning.
              (emitComp->opts.disDiffable && (imm == (int)0xD1FFAB1E))) // Don't display this as negative
-        printf("0x%02x", imm);
-    else // val <= -1000
-        printf("-0x%02x", -imm);
+    {
+        if (isAddrOffset)
+        {
+            printf("%02XH", imm);
+        }
+        else
+        {
+            printf("0x%02x", imm);
+        }
+    }
+    else
+    {
+        // val <= -1000
+        if (isAddrOffset)
+        {
+            printf("-%02XH", -imm);
+        }
+        else
+        {
+            printf("-0x%02x", -imm);
+        }
+    }
 
     if (addComma)
         printf(", ");
@@ -6953,7 +6974,7 @@ void emitter::emitDispAddrRI(regNumber reg, int imm, emitAttr attr)
             printf("+");
 #endif
         }
-        emitDispImm(imm, false, regIsSPorFP);
+        emitDispImm(imm, false, true, true);
     }
     printf("]");
     emitDispGC(attr);
@@ -7029,7 +7050,7 @@ void emitter::emitDispAddrPUW(regNumber reg, int imm, insOpts opt, emitAttr attr
             printf("+");
 #endif
         }
-        emitDispImm(imm, false, regIsSPorFP);
+        emitDispImm(imm, false, true, true);
     }
     printf("]");
 

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -28,7 +28,7 @@ unsigned emitOutput_Thumb2Instr(BYTE* dst, code_t code);
 /************************************************************************/
 
 void emitDispInst(instruction ins, insFlags flags);
-void emitDispImm(int imm, bool addComma, bool alwaysHex = false);
+void emitDispImm(int imm, bool addComma, bool alwaysHex = false, bool isAddrOffset = false);
 void emitDispReloc(BYTE* addr);
 void emitDispCond(int cond);
 void emitDispShiftOpts(insOpts opt);

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -11790,9 +11790,13 @@ void emitter::emitDispInst(instruction ins)
  *
  *  Display an immediate value
  */
-void emitter::emitDispImm(ssize_t imm, bool addComma, bool alwaysHex /* =false */)
+void emitter::emitDispImm(ssize_t imm, bool addComma, bool alwaysHex /* =false */, bool isAddrOffset /* =false */)
 {
-    if (strictArmAsm)
+    if (isAddrOffset)
+    {
+        alwaysHex = true;
+    }
+    else if (strictArmAsm)
     {
         printf("#");
     }
@@ -11821,11 +11825,18 @@ void emitter::emitDispImm(ssize_t imm, bool addComma, bool alwaysHex /* =false *
 
         if ((imm & 0xFFFFFFFF00000000LL) != 0)
         {
-            printf("0x%llx", imm);
+            if (isAddrOffset)
+            {
+                printf("%08XH", imm);
+            }
+            else
+            {
+                printf("0x%llx", imm);
+            }
         }
         else
         {
-            printf("0x%02x", (unsigned)imm);
+            printf("%02XH", (unsigned)imm);
         }
     }
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -11827,7 +11827,7 @@ void emitter::emitDispImm(ssize_t imm, bool addComma, bool alwaysHex /* =false *
         {
             if (isAddrOffset)
             {
-                printf("%08XH", imm);
+                printf("%llXH", imm);
             }
             else
             {
@@ -12264,7 +12264,7 @@ void emitter::emitDispAddrRI(regNumber reg, insOpts opt, ssize_t imm)
         if (!insOptsPostIndex(opt) && (imm != 0))
         {
             printf(",");
-            emitDispImm(imm, false);
+            emitDispImm(imm, false, true, true);
         }
         printf("]");
 
@@ -12275,7 +12275,7 @@ void emitter::emitDispAddrRI(regNumber reg, insOpts opt, ssize_t imm)
         else if (insOptsPostIndex(opt))
         {
             printf(",");
-            emitDispImm(imm, false);
+            emitDispImm(imm, false, true, true);
         }
     }
     else // !strictArmAsm
@@ -12309,7 +12309,7 @@ void emitter::emitDispAddrRI(regNumber reg, insOpts opt, ssize_t imm)
         {
             printf("%c", operStr[1]);
         }
-        emitDispImm(imm, false);
+        emitDispImm(imm, false, true, true);
         printf("]");
     }
 }

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -26,7 +26,7 @@ void emitDispInsHelp(
 void emitDispLargeJmp(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig);
 void emitDispInst(instruction ins);
-void emitDispImm(ssize_t imm, bool addComma, bool alwaysHex = false);
+void emitDispImm(ssize_t imm, bool addComma, bool alwaysHex = false, bool isAddrOffset = false);
 void emitDispFloatZero();
 void emitDispFloatImm(ssize_t imm8);
 void emitDispImmOptsLSL12(ssize_t imm, insOpts opt);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8710,7 +8710,7 @@ void emitter::emitDispAddrMode(instrDesc* id, bool noDetail)
             }
             else if (disp < 1000)
             {
-                printf("%d", (unsigned)disp);
+                printf("%02XH", (unsigned)disp);
             }
             else if (disp <= 0xFFFF)
             {
@@ -8729,7 +8729,7 @@ void emitter::emitDispAddrMode(instrDesc* id, bool noDetail)
             }
             else if (disp > -1000)
             {
-                printf("-%d", (unsigned)-disp);
+                printf("-%02XH", (unsigned)-disp);
             }
             else if (disp >= -0xFFFF)
             {


### PR DESCRIPTION
Make the address offset displayed in hex which is in sync with how we display in local variables table. I often find a need to search for given address offset displayed in local variables tables by I have to convert the hex to decimal. This PR converts displaying the address offset in same format. Here is the diff:


<img width="1711" alt="image" src="https://user-images.githubusercontent.com/12488060/184240450-2816368d-c12b-4e7b-8101-f4d19aa206ff.png">
