### PR TITLE
Clean up temp directory methods in System.ComponentModel.Composition tests

### DIFF
--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogDebuggerProxyTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogDebuggerProxyTests.cs
@@ -28,7 +28,7 @@ namespace System.ComponentModel.Composition.Primitives
 
             foreach (var e in expectations)
             {
-                string directoryPath = GetTemporaryDirectory(e.Location);
+                string directoryPath = TemporaryFileCopier.GetNewTemporaryDirectory();
                 var catalog = CreateDirectoryCatalog(directoryPath);
 
                 var proxy = new DirectoryCatalog.DirectoryCatalogDebuggerProxy(catalog);
@@ -41,7 +41,7 @@ namespace System.ComponentModel.Composition.Primitives
         [ActiveIssue("https://github.com/dotnet/runtime/issues/24240")]
         public void Constructor_ValueAsCatalogArgument_ShouldSetAssemblyProperty()
         {
-            string directoryPath = GetTemporaryDirectory();
+            string directoryPath = TemporaryFileCopier.GetNewTemporaryDirectory();
             var expectations = Expectations.GetAssemblies();
 
             foreach (string fileName in expectations.Select(assembly => assembly.Location).ToArray())
@@ -58,7 +58,7 @@ namespace System.ComponentModel.Composition.Primitives
         [Fact]
         public void Constructor_ValueAsCatalogArgument_ShouldSetPathProperty()
         {
-            string path = GetTemporaryDirectory();
+            string path = TemporaryFileCopier.GetNewTemporaryDirectory();
 
             var catalog = CreateDirectoryCatalog(path);
             var proxy = new DirectoryCatalog.DirectoryCatalogDebuggerProxy(catalog);
@@ -70,7 +70,7 @@ namespace System.ComponentModel.Composition.Primitives
         [ActiveIssue("https://github.com/dotnet/runtime/issues/24240", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void Constructor_ValueAsCatalogArgument_ShouldSetSearchPatternProperty()
         {
-            string directoryPath = GetTemporaryDirectory();
+            string directoryPath = TemporaryFileCopier.GetNewTemporaryDirectory();
             var expectations = new ExpectationCollection<string, string>();
 
             expectations.Add("*.*", "*.*");
@@ -92,7 +92,7 @@ namespace System.ComponentModel.Composition.Primitives
         [ActiveIssue("https://github.com/dotnet/runtime/issues/24240")]
         public void FullPath_ValidPath_ShouldBeFine()
         {
-            string directoryPath = GetTemporaryDirectory();
+            string directoryPath = TemporaryFileCopier.GetNewTemporaryDirectory();
             var expectations = new ExpectationCollection<string, string>();
 
             // Ensure the path is always normalized properly.
@@ -118,7 +118,7 @@ namespace System.ComponentModel.Composition.Primitives
         [ActiveIssue("https://github.com/dotnet/runtime/issues/24240", TestPlatforms.AnyUnix)] // System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.
         public void LoadedFiles_EmptyDirectory_ShouldBeFine()
         {
-            string directoryPath = GetTemporaryDirectory();
+            string directoryPath = TemporaryFileCopier.GetNewTemporaryDirectory();
             var cat = CreateDirectoryCatalog(directoryPath);
             var proxy = new DirectoryCatalog.DirectoryCatalogDebuggerProxy(cat);
 
@@ -129,7 +129,7 @@ namespace System.ComponentModel.Composition.Primitives
         [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         public void LoadedFiles_ContainsMultipleDllsAndSomeNonDll_ShouldOnlyContainDlls()
         {
-            string directoryPath = GetTemporaryDirectory();
+            string directoryPath = TemporaryFileCopier.GetNewTemporaryDirectory();
             // Add one text file
             using (File.CreateText(Path.Combine(directoryPath, "Test.txt")))
             { }
@@ -161,11 +161,6 @@ namespace System.ComponentModel.Composition.Primitives
         {
             return new DirectoryCatalog(path, filter);
         }
-
-        private string GetTemporaryDirectory(string location = null)
-        {
-            return Directory.CreateTempSubdirectory().FullName;
-        }
     }
 
     public class TemporaryFileCopier
@@ -190,11 +185,6 @@ namespace System.ComponentModel.Composition.Primitives
         }
 
         public static string GetNewTemporaryDirectory()
-        {
-            return Directory.CreateTempSubdirectory().FullName;
-        }
-
-        public static string GetTemporaryDirectory()
         {
             return Directory.CreateTempSubdirectory().FullName;
         }

--- a/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/Hosting/DirectoryCatalogTests.cs
@@ -251,7 +251,7 @@ namespace System.ComponentModel.Composition
         [ActiveIssue("https://github.com/dotnet/runtime/issues/24240")]
         public void Parts()
         {
-                var catalog = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var catalog = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
                 Assert.NotNull(catalog.Parts);
                 Assert.True(catalog.Parts.Count() > 0);
         }
@@ -260,7 +260,7 @@ namespace System.ComponentModel.Composition
         [ActiveIssue("https://github.com/dotnet/runtime/issues/24240")]
         public void Parts_ShouldSetDefinitionOriginToCatalogItself()
         {
-                var catalog = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var catalog = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
                 Assert.True(catalog.Parts.Count() > 0);
 
                 foreach (ICompositionElement definition in catalog.Parts)
@@ -278,7 +278,7 @@ namespace System.ComponentModel.Composition
                 expectations.Add(".", ".");
                 expectations.Add(TemporaryFileCopier.RootTemporaryDirectoryName, TemporaryFileCopier.RootTemporaryDirectoryName);
                 expectations.Add(TemporaryFileCopier.GetRootTemporaryDirectory(), TemporaryFileCopier.GetRootTemporaryDirectory());
-                expectations.Add(TemporaryFileCopier.GetTemporaryDirectory(), TemporaryFileCopier.GetTemporaryDirectory());
+                expectations.Add(TemporaryFileCopier.GetNewTemporaryDirectory(), TemporaryFileCopier.GetNewTemporaryDirectory());
 
                 foreach (var e in expectations)
                 {
@@ -302,7 +302,7 @@ namespace System.ComponentModel.Composition
                 expectations.Add(".", Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".")).ToUpperInvariant());
                 expectations.Add(TemporaryFileCopier.RootTemporaryDirectoryName, rootTempPath);
                 expectations.Add(TemporaryFileCopier.GetRootTemporaryDirectory(), rootTempPath);
-                expectations.Add(TemporaryFileCopier.GetTemporaryDirectory(), Path.GetFullPath(TemporaryFileCopier.GetTemporaryDirectory()).ToUpperInvariant());
+                expectations.Add(TemporaryFileCopier.GetNewTemporaryDirectory(), Path.GetFullPath(TemporaryFileCopier.GetNewTemporaryDirectory()).ToUpperInvariant());
 
                 foreach (var e in expectations)
                 {
@@ -315,7 +315,7 @@ namespace System.ComponentModel.Composition
         [Fact]
         public void LoadedFiles_EmptyDirectory_ShouldBeFine()
         {
-                var cat = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var cat = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
 
                 Assert.Equal(0, cat.LoadedFiles.Count);
         }
@@ -325,15 +325,15 @@ namespace System.ComponentModel.Composition
         public void LoadedFiles_ContainsMultipleDllsAndSomeNonDll_ShouldOnlyContainDlls()
         {
                 // Add one text file
-                using (File.CreateText(Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test.txt"))) { }
+                using (File.CreateText(Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "Test.txt"))) { }
 
                 // Add two dll's
-                string dll1 = Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test1.dll");
-                string dll2 = Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test2.dll");
+                string dll1 = Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "Test1.dll");
+                string dll2 = Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "Test2.dll");
                 File.Copy(Assembly.GetExecutingAssembly().Location, dll1);
                 File.Copy(Assembly.GetExecutingAssembly().Location, dll2);
 
-                var cat = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var cat = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
 
                 EqualityExtensions.CheckEquals(new string[] { dll1.ToUpperInvariant(), dll2.ToUpperInvariant() },
                     cat.LoadedFiles);
@@ -355,18 +355,18 @@ namespace System.ComponentModel.Composition
         [Fact]
         public void Constructor_InvalidAssembly_ShouldBeFine()
         {
-                using (File.CreateText(Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test.dll"))) { }
-                var cat = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                using (File.CreateText(Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "Test.dll"))) { }
+                var cat = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
         }
 
         [Fact]
         public void Constructor_NonExistentDirectory_ShouldThrow()
         {
                 Assert.Throws<DirectoryNotFoundException>(() =>
-                   new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory() + @"\NonexistentDirectoryWithoutEndingSlash"));
+                   new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory() + @"\NonexistentDirectoryWithoutEndingSlash"));
 
                 Assert.Throws<DirectoryNotFoundException>(() =>
-                   new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory() + @"\NonexistentDirectoryWithEndingSlash\"));
+                   new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory() + @"\NonexistentDirectoryWithEndingSlash\"));
 
         }
 
@@ -374,16 +374,16 @@ namespace System.ComponentModel.Composition
         [ActiveIssue("https://github.com/dotnet/runtime/issues/24240")]
         public void Constructor_PassExistingFileName_ShouldThrow()
         {
-                using (File.CreateText(Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test.txt"))) { }
+                using (File.CreateText(Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "Test.txt"))) { }
                 Assert.Throws<IOException>(() =>
-                    new DirectoryCatalog(Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test.txt")));
+                    new DirectoryCatalog(Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "Test.txt")));
         }
 
         [Fact]
         public void Constructor_PassNonExistingFileName_ShouldThrow()
         {
                 Assert.Throws<DirectoryNotFoundException>(() =>
-                    new DirectoryCatalog(Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "NonExistingFile.txt")));
+                    new DirectoryCatalog(Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "NonExistingFile.txt")));
         }
 
         [Fact]
@@ -392,7 +392,7 @@ namespace System.ComponentModel.Composition
         {
                 bool changedFired = false;
                 bool changingFired = false;
-                var cat = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var cat = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
 
                 Assert.Equal(0, cat.Parts.Count());
 
@@ -408,7 +408,7 @@ namespace System.ComponentModel.Composition
                         changedFired = true;
                     });
 
-                File.Copy(Assembly.GetExecutingAssembly().Location, Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test.dll"));
+                File.Copy(Assembly.GetExecutingAssembly().Location, Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "Test.dll"));
 
                 cat.Refresh();
 
@@ -420,10 +420,10 @@ namespace System.ComponentModel.Composition
         [ActiveIssue("https://github.com/dotnet/runtime/issues/24240")]
         public void Refresh_AssemblyRemoved_ShouldFireOnChanged()
         {
-                string file = Path.Combine(TemporaryFileCopier.GetTemporaryDirectory(), "Test.dll");
+                string file = Path.Combine(TemporaryFileCopier.GetNewTemporaryDirectory(), "Test.dll");
                 File.Copy(Assembly.GetExecutingAssembly().Location, file);
                 bool changedFired = false;
-                var cat = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var cat = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
 
                 cat.Changed += new EventHandler<ComposablePartCatalogChangeEventArgs>((o, e) =>
                     changedFired = true);
@@ -440,7 +440,7 @@ namespace System.ComponentModel.Composition
         [Fact]
         public void Refresh_NoChanges_ShouldNotFireOnChanged()
         {
-                var cat = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var cat = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
 
                 cat.Changed += new EventHandler<ComposablePartCatalogChangeEventArgs>((o, e) =>
                     Assert.False(true));
@@ -453,7 +453,7 @@ namespace System.ComponentModel.Composition
         public void Refresh_DirectoryRemoved_ShouldThrowDirectoryNotFound()
         {
             DirectoryCatalog cat;
-                cat = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                cat = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
 
             ExceptionAssert.Throws<DirectoryNotFoundException>(RetryMode.DoNotRetry, () =>
                 cat.Refresh());
@@ -470,7 +470,7 @@ namespace System.ComponentModel.Composition
                 Assert.NotNull(matchingExports);
                 Assert.True(matchingExports.Count() == 0);
 
-                var testsDirectoryCatalog = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var testsDirectoryCatalog = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
                 catalog.Catalogs.Add(testsDirectoryCatalog);
                 matchingExports = catalog.GetExports(constraint);
 
@@ -498,7 +498,7 @@ namespace System.ComponentModel.Composition
 
                 Assert.False(container.IsPresent<MyExport>());
 
-                var dir1 = new DirectoryCatalog(TemporaryFileCopier.GetTemporaryDirectory());
+                var dir1 = new DirectoryCatalog(TemporaryFileCopier.GetNewTemporaryDirectory());
                 cat.Catalogs.Add(dir1);
                 Assert.True(container.IsPresent<MyExport>());
 


### PR DESCRIPTION
These tests had 3 methods that do the same thing. Consolidating down to one.

Follow up to #73408