### PR TITLE
Improve failure mode when PublishSingleFile and PublishAot are specified together

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -50,6 +50,8 @@
 
     <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
 
+    <Error Condition="'$(PublishAot)' == 'true' and '$(PublishSingleFile)' == 'true'" Text="PublishAot and PublishSingleFile cannot be specified at the same time." />
+
     <!-- Fail with descriptive error message for common unsupported cases. -->
     <Error Condition="'$(DisableUnsupportedError)' != 'true' and '$(OS)' == 'Windows_NT' and !$(RuntimeIdentifier.StartsWith('win'))"
       Text="Cross-OS native compilation is not supported." />


### PR DESCRIPTION
Better than

```
C:\dotnet7\sdk\7.0.100-rc.1.22375.3\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(898,5): error MSB4018:
 The "GenerateBundle" task failed unexpectedly. [C:\dotnet7\incremental\incremental.csproj]
C:\dotnet7\sdk\7.0.100-rc.1.22375.3\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Publish.targets(898,5): error MSB4018:
 System.ArgumentException: Invalid input specification: Must specify the host binary [C:\dotnet7\incremental\incrementa
l.csproj]
```

Fixes #72559.

Cc @dotnet/ilc-contrib 