### PR TITLE
Fix exceptions with missing HResult assignment

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/MissingFieldException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MissingFieldException.cs
@@ -31,6 +31,7 @@ namespace System
         {
             ClassName = className;
             MemberName = fieldName;
+            HResult = HResults.COR_E_MISSINGFIELD;
         }
 
         protected MissingFieldException(SerializationInfo info, StreamingContext context)

--- a/src/libraries/System.Private.CoreLib/src/System/MissingMemberException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MissingMemberException.cs
@@ -31,6 +31,7 @@ namespace System
         {
             ClassName = className;
             MemberName = memberName;
+            HResult = HResults.COR_E_MISSINGMEMBER;
         }
 
         protected MissingMemberException(SerializationInfo info, StreamingContext context)

--- a/src/libraries/System.Private.CoreLib/src/System/MissingMethodException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MissingMethodException.cs
@@ -40,6 +40,7 @@ namespace System
         {
             ClassName = className;
             MemberName = methodName;
+            HResult = HResults.COR_E_MISSINGMETHOD;
         }
 
         protected MissingMethodException(SerializationInfo info, StreamingContext context)

--- a/src/libraries/System.Runtime/tests/System/MissingFieldExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/MissingFieldExceptionTests.cs
@@ -47,6 +47,7 @@ namespace System.Tests
             var exception = new MissingFieldException(className, memberName);
             Assert.Contains(className, exception.Message);
             Assert.Contains(memberName, exception.Message);
+            Assert.Equal(COR_E_MISSINGFIELD, exception.HResult);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/MissingMemberExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/MissingMemberExceptionTests.cs
@@ -47,6 +47,7 @@ namespace System.Tests
             var exception = new MissingMemberException(className, memberName);
             Assert.Contains(className, exception.Message);
             Assert.Contains(memberName, exception.Message);
+            Assert.Equal(COR_E_MISSINGMEMBER, exception.HResult);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/MissingMethodExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/MissingMethodExceptionTests.cs
@@ -46,6 +46,7 @@ namespace System.Tests
             var exception = new MissingMethodException(className, memberName);
             Assert.Contains(className, exception.Message);
             Assert.Contains(memberName, exception.Message);
+            Assert.Equal(COR_E_MISSINGMETHOD, exception.HResult);
         }
     }
 }

--- a/src/libraries/System.Security.Permissions/src/System/Security/HostProtectionException.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/HostProtectionException.cs
@@ -20,18 +20,21 @@ namespace System.Security
 
         public HostProtectionException() : base()
         {
+            HResult = E_HostProtection;
             ProtectedResources = HostProtectionResource.None;
             DemandedResources = HostProtectionResource.None;
         }
 
         public HostProtectionException(string message) : base(message)
         {
+            HResult = E_HostProtection;
             ProtectedResources = HostProtectionResource.None;
             DemandedResources = HostProtectionResource.None;
         }
 
         public HostProtectionException(string message, Exception e) : base(message, e)
         {
+            HResult = E_HostProtection;
             ProtectedResources = HostProtectionResource.None;
             DemandedResources = HostProtectionResource.None;
         }

--- a/src/libraries/System.Security.Permissions/tests/HostProtectionTests.cs
+++ b/src/libraries/System.Security.Permissions/tests/HostProtectionTests.cs
@@ -7,11 +7,57 @@ namespace System.Security.Permissions.Tests
 {
     public class HostProtectionTests
     {
+        private const int COR_E_HOSTPROTECTION = unchecked((int)0x80131640);
+
         [Fact]
         public static void HostProtectionExceptionCallMethods()
         {
             HostProtectionException hpe = new HostProtectionException();
             hpe.ToString();
+        }
+
+        [Fact]
+        public static void HostProtectionException_Ctor_Empty()
+        {
+            HostProtectionException hpe = new();
+            Assert.Equal(COR_E_HOSTPROTECTION, hpe.HResult);
+            Assert.Equal(HostProtectionResource.None, hpe.ProtectedResources);
+            Assert.Equal(HostProtectionResource.None, hpe.DemandedResources);
+        }
+
+        [Fact]
+        public static void HostProtectionException_Ctor_String()
+        {
+            string message = "Created HostProtectionException";
+            HostProtectionException hpe = new(message);
+            Assert.Equal(message, hpe.Message);
+            Assert.Equal(COR_E_HOSTPROTECTION, hpe.HResult);
+            Assert.Equal(HostProtectionResource.None, hpe.ProtectedResources);
+            Assert.Equal(HostProtectionResource.None, hpe.DemandedResources);
+        }
+
+        [Fact]
+        public static void HostProtectionException_Ctor_String_Exception()
+        {
+            string message = "Created HostProtectionException";
+            Exception innerException = new("Created inner exception");
+            HostProtectionException hpe = new(message, innerException);
+            Assert.Equal(message, hpe.Message);
+            Assert.Equal(COR_E_HOSTPROTECTION, hpe.HResult);
+            Assert.Equal(HostProtectionResource.None, hpe.ProtectedResources);
+            Assert.Equal(HostProtectionResource.None, hpe.DemandedResources);
+            Assert.Same(innerException, hpe.InnerException);
+        }
+
+        [Fact]
+        public static void HostProtectionException_Ctor_String_HostProtectionResource_HostProtectionResource()
+        {
+            string message = "Created HostProtectionException";
+            HostProtectionException hpe = new(message, HostProtectionResource.SecurityInfrastructure, HostProtectionResource.MayLeakOnAbort);
+            Assert.Equal(message, hpe.Message);
+            Assert.Equal(COR_E_HOSTPROTECTION, hpe.HResult);
+            Assert.Equal(HostProtectionResource.SecurityInfrastructure, hpe.ProtectedResources);
+            Assert.Equal(HostProtectionResource.MayLeakOnAbort, hpe.DemandedResources);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #73750

While waiting for builds I did a cursory audit of all exceptions which set `HResult` and found `MissingFieldException`, `MissingMemberException`, and `HostProtectionException` had similar issues, so I fixed them too.