### PR TITLE
Convert more jit phases to opt into common post phase checks

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4536,15 +4536,11 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     // Promote struct locals
     //
-    auto promoteStructsPhase = [this]() {
+    DoPhase(this, PHASE_PROMOTE_STRUCTS, &Compiler::fgPromoteStructs);
 
-        // For x64 and ARM64 we need to mark irregular parameters
-        lvaRefCountState = RCS_EARLY;
-        fgResetImplicitByRefRefCount();
-
-        fgPromoteStructs();
-    };
-    DoPhase(this, PHASE_PROMOTE_STRUCTS, promoteStructsPhase);
+    // Enable early ref counting of locals
+    //
+    lvaRefCountState = RCS_EARLY;
 
     // Figure out what locals are address-taken.
     //

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4531,11 +4531,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
         // Run an early flow graph simplification pass
         //
-        auto earlyUpdateFlowGraphPhase = [this]() {
-            constexpr bool doTailDup = false;
-            fgUpdateFlowGraph(doTailDup);
-        };
-        DoPhase(this, PHASE_EARLY_UPDATE_FLOW_GRAPH, earlyUpdateFlowGraphPhase);
+        DoPhase(this, PHASE_EARLY_UPDATE_FLOW_GRAPH, &Compiler::fgUpdateFlowGraphPhase);
     }
 
     // Promote struct locals
@@ -4830,11 +4826,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             {
                 // update the flowgraph if we modified it during the optimization phase
                 //
-                auto optUpdateFlowGraphPhase = [this]() {
-                    constexpr bool doTailDup = false;
-                    fgUpdateFlowGraph(doTailDup);
-                };
-                DoPhase(this, PHASE_OPT_UPDATE_FLOW_GRAPH, optUpdateFlowGraphPhase);
+                DoPhase(this, PHASE_OPT_UPDATE_FLOW_GRAPH, &Compiler::fgUpdateFlowGraphPhase);
 
                 // Recompute the edge weight if we have modified the flow graph
                 //

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4602,29 +4602,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     // GS security checks for unsafe buffers
     //
-    auto gsPhase = [this]() {
-        unsigned prevBBCount = fgBBcount;
-        if (getNeedsGSSecurityCookie())
-        {
-            gsGSChecksInitCookie();
-
-            if (compGSReorderStackLayout)
-            {
-                gsCopyShadowParams();
-            }
-
-            // If we needed to create any new BasicBlocks then renumber the blocks
-            if (fgBBcount > prevBBCount)
-            {
-                fgRenumberBlocks();
-            }
-        }
-        else
-        {
-            JITDUMP("No GS security needed\n");
-        }
-    };
-    DoPhase(this, PHASE_GS_COOKIE, gsPhase);
+    DoPhase(this, PHASE_GS_COOKIE, &Compiler::gsPhase);
 
     // Compute the block and edge weights
     //

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4395,96 +4395,9 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         return;
     }
 
-#if !FEATURE_EH
-    // If we aren't yet supporting EH in a compiler bring-up, remove as many EH handlers as possible, so
-    // we can pass tests that contain try/catch EH, but don't actually throw any exceptions.
-    fgRemoveEH();
-#endif // !FEATURE_EH
-
-    // We could allow ESP frames. Just need to reserve space for
-    // pushing EBP if the method becomes an EBP-frame after an edit.
-    // Note that requiring a EBP Frame disallows double alignment.  Thus if we change this
-    // we either have to disallow double alignment for E&C some other way or handle it in EETwain.
-
-    if (opts.compDbgEnC)
-    {
-        codeGen->setFramePointerRequired(true);
-
-        // We don't care about localloc right now. If we do support it,
-        // EECodeManager::FixContextForEnC() needs to handle it smartly
-        // in case the localloc was actually executed.
-        //
-        // compLocallocUsed            = true;
-    }
-
-    // Start phases that are broadly called morphing, and includes
-    // global morph, as well as other phases that massage the trees so
-    // that we can generate code out of them.
+    // Prepare for the morph phases
     //
