### PR TITLE
Fix unnecessary failure when Crossgen'ing dll's without proper Debug Directory data

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -200,26 +200,8 @@ namespace ILCompiler
                     throw new NotSupportedException($"Error: C++/CLI is not supported: '{filePath}'");
 #endif
 
-                    try
-                    {
-                        pdbReader = PortablePdbSymbolReader.TryOpenEmbedded(peReader, GetMetadataStringDecoder())
-                                    ?? OpenAssociatedSymbolFile(filePath, peReader);
-                    }
-                    catch (BadImageFormatException e)
-                    {
-                        if (e.Message.Equals("Invalid directory size."))
-                        {
-                            int actualDbgDirSize = peReader.PEHeaders.PEHeader.DebugTableDirectory.Size;
-
-                            // This comes from the Size property of the DebugDirectoryEntry class.
-                            int expectedDbgDirSizeBase = 28;
-
-                            Console.WriteLine("WARNING: This image's Debug Directory Entry size should be a"
-                                            + $" multiple of {expectedDbgDirSizeBase}, but was {actualDbgDirSize}."
-                                            + " Debugging tools may not work correctly with this image.");
-                        }
-                        else throw;
-                    }
+                    pdbReader = PortablePdbSymbolReader.TryOpenEmbedded(peReader, GetMetadataStringDecoder())
+                                ?? OpenAssociatedSymbolFile(filePath, peReader);
                 }
                 else
                 {
@@ -346,7 +328,7 @@ namespace ILCompiler
             string pdbFileName = null;
             BlobContentId pdbContentId = default;
 
-            foreach (DebugDirectoryEntry debugEntry in peReader.ReadDebugDirectory())
+            foreach (DebugDirectoryEntry debugEntry in peReader.SafeReadDebugDirectory())
             {
                 if (debugEntry.Type != DebugDirectoryEntryType.CodeView)
                     continue;

--- a/src/coreclr/tools/Common/TypeSystem/Common/PortableExecutableMethodExtensions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/PortableExecutableMethodExtensions.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
+
+namespace Internal.TypeSystem
+{
+    public static class PortableExecutableMethodExtensions
+    {
+        public static ImmutableArray<DebugDirectoryEntry> SafeReadDebugDirectory(this PEReader peReader)
+        {
+            int actualDbgDirSize = peReader.PEHeaders.PEHeader.DebugTableDirectory.Size;
+
+            // This comes from the Size property of the DebugDirectoryEntry class.
+            int expectedDbgDirSizeBase = 28;
+
+            if (actualDbgDirSize % expectedDbgDirSizeBase != 0)
+                return ImmutableArray<DebugDirectoryEntry>.Empty;
+
+            return peReader.ReadDebugDirectory();
+        }
+    }
+}

--- a/src/coreclr/tools/Common/TypeSystem/Common/PortableExecutableMethodExtensions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/PortableExecutableMethodExtensions.cs
@@ -13,7 +13,7 @@ namespace Internal.TypeSystem
             int actualDbgDirSize = peReader.PEHeaders.PEHeader.DebugTableDirectory.Size;
 
             // This comes from the Size property of the DebugDirectoryEntry class.
-            int expectedDbgDirSizeBase = 28;
+            const int expectedDbgDirSizeBase = 28;
 
             if (actualDbgDirSize % expectedDbgDirSizeBase != 0)
                 return ImmutableArray<DebugDirectoryEntry>.Empty;

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs
@@ -81,7 +81,7 @@ namespace Internal.TypeSystem.Ecma
 
         public static PdbSymbolReader TryOpenEmbedded(PEReader peReader, MetadataStringDecoder stringDecoder)
         {
-            foreach (DebugDirectoryEntry debugEntry in peReader.ReadDebugDirectory())
+            foreach (DebugDirectoryEntry debugEntry in peReader.SafeReadDebugDirectory())
             {
                 if (debugEntry.Type != DebugDirectoryEntryType.EmbeddedPortablePdb)
                     continue;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryEntryNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryEntryNode.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Reflection.PortableExecutable;
 
 using Internal.Text;
+using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using System.IO;
 using System.Collections.Immutable;
@@ -250,7 +251,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
             }
 
-            ImmutableArray<DebugDirectoryEntry> entries = _module.PEReader.ReadDebugDirectory();
+            ImmutableArray<DebugDirectoryEntry> entries = _module.PEReader.SafeReadDebugDirectory();
             Debug.Assert(entries != null && _debugEntryIndex < entries.Length);
 
             DebugDirectoryEntry sourceDebugEntry = entries[_debugEntryIndex];

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
-using Internal.IL;
 using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
@@ -31,6 +31,7 @@
       <Version>1.4.0</Version>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\..\Common\TypeSystem\Common\ArrayMethod.Diagnostic.cs">
       <Link>TypeSystem\Common\ArrayMethod.Diagnostic.cs</Link>
@@ -358,6 +359,9 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\RuntimeInterfacesAlgorithm.cs">
       <Link>TypeSystem\Common\RuntimeInterfacesAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\PortableExecutableMethodExtensions.cs">
+      <Link>Compiler\PortableExecutableMethodExtensions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Ecma\CustomAttributeTypeProvider.cs">
       <Link>Ecma\CustomAttributeTypeProvider.cs</Link>

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1299,7 +1299,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     bool matched = false;
                     bool mismatch = false;
                     bool mismatchHandled = false;
-                    foreach (var debugEntry in ecmaModule.PEReader.ReadDebugDirectory())
+                    foreach (DebugDirectoryEntry debugEntry in ecmaModule.PEReader.SafeReadDebugDirectory())
                     {
                         if (debugEntry.Type == DebugDirectoryEntryType.CodeView)
                         {

--- a/src/coreclr/tools/dotnet-pgo/TraceTypeSystemContext.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceTypeSystemContext.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             string pdbFileName = null;
             BlobContentId pdbContentId = default;
 
-            foreach (DebugDirectoryEntry debugEntry in peReader.ReadDebugDirectory())
+            foreach (DebugDirectoryEntry debugEntry in peReader.SafeReadDebugDirectory())
             {
                 if (debugEntry.Type != DebugDirectoryEntryType.CodeView)
                     continue;


### PR DESCRIPTION
Fixes #72425. When trying to use Crossgen2 with dll's that do not have the proper debug directory data (e.g. obfuscated dll's), a `BadImageException` error is thrown and thus failing the process. In this case, the dll is still usable though debugging tools will probably not work. So, instead of failing, we ought to let the user continue but we shall warn them about this. As a history tidbit, this was the default behavior in .NET 5.