### PR TITLE
Implementation of [Try]GetValue<T>()

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -34,6 +34,10 @@ namespace System.Text.Json
         public System.Text.Json.JsonCommentHandling CommentHandling { readonly get { throw null; } set { } }
         public int MaxDepth { readonly get { throw null; } set { } }
     }
+
+    public delegate bool Utf8Parser<TResult>(ReadOnlySpan<byte> span, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value);
+    public delegate bool Parser<TResult>(ReadOnlySpan<char> span, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value);
+
     public readonly partial struct JsonElement
     {
         private readonly object _dummy;
@@ -55,6 +59,8 @@ namespace System.Text.Json
         public short GetInt16() { throw null; }
         public int GetInt32() { throw null; }
         public long GetInt64() { throw null; }
+        public T GetValue<T>(System.Text.Json.Parser<T> parser) { throw null; }
+        public T GetValue<T>(System.Text.Json.Utf8Parser<T> parser) { throw null; }
         public System.Text.Json.JsonElement GetProperty(System.ReadOnlySpan<byte> utf8PropertyName) { throw null; }
         public System.Text.Json.JsonElement GetProperty(System.ReadOnlySpan<char> propertyName) { throw null; }
         public System.Text.Json.JsonElement GetProperty(string propertyName) { throw null; }
@@ -81,6 +87,9 @@ namespace System.Text.Json
         public bool TryGetInt16(out short value) { throw null; }
         public bool TryGetInt32(out int value) { throw null; }
         public bool TryGetInt64(out long value) { throw null; }
+        public bool TryGetValue<T>(System.Text.Json.Parser<T> parser, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T? value) { throw null; }
+        public bool TryGetValue<T>(System.Text.Json.Utf8Parser<T> parser, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T? value) { throw null; }
+        public bool TryGetValue<T>(System.Text.Json.Utf8Parser<T> parser, bool decode, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T? value) { throw null; }
         public bool TryGetProperty(System.ReadOnlySpan<byte> utf8PropertyName, out System.Text.Json.JsonElement value) { throw null; }
         public bool TryGetProperty(System.ReadOnlySpan<char> propertyName, out System.Text.Json.JsonElement value) { throw null; }
         public bool TryGetProperty(string propertyName, out System.Text.Json.JsonElement value) { throw null; }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -35,8 +35,8 @@ namespace System.Text.Json
         public int MaxDepth { readonly get { throw null; } set { } }
     }
 
