### PR TITLE
[wasm][debugger] Hide members from classes that don't have debug information

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -701,6 +701,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal int Token { get; }
         internal string Namespace { get; }
         internal bool IsCompilerGenerated { get; }
+        internal bool NonUserCode { get; }
         public string FullName { get; }
         public List<MethodInfo> Methods { get; } = new();
         public Dictionary<string, DebuggerBrowsableState?> DebuggerBrowsableFields = new();
@@ -769,8 +770,15 @@ namespace Microsoft.WebAssembly.Diagnostics
                     continue;
                 var container = metadataReader.GetMemberReference((MemberReferenceHandle)ctorHandle).Parent;
                 var attributeName = assembly.EnCGetString(metadataReader.GetTypeReference((TypeReferenceHandle)container).Name);
-                if (attributeName == nameof(CompilerGeneratedAttribute))
-                    IsCompilerGenerated = true;
+                switch (attributeName)
+                {
+                    case nameof(CompilerGeneratedAttribute):
+                        IsCompilerGenerated = true;
+                        break;
+                    case nameof(DebuggerNonUserCodeAttribute):
+                        NonUserCode = true;
+                        break;
+                }
             }
 
             void AppendToBrowsable(Dictionary<string, DebuggerBrowsableState?> dict, CustomAttributeHandleCollection customAttrs, string fieldName)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -701,8 +701,9 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal int Token { get; }
         internal string Namespace { get; }
         internal bool IsCompilerGenerated { get; }
-        internal bool NonUserCode { get; }
+        private bool NonUserCode { get; }
         public string FullName { get; }
+        internal bool IsNonUserCode => assembly.pdbMetadataReader == null || NonUserCode;
         public List<MethodInfo> Methods { get; } = new();
         public Dictionary<string, DebuggerBrowsableState?> DebuggerBrowsableFields = new();
         public Dictionary<string, DebuggerBrowsableState?> DebuggerBrowsableProperties = new();

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberObjectsExplorer.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberObjectsExplorer.cs
@@ -568,14 +568,15 @@ namespace BrowserDebugProxy
             for (int i = 0; i < typeIdsCnt; i++)
             {
                 int typeId = typeIdsIncludingParents[i];
+                var typeInfo = await sdbHelper.GetTypeInfo(typeId, token);
+
+                if (typeInfo.Info.IsNonUserCode && getCommandType.HasFlag(GetObjectCommandOptions.JustMyCode))
+                    continue;
+
                 int parentTypeId = i + 1 < typeIdsCnt ? typeIdsIncludingParents[i + 1] : -1;
                 string typeName = await sdbHelper.GetTypeName(typeId, token);
                 // 0th id is for the object itself, and then its ancestors
                 bool isOwn = i == 0;
-                var typeInfo = await sdbHelper.GetTypeInfo(typeId, token);
-
-                if (typeInfo.Info.IsNonUserCode && getCommandType.HasFlag(GetObjectCommandOptions.JustMyCode))
-                    break;
 
                 IReadOnlyList<FieldTypeClass> thisTypeFields = await sdbHelper.GetTypeFields(typeId, token);
                 if (!includeStatic)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberObjectsExplorer.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberObjectsExplorer.cs
@@ -71,6 +71,10 @@ namespace BrowserDebugProxy
                 FieldAttributes.Public => "result",
                 _ => "internal"
             };
+
+            if (!isOwn && typeInfo.Info.NonUserCode && getObjectOptions.HasFlag(GetObjectCommandOptions.JustMyCode))
+                fieldValue["__section"] = "private";
+
             if (field.IsBackingField)
             {
                 fieldValue["__isBackingField"] = true;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -748,6 +748,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                 if (args["forDebuggerDisplayAttribute"]?.Value<bool>() == true)
                     getObjectOptions |= GetObjectCommandOptions.ForDebuggerDisplayAttribute;
             }
+            if (JustMyCode)
+                getObjectOptions |= GetObjectCommandOptions.JustMyCode;
             try
             {
                 switch (objectId.Scheme)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -59,7 +59,8 @@ namespace Microsoft.WebAssembly.Diagnostics
         OwnProperties = 4,
         ForDebuggerProxyAttribute = 8,
         ForDebuggerDisplayAttribute = 16,
-        WithProperties = 32
+        WithProperties = 32,
+        JustMyCode = 64
     }
 
     internal enum CommandSet {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1039,5 +1039,27 @@ namespace DebuggerTests
                 }
             );
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task InspectThisThatInheritsFromClassNonUserCode(bool jmc)
+        {
+            await SetJustMyCode(jmc);
+            var expression = $"{{ invoke_static_method('[debugger-test] ClassInheritsFromClassWithoutDebugSymbols:Run'); }}";
+
+            await EvaluateAndCheck(
+                "window.setTimeout(function() {" + expression + "; }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 1287, 8,
+                $"ClassInheritsFromClassWithoutDebugSymbols.CallMethod",
+                locals_fn: async (locals) =>
+                {
+                    var this_props = await GetObjectOnLocals(locals, "this");
+                    await CheckProps(this_props, new
+                    {
+                    }, "this_props", num_fields: jmc ? 1 : 7);
+                }
+            );
+        }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1045,6 +1045,8 @@ namespace DebuggerTests
         [InlineData("ClassInheritsFromClassWithoutDebugSymbols", 1287, false)]
         [InlineData("ClassInheritsFromNonUserCodeClass", 1335, true)]
         [InlineData("ClassInheritsFromNonUserCodeClass", 1335, false)]
