### PR TITLE
Change to GetLastPInvokeError where possible

### DIFF
--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.Sysctl.cs
@@ -42,7 +42,7 @@ internal static partial class Interop
                 ret = Sysctl(name, name_len, value, &bytesLength);
                 if (ret != 0)
                 {
-                    throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastWin32Error()));
+                    throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastPInvokeError()));
                 }
                 value = (byte*)Marshal.AllocHGlobal((int)bytesLength);
             }
@@ -75,7 +75,7 @@ internal static partial class Interop
                 {
                     Marshal.FreeHGlobal((IntPtr)value);
                 }
-                throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastWin32Error()));
+                throw new InvalidOperationException(SR.Format(SR.InvalidSysctl, *name, Marshal.GetLastPInvokeError()));
             }
 
             len = (int)bytesLength;

--- a/src/libraries/Common/src/Interop/Unix/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Errors.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
         // These values were defined in src/Native/System.Native/fxerrno.h
         //
-        // They compare against values obtained via Interop.Sys.GetLastError() not Marshal.GetLastWin32Error()
+        // They compare against values obtained via Interop.Sys.GetLastError() not Marshal.GetLastPInvokeError()
         // which obtains the raw errno that varies between unixes. The strong typing as an enum is meant to
         // prevent confusing the two. Casting to or from int is suspect. Use GetLastErrorInfo() if you need to
         // correlate these to the underlying platform values or obtain the corresponding error message.
@@ -155,12 +155,12 @@ internal static partial class Interop
     {
         internal static Error GetLastError()
         {
-            return ConvertErrorPlatformToPal(Marshal.GetLastWin32Error());
+            return ConvertErrorPlatformToPal(Marshal.GetLastPInvokeError());
         }
 
         internal static ErrorInfo GetLastErrorInfo()
         {
-            return new ErrorInfo(Marshal.GetLastWin32Error());
+            return new ErrorInfo(Marshal.GetLastPInvokeError());
         }
 
         internal static unsafe string StrError(int platformErrno)

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
@@ -31,7 +31,7 @@ internal static partial class Interop
                         setUser ? 1 : 0, userId, groupId, pGroups, groups?.Length ?? 0,
                         out lpChildPid, out stdinFd, out stdoutFd, out stderrFd);
                 }
