### PR TITLE
Add support for `<TrimmerRootDescriptor>`

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -189,7 +189,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Target>
 
   <Target Name="WriteIlcRspFileForCompilation"
-      Inputs="@(IlcCompileInput);@(RdXmlFile)"
+      Inputs="@(IlcCompileInput);@(RdXmlFile);@(TrimmerRootDescriptor)"
       Outputs="%(ManagedBinary.IlcRspFile)"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
@@ -216,6 +216,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcGenerateDgmlFile) == 'true'" Include="--dgmllog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).codegen.dgml.xml" />
       <IlcArg Condition="$(IlcGenerateDgmlFile) == 'true'" Include="--scandgmllog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).scan.dgml.xml" />
       <IlcArg Include="@(RdXmlFile->'--rdxml:%(FullPath)')" />
+      <IlcArg Include="@(TrimmerRootDescriptor->'--descriptor:%(FullPath)')" />
       <IlcArg Condition="$(NativeLib) != ''" Include="--nativelib" />
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EmbeddedTrimmingDescriptorNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EmbeddedTrimmingDescriptorNode.cs
@@ -60,7 +60,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory factory)
         {
-            return $"Getting embedded descriptor file from {_module.ToString()}";
+            return $"Embedded descriptor from {_module.ToString()}";
         }
 
         public override bool InterestingForDynamicDependencyAnalysis => false;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TrimmingDescriptorNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TrimmingDescriptorNode.cs
@@ -1,0 +1,46 @@
+﻿//Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public class TrimmingDescriptorNode : DependencyNodeCore<NodeFactory>, ICompilationRootProvider
+    {
+        private readonly string _fileName;
+
+        public TrimmingDescriptorNode(string fileName)
+        {
+            _fileName = fileName;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            using (Stream fs = File.OpenRead(_fileName))
+            {
+                var metadataManager = (UsageBasedMetadataManager)factory.MetadataManager;
+                return DescriptorMarker.GetDependencies(factory, fs, default, default, _fileName, metadataManager.FeatureSwitches);
+            }
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return $"Descriptor in {_fileName}";
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+        void ICompilationRootProvider.AddCompilationRoots(IRootingServiceProvider rootProvider) => rootProvider.AddCompilationRoot(this, "Descriptor from command line");
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DescriptorMarker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DescriptorMarker.cs
@@ -219,7 +219,7 @@ namespace ILCompiler
                 // LogWarning(nav, DiagnosticId.XmlDuplicatePreserveMember, field.FullName);
             }*/
 
-            _dependencies.Add(_factory.ReflectableField(field), "field kept due to embedded descriptor");
+            _dependencies.Add(_factory.ReflectableField(field), "field kept due to descriptor");
         }
 
         protected override void ProcessMethod(TypeDesc type, MethodDesc method, XPathNavigator nav, object? customData)
@@ -234,11 +234,11 @@ namespace ILCompiler
             if (customData is bool required && !required)
             {
                 //TODO: Add a conditional dependency if the type is used also mark the method
-                _dependencies.Add(_factory.ReflectableMethod(method), "method kept due to embedded descriptor");
+                _dependencies.Add(_factory.ReflectableMethod(method), "method kept due to descriptor");
             }
             else
             {
-                _dependencies.Add(_factory.ReflectableMethod(method), "method kept due to embedded descriptor");
+                _dependencies.Add(_factory.ReflectableMethod(method), "method kept due to descriptor");
             }
         }
 
@@ -332,7 +332,7 @@ namespace ILCompiler
             return _accessorsAll;
         }
 
-        public static DependencyList GetDependencies(NodeFactory factory, UnmanagedMemoryStream documentStream, ManifestResource resource, ModuleDesc resourceAssembly, string xmlDocumentLocation, IReadOnlyDictionary<string, bool> featureSwitchValues)
+        public static DependencyList GetDependencies(NodeFactory factory, Stream documentStream, ManifestResource resource, ModuleDesc resourceAssembly, string xmlDocumentLocation, IReadOnlyDictionary<string, bool> featureSwitchValues)
         {
             var descriptor = new DescriptorMarker(factory, documentStream, resource, resourceAssembly, xmlDocumentLocation, featureSwitchValues);
             descriptor.ProcessXml(false);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
@@ -21,5 +21,6 @@ namespace ILCompiler
         void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName);
         void RootDelegateMarshallingData(DefType type, string reason);
         void RootStructMarshallingData(DefType type, string reason);
+        void AddCompilationRoot(object o, string reason);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessLinkerXmlBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessLinkerXmlBase.cs
@@ -5,19 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
 using ILCompiler.Dataflow;
