### PR TITLE
Safer state handling in distributed transactions

### DIFF
--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
@@ -95,7 +95,6 @@ internal sealed class DtcProxyShimFactory
                 pImportWhereabouts.GetWhereabouts(whereaboutsSize, tmpWhereabouts, out uint pcbUsed);
                 Debug.Assert(pcbUsed == tmpWhereabouts.Length);
             });
-            whereabouts = tmpWhereabouts;
 
             // Now we need to create the internal resource manager.
             var rmFactory = (IResourceManagerFactory2)localDispenser;
@@ -117,6 +116,7 @@ internal sealed class DtcProxyShimFactory
 
             resourceManagerShim = rmShim;
             _transactionDispenser = localDispenser;
+            whereabouts = tmpWhereabouts;
         }
     }
 


### PR DESCRIPTION
Make sure we don't accidentally set our state to initialized when an exception occurs.

Related to #73874.