### PR TITLE
Fix arm64 scalar intrinsic use with small arguments

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -58,6 +58,10 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #include "emit.h"
 
+// Forward declaration
+template <class T>
+inline var_types genActualType(T value);
+
 #include "hwintrinsic.h"
 #include "simd.h"
 #include "simdashwintrinsic.h"

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -866,6 +866,11 @@ private:
             {
                 baseType = node->TypeGet();
             }
+
+            if (category == HW_Category_Scalar)
+            {
+                baseType = genActualType(baseType);
+            }
         }
     }
 };

--- a/src/tests/JIT/Regression/JitBlue/Runtime_73804/Runtime_73804.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_73804/Runtime_73804.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public unsafe class Runtime_73804
+{
+    public static int Main()
+    {
+        short value = 0x1000;
+        int r = Problem(&value);
+
+        return 100 + r - System.Numerics.BitOperations.LeadingZeroCount((uint)value);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Problem(short* s)
+    {
+        if (System.Runtime.Intrinsics.Arm.ArmBase.IsSupported)
+        {
+            return System.Runtime.Intrinsics.Arm.ArmBase.LeadingZeroCount(*s);
+        }
+        else
+        {
+            return System.Numerics.BitOperations.LeadingZeroCount((uint)*s);
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_73804/Runtime_73804.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_73804/Runtime_73804.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The code already uses `emitActualTypeSize` in the scalar case;
this also uses `genActualType` to get the "actual" type of small
types when deciding the intrinsic base type, used in codegen.

Fixes #73804