### PR TITLE
Backport crossgen2 fix for musl-libc

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -144,7 +144,8 @@
     <_runtimeOS Condition="$(_runtimeOS.StartsWith('tizen'))">linux</_runtimeOS>
     <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
 
-    <_packageOS Condition="'$(CrossBuild)' == 'true'">$(_hostOS.ToLowerInvariant)</_packageOS>
+    <_packageLibc Condition="$(_runtimeOS.Contains('musl'))">-musl</_packageLibc>
+    <_packageOS Condition="'$(CrossBuild)' == 'true'">$(_hostOS.ToLowerInvariant)$(_packageLibc)</_packageOS>
     <_packageOS Condition="'$(_packageOS)' == '' and '$(PortableBuild)' == 'true'">$(_portableOS)</_packageOS>
     <_packageOS Condition="'$(_packageOS)' == ''">$(_runtimeOS)</_packageOS>
   </PropertyGroup>


### PR DESCRIPTION
#### Customer Impact

On the operating systems using musl-libc, some of the compiled binaries such as crossgen2 were incorrectly linked with glibc and that forces the consumer to install glibc on those systems (which is unintended as rest of the runtime artifacts are linked to musl-libc). The issue is that we are not taking libc flavor into account when calculating the OS value in 6.0.

#### Testing

This fix is tested on 7.0. This fix was made during the addition of another libc flavor (bionic-libc), in order to diversify the OS calculation. I have done some sanity testing locally, but not the entire platform matrix which uses cross-building. I will wait for the CI results.

 #### Risk

Low. When CI legs are green, that will indicate that the platforms for which we cross-compile and run tests in Helix are largely unaffected. However, we need to make sure that crossgen2 binary is in working condition on those platforms since we are lacking tests for cross-compiled, crossgen2 binary.

Fixes #73908