### PR TITLE
Improve Directory.CreateDirectory performance

### DIFF
--- a/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
@@ -5,8 +5,9 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System.IO
@@ -26,55 +27,6 @@ namespace System.IO
                 return;
             }
 
-            List<string> stackDir = new List<string>();
-
-            // Attempt to figure out which directories don't exist, and only
-            // create the ones we need.  Note that FileExists may fail due
-            // to Win32 ACL's preventing us from seeing a directory, and this
-            // isn't threadsafe.
-
-            bool somepathexists = false;
-            int length = fullPath.Length;
-
-            // We need to trim the trailing slash or the code will try to create 2 directories of the same name.
-            if (length >= 2 && PathInternal.EndsInDirectorySeparator(fullPath.AsSpan()))
-            {
-                length--;
-            }
-
-            int lengthRoot = PathInternal.GetRootLength(fullPath.AsSpan());
-
-            if (length > lengthRoot)
-            {
-                // Special case root (fullpath = X:\\)
-                int i = length - 1;
-                while (i >= lengthRoot && !somepathexists)
-                {
-                    string dir = fullPath.Substring(0, i + 1);
-
-                    if (!DirectoryExists(dir)) // Create only the ones missing
-                    {
-                        stackDir.Add(dir);
-                    }
-                    else
-                    {
-                        somepathexists = true;
-                    }
-
-                    while (i > lengthRoot && !PathInternal.IsDirectorySeparator(fullPath[i]))
-                    {
-                        i--;
-                    }
-
-                    i--;
-                }
-            }
-
-            int count = stackDir.Count;
-            bool r = true;
-            int firstError = 0;
-            string errorString = fullPath;
-
             fixed (byte* pSecurityDescriptor = securityDescriptor)
             {
                 Interop.Kernel32.SECURITY_ATTRIBUTES secAttrs = new Interop.Kernel32.SECURITY_ATTRIBUTES
@@ -83,15 +35,84 @@ namespace System.IO
                     lpSecurityDescriptor = (IntPtr)pSecurityDescriptor
                 };
 
-                while (stackDir.Count > 0)
+                // Every call to CreateDirectory uses EnsureExtendedPrefix on the supplied path, which
+                // creates a new string if the prefix was missing.  Since we're making at least one and
+                // potentially multiple calls to CreateDirectory, we lift out that prefixing so that the
+                // string that's created can be shared across all calls rather than having a temporary in each.
+                fullPath = PathInternal.EnsureExtendedPrefix(fullPath);
+
+                // We know the directory doesn't exist.  Before doing more work to parse the path into
+                // subdirectories and checking each one for existence, try to just create the directory.
+                // If it works, which is a common case when the parent directory already exists, we're done.
+                // Otherwise, ignore the error and proceed with the full handling. This makes a fast path
+                // faster and a slow path a little bit slower.
+                if (Interop.Kernel32.CreateDirectory(fullPath, &secAttrs))
                 {
-                    string name = stackDir[stackDir.Count - 1];
-                    stackDir.RemoveAt(stackDir.Count - 1);
+                    return;
+                }
+
+                // Use enough stack space to hold three directory paths.  After that, ValueListBuilder
+                // will grow with ArrayPool arrays.
+                ThreeObjects scratch = default;
+                var stackDir = new ValueListBuilder<string>(MemoryMarshal.CreateSpan(ref Unsafe.As<object, string>(ref scratch.Arg0!), 3));
+
+                // Attempt to figure out which directories don't exist, and only
+                // create the ones we need.  Note that FileExists may fail due
+                // to Win32 ACL's preventing us from seeing a directory, and this
+                // isn't threadsafe.
+
+                bool somepathexists = false;
+                int length = fullPath.Length;
+
+                // We need to trim the trailing slash or the code will try to create 2 directories of the same name.
+                if (length >= 2 && PathInternal.EndsInDirectorySeparator(fullPath.AsSpan()))
+                {
+                    length--;
+                }
+
+                int lengthRoot = PathInternal.GetRootLength(fullPath.AsSpan());
+
+                if (length > lengthRoot)
+                {
+                    // Special case root (fullpath = X:\\)
+                    int i = length - 1;
+                    while (i >= lengthRoot && !somepathexists)
+                    {
+                        string dir = fullPath.Substring(0, i + 1);
+
+                        if (!DirectoryExists(dir)) // Create only the ones missing
+                        {
+                            stackDir.Append(dir);
+                        }
+                        else
+                        {
+                            somepathexists = true;
+                        }
+
+                        while (i > lengthRoot && !PathInternal.IsDirectorySeparator(fullPath[i]))
+                        {
+                            i--;
+                        }
+
+                        i--;
+                    }
+                }
+
+                int count = stackDir.Length;
+                bool r = true;
+                int firstError = 0;
+                string errorString = fullPath;
+
+                while (stackDir.Length > 0)
+                {
+                    ref string slot = ref stackDir[^1];
+                    string name = slot;
+                    slot = null!; // to avoid keeping these strings alive in pooled arrays
+                    stackDir.Length--;
 
                     r = Interop.Kernel32.CreateDirectory(name, &secAttrs);
                     if (!r && (firstError == 0))
                     {
-                        int currentError = Marshal.GetLastWin32Error();
                         // While we tried to avoid creating directories that don't
                         // exist above, there are at least two cases that will
                         // cause us to see ERROR_ALREADY_EXISTS here.  FileExists
@@ -100,6 +121,7 @@ namespace System.IO
                         // create the directory between the time we check and the
                         // time we try using the directory.  Thirdly, it could
                         // fail because the target does exist, but is a file.
+                        int currentError = Marshal.GetLastWin32Error();
                         if (currentError != Interop.Errors.ERROR_ALREADY_EXISTS)
                         {
                             firstError = currentError;
@@ -115,27 +137,28 @@ namespace System.IO
                         }
                     }
                 }
