### PR TITLE
Use {Last}IndexOfAnyExcept in RegexCompiler and source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -2883,17 +2883,20 @@ namespace System.Text.RegularExpressions.Generator
                 // We're backtracking.  Check the timeout.
                 EmitTimeoutCheckIfNeeded(writer, rm);
 
-                if (!rtl && subsequent?.FindStartingLiteral() is ValueTuple<char, string?, string?> literal)
+                if (!rtl && subsequent?.FindStartingLiteral() is ValueTuple<char, string?, string?, bool> literal) // char, string, chars, negated
                 {
                     writer.WriteLine($"if ({startingPos} >= {endingPos} ||");
+                    (string lastIndexOfName, string lastIndexOfAnyName) = !literal.Item4 ?
+                        ("LastIndexOf", "LastIndexOfAny") :
+                        ("LastIndexOfAnyExcept", "LastIndexOfAnyExcept");
                     using (EmitBlock(writer,
-                        literal.Item2 is not null ? $"    ({endingPos} = inputSpan.Slice({startingPos}, Math.Min(inputSpan.Length, {endingPos} + {literal.Item2.Length - 1}) - {startingPos}).LastIndexOf({Literal(literal.Item2)})) < 0)" :
-                        literal.Item3 is null ? $"    ({endingPos} = inputSpan.Slice({startingPos}, {endingPos} - {startingPos}).LastIndexOf({Literal(literal.Item1)})) < 0)" :
+                        literal.Item2 is not null ? $"    ({endingPos} = inputSpan.Slice({startingPos}, Math.Min(inputSpan.Length, {endingPos} + {literal.Item2.Length - 1}) - {startingPos}).{lastIndexOfName}({Literal(literal.Item2)})) < 0)" :
+                        literal.Item3 is null ? $"    ({endingPos} = inputSpan.Slice({startingPos}, {endingPos} - {startingPos}).{lastIndexOfName}({Literal(literal.Item1)})) < 0)" :
                         literal.Item3.Length switch
                         {
-                            2 => $"    ({endingPos} = inputSpan.Slice({startingPos}, {endingPos} - {startingPos}).LastIndexOfAny({Literal(literal.Item3[0])}, {Literal(literal.Item3[1])})) < 0)",
-                            3 => $"    ({endingPos} = inputSpan.Slice({startingPos}, {endingPos} - {startingPos}).LastIndexOfAny({Literal(literal.Item3[0])}, {Literal(literal.Item3[1])}, {Literal(literal.Item3[2])})) < 0)",
-                            _ => $"    ({endingPos} = inputSpan.Slice({startingPos}, {endingPos} - {startingPos}).LastIndexOfAny({Literal(literal.Item3)})) < 0)",
+                            2 => $"    ({endingPos} = inputSpan.Slice({startingPos}, {endingPos} - {startingPos}).{lastIndexOfAnyName}({Literal(literal.Item3[0])}, {Literal(literal.Item3[1])})) < 0)",
+                            3 => $"    ({endingPos} = inputSpan.Slice({startingPos}, {endingPos} - {startingPos}).{lastIndexOfAnyName}({Literal(literal.Item3[0])}, {Literal(literal.Item3[1])}, {Literal(literal.Item3[2])})) < 0)",
+                            _ => $"    ({endingPos} = inputSpan.Slice({startingPos}, {endingPos} - {startingPos}).{lastIndexOfAnyName}({Literal(literal.Item3)})) < 0)",
                         }))
                     {
                         Goto(doneLabel);
@@ -3040,7 +3043,8 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     if (iterationCount is null &&
                         node.Kind is RegexNodeKind.Notonelazy &&
-                        subsequent?.FindStartingLiteral(4) is ValueTuple<char, string?, string?> literal) // 5 == max optimized by IndexOfAny, and we need to reserve 1 for node.Ch
+                        subsequent?.FindStartingLiteral(4) is ValueTuple<char, string?, string?, bool> literal && // 5 == max optimized by IndexOfAny, and we need to reserve 1 for node.Ch
+                        !literal.Item4) // not negated; can't search for both the node.Ch and a negated subsequent char with an IndexOf* method
                     {
                         // e.g. "<[^>]*?>"
 
@@ -3098,19 +3102,22 @@ namespace System.Text.RegularExpressions.Generator
                     else if (iterationCount is null &&
                         node.Kind is RegexNodeKind.Setlazy &&
                         node.Str == RegexCharClass.AnyClass &&
-                        subsequent?.FindStartingLiteral() is ValueTuple<char, string?, string?> literal2)
+                        subsequent?.FindStartingLiteral() is ValueTuple<char, string?, string?, bool> literal2)
                     {
                         // e.g. ".*?string" with RegexOptions.Singleline
                         // This lazy loop will consume all characters until the subsequent literal. If the subsequent literal
                         // isn't found, the loop fails. We can implement it to just search for that literal.
+                        (string indexOfName, string indexOfAnyName) = !literal2.Item4 ?
+                            ("IndexOf", "IndexOfAny") :
+                            ("IndexOfAnyExcept", "IndexOfAnyExcept");
                         writer.WriteLine(
-                            literal2.Item2 is not null ? $"{startingPos} = {sliceSpan}.IndexOf({Literal(literal2.Item2)});" :
-                            literal2.Item3 is null ? $"{startingPos} = {sliceSpan}.IndexOf({Literal(literal2.Item1)});" :
+                            literal2.Item2 is not null ? $"{startingPos} = {sliceSpan}.{indexOfName}({Literal(literal2.Item2)});" :
+                            literal2.Item3 is null ? $"{startingPos} = {sliceSpan}.{indexOfName}({Literal(literal2.Item1)});" :
                             literal2.Item3.Length switch
                             {
-                                2 => $"{startingPos} = {sliceSpan}.IndexOfAny({Literal(literal2.Item3[0])}, {Literal(literal2.Item3[1])});",
-                                3 => $"{startingPos} = {sliceSpan}.IndexOfAny({Literal(literal2.Item3[0])}, {Literal(literal2.Item3[1])}, {Literal(literal2.Item3[2])});",
-                                _ => $"{startingPos} = {sliceSpan}.IndexOfAny({Literal(literal2.Item3)});",
+                                2 => $"{startingPos} = {sliceSpan}.{indexOfAnyName}({Literal(literal2.Item3[0])}, {Literal(literal2.Item3[1])});",
+                                3 => $"{startingPos} = {sliceSpan}.{indexOfAnyName}({Literal(literal2.Item3[0])}, {Literal(literal2.Item3[1])}, {Literal(literal2.Item3[2])});",
+                                _ => $"{startingPos} = {sliceSpan}.{indexOfAnyName}({Literal(literal2.Item3)});",
                             });
                         using (EmitBlock(writer, $"if ({startingPos} < 0)"))
                         {
@@ -3616,11 +3623,11 @@ namespace System.Text.RegularExpressions.Generator
                         writer.WriteLine();
                     }
                 }
-                else if (node.IsNotoneFamily && maxIterations == int.MaxValue)
+                else if ((node.IsOneFamily || node.IsNotoneFamily) && maxIterations == int.MaxValue)
                 {
-                    // For Notone, we're looking for a specific character, as everything until we find
-                    // it is consumed by the loop.  If we're unbounded, such as with ".*" and if we're case-sensitive,
-                    // we can use the vectorized IndexOf to do the search, rather than open-coding it.  The unbounded
+                    // For One or Notone, we're looking for a specific character, as everything until we find
+                    // it (or its negation in the case of One) is consumed by the loop.  If we're unbounded, such as with ".*" and if we're case-sensitive,
+                    // we can use the vectorized IndexOf{AnyExcept} to do the search, rather than open-coding it.  The unbounded
                     // restriction is purely for simplicity; it could be removed in the future with additional code to
                     // handle the unbounded case.
 
@@ -3629,7 +3636,8 @@ namespace System.Text.RegularExpressions.Generator
                     {
                         writer.Write($".Slice({sliceStaticPos})");
                     }
-                    writer.WriteLine($".IndexOf({Literal(node.Ch)});");
+                    string op = node.IsNotoneFamily ? "IndexOf" : "IndexOfAnyExcept";
+                    writer.WriteLine($".{op}({Literal(node.Ch)});");
 
                     using (EmitBlock(writer, $"if ({iterationLocal} < 0)"))
                     {
@@ -3641,11 +3649,10 @@ namespace System.Text.RegularExpressions.Generator
                 }
                 else if (node.IsSetFamily &&
                     maxIterations == int.MaxValue &&
-                    (numSetChars = RegexCharClass.GetSetChars(node.Str!, setChars)) != 0 &&
-                    RegexCharClass.IsNegated(node.Str!))
+                    (numSetChars = RegexCharClass.GetSetChars(node.Str!, setChars)) != 0)
                 {
-                    // If the set is negated and contains only a few characters (if it contained 1 and was negated, it should
-                    // have been reduced to a Notone), we can use an IndexOfAny to find any of the target characters.
+                    // If the set contains only a few characters (if it contained 1 and was negated, it should
+                    // have been reduced to a Notone), we can use an IndexOfAny{Except} to find any of the target characters.
                     // As with the notoneloopatomic above, the unbounded constraint is purely for simplicity.
                     Debug.Assert(numSetChars > 1);
 
@@ -3654,11 +3661,14 @@ namespace System.Text.RegularExpressions.Generator
                     {
                         writer.Write($".Slice({sliceStaticPos})");
                     }
-                    writer.WriteLine(numSetChars switch
+                    writer.WriteLine((numSetChars, RegexCharClass.IsNegated(node.Str!)) switch
                     {
-                        2 => $".IndexOfAny({Literal(setChars[0])}, {Literal(setChars[1])});",
-                        3 => $".IndexOfAny({Literal(setChars[0])}, {Literal(setChars[1])}, {Literal(setChars[2])});",
-                        _ => $".IndexOfAny({Literal(setChars.Slice(0, numSetChars).ToString())});",
+                        (2, true)  => $".IndexOfAny({Literal(setChars[0])}, {Literal(setChars[1])});",
+                        (3, true)  => $".IndexOfAny({Literal(setChars[0])}, {Literal(setChars[1])}, {Literal(setChars[2])});",
+                        (_, true)  => $".IndexOfAny({Literal(setChars.Slice(0, numSetChars).ToString())});",
+                        (2, false) => $".IndexOfAnyExcept({Literal(setChars[0])}, {Literal(setChars[1])});",
+                        (3, false) => $".IndexOfAnyExcept({Literal(setChars[0])}, {Literal(setChars[1])}, {Literal(setChars[2])});",
+                        (_, false) => $".IndexOfAnyExcept({Literal(setChars.Slice(0, numSetChars).ToString())});",
                     });
                     using (EmitBlock(writer, $"if ({iterationLocal} < 0)"))
                     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -63,11 +63,19 @@ namespace System.Text.RegularExpressions
         private static readonly MethodInfo s_spanIndexOfAnyCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanIndexOfAnyCharCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanIndexOfAnySpan = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOfAnyExceptChar = typeof(MemoryExtensions).GetMethod("IndexOfAnyExcept", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOfAnyExceptCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAnyExcept", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOfAnyExceptCharCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAnyExcept", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOfAnyExceptSpan = typeof(MemoryExtensions).GetMethod("IndexOfAnyExcept", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanLastIndexOfChar = typeof(MemoryExtensions).GetMethod("LastIndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanLastIndexOfAnyCharChar = typeof(MemoryExtensions).GetMethod("LastIndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanLastIndexOfAnyCharCharChar = typeof(MemoryExtensions).GetMethod("LastIndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanLastIndexOfAnySpan = typeof(MemoryExtensions).GetMethod("LastIndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanLastIndexOfSpan = typeof(MemoryExtensions).GetMethod("LastIndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanLastIndexOfAnyExceptChar = typeof(MemoryExtensions).GetMethod("LastIndexOfAnyExcept", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanLastIndexOfAnyExceptCharChar = typeof(MemoryExtensions).GetMethod("LastIndexOfAnyExcept", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanLastIndexOfAnyExceptCharCharChar = typeof(MemoryExtensions).GetMethod("LastIndexOfAnyExcept", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanLastIndexOfAnyExceptSpan = typeof(MemoryExtensions).GetMethod("LastIndexOfAnyExcept", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanSliceIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int) })!;
         private static readonly MethodInfo s_spanSliceIntIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int), typeof(int) })!;
         private static readonly MethodInfo s_spanStartsWithSpan = typeof(MemoryExtensions).GetMethod("StartsWith", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
@@ -3143,17 +3151,19 @@ namespace System.Text.RegularExpressions
                     BleFar(doneLabel);
                 }
 
-                if (!rtl && subsequent?.FindStartingLiteral() is ValueTuple<char, string?, string?> literal)
+                if (!rtl && subsequent?.FindStartingLiteral() is ValueTuple<char, string?, string?, bool> literal)
                 {
                     // endingPos = inputSpan.Slice(startingPos, Math.Min(inputSpan.Length, endingPos + literal.Length - 1) - startingPos).LastIndexOf(literal);
                     // if (endingPos < 0)
                     // {
                     //     goto doneLabel;
                     // }
+                    bool negated = literal.Item4;
                     Ldloca(inputSpan);
                     Ldloc(startingPos);
                     if (literal.Item2 is not null)
                     {
+                        Debug.Assert(!negated, "strings should not be negated");
                         Ldloca(inputSpan);
                         Call(s_spanGetLengthMethod);
                         Ldloc(endingPos);
@@ -3180,27 +3190,27 @@ namespace System.Text.RegularExpressions
                                 case 2:
                                     Ldc(literal.Item3[0]);
                                     Ldc(literal.Item3[1]);
-                                    Call(s_spanLastIndexOfAnyCharChar);
+                                    Call(negated ? s_spanLastIndexOfAnyExceptCharChar : s_spanLastIndexOfAnyCharChar);
                                     break;
 
                                 case 3:
                                     Ldc(literal.Item3[0]);
                                     Ldc(literal.Item3[1]);
                                     Ldc(literal.Item3[2]);
-                                    Call(s_spanLastIndexOfAnyCharCharChar);
+                                    Call(negated ? s_spanLastIndexOfAnyExceptCharCharChar : s_spanLastIndexOfAnyCharCharChar);
                                     break;
 
                                 default:
                                     Ldstr(literal.Item3);
                                     Call(s_stringAsSpanMethod);
-                                    Call(s_spanLastIndexOfAnySpan);
+                                    Call(negated ? s_spanLastIndexOfAnyExceptSpan : s_spanLastIndexOfAnySpan);
                                     break;
                             }
                         }
                         else
                         {
                             Ldc(literal.Item1);
-                            Call(s_spanLastIndexOfChar);
+                            Call(negated ? s_spanLastIndexOfAnyExceptChar : s_spanLastIndexOfChar);
                         }
                     }
                     Stloc(endingPos);
@@ -3371,7 +3381,8 @@ namespace System.Text.RegularExpressions
                 if (!rtl &&
                     iterationCount is null &&
                     node.Kind is RegexNodeKind.Notonelazy &&
-                    subsequent?.FindStartingLiteral(4) is ValueTuple<char, string?, string?> literal) // 5 == max optimized by IndexOfAny, and we need to reserve 1 for node.Ch
+                    subsequent?.FindStartingLiteral(4) is ValueTuple<char, string?, string?, bool> literal && // 5 == max optimized by IndexOfAny, and we need to reserve 1 for node.Ch
+                    !literal.Item4) // not negated; can't search for both the node.Ch and a negated subsequent char with an IndexOf* method
                 {
                     // e.g. "<[^>]*?>"
 
@@ -3504,16 +3515,18 @@ namespace System.Text.RegularExpressions
                     iterationCount is null &&
                     node.Kind is RegexNodeKind.Setlazy &&
                     node.Str == RegexCharClass.AnyClass &&
-                    subsequent?.FindStartingLiteral() is ValueTuple<char, string?, string?> literal2)
+                    subsequent?.FindStartingLiteral() is ValueTuple<char, string?, string?, bool> literal2)
                 {
                     // e.g. ".*?string" with RegexOptions.Singleline
                     // This lazy loop will consume all characters until the subsequent literal. If the subsequent literal
                     // isn't found, the loop fails. We can implement it to just search for that literal.
+                    bool negated = literal2.Item4;
 
                     // startingPos = slice.IndexOf(literal);
                     Ldloc(slice);
                     if (literal2.Item2 is not null)
                     {
+                        Debug.Assert(!negated, "strings should not be negated");
                         Ldstr(literal2.Item2);
                         Call(s_stringAsSpanMethod);
                         Call(s_spanIndexOfSpan);
@@ -3525,27 +3538,27 @@ namespace System.Text.RegularExpressions
                             case 2:
                                 Ldc(literal2.Item3[0]);
                                 Ldc(literal2.Item3[1]);
-                                Call(s_spanIndexOfAnyCharChar);
+                                Call(negated ? s_spanIndexOfAnyExceptCharChar : s_spanIndexOfAnyCharChar);
                                 break;
 
                             case 3:
                                 Ldc(literal2.Item3[0]);
                                 Ldc(literal2.Item3[1]);
                                 Ldc(literal2.Item3[2]);
-                                Call(s_spanIndexOfAnyCharCharChar);
+                                Call(negated ? s_spanIndexOfAnyExceptCharCharChar : s_spanIndexOfAnyCharCharChar);
                                 break;
 
                             default:
                                 Ldstr(literal2.Item3);
                                 Call(s_stringAsSpanMethod);
-                                Call(s_spanIndexOfAnySpan);
+                                Call(negated ? s_spanIndexOfAnyExceptSpan : s_spanIndexOfAnySpan);
                                 break;
                         }
                     }
                     else
                     {
                         Ldc(literal2.Item1);
-                        Call(s_spanIndexOfChar);
+                        Call(negated ? s_spanIndexOfAnyExceptChar : s_spanIndexOfChar);
                     }
                     Stloc(startingPos);
 
@@ -4215,12 +4228,11 @@ namespace System.Text.RegularExpressions
                         BrFar(bodyLabel);
                     }
                 }
