### PR TITLE
[NativeAOT] Fix a stress crash in thread detach at process shutdown.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -441,12 +441,7 @@ void RuntimeThreadShutdown(void* thread)
     ASSERT((Thread*)thread == ThreadStore::GetCurrentThread());
 #endif
 
-    if (g_processShutdownHasStarted)
-    {
-        return;
-    }
-
-    ThreadStore::DetachCurrentThread();
+    ThreadStore::DetachCurrentThread(g_processShutdownHasStarted);
 }
 
 extern "C" bool RhInitialize()

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -173,14 +173,13 @@ void ThreadStore::DetachCurrentThread(bool shutdownStarted)
         ReaderWriterLock::WriteHolder write(&pTS->m_Lock);
         ASSERT(rh::std::count(pTS->m_ThreadList.Begin(), pTS->m_ThreadList.End(), pDetachingThread) == 1);
         pTS->m_ThreadList.RemoveFirst(pDetachingThread);
-
-        // the rest of cleanup is not necessary if we are shutting down.
-        if (shutdownStarted)
-        {
-            return;
-        }
-
         pDetachingThread->Detach();
+    }
+
+    // the rest of cleanup is not necessary if we are shutting down.
+    if (shutdownStarted)
+    {
+        return;
     }
 
     pDetachingThread->Destroy();

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -148,7 +148,7 @@ void ThreadStore::AttachCurrentThread()
     AttachCurrentThread(true);
 }
 
-void ThreadStore::DetachCurrentThread()
+void ThreadStore::DetachCurrentThread(bool shutdownStarted)
 {
     // The thread may not have been initialized because it may never have run managed code before.
     Thread * pDetachingThread = RawGetCurrentThread();
@@ -165,10 +165,21 @@ void ThreadStore::DetachCurrentThread()
     }
 
     {
+        // remove the thread from the list.
+        // this must be done even when shutdown is in progress.
+        // departing threads will be releasing their TLS storage and if not removed,
+        // will corrupt the thread list, while some prior to shutdown detach might still be in progress.
         ThreadStore* pTS = GetThreadStore();
         ReaderWriterLock::WriteHolder write(&pTS->m_Lock);
         ASSERT(rh::std::count(pTS->m_ThreadList.Begin(), pTS->m_ThreadList.End(), pDetachingThread) == 1);
         pTS->m_ThreadList.RemoveFirst(pDetachingThread);
+
+        // the rest of cleanup is not necessary if we are shutting down.
+        if (shutdownStarted)
+        {
+            return;
+        }
+
         pDetachingThread->Detach();
     }
 

--- a/src/coreclr/nativeaot/Runtime/threadstore.h
+++ b/src/coreclr/nativeaot/Runtime/threadstore.h
@@ -48,7 +48,7 @@ public:
     static PTR_Thread       GetSuspendingThread();
     static void             AttachCurrentThread();
     static void             AttachCurrentThread(bool fAcquireThreadStoreLock);
-    static void             DetachCurrentThread();
+    static void             DetachCurrentThread(bool shutdownStarted);
 #ifndef DACCESS_COMPILE
     static void             SaveCurrentThreadOffsetForDAC();
     void                    InitiateThreadAbort(Thread* targetThread, Object * threadAbortException, bool doRudeAbort);


### PR DESCRIPTION
fixes: https://github.com/dotnet/runtime/issues/73116

At shutdown we allow some threads to terminate without removing themselves from the thread list. Once a TLS of such thread is released, the thread list becomes corrupted, so whoever iterates the list now or later crashes.

Since we cannot be sure that every thread is promptly aware that we are shutting down, we cannot let threads to exit without removing themselves from the thread list first.