### PR TITLE
Remove ActiveIssue for Matrix4x4CreateFromAxisAngleTest

### DIFF
--- a/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -579,7 +579,6 @@ namespace System.Numerics.Tests
 
         // A test for CreateFromAxisAngle(Vector3f,float)
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72149", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void Matrix4x4CreateFromAxisAngleTest()
         {
             float radians = MathHelper.ToRadians(-30.0f);


### PR DESCRIPTION
Fixes #72149.

https://github.com/dotnet/runtime/issues/72149#issuecomment-1213526765