-                else if (node.IsNotoneFamily &&
-                    maxIterations == int.MaxValue)
+                else if ((node.IsOneFamily || node.IsNotoneFamily) && maxIterations == int.MaxValue)
                 {
-                    // For Notone, we're looking for a specific character, as everything until we find
-                    // it is consumed by the loop.  If we're unbounded, such as with ".*" and if we're case-sensitive,
-                    // we can use the vectorized IndexOf to do the search, rather than open-coding it.  The unbounded
+                    // For One or Notone, we're looking for a specific character, as everything until we find
+                    // it (or its negation in the case of One) is consumed by the loop.  If we're unbounded, such as with ".*" and if we're case-sensitive,
+                    // we can use the vectorized IndexOf{AnyExcept} to do the search, rather than open-coding it.  The unbounded
                     // restriction is purely for simplicity; it could be removed in the future with additional code to
                     // handle the unbounded case.
 
@@ -4236,7 +4248,7 @@ namespace System.Text.RegularExpressions
                         Ldloc(slice);
                     }
                     Ldc(node.Ch);
-                    Call(s_spanIndexOfChar);
+                    Call(node.IsNotoneFamily ? s_spanIndexOfChar : s_spanIndexOfAnyExceptChar);
                     Stloc(iterationLocal);
 
                     // if (i >= 0) goto atomicLoopDoneLabel;
