### PR TITLE
Disable ILASM roundtrip for mainv2 test

### DIFF
--- a/src/tests/readytorun/tests/mainv2.csproj
+++ b/src/tests/readytorun/tests/mainv2.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>exe</OutputType>
     <CrossGenTest>false</CrossGenTest>
+    <!-- https://github.com/dotnet/runtime/issues/73954 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="fieldgetter.ilproj" />


### PR DESCRIPTION
Temporary resolution for https://github.com/dotnet/runtime/issues/73954 to keep CI clean.