### PR TITLE
Bring back PreInitializedAttribute handling to NativeAOT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -997,6 +997,8 @@ namespace ILCompiler
 
             preinitManager.LogStatistics(logger);
 
+            preinitManager.CheckPreInitializedAttribute(logger);
+
             return 0;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -997,8 +997,6 @@ namespace ILCompiler
 
             preinitManager.LogStatistics(logger);
 
-            preinitManager.CheckPreInitializedAttribute(logger);
-
             return 0;
         }
 


### PR DESCRIPTION
Readds the ability to have NativeAOT issue a message
when a type requires runtime static constructor
execution.

Used the same attribute name as .Net Native has.

Had to introduce separate tracking since as far as I could see, the IsGenericDefinition check in IsPreinitialized prevents generic types from going into the hash table.

@MichalStrehovsky we've discussed this on discord a while ago.