-                return result == 0 ? 0 : Marshal.GetLastWin32Error();
+                return result == 0 ? 0 : Marshal.GetLastPInvokeError();
             }
             finally
             {

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetSetPriority.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetSetPriority.cs
@@ -32,7 +32,7 @@ internal static partial class Interop
         internal static int GetPriority(PriorityWhich which, int who, out int priority)
         {
             priority = GetPriority(which, who);
-            return Marshal.GetLastWin32Error();
+            return Marshal.GetLastPInvokeError();
         }
 
         internal static System.Diagnostics.ThreadPriorityLevel GetThreadPriorityFromNiceValue(int nice)

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptEncodeDecodeWrappers.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CryptEncodeDecodeWrappers.cs
@@ -30,13 +30,13 @@ internal static partial class Interop
 
             if (!CryptDecodeObject(MsgEncodingType.All, (IntPtr)lpszStructType, pbEncoded, cbEncoded, 0, null, ref cbRequired))
             {
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             SafeHandle sh = SafeHeapAllocHandle.Alloc(cbRequired);
             if (!CryptDecodeObject(MsgEncodingType.All, (IntPtr)lpszStructType, pbEncoded, cbEncoded, 0, (void*)sh.DangerousGetHandle(), ref cbRequired))
             {
-                Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                 sh.Dispose();
                 throw e;
             }
@@ -49,13 +49,13 @@ internal static partial class Interop
             int cb = 0;
             if (!CryptEncodeObject(MsgEncodingType.All, lpszStructType, decoded, null, ref cb))
             {
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             byte[] encoded = new byte[cb];
             if (!CryptEncodeObject(MsgEncodingType.All, lpszStructType, decoded, encoded, ref cb))
             {
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             return encoded.Resize(cb);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CopyFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CopyFile.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
             int cancel = 0;
             if (!Interop.Kernel32.CopyFileEx(src, dst, IntPtr.Zero, IntPtr.Zero, ref cancel, copyFlags))
             {
-                return Marshal.GetLastWin32Error();
+                return Marshal.GetLastPInvokeError();
             }
 
             return Interop.Errors.ERROR_SUCCESS;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessName.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
                             {
                                 return buffer.Slice(0, (int)length).ToString();
                             }
-                            else if (Marshal.GetLastWin32Error() != Errors.ERROR_INSUFFICIENT_BUFFER)
+                            else if (Marshal.GetLastPInvokeError() != Errors.ERROR_INSUFFICIENT_BUFFER)
                             {
                                 return null;
                             }

--- a/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
@@ -58,7 +58,7 @@ namespace System.IO
             {
                 if (!Interop.Kernel32.GetFileAttributesEx(path, Interop.Kernel32.GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, ref data))
                 {
-                    errorCode = Marshal.GetLastWin32Error();
+                    errorCode = Marshal.GetLastPInvokeError();
 
                     if (!IsPathUnreachableError(errorCode))
                     {
@@ -84,7 +84,7 @@ namespace System.IO
                         {
                             if (handle.IsInvalid)
                             {
-                                errorCode = Marshal.GetLastWin32Error();
+                                errorCode = Marshal.GetLastPInvokeError();
                             }
                             else
                             {

--- a/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.DirectoryCreation.Windows.cs
@@ -91,7 +91,7 @@ namespace System.IO
                     r = Interop.Kernel32.CreateDirectory(name, &secAttrs);
                     if (!r && (firstError == 0))
                     {
-                        int currentError = Marshal.GetLastWin32Error();
+                        int currentError = Marshal.GetLastPInvokeError();
                         // While we tried to avoid creating directories that don't
                         // exist above, there are at least two cases that will
                         // cause us to see ERROR_ALREADY_EXISTS here.  FileExists

--- a/src/libraries/Common/src/System/IO/Win32Marshal.cs
+++ b/src/libraries/Common/src/System/IO/Win32Marshal.cs
@@ -16,7 +16,7 @@ namespace System.IO
         /// including the specified path in the error message.
         /// </summary>
         internal static Exception GetExceptionForLastWin32Error(string? path = "")
-            => GetExceptionForWin32Error(Marshal.GetLastWin32Error(), path);
+            => GetExceptionForWin32Error(Marshal.GetLastPInvokeError(), path);
 
         /// <summary>
         /// Converts the specified Win32 error into a corresponding <see cref="Exception"/> object, optionally

--- a/src/libraries/Common/src/System/Net/NetworkInformation/NetworkInformationException.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/NetworkInformationException.cs
@@ -22,7 +22,7 @@ namespace System.Net.NetworkInformation
         ///       Creates a new instance of the <see cref='System.Net.NetworkInformation.NetworkInformationException'/> class with the default error code.
         ///    </para>
         /// </devdoc>
-        public NetworkInformationException() : base(Marshal.GetLastWin32Error())
+        public NetworkInformationException() : base(Marshal.GetLastPInvokeError())
         {
         }
 

--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Windows.cs
@@ -22,7 +22,7 @@ namespace System.Net
                 socket = Interop.Winsock.WSASocketW(af, SocketType.Stream, 0, IntPtr.Zero, 0, (int)Interop.Winsock.SocketConstructorFlags.WSA_FLAG_NO_HANDLE_INHERIT);
                 return
                     socket != INVALID_SOCKET ||
-                    (SocketError)Marshal.GetLastWin32Error() != SocketError.AddressFamilyNotSupported;
+                    (SocketError)Marshal.GetLastPInvokeError() != SocketError.AddressFamilyNotSupported;
             }
             finally
             {

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
@@ -680,7 +680,7 @@ namespace Microsoft.Win32
                 if (Interop.User32.RegisterClassW(ref windowClass) == 0)
                 {
                     _windowProc = null;
-                    Debug.WriteLine("Unable to register broadcast window class: {0}", Marshal.GetLastWin32Error());
+                    Debug.WriteLine("Unable to register broadcast window class: {0}", Marshal.GetLastPInvokeError());
                 }
                 else
                 {

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AuthZSet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AuthZSet.cs
@@ -101,7 +101,7 @@ namespace System.DirectoryServices.AccountManagement
                                                     out bufferSize,
                                                     IntPtr.Zero
                                                     );
-                        if (!f && (bufferSize > 0) && (Marshal.GetLastWin32Error() == 122) /*ERROR_INSUFFICIENT_BUFFER*/)
+                        if (!f && (bufferSize > 0) && (Marshal.GetLastPInvokeError() == 122) /*ERROR_INSUFFICIENT_BUFFER*/)
                         {
                             GlobalDebug.WriteLineIf(GlobalDebug.Info, "AuthZSet", "Getting info from ctx (size={0})", bufferSize);
 
@@ -155,23 +155,23 @@ namespace System.DirectoryServices.AccountManagement
                             }
                             else
                             {
-                                lastError = Marshal.GetLastWin32Error();
+                                lastError = Marshal.GetLastPInvokeError();
                             }
                         }
                         else
                         {
-                            lastError = Marshal.GetLastWin32Error();
+                            lastError = Marshal.GetLastPInvokeError();
                             Debug.Fail("With a zero-length buffer, this should have never succeeded");
                         }
                     }
                     else
                     {
-                        lastError = Marshal.GetLastWin32Error();
+                        lastError = Marshal.GetLastPInvokeError();
                     }
                 }
                 else
                 {
-                    lastError = Marshal.GetLastWin32Error();
+                    lastError = Marshal.GetLastPInvokeError();
                 }
 
                 if (!f)

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Utils.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Utils.cs
@@ -129,7 +129,7 @@ namespace System.DirectoryServices.AccountManagement
                 }
                 else
                 {
-                    int lastErrorCode = Marshal.GetLastWin32Error();
+                    int lastErrorCode = Marshal.GetLastPInvokeError();
 
                     GlobalDebug.WriteLineIf(
                                       GlobalDebug.Warn,
@@ -354,7 +354,7 @@ namespace System.DirectoryServices.AccountManagement
                                 out tokenHandle
                                 ))
                 {
-                    if ((error = Marshal.GetLastWin32Error()) == 1008) // ERROR_NO_TOKEN
+                    if ((error = Marshal.GetLastPInvokeError()) == 1008) // ERROR_NO_TOKEN
                     {
                         Debug.Assert(tokenHandle.IsInvalid);
                         tokenHandle.Dispose();
@@ -366,7 +366,7 @@ namespace System.DirectoryServices.AccountManagement
                                         out tokenHandle
                                         ))
                         {
-                            int lastError = Marshal.GetLastWin32Error();
+                            int lastError = Marshal.GetLastPInvokeError();
                             GlobalDebug.WriteLineIf(GlobalDebug.Error, "Utils", "GetCurrentUserSid: OpenProcessToken failed, gle=" + lastError);
 
                             throw new PrincipalOperationException(SR.Format(SR.UnableToOpenToken, lastError));
@@ -394,7 +394,7 @@ namespace System.DirectoryServices.AccountManagement
                                         out neededBufferSize);
 
                 int getTokenInfoError = 0;
-                if ((getTokenInfoError = Marshal.GetLastWin32Error()) != 122) // ERROR_INSUFFICIENT_BUFFER
+                if ((getTokenInfoError = Marshal.GetLastPInvokeError()) != 122) // ERROR_INSUFFICIENT_BUFFER
                 {
                     GlobalDebug.WriteLineIf(GlobalDebug.Error, "Utils", "GetCurrentUserSid: GetTokenInformation (1st try) failed, gle=" + getTokenInfoError);
 
@@ -416,7 +416,7 @@ namespace System.DirectoryServices.AccountManagement
 
                 if (!success)
                 {
-                    int lastError = Marshal.GetLastWin32Error();
+                    int lastError = Marshal.GetLastPInvokeError();
                     GlobalDebug.WriteLineIf(GlobalDebug.Error,
                                       "Utils",
                                       "GetCurrentUserSid: GetTokenInformation (2nd try) failed, neededBufferSize=" + neededBufferSize + ", gle=" + lastError);
@@ -437,7 +437,7 @@ namespace System.DirectoryServices.AccountManagement
                 success = Interop.Advapi32.CopySid(userSidLength, pCopyOfUserSid, pUserSid);
                 if (!success)
                 {
-                    int lastError = Marshal.GetLastWin32Error();
+                    int lastError = Marshal.GetLastPInvokeError();
                     GlobalDebug.WriteLineIf(GlobalDebug.Error,
                                       "Utils",
                                       "GetCurrentUserSid: CopySid failed, errorcode=" + lastError);
@@ -508,7 +508,7 @@ namespace System.DirectoryServices.AccountManagement
                 bool success = Interop.Advapi32.CopySid(sidLength, pCopyOfSid, info.DomainSid);
                 if (!success)
                 {
-                    int lastError = Marshal.GetLastWin32Error();
+                    int lastError = Marshal.GetLastPInvokeError();
                     GlobalDebug.WriteLineIf(GlobalDebug.Error,
                                       "Utils",
                                       "GetMachineDomainSid: CopySid failed, errorcode=" + lastError);
@@ -603,7 +603,7 @@ namespace System.DirectoryServices.AccountManagement
 
                 int f = Interop.Advapi32.LookupAccountSid(serverName, sid, null, ref nameLength, null, ref domainNameLength, out accountUsage);
 
-                int lastErr = Marshal.GetLastWin32Error();
+                int lastErr = Marshal.GetLastPInvokeError();
                 if (lastErr != 122) // ERROR_INSUFFICIENT_BUFFER
                 {
                     GlobalDebug.WriteLineIf(GlobalDebug.Error, "Utils", "LookupSid: LookupAccountSid (1st try) failed, gle=" + lastErr);
@@ -622,7 +622,7 @@ namespace System.DirectoryServices.AccountManagement
 
                     if (f == 0)
                     {
-                        lastErr = Marshal.GetLastWin32Error();
+                        lastErr = Marshal.GetLastPInvokeError();
                         Debug.Assert(lastErr != 0);
 
                         GlobalDebug.WriteLineIf(GlobalDebug.Error, "Utils", "LookupSid: LookupAccountSid (2nd try) failed, gle=" + lastErr);
@@ -752,7 +752,7 @@ namespace System.DirectoryServices.AccountManagement
             // check the result
             if (result == 0)
             {
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 GlobalDebug.WriteLineIf(GlobalDebug.Error, "Utils", "BeginImpersonation: LogonUser failed, gle=" + lastError);
 
                 throw new PrincipalOperationException(
@@ -762,7 +762,7 @@ namespace System.DirectoryServices.AccountManagement
             result = Interop.Advapi32.ImpersonateLoggedOnUser(hToken);
             if (result == 0)
             {
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 GlobalDebug.WriteLineIf(GlobalDebug.Error, "Utils", "BeginImpersonation: ImpersonateLoggedOnUser failed, gle=" + lastError);
 
                 // Close the token the was created above....

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySite.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySite.cs
@@ -1303,7 +1303,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 var dsListDomainsInSiteW = (delegate* unmanaged<IntPtr, char*, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsListDomainsInSiteW");
                 if (dsListDomainsInSiteW == null)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
 
                 fixed (char* distinguishedName = (string)PropertyManager.GetPropertyValue(context, cachedEntry, PropertyManager.DistinguishedName)!)
@@ -1347,7 +1347,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     var dsFreeNameResultW = (delegate* unmanaged<IntPtr, void>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
                     if (dsFreeNameResultW == null)
                     {
-                        throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                        throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                     }
 
                     dsFreeNameResultW(info);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryContext.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryContext.cs
@@ -693,7 +693,7 @@ namespace System.DirectoryServices.ActiveDirectory
             IntPtr tempHandle = global::Interop.Kernel32.LoadLibrary(systemPath + "\\ntdsapi.dll");
             if (tempHandle == (IntPtr)0)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
             else
             {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
@@ -285,7 +285,7 @@ namespace System.DirectoryServices.ActiveDirectory
             var replicaConsistencyCheck = (delegate* unmanaged<IntPtr, int, int, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaConsistencyCheck");
             if (replicaConsistencyCheck == null)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
 
             int result = replicaConsistencyCheck(dsHandle, 0, 0);
@@ -309,7 +309,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 var dsReplicaGetInfoW = (delegate* unmanaged<IntPtr, int, char*, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaGetInfoW");
                 if (dsReplicaGetInfoW == null)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
                 fixed (char* partitionPtr = partition)
                 {
@@ -333,7 +333,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 var dsReplicaGetInfoW = (delegate* unmanaged<IntPtr, int, char*, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaGetInfoW");
                 if (dsReplicaGetInfoW == null)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
 
                 fixed (char* partitionPtr = partition)
@@ -636,7 +636,7 @@ namespace System.DirectoryServices.ActiveDirectory
             var dsReplicaSyncAllW = (delegate* unmanaged<IntPtr, char*, int, IntPtr, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaSyncAllW");
             if (dsReplicaSyncAllW == null)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
 
             int result;
@@ -681,7 +681,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 var dsReplicaFreeInfo = (delegate* unmanaged<int, IntPtr, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaFreeInfo");
                 if (dsReplicaFreeInfo == null)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
                 dsReplicaFreeInfo((int)type, value);
             }
@@ -719,7 +719,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 var dsReplicaSyncW = (delegate* unmanaged<IntPtr, char*, IntPtr, int, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsReplicaSyncW");
                 if (dsReplicaSyncW == null)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
 
                 fixed (char* partitionPtr = partition)

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DomainController.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DomainController.cs
@@ -1087,7 +1087,7 @@ namespace System.DirectoryServices.ActiveDirectory
             var dsGetDomainControllerInfo = (delegate* unmanaged<IntPtr, char*, int, int*, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsGetDomainControllerInfoW");
             if (dsGetDomainControllerInfo == null)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
 
             fixed (char* domainName = Domain.Name)
@@ -1171,7 +1171,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         var dsFreeDomainControllerInfo = (delegate* unmanaged<int, int, IntPtr, void>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsFreeDomainControllerInfoW");
                         if (dsFreeDomainControllerInfo == null)
                         {
-                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                         }
                         dsFreeDomainControllerInfo(dcInfoLevel, dcCount, dcInfoPtr);
                     }
@@ -1259,7 +1259,7 @@ namespace System.DirectoryServices.ActiveDirectory
             var dsListRoles = (delegate* unmanaged<IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsListRolesW");
             if (dsListRoles == null)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
 
             result = dsListRoles(_dsHandle, &rolesPtr);
@@ -1298,7 +1298,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         var dsFreeNameResult = (delegate* unmanaged<IntPtr, void>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
                         if (dsFreeNameResult == null)
                         {
-                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                         }
                         dsFreeNameResult(rolesPtr);
                     }

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Forest.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Forest.cs
@@ -864,7 +864,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 var dsListSites = (delegate* unmanaged<IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsListSitesW");
                 if (dsListSites == null)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
 
                 result = dsListSites(dsHandle, &sitesPtr);
@@ -900,7 +900,7 @@ namespace System.DirectoryServices.ActiveDirectory
                             var dsFreeNameResultW = (delegate* unmanaged<IntPtr, void>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
                             if (dsFreeNameResultW == null)
                             {
-                                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                             }
                             dsFreeNameResultW(sitesPtr);
                         }

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustDomainInformation.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustDomainInformation.cs
@@ -30,7 +30,7 @@ namespace System.DirectoryServices.ActiveDirectory
             global::Interop.BOOL result = global::Interop.Advapi32.ConvertSidToStringSid(domainInfo.sid, out sidLocal);
             if (result == global::Interop.BOOL.FALSE)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
 
             DomainSid = sidLocal;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
@@ -185,7 +185,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         global::Interop.BOOL result = global::Interop.Advapi32.ConvertStringSidToSid(tmp.DomainSid, out pSid);
                         if (result == global::Interop.BOOL.FALSE)
                         {
-                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                         }
                         record.DomainInfo.sid = pSid;
                         sidList.Add(pSid);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
@@ -120,7 +120,7 @@ namespace System.DirectoryServices.ActiveDirectory
             var dsCrackNames = (delegate* unmanaged<IntPtr, int, int, int, int, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsCrackNamesW");
             if (dsCrackNames == null)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
 
             IntPtr name = Marshal.StringToHGlobalUni(distinguishedName);
@@ -175,7 +175,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         var dsFreeNameResultW = (delegate* unmanaged<IntPtr, void>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
                         if (dsFreeNameResultW == null)
                         {
-                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                         }
                         dsFreeNameResultW(results);
                     }
@@ -215,7 +215,7 @@ namespace System.DirectoryServices.ActiveDirectory
             var dsCrackNames = (delegate* unmanaged<IntPtr, int, int, int, int, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsCrackNamesW");
             if (dsCrackNames == null)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
             IntPtr name = Marshal.StringToHGlobalUni(dnsName + "/");
             IntPtr ptr = Marshal.AllocHGlobal(IntPtr.Size);
@@ -250,7 +250,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         var dsFreeNameResultW = (delegate* unmanaged<IntPtr, void>)global::Interop.Kernel32.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
                         if (dsFreeNameResultW == null)
                         {
-                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                            throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                         }
                         dsFreeNameResultW(results);
                     }
@@ -644,7 +644,7 @@ namespace System.DirectoryServices.ActiveDirectory
             var dsMakePasswordCredentials = (delegate* unmanaged<char*, char*, char*, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsMakePasswordCredentialsW");
             if (dsMakePasswordCredentials == null)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
 
             fixed (char* usernamePtr = username)
@@ -673,7 +673,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 var dsFreePasswordCredentials = (delegate* unmanaged<IntPtr, void>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsFreePasswordCredentials");
                 if (dsFreePasswordCredentials == null)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
                 dsFreePasswordCredentials(authIdentity);
             }
@@ -695,7 +695,7 @@ namespace System.DirectoryServices.ActiveDirectory
             var bindWithCred = (delegate* unmanaged<char*, char*, IntPtr, IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsBindWithCredW");
             if (bindWithCred == null)
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
 
             fixed (char* domainControllerNamePtr = domainControllerName)
@@ -722,7 +722,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 var dsUnBind = (delegate* unmanaged<IntPtr*, int>)global::Interop.Kernel32.GetProcAddress(libHandle, "DsUnBindW");
                 if (dsUnBind == null)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
                 _ = dsUnBind(&dsHandle);
             }
@@ -967,14 +967,14 @@ namespace System.DirectoryServices.ActiveDirectory
             int result = global::Interop.Advapi32.LogonUser(userName!, domainName, context.Password, LOGON32_LOGON_NEW_CREDENTIALS, LOGON32_PROVIDER_WINNT50, ref hToken);
             // check the result
             if (result == 0)
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
 
             try
             {
                 result = global::Interop.Advapi32.ImpersonateLoggedOnUser(hToken);
                 if (result == 0)
                 {
-                    result = Marshal.GetLastWin32Error();
+                    result = Marshal.GetLastPInvokeError();
                     throw ExceptionHelper.GetExceptionFromErrorCode(result);
                 }
             }
@@ -991,13 +991,13 @@ namespace System.DirectoryServices.ActiveDirectory
         {
             IntPtr hThread = UnsafeNativeMethods.OpenThread(THREAD_ALL_ACCESS, false, global::Interop.Kernel32.GetCurrentThreadId());
             if (hThread == (IntPtr)0)
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
 
             try
             {
                 int result = UnsafeNativeMethods.ImpersonateAnonymousToken(hThread);
                 if (result == 0)
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
             finally
             {
@@ -1010,7 +1010,7 @@ namespace System.DirectoryServices.ActiveDirectory
         {
             if (!global::Interop.Advapi32.RevertToSelf())
             {
-                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
             }
         }
 
@@ -1872,7 +1872,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 result = NativeMethods.CompareString(LCID, compareFlags, lpString1, cchCount1, lpString2, cchCount2);
                 if (result == 0)
                 {
-                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
+                    throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastPInvokeError());
                 }
             }
             finally
@@ -2079,7 +2079,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                 out tokenHandle
                                 ))
                 {
-                    if ((error = Marshal.GetLastWin32Error()) == 1008) // ERROR_NO_TOKEN
+                    if ((error = Marshal.GetLastPInvokeError()) == 1008) // ERROR_NO_TOKEN
                     {
                         Debug.Assert(tokenHandle.IsInvalid);
                         tokenHandle.Dispose();
@@ -2091,7 +2091,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                         out tokenHandle
                                         ))
                         {
-                            int lastError = Marshal.GetLastWin32Error();
+                            int lastError = Marshal.GetLastPInvokeError();
                             throw new InvalidOperationException(SR.Format(SR.UnableToOpenToken, lastError));
                         }
                     }
@@ -2115,7 +2115,7 @@ namespace System.DirectoryServices.ActiveDirectory
                                         out neededBufferSize);
 
                 int getTokenInfoError = 0;
-                if ((getTokenInfoError = Marshal.GetLastWin32Error()) != 122) // ERROR_INSUFFICIENT_BUFFER
+                if ((getTokenInfoError = Marshal.GetLastPInvokeError()) != 122) // ERROR_INSUFFICIENT_BUFFER
                 {
                     throw new InvalidOperationException(
                                     SR.Format(SR.UnableToRetrieveTokenInfo, getTokenInfoError));
@@ -2135,7 +2135,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
                 if (!success)
                 {
-                    int lastError = Marshal.GetLastWin32Error();
+                    int lastError = Marshal.GetLastPInvokeError();
                     throw new InvalidOperationException(
                                     SR.Format(SR.UnableToRetrieveTokenInfo, lastError));
                 }
@@ -2152,7 +2152,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 success = global::Interop.Advapi32.CopySid(userSidLength, pCopyOfUserSid, pUserSid);
                 if (!success)
                 {
-                    int lastError = Marshal.GetLastWin32Error();
+                    int lastError = Marshal.GetLastPInvokeError();
                     throw new InvalidOperationException(
                                     SR.Format(SR.UnableToRetrieveTokenInfo, lastError));
                 }
@@ -2210,7 +2210,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 bool success = global::Interop.Advapi32.CopySid(sidLength, pCopyOfSid, info.DomainSid);
                 if (!success)
                 {
-                    int lastError = Marshal.GetLastWin32Error();
+                    int lastError = Marshal.GetLastPInvokeError();
                     throw new InvalidOperationException(
                                     SR.Format(SR.UnableToRetrievePolicy, lastError));
                 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
@@ -42,7 +42,7 @@ namespace System.Drawing.Printing
             int result = Interop.Gdi32.StartDoc(new HandleRef(_dc, _dc.Hdc), info);
             if (result <= 0)
             {
-                int error = Marshal.GetLastWin32Error();
+                int error = Marshal.GetLastPInvokeError();
                 if (error == SafeNativeMethods.ERROR_CANCELLED)
                 {
                     e.Cancel = true;

--- a/src/libraries/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
@@ -47,7 +47,7 @@ namespace System.Drawing.Tests
         {
             if (handleCount == 0)
             {
-                int error = Marshal.GetLastWin32Error();
+                int error = Marshal.GetLastPInvokeError();
 
                 if (error != 0)
                     throw new XunitException($"GetGuiResources failed with win32 error: {error}");

--- a/src/libraries/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
@@ -47,7 +47,7 @@ namespace System.Drawing.Tests
         {
             if (handleCount == 0)
             {
-                int error = Marshal.GetLastPInvokeError();
+                int error = Marshal.GetLastWin32Error();
 
                 if (error != 0)
                     throw new XunitException($"GetGuiResources failed with win32 error: {error}");

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -316,7 +316,7 @@ namespace System.IO
                 // NT5 oddity - when trying to open "C:\" as a FileStream,
                 // we usually get ERROR_PATH_NOT_FOUND from the OS.  We should
                 // probably be consistent w/ every other directory.
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
 
                 if (errorCode == Interop.Errors.ERROR_PATH_NOT_FOUND && fullPath.Length == Path.GetPathRoot(fullPath)!.Length)
                 {

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.Windows.cs
@@ -231,7 +231,7 @@ namespace System.IO.Tests
                 uint deviceIndex = 0;
                 while (SetupDiEnumDeviceInfo(deviceInfoSet, deviceIndex++, ref deviceInfoData))
                 {
-                    if (Marshal.GetLastWin32Error() == ERROR_NO_MORE_ITEMS)
+                    if (Marshal.GetLastPInvokeError() == ERROR_NO_MORE_ITEMS)
                     {
                         break;
                     }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Windows.cs
@@ -233,7 +233,7 @@ namespace System.IO.MemoryMappedFiles
         {
             SafeMemoryMappedFileHandle handle = Interop.OpenFileMapping(
                 desiredAccessRights, (inheritability & HandleInheritability.Inheritable) != 0, mapName);
-            int lastError = Marshal.GetLastWin32Error();
+            int lastError = Marshal.GetLastPInvokeError();
 
             if (handle.IsInvalid)
             {

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -616,7 +616,7 @@ namespace System.IO.Ports
                 {
                     // If the portName they have passed in is a FILE_TYPE_CHAR but not a serial port,
                     // for example "LPT1", this API will fail.  For this reason we handle the error message specially.
-                    int errorCode = Marshal.GetLastWin32Error();
+                    int errorCode = Marshal.GetLastPInvokeError();
                     if ((errorCode == Interop.Errors.ERROR_INVALID_PARAMETER) || (errorCode == Interop.Errors.ERROR_INVALID_HANDLE))
                         throw new ArgumentException(SR.Arg_InvalidSerialPortExtended, nameof(portName));
                     else
@@ -719,7 +719,7 @@ namespace System.IO.Ports
                     Interop.Kernel32.SetCommMask(_handle, 0);
                     if (!Interop.Kernel32.EscapeCommFunction(_handle, Interop.Kernel32.CommFunctions.CLRDTR))
                     {
-                        int hr = Marshal.GetLastWin32Error();
+                        int hr = Marshal.GetLastPInvokeError();
 
                         // access denied can happen if USB is yanked out. If that happens, we
                         // want to at least allow finalize to succeed and clean up everything
@@ -1131,7 +1131,7 @@ namespace System.IO.Ports
                 if (numBytes == -1)
                 {
                     // This is how writes timeout on Win9x.
-                    if (Marshal.GetLastWin32Error() == Interop.Errors.ERROR_COUNTER_TIMEOUT)
+                    if (Marshal.GetLastPInvokeError() == Interop.Errors.ERROR_COUNTER_TIMEOUT)
                         throw new TimeoutException(SR.Write_timed_out);
 
                     throw Win32Marshal.GetExceptionForLastWin32Error();
@@ -1428,7 +1428,7 @@ namespace System.IO.Ports
 
             if (r == 0)
             {
-                hr = Marshal.GetLastWin32Error();
+                hr = Marshal.GetLastPInvokeError();
 
                 // Note: we should never silently ignore an error here without some
                 // extra work.  We must make sure that BeginReadCore won't return an
@@ -1477,7 +1477,7 @@ namespace System.IO.Ports
 
             if (r == 0)
             {
-                hr = Marshal.GetLastWin32Error();
+                hr = Marshal.GetLastPInvokeError();
                 // Note: we should never silently ignore an error here without some
                 // extra work.  We must make sure that BeginWriteCore won't return an
                 // IAsyncResult that will cause EndWrite to block, since the OS won't
@@ -1607,7 +1607,7 @@ namespace System.IO.Ports
                     {
                         if (Interop.Kernel32.WaitCommEvent(handle, eventsOccurredPtr, intOverlapped) == false)
                         {
-                            int hr = Marshal.GetLastWin32Error();
+                            int hr = Marshal.GetLastPInvokeError();
 
                             // When a device is disconnected unexpectedly from a serial port, there appear to be
                             // at least three error codes Windows or drivers may return.
@@ -1625,13 +1625,13 @@ namespace System.IO.Ports
                                 // if we get IO pending, MSDN says we should wait on the WaitHandle, then call GetOverlappedResult
                                 // to get the results of WaitCommEvent.
                                 bool success = waitCommEventWaitHandle.WaitOne();
-                                Debug.Assert(success, $"waitCommEventWaitHandle.WaitOne() returned error {Marshal.GetLastWin32Error()}");
+                                Debug.Assert(success, $"waitCommEventWaitHandle.WaitOne() returned error {Marshal.GetLastPInvokeError()}");
 
                                 do
                                 {
                                     // NOTE: GetOverlappedResult will modify the original pointer passed into WaitCommEvent.
                                     success = Interop.Kernel32.GetOverlappedResult(handle, intOverlapped, ref unused, false);
-                                    error = Marshal.GetLastWin32Error();
+                                    error = Marshal.GetLastPInvokeError();
                                 }
                                 while (error == Interop.Errors.ERROR_IO_INCOMPLETE && !ShutdownLoop && !success);
 

--- a/src/libraries/System.IO.Ports/tests/SerialPort/DosDevices.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/DosDevices.cs
@@ -122,7 +122,7 @@ namespace System.IO.Ports.Tests
             dataSize = QueryDosDevice(name, buffer, buffer.Length);
             while (dataSize <= 0)
             {
-                int lastError = Marshal.GetLastPInvokeError();
+                int lastError = Marshal.GetLastWin32Error();
                 if (lastError == ERROR_INSUFFICIENT_BUFFER || lastError == ERROR_MORE_DATA)
                 {
                     buffer = new char[buffer.Length * 2];

--- a/src/libraries/System.IO.Ports/tests/SerialPort/DosDevices.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/DosDevices.cs
@@ -122,7 +122,7 @@ namespace System.IO.Ports.Tests
             dataSize = QueryDosDevice(name, buffer, buffer.Length);
             while (dataSize <= 0)
             {
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 if (lastError == ERROR_INSUFFICIENT_BUFFER || lastError == ERROR_MORE_DATA)
                 {
                     buffer = new char[buffer.Length * 2];

--- a/src/libraries/System.Management/src/System/Management/ManagementScope.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementScope.cs
@@ -311,7 +311,7 @@ namespace System.Management
             if (hModule == IntPtr.Zero)
             {
                 // This is unlikely, so having the TypeInitializationException wrapping it is fine.
-                throw new Win32Exception(Marshal.GetLastWin32Error(), SR.Format(SR.LoadLibraryFailed, wminet_utilsPath));
+                throw new Win32Exception(Marshal.GetLastPInvokeError(), SR.Format(SR.LoadLibraryFailed, wminet_utilsPath));
             }
 
             if (LoadDelegate(ref ResetSecurity_f, hModule, "ResetSecurity") &&

--- a/src/libraries/System.Net.Primitives/src/System/Net/SocketException.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/SocketException.cs
@@ -26,7 +26,7 @@ namespace System.Net.Sockets
             // Hence, no translation on the supplied code.  This does mean on Unix there's a difference between:
             //     new SocketException(); // will treat the last error as a native error code and translate it appropriately
             // and:
-            //     new SocketException(Marshal.GetLastWin32Error()); // will treat the last error as a SocketError, inappropriately
+            //     new SocketException(Marshal.GetLastPInvokeError()); // will treat the last error as a SocketError, inappropriately
             // but that's the least bad option right now.
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Windows.cs
@@ -146,7 +146,7 @@ namespace System.Net.Sockets
 #if DEBUG
                 _closeSocketResult = errorCode;
 #endif
-                if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
+                if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastPInvokeError();
 
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, closesocket()#1:{errorCode}");
 
@@ -163,7 +163,7 @@ namespace System.Net.Sockets
                     handle,
                     Interop.Winsock.IoctlSocketConstants.FIONBIO,
                     ref nonBlockCmd);
-                if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
+                if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastPInvokeError();
 
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, ioctlsocket()#1:{errorCode}");
 
@@ -174,7 +174,7 @@ namespace System.Net.Sockets
 #if DEBUG
                     _closeSocketResult = errorCode;
 #endif
-                    if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
+                    if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastPInvokeError();
                     if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, closesocket#2():{errorCode}");
 
                     // If it's not WSAEWOULDBLOCK, there's no more recourse - we either succeeded or failed.
@@ -201,7 +201,7 @@ namespace System.Net.Sockets
 #if DEBUG
             _closeSocketLinger = errorCode;
 #endif
-            if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
+            if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastPInvokeError();
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, setsockopt():{errorCode}");
 
             if (errorCode != SocketError.Success && errorCode != SocketError.InvalidArgument && errorCode != SocketError.ProtocolOption)
@@ -214,7 +214,7 @@ namespace System.Net.Sockets
 #if DEBUG
             _closeSocketResult = errorCode;
 #endif
-            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, closesocket#3():{(errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode)}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, closesocket#3():{(errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastPInvokeError() : errorCode)}");
 
             return errorCode;
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -203,7 +203,7 @@ namespace System.Net.Sockets
                                 {
                                     NetEventSource.Info(thisRef, canceled ?
                                         "Socket operation canceled." :
-                                        $"CancelIoEx failed with error '{Marshal.GetLastWin32Error()}'.");
+                                        $"CancelIoEx failed with error '{Marshal.GetLastPInvokeError()}'.");
                                 }
                             }
                             catch (ObjectDisposedException)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -31,7 +31,7 @@ namespace System.Net.Sockets
 
         public static SocketError GetLastSocketError()
         {
-            int win32Error = Marshal.GetLastWin32Error();
+            int win32Error = Marshal.GetLastPInvokeError();
             Debug.Assert(win32Error != 0, "Expected non-0 error");
             return (SocketError)win32Error;
         }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Win32.SafeHandles
                 // a) IsDevice can modify last error (not true today, but can be in the future),
                 // b) DeviceIoControl can succeed (last error set to ERROR_SUCCESS) but return fewer bytes than requested.
                 // The error is stored and in such cases exception for the first failure is going to be thrown.
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
 
                 if (Path is null || !PathInternal.IsDevice(Path))
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.Windows.cs
@@ -46,7 +46,7 @@ namespace System.IO
                 if (!directoryCreated)
                 {
                     // in the off-chance that the directory already exists, try again
-                    int error = Marshal.GetLastWin32Error();
+                    int error = Marshal.GetLastPInvokeError();
                     if (error == Interop.Errors.ERROR_ALREADY_EXISTS)
                     {
                         builder.Length = initialTempPathLength;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -173,7 +173,7 @@ namespace System.IO.Enumeration
 
             if (handle == IntPtr.Zero || handle == (IntPtr)(-1))
             {
-                int error = Marshal.GetLastWin32Error();
+                int error = Marshal.GetLastPInvokeError();
 
                 if (ContinueOnDirectoryError(error, ignoreNotFound))
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -33,7 +33,7 @@ namespace System.IO
 
         private static unsafe void ThrowExceptionEncryptDecryptFail(string fullPath)
         {
-            int errorCode = Marshal.GetLastWin32Error();
+            int errorCode = Marshal.GetLastPInvokeError();
             if (errorCode == Interop.Errors.ERROR_ACCESS_DENIED)
             {
                 // Check to see if the file system support the Encrypted File System (EFS)
@@ -43,7 +43,7 @@ namespace System.IO
                 {
                     if (!Interop.Kernel32.GetVolumeInformation(name, null, 0, null, null, out int fileSystemFlags, null, 0))
                     {
-                        errorCode = Marshal.GetLastWin32Error();
+                        errorCode = Marshal.GetLastPInvokeError();
                         throw Win32Marshal.GetExceptionForWin32Error(errorCode, name);
                     }
 
@@ -91,7 +91,7 @@ namespace System.IO
 
             if (!Interop.Kernel32.ReplaceFile(destFullPath, sourceFullPath, destBackupFullPath, flags, IntPtr.Zero, IntPtr.Zero))
             {
-                throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastWin32Error());
+                throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastPInvokeError());
             }
         }
 
@@ -100,7 +100,7 @@ namespace System.IO
             bool r = Interop.Kernel32.DeleteFile(fullPath);
             if (!r)
             {
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
                 if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     return;
                 else
@@ -163,7 +163,7 @@ namespace System.IO
                 fileHandle,
                 out Interop.Kernel32.BY_HANDLE_FILE_INFORMATION fileInformationData))
             {
-                return Marshal.GetLastWin32Error();
+                return Marshal.GetLastPInvokeError();
             }
 
             PopulateAttributeData(ref data, fileInformationData);
@@ -192,7 +192,7 @@ namespace System.IO
 
             if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath, overwrite: false))
             {
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
 
                 if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_PATH_NOT_FOUND, sourceFullPath);
@@ -239,7 +239,7 @@ namespace System.IO
 
             if (handle.IsInvalid)
             {
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
 
                 // NT5 oddity - when trying to open "C:\" as a File,
                 // we usually get ERROR_PATH_NOT_FOUND from the OS.  We should
@@ -285,7 +285,7 @@ namespace System.IO
             using SafeFindHandle handle = Interop.Kernel32.FindFirstFile(Path.TrimEndingDirectorySeparator(fullPath), ref findData);
             if (handle.IsInvalid)
             {
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
                 // File not found doesn't make much sense coming from a directory.
                 if (isDirectory && errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     errorCode = Interop.Errors.ERROR_PATH_NOT_FOUND;
@@ -329,7 +329,7 @@ namespace System.IO
                         string fileName = findData.cFileName.GetStringFromFixedBuffer();
                         if (!Interop.Kernel32.DeleteFile(Path.Combine(fullPath, fileName)) && exception == null)
                         {
-                            errorCode = Marshal.GetLastWin32Error();
+                            errorCode = Marshal.GetLastPInvokeError();
 
                             // We don't care if something else deleted the file first
                             if (errorCode != Interop.Errors.ERROR_FILE_NOT_FOUND)
@@ -372,7 +372,7 @@ namespace System.IO
                                 string mountPoint = Path.Join(fullPath, fileName, PathInternal.DirectorySeparatorCharAsString);
                                 if (!Interop.Kernel32.DeleteVolumeMountPoint(mountPoint) && exception == null)
                                 {
-                                    errorCode = Marshal.GetLastWin32Error();
+                                    errorCode = Marshal.GetLastPInvokeError();
                                     if (errorCode != Interop.Errors.ERROR_SUCCESS &&
                                         errorCode != Interop.Errors.ERROR_PATH_NOT_FOUND)
                                     {
@@ -384,7 +384,7 @@ namespace System.IO
                             // Note that RemoveDirectory on a symbolic link will remove the link itself.
                             if (!Interop.Kernel32.RemoveDirectory(Path.Combine(fullPath, fileName)) && exception == null)
                             {
-                                errorCode = Marshal.GetLastWin32Error();
+                                errorCode = Marshal.GetLastPInvokeError();
                                 if (errorCode != Interop.Errors.ERROR_PATH_NOT_FOUND)
                                 {
                                     exception = Win32Marshal.GetExceptionForWin32Error(errorCode, fileName);
@@ -397,7 +397,7 @@ namespace System.IO
                 if (exception != null)
                     throw exception;
 
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
                 if (errorCode != Interop.Errors.ERROR_SUCCESS && errorCode != Interop.Errors.ERROR_NO_MORE_FILES)
                     throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
             }
@@ -412,7 +412,7 @@ namespace System.IO
         {
             if (!Interop.Kernel32.RemoveDirectory(fullPath))
             {
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
                 switch (errorCode)
                 {
                     case Interop.Errors.ERROR_FILE_NOT_FOUND:
@@ -444,7 +444,7 @@ namespace System.IO
                 return;
             }
 
-            int errorCode = Marshal.GetLastWin32Error();
+            int errorCode = Marshal.GetLastPInvokeError();
             if (errorCode == Interop.Errors.ERROR_INVALID_PARAMETER)
                 throw new ArgumentException(SR.Arg_InvalidFileAttrs, nameof(attributes));
             throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
@@ -561,7 +561,7 @@ namespace System.IO
                     return null;
                 }
 
-                int error = Marshal.GetLastWin32Error();
+                int error = Marshal.GetLastPInvokeError();
                 // File not found doesn't make much sense coming from a directory.
                 if (isDirectory && error == Interop.Errors.ERROR_FILE_NOT_FOUND)
                 {
@@ -596,7 +596,7 @@ namespace System.IO
                         return null;
                     }
 
-                    int error = Marshal.GetLastWin32Error();
+                    int error = Marshal.GetLastPInvokeError();
                     // The file or directory is not a reparse point.
                     if (error == Interop.Errors.ERROR_NOT_A_REPARSE_POINT)
                     {
@@ -695,7 +695,7 @@ namespace System.IO
             {
                 // If the handle fails because it is unreachable, is because the link was broken.
                 // We need to fallback to manually traverse the links and return the target of the last resolved link.
-                int error = Marshal.GetLastWin32Error();
+                int error = Marshal.GetLastPInvokeError();
                 if (IsPathUnreachableError(error))
                 {
                     return GetFinalLinkTargetSlow(linkPath);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/PathHelper.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/PathHelper.Windows.cs
@@ -83,7 +83,7 @@ namespace System.IO
             if (result == 0)
             {
                 // Failure, get the error and throw
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
                 if (errorCode == 0)
                     errorCode = Interop.Errors.ERROR_BAD_PATHNAME;
                 throw Win32Marshal.GetExceptionForWin32Error(errorCode, path.ToString());
@@ -185,7 +185,7 @@ namespace System.IO
                 if (result == 0)
                 {
                     // Look to see if we couldn't find the file
-                    int error = Marshal.GetLastWin32Error();
+                    int error = Marshal.GetLastPInvokeError();
                     if (error != Interop.Errors.ERROR_FILE_NOT_FOUND && error != Interop.Errors.ERROR_PATH_NOT_FOUND)
                     {
                         // Some other failure, give up

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PosixSignalRegistration.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PosixSignalRegistration.Windows.cs
@@ -56,7 +56,7 @@ namespace System.Runtime.InteropServices
                         // Ignore errors due to the handler no longer being registered; this can happen, for example, with
                         // direct use of Alloc/Attach/FreeConsole which result in the table of control handlers being reset.
                         // Throw for everything else.
-                        int error = Marshal.GetLastWin32Error();
+                        int error = Marshal.GetLastPInvokeError();
                         if (error != Interop.Errors.ERROR_INVALID_PARAMETER)
                         {
                             throw Win32Marshal.GetExceptionForWin32Error(error);

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/SetLastErrorTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/SetLastErrorTests.cs
@@ -52,21 +52,21 @@ namespace LibraryImportGenerator.IntegrationTests
         {
             string errorString = error.ToString();
             string ret = NativeExportsNE.SetLastError.SetError_NonBlittableSignature(error, shouldSetError: true, errorString);
-            Assert.Equal(error, Marshal.GetLastWin32Error());
+            Assert.Equal(error, Marshal.GetLastPInvokeError());
             Assert.Equal(errorString, ret);
 
             // Clear the last error
             Marshal.SetLastPInvokeError(0);
 
             NativeExportsNE.SetLastError.SetError(error, shouldSetError: 1);
-            Assert.Equal(error, Marshal.GetLastWin32Error());
+            Assert.Equal(error, Marshal.GetLastPInvokeError());
 
             Marshal.SetLastPInvokeError(0);
 
             // Custom marshalling sets the last error on unmarshalling.
             // Last error should reflect error from native call, not unmarshalling.
             NativeExportsNE.SetLastError.SetError_CustomMarshallingSetsError(error, shouldSetError: 1);
-            Assert.Equal(error, Marshal.GetLastWin32Error());
+            Assert.Equal(error, Marshal.GetLastPInvokeError());
         }
 
         [Fact]
@@ -79,19 +79,19 @@ namespace LibraryImportGenerator.IntegrationTests
             // Don't actually set the error in the native call. SetLastError=true should clear any existing error.
             string errorString = error.ToString();
             string ret = NativeExportsNE.SetLastError.SetError_NonBlittableSignature(error, shouldSetError: false, errorString);
-            Assert.Equal(0, Marshal.GetLastWin32Error());
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
             Assert.Equal(errorString, ret);
 
             Marshal.SetLastPInvokeError(error);
 
             // Don't actually set the error in the native call. SetLastError=true should clear any existing error.
             NativeExportsNE.SetLastError.SetError(error, shouldSetError: 0);
-            Assert.Equal(0, Marshal.GetLastWin32Error());
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
 
             // Don't actually set the error in the native call. Custom marshalling still sets the last error.
             // SetLastError=true should clear any existing error and ignore error set by custom marshalling.
             NativeExportsNE.SetLastError.SetError_CustomMarshallingSetsError(error, shouldSetError: 0);
-            Assert.Equal(0, Marshal.GetLastWin32Error());
+            Assert.Equal(0, Marshal.GetLastPInvokeError());
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/LastErrorTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/LastErrorTests.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.InteropServices.Tests
         {
             int errorExpected = 123;
             Marshal.SetLastPInvokeError(errorExpected);
-            Assert.Equal(errorExpected, Marshal.GetLastWin32Error());
+            Assert.Equal(errorExpected, Marshal.GetLastPInvokeError());
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace System.Runtime.InteropServices.Tests
             Assert.NotEqual(systemError, pinvokeActual);
             Assert.Equal(pinvokeError, pinvokeActual);
 
-            int win32Actual = Marshal.GetLastWin32Error();
+            int win32Actual = Marshal.GetLastPInvokeError();
             Assert.NotEqual(systemError, win32Actual);
             Assert.Equal(pinvokeError, win32Actual);
         }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -99,7 +99,7 @@ namespace System.Security.AccessControl
 
                     if (false == Interop.Advapi32.LookupPrivilegeValue(null, privilege, out luid))
                     {
-                        int error = Marshal.GetLastWin32Error();
+                        int error = Marshal.GetLastPInvokeError();
 
                         if (error == Interop.Errors.ERROR_NOT_ENOUGH_MEMORY)
                         {
@@ -177,7 +177,7 @@ namespace System.Security.AccessControl
                                             TokenAccessLevels.Duplicate,
                                             out localProcessHandle))
                             {
-                                cachingError = Marshal.GetLastWin32Error();
+                                cachingError = Marshal.GetLastPInvokeError();
                                 success = false;
                             }
                             processHandle = localProcessHandle;
@@ -223,7 +223,7 @@ namespace System.Security.AccessControl
                                                 System.Security.Principal.TokenType.TokenImpersonation,
                                                 ref this.threadHandle))
                                 {
-                                    error = Marshal.GetLastWin32Error();
+                                    error = Marshal.GetLastPInvokeError();
                                     success = false;
                                 }
                             }
@@ -456,9 +456,9 @@ namespace System.Security.AccessControl
                                   &previousState,
                                   &previousSize))
                 {
-                    error = Marshal.GetLastWin32Error();
+                    error = Marshal.GetLastPInvokeError();
                 }
-                else if (Interop.Errors.ERROR_NOT_ALL_ASSIGNED == Marshal.GetLastWin32Error())
+                else if (Interop.Errors.ERROR_NOT_ALL_ASSIGNED == Marshal.GetLastPInvokeError())
                 {
                     error = Interop.Errors.ERROR_NOT_ALL_ASSIGNED;
                 }
@@ -551,7 +551,7 @@ namespace System.Security.AccessControl
                                       null,
                                       null))
                     {
-                        error = Marshal.GetLastWin32Error();
+                        error = Marshal.GetLastPInvokeError();
                         success = false;
                     }
                 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
@@ -632,7 +632,7 @@ namespace System.Security.AccessControl
                         out byteArray,
                         ref byteArraySize))
                 {
-                    error = Marshal.GetLastWin32Error();
+                    error = Marshal.GetLastPInvokeError();
 
                     if (error == Interop.Errors.ERROR_INVALID_PARAMETER ||
                         error == Interop.Errors.ERROR_INVALID_ACL ||

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Win32.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Win32.cs
@@ -32,7 +32,7 @@ namespace System.Security.AccessControl
 
             if (!Interop.Advapi32.ConvertSdToStringSd(binaryForm, (uint)requestedRevision, (uint)si, out ByteArray, ref ByteArraySize))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
                 goto Error;
             }
 

--- a/src/libraries/System.Security.AccessControl/tests/RawAcl/RawAcl_GetBinaryForm.cs
+++ b/src/libraries/System.Security.AccessControl/tests/RawAcl/RawAcl_GetBinaryForm.cs
@@ -34,12 +34,12 @@ namespace System.Security.AccessControl.Tests
             if (0 == Utils.Win32AclLayer.InitializeAclNative
                 (verifierBinaryForm, (uint)rAcl.BinaryLength, (uint)GenericAcl.AclRevision))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
             }
             else if (0 == Utils.Win32AclLayer.AddAccessAllowedAceExNative
                 (verifierBinaryForm, (uint)GenericAcl.AclRevision, (uint)AceFlags.None, (uint)1, sidBinaryForm))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
             }
             else
                 Assert.True(Utils.IsBinaryFormEqual(binaryForm, verifierBinaryForm));
@@ -60,12 +60,12 @@ namespace System.Security.AccessControl.Tests
             if (0 == Utils.Win32AclLayer.InitializeAclNative
                 (verifierBinaryForm, (uint)rAcl.BinaryLength, (uint)GenericAcl.AclRevision))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
             }
             else if (0 == Utils.Win32AclLayer.AddAccessDeniedAceExNative
                 (verifierBinaryForm, (uint)GenericAcl.AclRevision, (uint)31, (uint)1, sidBinaryForm))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
             }
             else
                 Assert.True(Utils.IsBinaryFormEqual(binaryForm, verifierBinaryForm));
@@ -86,12 +86,12 @@ namespace System.Security.AccessControl.Tests
             if (0 == Utils.Win32AclLayer.InitializeAclNative
                 (verifierBinaryForm, (uint)rAcl.BinaryLength, (uint)GenericAcl.AclRevision))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
             }
             else if (0 == Utils.Win32AclLayer.AddAuditAccessAceExNative
                 (verifierBinaryForm, (uint)GenericAcl.AclRevision, (uint)223, (uint)1, sidBinaryForm, 1, 1))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
             }
             else
                 Assert.True(Utils.IsBinaryFormEqual(binaryForm, verifierBinaryForm));
@@ -174,7 +174,7 @@ namespace System.Security.AccessControl.Tests
             if (0 == Utils.Win32AclLayer.InitializeAclNative
                 (verifierBinaryForm, (uint)8, (uint)GenericAcl.AclRevision))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
             }
             else
                 Assert.True(Utils.IsBinaryFormEqual(binaryForm, verifierBinaryForm));
@@ -203,7 +203,7 @@ namespace System.Security.AccessControl.Tests
             if (0 == Utils.Win32AclLayer.InitializeAclNative
                 (verifierBinaryForm, (uint)rAcl.BinaryLength, (uint)GenericAcl.AclRevision))
             {
-                errorCode = Marshal.GetLastWin32Error();
+                errorCode = Marshal.GetLastPInvokeError();
             }
             else
             {
@@ -213,19 +213,19 @@ namespace System.Security.AccessControl.Tests
                     if (0 == Utils.Win32AclLayer.AddAccessAllowedAceExNative
                     (verifierBinaryForm, (uint)GenericAcl.AclRevision, (uint)AceFlags.None, (uint)i, sidBinaryForm))
                     {
-                        errorCode = Marshal.GetLastWin32Error();
+                        errorCode = Marshal.GetLastPInvokeError();
                         break;
                     }
                     if (0 == Utils.Win32AclLayer.AddAuditAccessAceExNative
                     (verifierBinaryForm, (uint)GenericAcl.AclRevision, (uint)223, (uint)(i + 1), sidBinaryForm, 1, 1))
                     {
-                        errorCode = Marshal.GetLastWin32Error();
+                        errorCode = Marshal.GetLastPInvokeError();
                         break;
                     }
                     if (0 == Utils.Win32AclLayer.AddAccessDeniedAceExNative
                     (verifierBinaryForm, (uint)GenericAcl.AclRevision, (uint)31, (uint)(i + 2), sidBinaryForm))
                     {
-                        errorCode = Marshal.GetLastWin32Error();
+                        errorCode = Marshal.GetLastPInvokeError();
                         break;
                     }
                 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decode.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decode.cs
@@ -30,7 +30,7 @@ namespace Internal.Cryptography.Pal.Windows
             {
                 hCryptMsg = Interop.Crypt32.CryptMsgOpenToDecode(MsgEncodingType.All, 0, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
                 if (hCryptMsg == null || hCryptMsg.IsInvalid)
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
                 if (!Interop.Crypt32.CryptMsgUpdate(
                     hCryptMsg,
@@ -38,7 +38,7 @@ namespace Internal.Cryptography.Pal.Windows
                     encodedMessage.Length,
                     fFinal: true))
                 {
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
 
                 CryptMsgType cryptMsgType = hCryptMsg.GetMessageType();

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.DecodeRecipients.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.DecodeRecipients.cs
@@ -19,7 +19,7 @@ namespace Internal.Cryptography.Pal.Windows
             int numRecipients;
             int cbRecipientsCount = sizeof(int);
             if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, CryptMsgParamType.CMSG_CMS_RECIPIENT_COUNT_PARAM, 0, out numRecipients, ref cbRecipientsCount))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             List<RecipientInfo> recipientInfos = new List<RecipientInfo>(numRecipients);
             for (int index = 0; index < numRecipients; index++)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/DecryptorPalWindows.Decrypt.cs
@@ -137,7 +137,7 @@ namespace Internal.Cryptography.Pal.Windows
 
                 if (!Interop.Crypt32.CertGetCertificateContextProperty(hCertContext, CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID, null, ref cbSize))
                 {
-                    ErrorCode errorCode = (ErrorCode)(Marshal.GetLastWin32Error());
+                    ErrorCode errorCode = (ErrorCode)(Marshal.GetLastPInvokeError());
                     keySpec = default(CryptKeySpec);
                     return errorCode.ToCryptographicException();
                 }
@@ -149,7 +149,7 @@ namespace Internal.Cryptography.Pal.Windows
                     {
                         if (!Interop.Crypt32.CertGetCertificateContextProperty(hCertContext, CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID, pData, ref cbSize))
                         {
-                            ErrorCode errorCode = (ErrorCode)(Marshal.GetLastWin32Error());
+                            ErrorCode errorCode = (ErrorCode)(Marshal.GetLastPInvokeError());
                             keySpec = default(CryptKeySpec);
                             return errorCode.ToCryptographicException();
                         }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/HelpersWindows.cs
@@ -36,13 +36,13 @@ namespace Internal.Cryptography.Pal.Windows
         {
             int cbData = 0;
             if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, paramType, index, IntPtr.Zero, ref cbData))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             byte[] data = new byte[cbData];
             fixed (byte* pvData = data)
             {
                 if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, paramType, index, pvData, ref cbData))
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             return data.Resize(cbData);
@@ -54,13 +54,13 @@ namespace Internal.Cryptography.Pal.Windows
             int cbData = 0;
             if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, paramType, index, IntPtr.Zero, ref cbData))
             {
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             SafeHandle pvData = SafeHeapAllocHandle.Alloc(cbData);
             if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, paramType, index, pvData.DangerousGetHandle(), ref cbData))
             {
-                Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                 pvData.Dispose();
                 throw e;
             }
@@ -84,7 +84,7 @@ namespace Internal.Cryptography.Pal.Windows
             int cbData = sizeof(CryptMsgType);
             CryptMsgType cryptMsgType;
             if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, CryptMsgParamType.CMSG_TYPE_PARAM, 0, out cryptMsgType, ref cbData))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             return cryptMsgType;
         }
 
@@ -93,7 +93,7 @@ namespace Internal.Cryptography.Pal.Windows
             int cbData = sizeof(int);
             int version;
             if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, CryptMsgParamType.CMSG_VERSION_PARAM, 0, out version, ref cbData))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             return version;
         }
 
@@ -128,7 +128,7 @@ namespace Internal.Cryptography.Pal.Windows
             int numCertificates;
             int cbNumCertificates = sizeof(int);
             if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, CryptMsgParamType.CMSG_CERT_COUNT_PARAM, 0, out numCertificates, ref cbNumCertificates))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             X509Certificate2Collection certs = new X509Certificate2Collection();
             for (int index = 0; index < numCertificates; index++)
             {
@@ -161,11 +161,11 @@ namespace Internal.Cryptography.Pal.Windows
         {
             int cbData = 0;
             if (!Interop.Crypt32.CertGetCertificateContextProperty(hCertContext, CertContextPropId.CERT_KEY_IDENTIFIER_PROP_ID, null, ref cbData))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             byte[] ski = new byte[cbData];
             if (!Interop.Crypt32.CertGetCertificateContextProperty(hCertContext, CertContextPropId.CERT_KEY_IDENTIFIER_PROP_ID, ski, ref cbData))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             return ski.Resize(cbData);
         }
@@ -186,7 +186,7 @@ namespace Internal.Cryptography.Pal.Windows
                             int nc = Interop.Crypt32.CertNameToStr((int)MsgEncodingType.All, dataBlobPtr, dwStrType, null, 0);
                             if (nc <= 1) // The API actually return 1 when it fails; which is not what the documentation says.
                             {
-                                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                                throw Marshal.GetLastPInvokeError().ToCryptographicException();
                             }
 
                             Span<char> name = nc <= 128 ? stackalloc char[128] : new char[nc];
@@ -195,7 +195,7 @@ namespace Internal.Cryptography.Pal.Windows
                                 nc = Interop.Crypt32.CertNameToStr((int)MsgEncodingType.All, dataBlobPtr, dwStrType, namePtr, nc);
                                 if (nc <= 1) // The API actually return 1 when it fails; which is not what the documentation says.
                                 {
-                                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                                 }
 
                                 issuer = new string(namePtr);
@@ -272,7 +272,7 @@ namespace Internal.Cryptography.Pal.Windows
                             {
                                 int cbSize = sizeof(CRYPT_RC2_CBC_PARAMETERS);
                                 if (!Interop.Crypt32.CryptDecodeObject(CryptDecodeObjectStructType.PKCS_RC2_CBC_PARAMETERS, cryptAlgorithmIdentifier.Parameters.pbData, (int)(cryptAlgorithmIdentifier.Parameters.cbData), &rc2Parameters, ref cbSize))
-                                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                             }
 
                             keyLength = rc2Parameters.dwVersion switch
@@ -341,7 +341,7 @@ namespace Internal.Cryptography.Pal.Windows
             int cbUnprotectedAttr = 0;
             if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, CryptMsgParamType.CMSG_UNPROTECTED_ATTR_PARAM, 0, IntPtr.Zero, ref cbUnprotectedAttr))
             {
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 if (lastError == (int)ErrorCode.CRYPT_E_ATTRIBUTES_MISSING)
                     return new CryptographicAttributeObjectCollection();
                 throw lastError.ToCryptographicException();
@@ -378,7 +378,7 @@ namespace Internal.Cryptography.Pal.Windows
 
             if (!Interop.Advapi32.CryptGetProvParam(handle, CryptProvParam.PP_PROVTYPE, stackSpan, ref size))
             {
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             if (size != sizeof(int))
@@ -392,7 +392,7 @@ namespace Internal.Cryptography.Pal.Windows
             size = stackSpan.Length;
             if (!Interop.Advapi32.CryptGetProvParam(handle, CryptProvParam.PP_KEYSET_TYPE, stackSpan, ref size))
             {
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             if (size != sizeof(int))
@@ -454,12 +454,12 @@ namespace Internal.Cryptography.Pal.Windows
                 }
                 else
                 {
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
 
                 if (!Interop.Advapi32.CryptGetProvParam(handle, dwParam, buf, ref len))
                 {
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.Encrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.Encrypt.cs
@@ -48,7 +48,7 @@ namespace Internal.Cryptography.Pal.Windows
                         try
                         {
                             if (!Interop.Crypt32.CryptMsgUpdate(hCryptMsg, encodedContent, encodedContent.Length, fFinal: true))
-                                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                                throw Marshal.GetLastPInvokeError().ToCryptographicException();
                         }
                         finally
                         {
@@ -123,7 +123,7 @@ namespace Internal.Cryptography.Pal.Windows
                         SafeCryptMsgHandle hCryptMsg = Interop.Crypt32.CryptMsgOpenToEncode(MsgEncodingType.All, 0, CryptMsgType.CMSG_ENVELOPED, pEnvelopedEncodeInfo, innerContentType.Value!, IntPtr.Zero);
                         if (hCryptMsg == null || hCryptMsg.IsInvalid)
                         {
-                            Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                            Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                             hCryptMsg?.Dispose();
                             throw e;
                         }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.cs
@@ -33,15 +33,15 @@ namespace Internal.Cryptography.Pal.Windows
             using (SafeCryptMsgHandle hCryptMsg = Interop.Crypt32.CryptMsgOpenToDecode(MsgEncodingType.All, 0, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero))
             {
                 if (hCryptMsg == null || hCryptMsg.IsInvalid)
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
                 if (!Interop.Crypt32.CryptMsgUpdate(hCryptMsg, ref MemoryMarshal.GetReference(encodedMessage), encodedMessage.Length, fFinal: true))
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
                 int msgTypeAsInt;
                 int cbSize = sizeof(int);
                 if (!Interop.Crypt32.CryptMsgGetParam(hCryptMsg, CryptMsgParamType.CMSG_TYPE_PARAM, 0, out msgTypeAsInt, ref cbSize))
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
                 return (CryptMsgType)msgTypeAsInt switch
                 {

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography
                             Interop.Crypt32.CryptUnprotectData(in userDataBlob, IntPtr.Zero, ref optionalEntropyBlob, IntPtr.Zero, IntPtr.Zero, flags, out outputBlob);
                         if (!success)
                         {
-                            int lastWin32Error = Marshal.GetLastWin32Error();
+                            int lastWin32Error = Marshal.GetLastPInvokeError();
                             if (protect && ErrorMayBeCausedByUnloadedProfile(lastWin32Error))
                                 throw new CryptographicException(SR.Cryptography_DpApi_ProfileMayNotBeLoaded);
                             else

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.PrivateKey.cs
@@ -327,7 +327,7 @@ namespace System.Security.Cryptography.X509Certificates
             int cbData = 0;
             if (!Interop.Crypt32.CertGetCertificateContextProperty(_certContext, Interop.Crypt32.CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID, null, ref cbData))
             {
-                int dwErrorCode = Marshal.GetLastWin32Error();
+                int dwErrorCode = Marshal.GetLastPInvokeError();
                 if (dwErrorCode == ErrorCode.CRYPT_E_NOT_FOUND)
                     return null;
                 throw dwErrorCode.ToCryptographicException();
@@ -339,7 +339,7 @@ namespace System.Security.Cryptography.X509Certificates
                 fixed (byte* pPrivateKey = privateKey)
                 {
                     if (!Interop.Crypt32.CertGetCertificateContextProperty(_certContext, Interop.Crypt32.CertContextPropId.CERT_KEY_PROV_INFO_PROP_ID, privateKey, ref cbData))
-                        throw Marshal.GetLastWin32Error().ToCryptographicException();
+                        throw Marshal.GetLastPInvokeError().ToCryptographicException();
                     Interop.Crypt32.CRYPT_KEY_PROV_INFO* pKeyProvInfo = (Interop.Crypt32.CRYPT_KEY_PROV_INFO*)pPrivateKey;
 
                     CspParameters cspParameters = new CspParameters();
@@ -387,7 +387,7 @@ namespace System.Security.Cryptography.X509Certificates
                     Interop.Crypt32.CertSetPropertyFlags.None,
                     &keyProvInfo))
                 {
-                    Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                    Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                     pal.Dispose();
                     throw e;
                 }
@@ -576,7 +576,7 @@ namespace System.Security.Cryptography.X509Certificates
                     Interop.Crypt32.CertSetPropertyFlags.None,
                     &keyProvInfo))
                 {
-                    Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                    Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                     pal.Dispose();
                     throw e;
                 }
@@ -604,7 +604,7 @@ namespace System.Security.Cryptography.X509Certificates
                         Interop.Crypt32.CertSetPropertyFlags.CERT_SET_PROPERTY_INHIBIT_PERSIST_FLAG,
                         handle))
                     {
-                        throw Marshal.GetLastWin32Error().ToCryptographicException();
+                        throw Marshal.GetLastPInvokeError().ToCryptographicException();
                     }
 
                     // The value was transferred to the certificate.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
@@ -277,7 +277,7 @@ namespace System.Security.Cryptography.X509Certificates
                     Interop.Crypt32.DATA_BLOB blob = new Interop.Crypt32.DATA_BLOB(IntPtr.Zero, 0);
                     Interop.Crypt32.DATA_BLOB* pValue = value ? &blob : (Interop.Crypt32.DATA_BLOB*)null;
                     if (!Interop.Crypt32.CertSetCertificateContextProperty(_certContext, Interop.Crypt32.CertContextPropId.CERT_ARCHIVED_PROP_ID, Interop.Crypt32.CertSetPropertyFlags.None, pValue))
-                        throw Marshal.GetLastWin32Error().ToCryptographicException();
+                        throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
             }
         }
@@ -316,7 +316,7 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         Interop.Crypt32.DATA_BLOB blob = new Interop.Crypt32.DATA_BLOB(pFriendlyName, checked(2 * ((uint)friendlyName.Length + 1)));
                         if (!Interop.Crypt32.CertSetCertificateContextProperty(_certContext, Interop.Crypt32.CertContextPropId.CERT_FRIENDLY_NAME_PROP_ID, Interop.Crypt32.CertSetPropertyFlags.None, &blob))
-                            throw Marshal.GetLastWin32Error().ToCryptographicException();
+                            throw Marshal.GetLastPInvokeError().ToCryptographicException();
                     }
                     finally
                     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Windows.cs
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 if (!Interop.crypt32.CertVerifyCertificateChainPolicy(ChainPolicy.CERT_CHAIN_POLICY_BASE, _chain, ref para, ref status))
                 {
-                    int errorCode = Marshal.GetLastWin32Error();
+                    int errorCode = Marshal.GetLastPInvokeError();
                     exception = errorCode.ToCryptographicException();
                     return default(bool?);
                 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/FindPal.Windows.cs
@@ -419,7 +419,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 if (!Interop.Crypt32.CertAddCertificateLinkToStore(findResults, pCertContext, Interop.Crypt32.CertStoreAddDisposition.CERT_STORE_ADD_ALWAYS, IntPtr.Zero))
                 {
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.Export.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.Export.cs
@@ -106,14 +106,14 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 Interop.Crypt32.DATA_BLOB blob = new Interop.Crypt32.DATA_BLOB(IntPtr.Zero, 0);
                 if (!Interop.Crypt32.CertSaveStore(_certStore, Interop.Crypt32.CertEncodingType.All, dwSaveAs, Interop.Crypt32.CertStoreSaveTo.CERT_STORE_SAVE_TO_MEMORY, ref blob, 0))
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
                 byte[] exportedData = new byte[blob.cbData];
                 fixed (byte* pExportedData = exportedData)
                 {
                     blob.pbData = new IntPtr(pExportedData);
                     if (!Interop.Crypt32.CertSaveStore(_certStore, Interop.Crypt32.CertEncodingType.All, dwSaveAs, Interop.Crypt32.CertStoreSaveTo.CERT_STORE_SAVE_TO_MEMORY, ref blob, 0))
-                        throw Marshal.GetLastWin32Error().ToCryptographicException();
+                        throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
 
                 // When calling CertSaveStore to get the initial length, it returns a cbData that is big enough but

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.Import.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.Import.cs
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.X509Certificates
                             IntPtr.Zero
                             ))
                         {
-                            Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                            Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                             certStore.Dispose();
                             throw e;
                         }
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.X509Certificates
                                 certStore = Interop.Crypt32.PFXImportCertStore(ref blob2, password, certStoreFlags);
                                 if (certStore == null || certStore.IsInvalid)
                                 {
-                                    Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                                    Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                                     certStore?.Dispose();
                                     throw e;
                                 }
@@ -93,7 +93,7 @@ namespace System.Security.Cryptography.X509Certificates
                                     Interop.Crypt32.DATA_BLOB nullBlob = new Interop.Crypt32.DATA_BLOB(IntPtr.Zero, 0);
                                     if (!Interop.Crypt32.CertSetCertificateContextProperty(pCertContext, Interop.Crypt32.CertContextPropId.CERT_CLR_DELETE_KEY_PROP_ID, Interop.Crypt32.CertSetPropertyFlags.CERT_SET_PROPERTY_INHIBIT_PERSIST_FLAG, &nullBlob))
                                     {
-                                        Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                                        Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                                         certStore.Dispose();
                                         throw e;
                                     }
@@ -165,7 +165,7 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         if (!Interop.Crypt32.CertAddCertificateLinkToStore(certStore, certContext, Interop.Crypt32.CertStoreAddDisposition.CERT_STORE_ADD_ALWAYS, IntPtr.Zero))
                         {
-                            throw Marshal.GetLastWin32Error().ToCryptographicException();
+                            throw Marshal.GetLastPInvokeError().ToCryptographicException();
                         }
                     }
                 }
@@ -186,7 +186,7 @@ namespace System.Security.Cryptography.X509Certificates
             SafeCertStoreHandle certStore = Interop.crypt32.CertOpenStore(CertStoreProvider.CERT_STORE_PROV_SYSTEM_W, Interop.Crypt32.CertEncodingType.All, IntPtr.Zero, certStoreFlags, storeName);
             if (certStore.IsInvalid)
             {
-                Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                 certStore.Dispose();
                 throw e;
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.cs
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography.X509Certificates
             using (SafeCertContextHandle certContext = ((CertificatePal)certificate).GetCertContext())
             {
                 if (!Interop.Crypt32.CertAddCertificateContextToStore(_certStore, certContext, Interop.Crypt32.CertStoreAddDisposition.CERT_STORE_ADD_REPLACE_EXISTING_INHERIT_PROPERTIES, IntPtr.Zero))
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
         }
 
@@ -69,7 +69,7 @@ namespace System.Security.Cryptography.X509Certificates
                 enumCertContext.Dispose();
 
                 if (!Interop.Crypt32.CertDeleteCertificateFromStore(pCertContextToDelete))
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsHelpers.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsHelpers.cs
@@ -96,7 +96,7 @@ namespace Internal.Cryptography
                     null,
                     ref cb))
                 {
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
 
                 int MaxStackAllocSize = 256;
@@ -118,7 +118,7 @@ namespace Internal.Cryptography
                         pDecoded,
                         ref cb))
                     {
-                        throw Marshal.GetLastWin32Error().ToCryptographicException();
+                        throw Marshal.GetLastPInvokeError().ToCryptographicException();
                     }
 
                     return receiver(pDecoded, cb);
@@ -142,7 +142,7 @@ namespace Internal.Cryptography
                 null,
                 ref cb))
             {
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             const int MaxStackAllocSize = 256;
@@ -164,7 +164,7 @@ namespace Internal.Cryptography
                     pDecoded,
                     ref cb))
                 {
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
 
                 return receiver(pDecoded, cb);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsInterop.crypt32.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/WindowsInterop.crypt32.cs
@@ -28,7 +28,7 @@ internal static partial class Interop
             int cchCount = Crypt32.CertGetNameString(certContext, certNameType, certNameFlags, strType, null, 0);
             if (cchCount == 0)
             {
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
             }
 
             Span<char> buffer = cchCount <= 256 ? stackalloc char[cchCount] : new char[cchCount];
@@ -36,7 +36,7 @@ internal static partial class Interop
             {
                 if (Crypt32.CertGetNameString(certContext, certNameType, certNameFlags, strType, ptr, cchCount) == 0)
                 {
-                    throw Marshal.GetLastWin32Error().ToCryptographicException();
+                    throw Marshal.GetLastPInvokeError().ToCryptographicException();
                 }
 
                 Debug.Assert(buffer[cchCount - 1] == '\0');
@@ -107,11 +107,11 @@ internal static partial class Interop
         {
             int cb = 0;
             if (!Interop.crypt32.CryptEncodeObject(Interop.Crypt32.CertEncodingType.All, lpszStructType, decoded, null, ref cb))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             byte[] encoded = new byte[cb];
             if (!Interop.crypt32.CryptEncodeObject(Interop.Crypt32.CertEncodingType.All, lpszStructType, decoded, encoded, ref cb))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             return encoded;
         }
@@ -120,11 +120,11 @@ internal static partial class Interop
         {
             int cb = 0;
             if (!Interop.Crypt32.CryptEncodeObject(Interop.Crypt32.CertEncodingType.All, lpszStructType, decoded, null, ref cb))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             byte[] encoded = new byte[cb];
             if (!Interop.Crypt32.CryptEncodeObject(Interop.Crypt32.CertEncodingType.All, lpszStructType, decoded, encoded, ref cb))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             return encoded;
         }
@@ -133,7 +133,7 @@ internal static partial class Interop
         {
             if (!Interop.Crypt32.CertCreateCertificateChainEngine(ref config, out SafeChainEngineHandle chainEngineHandle))
             {
-                Exception e = Marshal.GetLastWin32Error().ToCryptographicException();
+                Exception e = Marshal.GetLastPInvokeError().ToCryptographicException();
                 chainEngineHandle.Dispose();
                 throw e;
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.GetCertContentType.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.GetCertContentType.cs
@@ -34,7 +34,7 @@ namespace System.Security.Cryptography.X509Certificates
                         IntPtr.Zero,
                         IntPtr.Zero))
                     {
-                        throw Marshal.GetLastWin32Error().ToCryptographicException();
+                        throw Marshal.GetLastPInvokeError().ToCryptographicException();
                     }
                 }
             }
@@ -63,7 +63,7 @@ namespace System.Security.Cryptography.X509Certificates
                         IntPtr.Zero,
                         IntPtr.Zero))
                     {
-                        throw Marshal.GetLastWin32Error().ToCryptographicException();
+                        throw Marshal.GetLastPInvokeError().ToCryptographicException();
                     }
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.PublicKey.cs
@@ -201,11 +201,11 @@ namespace System.Security.Cryptography.X509Certificates
         {
             int cbDecoded = 0;
             if (!Interop.crypt32.CryptDecodeObject(CertEncodingType.All, lpszStructType, encodedKeyValue, encodedKeyValue.Length, CryptDecodeObjectFlags.None, null, ref cbDecoded))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             byte[] keyBlob = new byte[cbDecoded];
             if (!Interop.crypt32.CryptDecodeObject(CertEncodingType.All, lpszStructType, encodedKeyValue, encodedKeyValue.Length, CryptDecodeObjectFlags.None, keyBlob, ref cbDecoded))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             return keyBlob;
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.X500DistinguishedName.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.X500DistinguishedName.cs
@@ -48,11 +48,11 @@ namespace System.Security.Cryptography.X509Certificates
 
             int cbEncoded = 0;
             if (!Interop.Crypt32.CertStrToName(Interop.Crypt32.CertEncodingType.All, distinguishedName, dwStrType, IntPtr.Zero, null, ref cbEncoded, IntPtr.Zero))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             byte[] encodedName = new byte[cbEncoded];
             if (!Interop.Crypt32.CertStrToName(Interop.Crypt32.CertEncodingType.All, distinguishedName, dwStrType, IntPtr.Zero, encodedName, ref cbEncoded, IntPtr.Zero))
-                throw Marshal.GetLastWin32Error().ToCryptographicException();
+                throw Marshal.GetLastPInvokeError().ToCryptographicException();
 
             return encodedName;
         }

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
@@ -109,7 +109,7 @@ namespace System.Security.Principal
             {
                 if (Interop.BOOL.FALSE == Interop.Advapi32.ConvertStringSidToSid(stringSid, out ByteArray))
                 {
-                    ErrorCode = Marshal.GetLastWin32Error();
+                    ErrorCode = Marshal.GetLastPInvokeError();
                     goto Error;
                 }
 
@@ -163,7 +163,7 @@ namespace System.Security.Principal
             {
                 resultSid = null;
 
-                return Marshal.GetLastWin32Error();
+                return Marshal.GetLastPInvokeError();
             }
         }
 
@@ -218,7 +218,7 @@ namespace System.Security.Principal
             {
                 resultSid = null;
 
-                return Marshal.GetLastWin32Error();
+                return Marshal.GetLastPInvokeError();
             }
         }
 

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -270,7 +270,7 @@ namespace System.Security.Principal
                     IntPtr.Zero,
                     0,
                     out _) &&
-                Marshal.GetLastWin32Error() == Interop.Errors.ERROR_INVALID_HANDLE)
+                Marshal.GetLastPInvokeError() == Interop.Errors.ERROR_INVALID_HANDLE)
             {
                 throw new ArgumentException(SR.Argument_InvalidImpersonationToken);
             }
@@ -875,7 +875,7 @@ namespace System.Security.Principal
         {
             hr = 0;
             if (!Interop.Advapi32.OpenProcessToken(Interop.Kernel32.GetCurrentProcess(), desiredAccess, out SafeAccessTokenHandle safeTokenHandle))
-                hr = GetHRForWin32Error(Marshal.GetLastWin32Error());
+                hr = GetHRForWin32Error(Marshal.GetLastPInvokeError());
             return safeTokenHandle;
         }
 
@@ -915,7 +915,7 @@ namespace System.Security.Principal
                                                               safeLocalAllocHandle,
                                                               0,
                                                               out uint dwLength);
-                int dwErrorCode = Marshal.GetLastWin32Error();
+                int dwErrorCode = Marshal.GetLastPInvokeError();
                 switch (dwErrorCode)
                 {
                     case Interop.Errors.ERROR_BAD_LENGTH: // special case for TokenSessionId. Falling through

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -192,7 +192,7 @@ namespace System.ServiceProcess
                         return _dependentServices;
                     }
 
-                    int lastError = Marshal.GetLastWin32Error();
+                    int lastError = Marshal.GetLastPInvokeError();
                     if (lastError != Interop.Errors.ERROR_MORE_DATA)
                         throw new Win32Exception(lastError);
 
@@ -305,7 +305,7 @@ namespace System.ServiceProcess
                     return _servicesDependedOn;
                 }
 
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 if (lastError != Interop.Errors.ERROR_INSUFFICIENT_BUFFER)
                     throw new Win32Exception(lastError);
 
@@ -384,7 +384,7 @@ namespace System.ServiceProcess
                 using var serviceHandle = GetServiceHandle(Interop.Advapi32.ServiceOptions.SERVICE_QUERY_CONFIG);
                 bool success = Interop.Advapi32.QueryServiceConfig(serviceHandle, IntPtr.Zero, 0, out int bytesNeeded);
 
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 if (lastError != Interop.Errors.ERROR_INSUFFICIENT_BUFFER)
                     throw new Win32Exception(lastError);
 
@@ -575,7 +575,7 @@ namespace System.ServiceProcess
                         break;
                 }
 
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 if (lastError == Interop.Errors.ERROR_SERVICE_DOES_NOT_EXIST)
                 {
                     return null;
@@ -606,7 +606,7 @@ namespace System.ServiceProcess
                         break;
                 }
 
-                int lastError = Marshal.GetLastWin32Error();
+                int lastError = Marshal.GetLastPInvokeError();
                 if (lastError == Interop.Errors.ERROR_SERVICE_DOES_NOT_EXIST)
                 {
                     return null;

--- a/src/libraries/System.Threading.AccessControl/src/System/Threading/EventWaitHandleAcl.cs
+++ b/src/libraries/System.Threading.AccessControl/src/System/Threading/EventWaitHandleAcl.cs
@@ -58,7 +58,7 @@ namespace System.Threading
                     eventFlags,
                     (uint)EventWaitHandleRights.FullControl);
 
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
 
                 if (handle.IsInvalid)
                 {
@@ -136,7 +136,7 @@ namespace System.Threading
             result = null;
             SafeWaitHandle existingHandle = Interop.Kernel32.OpenEvent((uint)rights, false, name);
 
-            int errorCode = Marshal.GetLastWin32Error();
+            int errorCode = Marshal.GetLastPInvokeError();
             if (existingHandle.IsInvalid)
             {
                 existingHandle.Dispose();

--- a/src/libraries/System.Threading.AccessControl/src/System/Threading/MutexAcl.cs
+++ b/src/libraries/System.Threading.AccessControl/src/System/Threading/MutexAcl.cs
@@ -44,7 +44,7 @@ namespace System.Threading
                     (uint)MutexRights.FullControl // Equivalent to MUTEX_ALL_ACCESS
                 );
 
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
 
                 if (handle.IsInvalid)
                 {
@@ -127,7 +127,7 @@ namespace System.Threading
             result = null;
             SafeWaitHandle existingHandle = Interop.Kernel32.OpenMutex((uint)rights, false, name);
 
-            int errorCode = Marshal.GetLastWin32Error();
+            int errorCode = Marshal.GetLastPInvokeError();
             if (existingHandle.IsInvalid)
             {
                 existingHandle.Dispose();

--- a/src/libraries/System.Threading.AccessControl/src/System/Threading/SemaphoreAcl.cs
+++ b/src/libraries/System.Threading.AccessControl/src/System/Threading/SemaphoreAcl.cs
@@ -63,7 +63,7 @@ namespace System.Threading
                     (uint)SemaphoreRights.FullControl // Equivalent to SEMAPHORE_ALL_ACCESS
                 );
 
-                int errorCode = Marshal.GetLastWin32Error();
+                int errorCode = Marshal.GetLastPInvokeError();
 
                 if (handle.IsInvalid)
                 {
@@ -142,7 +142,7 @@ namespace System.Threading
             result = null;
             SafeWaitHandle handle = Interop.Kernel32.OpenSemaphore((uint)rights, false, name);
 
-            int errorCode = Marshal.GetLastWin32Error();
+            int errorCode = Marshal.GetLastPInvokeError();
             if (handle.IsInvalid)
             {
                 handle.Dispose();

--- a/src/libraries/System.Threading.Overlapped/tests/HandleFactory.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/HandleFactory.cs
@@ -39,7 +39,7 @@ internal static partial class HandleFactory
             return handle;
         }
 
-        int errorCode = Marshal.GetLastWin32Error();
+        int errorCode = Marshal.GetLastPInvokeError();
         string filePath = Path.GetFullPath(fileName);
         string message =
             $"CreateFile or CreateFile2 failed (error code {errorCode}): {new Win32Exception(errorCode).Message}{Environment.NewLine}" +

--- a/src/libraries/System.Windows.Extensions/src/System/Security/Cryptography/X509Certificates/X509Certificate2UI.cs
+++ b/src/libraries/System.Windows.Extensions/src/System/Security/Cryptography/X509Certificates/X509Certificate2UI.cs
@@ -78,7 +78,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 // View the certificate
                 if (!Interop.CryptUI.CryptUIDlgViewCertificateW(ViewInfo, IntPtr.Zero))
-                    dwErrorCode = Marshal.GetLastWin32Error();
+                    dwErrorCode = Marshal.GetLastPInvokeError();
 
                 // CryptUIDlgViewCertificateW returns ERROR_CANCELLED if the user closes
                 // the window through the x button or by pressing CANCEL, so ignore this error code
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             if (safeCertStoreHandle == null || safeCertStoreHandle.IsInvalid)
             {
-                Exception e = new CryptographicException(Marshal.GetLastWin32Error());
+                Exception e = new CryptographicException(Marshal.GetLastPInvokeError());
                 safeCertStoreHandle?.Dispose();
                 throw e;
             }
@@ -159,7 +159,7 @@ namespace System.Security.Cryptography.X509Certificates
                                                         Interop.Crypt32.CERT_STORE_ADD_ALWAYS,
                                                         ppStoreContext))
                 {
-                    dwErrorCode = Marshal.GetLastWin32Error();
+                    dwErrorCode = Marshal.GetLastPInvokeError();
                 }
             }
 

--- a/src/libraries/System.Windows.Extensions/src/System/Security/Cryptography/X509Certificates/X509Utils.cs
+++ b/src/libraries/System.Windows.Extensions/src/System/Security/Cryptography/X509Certificates/X509Utils.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             if (safeCertStoreHandle == null || safeCertStoreHandle.IsInvalid)
             {
-                Exception e = new CryptographicException(Marshal.GetLastWin32Error());
+                Exception e = new CryptographicException(Marshal.GetLastPInvokeError());
                 safeCertStoreHandle?.Dispose();
                 throw e;
             }
@@ -50,7 +50,7 @@ namespace System.Security.Cryptography.X509Certificates
                         Interop.Crypt32.CERT_STORE_ADD_ALWAYS,
                         SafeCertContextHandle.InvalidHandle))
                     {
-                        throw new CryptographicException(Marshal.GetLastWin32Error());
+                        throw new CryptographicException(Marshal.GetLastPInvokeError());
                     }
                 }
             }


### PR DESCRIPTION
We added `Marshal.GetLastPInvokeError()` a while back, and made `GetLastWin32Error()` an alias for it, in order to reduce the use of "Win32" in non Windows contexts.

This now uses it whereever it's available. No functional change.