### PR TITLE
hold reference to SslContextHandle to prevent crashes

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -409,6 +409,9 @@ internal static partial class Interop
                     if (cacheSslContext && !string.IsNullOrEmpty(punyCode))
                     {
                         sslCtxHandle.TrySetSession(sslHandle, punyCode);
+                        bool ignored = false;   // DangerousAddRef will throw on failure
+                        sslCtxHandle.DangerousAddRef(ref ignored);
+                        sslHandle.SslContextHandle = sslCtxHandle;
                     }
 
                     // relevant to TLS 1.3 only: if user supplied a client cert or cert callback,

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -409,7 +409,7 @@ internal static partial class Interop
                     if (cacheSslContext && !string.IsNullOrEmpty(punyCode))
                     {
                         sslCtxHandle.TrySetSession(sslHandle, punyCode);
-                        bool ignored = false;   // DangerousAddRef will throw on failure
+                        bool ignored = false;
                         sslCtxHandle.DangerousAddRef(ref ignored);
                         sslHandle.SslContextHandle = sslCtxHandle;
                     }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -335,6 +335,7 @@ namespace Microsoft.Win32.SafeHandles
         private bool _handshakeCompleted;
 
         public GCHandle AlpnHandle;
+        public SafeSslContextHandle? SslContextHandle;
 
         public bool IsServer
         {
@@ -431,6 +432,8 @@ namespace Microsoft.Win32.SafeHandles
             {
                 Disconnect();
             }
+
+            SslContextHandle?.DangerousRelease();
 
             IntPtr h = handle;
             SetHandle(IntPtr.Zero);


### PR DESCRIPTION
This is speculative fix for #73621 and #69125. 
I was unable to reproduce it locally so this is based on code inspection, experiments and discussions on #73621.
The assumption is that this is regression caused by #64369 

The theory is like this:
OpenSSL has its own referencing mechanism. The particular `SSL` structure it can still hold reference to `SSL_CTX` it was created with. That for example allows to use TLS session cache attached to `SSL_CTX`.
Now, from .NET prospective the `SafeSslContextHandle` representing `SSL_CTX` can be released as soon as we create `SafeSslHandle` - we don't use it for anything else but initial setup. Calling `ReleaseHandle` would free the `GCHandle` and _if_ any of the callbacks fire after that, they can step on memory that holds garbage. 

This change grabs reference on `SafeSslContextHandle` (if eligible for TLS resume) to preserve it while the session is in use to mimic `OpenSSL` life cycle. With that, the native callbacks should point to valid memory. 

The crashes are happening daily in CI so we should know in next few days if this fixes the crashes. 

 