-    auto morphInitPhase = [this]() {
-
-        // Initialize the BlockSet epoch
-        NewBasicBlockEpoch();
-
-        fgOutgoingArgTemps = nullptr;
-
-        // Insert call to class constructor as the first basic block if
-        // we were asked to do so.
-        if (info.compCompHnd->initClass(nullptr /* field */, nullptr /* method */,
-                                        impTokenLookupContextHandle /* context */) &
-            CORINFO_INITCLASS_USE_HELPER)
-        {
-            fgEnsureFirstBBisScratch();
-            fgNewStmtAtBeg(fgFirstBB, fgInitThisClass());
-        }
-
-#ifdef DEBUG
-        if (opts.compGcChecks)
-        {
-            for (unsigned i = 0; i < info.compArgsCount; i++)
-            {
-                if (lvaGetDesc(i)->TypeGet() == TYP_REF)
-                {
-                    // confirm that the argument is a GC pointer (for debugging (GC stress))
-                    GenTree* op = gtNewLclvNode(i, TYP_REF);
-                    op          = gtNewHelperCallNode(CORINFO_HELP_CHECK_OBJ, TYP_VOID, op);
-
-                    fgEnsureFirstBBisScratch();
-                    fgNewStmtAtEnd(fgFirstBB, op);
-
-                    if (verbose)
-                    {
-                        printf("\ncompGcChecks tree:\n");
-                        gtDispTree(op);
-                    }
-                }
-            }
-        }
-#endif // DEBUG
-
-#if defined(DEBUG) && defined(TARGET_XARCH)
-        if (opts.compStackCheckOnRet)
-        {
-            lvaReturnSpCheck = lvaGrabTempWithImplicitUse(false DEBUGARG("ReturnSpCheck"));
-            lvaSetVarDoNotEnregister(lvaReturnSpCheck, DoNotEnregisterReason::ReturnSpCheck);
-            lvaGetDesc(lvaReturnSpCheck)->lvType = TYP_I_IMPL;
-        }
-#endif // defined(DEBUG) && defined(TARGET_XARCH)
-
-#if defined(DEBUG) && defined(TARGET_X86)
-        if (opts.compStackCheckOnCall)
-        {
-            lvaCallSpCheck                     = lvaGrabTempWithImplicitUse(false DEBUGARG("CallSpCheck"));
-            lvaGetDesc(lvaCallSpCheck)->lvType = TYP_I_IMPL;
-        }
-#endif // defined(DEBUG) && defined(TARGET_X86)
-    };
-    DoPhase(this, PHASE_MORPH_INIT, morphInitPhase);
-
-#ifdef DEBUG
-    // Inliner could add basic blocks. Check that the flowgraph data is up-to-date
-    fgDebugCheckBBlist(false, false);
-#endif // DEBUG
+    DoPhase(this, PHASE_MORPH_INIT, &Compiler::fgMorphInit);
 
     // Inline callee methods into this root method
     //

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4461,6 +4461,8 @@ public:
 
     PhaseStatus fgTransformPatchpoints();
 
+    PhaseStatus fgMorphInit();
+
     PhaseStatus fgInline();
 
     PhaseStatus fgRemoveEmptyTry();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5913,7 +5913,7 @@ private:
     // Clear up annotations for any struct promotion temps created for implicit byrefs.
     void fgMarkDemotedImplicitByRefArgs();
 
-    void fgMarkAddressExposedLocals();
+    PhaseStatus fgMarkAddressExposedLocals();
     void fgMarkAddressExposedLocals(Statement* stmt);
 
     PhaseStatus fgForwardSub();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5222,7 +5222,7 @@ public:
 
     unsigned fgGetNestingLevel(BasicBlock* block, unsigned* pFinallyNesting = nullptr);
 
-    void fgPostImportationCleanup();
+    PhaseStatus fgPostImportationCleanup();
 
     void fgRemoveStmt(BasicBlock* block, Statement* stmt DEBUGARG(bool isUnlink = false));
     void fgUnlinkStmt(BasicBlock* block, Statement* stmt);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5899,7 +5899,7 @@ private:
     static fgWalkPreFn fgDebugCheckForTransformableIndirectCalls;
 #endif
 
-    void fgPromoteStructs();
+    PhaseStatus fgPromoteStructs();
     void fgMorphStructField(GenTree* tree, GenTree* parent);
     void fgMorphLocalField(GenTree* tree, GenTree* parent);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10375,10 +10375,11 @@ public:
     GSCookie            gsGlobalSecurityCookieVal;  // Value of global cookie if addr is NULL
     ShadowParamVarInfo* gsShadowVarInfo;            // Table used by shadow param analysis code
 
-    void gsGSChecksInitCookie();   // Grabs cookie variable
-    void gsCopyShadowParams();     // Identify vulnerable params and create dhadow copies
-    bool gsFindVulnerableParams(); // Shadow param analysis code
-    void gsParamsToShadows();      // Insert copy code and replave param uses by shadow
+    PhaseStatus gsPhase();
+    void        gsGSChecksInitCookie();   // Grabs cookie variable
+    void        gsCopyShadowParams();     // Identify vulnerable params and create dhadow copies
+    bool        gsFindVulnerableParams(); // Shadow param analysis code
+    void        gsParamsToShadows();      // Insert copy code and replave param uses by shadow
 
     static fgWalkPreFn gsMarkPtrsAndAssignGroups; // Shadow param analysis tree-walk
     static fgWalkPreFn gsReplaceShadowParams;     // Shadow param replacement tree-walk

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5908,7 +5908,7 @@ private:
 
     // Change implicit byrefs' types from struct to pointer, and for any that were
     // promoted, create new promoted struct temps.
-    void fgRetypeImplicitByRefArgs();
+    PhaseStatus fgRetypeImplicitByRefArgs();
 
     // Clear up annotations for any struct promotion temps created for implicit byrefs.
     void fgMarkDemotedImplicitByRefArgs();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5318,7 +5318,8 @@ public:
 
     bool fgIsForwardBranch(BasicBlock* bJump, BasicBlock* bSrc = nullptr);
 
-    bool fgUpdateFlowGraph(bool doTailDup = false);
+    bool fgUpdateFlowGraph(bool doTailDup = false, bool isPhase = false);
+    PhaseStatus fgUpdateFlowGraphPhase();
 
     PhaseStatus fgFindOperOrder();
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5277,7 +5277,7 @@ public:
     bool fgIsIntraHandlerPred(BasicBlock* predBlock, BasicBlock* block);
     bool fgAnyIntraHandlerPreds(BasicBlock* block);
     void fgInsertFuncletPrologBlock(BasicBlock* block);
