### PR TITLE
Allow for null XmlSerialziers when loading pre-gen from mappings.

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -535,13 +535,13 @@ namespace System.Xml.Serialization
         }
 
         [RequiresUnreferencedCode(TrimSerializationWarning)]
-        public static XmlSerializer[] FromMappings(XmlMapping[]? mappings)
+        public static XmlSerializer?[] FromMappings(XmlMapping[]? mappings)
         {
             return FromMappings(mappings, (Type?)null);
         }
 
         [RequiresUnreferencedCode(TrimSerializationWarning)]
-        public static XmlSerializer[] FromMappings(XmlMapping[]? mappings, Type? type)
+        public static XmlSerializer?[] FromMappings(XmlMapping[]? mappings, Type? type)
         {
             if (mappings == null || mappings.Length == 0) return Array.Empty<XmlSerializer>();
             bool anySoapMapping = false;
@@ -601,11 +601,12 @@ namespace System.Xml.Serialization
             }
             else
             {
-                XmlSerializer[] serializers = new XmlSerializer[mappings.Length];
+                XmlSerializer?[] serializers = new XmlSerializer?[mappings.Length];
                 for (int i = 0; i < serializers.Length; i++)
                 {
-                    serializers[i] = (XmlSerializer)contract!.TypedSerializers[mappings[i].Key!]!;
-                    TempAssembly.VerifyLoadContext(serializers[i]._rootType, type!.Assembly);
+                    serializers[i] = contract!.TypedSerializers[mappings[i].Key!] as XmlSerializer;
+                    if (serializers[i] != null)
+                        TempAssembly.VerifyLoadContext(serializers[i]!._rootType, type!.Assembly);
                 }
                 return serializers;
             }
@@ -714,7 +715,7 @@ namespace System.Xml.Serialization
         }
 
         [RequiresUnreferencedCode(TrimSerializationWarning)]
-        public static XmlSerializer[] FromTypes(Type[]? types)
+        public static XmlSerializer?[] FromTypes(Type[]? types)
         {
             if (types == null)
                 return Array.Empty<XmlSerializer>();

--- a/src/libraries/System.Xml.XmlSerializer/ref/System.Xml.XmlSerializer.cs
+++ b/src/libraries/System.Xml.XmlSerializer/ref/System.Xml.XmlSerializer.cs
@@ -734,11 +734,11 @@ namespace System.Xml.Serialization
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members from deserialized types may be trimmed if not referenced directly")]
         public object? Deserialize(System.Xml.XmlReader xmlReader, System.Xml.Serialization.XmlDeserializationEvents events) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members from serialized types may be trimmed if not referenced directly")]
-        public static System.Xml.Serialization.XmlSerializer[] FromMappings(System.Xml.Serialization.XmlMapping[]? mappings) { throw null; }
+        public static System.Xml.Serialization.XmlSerializer?[] FromMappings(System.Xml.Serialization.XmlMapping[]? mappings) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members from serialized types may be trimmed if not referenced directly")]
-        public static System.Xml.Serialization.XmlSerializer[] FromMappings(System.Xml.Serialization.XmlMapping[]? mappings, System.Type? type) { throw null; }
+        public static System.Xml.Serialization.XmlSerializer?[] FromMappings(System.Xml.Serialization.XmlMapping[]? mappings, System.Type? type) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members from serialized types may be trimmed if not referenced directly")]
-        public static System.Xml.Serialization.XmlSerializer[] FromTypes(System.Type[]? types) { throw null; }
+        public static System.Xml.Serialization.XmlSerializer?[] FromTypes(System.Type[]? types) { throw null; }
         public static string GetXmlSerializerAssemblyName(System.Type type) { throw null; }
         public static string GetXmlSerializerAssemblyName(System.Type type, string? defaultNamespace) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members from serialized types may be trimmed if not referenced directly")]


### PR DESCRIPTION
Fixes #68659

When nullable annotations were [added to System.Xml](https://github.com/dotnet/runtime/pull/41261/files#diff-fa07acc29a1aed946fd7f4fca4b198bc71c7bb4204019cd407b9447882af374bR515), the return type of `XmlSerializer.FromMappings()` was not annotated. Mistakenly. While I believe it is true that we generate an XmlSerializer for every mapping passed into the method in the runtime-generated-serializer case, when drawing serializers from a pre-generated serializer assembly... if the assembly doesn't have a matching serializer for the mapping, we don't generate one. Ideally the pre-gen assembly and list of mappings in use are under the control of the same project/team/application or whatever, so there is a serializer for every mapping. But "ideally" isn't always the case. And in this code, the mappings array and the pregenerated serializer assembly are in theory from different sources and may not match up. And when that happens, we need to return a null entry in the serializer array - because there is the expectation that positions in the returned serializer array match up with the corresponding position in the mapping array passed in.

That's all a long-winded way of saying that we might return null serializer entries in the pre-gen case. That's has always been the case and it is expected. The nullable notation missed that, and as a result, we missed [this potential null-ref](https://github.com/dotnet/runtime/pull/58932/files#diff-fa07acc29a1aed946fd7f4fca4b198bc71c7bb4204019cd407b9447882af374bR634).