### PR TITLE
Baseline failing tests

### DIFF
--- a/src/libraries/System.Security.Cryptography.Csp/tests/PasswordDeriveBytesTests.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/PasswordDeriveBytesTests.cs
@@ -343,7 +343,7 @@ namespace System.Security.Cryptography.DeriveBytesTests
                 ByteUtils.HexToByteArray("F8D88E9DAFC828DA2400F5144271C2F630A1C061C654FC9DE2E7900E121461B9"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public static void GetBytes_KnownValues_SHA256_40()
         {
             TestKnownValue_GetBytes(

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -470,6 +470,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Speech\tests\System.Speech.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.DirectoryServices\tests\System.DirectoryServices.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.DirectoryServices.AccountManagement\tests\System.DirectoryServices.AccountManagement.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Transactions.Local\tests\System.Transactions.Local.Tests.csproj" />
 
     <!-- Uses something weird for testing ("Stashbox"), doesn't work without Ref.Emit at all -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.External.Tests\Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj" />


### PR DESCRIPTION
* S,Transactions is a new test with a bunch of COM
* PasswordDeriveBytes calls into RequiresUnreferencedCode. It used to be lucky. Not anymore because we trim more.