-    bool        fgCreateFuncletPrologBlocks();
+    void        fgCreateFuncletPrologBlocks();
     PhaseStatus fgCreateFunclets();
 #else  // !FEATURE_EH_FUNCLETS
     bool fgRelocateEHRegions();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2220,7 +2220,7 @@ public:
     bool fgNormalizeEHCase2();
     bool fgNormalizeEHCase3();
 
-    void fgCreateFiltersForGenericExceptions();
+    bool fgCreateFiltersForGenericExceptions();
 
     void fgCheckForLoopsInHandlers();
 
@@ -4339,7 +4339,7 @@ public:
     }
 
     BasicBlock* fgNewBasicBlock(BBjumpKinds jumpKind);
-    void fgEnsureFirstBBisScratch();
+    bool fgEnsureFirstBBisScratch();
     bool fgFirstBBisScratch();
     bool fgBBisScratch(BasicBlock* block);
 
@@ -4524,7 +4524,7 @@ public:
     // The number of separate return points in the method.
     unsigned fgReturnCount;
 
-    void fgAddInternal();
+    PhaseStatus fgAddInternal();
 
     enum class FoldResult
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5303,10 +5303,10 @@ public:
 #ifdef DEBUG
     void fgPrintEdgeWeights();
 #endif
-    void     fgComputeBlockAndEdgeWeights();
-    weight_t fgComputeMissingBlockWeights();
-    void fgComputeCalledCount(weight_t returnWeight);
-    void fgComputeEdgeWeights();
+    PhaseStatus fgComputeBlockAndEdgeWeights();
+    bool fgComputeMissingBlockWeights(weight_t* returnWeight);
+    bool fgComputeCalledCount(weight_t returnWeight);
+    PhaseStatus fgComputeEdgeWeights();
 
     bool fgReorderBlocks(bool useProfile);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5277,8 +5277,8 @@ public:
     bool fgIsIntraHandlerPred(BasicBlock* predBlock, BasicBlock* block);
     bool fgAnyIntraHandlerPreds(BasicBlock* block);
     void fgInsertFuncletPrologBlock(BasicBlock* block);
-    void fgCreateFuncletPrologBlocks();
-    void fgCreateFunclets();
+    bool        fgCreateFuncletPrologBlocks();
+    PhaseStatus fgCreateFunclets();
 #else  // !FEATURE_EH_FUNCLETS
     bool fgRelocateEHRegions();
 #endif // !FEATURE_EH_FUNCLETS

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -231,7 +231,7 @@ BasicBlock* Compiler::fgNewBasicBlock(BBjumpKinds jumpKind)
 // fgEnsureFirstBBisScratch: Ensure that fgFirstBB is a scratch BasicBlock
 //
 // Returns:
-//   Nothing. May allocate a new block and alter the value of fgFirstBB.
+//   True, if a new basic block was allocated.
 //
 // Notes:
 //   This should be called before adding on-entry initialization code to
@@ -249,12 +249,12 @@ BasicBlock* Compiler::fgNewBasicBlock(BBjumpKinds jumpKind)
 //
 //   Can be called at any time, and can be called multiple times.
 //
-void Compiler::fgEnsureFirstBBisScratch()
+bool Compiler::fgEnsureFirstBBisScratch()
 {
     // Have we already allocated a scratch block?
     if (fgFirstBBisScratch())
     {
-        return;
+        return false;
     }
 
     assert(fgFirstBBScratch == nullptr);
@@ -303,6 +303,8 @@ void Compiler::fgEnsureFirstBBisScratch()
         printf("New scratch " FMT_BB "\n", block->bbNum);
     }
 #endif
+
+    return true;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -673,13 +673,6 @@ void Compiler::fgComputePreds()
     noway_assert(fgFirstBB != nullptr);
 
 #ifdef DEBUG
-    if (verbose)
-    {
-        printf("\n*************** In fgComputePreds()\n");
-        fgDispBasicBlocks();
-        printf("\n");
-    }
-
     // Check that the block numbers are increasing order.
     unsigned lastBBnum = fgFirstBB->bbNum;
     for (BasicBlock* const block : Blocks(fgFirstBB->bbNext))
@@ -831,15 +824,6 @@ void Compiler::fgComputePreds()
 
     fgModified         = false;
     fgComputePredsDone = true;
