### PR TITLE
Fix breakage from #70661

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -50,7 +50,7 @@ internal static partial class Interop
     /// </summary>
     internal static void ThrowIOExceptionForLastError()
     {
-        ThrowExceptionForIoErrno(Sys.GetLastErrorInfo(), path: null, isDirectory: false);
+        ThrowExceptionForIoErrno(Sys.GetLastErrorInfo(), path: null, isDirError: false);
     }
 
     /// <summary>


### PR DESCRIPTION
`/home/directhex/Projects/runtime/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs(53,70): error CS1739: The best overload for 'ThrowExceptionForIoErrno' does not have a parameter named 'isDirectory' [/home/directhex/Projects/runtime/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj]`