### PR TITLE
perf pipeline: Switch to node 14.x

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -64,6 +64,13 @@ jobs:
       - HelixPerfUploadTokenValue: '$(PerfCommandUploadTokenLinux)'
     - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(parameters.osGroup, 'windows')) }}:
       - HelixPerfUploadTokenValue: '$(PerfCommandUploadToken)'
+    - ${{ if eq(parameters.runtimeType, 'wasm') }}:
+      - HelixPreCommandsWasmOnLinux: >-
+        sudo apt-get -y remove nodejs &&
+        curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&
+        sudo apt-get -y install nodejs &&
+        npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
+        $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 --engines=v8,javascriptcore
     - HelixPreCommandStemWindows: 'set ORIGPYPATH=%PYTHONPATH%;py -m pip install -U pip;py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install -U pip;py -3 -m pip install azure.storage.blob==12.0.0;py -3 -m pip install azure.storage.queue==12.0.0;set "PERFLAB_UPLOAD_TOKEN=$(HelixPerfUploadTokenValue)"'
     - HelixPreCommandStemLinux: >-
         export ORIGPYPATH=$PYTHONPATH
@@ -79,11 +86,7 @@ jobs:
         pip3 install azure.storage.queue==12.0.0 &&
         sudo apt-get update &&
         sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates &&
-        sudo apt-get -y remove nodejs &&
-        curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&
-        sudo apt-get -y install nodejs &&
-        npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
-        $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 --engines=v8,javascriptcore &&
+        $(HelixPreCommandsWasmOnLinux) &&
         export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)" &&
         export PERF_PREREQS_INSTALLED=1;
         test "x$PERF_PREREQS_INSTALLED" = "x1" || echo "** Error: Failed to install prerequites **"

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -78,21 +78,21 @@ jobs:
         export ORIGPYPATH=$PYTHONPATH
         export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true;
         echo "** Installing prerequistes **";
-        python3 -m pip install -U pip &&
+        python3 -m pip install --user -U pip &&
         sudo apt-get -y install python3-venv &&
         python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv &&
         ls -l $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate &&
         export PYTHONPATH= &&
-        python3 -m pip install -U pip &&
-        pip3 install azure.storage.blob==12.0.0 &&
-        pip3 install azure.storage.queue==12.0.0 &&
+        python3 -m pip install --user -U pip &&
+        pip3 install --user azure.storage.blob==12.0.0 &&
+        pip3 install --user azure.storage.queue==12.0.0 &&
         sudo apt-get update &&
         sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates &&
         $(HelixPreCommandsWasmOnLinux) &&
         export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)"
         || export PERF_PREREQS_INSTALL_FAILED=1;
         test "x$PERF_PREREQS_INSTALL_FAILED" = "x1" && echo "** Error: Failed to install prerequites **"
-    - HelixPreCommandStemMusl: 'export ORIGPYPATH=$PYTHONPATH;sudo apk add icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib cargo;sudo apk add libgdiplus --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing; python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;source $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.7.1;pip3 install azure.storage.queue==12.1.5;export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)"'
+    - HelixPreCommandStemMusl: 'export ORIGPYPATH=$PYTHONPATH;sudo apk add icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib cargo;sudo apk add libgdiplus --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing; python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;source $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install --user -U pip;pip3 install --user azure.storage.blob==12.7.1;pip3 install --user azure.storage.queue==12.1.5;export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)"'
     - ExtraMSBuildLogsWindows: 'set MSBUILDDEBUGCOMM=1;set "MSBUILDDEBUGPATH=%HELIX_WORKITEM_UPLOAD_ROOT%"'
     - ExtraMSBuildLogsLinux: 'export MSBUILDDEBUGCOMM=1;export "MSBUILDDEBUGPATH=$HELIX_WORKITEM_UPLOAD_ROOT"'
     - HelixPreCommand: ''

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -79,7 +79,8 @@ jobs:
         pip3 install azure.storage.queue==12.0.0 &&
         sudo apt-get update &&
         sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates &&
-        curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - &&
+        sudo apt-get -y remove nodejs &&
+        curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&
         sudo apt-get -y install nodejs &&
         npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
         $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 --engines=v8,javascriptcore &&

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -89,9 +89,9 @@ jobs:
         sudo apt-get update &&
         sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates &&
         $(HelixPreCommandsWasmOnLinux) &&
-        export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)" &&
-        export PERF_PREREQS_INSTALLED=1;
-        test "x$PERF_PREREQS_INSTALLED" = "x1" || echo "** Error: Failed to install prerequites **"
+        export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)"
+        || export PERF_PREREQS_INSTALL_FAILED=1;
+        test "x$PERF_PREREQS_INSTALL_FAILED" = "x1" && echo "** Error: Failed to install prerequites **"
     - HelixPreCommandStemMusl: 'export ORIGPYPATH=$PYTHONPATH;sudo apk add icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib cargo;sudo apk add libgdiplus --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing; python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;source $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.7.1;pip3 install azure.storage.queue==12.1.5;export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)"'
     - ExtraMSBuildLogsWindows: 'set MSBUILDDEBUGCOMM=1;set "MSBUILDDEBUGPATH=%HELIX_WORKITEM_UPLOAD_ROOT%"'
     - ExtraMSBuildLogsLinux: 'export MSBUILDDEBUGCOMM=1;export "MSBUILDDEBUGPATH=$HELIX_WORKITEM_UPLOAD_ROOT"'

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -66,11 +66,13 @@ jobs:
       - HelixPerfUploadTokenValue: '$(PerfCommandUploadToken)'
     - ${{ if eq(parameters.runtimeType, 'wasm') }}:
       - HelixPreCommandsWasmOnLinux: >-