-
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("\n*************** After fgComputePreds()\n");
-        fgDispBasicBlocks();
-        printf("\n");
-    }
-#endif
 }
 
 unsigned Compiler::fgNSuccsOfFinallyRet(BasicBlock* block)

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -652,6 +652,11 @@ private:
 //
 PhaseStatus Compiler::fgInline()
 {
+#ifdef DEBUG
+    // Inliner could add basic blocks. Check that the flowgraph data is up-to-date
+    fgDebugCheckBBlist(false, false);
+#endif // DEBUG
+
     if (!opts.OptEnabled(CLFLG_INLINING))
     {
         return PhaseStatus::MODIFIED_NOTHING;

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1365,6 +1365,9 @@ void Compiler::fgInitBlockVarSets()
 //------------------------------------------------------------------------
 // fgPostImportationCleanups: clean up flow graph after importation
 //
+// Returns:
+//   suitable phase status
+//
 // Notes:
 //
 //  Find and remove any basic blocks that are useless (e.g. they have not been
@@ -1414,9 +1417,34 @@ void Compiler::fgInitBlockVarSets()
 //  from OSR method entry, and flow always enters the try blocks at the
 //  first block of the try.
 //
-void Compiler::fgPostImportationCleanup()
+PhaseStatus Compiler::fgPostImportationCleanup()
 {
-    JITDUMP("\n*************** In fgPostImportationCleanup\n");
+    // Bail, if this is a failed inline
+    //
+    if (compDonotInline())
+    {
+        return PhaseStatus::MODIFIED_NOTHING;
+    }
+
+    if (compIsForInlining())
+    {
+        // Update type of return spill temp if we have gathered
+        // better info when importing the inlinee, and the return
+        // spill temp is single def.
+        if (fgNeedReturnSpillTemp())
+        {
+            CORINFO_CLASS_HANDLE retExprClassHnd = impInlineInfo->retExprClassHnd;
+            if (retExprClassHnd != nullptr)
+            {
+                LclVarDsc* returnSpillVarDsc = lvaGetDesc(lvaInlineeReturnSpillTemp);
+
+                if (returnSpillVarDsc->lvSingleDef)
+                {
+                    lvaUpdateClass(lvaInlineeReturnSpillTemp, retExprClassHnd, impInlineInfo->retExprClassHndIsExact);
+                }
+            }
+        }
+    }
 
     BasicBlock* cur;
     BasicBlock* nxt;
@@ -1462,7 +1490,7 @@ void Compiler::fgPostImportationCleanup()
     //
     if ((removedBlks == 0) && !(opts.IsOSR() && fgOSREntryBB->hasTryIndex()))
     {
-        return;
+        return PhaseStatus::MODIFIED_NOTHING;
     }
 
     // Update all references in the exception handler table.
@@ -1662,6 +1690,8 @@ void Compiler::fgPostImportationCleanup()
     // If this is OSR, and the OSR entry was mid-try or in a nested try entry,
     // add the appropriate step block logic.
     //
+    unsigned addedBlocks = 0;
+
     if (opts.IsOSR())
     {
         BasicBlock* const osrEntry        = fgOSREntryBB;
@@ -1700,8 +1730,8 @@ void Compiler::fgPostImportationCleanup()
 
                 // Helper method to add flow
                 //
-                auto addConditionalFlow = [this, entryStateVar, &entryJumpTarget](BasicBlock* fromBlock,
-                                                                                  BasicBlock* toBlock) {
+                auto addConditionalFlow = [this, entryStateVar, &entryJumpTarget, &addedBlocks](BasicBlock* fromBlock,
+                                                                                                BasicBlock* toBlock) {
 
                     // We may have previously though this try entry was unreachable, but now we're going to
                     // step through it on the way to the OSR entry. So ensure it has plausible profile weight.
@@ -1716,6 +1746,7 @@ void Compiler::fgPostImportationCleanup()
                     BasicBlock* const newBlock = fgSplitBlockAtBeginning(fromBlock);
                     fromBlock->bbFlags |= BBF_INTERNAL;
                     newBlock->bbFlags &= ~BBF_DONT_REMOVE;
+                    addedBlocks++;
 
                     GenTree* const entryStateLcl = gtNewLclvNode(entryStateVar, TYP_INT);
                     GenTree* const compareEntryStateToZero =
@@ -1807,13 +1838,23 @@ void Compiler::fgPostImportationCleanup()
         }
     }
 
-    // Renumber the basic blocks
-    JITDUMP("\nRenumbering the basic blocks for fgPostImporterCleanup\n");
-    fgRenumberBlocks();
+    // Did we alter any flow or EH?
+    //
+    const bool madeChanges = (addedBlocks > 0) || (delCnt > 0) || (removedBlks > 0);
+
+    // Renumber the basic blocks if so.
+    //
+    if (madeChanges)
+    {
+        JITDUMP("\nRenumbering the basic blocks for fgPostImportationCleanup\n");
+        fgRenumberBlocks();
+    }
 
 #ifdef DEBUG
     fgVerifyHandlerTab();
 #endif // DEBUG
+
+    return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 
 //-------------------------------------------------------------

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3511,7 +3511,7 @@ PhaseStatus Compiler::fgComputeBlockAndEdgeWeights()
 //   that were not profiled and do not yet have weights.
 //
 // Arguments
-//    return weight [out] - sum of weights for all return and throw blocks
+//    returnWeight [out] - sum of weights for all return and throw blocks
 //
 // Returns:
 //    true if any changes made

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3464,15 +3464,16 @@ void flowList::setEdgeWeights(weight_t theMinWeight, weight_t theMaxWeight, Basi
 // fgComputeBlockAndEdgeWeights: determine weights for blocks
 //   and optionally for edges
 //
-void Compiler::fgComputeBlockAndEdgeWeights()
+// Returns:
+//    Suitable phase status
+//
+PhaseStatus Compiler::fgComputeBlockAndEdgeWeights()
 {
-    JITDUMP("*************** In fgComputeBlockAndEdgeWeights()\n");
-
     const bool usingProfileWeights = fgIsUsingProfileWeights();
-
-    fgModified             = false;
-    fgHaveValidEdgeWeights = false;
-    fgCalledCount          = BB_UNITY_WEIGHT;
+    bool       madeChanges         = false;
+    fgModified                     = false;
+    fgHaveValidEdgeWeights         = false;
+    fgCalledCount                  = BB_UNITY_WEIGHT;
 
 #if DEBUG
     if (verbose)
@@ -3482,35 +3483,47 @@ void Compiler::fgComputeBlockAndEdgeWeights()
     }
 #endif // DEBUG
 
-    const weight_t returnWeight = fgComputeMissingBlockWeights();
+    weight_t returnWeight = BB_UNITY_WEIGHT;
+
+    madeChanges |= fgComputeMissingBlockWeights(&returnWeight);
 
     if (usingProfileWeights)
     {
-        fgComputeCalledCount(returnWeight);
+        madeChanges |= fgComputeCalledCount(returnWeight);
     }
     else
     {
         JITDUMP(" -- no profile data, so using default called count\n");
     }
 
-    fgComputeEdgeWeights();
+    PhaseStatus edgeStatus = fgComputeEdgeWeights();
+
+    if (edgeStatus != PhaseStatus::MODIFIED_NOTHING)
+    {
+        return edgeStatus;
+    }
+
+    return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 
 //-------------------------------------------------------------
 // fgComputeMissingBlockWeights: determine weights for blocks
 //   that were not profiled and do not yet have weights.
 //
+// Arguments
+//    return weight [out] - sum of weights for all return and throw blocks
+//
 // Returns:
-//   sum of weights for all return and throw blocks in the method
-
-weight_t Compiler::fgComputeMissingBlockWeights()
+//    true if any changes made
+//
+bool Compiler::fgComputeMissingBlockWeights(weight_t* returnWeight)
 {
     BasicBlock* bSrc;
     BasicBlock* bDst;
     unsigned    iterations = 0;
     bool        changed;
     bool        modified = false;
-    weight_t    returnWeight;
+    weight_t    weight;
 
     // If we have any blocks that did not have profile derived weight
     // we will try to fix their weight up here
@@ -3518,8 +3531,8 @@ weight_t Compiler::fgComputeMissingBlockWeights()
     modified = false;
     do // while (changed)
     {
-        changed      = false;
-        returnWeight = 0;
+        changed = false;
+        weight  = 0;
         iterations++;
 
         for (bDst = fgFirstBB; bDst != nullptr; bDst = bDst->bbNext)
@@ -3640,7 +3653,7 @@ weight_t Compiler::fgComputeMissingBlockWeights()
             //
             if (bDst->hasProfileWeight() && bDst->KindIs(BBJ_RETURN, BBJ_THROW))
             {
-                returnWeight += bDst->bbWeight;
+                weight += bDst->bbWeight;
             }
         }
     }
@@ -3658,7 +3671,9 @@ weight_t Compiler::fgComputeMissingBlockWeights()
     }
 #endif
 
-    return returnWeight;
+    *returnWeight = weight;
+
+    return modified;
 }
 
 //-------------------------------------------------------------
@@ -3667,12 +3682,16 @@ weight_t Compiler::fgComputeMissingBlockWeights()
 //
 // Argument:
 //   returnWeight - sum of weights for all return and throw blocks
-
-void Compiler::fgComputeCalledCount(weight_t returnWeight)
+//
+// Returns:
+//   true if any changes were made
+//
+bool Compiler::fgComputeCalledCount(weight_t returnWeight)
 {
     // When we are not using profile data we have already setup fgCalledCount
     // only set it here if we are using profile data
     assert(fgIsUsingProfileWeights());
+    bool madeChanges = false;
 
     BasicBlock* firstILBlock = fgFirstBB; // The first block for IL code (i.e. for the IL code at offset 0)
 
@@ -3714,6 +3733,7 @@ void Compiler::fgComputeCalledCount(weight_t returnWeight)
     if (fgFirstBBisScratch())
     {
         fgFirstBB->setBBProfileWeight(fgCalledCount);
+        madeChanges = true;
     }
 
 #if DEBUG
@@ -3722,12 +3742,17 @@ void Compiler::fgComputeCalledCount(weight_t returnWeight)
         printf("We are using the Profile Weights and fgCalledCount is " FMT_WT "\n", fgCalledCount);
     }
 #endif
+
+    return madeChanges;
 }
 
 //-------------------------------------------------------------
 // fgComputeEdgeWeights: compute edge weights from block weights
-
-void Compiler::fgComputeEdgeWeights()
+//
+// Returns:
+//   Suitable phase status
+//
+PhaseStatus Compiler::fgComputeEdgeWeights()
 {
     const bool isOptimizing        = opts.OptimizationEnabled();
     const bool usingProfileWeights = fgIsUsingProfileWeights();
@@ -3735,7 +3760,7 @@ void Compiler::fgComputeEdgeWeights()
     if (!isOptimizing || !usingProfileWeights)
     {
         JITDUMP(" -- not optimizing or no profile data, so not computing edge weights\n");
-        return;
+        return PhaseStatus::MODIFIED_NOTHING;
     }
 
     BasicBlock* bSrc;
@@ -4102,6 +4127,8 @@ EARLY_EXIT:;
 
     fgHaveValidEdgeWeights = !inconsistentProfileData;
     fgEdgeWeightsComputed  = true;
+
+    return PhaseStatus::MODIFIED_EVERYTHING;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3302,9 +3302,6 @@ void Compiler::fgInsertFuncletPrologBlock(BasicBlock* block)
 //------------------------------------------------------------------------
 // fgCreateFuncletPrologBlocks: create prolog blocks for funclets if needed
 //
-// Returns:
-//   true if any changes were made
-//
 // Notes:
 //   Every funclet will have a prolog. That prolog will be inserted as the first instructions
 //   in the first block of the funclet. If the prolog is also the head block of a loop, we
@@ -3313,7 +3310,7 @@ void Compiler::fgInsertFuncletPrologBlock(BasicBlock* block)
 //   block when needed. We detect a loop by looking for any predecessor that isn't in the
 //   handler's try region, since the only way to get into a handler is via that try region.
 //
-bool Compiler::fgCreateFuncletPrologBlocks()
+void Compiler::fgCreateFuncletPrologBlocks()
 {
     noway_assert(fgComputePredsDone);
     noway_assert(!fgDomsComputed); // this function doesn't maintain the dom sets
@@ -3367,8 +3364,6 @@ bool Compiler::fgCreateFuncletPrologBlocks()
         fgDebugCheckBBlist();
 #endif // DEBUG
     }
-
-    return prologBlocksCreated;
 }
 
 //------------------------------------------------------------------------
@@ -3384,7 +3379,7 @@ PhaseStatus Compiler::fgCreateFunclets()
 {
     assert(!fgFuncletsCreated);
 
-    bool madeChanges = fgCreateFuncletPrologBlocks();
+    fgCreateFuncletPrologBlocks();
 
     unsigned           XTnum;
     EHblkDsc*          HBtab;
@@ -3431,7 +3426,6 @@ PhaseStatus Compiler::fgCreateFunclets()
         HBtab->ebdFuncIndex          = funcIdx;
         funcIdx++;
         fgRelocateEHRange(XTnum, FG_RELOCATE_HANDLER);
-        madeChanges = true;
     }
 
     // We better have populated all of them by now
@@ -3444,7 +3438,7 @@ PhaseStatus Compiler::fgCreateFunclets()
 
     fgFuncletsCreated = true;
 
-    return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
+    return (compHndBBtabCount > 0) ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2210,7 +2210,10 @@ public:
 
     //------------------------------------------------------------------------
     // PlaceReturns: Move any generated const return blocks to an appropriate
-    //     spot in the lexical block list.
+    //    spot in the lexical block list.
+    //
+    // Returns:
+    //    True if any returns were impacted.
     //
     // Notes:
     //    The goal is to set things up favorably for a reasonable layout without
@@ -2221,12 +2224,12 @@ public:
     //    there to it can become fallthrough without requiring any motion to be
     //    performed by fgReorderBlocks.
     //
-    void PlaceReturns()
+    bool PlaceReturns()
     {
         if (!mergingReturns)
         {
             // No returns generated => no returns to place.
-            return;
+            return false;
         }
 
         for (unsigned index = 0; index < comp->fgReturnCount; ++index)
@@ -2249,6 +2252,8 @@ public:
             // affect program behavior.
             comp->fgExtendEHRegionAfter(insertionPoint);
         }
+
+        return true;
     }
 
 private:
@@ -2581,24 +2586,35 @@ private:
 };
 }
 