-            }
 
-            // We need this check to mask OS differences
-            // Handle CreateDirectory("X:\\") when X: doesn't exist. Similarly for n/w paths.
-            if ((count == 0) && !somepathexists)
-            {
-                string? root = Path.GetPathRoot(fullPath);
+                stackDir.Dispose();
 
-                if (!DirectoryExists(root))
+                // We need this check to mask OS differences
+                // Handle CreateDirectory("X:\\") when X: doesn't exist. Similarly for n/w paths.
+                if ((count == 0) && !somepathexists)
                 {
-                    throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_PATH_NOT_FOUND, root);
+                    string? root = Path.GetPathRoot(fullPath);
+                    if (root is null || !DirectoryExists(root))
+                    {
+                        throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_PATH_NOT_FOUND, root);
+                    }
+
+                    return;
                 }
 
-                return;
-            }
-
-            // Only throw an exception if creating the exact directory we
-            // wanted failed to work correctly.
-            if (!r && (firstError != 0))
-            {
-                throw Win32Marshal.GetExceptionForWin32Error(firstError, errorString);
+                // Only throw an exception if creating the exact directory we
+                // wanted failed to work correctly.
+                if (!r && (firstError != 0))
+                {
+                    throw Win32Marshal.GetExceptionForWin32Error(firstError, errorString);
+                }
             }
         }
     }

--- a/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
@@ -35,12 +35,6 @@ namespace System.IO
                     lpSecurityDescriptor = (IntPtr)pSecurityDescriptor
                 };
 
-                // Every call to CreateDirectory uses EnsureExtendedPrefix on the supplied path, which
-                // creates a new string if the prefix was missing.  Since we're making at least one and
-                // potentially multiple calls to CreateDirectory, we lift out that prefixing so that the
-                // string that's created can be shared across all calls rather than having a temporary in each.
-                fullPath = PathInternal.EnsureExtendedPrefix(fullPath);
-
                 // We know the directory doesn't exist.  Before doing more work to parse the path into
                 // subdirectories and checking each one for existence, try to just create the directory.
                 // If it works, which is a common case when the parent directory already exists, we're done.

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
@@ -86,6 +86,10 @@
              Link="Common\System\IO\FileSystem.Attributes.Windows.cs" />
     <Compile Include="$(CommonPath)System\IO\FileSystem.DirectoryCreation.Windows.cs"
              Link="Common\System\IO\FileSystem.DirectoryCreation.Windows.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Collections\Generic\ValueListBuilder.cs"