@@ -4256,13 +4268,13 @@ namespace System.Text.RegularExpressions
                 }
                 else if (node.IsSetFamily &&
                     maxIterations == int.MaxValue &&
-                    (numSetChars = RegexCharClass.GetSetChars(node.Str!, setChars)) != 0 &&
-                    RegexCharClass.IsNegated(node.Str!))
+                    (numSetChars = RegexCharClass.GetSetChars(node.Str!, setChars)) != 0)
                 {
-                    // If the set is negated and contains only a few characters (if it contained 1 and was negated, it would
-                    // have been reduced to a Notone), we can use an IndexOfAny to find any of the target characters.
+                    // If the set contains only a few characters (if it contained 1 and was negated, it should
+                    // have been reduced to a Notone), we can use an IndexOfAny{Except} to find any of the target characters.
                     // As with the notoneloopatomic above, the unbounded constraint is purely for simplicity.
                     Debug.Assert(numSetChars > 1);
+                    bool negated = RegexCharClass.IsNegated(node.Str!);
 
                     // int i = slice.Slice(sliceStaticPos).IndexOfAny(ch1, ch2, ...);
                     if (sliceStaticPos > 0)
@@ -4280,20 +4292,20 @@ namespace System.Text.RegularExpressions
                         case 2:
                             Ldc(setChars[0]);
                             Ldc(setChars[1]);
-                            Call(s_spanIndexOfAnyCharChar);
+                            Call(negated ? s_spanIndexOfAnyCharChar : s_spanIndexOfAnyExceptCharChar);
                             break;
 
                         case 3:
                             Ldc(setChars[0]);
                             Ldc(setChars[1]);
                             Ldc(setChars[2]);
-                            Call(s_spanIndexOfAnyCharCharChar);
+                            Call(negated ? s_spanIndexOfAnyCharCharChar : s_spanIndexOfAnyExceptCharCharChar);
                             break;
 
                         default:
                             Ldstr(setChars.Slice(0, numSetChars).ToString());
                             Call(s_stringAsSpanMethod);
-                            Call(s_spanIndexOfAnySpan);
+                            Call(negated ? s_spanIndexOfAnySpan : s_spanIndexOfAnyExceptSpan);
                             break;
                     }
                     Stloc(iterationLocal);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1377,7 +1377,11 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>Finds the guaranteed beginning literal(s) of the node, or null if none exists.</summary>