-/*****************************************************************************
-*
-*  Add any internal blocks/trees we may need
-*/
-
-void Compiler::fgAddInternal()
+//------------------------------------------------------------------------
+// fgAddInternal: add blocks and trees to express special method semantics
+//
+// Notes:
+//   * rewrites shared generic catches in to filters
+//   * adds code to handle modifiable this
+//   * determines number of epilogs and merges returns
+//   * does special setup for pinvoke/reverse pinvoke methods
+//   * adds callouts and EH for synchronized methods
+//   * adds just my code callback
+//
+// Returns:
+//   Suitable phase status.
+//
+PhaseStatus Compiler::fgAddInternal()
 {
     noway_assert(!compIsForInlining());
 
+    bool madeChanges = false;
+
     // For runtime determined Exception types we're going to emit a fake EH filter with isinst for this
     // type with a runtime lookup
-    fgCreateFiltersForGenericExceptions();
+    madeChanges |= fgCreateFiltersForGenericExceptions();
 
     // The backend requires a scratch BB into which it can safely insert a P/Invoke method prolog if one is
     // required. Similarly, we need a scratch BB for poisoning. Create it here.
     if (compMethodRequiresPInvokeFrame() || compShouldPoisonFrame())
     {
-        fgEnsureFirstBBisScratch();
+        madeChanges |= fgEnsureFirstBBisScratch();
         fgFirstBB->bbFlags |= BBF_DONT_REMOVE;
     }
 
@@ -2660,6 +2676,8 @@ void Compiler::fgAddInternal()
                 printf("\n");
             }
 #endif