-        sudo apt-get -y remove nodejs &&
-        curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&
-        sudo apt-get -y install nodejs &&
-        npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
-        $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 --engines=v8,javascriptcore
+          sudo apt-get -y remove nodejs &&
+          curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&
+          sudo apt-get -y install nodejs &&
+          npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
+          $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 --engines=v8,javascriptcore
+    - ${{ if ne(parameters.runtimeType, 'wasm') }}:
+      - HelixPreCommandsWasmOnLinux: echo
     - HelixPreCommandStemWindows: 'set ORIGPYPATH=%PYTHONPATH%;py -m pip install -U pip;py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install -U pip;py -3 -m pip install azure.storage.blob==12.0.0;py -3 -m pip install azure.storage.queue==12.0.0;set "PERFLAB_UPLOAD_TOKEN=$(HelixPerfUploadTokenValue)"'
     - HelixPreCommandStemLinux: >-
         export ORIGPYPATH=$PYTHONPATH

--- a/eng/testing/performance/microbenchmarks.proj
+++ b/eng/testing/performance/microbenchmarks.proj
@@ -135,7 +135,7 @@
         if [ "x$PERF_PREREQS_INSTALLED" = "x1" ]; then
           $(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)";
         else
-          echo "\n\n** Error: Failed to install prerequisites **\n\n"; export _commandExitCode=1;
+          echo "\n\n** Error: Failed to install prerequisites **\n\n"; (exit 1);
         fi</Command>
       <Command Condition="'$(AGENT_OS)' == 'Windows_NT'">$(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</Command>
       <PostCommands Condition="'$(Compare)' == 'true'">$(DotnetExe) run -f $(PERFLAB_Framework) -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults);$(FinalCommand)</PostCommands>

--- a/eng/testing/performance/microbenchmarks.proj
+++ b/eng/testing/performance/microbenchmarks.proj
@@ -149,7 +149,7 @@
       <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-artifacts $(BaselineArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument)"</PreCommands>
       <Command Condition="'$(AGENT_OS)' != 'Windows_NT'">
         if [ "x$PERF_PREREQS_INSTALL_FAILED" = "x1" ]; then
-          echo "\n\n** Error: Failed to install prerequisites **\n\n"; export _commandExitCode=1;
+          echo "\n\n** Error: Failed to install prerequisites **\n\n"; (exit 1);
         else
           $(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument)";
         fi</Command>

--- a/eng/testing/performance/microbenchmarks.proj
+++ b/eng/testing/performance/microbenchmarks.proj
@@ -132,10 +132,10 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-artifacts $(BaselineArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</PreCommands>
       <Command Condition="'$(AGENT_OS)' != 'Windows_NT'">
-        if [ "x$PERF_PREREQS_INSTALLED" = "x1" ]; then
-          $(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)";
-        else
+        if [ "x$PERF_PREREQS_INSTALL_FAILED" = "x1" ]; then
           echo "\n\n** Error: Failed to install prerequisites **\n\n"; (exit 1);
+        else
+          $(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)";
         fi</Command>
       <Command Condition="'$(AGENT_OS)' == 'Windows_NT'">$(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</Command>
       <PostCommands Condition="'$(Compare)' == 'true'">$(DotnetExe) run -f $(PERFLAB_Framework) -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults);$(FinalCommand)</PostCommands>
@@ -148,10 +148,10 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands Condition="'$(Compare)' == 'true'">$(WorkItemCommand) --bdn-artifacts $(BaselineArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(BaselineCoreRunArgument)"</PreCommands>
       <Command Condition="'$(AGENT_OS)' != 'Windows_NT'">
-        if [ "x$PERF_PREREQS_INSTALLED" = "x1" ]; then
-          $(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument)";
-        else
+        if [ "x$PERF_PREREQS_INSTALL_FAILED" = "x1" ]; then
           echo "\n\n** Error: Failed to install prerequisites **\n\n"; export _commandExitCode=1;
+        else
+          $(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument)";
         fi</Command>
       <Command Condition="'$(AGENT_OS)' == 'Windows_NT'">$(WorkItemCommand) --bdn-artifacts $(ArtifactsDirectory) --bdn-arguments="--anyCategories $(BDNCategories) $(ExtraBenchmarkDotNetArguments) $(CoreRunArgument)"</Command>
       <PostCommands Condition="'$(Compare)' == 'true'">$(DotnetExe) run -f $(PERFLAB_Framework) -p $(ResultsComparer) --base $(BaselineArtifactsDirectory) --diff $(ArtifactsDirectory) --threshold 2$(Percent) --xml $(XMLResults)</PostCommands>


### PR DESCRIPTION
- Switch to node 14.x instead of 18.x, because the latter doesn't seem
to be compatible with ubuntu 18.x:
`node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)`

- remove the existing `nodejs` package before installing a new
one, because these machines are shared, and would get affected by
installations performed by other runs.

- Fix the case where pre-requisites would fail to install, but then helix would exit with exit code 0, and it would "look" as if everything went fine. This was happening because we set `_commandExitCode=1`, but helix sets this itself based on `$?`. So, to fix this we exit with `(exit 1)`, and helix should be able to pick that up, thus causing the whole job to fail, as expected

- Install node, and jsvu only for the wasm jobs, as they are not needed by others