### PR TITLE
JIT: Fix STORE_DYN_BLK morphing

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7541,6 +7541,8 @@ GenTree* Compiler::gtNewStructVal(ClassLayout* layout, GenTree* addr)
         blkNode = gtNewObjNode(layout, addr);
     }
 
+    blkNode->SetIndirExceptionFlags(this);
+
     return blkNode;
 }
 

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1550,8 +1550,6 @@ GenTree* Compiler::fgMorphStoreDynBlock(GenTreeStoreDynBlk* tree)
         if (size != 0)
         {
             GenTree* lhs = gtNewBlockVal(tree->Addr(), static_cast<unsigned>(size));
-            lhs->SetIndirExceptionFlags(this);
-
             GenTree* asg = gtNewAssignNode(lhs, tree->Data());
             asg->gtFlags |= (tree->gtFlags & (GTF_ALL_EFFECT | GTF_BLK_VOLATILE | GTF_BLK_UNALIGNED));
             INDEBUG(asg->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1556,6 +1556,12 @@ GenTree* Compiler::fgMorphStoreDynBlock(GenTreeStoreDynBlk* tree)
 
             JITDUMP("MorphStoreDynBlock: transformed STORE_DYN_BLK into ASG(BLK, Data())\n");
 
+            GenTree* lclVarTree = fgIsIndirOfAddrOfLocal(lhs);
+            if (lclVarTree != nullptr)
+            {
+                lclVarTree->gtFlags |= GTF_VAR_DEF;
+            }
+
             return tree->OperIsCopyBlkOp() ? fgMorphCopyBlock(asg) : fgMorphInitBlock(asg);
         }
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_73821/Runtime_73821.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_73821/Runtime_73821.cs
@@ -9,8 +9,9 @@ unsafe class Runtime_73821
     {
         public int F;
     }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static S TestMethod(int val)
+    public static S Test1(int val)
     {
         S s;
         int size = sizeof(S);
@@ -18,8 +19,17 @@ unsafe class Runtime_73821
         return s;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Test2(int val)
+    {
+        int val2;
+        int size = sizeof(int);
+        Unsafe.CopyBlockUnaligned(&val2, &val, (uint)size);
+        return val2;
+    }
+
     static int Main()
     {
-        return TestMethod(100).F;
+        return Test1(33).F + Test2(67);
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_73821/Runtime_73821.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_73821/Runtime_73821.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+unsafe class Runtime_73821
+{
+    public struct S
+    {
+        public int F;
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static S TestMethod(int val)
+    {
+        S s;
+        int size = sizeof(S);
+        Unsafe.CopyBlockUnaligned(&s, &val, (uint)size);
+        return s;
+    }
+
+    static int Main()
+    {
+        return TestMethod(100).F;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_73821/Runtime_73821.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_73821/Runtime_73821.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Make sure to properly call `SetIndirExceptionFlags` and to properly mark defs (that will otherwise hit asserts in rationalization).

Fix #73821