### PR TITLE
Fix ASAN-detected alloc-dealloc mismatch

### DIFF
--- a/src/coreclr/vm/crossloaderallocatorhash.h
+++ b/src/coreclr/vm/crossloaderallocatorhash.h
@@ -192,8 +192,12 @@ private:
     private:
         KeyValueStore(TCount capacity, const TKey &key) : _capacity(capacity), _key(key) {}
 
+        struct CountWrapper
+        {
+            TCount value;
+        };
         static void* operator new(size_t) = delete;
-        static void* operator new(size_t baseSize, TCount capacity);
+        static void* operator new(size_t baseSize, CountWrapper capacity);
 
     public:
         static KeyValueStore *Create(TCount capacity, const TKey &key);

--- a/src/coreclr/vm/crossloaderallocatorhash.h
+++ b/src/coreclr/vm/crossloaderallocatorhash.h
@@ -23,11 +23,11 @@ public:
     // CrossLoaderAllocatorHash requires that a particular null value exist, which represents an empty value slot
     static bool IsNullValue(const TValue &value) { return value == NULL; }
     static TValue NullValue() { return NULL; }
-    
+
     static BOOL KeyEquals(const TKey &k1, const TKey &k2) { return k1 == k2; }
     static BOOL ValueEquals(const TValue &v1, const TValue &v2) { return v1 == v2; }
     static TCount Hash(const TKey &k) { return (TCount)(size_t)k; }
-    
+
     static LoaderAllocator *GetLoaderAllocator(const TKey &k) { return k->GetLoaderAllocator(); }
 };
 
@@ -191,6 +191,9 @@ private:
 
     private:
         KeyValueStore(TCount capacity, const TKey &key) : _capacity(capacity), _key(key) {}
+
+        static void* operator new(size_t) = delete;
+        static void* operator new(size_t baseSize, TCount capacity);
 
     public:
         static KeyValueStore *Create(TCount capacity, const TKey &key);

--- a/src/coreclr/vm/crossloaderallocatorhash.inl
+++ b/src/coreclr/vm/crossloaderallocatorhash.inl
@@ -83,6 +83,12 @@ template<class TRAITS>
 }
 
 template<class TRAITS>
+/*static*/ void* CrossLoaderAllocatorHash<TRAITS>::KeyValueStore::operator new(size_t baseSize, TCount capacity)
+{
+    return ::operator new(baseSize + capacity * sizeof(TValue));
+}
+
+template<class TRAITS>
 /*static*/ typename CrossLoaderAllocatorHash<TRAITS>::KeyValueStore *CrossLoaderAllocatorHash<TRAITS>::KeyValueStore::Create(
     TCount capacity,
     const TKey &key)
@@ -95,9 +101,7 @@ template<class TRAITS>
     }
     CONTRACTL_END;
 
-    NewArrayHolder<BYTE> bufferHolder = new BYTE[sizeof(KeyValueStore) + capacity * sizeof(TValue)];
-    KeyValueStore *keyValueStore = new(bufferHolder) KeyValueStore(capacity, key);
-    bufferHolder.SuppressRelease();
+    KeyValueStore *keyValueStore = new(capacity) KeyValueStore(capacity, key);
     for (TCount i = 0; i < capacity; i++)
     {
         keyValueStore->GetValues()[i] = TRAITS::NullValue();

--- a/src/coreclr/vm/crossloaderallocatorhash.inl
+++ b/src/coreclr/vm/crossloaderallocatorhash.inl
@@ -83,9 +83,9 @@ template<class TRAITS>
 }
 
 template<class TRAITS>
-/*static*/ void* CrossLoaderAllocatorHash<TRAITS>::KeyValueStore::operator new(size_t baseSize, TCount capacity)
+/*static*/ void* CrossLoaderAllocatorHash<TRAITS>::KeyValueStore::operator new(size_t baseSize, CountWrapper capacity)
 {
-    return ::operator new(baseSize + capacity * sizeof(TValue));
+    return ::operator new(baseSize + capacity.value * sizeof(TValue));
 }
 
 template<class TRAITS>
@@ -101,7 +101,7 @@ template<class TRAITS>
     }
     CONTRACTL_END;
 
-    KeyValueStore *keyValueStore = new(capacity) KeyValueStore(capacity, key);
+    KeyValueStore *keyValueStore = new({capacity}) KeyValueStore(capacity, key);
     for (TCount i = 0; i < capacity; i++)
     {
         keyValueStore->GetValues()[i] = TRAITS::NullValue();


### PR DESCRIPTION
Fix an alloc-dealloc mismatch in ASAN.

Fixes https://github.com/dotnet/runtime/issues/73789

Alternative to https://github.com/dotnet/runtime/pull/73790 that better fits how we've fixed alloc-dealloc mismatches of this style in the repo.