### PR TITLE
Allow more than 64 ISA flags for jit interface.

### DIFF
--- a/src/coreclr/inc/corjitflags.h
+++ b/src/coreclr/inc/corjitflags.h
@@ -202,9 +202,19 @@ public:
     }
 
     // DO NOT USE THIS FUNCTION! (except in very restricted special cases)
-    uint64_t GetInstructionSetFlagsRaw()
+    uint64_t* GetInstructionSetFlagsRaw()
     {
         return instructionSetFlags.GetFlagsRaw();
+    }
+
+    CORINFO_InstructionSetFlags GetInstructionSetFlags()
+    {
+        return instructionSetFlags;
+    }
+
+    const int GetInstructionFlagsFieldCount()
+    {
+        return instructionSetFlags.GetInstructionFlagsFieldCount();
     }
 
 private:

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2270,10 +2270,9 @@ void Compiler::compSetProcessor()
     // the total sum of flags is still valid.
 
     CORINFO_InstructionSetFlags instructionSetFlags = jitFlags.GetInstructionSetFlags();
-
-    opts.compSupportsISA         = 0;
-    opts.compSupportsISAReported = 0;
-    opts.compSupportsISAExactly  = 0;
+    opts.compSupportsISA.Reset();
+    opts.compSupportsISAReported.Reset();
+    opts.compSupportsISAExactly.Reset();
 
 #if defined(TARGET_XARCH)
     instructionSetFlags.AddInstructionSet(InstructionSet_Vector128);

--- a/src/coreclr/jit/jitee.h
+++ b/src/coreclr/jit/jitee.h
@@ -161,8 +161,8 @@ public:
     {
         // We don't want to have to check every one, so we assume it is exactly the same values as the JitFlag
         // values defined in this type.
-        m_jitFlags = flags.GetFlagsRaw();
-        m_instructionSetFlags.SetFromFlagsRaw(flags.GetInstructionSetFlagsRaw());
+        m_jitFlags            = flags.GetFlagsRaw();
+        m_instructionSetFlags = flags.GetInstructionSetFlags();
 
         C_ASSERT(sizeof(JitFlags) == sizeof(CORJIT_FLAGS));
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
@@ -120,7 +120,6 @@ namespace Internal.JitInterface
         X86_MOVBE_X64 = InstructionSet_X86.MOVBE_X64,
         X86_X86Serialize_X64 = InstructionSet_X86.X86Serialize_X64,
     }
-
     public enum InstructionSet_ARM64
     {
         ILLEGAL = InstructionSet.ILLEGAL,
@@ -240,54 +239,96 @@ namespace Internal.JitInterface
         X86Serialize_X64 = 40,
     }
 
