### PR TITLE
Make FileInfo/DirectoryInfo.Name lazy

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
@@ -34,13 +34,28 @@ namespace System.IO
             fullPath ??= originalPath;
             fullPath = isNormalized ? fullPath : Path.GetFullPath(fullPath);
 
-            _name = fileName ?? (PathInternal.IsRoot(fullPath.AsSpan()) ?
-                    fullPath.AsSpan() :
-                    Path.GetFileName(Path.TrimEndingDirectorySeparator(fullPath.AsSpan()))).ToString();
+            _name = fileName;
 
             FullPath = fullPath;
 
             _isNormalized = isNormalized;
+        }
+
+        public override string Name
+        {
+            get
+            {
+                string? name = _name;
+                if (name is null)
+                {
+                    ReadOnlySpan<char> fullPath = FullPath.AsSpan();
+                    _name = name = (PathInternal.IsRoot(fullPath) ?
+                        fullPath :
+                        Path.GetFileName(Path.TrimEndingDirectorySeparator(fullPath))).ToString();
+                }
+
+                return name;
+            }
         }
 
         public DirectoryInfo? Parent

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -29,8 +29,10 @@ namespace System.IO
             Debug.Assert(!isNormalized || !PathInternal.IsPartiallyQualified(fullPath.AsSpan()), "should be fully qualified if normalized");
 
             FullPath = isNormalized ? fullPath ?? originalPath : Path.GetFullPath(fullPath);
-            _name = fileName ?? Path.GetFileName(originalPath);
+            _name = fileName;
         }
+
+        public override string Name => _name ??= Path.GetFileName(OriginalPath);
 
         public long Length
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystemInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystemInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Versioning;
@@ -14,7 +15,7 @@ namespace System.IO
         protected string FullPath = null!;          // fully qualified path of the file or directory
         protected string OriginalPath = null!;      // path passed in by the user
 
-        internal string _name = null!; // Fields initiated in derived classes
+        internal string? _name;
 
         private string? _linkTarget;
         private bool _linkTargetIsValid;
@@ -55,7 +56,14 @@ namespace System.IO
             }
         }
 
-        public virtual string Name => _name;
+        public virtual string Name
+        {
+            get
+            {
+                Debug.Fail("Property is abstract in the ref assembly and both Directory/FileInfo override it.");
+                return _name!;
+            }
+        }
 
         // Whether a file/directory exists
         public virtual bool Exists


### PR DESCRIPTION
We can delay the string allocation until it's actually requested.

Separated out of the already-approved https://github.com/dotnet/runtime/pull/73942.