+
+            madeChanges = true;
         }
     }
 
@@ -2732,7 +2750,7 @@ void Compiler::fgAddInternal()
         }
     }
 
-    merger.PlaceReturns();
+    madeChanges |= merger.PlaceReturns();
 
     if (compMethodRequiresPInvokeFrame())
     {
@@ -2796,6 +2814,8 @@ void Compiler::fgAddInternal()
 
         fgEnsureFirstBBisScratch();
         fgNewStmtAtEnd(fgFirstBB, gtNewQmarkNode(TYP_VOID, guardCheckCond, callback->AsColon()));
+
+        madeChanges = true;
     }
 
 #if !defined(FEATURE_EH_FUNCLETS)
@@ -2872,6 +2892,7 @@ void Compiler::fgAddInternal()
         // Reset cookies used to track start and end of the protected region in synchronized methods
         syncStartEmitCookie = NULL;
         syncEndEmitCookie   = NULL;
+        madeChanges         = true;
     }
 
 #endif // !FEATURE_EH_FUNCLETS
@@ -2879,6 +2900,7 @@ void Compiler::fgAddInternal()
     if (opts.IsReversePInvoke())
     {
         fgAddReversePInvokeEnterExit();
+        madeChanges = true;
     }
 
 #ifdef DEBUG