+             Link="Common\System\Collections\Generic\ValueListBuilder.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\ParamsArray.cs"
+             Link="Common\System\ParamsArray.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Buffers" Condition="'$(TargetPlatformIdentifier)' == 'windows'" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
@@ -34,13 +34,29 @@ namespace System.IO
             fullPath ??= originalPath;
             fullPath = isNormalized ? fullPath : Path.GetFullPath(fullPath);
 
-            _name = fileName ?? (PathInternal.IsRoot(fullPath.AsSpan()) ?
-                    fullPath.AsSpan() :
-                    Path.GetFileName(Path.TrimEndingDirectorySeparator(fullPath.AsSpan()))).ToString();
+            _name = fileName;
 
             FullPath = fullPath;
 
             _isNormalized = isNormalized;
+        }
+
+        public override string Name
+        {
+            get
+            {
+                string? name = _name;
+                if (name is null)
+                {
+                    ReadOnlySpan<char> fullPath = FullPath.AsSpan();
+                    _name = name = (PathInternal.IsRoot(fullPath) ?
+                        fullPath :
+                        Path.GetFileName(Path.TrimEndingDirectorySeparator(fullPath))).ToString();
+                }
+
+                return name;
+
+            }
         }
 
         public DirectoryInfo? Parent

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -29,8 +29,10 @@ namespace System.IO
             Debug.Assert(!isNormalized || !PathInternal.IsPartiallyQualified(fullPath.AsSpan()), "should be fully qualified if normalized");
 
             FullPath = isNormalized ? fullPath ?? originalPath : Path.GetFullPath(fullPath);
-            _name = fileName ?? Path.GetFileName(originalPath);
+            _name = fileName;
         }
+
+        public override string Name => _name ??= Path.GetFileName(OriginalPath);
 
         public long Length
         {
@@ -156,7 +158,7 @@ namespace System.IO
 
             FullPath = fullDestFileName;
             OriginalPath = destFileName;
-            _name = Path.GetFileName(fullDestFileName);
+            _name = null;
 
             // Flush any cached information about the file.
             Invalidate();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystemInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystemInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Versioning;
@@ -14,7 +15,7 @@ namespace System.IO
         protected string FullPath = null!;          // fully qualified path of the file or directory
         protected string OriginalPath = null!;      // path passed in by the user
 
-        internal string _name = null!; // Fields initiated in derived classes
+        internal string? _name;
 
         private string? _linkTarget;
         private bool _linkTargetIsValid;
@@ -55,7 +56,14 @@ namespace System.IO
             }
         }
 
-        public virtual string Name => _name;
+        public virtual string Name
+        {
+            get
+            {
+                Debug.Fail("Property is abstract in the ref assembly and both Directory/FileInfo override it.");
+                return _name!;
+            }
+        }
 
         // Whether a file/directory exists
         public virtual bool Exists


### PR DESCRIPTION
This does a few things:
- On all OSes, makes DirectoryInfo.Name and FileInfo.Name lazy.  For a case like `DirectoryInfo.CreateDirectory(fullPath)` where the returned `DirectoryInfo` is ignored, previously we would still promptly allocate a `string` for the name, and now we won't, waiting instead until the property is accessed.
- On Windows, after checking whether the target directory exists and finding it doesn't, rather than proceeding with the full logic to parse the path, find the first segment that exists, and then create them all, it adds a fast-path check to just try to create the target, under the assumption that creating a directory in a directory that already exists is very common.  In such a case, it measurably speeds up throughput.  If the parent doesn't already exist, this does add one syscall of overhead, and it can be measurable, but it's relatively small compared to the other costs involved on this slower path.
- On Windows, on the slow path rather than allocating a `List<string>` to store the segments, it uses a `ValueListBuilder<string>` seeded with some stack space.
- Fixes the nullable annotation on the internal DirectoryExists helper
- Normalizes some parameter names

Contributes to https://github.com/dotnet/runtime/issues/61954