### PR TITLE
Directory.CreateDirectory: create missing parents using default UnixFileMode.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -287,12 +287,12 @@ namespace System.Formats.Tar
 
             if (EntryType == TarEntryType.Directory)
             {
-                TarHelpers.CreateDirectory(fileDestinationPath, Mode, overwrite, pendingModes);
+                TarHelpers.CreateDirectory(fileDestinationPath, Mode, pendingModes);
             }
             else
             {
                 // If it is a file, create containing directory.
-                TarHelpers.CreateDirectory(Path.GetDirectoryName(fileDestinationPath)!, mode: null, overwrite, pendingModes);
+                TarHelpers.CreateDirectory(Path.GetDirectoryName(fileDestinationPath)!, mode: null, pendingModes);
                 ExtractToFileInternal(fileDestinationPath, linkTargetPath, overwrite);
             }
         }
@@ -309,13 +309,13 @@ namespace System.Formats.Tar
 
             if (EntryType == TarEntryType.Directory)
             {
-                TarHelpers.CreateDirectory(fileDestinationPath, Mode, overwrite, pendingModes);
+                TarHelpers.CreateDirectory(fileDestinationPath, Mode, pendingModes);
                 return Task.CompletedTask;
             }
             else
             {
                 // If it is a file, create containing directory.
-                TarHelpers.CreateDirectory(Path.GetDirectoryName(fileDestinationPath)!, mode: null, overwrite, pendingModes);
+                TarHelpers.CreateDirectory(Path.GetDirectoryName(fileDestinationPath)!, mode: null, pendingModes);
                 return ExtractToFileInternalAsync(fileDestinationPath, linkTargetPath, overwrite, cancellationToken);
             }
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.Unix.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.Unix.cs
@@ -52,7 +52,7 @@ namespace System.Formats.Tar
         internal static SortedDictionary<string, UnixFileMode>? CreatePendingModesDictionary()
             => new SortedDictionary<string, UnixFileMode>(s_reverseStringComparer);
 
-        internal static void CreateDirectory(string fullPath, UnixFileMode? mode, bool overwriteMetadata, SortedDictionary<string, UnixFileMode>? pendingModes)
+        internal static void CreateDirectory(string fullPath, UnixFileMode? mode, SortedDictionary<string, UnixFileMode>? pendingModes)
         {
             // Minimal permissions required for extracting.
             const UnixFileMode ExtractPermissions = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
@@ -61,8 +61,8 @@ namespace System.Formats.Tar
 
             if (Directory.Exists(fullPath))
             {
-                // Apply permissions to an existing directory when we're overwriting metadata.
-                if (mode.HasValue && overwriteMetadata)
+                // Apply permissions to an existing directory.
+                if (mode.HasValue)
                 {
                     // Ensure we have sufficient permissions to extract in the directory.
                     bool hasExtractPermissions = (mode.Value & ExtractPermissions) == ExtractPermissions;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.Unix.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.Unix.cs
@@ -81,7 +81,7 @@ namespace System.Formats.Tar
                 return;
             }
 
-            // Missing parents are created using default permissions.
+            // If there are missing parents, Directory.CreateDirectory will create them using default permissions.
             if (mode.HasValue)
             {
                 // Ensure we have sufficient permissions to extract in the directory.
@@ -95,7 +95,6 @@ namespace System.Formats.Tar
             }
             else
             {
-                // Create directory using default permissions.
                 Directory.CreateDirectory(fullPath);
             }
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.Windows.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.Windows.cs
@@ -13,7 +13,7 @@ namespace System.Formats.Tar
         internal static SortedDictionary<string, UnixFileMode>? CreatePendingModesDictionary()
             => null;
 
-        internal static void CreateDirectory(string fullPath, UnixFileMode? mode, bool overwriteMetadata, SortedDictionary<string, UnixFileMode>? pendingModes)
+        internal static void CreateDirectory(string fullPath, UnixFileMode? mode, SortedDictionary<string, UnixFileMode>? pendingModes)
             => Directory.CreateDirectory(fullPath);
 
         internal static void SetPendingModes(SortedDictionary<string, UnixFileMode>? pendingModes)

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -225,7 +225,7 @@ namespace System.Formats.Tar.Tests
 
             // Directory modes that are out-of-order are still applied.
             Assert.True(Directory.Exists(outOfOrderDirPath), $"{outOfOrderDirPath}' does not exist.");
-            AssertFileModeEquals(outOfOrderDirPath, overwrite ? TestPermission4 : CreateDirectoryDefaultMode);
+            AssertFileModeEquals(outOfOrderDirPath, TestPermission4);
         }
 
         [Theory]

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -216,20 +216,16 @@ namespace System.Formats.Tar.Tests
             Assert.True(File.Exists(filePath), $"{filePath}' does not exist.");
             AssertFileModeEquals(filePath, TestPermission2);
 
-            // Missing parents are created with DefaultDirectoryMode.
-            // The mode is not set when overwrite == true if there is no entry and the directory exists before extracting.
+            // Missing parents are created with CreateDirectoryDefaultMode.
             Assert.True(Directory.Exists(missingParentPath), $"{missingParentPath}' does not exist.");
-            if (!overwrite)
-            {
-                AssertFileModeEquals(missingParentPath, DefaultDirectoryMode);
-            }
+            AssertFileModeEquals(missingParentPath, CreateDirectoryDefaultMode);
 
             Assert.True(Directory.Exists(missingParentDirPath), $"{missingParentDirPath}' does not exist.");
             AssertFileModeEquals(missingParentDirPath, TestPermission3);
 
             // Directory modes that are out-of-order are still applied.
             Assert.True(Directory.Exists(outOfOrderDirPath), $"{outOfOrderDirPath}' does not exist.");
-            AssertFileModeEquals(outOfOrderDirPath, TestPermission4);
+            AssertFileModeEquals(outOfOrderDirPath, overwrite ? TestPermission4 : CreateDirectoryDefaultMode);
         }
 
         [Theory]

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -241,7 +241,7 @@ namespace System.Formats.Tar.Tests
 
             await TarFile.ExtractToDirectoryAsync(archivePath, destination.Path, overwriteFiles: overwrite);
 
