### PR TITLE
[LoongArch64] The `conv_ovf_i8_i.ilproj` is not supported the LA64.

### DIFF
--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i.ilproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'x64'">true</CLRTestTargetUnsupported>
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm64'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'loongarch64'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

The `conv_ovf_i8_i.ilproj` is not supported the LA64.