-using ILLink.Shared;
 
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -68,7 +64,7 @@ namespace ILCompiler
         protected ProcessLinkerXmlBase(TypeSystemContext context, Stream documentStream, ManifestResource resource, ModuleDesc resourceAssembly, string xmlDocumentLocation, IReadOnlyDictionary<string, bool> featureSwitchValues)
             : this(context, documentStream, xmlDocumentLocation, featureSwitchValues)
         {
-            _owningModule = resourceAssembly ?? throw new ArgumentNullException(nameof(resourceAssembly));
+            _owningModule = resourceAssembly;
         }
 
         protected virtual bool ShouldProcessElement(XPathNavigator nav) => FeatureSettings.ShouldProcessElement(nav, _featureSwitchValues);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysisFramework;
 
 using Internal.TypeSystem;
 
@@ -50,6 +51,12 @@ namespace ILCompiler
         {
             if (!_factory.MetadataManager.IsReflectionBlocked(field))
                 _rootAdder(_factory.ReflectableField(field), reason);
+        }
+
+        public void AddCompilationRoot(object o, string reason)
+        {
+            Debug.Assert(o is IDependencyNode<NodeFactory>);
+            _rootAdder(o, reason);
         }
 
         public void RootThreadStaticBaseForType(TypeDesc type, string reason)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -394,6 +394,7 @@
     <Compile Include="Compiler\DependencyAnalysis\Target_X86\X86TentativeMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\TentativeInstanceMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\TentativeMethodNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\TrimmingDescriptorNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\VariantInterfaceMethodUseNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\CustomAttributeBasedDependencyAlgorithm.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FieldMetadataNode.cs" />

--- a/src/tests/nativeaot/SmokeTests/EmbeddedDescriptor/EmbeddedDescriptor.cs
+++ b/src/tests/nativeaot/SmokeTests/EmbeddedDescriptor/EmbeddedDescriptor.cs
@@ -12,6 +12,8 @@ class Program
     static int Main()
     {
         ThrowIfMemberNotPresent(typeof(Program), nameof(methodKeptViaDescriptor));
+        ThrowIfMemberNotPresent(typeof(Program), nameof(methodKeptViaStandaloneDescriptor));
+        ThrowIfMemberPresent(typeof(Program), nameof(methodNotKept));
         ThrowIfMemberNotPresent(typeof(Program), nameof(fieldKeptViaDescriptor));
         ThrowIfMemberNotPresent(typeof(Program), nameof(PropertyKeptViaDescriptor));
         ThrowIfMemberNotPresent(typeof(Program), nameof(EventKeptViaDescriptor));
@@ -21,6 +23,14 @@ class Program
     }
 
     public static void methodKeptViaDescriptor()
+    {
+    }
+
+    public static void methodKeptViaStandaloneDescriptor()
+    {
+    }
+
+    public static void methodNotKept()
     {
     }
 
@@ -72,6 +82,14 @@ class Program
     private static void ThrowIfMemberNotPresent(Type testType, string memberName)
     {
         if (!IsMemberPresent(testType, memberName))
+        {
+            throw new Exception(memberName);
+        }
+    }
+
+    private static void ThrowIfMemberPresent(Type testType, string memberName)
+    {
+        if (IsMemberPresent(testType, memberName))
         {
             throw new Exception(memberName);
         }

--- a/src/tests/nativeaot/SmokeTests/EmbeddedDescriptor/EmbeddedDescriptor.csproj
+++ b/src/tests/nativeaot/SmokeTests/EmbeddedDescriptor/EmbeddedDescriptor.csproj
@@ -11,5 +11,7 @@
     <EmbeddedResource Include="ILLink.Descriptors.xml">
       <LogicalName>ILLink.Descriptors.xml</LogicalName>
     </EmbeddedResource>
+
+    <TrimmerRootDescriptor Include="NonEmbedded.ILLink.Descriptor.xml" />
   </ItemGroup>
 </Project>

--- a/src/tests/nativeaot/SmokeTests/EmbeddedDescriptor/NonEmbedded.ILLink.Descriptor.xml
+++ b/src/tests/nativeaot/SmokeTests/EmbeddedDescriptor/NonEmbedded.ILLink.Descriptor.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="EmbeddedDescriptor">
+    <type fullname="Program">
+      <method name="methodKeptViaStandaloneDescriptor"/>
+    </type>
+  </assembly>
+</linker>


### PR DESCRIPTION
Fixes #70810.

Hopefully it's all pretty straightforward.

Cc @dotnet/ilc-contrib 

@LakshanF @sbomer Vitek, Jan, Tlaka are all out. It's on you whether this can make it before 7.0 cutoff. No pressure.