### PR TITLE
Enable Android x86 double related issues

### DIFF
--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/ctor.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/ctor.cs
@@ -659,7 +659,7 @@ namespace System.Numerics.Tests
             VerifyBigIntegerUsingIdentities(bigInteger, 0 == expectedValue);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroidX86))]   // disabled on Android x86, see https://github.com/dotnet/runtime/issues/37093
+        [Fact]
         public static void RunCtorByteArrayTests()
         {
             ulong tempUInt64;

--- a/src/libraries/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -1302,7 +1302,7 @@ namespace System.Numerics.Tests
             VerifyRealImaginaryProperties(result, expectedReal, expectedImaginary);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroidX86))]   // disabled on Android x86, see https://github.com/dotnet/runtime/issues/37093
+        [Theory]
         [MemberData(nameof(Boundaries_2_TestData))]
         [MemberData(nameof(Primitives_2_TestData))]
         [MemberData(nameof(SmallRandom_2_TestData))]

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -1504,7 +1504,7 @@ namespace System.Tests
             AssertExtensions.Equal(+expectedResult, double.Atan2Pi(+y, +x), allowedVariance);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotAndroidX86))]   // disabled on Android x86, see https://github.com/dotnet/runtime/issues/71252
+        [Theory]
         [InlineData( double.NaN,               double.NaN,          0.0)]
         [InlineData( 0.0,                      0.0,                 0.0)]
         [InlineData( 1.5574077246549022,       0.31830988618379067, CrossPlatformMachineEpsilon)]

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Cache.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Cache.cs
@@ -22,7 +22,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task MultipleThreads()
         {
             // Verify the test class has >32 properties since that is a threshold for using the fallback dictionary.
@@ -105,7 +104,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task PropertyCacheWithMinInputsLast()
         {
             // Use local options to avoid obtaining already cached metadata from the default options.

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Stream.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Stream.cs
@@ -12,7 +12,6 @@ namespace System.Text.Json.Serialization.Tests
     {
         [Fact]
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task ReadSimpleObjectAsync()
         {
             if (StreamingSerializer is null)
@@ -66,7 +65,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task ReadSimpleObjectWithTrailingTriviaAsync()
         {
             if (StreamingSerializer is null)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
@@ -87,7 +87,6 @@ namespace System.Text.Json.Nodes.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void ExplicitOperators_FromValues()
         {
             Assert.Equal(1, (short)(JsonNode)(short)1);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ContinuationTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ContinuationTests.cs
@@ -124,7 +124,6 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [MemberData(nameof(TestData), /* enumeratePayloadTweaks: */ false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/42677", platforms: TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static async Task ShouldWorkAtAnyPosition_Stream(
             string json,
             int bufferSize,
@@ -183,7 +182,6 @@ namespace System.Text.Json.Serialization.Tests
         [MemberData(nameof(TestData), /* enumeratePayloadTweaks: */ false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/42677", platforms: TestPlatforms.Windows, runtimes: TestRuntimes.Mono)]
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void ShouldWorkAtAnyPosition_Sequence(
             string json,
             int bufferSize,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
@@ -61,11 +61,7 @@ namespace System.Text.Json.Serialization.Tests
             RunAsRootTypeTest(JsonNumberTestData.UInts);
             RunAsRootTypeTest(JsonNumberTestData.ULongs);
             RunAsRootTypeTest(JsonNumberTestData.Floats);
-            // https://github.com/dotnet/runtime/issues/72862
-            if (!PlatformDetection.IsAndroidX86)
-            {
-                RunAsRootTypeTest(JsonNumberTestData.Doubles);
-            }
+            RunAsRootTypeTest(JsonNumberTestData.Doubles);
             RunAsRootTypeTest(JsonNumberTestData.Decimals);
             RunAsRootTypeTest(JsonNumberTestData.NullableBytes);
             RunAsRootTypeTest(JsonNumberTestData.NullableSBytes);
@@ -76,11 +72,7 @@ namespace System.Text.Json.Serialization.Tests
             RunAsRootTypeTest(JsonNumberTestData.NullableUInts);
             RunAsRootTypeTest(JsonNumberTestData.NullableULongs);
             RunAsRootTypeTest(JsonNumberTestData.NullableFloats);
-            // https://github.com/dotnet/runtime/issues/72862
-            if (!PlatformDetection.IsAndroidX86)
-            {
-                RunAsRootTypeTest(JsonNumberTestData.NullableDoubles);
-            }
+            RunAsRootTypeTest(JsonNumberTestData.NullableDoubles);
             RunAsRootTypeTest(JsonNumberTestData.NullableDecimals);
         }
 
@@ -97,15 +89,6 @@ namespace System.Text.Json.Serialization.Tests
 
         private static string GetNumberAsString<T>(T number)
         {
-            // Added float case for x86 android due to nan conversion in below switch
-            // There is active issue https://github.com/dotnet/runtime/issues/68906 on x86 Android 
-#if NETCOREAPP
-            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.X86 && Type.GetTypeCode(typeof(T)) == TypeCode.Single)
-            {
-                return Convert.ToSingle(number).ToString(JsonTestHelper.SingleFormatString, CultureInfo.InvariantCulture);
-            }
-#endif
-
             return number switch
             {
                 double @double => @double.ToString(JsonTestHelper.DoubleFormatString, CultureInfo.InvariantCulture),
@@ -388,11 +371,7 @@ namespace System.Text.Json.Serialization.Tests
             RunAsCollectionElementTest(JsonNumberTestData.UInts);
             RunAsCollectionElementTest(JsonNumberTestData.ULongs);
             RunAsCollectionElementTest(JsonNumberTestData.Floats);
-            // https://github.com/dotnet/runtime/issues/72862
-            if (!PlatformDetection.IsAndroidX86)
-            {
-                RunAsCollectionElementTest(JsonNumberTestData.Doubles);
-            }
+            RunAsCollectionElementTest(JsonNumberTestData.Doubles);
             RunAsCollectionElementTest(JsonNumberTestData.Decimals);
 
             // https://github.com/dotnet/runtime/issues/66220
@@ -407,11 +386,7 @@ namespace System.Text.Json.Serialization.Tests
                 RunAsCollectionElementTest(JsonNumberTestData.NullableUInts);
                 RunAsCollectionElementTest(JsonNumberTestData.NullableULongs);
                 RunAsCollectionElementTest(JsonNumberTestData.NullableFloats);
-                // https://github.com/dotnet/runtime/issues/72862
-                if (!PlatformDetection.IsAndroidX86)
-                {
-                    RunAsCollectionElementTest(JsonNumberTestData.NullableDoubles);
-                }
+                RunAsCollectionElementTest(JsonNumberTestData.NullableDoubles);
                 RunAsCollectionElementTest(JsonNumberTestData.NullableDecimals);
             }
         }
@@ -637,11 +612,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             RunAllDictionariessRoundTripTest(JsonNumberTestData.ULongs);
             RunAllDictionariessRoundTripTest(JsonNumberTestData.Floats);
-            // https://github.com/dotnet/runtime/issues/72862
-            if (!PlatformDetection.IsAndroidX86)
-            {
-                RunAllDictionariessRoundTripTest(JsonNumberTestData.Doubles);
-            }
+            RunAllDictionariessRoundTripTest(JsonNumberTestData.Doubles);
         }
 
         private static void RunAllDictionariessRoundTripTest<T>(List<T> numbers)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.cs
@@ -15,7 +15,6 @@ namespace System.Text.Json.Tests
     public static partial class Utf8JsonReaderTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void TestingNumbers_TryGetMethods()
         {
             byte[] dataUtf8 = JsonNumberTestData.JsonData;
@@ -154,7 +153,6 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72862", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public static void TestingNumbers_GetMethods()
         {
             byte[] dataUtf8 = JsonNumberTestData.JsonData;


### PR DESCRIPTION
Issue was fixed by https://github.com/dotnet/runtime/pull/65723, enabling all related tests.

Fixes #72862
Fixes #37093
Fixes #71252
Fixes #68906