-           Assert.True(Directory.Exists(dirPath), $"{dirPath}' does not exist.");
+            Assert.True(Directory.Exists(dirPath), $"{dirPath}' does not exist.");
             AssertFileModeEquals(dirPath, TestPermission1);
 
             Assert.True(File.Exists(filePath), $"{filePath}' does not exist.");

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -191,8 +191,10 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        [Fact]
-        public async Task UnixFileModes_Async()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task UnixFileModes_Async(bool overwrite)
         {
             using TempDirectory source = new TempDirectory();
             using TempDirectory destination = new TempDirectory();
@@ -223,29 +225,38 @@ namespace System.Formats.Tar.Tests
                 writer.WriteEntry(outOfOrderDir);
             }
 
-            await TarFile.ExtractToDirectoryAsync(archivePath, destination.Path, overwriteFiles: false);
-
             string dirPath = Path.Join(destination.Path, "dir");
-            Assert.True(Directory.Exists(dirPath), $"{dirPath}' does not exist.");
+            string filePath = Path.Join(destination.Path, "file");
+            string missingParentPath = Path.Join(destination.Path, "missing_parent");
+            string missingParentDirPath = Path.Join(missingParentPath, "dir");
+            string outOfOrderDirPath = Path.Join(destination.Path, "out_of_order_parent");
+
+            if (overwrite)
+            {
+                File.OpenWrite(filePath).Dispose();
+                Directory.CreateDirectory(dirPath);
+                Directory.CreateDirectory(missingParentDirPath);
+                Directory.CreateDirectory(outOfOrderDirPath);
+            }
+
+            await TarFile.ExtractToDirectoryAsync(archivePath, destination.Path, overwriteFiles: overwrite);
+
+           Assert.True(Directory.Exists(dirPath), $"{dirPath}' does not exist.");
             AssertFileModeEquals(dirPath, TestPermission1);
 
-            string filePath = Path.Join(destination.Path, "file");
             Assert.True(File.Exists(filePath), $"{filePath}' does not exist.");
             AssertFileModeEquals(filePath, TestPermission2);
 
-            // Missing parents are created with DefaultDirectoryMode.
-            string missingParentPath = Path.Join(destination.Path, "missing_parent");
+            // Missing parents are created with CreateDirectoryDefaultMode.
             Assert.True(Directory.Exists(missingParentPath), $"{missingParentPath}' does not exist.");
-            AssertFileModeEquals(missingParentPath, DefaultDirectoryMode);
+            AssertFileModeEquals(missingParentPath, CreateDirectoryDefaultMode);
 
-            string missingParentDirPath = Path.Join(missingParentPath, "dir");
             Assert.True(Directory.Exists(missingParentDirPath), $"{missingParentDirPath}' does not exist.");
             AssertFileModeEquals(missingParentDirPath, TestPermission3);
 
             // Directory modes that are out-of-order are still applied.
-            string outOfOrderDirPath = Path.Join(destination.Path, "out_of_order_parent");
             Assert.True(Directory.Exists(outOfOrderDirPath), $"{outOfOrderDirPath}' does not exist.");
-            AssertFileModeEquals(outOfOrderDirPath, TestPermission4);
+            AssertFileModeEquals(outOfOrderDirPath, overwrite ? TestPermission4 : CreateDirectoryDefaultMode);
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -256,7 +256,7 @@ namespace System.Formats.Tar.Tests
 
             // Directory modes that are out-of-order are still applied.
             Assert.True(Directory.Exists(outOfOrderDirPath), $"{outOfOrderDirPath}' does not exist.");
