### PR TITLE
Remove unnecessary runtime lookup for constrained callvirt

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -4882,7 +4882,7 @@ void CEEInfo::getCallInfo(
     MethodDesc * pTargetMD = pMDAfterConstraintResolution;
     DWORD dwTargetMethodAttrs = pTargetMD->GetAttrs();
 
-    pResult->exactContextNeedsRuntimeLookup = (!constrainedType.IsNull() && constrainedType.IsCanonicalSubtype());
+    pResult->exactContextNeedsRuntimeLookup = (fIsStaticVirtualMethod && !fResolvedConstraint && !constrainedType.IsNull() && constrainedType.IsCanonicalSubtype());
 
     if (pTargetMD->HasMethodInstantiation())
     {


### PR DESCRIPTION
In my change adding support for default static virtual interface
method implementations I made a subtle bug that caused
behavioral change for some pre-existing constrained virtual calls
that newly started to require runtime lookup. This is unnecessary
and perf-negative, I have modified the code so that my change
kicks in only for static virtual methods.

Thanks

Tomas

/cc @dotnet/jit-contrib