### PR TITLE
Make PublishAot incremental

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -50,21 +50,21 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
-      <NativeLibrary Include="advapi32.lib" />
-      <NativeLibrary Include="bcrypt.lib" />
-      <NativeLibrary Include="crypt32.lib" />
-      <NativeLibrary Include="iphlpapi.lib" />
-      <NativeLibrary Include="kernel32.lib" />
-      <NativeLibrary Include="mswsock.lib" />
-      <NativeLibrary Include="ncrypt.lib" />
-      <NativeLibrary Include="normaliz.lib" />
-      <NativeLibrary Include="ntdll.lib" />
-      <NativeLibrary Include="ole32.lib" />
-      <NativeLibrary Include="oleaut32.lib" />
-      <NativeLibrary Include="secur32.lib" />
-      <NativeLibrary Include="user32.lib" />
-      <NativeLibrary Include="version.lib" />
-      <NativeLibrary Include="ws2_32.lib" />
+      <SdkNativeLibrary Include="advapi32.lib" />
+      <SdkNativeLibrary Include="bcrypt.lib" />
+      <SdkNativeLibrary Include="crypt32.lib" />
+      <SdkNativeLibrary Include="iphlpapi.lib" />
+      <SdkNativeLibrary Include="kernel32.lib" />
+      <SdkNativeLibrary Include="mswsock.lib" />
+      <SdkNativeLibrary Include="ncrypt.lib" />
+      <SdkNativeLibrary Include="normaliz.lib" />
+      <SdkNativeLibrary Include="ntdll.lib" />
+      <SdkNativeLibrary Include="ole32.lib" />
+      <SdkNativeLibrary Include="oleaut32.lib" />
+      <SdkNativeLibrary Include="secur32.lib" />
+      <SdkNativeLibrary Include="user32.lib" />
+      <SdkNativeLibrary Include="version.lib" />
+      <SdkNativeLibrary Include="ws2_32.lib" />
     </ItemGroup>
 
     <ItemGroup>
@@ -74,6 +74,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup>
       <LinkerArg Condition="$(NativeLib) == 'Shared'" Include="/DLL" />
       <LinkerArg Include="@(NativeLibrary->'&quot;%(Identity)&quot;')" />
+      <LinkerArg Include="@(SdkNativeLibrary->'&quot;%(Identity)&quot;')" />
       <LinkerArg Include="/NOLOGO /MANIFEST:NO" />
       <LinkerArg Condition="$(NativeDebugSymbols) == 'true'" Include="/DEBUG" />
       <!-- The runtime is not compatible with jump stubs inserted by incremental linking. -->


### PR DESCRIPTION
`NativeLibrary` is an input to `LinkNative` target. Since these are not fully qualified paths (we rely on link.exe doing a thing to find them) the target always re-runs. It should not.

The ideal fix would be to make this paths fully qualified, but I don't see an easy way to do that. SDK libraries don't really change in meaningful ways.

Cc @dotnet/ilc-contrib 