### PR TITLE
More updates for recent compiler changes for ref fields

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -588,7 +588,7 @@ namespace System.Runtime
             FallbackFailFast(RhFailFastReason.InternalError, null);
         }
 
-        private static void DispatchEx(ref StackFrameIterator frameIter, ref ExInfo exInfo, uint startIdx)
+        private static void DispatchEx(scoped ref StackFrameIterator frameIter, ref ExInfo exInfo, uint startIdx)
         {
             Debug.Assert(exInfo._passNumber == 1, "expected asm throw routine to set the pass");
             object exceptionObj = exInfo.ThrownException;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
@@ -3611,7 +3611,7 @@ namespace System.Text.Json.Tests
             out Utf8JsonReader reader,
             ReadOnlyMemory<byte> data,
             int segmentCount,
-            in JsonReaderState state,
+            scoped in JsonReaderState state,
             bool isFinalBlock = false)
         {
             if (segmentCount == 0)


### PR DESCRIPTION
Updates to compile with the latest C# compiler.

Compiles cleanly from the root with `build -rc Release` - with the exception of `tools/dotnet-pgo` which fails to compile since it still references .NET preview 5 SDK.