### PR TITLE
Filter out Tailscale from LinkLocal address list

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
+++ b/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
@@ -112,6 +112,7 @@ namespace System.Net.Http.Functional.Tests
                 .Where(i => !i.Description.StartsWith("PANGP Virtual Ethernet"))    // This is a VPN adapter, but is reported as a regular Ethernet interface with
                                                                                     // a valid link-local address, but the link-local address doesn't actually work.
                                                                                     // So just manually filter it out.
+                .Where(i => !i.Name.Contains("Tailscale"))                          // Same as PANGP above.
                 .SelectMany(i => i.GetIPProperties().UnicastAddresses)
                 .Select(a => a.Address)
                 .Where(a => a.IsIPv6LinkLocal)


### PR DESCRIPTION
Same as #27484 but with Tailscale installed.

SocketsHttpHandler and WinHttpHandler LinkLocal tests have been failing consistently for me.