-        public (char Char, string? String, string? SetChars)? FindStartingLiteral(int maxSetCharacters = 5) // 5 is max optimized by IndexOfAny today
+        /// <returns>
+        /// A tuple of data about the literal: only one of the Char/String/SetChars fields is relevant.
+        /// The Negated value indicates whether the Char/SetChars should be considered exclusionary.
+        /// </returns>
+        public (char Char, string? String, string? SetChars, bool Negated)? FindStartingLiteral(int maxSetCharacters = 5) // 5 is max optimized by IndexOfAny today
         {
             Debug.Assert(maxSetCharacters >= 0 && maxSetCharacters <= 128, $"{nameof(maxSetCharacters)} == {maxSetCharacters} should be small enough to be stack allocated.");
 
@@ -1390,31 +1394,23 @@ namespace System.Text.RegularExpressions
                     {
                         case RegexNodeKind.One:
                         case RegexNodeKind.Oneloop or RegexNodeKind.Oneloopatomic or RegexNodeKind.Onelazy when node.M > 0:
-                            if ((node.Options & RegexOptions.IgnoreCase) == 0 || !RegexCharClass.ParticipatesInCaseConversion(node.Ch))
-                            {
-                                return (node.Ch, null, null);
-                            }
-                            break;
+                            return (node.Ch, null, null, false);
+
+                        case RegexNodeKind.Notone:
+                        case RegexNodeKind.Notoneloop or RegexNodeKind.Notoneloopatomic or RegexNodeKind.Notonelazy when node.M > 0:
+                            return (node.Ch, null, null, true);
 
                         case RegexNodeKind.Multi:
-                            if ((node.Options & RegexOptions.IgnoreCase) == 0 || !RegexCharClass.ParticipatesInCaseConversion(node.Str.AsSpan()))
-                            {
-                                return ('\0', node.Str, null);
-                            }
-                            break;
+                            return ('\0', node.Str, null, false);
 
                         case RegexNodeKind.Set:
                         case RegexNodeKind.Setloop or RegexNodeKind.Setloopatomic or RegexNodeKind.Setlazy when node.M > 0:
                             Span<char> setChars = stackalloc char[maxSetCharacters];
                             int numChars;
-                            if (!RegexCharClass.IsNegated(node.Str!) &&
-                                (numChars = RegexCharClass.GetSetChars(node.Str!, setChars)) != 0)
+                            if ((numChars = RegexCharClass.GetSetChars(node.Str!, setChars)) != 0)
                             {
                                 setChars = setChars.Slice(0, numChars);
-                                if ((node.Options & RegexOptions.IgnoreCase) == 0 || !RegexCharClass.ParticipatesInCaseConversion(setChars))
-                                {
-                                    return ('\0', null, setChars.ToString());
-                                }
+                                return ('\0', null, setChars.ToString(), RegexCharClass.IsNegated(node.Str!));
                             }
                             break;
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -316,6 +316,14 @@ namespace System.Text.RegularExpressions.Tests
 
                 yield return (@".*?", "abc", lineOption, 1, 2, true, "");
                 yield return (@".*?c", "abc", lineOption, 1, 2, true, "bc");
+                yield return (@".*?[^c]", "abc", lineOption, 1, 2, true, "b");
+                yield return (@".*?[^cz]", "abc", lineOption, 1, 2, true, "b");
+                yield return (@".*?[^u]", "abc", lineOption, 1, 2, true, "b");
+                yield return (@".*?[^uv]", "abc", lineOption, 1, 2, true, "b");
+                yield return (@".*?[^uvw]", "abc", lineOption, 1, 2, true, "b");
+                yield return (@".*?[^uvwx]", "abc", lineOption, 1, 2, true, "b");
+                yield return (@".*?[^uvwxy]", "abc", lineOption, 1, 2, true, "b");
+                yield return (@".*?[^uvwxyz]", "abc", lineOption, 1, 2, true, "b");
                 yield return (@"b.*?", "abc", lineOption, 1, 2, true, "b");
                 yield return (@".*?", "abc", lineOption, 2, 1, true, "");
 


### PR DESCRIPTION
In almost every place we use {Last}IndexOf{Any} for a given character or set of characters, we can use {Last}IndexOfAnyExcept for the negated counterpart.  This leads to cleaner generated code, and for longer searches, benefits from vectorization.  This includes:
- In set loops of a small number of negated chars, finding the end of the loop with IndexOfAnyExcept.
- In loops followed by a set of a small number of negated chars, using LastIndexOfAnyExcept to find the next location to which to backtrack.
- In Singleline .*? lazy loops followed by a set of a small number of negated chars, using IndexOfAnyExcept to find the next location to backtrack to.
- In unbounded atomic one and set loops, using IndexOfAnyExcept to find the end of the loop

The two places we don't currently use IndexOf* but don't use the *Except variants are:
- As part of TryFindNextPossibleStartingPosition.  There appear to be relatively few patterns in the wild this would benefit, and we'd need custom logic for finding the set of negated starting characters.
- As part of backtracking in a non-Singleline lazy loop.  It needs to search for the target plus a \n, which works well when the target is a non-negated char (as it just adds the char to the set of things to search for) but doesn't when working with a negated char (as then different elements of the search have different polarities).