### PR TITLE
Publish ILC as a trimmed+R2R+singlefile executable

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -24,7 +24,7 @@
   <PropertyGroup>
     <CoreCLRSharedFrameworkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'sharedFramework'))</CoreCLRSharedFrameworkDir>
     <CoreCLRCrossgen2Dir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'crossgen2'))</CoreCLRCrossgen2Dir>
-    <CoreCLRILCompilerDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'ilc'))</CoreCLRILCompilerDir>
+    <CoreCLRILCompilerDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'ilc-published'))</CoreCLRILCompilerDir>
     <CoreCLRCrossILCompilerDir Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)'">$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', '$(BuildArchitecture)', 'ilc'))</CoreCLRCrossILCompilerDir>
     <CoreCLRAotSdkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'aotsdk'))</CoreCLRAotSdkDir>
     <CoreCLRBuildIntegrationDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'build'))</CoreCLRBuildIntegrationDir>

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>ILCompiler.Build.Tasks</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>$(RuntimeBinDir)/ilc/netstandard</OutputPath>
+    <OutputPath>$(RuntimeBinDir)/ilc-published/netstandard</OutputPath>
     <Configurations>Debug;Release;Checked</Configurations>
     <PlatformTarget>AnyCPU</PlatformTarget>
 

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -5,4 +5,28 @@
   </PropertyGroup>
 
   <Import Project="ILCompiler.props" />
+
+
+  <!-- BEGIN: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
+  <PropertyGroup>
+    <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+  </PropertyGroup>
+
+  <Target Name="PublishCompiler"
+          Condition="'$(BuildingInsideVisualStudio)' != 'true'"
+          AfterTargets="Build"
+          DependsOnTargets="Publish;StompSingleFileHostPath" />
+
+  <!--  HACK: liveBuilds stomps over SingleFileHostSourcePath, setting it to the host that we just built.
+        That's unfortunate because it's not the host we're supposed to use here. -->
+  <Target Name="StompSingleFileHostPath"
+          BeforeTargets="ResolveFrameworkReferences">
+    <PropertyGroup>
+      <SingleFileHostSourcePath></SingleFileHostSourcePath>
+    </PropertyGroup>
+  </Target>
+  <!-- END: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
 </Project>


### PR DESCRIPTION
This is the same configuration that we ship crossgen2 with on platforms that don't have NativeAOT. It produces a lot smaller packages with faster startup time. Setting this as `CoreCLRILCompilerDir` ensures that this is the ILCompiler that we test, build crossgen2 with, and package.

I don't have high confidence that we can get #67742 in time for .NET 7 but since we still have some runway before .NET 7 snaps, proposing checking this in as a plan B.

This change would be temporary until #67742 is fixed.

Cc @dotnet/ilc-contrib 