### PR TITLE
Fix build error in mini-ppc.h

### DIFF
--- a/src/mono/mono/mini/mini-ppc.h
+++ b/src/mono/mono/mini/mini-ppc.h
@@ -118,8 +118,7 @@ typedef struct MonoCompileArch {
 #else
 #define MONO_ARCH_CALLEE_FREGS (0xff << ppc_f1)
 #endif
-#define MONO_ARCH_CALLEE_SAVED_FREGS (~(MONO_ARCH_CALLEE_FRE
-GS | 1))
+#define MONO_ARCH_CALLEE_SAVED_FREGS (~(MONO_ARCH_CALLEE_FREGS | 1))
 
 #ifdef TARGET_POWERPC64
 #define MONO_ARCH_INST_FIXED_REG(desc) (((desc) == 'a')? ppc_r3:	\


### PR DESCRIPTION
Looks like this got inadvertently broken by https://github.com/dotnet/runtime/pull/65723