@@ -2889,6 +2911,8 @@ void Compiler::fgAddInternal()
         fgDispHandlerTab();
     }
 #endif
+
+    return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 
 /*****************************************************************************/

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -2512,9 +2512,13 @@ bool Compiler::fgNormalizeEHCase2()
 //     EH filter that performs "catchArg isinst T!!" and in case of success forwards to the
 //     original EH handler.
 //
-
-void Compiler::fgCreateFiltersForGenericExceptions()
+// Returns:
+//     True if any changes were made
+//
+bool Compiler::fgCreateFiltersForGenericExceptions()
 {
+    bool madeChanges = false;
+
     for (unsigned ehNum = 0; ehNum < compHndBBtabCount; ehNum++)
     {
         EHblkDsc* eh = ehGetDsc(ehNum);
@@ -2589,8 +2593,12 @@ void Compiler::fgCreateFiltersForGenericExceptions()
                 fgDumpBlock(filterBb);
             }
 #endif // DEBUG
+
+            madeChanges = true;
         }
     }
+
+    return madeChanges;
 }
 
 bool Compiler::fgNormalizeEHCase3()

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16441,15 +16441,14 @@ void Compiler::fgMorphLocalField(GenTree* tree, GenTree* parent)
 //                            so that fgMorphExpandImplicitByRefArg will know to rewrite their
 //                            appearances using indirections off the pointer parameters.
 //
-void Compiler::fgRetypeImplicitByRefArgs()
+// Returns:
+//    Suitable phase status
+//
+PhaseStatus Compiler::fgRetypeImplicitByRefArgs()
 {
+    bool madeChanges = false;
+
 #if FEATURE_IMPLICIT_BYREFS
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("\n*************** In fgRetypeImplicitByRefArgs()\n");
-    }
-#endif // DEBUG
 
     for (unsigned lclNum = 0; lclNum < info.compArgsCount; lclNum++)
     {
@@ -16457,6 +16456,8 @@ void Compiler::fgRetypeImplicitByRefArgs()
 
         if (lvaIsImplicitByRefLocal(lclNum))
         {
+            madeChanges = true;
+
             unsigned size;
 
             if (varDsc->lvSize() > REGSIZE_BYTES)
@@ -16650,6 +16651,8 @@ void Compiler::fgRetypeImplicitByRefArgs()
     }
 
 #endif // FEATURE_IMPLICIT_BYREFS
+
+    return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -96,6 +96,7 @@ PhaseStatus Compiler::fgMorphInit()
         lvaReturnSpCheck = lvaGrabTempWithImplicitUse(false DEBUGARG("ReturnSpCheck"));
         lvaSetVarDoNotEnregister(lvaReturnSpCheck, DoNotEnregisterReason::ReturnSpCheck);
         lvaGetDesc(lvaReturnSpCheck)->lvType = TYP_I_IMPL;
+        madeChanges                          = true;
     }
 #endif // defined(DEBUG) && defined(TARGET_XARCH)
 
@@ -104,6 +105,7 @@ PhaseStatus Compiler::fgMorphInit()
     {
         lvaCallSpCheck                     = lvaGrabTempWithImplicitUse(false DEBUGARG("CallSpCheck"));
         lvaGetDesc(lvaCallSpCheck)->lvType = TYP_I_IMPL;
+        madeChanges                        = true;
     }
 #endif // defined(DEBUG) && defined(TARGET_X86)
 

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -190,7 +190,7 @@ void Phase::PostPhase(PhaseStatus status)
         PHASE_PROMOTE_STRUCTS,
         PHASE_STR_ADRLCL,
         PHASE_FWD_SUB,
-        // morph implicit byref
+        PHASE_MORPH_IMPBYREF,
         //
         // (enable all phase checks)
         //

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -178,7 +178,7 @@ void Phase::PostPhase(PhaseStatus status)
         PHASE_MORPH_INIT,
         PHASE_MORPH_INLINE,
         PHASE_ALLOCATE_OBJECTS,
