### PR TITLE
Streamline String.Substring

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1833,7 +1833,6 @@ namespace System
 
             if (length == 0)
             {
-                Debug.Assert(startIndex == Length);
                 return Empty;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1798,41 +1798,64 @@ namespace System
 
         // Returns a substring of this string.
         //
-        public string Substring(int startIndex) => Substring(startIndex, Length - startIndex);
-
-        public string Substring(int startIndex, int length)
+        public string Substring(int startIndex)
         {
-            if (startIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_StartIndex);
-            }
-
-            if (startIndex > Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_StartIndexLargerThanLength);
-            }
-
-            if (length < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(length), SR.ArgumentOutOfRange_NegativeLength);
-            }
-
-            if (startIndex > Length - length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(length), SR.ArgumentOutOfRange_IndexLength);
-            }
-
-            if (length == 0)
-            {
-                return string.Empty;
-            }
-
-            if (startIndex == 0 && length == this.Length)
+            if (startIndex == 0)
             {
                 return this;
             }
 
+            int length = Length - startIndex;
+            if (length == 0)
+            {
+                return Empty;
+            }
+
+            if ((uint)startIndex > (uint)Length)
+            {
+                ThrowSubstringArgumentOutOfRange(startIndex, length);
+            }
+
             return InternalSubString(startIndex, length);
+        }
+
+        public string Substring(int startIndex, int length)
+        {
+#if TARGET_64BIT
+            // See comment in Span<T>.Slice for how this works.
+            if ((ulong)(uint)startIndex + (ulong)(uint)length > (ulong)(uint)Length)
+#else
+            if ((uint)startIndex > (uint)Length || (uint)length > (uint)(Length - startIndex))
+#endif
+            {
+                ThrowSubstringArgumentOutOfRange(startIndex, length);
+            }
+
+            if (length == 0)
+            {
+                Debug.Assert(startIndex == Length);
+                return Empty;
+            }
+
+            if (length == Length)
+            {
+                Debug.Assert(startIndex == 0);
+                return this;
+            }
+
+            return InternalSubString(startIndex, length);
+        }
+
+        [DoesNotReturn]
+        private void ThrowSubstringArgumentOutOfRange(int startIndex, int length)
+        {
+            (string paramName, string message) =
+                startIndex < 0 ? (nameof(startIndex), SR.ArgumentOutOfRange_StartIndex) :
+                startIndex > Length ? (nameof(startIndex), SR.ArgumentOutOfRange_StartIndexLargerThanLength) :
+                length < 0 ? (nameof(length), SR.ArgumentOutOfRange_NegativeLength) :
+                (nameof(length), SR.ArgumentOutOfRange_IndexLength);
+
+            throw new ArgumentOutOfRangeException(paramName, message);
         }
 
         private string InternalSubString(int startIndex, int length)


### PR DESCRIPTION
- Split the one-arg Substring from the two-arg Substring to avoid unnecessary checks in the former
- Employ the same argument validation checks as Span, and then delegate to a helper that does more detailed checking to throw the right exception
- Avoid duplicative checks in the body
- Reorder checks in one-arg overload to do success paths before error paths where possible

|  Method |        Job |         Toolchain | StartIndex |      Mean |     Error |    StdDev | Ratio | RatioSD |
|-------- |----------- |------------------ |----------- |----------:|----------:|----------:|------:|--------:|
|  OneArg | Job-LMVHFB | \main\corerun.exe |          0 |  2.106 ns | 0.0840 ns | 0.0825 ns |  1.00 |    0.00 |
|  OneArg | Job-BIJWCO |   \pr\corerun.exe |          0 |  1.418 ns | 0.0337 ns | 0.0315 ns |  0.67 |    0.02 |
|         |            |                   |            |           |           |           |       |         |
| TwoArgs | Job-LMVHFB | \main\corerun.exe |          0 |  1.927 ns | 0.0137 ns | 0.0114 ns |  1.00 |    0.00 |
| TwoArgs | Job-BIJWCO |   \pr\corerun.exe |          0 |  1.750 ns | 0.0300 ns | 0.0266 ns |  0.91 |    0.02 |
|         |            |                   |            |           |           |           |       |         |
|  OneArg | Job-LMVHFB | \main\corerun.exe |          6 | 10.272 ns | 0.0776 ns | 0.0688 ns |  1.00 |    0.00 |
|  OneArg | Job-BIJWCO |   \pr\corerun.exe |          6 |  9.869 ns | 0.0226 ns | 0.0189 ns |  0.96 |    0.01 |
|         |            |                   |            |           |           |           |       |         |
| TwoArgs | Job-LMVHFB | \main\corerun.exe |          6 | 10.231 ns | 0.0793 ns | 0.0703 ns |  1.00 |    0.00 |
| TwoArgs | Job-BIJWCO |   \pr\corerun.exe |          6 | 10.185 ns | 0.2332 ns | 0.1947 ns |  0.99 |    0.02 |
|         |            |                   |            |           |           |           |       |         |
|  OneArg | Job-LMVHFB | \main\corerun.exe |         11 |  2.040 ns | 0.0252 ns | 0.0197 ns |  1.00 |    0.00 |
|  OneArg | Job-BIJWCO |   \pr\corerun.exe |         11 |  1.838 ns | 0.0572 ns | 0.0507 ns |  0.90 |    0.03 |
|         |            |                   |            |           |           |           |       |         |
| TwoArgs | Job-LMVHFB | \main\corerun.exe |         11 |  2.323 ns | 0.0313 ns | 0.0293 ns |  1.00 |    0.00 |
| TwoArgs | Job-BIJWCO |   \pr\corerun.exe |         11 |  1.640 ns | 0.0872 ns | 0.1071 ns |  0.71 |    0.05 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

public partial class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private string _str = "hello world";

    [Params(0, 6, 11)]
    public int StartIndex { get; set; }

    [Benchmark]
    public string OneArg() => _str.Substring(StartIndex);

    [Benchmark]
    public string TwoArgs()
    {
        string s = _str;
        int startIndex = StartIndex;
        return s.Substring(startIndex, s.Length - startIndex);
    }
}
```