### PR TITLE
Bump main branding to 8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,7 +47,7 @@
 
   <!-- The TFMs to build and test against. -->
   <PropertyGroup>
-    <NetCoreAppCurrentVersion>7.0</NetCoreAppCurrentVersion>
+    <NetCoreAppCurrentVersion>$(PreviousReleaseMajorVersion).$(MinorVersion)</NetCoreAppCurrentVersion>
     <NetCoreAppCurrentIdentifier>.NETCoreApp</NetCoreAppCurrentIdentifier>
     <NetCoreAppCurrentTargetFrameworkMoniker>$(NetCoreAppCurrentIdentifier),Version=v$(NetCoreAppCurrentVersion)</NetCoreAppCurrentTargetFrameworkMoniker>
     <MicrosoftNetCoreAppFrameworkName>Microsoft.NETCore.App</MicrosoftNetCoreAppFrameworkName>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,7 +47,7 @@
 
   <!-- The TFMs to build and test against. -->
   <PropertyGroup>
-    <NetCoreAppCurrentVersion>$(PreviousReleaseMajorVersion).$(MinorVersion)</NetCoreAppCurrentVersion>
+    <NetCoreAppCurrentVersion>7.0</NetCoreAppCurrentVersion>
     <NetCoreAppCurrentIdentifier>.NETCoreApp</NetCoreAppCurrentIdentifier>
     <NetCoreAppCurrentTargetFrameworkMoniker>$(NetCoreAppCurrentIdentifier),Version=v$(NetCoreAppCurrentVersion)</NetCoreAppCurrentTargetFrameworkMoniker>
     <MicrosoftNetCoreAppFrameworkName>Microsoft.NETCore.App</MicrosoftNetCoreAppFrameworkName>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,17 +1,18 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>7.0.0</ProductVersion>
+    <ProductVersion>8.0.0</ProductVersion>
     <!-- File version numbers -->
-    <MajorVersion>7</MajorVersion>
+    <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>7.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreviousReleaseMajorVersion>7</PreviousReleaseMajorVersion>
     <!-- Set assembly version to align with major and minor version,
          as for the patches and revisions should be manually updated per assembly if it is serviced. -->
-    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <AssemblyVersion>$(PreviousReleaseMajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,10 +9,9 @@
     <SdkBandVersion>7.0.100</SdkBandVersion>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <PreviousReleaseMajorVersion>7</PreviousReleaseMajorVersion>
     <!-- Set assembly version to align with major and minor version,
          as for the patches and revisions should be manually updated per assembly if it is serviced. -->
-    <AssemblyVersion>$(PreviousReleaseMajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <AssemblyVersion>7.$(MinorVersion).0.0</AssemblyVersion>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/src/libraries/Microsoft.VisualBasic.Core/Directory.Build.props
+++ b/src/libraries/Microsoft.VisualBasic.Core/Directory.Build.props
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <!-- We need to set MajorVersion so that FileVersion is set correctly and is
     greater than the one in the previous release -->
-    <MajorVersion>$([MSBuild]::Add($(MajorVersion), 5))</MajorVersion>
-    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <MajorVersion>$([MSBuild]::Add($(PreviousReleaseMajorVersion), 5))</MajorVersion>
+    <AssemblyVersion>$(PreviousReleaseMajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>

--- a/src/libraries/Microsoft.VisualBasic.Core/Directory.Build.props
+++ b/src/libraries/Microsoft.VisualBasic.Core/Directory.Build.props
@@ -3,8 +3,9 @@
   <PropertyGroup>
     <!-- We need to set MajorVersion so that FileVersion is set correctly and is
     greater than the one in the previous release -->
-    <MajorVersion>$([MSBuild]::Add($(PreviousReleaseMajorVersion), 5))</MajorVersion>
-    <AssemblyVersion>$(PreviousReleaseMajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <MajorVersion>$([MSBuild]::Add($(MajorVersion), 5))</MajorVersion>
+    <!-- TODO: Change back to $(MajorVersion) when assembly versions are updated. -->
+    <AssemblyVersion>12.$(MinorVersion).0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>


### PR DESCRIPTION
Do not merge. This depends on snapping first.

This PR is loosely based on what we did last year: https://github.com/dotnet/runtime/pull/57095/files

I suspect this change is incomplete, since many of the elements modified in last year's PR do not exist today.
