### PR TITLE
Fix handling of corrupted state exceptions on Windows

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7392,13 +7392,10 @@ public:
 
 LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo)
 {
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
+    //
+    // DO NOT USE CONTRACTS HERE AS THIS ROUTINE MAY NEVER RETURN.  You can use
+    // static contracts, but currently this is all WRAPPER_NO_CONTRACT.
+    //
 
     //
     // WARNING WARNING WARNING WARNING WARNING WARNING WARNING
@@ -7522,7 +7519,8 @@ LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo)
         if (currentStackBase != stopPoint)
         {
             CantAllocHolder caHolder;
-            STRESS_LOG2(LF_EH, LL_INFO100, "In CLRVectoredExceptionHandler: mismatch of cached and current stack-base indicating use of Fibers, return with EXCEPTION_CONTINUE_SEARCH: current = %p; cache = %p\n",
+            STRESS_LOG2(LF_EH, LL_INFO100, "CLRVectoredExceptionShim: mismatch of cached and current stack-base "
+                "indicating use of Fibers, return with EXCEPTION_CONTINUE_SEARCH: current = %p; cache = %p\n",
                 currentStackBase, stopPoint);
             return EXCEPTION_CONTINUE_SEARCH;
         }


### PR DESCRIPTION
The new code for handling hardware exceptions (which was enabled only for Windows x64 with CET before #70428 and became enabled for all Windows targets after #70428) would translate hardware exceptions into managed exception in the `HandleManagedFault` function. That translation broke recognizing corrupted state exceptions in the `ProcessCLRException` function, because the exception would have the `EXCEPTION_COMPLUS` exception code instead of the original hardware exception code.

The fix is to recognize corrupted state exceptions in the `HandleManagedFault` function and raise a non-managed exception for them, which will be properly handled by `ProcessCLRException`.