-            AssertFileModeEquals(outOfOrderDirPath, overwrite ? TestPermission4 : CreateDirectoryDefaultMode);
+            AssertFileModeEquals(outOfOrderDirPath, TestPermission4);
         }
 
         [Fact]

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -17,6 +17,8 @@ namespace System.Formats.Tar.Tests
         protected const UnixFileMode DefaultFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead; // 644 in octal, internally used as default
         protected const UnixFileMode DefaultDirectoryMode = DefaultFileMode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute; // 755 in octal, internally used as default
 
+        protected readonly UnixFileMode CreateDirectoryDefaultMode; // Mode of directories created using Directory.CreateDirectory(string).
+
         // Mode assumed for files and directories on Windows.
         protected const UnixFileMode DefaultWindowsMode = DefaultFileMode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute; // 755 in octal, internally used as default
 
@@ -114,6 +116,11 @@ namespace System.Formats.Tar.Tests
         protected static bool IsUnixButNotSuperUser => !PlatformDetection.IsWindows && !PlatformDetection.IsSuperUser;
 
         protected static bool IsNotLinuxBionic => !PlatformDetection.IsLinuxBionic;
+
+        protected TarTestsBase()
+        {
+            CreateDirectoryDefaultMode = PlatformDetection.IsWindows ? UnixFileMode.None : Directory.CreateDirectory(GetRandomDirPath()).UnixFileMode;
+        }
 
         protected static string GetTestCaseUnarchivedFolderPath(string testCaseName) =>
             Path.Join(Directory.GetCurrentDirectory(), "unarchived", testCaseName);

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -119,7 +119,7 @@ namespace System.Formats.Tar.Tests
 
         protected TarTestsBase()
         {
-            CreateDirectoryDefaultMode = PlatformDetection.IsWindows ? UnixFileMode.None : Directory.CreateDirectory(GetRandomDirPath()).UnixFileMode;
+            CreateDirectoryDefaultMode = Directory.CreateDirectory(GetRandomDirPath()).UnixFileMode; // '0777 & ~umask'
         }
 
         protected static string GetTestCaseUnarchivedFolderPath(string testCaseName) =>
@@ -416,7 +416,8 @@ namespace System.Formats.Tar.Tests
 
         protected static void AssertFileModeEquals(string path, UnixFileMode mode)
         {
-            if (!PlatformDetection.IsWindows)
+            if (!PlatformDetection.IsWindows &&
+                !PlatformDetection.IsAndroid) // Android may change the requested permissions.
             {
                 Assert.Equal(mode, File.GetUnixFileMode(path));
             }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory_UnixFileMode.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory_UnixFileMode.Unix.cs
@@ -39,6 +39,21 @@ namespace System.IO.Tests
             Assert.Equal(initialMode, sameDir.UnixFileMode);
         }
 
+        [Fact]
+        public void MissingParentsHaveDefaultPermissions()
+        {
+            string parent = GetRandomDirPath();
+            string child = Path.Combine(parent, "child");
+
+            const UnixFileMode childMode = UnixFileMode.UserRead | UnixFileMode.UserExecute;
+            DirectoryInfo childDir = Directory.CreateDirectory(child, childMode);
+
+            Assert.Equal(childMode, childDir.UnixFileMode);
+
+            UnixFileMode defaultPermissions = Directory.CreateDirectory(GetRandomDirPath()).UnixFileMode;
+            Assert.Equal(defaultPermissions, File.GetUnixFileMode(parent));
+        }
+
         [Theory]
         [InlineData((UnixFileMode)(1 << 12), false)]
         [InlineData((UnixFileMode)(1 << 12), true)]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -328,7 +328,7 @@ namespace System.IO
                 }
 
                 ReadOnlySpan<char> mkdirPath = fullPath.AsSpan(0, i);
-                int result = Interop.Sys.MkDir(mkdirPath, (int)unixCreateMode);
+                int result = Interop.Sys.MkDir(mkdirPath, (int)DefaultUnixCreateDirectoryMode);
                 if (result == 0)
                 {
                     break; // Created parent.
@@ -360,7 +360,8 @@ namespace System.IO
             for (i = stackDir.Length - 1; i >= 0; i--)
             {
                 ReadOnlySpan<char> mkdirPath = fullPath.AsSpan(0, stackDir[i]);
-                int result = Interop.Sys.MkDir(mkdirPath, (int)unixCreateMode);
+                UnixFileMode mode = i == 0 ? unixCreateMode : DefaultUnixCreateDirectoryMode;
+                int result = Interop.Sys.MkDir(mkdirPath, (int)mode);
                 if (result < 0)
                 {
                     Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/73899.

@Jozkee @adamsitnik @eerhardt @dotnet/area-system-io ptal.