### PR TITLE
Fix one more Crossgen2 field layout mismatch with runtime

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -580,7 +580,7 @@ namespace Internal.TypeSystem
             // between base type and the current type.
             LayoutInt cumulativeInstanceFieldPos = CalculateFieldBaseOffset(type, requiresAlign8, requiresAlignedBase: false);
             LayoutInt offsetBias = LayoutInt.Zero;
-            if (!type.IsValueType && cumulativeInstanceFieldPos != LayoutInt.Zero && type.Context.Target.Architecture == TargetArchitecture.X86)
+            if (!type.IsValueType && cumulativeInstanceFieldPos != LayoutInt.Zero && type.Context.Target.Architecture != TargetArchitecture.ARM)
             {
                 offsetBias = type.Context.Target.LayoutPointerSize;
                 cumulativeInstanceFieldPos -= offsetBias;

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -580,6 +580,15 @@ namespace Internal.TypeSystem
             // between base type and the current type.
             LayoutInt cumulativeInstanceFieldPos = CalculateFieldBaseOffset(type, requiresAlign8, requiresAlignedBase: false);
             LayoutInt offsetBias = LayoutInt.Zero;
+
+            // The following conditional statement mimics the behavior of MethodTableBuilder::PlaceInstanceFields;
+            // the fundamental difference between CoreCLR native runtime and Crossgen2 regarding field placement is
+            // that the native runtime doesn't count the method table pointer at the beginning of reference types as a 'field'
+            // so that the first field in a class has offset 0 while its 'real' offset from the 'this' pointer is LayoutPointerSize.
+            // On ARM32, native runtime employs a special logic internally calculating the field offsets relative to the 'this'
+            // pointer (the Crossgen2 way) to ensure 8-alignment for longs and doubles as required by the ARM32 ISA. Please note
+            // that for 16-alignment used by Vector128 this logic actually ensures that the fields are 16-misaligned
+            // (they are 16-aligned after the 4-byte or 8-byte method table pointer).
             if (!type.IsValueType && cumulativeInstanceFieldPos != LayoutInt.Zero && type.Context.Target.Architecture != TargetArchitecture.ARM)
             {
                 offsetBias = type.Context.Target.LayoutPointerSize;

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/InstanceFieldLayout.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/InstanceFieldLayout.cs
@@ -436,7 +436,6 @@ namespace Auto
         public byte fld9;
     }
 
-<<<<<<< HEAD
     [StructLayout(LayoutKind.Auto)]
     public struct UInt128Struct
     {
@@ -447,12 +446,12 @@ namespace Auto
     public struct Int128Struct
     {
         Int128 fld1;
-=======
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     public class Class16Align
     {
         Vector128<byte> vector16Align;
->>>>>>> 7f70d973821 (Address David's PR feedback)
     }
 }
 

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/InstanceFieldLayout.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/InstanceFieldLayout.cs
@@ -224,6 +224,12 @@ namespace Sequential
         public StructByte fld1;
         public Auto.UInt128Struct fld2;
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public class Class16Align
+    {
+        Vector128<byte> vector16Align;
+    }
 }
 
 namespace Auto
@@ -430,6 +436,7 @@ namespace Auto
         public byte fld9;
     }
 
+<<<<<<< HEAD
     [StructLayout(LayoutKind.Auto)]
     public struct UInt128Struct
     {
@@ -440,6 +447,12 @@ namespace Auto
     public struct Int128Struct
     {
         Int128 fld1;
+=======
+    [StructLayout(LayoutKind.Sequential)]
+    public class Class16Align
+    {
+        Vector128<byte> vector16Align;
+>>>>>>> 7f70d973821 (Address David's PR feedback)
     }
 }
 

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/InstanceFieldLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/InstanceFieldLayoutTests.cs
@@ -282,6 +282,28 @@ namespace TypeSystemTests
         }
 
         [Fact]
+        public void TestSequentialTypeLayoutClass16Align()
+        {
+            MetadataType classType = _testModule.GetType("Sequential", "Class16Align");
+            Assert.Equal(0x18, classType.InstanceByteCount.AsInt);
+            foreach (var f in classType.GetFields())
+            {
+                if (f.IsStatic)
+                    continue;
+
+                switch (f.Name)
+                {
+                    case "vector16Align":
+                        Assert.Equal(0x8, f.Offset.AsInt);
+                        break;
+                    default:
+                        Assert.True(false);
+                        break;
+                }
+            }
+        }
+
+        [Fact]
         public void TestAutoLayoutStruct()
         {
             MetadataType structWithIntCharType = _testModule.GetType("Auto", "StructWithIntChar");
@@ -780,6 +802,28 @@ namespace TypeSystemTests
             MetadataType minPackingType = _testModule.GetType("Auto", "MinPacking`1");
             InstantiatedType inst = minPackingType.MakeInstantiatedType(_context.GetWellKnownType(type));
             Assert.Equal(expectedSize, inst.InstanceFieldSize.AsInt);
+        }
+
+        [Fact]
+        public void TestAutoTypeLayoutClass16Align()
+        {
+            MetadataType classType = _testModule.GetType("Auto", "Class16Align");
+            Assert.Equal(0x18, classType.InstanceByteCount.AsInt);
+            foreach (var f in classType.GetFields())
+            {
+                if (f.IsStatic)
+                    continue;
+
+                switch (f.Name)
+                {
+                    case "vector16Align":
+                        Assert.Equal(0x8, f.Offset.AsInt);
+                        break;
+                    default:
+                        Assert.True(false);
+                        break;
+                }
+            }
         }
 
         [Fact]

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/UniversalGenericFieldLayoutTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/UniversalGenericFieldLayoutTests.cs
@@ -372,6 +372,7 @@ namespace TypeSystemTests
             AssertClassIndeterminateSize(context, genOfUL, expectedIndeterminateByteAlignment);
         }
 
+        /* This test exercises universal shared generic layout that is currently unsupported and known to be buggy.
         [Fact]
         public void TestClassLayout()
         {
@@ -511,5 +512,6 @@ namespace TypeSystemTests
             Assert.Equal(LayoutInt.Indeterminate, genOfUI.GetFields().First().Offset);
             Assert.Equal(LayoutInt.Indeterminate, genOfUL.GetFields().First().Offset);
         }
+        */
     }
 }


### PR DESCRIPTION
The field offset mismatch in the test

JIT/Regression/JitBlue/Runtime_60035/Runtime_60035.csproj

specific to Crossgen2 composite mode is due to the recent
proliferation of 16-byte alignment specific to Vector across
the runtime repo. Previously, the largest supported alignment
was 8 and X86 was the only architecture not respecting it.

In general the problem is caused by the fact that the native
CoreCLR runtime method table builder calculates field offsets
without taking the method table pointer into account; in the
particular case of the Runtime_60035 test, the class
System.Text.Encodings.Web.OptimizedInboxTextEncoder
has a field named _allowedAsciiCodePoints that is 16-aligned
that exposes this inconsistency.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 

Fixes #73728 