-    public struct InstructionSetFlags : IEnumerable<InstructionSet>
+    public unsafe struct InstructionSetFlags : IEnumerable<InstructionSet>
     {
-        private ulong _flags;
-
+        private const int FlagsFieldCount = 1;
+        private const int BitsPerFlagsField = 64;
+        private fixed ulong _flags[FlagsFieldCount];
         public IEnumerable<InstructionSet_ARM64> ARM64Flags => this.Select((x) => (InstructionSet_ARM64)x);
 
         public IEnumerable<InstructionSet_X64> X64Flags => this.Select((x) => (InstructionSet_X64)x);
 
         public IEnumerable<InstructionSet_X86> X86Flags => this.Select((x) => (InstructionSet_X86)x);
 
+        public InstructionSetFlags() { }
+
+        private static uint GetFlagsFieldIndex(InstructionSet instructionSet)
+        {
+            uint bitIndex = (uint)instructionSet;
+            return (uint)(bitIndex / (uint)BitsPerFlagsField);
+        }
+
+        private static ulong GetRelativeBitMask(InstructionSet instructionSet)
+        {
+            return ((ulong)1) << ((int)instructionSet & 0x3F);
+        }
+
         public void AddInstructionSet(InstructionSet instructionSet)
         {
-            _flags = _flags | (((ulong)1) << (int)instructionSet);
+            uint index = GetFlagsFieldIndex(instructionSet);
+            _flags[index] |= GetRelativeBitMask(instructionSet);
         }
 
         public void RemoveInstructionSet(InstructionSet instructionSet)
         {
-            _flags = _flags & ~(((ulong)1) << (int)instructionSet);
+            uint index = GetFlagsFieldIndex(instructionSet);
+            ulong bitIndex = GetRelativeBitMask(instructionSet);
+            _flags[index] &= ~bitIndex;
         }
 
         public bool HasInstructionSet(InstructionSet instructionSet)
         {
-            return (_flags & (((ulong)1) << (int)instructionSet)) != 0;
+            uint index = GetFlagsFieldIndex(instructionSet);
+            ulong bitIndex = GetRelativeBitMask(instructionSet);
+            return ((_flags[index] & bitIndex) != 0);
         }
 
         public bool Equals(InstructionSetFlags other)
         {
-            return _flags == other._flags;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                if (_flags[i] != other._flags[i])
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         public void Add(InstructionSetFlags other)
         {
-            _flags |= other._flags;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                _flags[i] |= other._flags[i];
+            }
         }
 
         public void IntersectionWith(InstructionSetFlags other)
         {
-            _flags &= other._flags;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                _flags[i] &= other._flags[i];
+            }
         }
 
         public void Remove(InstructionSetFlags other)
         {
-            _flags &= ~other._flags;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                _flags[i] &= ~other._flags[i];
+            }
         }
 
         public bool IsEmpty()
         {
-            return _flags == 0;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                if (_flags[i] != 0)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetGenerator.cs
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetGenerator.cs
@@ -92,6 +92,8 @@ namespace Thunkerator
         Dictionary<string,List<string>> _architectureVectorInstructionSetJitNames = new Dictionary<string,List<string>>();
         HashSet<string> _64BitArchitectures = new HashSet<string>();
         Dictionary<string,string> _64BitVariantArchitectureJitNameSuffix = new Dictionary<string,string>();
+        // This represents the number of flags fields we currently track
+        const int FlagsFieldCount = 1;
 
         void ArchitectureEncountered(string arch)
         {
@@ -253,9 +255,9 @@ namespace Thunkerator
 
             foreach (var architectureInfo in _architectureJitNames)
             {
-                if (architectureInfo.Value.Count > 62)
+                if (architectureInfo.Value.Count > ((FlagsFieldCount * sizeof(ulong) * 8) - 2))
                 {
-                    throw new Exception("Too many instruction sets added. Scheme of using uint64_t as instruction mask will need updating");
+                    throw new Exception("Too many instruction sets added. Update FlagsFieldCount");
                 }
             }
 
@@ -385,8 +387,9 @@ namespace Internal.JitInterface
     public enum InstructionSet
     {
         ILLEGAL = 0,
-        NONE = 63,
 ");
+
+            tr.WriteLine($"        NONE = {((FlagsFieldCount * sizeof(ulong) * 8) - 1)},");
 
             foreach (string architecture in _architectures)
             {
@@ -397,7 +400,6 @@ namespace Internal.JitInterface
             }
 
             tr.Write(@"    }
-
 ");
 
             foreach (string architecture in _architectures)
@@ -419,11 +421,12 @@ namespace Internal.JitInterface
 ");
             }
 
-            tr.Write(@"    public struct InstructionSetFlags : IEnumerable<InstructionSet>
-    {
-        private ulong _flags;
-
-");
+            tr.Write(@"    public unsafe struct InstructionSetFlags : IEnumerable<InstructionSet>
+    {");
+            tr.WriteLine();
+            tr.WriteLine($"        private const int FlagsFieldCount = {FlagsFieldCount};");
+            tr.WriteLine($"        private const int BitsPerFlagsField = 64;");
+            tr.WriteLine($"        private fixed ulong _flags[FlagsFieldCount];");
 
             foreach (string architecture in _architectures)
             {
@@ -431,44 +434,85 @@ namespace Internal.JitInterface
                 tr.WriteLine();
             }
 
-            tr.Write(@"        public void AddInstructionSet(InstructionSet instructionSet)
+            tr.Write(@"        public InstructionSetFlags() { }
+
+        private static uint GetFlagsFieldIndex(InstructionSet instructionSet)
         {
-            _flags = _flags | (((ulong)1) << (int)instructionSet);
+            uint bitIndex = (uint)instructionSet;
+            return (uint)(bitIndex / (uint)BitsPerFlagsField);
+        }
+
+        private static ulong GetRelativeBitMask(InstructionSet instructionSet)
+        {
+            return ((ulong)1) << ((int)instructionSet & 0x3F);
+        }
+
+        public void AddInstructionSet(InstructionSet instructionSet)
+        {
+            uint index = GetFlagsFieldIndex(instructionSet);
+            _flags[index] |= GetRelativeBitMask(instructionSet);
         }
 
         public void RemoveInstructionSet(InstructionSet instructionSet)
         {
-            _flags = _flags & ~(((ulong)1) << (int)instructionSet);
+            uint index = GetFlagsFieldIndex(instructionSet);
+            ulong bitIndex = GetRelativeBitMask(instructionSet);
+            _flags[index] &= ~bitIndex;
         }
 
         public bool HasInstructionSet(InstructionSet instructionSet)
         {
-            return (_flags & (((ulong)1) << (int)instructionSet)) != 0;
+            uint index = GetFlagsFieldIndex(instructionSet);
+            ulong bitIndex = GetRelativeBitMask(instructionSet);
+            return ((_flags[index] & bitIndex) != 0);
         }
 
         public bool Equals(InstructionSetFlags other)
         {
-            return _flags == other._flags;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                if (_flags[i] != other._flags[i])
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         public void Add(InstructionSetFlags other)
         {
-            _flags |= other._flags;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                _flags[i] |= other._flags[i];
+            }
         }
 
         public void IntersectionWith(InstructionSetFlags other)
         {
-            _flags &= other._flags;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                _flags[i] &= other._flags[i];
+            }
         }
 
         public void Remove(InstructionSetFlags other)
         {
-            _flags &= ~other._flags;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                _flags[i] &= ~other._flags[i];
+            }
         }
 
         public bool IsEmpty()
         {
-            return _flags == 0;
+            for (int i = 0; i < FlagsFieldCount; i++)
+            {
+                if (_flags[i] != 0)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -761,8 +805,11 @@ namespace Internal.JitInterface
 enum CORINFO_InstructionSet
 {
     InstructionSet_ILLEGAL = 0,
-    InstructionSet_NONE = 63,
 ");
+
+            int lastAvailableBit = (FlagsFieldCount * 64) - 1;
+            tr.WriteLine($"    InstructionSet_NONE = {lastAvailableBit},");
+
             foreach (string architecture in _architectures)
             {
                 tr.WriteLine($"#ifdef TARGET_{ArchToIfDefArch(architecture)}");
@@ -779,41 +826,92 @@ enum CORINFO_InstructionSet
 struct CORINFO_InstructionSetFlags
 {
 private:
-    uint64_t _flags = 0;
+");
+
+            tr.WriteLine($"    static const int32_t FlagsFieldCount = {FlagsFieldCount};");
+            tr.WriteLine($"    static const int32_t BitsPerFlagsField = sizeof(uint64_t) * 8;");
+            tr.WriteLine($"    uint64_t _flags[FlagsFieldCount] = {{ }};");
+
+            tr.Write(@"
+
+    static uint32_t GetFlagsFieldIndex(CORINFO_InstructionSet instructionSet)
+    {
+        uint32_t bitIndex = (uint32_t)instructionSet;
+        return (uint32_t)(bitIndex / (uint32_t)BitsPerFlagsField);
+    }
+
+    static uint64_t GetRelativeBitMask(CORINFO_InstructionSet instructionSet)
+    {
+        return ((uint64_t)1) << (instructionSet & 0x3F);
+    }
+
 public:
+
+    const int GetInstructionFlagsFieldCount() const
+    {
+        return FlagsFieldCount;
+    }
+
     void AddInstructionSet(CORINFO_InstructionSet instructionSet)
     {
-        _flags = _flags | (((uint64_t)1) << instructionSet);
+        uint32_t index = GetFlagsFieldIndex(instructionSet);
+        _flags[index] |= GetRelativeBitMask(instructionSet);
     }
 
     void RemoveInstructionSet(CORINFO_InstructionSet instructionSet)
     {
-        _flags = _flags & ~(((uint64_t)1) << instructionSet);
+        uint32_t index = GetFlagsFieldIndex(instructionSet);
+        uint64_t bitIndex = GetRelativeBitMask(instructionSet);
+        _flags[index] &= ~bitIndex;
     }
 
     bool HasInstructionSet(CORINFO_InstructionSet instructionSet) const
     {
-        return _flags & (((uint64_t)1) << instructionSet);
+        uint32_t index = GetFlagsFieldIndex(instructionSet);
+        uint64_t bitIndex = GetRelativeBitMask(instructionSet);
+        return ((_flags[index] & bitIndex) != 0);
     }
 
     bool Equals(CORINFO_InstructionSetFlags other) const
     {
-        return _flags == other._flags;
+        for (int i = 0; i < FlagsFieldCount; i++)
+        {
+            if (_flags[i] != other._flags[i])
+            {
+                return false;
+            }
+
+        }
+        return true;
     }
 
     void Add(CORINFO_InstructionSetFlags other)
     {
-        _flags |= other._flags;
+        for (int i = 0; i < FlagsFieldCount; i++)
+        {
+            _flags[i] |= other._flags[i];
+        }
     }
 
     bool IsEmpty() const
     {
-        return _flags == 0;
+        for (int i = 0; i < FlagsFieldCount; i++)
+        {
+            if (_flags[i] != 0)
+            {
+                return false;
+            }
+
+        }
+        return true;
     }
 
     void Reset()
     {
-        _flags = 0;
+        for (int i = 0; i < FlagsFieldCount; i++)
+        {
+            _flags[i] = 0;
+        }
     }
 
     void Set64BitInstructionSetVariants()
@@ -838,14 +936,9 @@ public:
             tr.Write(@"
     }
 
-    uint64_t GetFlagsRaw()
+    uint64_t* GetFlagsRaw()
     {
         return _flags;
-    }
-
-    void SetFromFlagsRaw(uint64_t flags)
-    {
-        _flags = flags;
     }
 };
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -1241,7 +1241,14 @@ void MethodContext::recGetJitFlags(CORJIT_FLAGS* jitFlags, DWORD sizeInBytes, DW
 void MethodContext::dmpGetJitFlags(DWORD key, DD value)
 {
     CORJIT_FLAGS* jitflags = (CORJIT_FLAGS*)GetJitFlags->GetBuffer(value.A);
-    printf("GetJitFlags key %u sizeInBytes-%u jitFlags-%016llX instructionSetFlags-%016llX", key, value.B, jitflags->GetFlagsRaw(), jitflags->GetInstructionSetFlagsRaw());
+    printf("GetJitFlags key %u sizeInBytes-%u jitFlags-%016llX instructionSetFlags-", key, value.B, jitflags->GetFlagsRaw());
+
+    uint64_t *raw = jitflags->GetInstructionSetFlagsRaw();
+    const int flagsFieldCount = jitflags->GetInstructionFlagsFieldCount();
+    for (int i = flagsFieldCount - 1; i >= 0; i--)
+    {
+        printf("%016llX", raw[i]);
+    }
     GetJitFlags->Unlock();
 }
 DWORD MethodContext::repGetJitFlags(CORJIT_FLAGS* jitFlags, DWORD sizeInBytes)
@@ -7000,10 +7007,19 @@ int MethodContext::dumpMethodIdentityInfoToBuffer(char* buff, int len, bool igno
     len -= t;
 
     // Add Calling convention information, CorInfoOptions, CorInfoRegionKind, jit flags, and ISA flags.
-    t = sprintf_s(buff, len, "CallingConvention: %d, CorInfoOptions: %d, CorInfoRegionKind: %d, JitFlags %016llx, ISA Flags %016llx", pInfo->args.callConv,
-                  pInfo->options, pInfo->regionKind, corJitFlags.GetFlagsRaw(), corJitFlags.GetInstructionSetFlagsRaw());
+    t = sprintf_s(buff, len, "CallingConvention: %d, CorInfoOptions: %d, CorInfoRegionKind: %d, JitFlags %016llx, ISA Flags", pInfo->args.callConv,
+                  pInfo->options, pInfo->regionKind, corJitFlags.GetFlagsRaw());
     buff += t;
     len -= t;
+
+    uint64_t *raw = corJitFlags.GetInstructionSetFlagsRaw();
+    const int flagsFieldCount = corJitFlags.GetInstructionFlagsFieldCount();
+    for (int i = flagsFieldCount - 1; i >= 0; i--)
+    {
+        t = sprintf_s(buff, len, " %016llX", raw[i]);
+        buff += t;
+        len -= t;
+    }
 
     // Hash the IL Code for this method and append it to the ID info
     char ilHash[MD5_HASH_BUFFER_SIZE];


### PR DESCRIPTION
Currently since `_flags`  is a 64 bit variable, only 64 ISAs can be represented using this design. This change makes this an array thus enabling us to represent more than 64 ISAs.