### PR TITLE
SuperPMI collection fix by instantiating 'GetExactClasses' if it is null

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -2705,6 +2705,9 @@ CorInfoTypeWithMod MethodContext::repGetArgType(CORINFO_SIG_INFO*       sig,
 
 void MethodContext::recGetExactClasses(CORINFO_CLASS_HANDLE baseType, int maxExactClasses, CORINFO_CLASS_HANDLE* exactClsRet, int result)
 {
+    if (GetExactClasses == nullptr)
+        GetExactClasses = new LightWeightMap<DLD, DLD>();
+
     DLD key;
     ZeroMemory(&key, sizeof(key));
     key.A = CastHandle(baseType);


### PR DESCRIPTION
SuperPMI collections have been failing since yesterday. Upon investigation, I was able to reproduce the issue simply by trying to SuperPMI collect a hello world app. 

There was a null variable, `GetExactClasses`, trying to be accessed. It was added in https://github.com/dotnet/runtime/pull/64497. The fix is to initialize this variable if it is null. Looking at similar variables like this, the same logic exists, for example:
```cpp
    if (GetArgType == nullptr)
        GetArgType = new LightWeightMap<Agnostic_GetArgType_Key, Agnostic_GetArgType_Value>();
```