+        [InlineData("ClassInheritsFromNonUserCodeClassThatInheritsFromNormalClass", 1352, true)]
+        [InlineData("ClassInheritsFromNonUserCodeClassThatInheritsFromNormalClass", 1352, false)]
         public async Task InspectThisThatInheritsFromClassNonUserCode(string class_name, int line, bool jmc)
         {
             await SetJustMyCode(jmc);
@@ -1062,11 +1064,11 @@ namespace DebuggerTests
                         await CheckProps(this_props, new
                         {
                             myField = TNumber(0),
-                        }, "this_props", num_fields: 1);
+                            myField2 = TNumber(0),
+                        }, "this_props", num_fields: 2);
                     }
                     else
                     {
-                        Console.WriteLine(this_props);
                         await CheckProps(this_props, new
                         {
                             propA = TNumber(10),
@@ -1078,7 +1080,8 @@ namespace DebuggerTests
                             G = TGetter("G"),
                             H = TGetter("H"),
                             myField = TNumber(0),
-                        }, "this_props", num_fields: 9);
+                            myField2 = TNumber(0),
+                        }, "this_props", num_fields: 10);
                     }
                 }
             );

--- a/src/mono/wasm/debugger/tests/debugger-test-with-non-user-code-class/debugger-test-with-non-user-code-class.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-non-user-code-class/debugger-test-with-non-user-code-class.csproj
@@ -1,0 +1,4 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+  </PropertyGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-with-non-user-code-class/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-non-user-code-class/test.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace DebuggerTests
+{
+    public class NormalClass
+    {
+        public int myField2;
+    }
+    
+    [System.Diagnostics.DebuggerNonUserCode]
+    public class ClassNonUserCodeToInheritThatInheritsFromNormalClass : NormalClass
+    {
+        private int propA {get;}
+        public int propB {get;}
+        protected int propC {get;}
+        private int d;
+        public int e;
+        protected int f;
+        public int G
+        {
+            get {return f + 1;}
+        }
+        public int H => f;
+
+        public ClassNonUserCodeToInheritThatInheritsFromNormalClass()
+        {
+            propA = 10;
+            propB = 20;
+            propC = 30;
+            d = 40;
+            e = 50;
+            f = 60;
+            Console.WriteLine(propA);
+            Console.WriteLine(propB);
+            Console.WriteLine(propC);
+            Console.WriteLine(d);
+            Console.WriteLine(e);
+            Console.WriteLine(f);
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/debugger-test-without-debug-symbols-to-load.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/debugger-test-without-debug-symbols-to-load.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>  
+  </PropertyGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/test.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace DebuggerTests
+{
+    public class ClassWithoutDebugSymbolsToInherit
+    {
+        private int propA {get;}
+        public int propB {get;}
+        protected int propC {get;}
+        private int d;
+        public int e;
+        protected int f;
+        public ClassWithoutDebugSymbolsToInherit()
+        {
+            propA = 10;
+            propB = 20;
+            propC = 30;
+            d = 40;
+            e = 50;
+            f = 60;
+            Console.WriteLine(propA);
+            Console.WriteLine(propB);
+            Console.WriteLine(propC);
+            Console.WriteLine(d);
+            Console.WriteLine(e);
+            Console.WriteLine(f);
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/test.cs
@@ -10,6 +10,12 @@ namespace DebuggerTests
         private int d;
         public int e;
         protected int f;
+        public int G 
+        { 
+            get {return f + 1;} 
+        }
+        public int H => f;
+
         public ClassWithoutDebugSymbolsToInherit()
         {
             propA = 10;

--- a/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/test.cs
@@ -10,9 +10,9 @@ namespace DebuggerTests
         private int d;
         public int e;
         protected int f;
-        public int G 
-        { 
-            get {return f + 1;} 
+        public int G
+        {
+            get {return f + 1;}
         }
         public int H => f;
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1287,7 +1287,7 @@ public class ClassInheritsFromClassWithoutDebugSymbols : DebuggerTests.ClassWith
     {
         System.Diagnostics.Debugger.Break();
     }
-
+    public int myField2;
     public int myField;
 }
 
@@ -1328,6 +1328,23 @@ public class ClassInheritsFromNonUserCodeClass : ClassNonUserCodeToInherit
     public static void Run()
     {
         var myVar = new ClassInheritsFromNonUserCodeClass();
+        myVar.CallMethod();
+    }
+
+    public void CallMethod()
+    {
+        System.Diagnostics.Debugger.Break();
+    }
+
+    public int myField2;
+    public int myField;
+}
+
+public class ClassInheritsFromNonUserCodeClassThatInheritsFromNormalClass : DebuggerTests.ClassNonUserCodeToInheritThatInheritsFromNormalClass
+{
+    public static void Run()
+    {
+        var myVar = new ClassInheritsFromNonUserCodeClassThatInheritsFromNormalClass();
         myVar.CallMethod();
     }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1300,9 +1300,9 @@ public class ClassNonUserCodeToInherit
     private int d;
     public int e;
     protected int f;
-    public int G 
-    { 
-        get {return f + 1;} 
+    public int G
+    {
+        get {return f + 1;}
     }
     public int H => f;
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1275,3 +1275,18 @@ public partial class HiddenSequencePointTest {
 #line default
 }
 
+public class ClassInheritsFromClassWithoutDebugSymbols : DebuggerTests.ClassWithoutDebugSymbolsToInherit
+{
+    public static void Run()
+    {
+        var myVar = new ClassInheritsFromClassWithoutDebugSymbols();
+        myVar.CallMethod();
+    }
+
+    public void CallMethod()
+    {
+        System.Diagnostics.Debugger.Break();
+    }
+
+    public int myField;
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1290,3 +1290,51 @@ public class ClassInheritsFromClassWithoutDebugSymbols : DebuggerTests.ClassWith
 
     public int myField;
 }
+
+[System.Diagnostics.DebuggerNonUserCode]
+public class ClassNonUserCodeToInherit
+{
+    private int propA {get;}
+    public int propB {get;}
+    protected int propC {get;}
+    private int d;
+    public int e;
+    protected int f;
+    public int G 
+    { 
+        get {return f + 1;} 
+    }
+    public int H => f;
+
+    public ClassNonUserCodeToInherit()
+    {
+        propA = 10;
+        propB = 20;
+        propC = 30;
+        d = 40;
+        e = 50;
+        f = 60;
+        Console.WriteLine(propA);
+        Console.WriteLine(propB);
+        Console.WriteLine(propC);
+        Console.WriteLine(d);
+        Console.WriteLine(e);
+        Console.WriteLine(f);
+    }
+}
+
+public class ClassInheritsFromNonUserCodeClass : ClassNonUserCodeToInherit
+{
+    public static void Run()
+    {
+        var myVar = new ClassInheritsFromNonUserCodeClass();
+        myVar.CallMethod();
+    }
+
+    public void CallMethod()
+    {
+        System.Diagnostics.Debugger.Break();
+    }
+
+    public int myField;
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" ReferenceOutputAssembly="false" Private="true" />
+    <ProjectReference Include="..\debugger-test-without-debug-symbols-to-load\debugger-test-without-debug-symbols-to-load.csproj" Private="true" />
     <!-- loaded by *tests*, and not the test app -->
     <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" ReferenceOutputAssembly="false" Private="true" />
 
@@ -44,7 +45,6 @@
       <WasmMainJSPath>debugger-main.js</WasmMainJSPath>
       <!-- -1 enabled debugging and disables debug logging. -->
       <WasmDebugLevel Condition="'$(WasmDebugLevel)'==''">-1</WasmDebugLevel>
-
       <WasmResolveAssembliesBeforeBuild>true</WasmResolveAssembliesBeforeBuild>
     </PropertyGroup>
 
@@ -52,6 +52,7 @@
       <WasmAssembliesToBundle Include="$(OutDir)\$(TargetFileName)" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-special-char-in-path.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-without-debug-symbols-to-load.dll" />
       <WasmAssembliesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidDir)\lib\$(NetCoreappCurrent)\System.Runtime.InteropServices.JavaScript.dll" />
 
       <!-- Assemblies only dynamically loaded -->
@@ -63,6 +64,7 @@
 
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)native"/>
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
+      <WasmAssemblySearchPaths Include="$(OutDir)"/>
     </ItemGroup>
   </Target>
   <Target Name="PreserveEnCAssembliesFromLinking"

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" ReferenceOutputAssembly="false" Private="true" />
     <ProjectReference Include="..\debugger-test-without-debug-symbols-to-load\debugger-test-without-debug-symbols-to-load.csproj" Private="true" />
+    <ProjectReference Include="..\debugger-test-with-non-user-code-class\debugger-test-with-non-user-code-class.csproj" Private="true" />
     <!-- loaded by *tests*, and not the test app -->
     <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" ReferenceOutputAssembly="false" Private="true" />
 
@@ -53,6 +54,7 @@
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-special-char-in-path.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-without-debug-symbols-to-load.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-non-user-code-class.dll" />
       <WasmAssembliesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidDir)\lib\$(NetCoreappCurrent)\System.Runtime.InteropServices.JavaScript.dll" />
 
       <!-- Assemblies only dynamically loaded -->


### PR DESCRIPTION
Do not show members from classes that don't have debug information if JMC is enabled.

Fixes #43184