-    public delegate bool Utf8Parser<TResult>(ReadOnlySpan<byte> span, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value);
-    public delegate bool Parser<TResult>(ReadOnlySpan<char> span, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value);
+    public delegate bool Utf8Parser<TState, TResult>(ReadOnlySpan<byte> span, TState state, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value);
+    public delegate bool Parser<TState, TResult>(ReadOnlySpan<char> span, TState state, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value);
 
     public readonly partial struct JsonElement
     {
@@ -59,8 +59,8 @@ namespace System.Text.Json
         public short GetInt16() { throw null; }
         public int GetInt32() { throw null; }
         public long GetInt64() { throw null; }
-        public T GetValue<T>(System.Text.Json.Parser<T> parser) { throw null; }
-        public T GetValue<T>(System.Text.Json.Utf8Parser<T> parser) { throw null; }
+        public TResult GetValue<TState, TResult>(System.Text.Json.Parser<TState, TResult> parser, TState state) { throw null; }
+        public TResult GetValue<TState, TResult>(System.Text.Json.Utf8Parser<TState, TResult> parser, TState state) { throw null; }
         public System.Text.Json.JsonElement GetProperty(System.ReadOnlySpan<byte> utf8PropertyName) { throw null; }
         public System.Text.Json.JsonElement GetProperty(System.ReadOnlySpan<char> propertyName) { throw null; }
         public System.Text.Json.JsonElement GetProperty(string propertyName) { throw null; }
@@ -87,9 +87,9 @@ namespace System.Text.Json
         public bool TryGetInt16(out short value) { throw null; }
         public bool TryGetInt32(out int value) { throw null; }
         public bool TryGetInt64(out long value) { throw null; }
-        public bool TryGetValue<T>(System.Text.Json.Parser<T> parser, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T? value) { throw null; }
-        public bool TryGetValue<T>(System.Text.Json.Utf8Parser<T> parser, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T? value) { throw null; }
-        public bool TryGetValue<T>(System.Text.Json.Utf8Parser<T> parser, bool decode, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out T? value) { throw null; }
+        public bool TryGetValue<TState, TResult>(System.Text.Json.Parser<TState, TResult> parser, TState state, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value) { throw null; }
+        public bool TryGetValue<TState, TResult>(System.Text.Json.Utf8Parser<TState, TResult> parser, TState state, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value) { throw null; }
+        public bool TryGetValue<TState, TResult>(System.Text.Json.Utf8Parser<TState, TResult> parser, TState state, bool decode, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out TResult? value) { throw null; }
         public bool TryGetProperty(System.ReadOnlySpan<byte> utf8PropertyName, out System.Text.Json.JsonElement value) { throw null; }
         public bool TryGetProperty(System.ReadOnlySpan<char> propertyName, out System.Text.Json.JsonElement value) { throw null; }
         public bool TryGetProperty(string propertyName, out System.Text.Json.JsonElement value) { throw null; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -657,7 +657,7 @@ namespace System.Text.Json
             return false;
         }
 
-        internal bool TryGetValue<T>(int index, Utf8Parser<T> parser, bool decode, [NotNullWhen(true)] out T? value)
+        internal bool TryGetValue<TState, TResult>(int index, Utf8Parser<TState, TResult> parser, TState state, bool decode, [NotNullWhen(true)] out TResult? value)
         {
             CheckNotDisposed();
 
@@ -680,7 +680,7 @@ namespace System.Text.Json
                 Debug.Assert(written > 0);
                 sourceUnescaped = sourceUnescaped.Slice(0, written);
                 bool success = false;
-                if (parser(sourceUnescaped, out T? tmpUnescaped))
+                if (parser(sourceUnescaped, state, out TResult? tmpUnescaped))
                 {
                     value = tmpUnescaped;
                     success = true;
@@ -700,7 +700,7 @@ namespace System.Text.Json
             }
             else
             {
-                if (parser(segment, out T? tmp))
+                if (parser(segment, state, out TResult? tmp))
                 {
                     value = tmp;
                     return true;
@@ -711,7 +711,7 @@ namespace System.Text.Json
             return false;
         }
 
-        internal bool TryGetValue<T>(int index, Parser<T> parser, [NotNullWhen(true)] out T? value)
+        internal bool TryGetValue<TState, TResult>(int index, Parser<TState, TResult> parser, TState state, [NotNullWhen(true)] out TResult? value)
         {
             CheckNotDisposed();
 
@@ -734,7 +734,7 @@ namespace System.Text.Json
                 Debug.Assert(written > 0);
                 sourceUnescaped = sourceUnescaped.Slice(0, written);
 
-                bool success = TryGetValue(sourceUnescaped, parser, out value);
+                bool success = TryGetValue(sourceUnescaped, parser, state, out value);
 
                 if (sourceArray != null)
                 {
@@ -745,10 +745,10 @@ namespace System.Text.Json
                 return success;
             }
 
-            return TryGetValue(segment, parser, out value);
+            return TryGetValue(segment, parser, state, out value);
         }
 
-        internal bool TryGetValue<T>(ReadOnlySpan<byte> decodedUtf8String, Parser<T> parser, [NotNullWhen(true)] out T? value)
+        internal bool TryGetValue<TState, TResult>(ReadOnlySpan<byte> decodedUtf8String, Parser<TState, TResult> parser, TState state, [NotNullWhen(true)] out TResult? value)
         {
             char[]? sourceTranscodedArray = null;
             int length = checked(decodedUtf8String.Length * JsonConstants.MaxExpansionFactorWhileTranscoding);
@@ -760,7 +760,7 @@ namespace System.Text.Json
             sourceTranscoded = sourceTranscoded.Slice(0, writtenTranscoded);
 
             bool success = false;
-            if (parser(sourceTranscoded, out T? tmp))
+            if (parser(sourceTranscoded, state, out TResult? tmp))
             {
                 value = tmp;
                 success = true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -672,7 +672,7 @@ namespace System.Text.Json
             if (row.HasComplexChildren && decode)
             {
                 byte[]? sourceArray = null;
-                int length = checked(segment.Length * JsonConstants.MaxExpansionFactorWhileEscaping);
+                int length = segment.Length;
                 Span<byte> sourceUnescaped = length <= JsonConstants.StackallocByteThreshold ?
                 stackalloc byte[JsonConstants.StackallocByteThreshold] :
                 (sourceArray = ArrayPool<byte>.Shared.Rent(length));
@@ -726,7 +726,7 @@ namespace System.Text.Json
             if (row.HasComplexChildren)
             {
                 byte[]? sourceArray = null;
-                int length = checked(segment.Length * JsonConstants.MaxExpansionFactorWhileEscaping);
+                int length = segment.Length;
                 Span<byte> sourceUnescaped = length <= JsonConstants.StackallocByteThreshold ?
                 stackalloc byte[JsonConstants.StackallocByteThreshold] :
                 (sourceArray = ArrayPool<byte>.Shared.Rent(length));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1156,6 +1156,139 @@ namespace System.Text.Json
             return value;
         }
 
+        /// <summary>
+        ///   Attempts to represent the current JSON string as the given type.
+        /// </summary>
+        /// <typeparam name="T">The type with which to represent the JSON string.</typeparam>
+        /// <param name="parser">A delegate to the method that parses the JSON string.</param>
+        /// <param name="value">Receives the value.</param>
+        /// <remarks>
+        ///   This method does not create a representation of values other than JSON strings.
+        /// </remarks>
+        /// <returns>
+        ///   <see langword="true"/> if the string can be represented as the given type,
+        ///   <see langword="false"/> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        public bool TryGetValue<T>(Utf8Parser<T> parser, [NotNullWhen(true)] out T? value)
+        {
+            CheckValidInstance();
+
+            return _parent.TryGetValue(_idx, parser, decode: true, out value);
+        }
+
+        /// <summary>
+        ///   Attempts to represent the current JSON string as the given type.
+        /// </summary>
+        /// <typeparam name="T">The type with which to represent the JSON string.</typeparam>
+        /// <param name="parser">A delegate to the method that parses the JSON string.</param>
+        /// <param name="decode">Indicates whether the UTF8 JSON string should be decoded.</param>
+        /// <param name="value">Receives the value.</param>
+        /// <remarks>
+        ///   This method does not create a representation of values other than JSON strings.
+        /// </remarks>
+        /// <returns>
+        ///   <see langword="true"/> if the string can be represented as the given type,
+        ///   <see langword="false"/> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        public bool TryGetValue<T>(Utf8Parser<T> parser, bool decode, [NotNullWhen(true)] out T? value)
+        {
+            CheckValidInstance();
+
+            return _parent.TryGetValue(_idx, parser, decode, out value);
+        }
+
+        /// <summary>
+        ///   Attempts to represent the current JSON string as the given type.
+        /// </summary>
+        /// <typeparam name="T">The type with which to represent the JSON string.</typeparam>
+        /// <param name="parser">A delegate to the method that parses the JSON string.</param>
+        /// <param name="value">Receives the value.</param>
+        /// <remarks>
+        ///   This method does not create a representation of values other than JSON strings.
+        /// </remarks>
+        /// <returns>
+        ///   <see langword="true"/> if the string can be represented as the given type,
+        ///   <see langword="false"/> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        public bool TryGetValue<T>(Parser<T> parser, [NotNullWhen(true)] out T? value)
+        {
+            CheckValidInstance();
+
+            return _parent.TryGetValue(_idx, parser, out value);
+        }
+
+        /// <summary>
+        ///   Gets the value of the element as the given type.
+        /// </summary>
+        /// <remarks>
+        ///   This method does not create a representation of values other than JSON strings.
+        /// </remarks>
+        /// <returns>The value of the element as the given type.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   The value cannot be represented as a <see cref="Guid"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        /// <seealso cref="ToString"/>
+        public T GetValue<T>(Utf8Parser<T> parser)
+        {
+            if (!TryGetValue(parser, out T? value))
+            {
+                ThrowHelper.ThrowFormatException();
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        ///   Gets the value of the element as the given type.
+        /// </summary>
+        /// <remarks>
+        ///   This method does not create a representation of values other than JSON strings.
+        /// </remarks>
+        /// <returns>The value of the element as the given type.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   The value cannot be represented as a <see cref="Guid"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        /// <seealso cref="ToString"/>
+        public T GetValue<T>(Parser<T> parser)
+        {
+            if (!TryGetValue(parser, out T? value))
+            {
+                ThrowHelper.ThrowFormatException();
+            }
+
+            return value;
+        }
+
         internal string GetPropertyName()
         {
             CheckValidInstance();
@@ -1470,4 +1603,34 @@ namespace System.Text.Json
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string DebuggerDisplay => $"ValueKind = {ValueKind} : \"{ToString()}\"";
     }
+
+    /// <summary>
+    /// A delegate to a method that attempts to represent a JSON string as a given type.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the resulting value.</typeparam>
+    /// <param name="span">The UTF8-encoded JSON string. This may be encoded or decoded depending on context.</param>
+    /// <param name="value">The resulting value.</param>
+    /// <remarks>
+    ///   This method does not create a representation of values other than JSON strings.
+    /// </remarks>
+    /// <returns>
+    ///   <see langword="true"/> if the string can be represented as the given type,
+    ///   <see langword="false"/> otherwise.
+    /// </returns>
+    public delegate bool Utf8Parser<TResult>(ReadOnlySpan<byte> span, [NotNullWhen(true)] out TResult? value);
+
+    /// <summary>
+    /// A delegate to a method that attempts to represent a JSON string as a given type.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the resulting value.</typeparam>
+    /// <param name="span">The JSON string. This will always be in its decoded form.</param>
+    /// <param name="value">The resulting value.</param>
+    /// <remarks>
+    ///   This method does not create a representation of values other than JSON strings.
+    /// </remarks>
+    /// <returns>
+    ///   <see langword="true"/> if the string can be represented as the given type,
+    ///   <see langword="false"/> otherwise.
+    /// </returns>
+    public delegate bool Parser<TResult>(ReadOnlySpan<char> span, [NotNullWhen(true)] out TResult? value);
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1159,8 +1159,10 @@ namespace System.Text.Json
         /// <summary>
         ///   Attempts to represent the current JSON string as the given type.
         /// </summary>
-        /// <typeparam name="T">The type with which to represent the JSON string.</typeparam>
+        /// <typeparam name="TState">The type of the parser state.</typeparam>
+        /// <typeparam name="TResult">The type with which to represent the JSON string.</typeparam>
         /// <param name="parser">A delegate to the method that parses the JSON string.</param>
+        /// <param name="state">The state for the parser.</param>
         /// <param name="value">Receives the value.</param>
         /// <remarks>
         ///   This method does not create a representation of values other than JSON strings.
@@ -1175,18 +1177,20 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
-        public bool TryGetValue<T>(Utf8Parser<T> parser, [NotNullWhen(true)] out T? value)
+        public bool TryGetValue<TState, TResult>(Utf8Parser<TState, TResult> parser, TState state, [NotNullWhen(true)] out TResult? value)
         {
             CheckValidInstance();
 
-            return _parent.TryGetValue(_idx, parser, decode: true, out value);
+            return _parent.TryGetValue(_idx, parser, state, decode: true, out value);
         }
 
         /// <summary>
         ///   Attempts to represent the current JSON string as the given type.
         /// </summary>
-        /// <typeparam name="T">The type with which to represent the JSON string.</typeparam>
+        /// <typeparam name="TState">The type of the parser state.</typeparam>
+        /// <typeparam name="TResult">The type with which to represent the JSON string.</typeparam>
         /// <param name="parser">A delegate to the method that parses the JSON string.</param>
+        /// <param name="state">The state for the parser.</param>
         /// <param name="decode">Indicates whether the UTF8 JSON string should be decoded.</param>
         /// <param name="value">Receives the value.</param>
         /// <remarks>
@@ -1202,18 +1206,20 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
-        public bool TryGetValue<T>(Utf8Parser<T> parser, bool decode, [NotNullWhen(true)] out T? value)
+        public bool TryGetValue<TState, TResult>(Utf8Parser<TState, TResult> parser, TState state, bool decode, [NotNullWhen(true)] out TResult? value)
         {
             CheckValidInstance();
 
-            return _parent.TryGetValue(_idx, parser, decode, out value);
+            return _parent.TryGetValue(_idx, parser, state, decode, out value);
         }
 
         /// <summary>
         ///   Attempts to represent the current JSON string as the given type.
         /// </summary>
-        /// <typeparam name="T">The type with which to represent the JSON string.</typeparam>
+        /// <typeparam name="TState">The type of the parser state.</typeparam>
+        /// <typeparam name="TResult">The type with which to represent the JSON string.</typeparam>
         /// <param name="parser">A delegate to the method that parses the JSON string.</param>
+        /// <param name="state">The state for the parser.</param>
         /// <param name="value">Receives the value.</param>
         /// <remarks>
         ///   This method does not create a representation of values other than JSON strings.
@@ -1228,16 +1234,20 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
-        public bool TryGetValue<T>(Parser<T> parser, [NotNullWhen(true)] out T? value)
+        public bool TryGetValue<TState, TResult>(Parser<TState, TResult> parser, TState state, [NotNullWhen(true)] out TResult? value)
         {
             CheckValidInstance();
 
-            return _parent.TryGetValue(_idx, parser, out value);
+            return _parent.TryGetValue(_idx, parser, state, out value);
         }
 
         /// <summary>
         ///   Gets the value of the element as the given type.
         /// </summary>
+        /// <typeparam name="TState">The type of the parser state.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="parser">The parser for the result.</param>
+        /// <param name="state">The state for the parser.</param>
         /// <remarks>
         ///   This method does not create a representation of values other than JSON strings.
         /// </remarks>
@@ -1252,9 +1262,9 @@ namespace System.Text.Json
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
         /// <seealso cref="ToString"/>
-        public T GetValue<T>(Utf8Parser<T> parser)
+        public TResult GetValue<TState, TResult>(Utf8Parser<TState, TResult> parser, TState state)
         {
-            if (!TryGetValue(parser, out T? value))
+            if (!TryGetValue(parser, state, out TResult? value))
             {
                 ThrowHelper.ThrowFormatException();
             }
@@ -1265,6 +1275,10 @@ namespace System.Text.Json
         /// <summary>
         ///   Gets the value of the element as the given type.
         /// </summary>
+        /// <typeparam name="TState">The type of the parser state.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="parser">The parser for the result.</param>
+        /// <param name="state">The state for the parser.</param>
         /// <remarks>
         ///   This method does not create a representation of values other than JSON strings.
         /// </remarks>
@@ -1279,9 +1293,9 @@ namespace System.Text.Json
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
         /// <seealso cref="ToString"/>
-        public T GetValue<T>(Parser<T> parser)
+        public TResult GetValue<TState, TResult>(Parser<TState, TResult> parser, TState state)
         {
-            if (!TryGetValue(parser, out T? value))
+            if (!TryGetValue(parser, state, out TResult? value))
             {
                 ThrowHelper.ThrowFormatException();
             }
@@ -1607,8 +1621,10 @@ namespace System.Text.Json
     /// <summary>
     /// A delegate to a method that attempts to represent a JSON string as a given type.
     /// </summary>
+    /// <typeparam name="TState">The type of the state for the parser.</typeparam>
     /// <typeparam name="TResult">The type of the resulting value.</typeparam>
     /// <param name="span">The UTF8-encoded JSON string. This may be encoded or decoded depending on context.</param>
+    /// <param name="state">The state for the parser.</param>
     /// <param name="value">The resulting value.</param>
     /// <remarks>
     ///   This method does not create a representation of values other than JSON strings.
@@ -1617,13 +1633,15 @@ namespace System.Text.Json
     ///   <see langword="true"/> if the string can be represented as the given type,
     ///   <see langword="false"/> otherwise.
     /// </returns>
-    public delegate bool Utf8Parser<TResult>(ReadOnlySpan<byte> span, [NotNullWhen(true)] out TResult? value);
+    public delegate bool Utf8Parser<TState, TResult>(ReadOnlySpan<byte> span, TState state, [NotNullWhen(true)] out TResult? value);
 
     /// <summary>
     /// A delegate to a method that attempts to represent a JSON string as a given type.
     /// </summary>
+    /// <typeparam name="TState">The type of the state for the parser.</typeparam>
     /// <typeparam name="TResult">The type of the resulting value.</typeparam>
     /// <param name="span">The JSON string. This will always be in its decoded form.</param>
+    /// <param name="state">The state for the parser.</param>
     /// <param name="value">The resulting value.</param>
     /// <remarks>
     ///   This method does not create a representation of values other than JSON strings.
@@ -1632,5 +1650,5 @@ namespace System.Text.Json
     ///   <see langword="true"/> if the string can be represented as the given type,
     ///   <see langword="false"/> otherwise.
     /// </returns>
-    public delegate bool Parser<TResult>(ReadOnlySpan<char> span, [NotNullWhen(true)] out TResult? value);
+    public delegate bool Parser<TState, TResult>(ReadOnlySpan<char> span, TState state, [NotNullWhen(true)] out TResult? value);
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1246,7 +1246,7 @@ namespace System.Text.Json
         ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   The value cannot be represented as a <see cref="Guid"/>.
+        ///   The value cannot be represented as the given type.
         /// </exception>
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
@@ -1273,7 +1273,7 @@ namespace System.Text.Json
         ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   The value cannot be represented as a <see cref="Guid"/>.
+        ///   The value cannot be represented as the given type.
         /// </exception>
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.


### PR DESCRIPTION
Example of how we might allow people to create custom value conversion for `JsonValueKind.String` elements, optionally handling decoding and transcoding depending on the appetite for the developer to consume "raw" values; all allocations are either on the stack or from `ArrayPool`.

Tests are still to be written to demonstrate the usage.

```csharp
JsonElement element; // = get this from somewhere

if (element.TryGetValue(ParseLength, state: default(object?), decode: true, out int value))
{
    Console.WriteLine($"Length = {value}");
}
else
{
    Console.WriteLine($"Unable to parse the value.");
}

if (element.TryGetValue(ParseLengthFromDecodedChar, state: default(object?), out int value2))
{
    Console.WriteLine($"Length = {value2}");
}
else
{
    Console.WriteLine($"Unable to parse the value.");
}

static bool ParseLength(ReadOnlySpan<byte> input, object? state, out int result)
{
    result = input.Length;
    return true;
}

static bool ParseLengthFromDecodedChar(ReadOnlySpan<char> input, object? state, out int result)
{
    result = input.Length;
    return true;
}
```