### PR TITLE
Don't set PublishAot in SDK by default

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.props
@@ -11,8 +11,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
   <PropertyGroup>
-    <!-- Set the publishAot property to true if not set-->
-    <PublishAot Condition="'$(PublishAot)' == ''">true</PublishAot>
+    <!-- Set the publishAot property to true when imported from a package reference. -->
+    <PublishAot Condition="'$(PublishAot)' == '' And '$(AotRuntimePackageLoadedViaSDK)' != 'true'">true</PublishAot>
     <!-- N.B. The ILCompilerTargetsPath is used as a sentinel to indicate a version of this file has already been imported. It will also be the path
          used to import the targets later in the SDK. -->
     <ILCompilerTargetsPath>$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler.SingleEntry.targets</ILCompilerTargetsPath>


### PR DESCRIPTION
Opening this as an alternative to reverting the PublishAot changes in https://github.com/dotnet/runtime/pull/74036.
The intention was to default PublishAot to true when using the package reference, not when using the ILCompiler that ships with the SDK. These props get imported on both paths - I think it was just missing a check.