-        // add internal
+        PHASE_MORPH_ADD_INTERNAL,
         PHASE_EMPTY_TRY,
         PHASE_EMPTY_FINALLY,
         PHASE_MERGE_FINALLY_CHAINS,

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -197,7 +197,9 @@ void Phase::PostPhase(PhaseStatus status)
         PHASE_MORPH_GLOBAL,
         PHASE_GS_COOKIE,
         PHASE_COMPUTE_EDGE_WEIGHTS,
+#if defined(FEATURE_EH_FUNCLETS)
         PHASE_CREATE_FUNCLETS,
+#endif
         PHASE_INVERT_LOOPS,
         PHASE_OPTIMIZE_FLOW,
         // reachability

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -187,7 +187,7 @@ void Phase::PostPhase(PhaseStatus status)
         PHASE_COMPUTE_PREDS,
         PHASE_MERGE_THROWS,
         PHASE_EARLY_UPDATE_FLOW_GRAPH,
-        // promote structs
+        PHASE_PROMOTE_STRUCTS,
         // mark addr exposed locals
         PHASE_FWD_SUB,
         // morph implicit byref
@@ -221,7 +221,7 @@ void Phase::PostPhase(PhaseStatus status)
         // cse
         // assertion prop
         // range check
-        PHASE_OPT_UPDATE_FLOW_GRAPH,
+        // PHASE_OPT_UPDATE_FLOW_GRAPH,
         // edge weights 2
         PHASE_INSERT_GC_POLLS,
         PHASE_OPTIMIZE_LAYOUT,

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -196,7 +196,7 @@ void Phase::PostPhase(PhaseStatus status)
         //
         PHASE_MORPH_GLOBAL,
         PHASE_GS_COOKIE,
-        // compute edge weights
+        PHASE_COMPUTE_EDGE_WEIGHTS,
         // create funclets
         PHASE_INVERT_LOOPS,
         PHASE_OPTIMIZE_FLOW,

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -197,7 +197,7 @@ void Phase::PostPhase(PhaseStatus status)
         PHASE_MORPH_GLOBAL,
         PHASE_GS_COOKIE,
         PHASE_COMPUTE_EDGE_WEIGHTS,
-        // create funclets
+        PHASE_CREATE_FUNCLETS,
         PHASE_INVERT_LOOPS,
         PHASE_OPTIMIZE_FLOW,
         // reachability

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -167,14 +167,14 @@ void Phase::PostPhase(PhaseStatus status)
     // clang-format off
 
     static Phases s_allowlist[] = {
-        // pre import
+        PHASE_PRE_IMPORT,
         PHASE_INCPROFILE,
         PHASE_IBCPREP,
         PHASE_IMPORTATION,
         PHASE_PATCHPOINTS,
         PHASE_IBCINSTR,
         PHASE_INDXCALL,
-        // post import
+        PHASE_POST_IMPORT,
         // morph init
         PHASE_MORPH_INLINE,
         PHASE_ALLOCATE_OBJECTS,

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -175,7 +175,7 @@ void Phase::PostPhase(PhaseStatus status)
         PHASE_IBCINSTR,
         PHASE_INDXCALL,
         PHASE_POST_IMPORT,
-        // morph init
+        PHASE_MORPH_INIT,
         PHASE_MORPH_INLINE,
         PHASE_ALLOCATE_OBJECTS,
         // add internal

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -183,10 +183,10 @@ void Phase::PostPhase(PhaseStatus status)
         PHASE_EMPTY_FINALLY,
         PHASE_MERGE_FINALLY_CHAINS,
         PHASE_CLONE_FINALLY,
-        // finally flags
-        // compute preds
+        PHASE_UPDATE_FINALLY_FLAGS,
+        PHASE_COMPUTE_PREDS,
         PHASE_MERGE_THROWS,
-        // early fg update
+        PHASE_EARLY_UPDATE_FLOW_GRAPH,
         // promote structs
         // mark addr exposed locals
         PHASE_FWD_SUB,
@@ -221,7 +221,7 @@ void Phase::PostPhase(PhaseStatus status)
         // cse
         // assertion prop
         // range check
-        // update flow
+        PHASE_OPT_UPDATE_FLOW_GRAPH,
         // edge weights 2
         PHASE_INSERT_GC_POLLS,
         PHASE_OPTIMIZE_LAYOUT,

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -195,7 +195,7 @@ void Phase::PostPhase(PhaseStatus status)
         // (enable all phase checks)
         //
         PHASE_MORPH_GLOBAL,
-        // gs cookie
+        PHASE_GS_COOKIE,
         // compute edge weights
         // create funclets
         PHASE_INVERT_LOOPS,

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -188,7 +188,7 @@ void Phase::PostPhase(PhaseStatus status)
         PHASE_MERGE_THROWS,
         PHASE_EARLY_UPDATE_FLOW_GRAPH,
         PHASE_PROMOTE_STRUCTS,
-        // mark addr exposed locals
+        PHASE_STR_ADRLCL,
         PHASE_FWD_SUB,
         // morph implicit byref
         //


### PR DESCRIPTION
There are 20-odd phases that haven't yet been converted to running the common post phase checks. This converts the first half of them.

Note this is a bit of a lie. We actually don't run most checks until morph, but a future change will work on enabling checks throughout the phase list.

I also did a bit of cleanup here and there; most notably we no longer needed `fgResetImplicitByRefRefCount` as it was just setting the counts the values they already had.

Contributes to #2109.
