### PR TITLE
[release/7.0-rc1] Vectorize {Last}IndexOf{Any}{Except} without code duplication

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -176,7 +176,7 @@ namespace System.StubHelpers
 
         internal static unsafe string ConvertFixedToManaged(IntPtr cstr, int length)
         {
-            int end = SpanHelpers.IndexOf(ref *(byte*)cstr, 0, length);
+            int end = new ReadOnlySpan<byte>((byte*)cstr, length).IndexOf((byte)0);
             if (end >= 0)
             {
                 length = end;
@@ -450,7 +450,7 @@ namespace System.StubHelpers
 
         internal static unsafe string ConvertToManaged(IntPtr nativeHome, int length)
         {
-            int end = SpanHelpers.IndexOf(ref *(char*)nativeHome, '\0', length);
+            int end = new ReadOnlySpan<char>((char*)nativeHome, length).IndexOf('\0');
             if (end >= 0)
             {
                 length = end;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -55,8 +55,8 @@ namespace Internal.Runtime.CompilerHelpers
 
         public static unsafe string ByValAnsiStringToString(byte* buffer, int length)
         {
-            int end = SpanHelpers.IndexOf(ref *(byte*)buffer, 0, length);
-            if (end != -1)
+            int end = new ReadOnlySpan<byte>(buffer, length).IndexOf((byte)0);
+            if (end >= 0)
             {
                 length = end;
             }
@@ -77,8 +77,8 @@ namespace Internal.Runtime.CompilerHelpers
 
         internal static unsafe string UnicodeToStringFixedArray(ushort* buffer, int length)
         {
-            int end = SpanHelpers.IndexOf(ref *(char*)buffer, '\0', length);
-            if (end != -1)
+            int end = new ReadOnlySpan<char>(buffer, length).IndexOf('\0');
+            if (end >= 0)
             {
                 length = end;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1328,17 +1328,17 @@ namespace System
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
-                    int result = SpanHelpers.IndexOf(
+                    int result = SpanHelpers.IndexOfValueType(
                         ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<byte[]>(array)), startIndex),
                         Unsafe.As<T, byte>(ref value),
                         count);
                     return (result >= 0 ? startIndex : 0) + result;
                 }
-                else if (Unsafe.SizeOf<T>() == sizeof(char))
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
                 {
-                    int result = SpanHelpers.IndexOf(
-                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<char[]>(array)), startIndex),
-                        Unsafe.As<T, char>(ref value),
+                    int result = SpanHelpers.IndexOfValueType(
+                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<short[]>(array)), startIndex),
+                        Unsafe.As<T, short>(ref value),
                         count);
                     return (result >= 0 ? startIndex : 0) + result;
                 }
@@ -1586,19 +1586,19 @@ namespace System
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
                     int endIndex = startIndex - count + 1;
-                    int result = SpanHelpers.LastIndexOf(
+                    int result = SpanHelpers.LastIndexOfValueType(
                         ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<byte[]>(array)), endIndex),
                         Unsafe.As<T, byte>(ref value),
                         count);
 
                     return (result >= 0 ? endIndex : 0) + result;
                 }
-                else if (Unsafe.SizeOf<T>() == sizeof(char))
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
                 {
                     int endIndex = startIndex - count + 1;
-                    int result = SpanHelpers.LastIndexOf(
-                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<char[]>(array)), endIndex),
-                        Unsafe.As<T, char>(ref value),
+                    int result = SpanHelpers.LastIndexOfValueType(
+                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<short[]>(array)), endIndex),
+                        Unsafe.As<T, short>(ref value),
                         count);
 
                     return (result >= 0 ? endIndex : 0) + result;
@@ -1606,7 +1606,7 @@ namespace System
                 else if (Unsafe.SizeOf<T>() == sizeof(int))
                 {
                     int endIndex = startIndex - count + 1;
-                    int result = SpanHelpers.LastIndexOf(
+                    int result = SpanHelpers.LastIndexOfValueType(
                         ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<int[]>(array)), endIndex),
                         Unsafe.As<T, int>(ref value),
                         count);
@@ -1616,7 +1616,7 @@ namespace System
                 else if (Unsafe.SizeOf<T>() == sizeof(long))
                 {
                     int endIndex = startIndex - count + 1;
-                    int result = SpanHelpers.LastIndexOf(
+                    int result = SpanHelpers.LastIndexOfValueType(
                         ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<long[]>(array)), endIndex),
                         Unsafe.As<T, long>(ref value),
                         count);

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -436,7 +436,7 @@ namespace System
             int ulValuesLength = ulValues.Length;
             ref ulong start = ref MemoryMarshal.GetArrayDataReference(ulValues);
             return ulValuesLength <= NumberOfValuesThreshold ?
-                SpanHelpers.IndexOf(ref start, ulValue, ulValuesLength) :
+                SpanHelpers.IndexOfValueType(ref Unsafe.As<ulong, long>(ref start), (long)ulValue, ulValuesLength) :
                 SpanHelpers.BinarySearch(ref start, ulValuesLength, ulValue);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -264,8 +264,8 @@ namespace System.Globalization
             {
                 // Do a quick search for the first element of "value".
                 int relativeIndex = isLetter ?
-                    SpanHelpers.IndexOfAny(ref Unsafe.Add(ref searchSpace, offset), valueCharU, valueCharL, searchSpaceLength) :
-                    SpanHelpers.IndexOf(ref Unsafe.Add(ref searchSpace, offset), valueChar, searchSpaceLength);
+                    SpanHelpers.IndexOfAnyChar(ref Unsafe.Add(ref searchSpace, offset), valueCharU, valueCharL, searchSpaceLength) :
+                    SpanHelpers.IndexOfChar(ref Unsafe.Add(ref searchSpace, offset), valueChar, searchSpaceLength);
                 if (relativeIndex < 0)
                 {
                     break;

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 
 namespace System
 {
@@ -269,28 +268,33 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.Contains(
+                {
+                    return SpanHelpers.ContainsValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.Contains(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value),
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.ContainsValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(int))
-                    return 0 <= SpanHelpers.IndexOfValueType(
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                {
+                    return SpanHelpers.ContainsValueType(
                         ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, int>(ref value),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(long))
-                    return 0 <= SpanHelpers.IndexOfValueType(
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(long))
+                {
+                    return SpanHelpers.ContainsValueType(
                         ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, long>(ref value),
                         span.Length);
+                }
             }
 
             return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
@@ -308,28 +312,33 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.Contains(
+                {
+                    return SpanHelpers.ContainsValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.Contains(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value),
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.ContainsValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(int))
-                    return 0 <= SpanHelpers.IndexOfValueType(
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                {
+                    return SpanHelpers.ContainsValueType(
                         ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, int>(ref value),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(long))
-                    return 0 <= SpanHelpers.IndexOfValueType(
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(long))
+                {
+                    return SpanHelpers.ContainsValueType(
                         ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, long>(ref value),
                         span.Length);
+                }
             }
 
             return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
@@ -346,15 +355,15 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.IndexOf(
+                    return SpanHelpers.IndexOfValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value),
                         span.Length);
 
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.IndexOf(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value),
+                if (Unsafe.SizeOf<T>() == sizeof(short))
+                    return SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value),
                         span.Length);
 
                 if (Unsafe.SizeOf<T>() == sizeof(int))
@@ -412,16 +421,33 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.LastIndexOf(
+                {
+                    return SpanHelpers.LastIndexOfValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.LastIndexOf(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value),
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value),
                         span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                {
+                    return SpanHelpers.LastIndexOfValueType(
+                        ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, int>(ref value),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(long))
+                {
+                    return SpanHelpers.LastIndexOfValueType(
+                        ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, long>(ref value),
+                        span.Length);
+                }
             }
 
             return SpanHelpers.LastIndexOf<T>(ref MemoryMarshal.GetReference(span), value, span.Length);
@@ -503,7 +529,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T>?
         {
-            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            if (SpanHelpers.CanVectorizeAndBenefit<T>(span.Length))
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
@@ -512,36 +538,34 @@ namespace System
                         Unsafe.As<T, byte>(ref value),
                         span.Length);
                 }
-
-                if (Unsafe.SizeOf<T>() == sizeof(short))
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
                 {
                     return SpanHelpers.IndexOfAnyExceptValueType(
                         ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, short>(ref value),
                         span.Length);
                 }
-
-                if (Unsafe.SizeOf<T>() == sizeof(int))
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
                 {
                     return SpanHelpers.IndexOfAnyExceptValueType(
                         ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, int>(ref value),
                         span.Length);
                 }
-
-                if (Unsafe.SizeOf<T>() == sizeof(long))
+                else
                 {
+                    Debug.Assert(Unsafe.SizeOf<T>() == sizeof(long));
+
                     return SpanHelpers.IndexOfAnyExceptValueType(
                         ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, long>(ref value),
                         span.Length);
                 }
             }
-
-            return SpanHelpers.IndexOfAnyExcept(
-                ref MemoryMarshal.GetReference(span),
-                value,
-                span.Length);
+            else
+            {
+                return SpanHelpers.IndexOfAnyExcept(ref MemoryMarshal.GetReference(span), value, span.Length);
+            }
         }
 
         /// <summary>Searches for the first index of any value other than the specified <paramref name="value0"/> or <paramref name="value1"/>.</summary>
@@ -553,18 +577,30 @@ namespace System
         /// The index in the span of the first occurrence of any value other than <paramref name="value0"/> and <paramref name="value1"/>.
         /// If all of the values are <paramref name="value0"/> or <paramref name="value1"/>, returns -1.
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T>?
         {
-            for (int i = 0; i < span.Length; i++)
+            if (SpanHelpers.CanVectorizeAndBenefit<T>(span.Length))
             {
-                if (!EqualityComparer<T>.Default.Equals(span[i], value0) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value1))
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
-                    return i;
+                    return SpanHelpers.IndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.IndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        span.Length);
                 }
             }
 
-            return -1;
+            return SpanHelpers.IndexOfAnyExcept(ref MemoryMarshal.GetReference(span), value0, value1, span.Length);
         }
 
         /// <summary>Searches for the first index of any value other than the specified <paramref name="value0"/>, <paramref name="value1"/>, or <paramref name="value2"/>.</summary>
@@ -577,25 +613,38 @@ namespace System
         /// The index in the span of the first occurrence of any value other than <paramref name="value0"/>, <paramref name="value1"/>, and <paramref name="value2"/>.
         /// If all of the values are <paramref name="value0"/>, <paramref name="value1"/>, and <paramref name="value2"/>, returns -1.
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T>?
         {
-            for (int i = 0; i < span.Length; i++)
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
-                if (!EqualityComparer<T>.Default.Equals(span[i], value0) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value1) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value2))
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
-                    return i;
+                    return SpanHelpers.IndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        Unsafe.As<T, byte>(ref value2),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.IndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        Unsafe.As<T, short>(ref value2),
+                        span.Length);
                 }
             }
 
-            return -1;
+            return SpanHelpers.IndexOfAnyExcept(ref MemoryMarshal.GetReference(span), value0, value1, value2, span.Length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2, T value3) where T : IEquatable<T>?
+        private static int IndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2, T value3) where T : IEquatable<T>?
         {
-            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            if (SpanHelpers.CanVectorizeAndBenefit<T>(span.Length))
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
@@ -617,40 +666,9 @@ namespace System
                         Unsafe.As<T, short>(ref value3),
                         span.Length);
                 }
-                else if (Unsafe.SizeOf<T>() == sizeof(int))
-                {
-                    return SpanHelpers.IndexOfAnyExceptValueType(
-                        ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, int>(ref value0),
-                        Unsafe.As<T, int>(ref value1),
-                        Unsafe.As<T, int>(ref value2),
-                        Unsafe.As<T, int>(ref value3),
-                        span.Length);
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(long))
-                {
-                    return SpanHelpers.IndexOfAnyExceptValueType(
-                        ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, long>(ref value0),
-                        Unsafe.As<T, long>(ref value1),
-                        Unsafe.As<T, long>(ref value2),
-                        Unsafe.As<T, long>(ref value3),
-                        span.Length);
-                }
             }
 
-            for (int i = 0; i < span.Length; i++)
-            {
-                if (!EqualityComparer<T>.Default.Equals(span[i], value0) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value1) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value2) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value3))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
+            return SpanHelpers.IndexOfAnyExcept(ref MemoryMarshal.GetReference(span), value0, value1, value2, value3, span.Length);
         }
 
         /// <summary>Searches for the first index of any value other than the specified <paramref name="values"/>.</summary>
@@ -680,7 +698,7 @@ namespace System
                 case 3:
                     return IndexOfAnyExcept(span, values[0], values[1], values[2]);
 
-                case 4: // common for searching whitespaces
+                case 4:
                     return IndexOfAnyExcept(span, values[0], values[1], values[2], values[3]);
 
                 default:
@@ -751,17 +769,46 @@ namespace System
         /// The index in the span of the last occurrence of any value other than <paramref name="value"/>.
         /// If all of the values are <paramref name="value"/>, returns -1.
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value) where T : IEquatable<T>?
         {
-            for (int i = span.Length - 1; i >= 0; i--)
+            if (SpanHelpers.CanVectorizeAndBenefit<T>(span.Length))
             {
-                if (!EqualityComparer<T>.Default.Equals(span[i], value))
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
-                    return i;
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                {
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, int>(ref value),
+                        span.Length);
+                }
+                else
+                {
+                    Debug.Assert(Unsafe.SizeOf<T>() == sizeof(long));
+
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, long>(ref value),
+                        span.Length);
                 }
             }
-
-            return -1;
+            else
+            {
+                return SpanHelpers.LastIndexOfAnyExcept(ref MemoryMarshal.GetReference(span), value, span.Length);
+            }
         }
 
         /// <summary>Searches for the last index of any value other than the specified <paramref name="value0"/> or <paramref name="value1"/>.</summary>
@@ -773,18 +820,30 @@ namespace System
         /// The index in the span of the last occurrence of any value other than <paramref name="value0"/> and <paramref name="value1"/>.
         /// If all of the values are <paramref name="value0"/> or <paramref name="value1"/>, returns -1.
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T>?
         {
-            for (int i = span.Length - 1; i >= 0; i--)
+            if (SpanHelpers.CanVectorizeAndBenefit<T>(span.Length))
             {
-                if (!EqualityComparer<T>.Default.Equals(span[i], value0) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value1))
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
-                    return i;
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        span.Length);
                 }
             }
 
-            return -1;
+            return SpanHelpers.LastIndexOfAnyExcept(ref MemoryMarshal.GetReference(span), value0, value1, span.Length);
         }
 
         /// <summary>Searches for the last index of any value other than the specified <paramref name="value0"/>, <paramref name="value1"/>, or <paramref name="value2"/>.</summary>
@@ -797,19 +856,62 @@ namespace System
         /// The index in the span of the last occurrence of any value other than <paramref name="value0"/>, <paramref name="value1"/>, and <paramref name="value2"/>.
         /// If all of the values are <paramref name="value0"/>, <paramref name="value1"/>, and <paramref name="value2"/>, returns -1.
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T>?
         {
-            for (int i = span.Length - 1; i >= 0; i--)
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
-                if (!EqualityComparer<T>.Default.Equals(span[i], value0) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value1) &&
-                    !EqualityComparer<T>.Default.Equals(span[i], value2))
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
-                    return i;
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        Unsafe.As<T, byte>(ref value2),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        Unsafe.As<T, short>(ref value2),
+                        span.Length);
                 }
             }
 
-            return -1;
+            return SpanHelpers.LastIndexOfAnyExcept(ref MemoryMarshal.GetReference(span), value0, value1, value2, span.Length);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LastIndexOfAnyExcept<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2, T value3) where T : IEquatable<T>?
+        {
+            if (SpanHelpers.CanVectorizeAndBenefit<T>(span.Length))
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                {
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        Unsafe.As<T, byte>(ref value2),
+                        Unsafe.As<T, byte>(ref value3),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfAnyExceptValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        Unsafe.As<T, short>(ref value2),
+                        Unsafe.As<T, short>(ref value3),
+                        span.Length);
+                }
+            }
+
+            return SpanHelpers.LastIndexOfAnyExcept(ref MemoryMarshal.GetReference(span), value0, value1, value2, value3, span.Length);
         }
 
         /// <summary>Searches for the last index of any value other than the specified <paramref name="values"/>.</summary>
@@ -839,6 +941,9 @@ namespace System
 
                 case 3:
                     return LastIndexOfAnyExcept(span, values[0], values[1], values[2]);
+
+                case 4:
+                    return LastIndexOfAnyExcept(span, values[0], values[1], values[2], values[3]);
 
                 default:
                     for (int i = span.Length - 1; i >= 0; i--)
@@ -912,15 +1017,27 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.IndexOf(
+                    return SpanHelpers.IndexOfValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value),
                         span.Length);
 
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.IndexOf(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value),
+                if (Unsafe.SizeOf<T>() == sizeof(short))
+                    return SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value),
+                        span.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(int))
+                    return SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, int>(ref value),
+                        span.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(long))
+                    return SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, long>(ref value),
                         span.Length);
             }
 
@@ -966,16 +1083,33 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.LastIndexOf(
-                            ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
-                            Unsafe.As<T, byte>(ref value),
-                            span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.LastIndexOf(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value),
+                {
+                    return SpanHelpers.LastIndexOfValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value),
                         span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                {
+                    return SpanHelpers.LastIndexOfValueType(
+                        ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, int>(ref value),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(long))
+                {
+                    return SpanHelpers.LastIndexOfValueType(
+                        ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, long>(ref value),
+                        span.Length);
+                }
             }
 
             return SpanHelpers.LastIndexOf<T>(ref MemoryMarshal.GetReference(span), value, span.Length);
@@ -1024,18 +1158,21 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.IndexOfAny(
+                {
+                    return SpanHelpers.IndexOfAnyValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value0),
                         Unsafe.As<T, byte>(ref value1),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.IndexOfAny(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value0),
-                        Unsafe.As<T, char>(ref value1),
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.IndexOfAnyValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
                         span.Length);
+                }
             }
 
             return SpanHelpers.IndexOfAny(ref MemoryMarshal.GetReference(span), value0, value1, span.Length);
@@ -1054,20 +1191,23 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.IndexOfAny(
+                {
+                    return SpanHelpers.IndexOfAnyValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value0),
                         Unsafe.As<T, byte>(ref value1),
                         Unsafe.As<T, byte>(ref value2),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.IndexOfAny(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value0),
-                        Unsafe.As<T, char>(ref value1),
-                        Unsafe.As<T, char>(ref value2),
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.IndexOfAnyValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        Unsafe.As<T, short>(ref value2),
                         span.Length);
+                }
             }
 
             return SpanHelpers.IndexOfAny(ref MemoryMarshal.GetReference(span), value0, value1, value2, span.Length);
@@ -1094,18 +1234,21 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.IndexOfAny(
+                {
+                    return SpanHelpers.IndexOfAnyValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value0),
                         Unsafe.As<T, byte>(ref value1),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.IndexOfAny(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value0),
-                        Unsafe.As<T, char>(ref value1),
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.IndexOfAnyValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
                         span.Length);
+                }
             }
 
             return SpanHelpers.IndexOfAny(ref MemoryMarshal.GetReference(span), value0, value1, span.Length);
@@ -1124,20 +1267,23 @@ namespace System
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
-                    return SpanHelpers.IndexOfAny(
+                {
+                    return SpanHelpers.IndexOfAnyValueType(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref value0),
                         Unsafe.As<T, byte>(ref value1),
                         Unsafe.As<T, byte>(ref value2),
                         span.Length);
-
-                if (Unsafe.SizeOf<T>() == sizeof(char))
-                    return SpanHelpers.IndexOfAny(
-                        ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                        Unsafe.As<T, char>(ref value0),
-                        Unsafe.As<T, char>(ref value1),
-                        Unsafe.As<T, char>(ref value2),
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.IndexOfAnyValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        Unsafe.As<T, short>(ref value2),
                         span.Length);
+                }
             }
 
             return SpanHelpers.IndexOfAny(ref MemoryMarshal.GetReference(span), value0, value1, value2, span.Length);
@@ -1158,7 +1304,7 @@ namespace System
                     ref byte valueRef = ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values));
                     if (values.Length == 2)
                     {
-                        return SpanHelpers.IndexOfAny(
+                        return SpanHelpers.IndexOfAnyValueType(
                             ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                             valueRef,
                             Unsafe.Add(ref valueRef, 1),
@@ -1166,7 +1312,7 @@ namespace System
                     }
                     else if (values.Length == 3)
                     {
-                        return SpanHelpers.IndexOfAny(
+                        return SpanHelpers.IndexOfAnyValueType(
                             ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                             valueRef,
                             Unsafe.Add(ref valueRef, 1),
@@ -1175,30 +1321,27 @@ namespace System
                     }
                 }
 
-                if (Unsafe.SizeOf<T>() == sizeof(char))
+                if (Unsafe.SizeOf<T>() == sizeof(short))
                 {
-                    ref char spanRef = ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span));
-                    ref char valueRef = ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(values));
+                    ref short spanRef = ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span));
+                    ref short valueRef = ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(values));
                     switch (values.Length)
                     {
                         case 0:
                             return -1;
 
                         case 1:
-                            return SpanHelpers.IndexOf(
-                                ref spanRef,
-                                valueRef,
-                                span.Length);
+                            return SpanHelpers.IndexOfValueType(ref spanRef, valueRef, span.Length);
 
                         case 2:
-                            return SpanHelpers.IndexOfAny(
+                            return SpanHelpers.IndexOfAnyValueType(
                                 ref spanRef,
                                 valueRef,
                                 Unsafe.Add(ref valueRef, 1),
                                 span.Length);
 
                         case 3:
-                            return SpanHelpers.IndexOfAny(
+                            return SpanHelpers.IndexOfAnyValueType(
                                 ref spanRef,
                                 valueRef,
                                 Unsafe.Add(ref valueRef, 1),
@@ -1206,7 +1349,7 @@ namespace System
                                 span.Length);
 
                         case 4:
-                            return SpanHelpers.IndexOfAny(
+                            return SpanHelpers.IndexOfAnyValueType(
                                 ref spanRef,
                                 valueRef,
                                 Unsafe.Add(ref valueRef, 1),
@@ -1215,7 +1358,7 @@ namespace System
                                 span.Length);
 
                         case 5:
-                            return SpanHelpers.IndexOfAny(
+                            return SpanHelpers.IndexOfAnyValueType(
                                 ref spanRef,
                                 valueRef,
                                 Unsafe.Add(ref valueRef, 1),
@@ -1225,7 +1368,7 @@ namespace System
                                 span.Length);
 
                         default:
-                            return IndexOfAnyProbabilistic(ref spanRef, span.Length, ref valueRef, values.Length);
+                            return IndexOfAnyProbabilistic(ref Unsafe.As<short, char>(ref spanRef), span.Length, ref Unsafe.As<short, char>(ref valueRef), values.Length);
                     }
                 }
             }
@@ -1272,12 +1415,25 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAny<T>(this Span<T> span, T value0, T value1) where T : IEquatable<T>?
         {
-            if (Unsafe.SizeOf<T>() == sizeof(byte) && RuntimeHelpers.IsBitwiseEquatable<T>())
-                return SpanHelpers.LastIndexOfAny(
-                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
-                    Unsafe.As<T, byte>(ref value0),
-                    Unsafe.As<T, byte>(ref value1),
-                    span.Length);
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                {
+                    return SpanHelpers.LastIndexOfAnyValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfAnyValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        span.Length);
+                }
+            }
 
             return SpanHelpers.LastIndexOfAny(ref MemoryMarshal.GetReference(span), value0, value1, span.Length);
         }
@@ -1292,13 +1448,27 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAny<T>(this Span<T> span, T value0, T value1, T value2) where T : IEquatable<T>?
         {
-            if (Unsafe.SizeOf<T>() == sizeof(byte) && RuntimeHelpers.IsBitwiseEquatable<T>())
-                return SpanHelpers.LastIndexOfAny(
-                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
-                    Unsafe.As<T, byte>(ref value0),
-                    Unsafe.As<T, byte>(ref value1),
-                    Unsafe.As<T, byte>(ref value2),
-                    span.Length);
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                {
+                    return SpanHelpers.LastIndexOfAnyValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        Unsafe.As<T, byte>(ref value2),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfAnyValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        Unsafe.As<T, short>(ref value2),
+                        span.Length);
+                }
+            }
 
             return SpanHelpers.LastIndexOfAny(ref MemoryMarshal.GetReference(span), value0, value1, value2, span.Length);
         }
@@ -1330,12 +1500,25 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1) where T : IEquatable<T>?
         {
-            if (Unsafe.SizeOf<T>() == sizeof(byte) && RuntimeHelpers.IsBitwiseEquatable<T>())
-                return SpanHelpers.LastIndexOfAny(
-                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
-                    Unsafe.As<T, byte>(ref value0),
-                    Unsafe.As<T, byte>(ref value1),
-                    span.Length);
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                {
+                    return SpanHelpers.LastIndexOfAnyValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfAnyValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        span.Length);
+                }
+            }
 
             return SpanHelpers.LastIndexOfAny(ref MemoryMarshal.GetReference(span), value0, value1, span.Length);
         }
@@ -1350,13 +1533,27 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2) where T : IEquatable<T>?
         {
-            if (Unsafe.SizeOf<T>() == sizeof(byte) && RuntimeHelpers.IsBitwiseEquatable<T>())
-                return SpanHelpers.LastIndexOfAny(
-                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
-                    Unsafe.As<T, byte>(ref value0),
-                    Unsafe.As<T, byte>(ref value1),
-                    Unsafe.As<T, byte>(ref value2),
-                    span.Length);
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                {
+                    return SpanHelpers.LastIndexOfAnyValueType(
+                        ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, byte>(ref value0),
+                        Unsafe.As<T, byte>(ref value1),
+                        Unsafe.As<T, byte>(ref value2),
+                        span.Length);
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return SpanHelpers.LastIndexOfAnyValueType(
+                        ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, short>(ref value0),
+                        Unsafe.As<T, short>(ref value1),
+                        Unsafe.As<T, short>(ref value2),
+                        span.Length);
+                }
+            }
 
             return SpanHelpers.LastIndexOfAny(ref MemoryMarshal.GetReference(span), value0, value1, value2, span.Length);
         }
@@ -1371,28 +1568,66 @@ namespace System
         {
             if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
-                if (Unsafe.SizeOf<T>() == sizeof(char))
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
+                    ref byte valueRef = ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values));
+                    if (values.Length == 2)
+                    {
+                        return SpanHelpers.LastIndexOfAnyValueType(
+                            ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                            valueRef,
+                            Unsafe.Add(ref valueRef, 1),
+                            span.Length);
+                    }
+                    else if (values.Length == 3)
+                    {
+                        return SpanHelpers.LastIndexOfAnyValueType(
+                            ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                            valueRef,
+                            Unsafe.Add(ref valueRef, 1),
+                            Unsafe.Add(ref valueRef, 2),
+                            span.Length);
+                    }
+                }
+
+                if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    ref short spanRef = ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(span));
+                    ref short valueRef = ref Unsafe.As<T, short>(ref MemoryMarshal.GetReference(values));
                     switch (values.Length)
                     {
                         case 0:
                             return -1;
 
                         case 1:
-                            return LastIndexOf(span, values[0]);
+                            return SpanHelpers.LastIndexOfValueType(ref spanRef, valueRef, span.Length);
 
                         case 2:
-                            return LastIndexOfAny(span, values[0], values[1]);
+                            return SpanHelpers.LastIndexOfAnyValueType(
+                                ref spanRef,
+                                valueRef,
+                                Unsafe.Add(ref valueRef, 1),
+                                span.Length);
 
                         case 3:
-                            return LastIndexOfAny(span, values[0], values[1], values[2]);
+                            return SpanHelpers.LastIndexOfAnyValueType(
+                                ref spanRef,
+                                valueRef,
+                                Unsafe.Add(ref valueRef, 1),
+                                Unsafe.Add(ref valueRef, 2),
+                                span.Length);
+
+                        case 4:
+                            return SpanHelpers.LastIndexOfAnyValueType(
+                                ref spanRef,
+                                valueRef,
+                                Unsafe.Add(ref valueRef, 1),
+                                Unsafe.Add(ref valueRef, 2),
+                                Unsafe.Add(ref valueRef, 3),
+                                span.Length);
 
                         default:
-                            return LastIndexOfAnyProbabilistic(
-                                ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                                span.Length,
-                                ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(values)),
-                                values.Length);
+                            return LastIndexOfAnyProbabilistic(ref Unsafe.As<short, char>(ref spanRef), span.Length, ref Unsafe.As<short, char>(ref valueRef), values.Length);
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System
@@ -22,7 +22,7 @@ namespace System
 
             int valueTailLength = valueLength - 1;
             if (valueTailLength == 0)
-                return IndexOf(ref searchSpace, value, searchSpaceLength); // for single-byte values use plain IndexOf
+                return IndexOfValueType(ref searchSpace, value, searchSpaceLength); // for single-byte values use plain IndexOf
 
             nint offset = 0;
             byte valueHead = value;
@@ -38,7 +38,7 @@ namespace System
             while (remainingSearchSpaceLength > 0)
             {
                 // Do a quick search for the first element of "value".
-                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, offset), valueHead, remainingSearchSpaceLength);
+                int relativeIndex = IndexOfValueType(ref Unsafe.Add(ref searchSpace, offset), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex < 0)
                     break;
 
@@ -197,7 +197,7 @@ namespace System
 
             int valueTailLength = valueLength - 1;
             if (valueTailLength == 0)
-                return LastIndexOf(ref searchSpace, value, searchSpaceLength); // for single-byte values use plain LastIndexOf
+                return LastIndexOfValueType(ref searchSpace, value, searchSpaceLength); // for single-byte values use plain LastIndexOf
 
             int offset = 0;
             byte valueHead = value;
@@ -217,7 +217,7 @@ namespace System
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
-                int relativeIndex = LastIndexOf(ref searchSpace, valueHead, remainingSearchSpaceLength);
+                int relativeIndex = LastIndexOfValueType(ref searchSpace, valueHead, remainingSearchSpaceLength);
                 if (relativeIndex < 0)
                     break;
 
@@ -333,129 +333,31 @@ namespace System
             }
         }
 
-        // Adapted from IndexOf(...)
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static bool Contains(ref byte searchSpace, byte value, int length)
+        [DoesNotReturn]
+        private static void ThrowMustBeNullTerminatedString()
         {
-            Debug.Assert(length >= 0);
-
-            uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (uint)length;
-
-            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
-            {
-                lengthToExamine = UnalignedCountVector(ref searchSpace);
-            }
-
-            while (lengthToExamine >= 8)
-            {
-                lengthToExamine -= 8;
-                ref byte start = ref Unsafe.AddByteOffset(ref searchSpace, offset);
-
-                if (uValue == Unsafe.AddByteOffset(ref start, 0) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 1) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 2) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 3) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 4) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 5) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 6) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 7))
-                {
-                    goto Found;
-                }
-
-                offset += 8;
-            }
-
-            if (lengthToExamine >= 4)
-            {
-                lengthToExamine -= 4;
-                ref byte start = ref Unsafe.AddByteOffset(ref searchSpace, offset);
-
-                if (uValue == Unsafe.AddByteOffset(ref start, 0) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 1) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 2) ||
-                    uValue == Unsafe.AddByteOffset(ref start, 3))
-                {
-                    goto Found;
-                }
-
-                offset += 4;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lengthToExamine--;
-
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
-                    goto Found;
-
-                offset++;
-            }
-
-            if (Vector.IsHardwareAccelerated && (offset < (uint)length))
-            {
-                lengthToExamine = ((uint)length - offset) & (nuint)~(Vector<byte>.Count - 1);
-
-                Vector<byte> values = new(value);
-                Vector<byte> matches;
-
-                while (offset < lengthToExamine)
-                {
-                    matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
-                    if (matches == Vector<byte>.Zero)
-                    {
-                        offset += (nuint)Vector<byte>.Count;
-                        continue;
-                    }
-
-                    goto Found;
-                }
-
-                // The total length is at least Vector<byte>.Count, so instead of falling back to a
-                // sequential scan for the remainder, we check the vector read from the end -- note: unaligned read necessary.
-                // We do this only if at least one element is left.
-                if (offset < (uint)length)
-                {
-                    offset = (uint)(length - Vector<byte>.Count);
-                    matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
-                    if (matches != Vector<byte>.Zero)
-                    {
-                        goto Found;
-                    }
-                }
-            }
-
-            return false;
-
-        Found:
-            return true;
+            throw new ArgumentException(SR.Arg_MustBeNullTerminatedString);
         }
 
+        // IndexOfNullByte processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
+        // This behavior is an implementation detail of the runtime and callers outside System.Private.CoreLib must not depend on it.
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)
+        internal static unsafe int IndexOfNullByte(ref byte searchSpace)
         {
-            Debug.Assert(length >= 0);
+            const int Length = int.MaxValue;
 
-            uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            const uint uValue = 0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
+            nuint lengthToExamine = (nuint)(uint)Length;
 
             if (Vector128.IsHardwareAccelerated)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
-                if (length >= Vector128<byte>.Count * 2)
-                {
-                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
-                }
+                lengthToExamine = UnalignedCountVector128(ref searchSpace);
             }
             else if (Vector.IsHardwareAccelerated)
             {
-                if (length >= Vector<byte>.Count * 2)
-                {
-                    lengthToExamine = UnalignedCountVector(ref searchSpace);
-                }
+                lengthToExamine = UnalignedCountVector(ref searchSpace);
             }
         SequentialScan:
             while (lengthToExamine >= 8)
@@ -513,7 +415,7 @@ namespace System
             // have hardware accelerated. After processing Vector lengths we return to SequentialScan to finish any remaining.
             if (Vector256.IsHardwareAccelerated)
             {
-                if (offset < (nuint)(uint)length)
+                if (offset < (nuint)(uint)Length)
                 {
                     if ((((nuint)(uint)Unsafe.AsPointer(ref searchSpace) + offset) & (nuint)(Vector256<byte>.Count - 1)) != 0)
                     {
@@ -521,11 +423,10 @@ namespace System
                         // with no upper bound e.g. String.strlen.
                         // Start with a check on Vector128 to align to Vector256, before moving to processing Vector256.
                         // This ensures we do not fault across memory pages while searching for an end of string.
-                        Vector128<byte> values = Vector128.Create(value);
                         Vector128<byte> search = Vector128.LoadUnsafe(ref searchSpace, offset);
 
                         // Same method as below
-                        uint matches = Vector128.Equals(values, search).ExtractMostSignificantBits();
+                        uint matches = Vector128.Equals(Vector128<byte>.Zero, search).ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -538,14 +439,13 @@ namespace System
                         }
                     }
 
-                    lengthToExamine = GetByteVector256SpanLength(offset, length);
+                    lengthToExamine = GetByteVector256SpanLength(offset, Length);
                     if (lengthToExamine > offset)
                     {
-                        Vector256<byte> values = Vector256.Create(value);
                         do
                         {
                             Vector256<byte> search = Vector256.LoadUnsafe(ref searchSpace, offset);
-                            uint matches = Vector256.Equals(values, search).ExtractMostSignificantBits();
+                            uint matches = Vector256.Equals(Vector256<byte>.Zero, search).ExtractMostSignificantBits();
                             // Note that MoveMask has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
                             if (matches == 0)
@@ -560,14 +460,13 @@ namespace System
                         } while (lengthToExamine > offset);
                     }
 
-                    lengthToExamine = GetByteVector128SpanLength(offset, length);
+                    lengthToExamine = GetByteVector128SpanLength(offset, Length);
                     if (lengthToExamine > offset)
                     {
-                        Vector128<byte> values = Vector128.Create(value);
                         Vector128<byte> search = Vector128.LoadUnsafe(ref searchSpace, offset);
 
                         // Same method as above
-                        uint matches = Vector128.Equals(values, search).ExtractMostSignificantBits();
+                        uint matches = Vector128.Equals(Vector128<byte>.Zero, search).ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -580,26 +479,25 @@ namespace System
                         }
                     }
 
-                    if (offset < (nuint)(uint)length)
+                    if (offset < (nuint)(uint)Length)
                     {
-                        lengthToExamine = ((nuint)(uint)length - offset);
+                        lengthToExamine = ((nuint)(uint)Length - offset);
                         goto SequentialScan;
                     }
                 }
             }
             else if (Vector128.IsHardwareAccelerated)
             {
-                if (offset < (nuint)(uint)length)
+                if (offset < (nuint)(uint)Length)
                 {
-                    lengthToExamine = GetByteVector128SpanLength(offset, length);
+                    lengthToExamine = GetByteVector128SpanLength(offset, Length);
 
-                    Vector128<byte> values = Vector128.Create(value);
                     while (lengthToExamine > offset)
                     {
                         Vector128<byte> search = Vector128.LoadUnsafe(ref searchSpace, offset);
 
                         // Same method as above
-                        Vector128<byte> compareResult = Vector128.Equals(values, search);
+                        Vector128<byte> compareResult = Vector128.Equals(Vector128<byte>.Zero, search);
                         if (compareResult == Vector128<byte>.Zero)
                         {
                             // Zero flags set so no matches
@@ -612,24 +510,22 @@ namespace System
                         return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
                     }
 
-                    if (offset < (nuint)(uint)length)
+                    if (offset < (nuint)(uint)Length)
                     {
-                        lengthToExamine = ((nuint)(uint)length - offset);
+                        lengthToExamine = ((nuint)(uint)Length - offset);
                         goto SequentialScan;
                     }
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
-                if (offset < (nuint)(uint)length)
+                if (offset < (nuint)(uint)Length)
                 {
-                    lengthToExamine = GetByteVectorSpanLength(offset, length);
-
-                    Vector<byte> values = new Vector<byte>(value);
+                    lengthToExamine = GetByteVectorSpanLength(offset, Length);
 
                     while (lengthToExamine > offset)
                     {
-                        var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
+                        var matches = Vector.Equals(Vector<byte>.Zero, LoadVector(ref searchSpace, offset));
                         if (Vector<byte>.Zero.Equals(matches))
                         {
                             offset += (nuint)Vector<byte>.Count;
@@ -640,959 +536,15 @@ namespace System
                         return (int)offset + LocateFirstFoundByte(matches);
                     }
 
-                    if (offset < (nuint)(uint)length)
+                    if (offset < (nuint)(uint)Length)
                     {
-                        lengthToExamine = ((nuint)(uint)length - offset);
+                        lengthToExamine = ((nuint)(uint)Length - offset);
                         goto SequentialScan;
                     }
                 }
             }
-            return -1;
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return (int)offset;
-        Found1:
-            return (int)(offset + 1);
-        Found2:
-            return (int)(offset + 2);
-        Found3:
-            return (int)(offset + 3);
-        Found4:
-            return (int)(offset + 4);
-        Found5:
-            return (int)(offset + 5);
-        Found6:
-            return (int)(offset + 6);
-        Found7:
-            return (int)(offset + 7);
-        }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static int LastIndexOf(ref byte searchSpace, byte value, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            nuint offset = (nuint)(uint)length; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
-            {
-                lengthToExamine = UnalignedCountVectorFromEnd(ref searchSpace, length);
-            }
-        SequentialScan:
-            while (lengthToExamine >= 8)
-            {
-                lengthToExamine -= 8;
-                offset -= 8;
-
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
-                    goto Found7;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6))
-                    goto Found6;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5))
-                    goto Found5;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4))
-                    goto Found4;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
-                    goto Found3;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
-                    goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
-                    goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
-                    goto Found;
-            }
-
-            if (lengthToExamine >= 4)
-            {
-                lengthToExamine -= 4;
-                offset -= 4;
-
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
-                    goto Found3;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
-                    goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
-                    goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
-                    goto Found;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lengthToExamine -= 1;
-                offset -= 1;
-
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
-                    goto Found;
-            }
-
-            if (Vector.IsHardwareAccelerated && (offset > 0))
-            {
-                lengthToExamine = (offset & (nuint)~(Vector<byte>.Count - 1));
-
-                Vector<byte> values = new Vector<byte>(value);
-
-                while (lengthToExamine > (nuint)(Vector<byte>.Count - 1))
-                {
-                    var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset - (nuint)Vector<byte>.Count));
-                    if (Vector<byte>.Zero.Equals(matches))
-                    {
-                        offset -= (nuint)Vector<byte>.Count;
-                        lengthToExamine -= (nuint)Vector<byte>.Count;
-                        continue;
-                    }
-
-                    // Find offset of first match and add to current offset
-                    return (int)(offset) - Vector<byte>.Count + LocateLastFoundByte(matches);
-                }
-                if (offset > 0)
-                {
-                    lengthToExamine = offset;
-                    goto SequentialScan;
-                }
-            }
-            return -1;
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return (int)offset;
-        Found1:
-            return (int)(offset + 1);
-        Found2:
-            return (int)(offset + 2);
-        Found3:
-            return (int)(offset + 3);
-        Found4:
-            return (int)(offset + 4);
-        Found5:
-            return (int)(offset + 5);
-        Found6:
-            return (int)(offset + 6);
-        Found7:
-            return (int)(offset + 7);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static int IndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Sse2.IsSupported || AdvSimd.Arm64.IsSupported)
-            {
-                // Avx2 branch also operates on Sse2 sizes, so check is combined.
-                nint vectorDiff = (nint)length - Vector128<byte>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // >= Sse2 intrinsics are supported, and length is enough to use them so use that path.
-                    // We jump forward to the intrinsics at the end of the method so a naive branch predict
-                    // will choose the non-intrinsic path so short lengths which don't gain anything aren't
-                    // overly disadvantaged by having to jump over a lot of code. Whereas the longer lengths
-                    // more than make this back from the intrinsics.
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto IntrinsicsCompare;
-                }
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, as it is used later
-                nint vectorDiff = (nint)length - Vector<byte>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // Similar as above for Vector version
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto IntrinsicsCompare;
-                }
-            }
-
-            uint lookUp;
-            while (lengthToExamine >= 8)
-            {
-                lengthToExamine -= 8;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found7;
-
-                offset += 8;
-            }
-
-            if (lengthToExamine >= 4)
-            {
-                lengthToExamine -= 4;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found3;
-
-                offset += 4;
-            }
-
-            while (lengthToExamine > 0)
-            {
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found;
-
-                offset += 1;
-                lengthToExamine -= 1;
-            }
-
-        NotFound:
-            return -1;
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return (int)offset;
-        Found1:
-            return (int)(offset + 1);
-        Found2:
-            return (int)(offset + 2);
-        Found3:
-            return (int)(offset + 3);
-        Found4:
-            return (int)(offset + 4);
-        Found5:
-            return (int)(offset + 5);
-        Found6:
-            return (int)(offset + 6);
-        Found7:
-            return (int)(offset + 7);
-
-        IntrinsicsCompare:
-            // When we move into a Vectorized block, we process everything of Vector size;
-            // and then for any remainder we do a final compare of Vector size but starting at
-            // the end and forwards, which may overlap on an earlier compare.
-
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (Sse2.IsSupported)
-            {
-                int matches;
-                if (Avx2.IsSupported)
-                {
-                    Vector256<byte> search;
-                    // Guard as we may only have a valid size for Vector128; when we will move to the Sse2
-                    // We have already subtracted Vector128<byte>.Count from lengthToExamine so compare against that
-                    // to see if we have double the size for Vector256<byte>.Count
-                    if (lengthToExamine >= (nuint)Vector128<byte>.Count)
-                    {
-                        Vector256<byte> values0 = Vector256.Create(value0);
-                        Vector256<byte> values1 = Vector256.Create(value1);
-
-                        // Subtract Vector128<byte>.Count so we have now subtracted Vector256<byte>.Count
-                        lengthToExamine -= (nuint)Vector128<byte>.Count;
-                        // First time this checks again against 0, however we will move into final compare if it fails.
-                        while (lengthToExamine > offset)
-                        {
-                            search = LoadVector256(ref searchSpace, offset);
-                            // Bitwise Or to combine the flagged matches for the second value to our match flags
-                            matches = Avx2.MoveMask(
-                                            Avx2.Or(
-                                                Avx2.CompareEqual(values0, search),
-                                                Avx2.CompareEqual(values1, search)));
-                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
-                            if (matches == 0)
-                            {
-                                // None matched
-                                offset += (nuint)Vector256<byte>.Count;
-                                continue;
-                            }
-
-                            goto IntrinsicsMatch;
-                        }
-
-                        // Move to Vector length from end for final compare
-                        search = LoadVector256(ref searchSpace, lengthToExamine);
-                        offset = lengthToExamine;
-                        // Same as method as above
-                        matches = Avx2.MoveMask(
-                                    Avx2.Or(
-                                        Avx2.CompareEqual(values0, search),
-                                        Avx2.CompareEqual(values1, search)));
-                        if (matches == 0)
-                        {
-                            // None matched
-                            goto NotFound;
-                        }
-
-                        goto IntrinsicsMatch;
-                    }
-                }
-
-                // Initial size check was done on method entry.
-                Debug.Assert(length >= Vector128<byte>.Count);
-                {
-                    Vector128<byte> search;
-                    Vector128<byte> values0 = Vector128.Create(value0);
-                    Vector128<byte> values1 = Vector128.Create(value1);
-                    // First time this checks against 0 and we will move into final compare if it fails.
-                    while (lengthToExamine > offset)
-                    {
-                        search = LoadVector128(ref searchSpace, offset);
-
-                        matches = Sse2.MoveMask(
-                            Sse2.Or(
-                                Sse2.CompareEqual(values0, search),
-                                Sse2.CompareEqual(values1, search))
-                            .AsByte());
-                        // Note that MoveMask has converted the equal vector elements into a set of bit flags,
-                        // So the bit position in 'matches' corresponds to the element offset.
-                        if (matches == 0)
-                        {
-                            // None matched
-                            offset += (nuint)Vector128<byte>.Count;
-                            continue;
-                        }
-
-                        goto IntrinsicsMatch;
-                    }
-                    // Move to Vector length from end for final compare
-                    search = LoadVector128(ref searchSpace, lengthToExamine);
-                    offset = lengthToExamine;
-                    // Same as method as above
-                    matches = Sse2.MoveMask(
-                        Sse2.Or(
-                            Sse2.CompareEqual(values0, search),
-                            Sse2.CompareEqual(values1, search)));
-                    if (matches == 0)
-                    {
-                        // None matched
-                        goto NotFound;
-                    }
-                }
-
-            IntrinsicsMatch:
-                // Find bitflag offset of first difference and add to current offset
-                offset += (nuint)BitOperations.TrailingZeroCount(matches);
-                goto Found;
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                Vector128<byte> search;
-                Vector128<byte> matches;
-                Vector128<byte> values0 = Vector128.Create(value0);
-                Vector128<byte> values1 = Vector128.Create(value1);
-                // First time this checks against 0 and we will move into final compare if it fails.
-                while (lengthToExamine > offset)
-                {
-                    search = LoadVector128(ref searchSpace, offset);
-
-                    matches = AdvSimd.Or(
-                            AdvSimd.CompareEqual(values0, search),
-                            AdvSimd.CompareEqual(values1, search));
-
-                    if (matches == Vector128<byte>.Zero)
-                    {
-                        offset += (nuint)Vector128<byte>.Count;
-                        continue;
-                    }
-
-                    // Find bitflag offset of first match and add to current offset
-                    offset += FindFirstMatchedLane(matches);
-
-                    goto Found;
-                }
-
-                // Move to Vector length from end for final compare
-                search = LoadVector128(ref searchSpace, lengthToExamine);
-                offset = lengthToExamine;
-                // Same as method as above
-                matches = AdvSimd.Or(
-                        AdvSimd.CompareEqual(values0, search),
-                        AdvSimd.CompareEqual(values1, search));
-
-                if (matches == Vector128<byte>.Zero)
-                {
-                    // None matched
-                    goto NotFound;
-                }
-
-                // Find bitflag offset of first match and add to current offset
-                offset += FindFirstMatchedLane(matches);
-
-                goto Found;
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                Vector<byte> values0 = new Vector<byte>(value0);
-                Vector<byte> values1 = new Vector<byte>(value1);
-
-                Vector<byte> search;
-                // First time this checks against 0 and we will move into final compare if it fails.
-                while (lengthToExamine > offset)
-                {
-                    search = LoadVector(ref searchSpace, offset);
-                    search = Vector.BitwiseOr(
-                                    Vector.Equals(search, values0),
-                                    Vector.Equals(search, values1));
-                    if (Vector<byte>.Zero.Equals(search))
-                    {
-                        // None matched
-                        offset += (nuint)Vector<byte>.Count;
-                        continue;
-                    }
-
-                    goto VectorMatch;
-                }
-
-                // Move to Vector length from end for final compare
-                search = LoadVector(ref searchSpace, lengthToExamine);
-                offset = lengthToExamine;
-                search = Vector.BitwiseOr(
-                                Vector.Equals(search, values0),
-                                Vector.Equals(search, values1));
-                if (Vector<byte>.Zero.Equals(search))
-                {
-                    // None matched
-                    goto NotFound;
-                }
-
-            VectorMatch:
-                offset += (nuint)LocateFirstFoundByte(search);
-                goto Found;
-            }
-
-            Debug.Fail("Unreachable");
-            goto NotFound;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static int IndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Vector128.IsHardwareAccelerated)
-            {
-                // Avx2 branch also operates on Sse2 sizes, so check is combined.
-                nint vectorDiff = (nint)length - Vector128<byte>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // >= Vector128 is accelerated, and length is enough to use them so use that path.
-                    // We jump forward to the intrinsics at the end of the method so a naive branch predict
-                    // will choose the non-intrinsic path so short lengths which don't gain anything aren't
-                    // overly disadvantaged by having to jump over a lot of code. Whereas the longer lengths
-                    // more than make this back from the intrinsics.
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto IntrinsicsCompare;
-                }
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, as it is used later
-                nint vectorDiff = (nint)length - Vector<byte>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // Similar as above for Vector version
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto IntrinsicsCompare;
-                }
-            }
-
-            uint lookUp;
-            while (lengthToExamine >= 8)
-            {
-                lengthToExamine -= 8;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found7;
-
-                offset += 8;
-            }
-
-            if (lengthToExamine >= 4)
-            {
-                lengthToExamine -= 4;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found3;
-
-                offset += 4;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found;
-
-                offset += 1;
-                lengthToExamine -= 1;
-            }
-
-        NotFound:
-            return -1;
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return (int)offset;
-        Found1:
-            return (int)(offset + 1);
-        Found2:
-            return (int)(offset + 2);
-        Found3:
-            return (int)(offset + 3);
-        Found4:
-            return (int)(offset + 4);
-        Found5:
-            return (int)(offset + 5);
-        Found6:
-            return (int)(offset + 6);
-        Found7:
-            return (int)(offset + 7);
-
-        IntrinsicsCompare:
-            // When we move into a Vectorized block, we process everything of Vector size;
-            // and then for any remainder we do a final compare of Vector size but starting at
-            // the end and forwards, which may overlap on an earlier compare.
-
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (Vector128.IsHardwareAccelerated)
-            {
-                uint matches;
-                if (Vector256.IsHardwareAccelerated)
-                {
-                    Vector256<byte> search;
-                    // Guard as we may only have a valid size for Vector128; when we will move to the Sse2
-                    // We have already subtracted Vector128<byte>.Count from lengthToExamine so compare against that
-                    // to see if we have double the size for Vector256<byte>.Count
-                    if (lengthToExamine >= (nuint)Vector128<byte>.Count)
-                    {
-                        Vector256<byte> values0 = Vector256.Create(value0);
-                        Vector256<byte> values1 = Vector256.Create(value1);
-                        Vector256<byte> values2 = Vector256.Create(value2);
-
-                        // Subtract Vector128<byte>.Count so we have now subtracted Vector256<byte>.Count
-                        lengthToExamine -= (nuint)Vector128<byte>.Count;
-                        // First time this checks again against 0, however we will move into final compare if it fails.
-                        while (lengthToExamine > offset)
-                        {
-                            search = Vector256.LoadUnsafe(ref searchSpace, offset);
-                            // Bitwise Or to combine the flagged matches for the second value to our match flags
-                            matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search) | Vector256.Equals(values2, search)).ExtractMostSignificantBits();
-                            // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
-                            if (matches == 0)
-                            {
-                                // None matched
-                                offset += (nuint)Vector256<byte>.Count;
-                                continue;
-                            }
-
-                            goto IntrinsicsMatch;
-                        }
-
-                        // Move to Vector length from end for final compare
-                        search = Vector256.LoadUnsafe(ref searchSpace, lengthToExamine);
-                        offset = lengthToExamine;
-                        // Same as method as above
-                        matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search) | Vector256.Equals(values2, search)).ExtractMostSignificantBits();
-                        if (matches == 0)
-                        {
-                            // None matched
-                            goto NotFound;
-                        }
-
-                        goto IntrinsicsMatch;
-                    }
-                }
-
-                // Initial size check was done on method entry.
-                Debug.Assert(length >= Vector128<byte>.Count);
-                {
-                    Vector128<byte> search, compareResult;
-                    Vector128<byte> values0 = Vector128.Create(value0);
-                    Vector128<byte> values1 = Vector128.Create(value1);
-                    Vector128<byte> values2 = Vector128.Create(value2);
-                    // First time this checks against 0 and we will move into final compare if it fails.
-                    while (lengthToExamine > offset)
-                    {
-                        search = Vector128.LoadUnsafe(ref searchSpace, offset);
-
-                        compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search) | Vector128.Equals(values2, search);
-                        if (compareResult == Vector128<byte>.Zero)
-                        {
-                            // None matched
-                            offset += (nuint)Vector128<byte>.Count;
-                            continue;
-                        }
-
-                        // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                        // So the bit position in 'matches' corresponds to the element offset.
-                        matches = compareResult.ExtractMostSignificantBits();
-                        goto IntrinsicsMatch;
-                    }
-                    // Move to Vector length from end for final compare
-                    search = Vector128.LoadUnsafe(ref searchSpace, lengthToExamine);
-                    offset = lengthToExamine;
-                    // Same as method as above
-                    compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search) | Vector128.Equals(values2, search);
-                    if (compareResult == Vector128<byte>.Zero)
-                    {
-                        // None matched
-                        goto NotFound;
-                    }
-                    matches = compareResult.ExtractMostSignificantBits();
-                }
-
-            IntrinsicsMatch:
-                // Find bitflag offset of first difference and add to current offset
-                offset += (nuint)BitOperations.TrailingZeroCount(matches);
-                goto Found;
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                Vector<byte> values0 = new Vector<byte>(value0);
-                Vector<byte> values1 = new Vector<byte>(value1);
-                Vector<byte> values2 = new Vector<byte>(value2);
-
-                Vector<byte> search;
-                // First time this checks against 0 and we will move into final compare if it fails.
-                while (lengthToExamine > offset)
-                {
-                    search = LoadVector(ref searchSpace, offset);
-                    search = Vector.BitwiseOr(
-                                Vector.BitwiseOr(
-                                    Vector.Equals(search, values0),
-                                    Vector.Equals(search, values1)),
-                                Vector.Equals(search, values2));
-                    if (Vector<byte>.Zero.Equals(search))
-                    {
-                        // None matched
-                        offset += (nuint)Vector<byte>.Count;
-                        continue;
-                    }
-
-                    goto VectorMatch;
-                }
-
-                // Move to Vector length from end for final compare
-                search = LoadVector(ref searchSpace, lengthToExamine);
-                offset = lengthToExamine;
-                search = Vector.BitwiseOr(
-                            Vector.BitwiseOr(
-                                Vector.Equals(search, values0),
-                                Vector.Equals(search, values1)),
-                            Vector.Equals(search, values2));
-                if (Vector<byte>.Zero.Equals(search))
-                {
-                    // None matched
-                    goto NotFound;
-                }
-
-            VectorMatch:
-                offset += (nuint)LocateFirstFoundByte(search);
-                goto Found;
-            }
-
-            Debug.Fail("Unreachable");
-            goto NotFound;
-        }
-
-        public static int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            uint uValue1 = value1;
-            nuint offset = (nuint)(uint)length; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
-            {
-                lengthToExamine = UnalignedCountVectorFromEnd(ref searchSpace, length);
-            }
-        SequentialScan:
-            uint lookUp;
-            while (lengthToExamine >= 8)
-            {
-                lengthToExamine -= 8;
-                offset -= 8;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found7;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found;
-            }
-
-            if (lengthToExamine >= 4)
-            {
-                lengthToExamine -= 4;
-                offset -= 4;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lengthToExamine -= 1;
-                offset -= 1;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp)
-                    goto Found;
-            }
-
-            if (Vector.IsHardwareAccelerated && (offset > 0))
-            {
-                lengthToExamine = (offset & (nuint)~(Vector<byte>.Count - 1));
-
-                Vector<byte> values0 = new Vector<byte>(value0);
-                Vector<byte> values1 = new Vector<byte>(value1);
-
-                while (lengthToExamine > (nuint)(Vector<byte>.Count - 1))
-                {
-                    Vector<byte> search = LoadVector(ref searchSpace, offset - (nuint)Vector<byte>.Count);
-                    var matches = Vector.BitwiseOr(
-                                    Vector.Equals(search, values0),
-                                    Vector.Equals(search, values1));
-                    if (Vector<byte>.Zero.Equals(matches))
-                    {
-                        offset -= (nuint)Vector<byte>.Count;
-                        lengthToExamine -= (nuint)Vector<byte>.Count;
-                        continue;
-                    }
-
-                    // Find offset of first match and add to current offset
-                    return (int)(offset) - Vector<byte>.Count + LocateLastFoundByte(matches);
-                }
-
-                if (offset > 0)
-                {
-                    lengthToExamine = offset;
-                    goto SequentialScan;
-                }
-            }
-            return -1;
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return (int)offset;
-        Found1:
-            return (int)(offset + 1);
-        Found2:
-            return (int)(offset + 2);
-        Found3:
-            return (int)(offset + 3);
-        Found4:
-            return (int)(offset + 4);
-        Found5:
-            return (int)(offset + 5);
-        Found6:
-            return (int)(offset + 6);
-        Found7:
-            return (int)(offset + 7);
-        }
-
-        public static int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            uint uValue1 = value1;
-            uint uValue2 = value2;
-            nuint offset = (nuint)(uint)length; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
-            {
-                lengthToExamine = UnalignedCountVectorFromEnd(ref searchSpace, length);
-            }
-        SequentialScan:
-            uint lookUp;
-            while (lengthToExamine >= 8)
-            {
-                lengthToExamine -= 8;
-                offset -= 8;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found7;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found;
-            }
-
-            if (lengthToExamine >= 4)
-            {
-                lengthToExamine -= 4;
-                offset -= 4;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lengthToExamine -= 1;
-                offset -= 1;
-
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
-                if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
-                    goto Found;
-            }
-
-            if (Vector.IsHardwareAccelerated && (offset > 0))
-            {
-                lengthToExamine = (offset & (nuint)~(Vector<byte>.Count - 1));
-
-                Vector<byte> values0 = new Vector<byte>(value0);
-                Vector<byte> values1 = new Vector<byte>(value1);
-                Vector<byte> values2 = new Vector<byte>(value2);
-
-                while (lengthToExamine > (nuint)(Vector<byte>.Count - 1))
-                {
-                    Vector<byte> search = LoadVector(ref searchSpace, offset - (nuint)Vector<byte>.Count);
-
-                    var matches = Vector.BitwiseOr(
-                                    Vector.BitwiseOr(
-                                        Vector.Equals(search, values0),
-                                        Vector.Equals(search, values1)),
-                                    Vector.Equals(search, values2));
-
-                    if (Vector<byte>.Zero.Equals(matches))
-                    {
-                        offset -= (nuint)Vector<byte>.Count;
-                        lengthToExamine -= (nuint)Vector<byte>.Count;
-                        continue;
-                    }
-
-                    // Find offset of first match and add to current offset
-                    return (int)(offset) - Vector<byte>.Count + LocateLastFoundByte(matches);
-                }
-
-                if (offset > 0)
-                {
-                    lengthToExamine = offset;
-                    goto SequentialScan;
-                }
-            }
-            return -1;
+            ThrowMustBeNullTerminatedString();
         Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
             return (int)offset;
         Found1:
@@ -2199,34 +1151,6 @@ namespace System
         {
             nint unaligned = (nint)Unsafe.AsPointer(ref searchSpace) & (Vector128<byte>.Count - 1);
             return (nuint)(uint)((Vector128<byte>.Count - unaligned) & (Vector128<byte>.Count - 1));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe nuint UnalignedCountVectorFromEnd(ref byte searchSpace, int length)
-        {
-            nint unaligned = (nint)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-            return (nuint)(uint)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static uint FindFirstMatchedLane(Vector128<byte> compareResult)
-        {
-            Debug.Assert(AdvSimd.Arm64.IsSupported);
-
-            // Mask to help find the first lane in compareResult that is set.
-            // MSB 0x10 corresponds to 1st lane, 0x01 corresponds to 0th lane and so forth.
-            Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
-
-            // Find the first lane that is set inside compareResult.
-            Vector128<byte> maskedSelectedLanes = AdvSimd.And(compareResult, mask);
-            Vector128<byte> pairwiseSelectedLane = AdvSimd.Arm64.AddPairwise(maskedSelectedLanes, maskedSelectedLanes);
-            ulong selectedLanes = pairwiseSelectedLane.AsUInt64().ToScalar();
-
-            // It should be handled by compareResult != Vector.Zero
-            Debug.Assert(selectedLanes != 0);
-
-            // Find the first lane that is set inside compareResult.
-            return (uint)BitOperations.TrailingZeroCount(selectedLanes) >> 2;
         }
 
         public static void Reverse(ref byte buf, nuint length)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System
@@ -24,7 +23,7 @@ namespace System
             if (valueTailLength == 0)
             {
                 // for single-char values use plain IndexOf
-                return IndexOf(ref searchSpace, value, searchSpaceLength);
+                return IndexOfChar(ref searchSpace, value, searchSpaceLength);
             }
 
             nint offset = 0;
@@ -41,7 +40,7 @@ namespace System
             while (remainingSearchSpaceLength > 0)
             {
                 // Do a quick search for the first element of "value".
-                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, offset), valueHead, remainingSearchSpaceLength);
+                int relativeIndex = IndexOfChar(ref Unsafe.Add(ref searchSpace, offset), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex < 0)
                     break;
 
@@ -68,6 +67,7 @@ namespace System
             // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Muła
             // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_CHARS:
+            ref ushort ushortSearchSpace = ref Unsafe.As<char, ushort>(ref searchSpace);
             if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<ushort>.Count >= 0)
             {
                 // Find the last unique (which is not equal to ch1) character
@@ -88,8 +88,8 @@ namespace System
                     // Make sure we don't go out of bounds
                     Debug.Assert(offset + ch1ch2Distance + Vector256<ushort>.Count <= searchSpaceLength);
 
-                    Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, LoadVector256(ref searchSpace, offset + ch1ch2Distance));
-                    Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, LoadVector256(ref searchSpace, offset));
+                    Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, Vector256.LoadUnsafe(ref ushortSearchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, Vector256.LoadUnsafe(ref ushortSearchSpace, (nuint)offset));
                     Vector256<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
 
                     // Early out: cmpAnd is all zeros
@@ -155,8 +155,8 @@ namespace System
                     // Make sure we don't go out of bounds
                     Debug.Assert(offset + ch1ch2Distance + Vector128<ushort>.Count <= searchSpaceLength);
 
-                    Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, LoadVector128(ref searchSpace, offset + ch1ch2Distance));
-                    Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, LoadVector128(ref searchSpace, offset));
+                    Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, Vector128.LoadUnsafe(ref ushortSearchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, Vector128.LoadUnsafe(ref ushortSearchSpace, (nuint)offset));
                     Vector128<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
 
                     // Early out: cmpAnd is all zeros
@@ -214,7 +214,7 @@ namespace System
 
             int valueTailLength = valueLength - 1;
             if (valueTailLength == 0)
-                return LastIndexOf(ref searchSpace, value, searchSpaceLength); // for single-char values use plain LastIndexOf
+                return LastIndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value, searchSpaceLength); // for single-char values use plain LastIndexOf
 
             int offset = 0;
             char valueHead = value;
@@ -234,7 +234,7 @@ namespace System
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Do a quick search for the first element of "value".
-                int relativeIndex = LastIndexOf(ref searchSpace, valueHead, remainingSearchSpaceLength);
+                int relativeIndex = LastIndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
 
@@ -253,6 +253,7 @@ namespace System
             // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Muła
             // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_CHARS:
+            ref ushort ushortSearchSpace = ref Unsafe.As<char, ushort>(ref searchSpace);
             if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector256<ushort>.Count)
             {
                 offset = searchSpaceMinusValueTailLength - Vector256<ushort>.Count;
@@ -270,8 +271,8 @@ namespace System
                 do
                 {
 
-                    Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, LoadVector256(ref searchSpace, (nuint)offset));
-                    Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, LoadVector256(ref searchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, Vector256.LoadUnsafe(ref ushortSearchSpace, (nuint)offset));
+                    Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, Vector256.LoadUnsafe(ref ushortSearchSpace, (nuint)(offset + ch1ch2Distance)));
                     Vector256<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
 
                     // Early out: cmpAnd is all zeros
@@ -319,8 +320,8 @@ namespace System
 
                 do
                 {
-                    Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, LoadVector128(ref searchSpace, (nuint)offset));
-                    Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, LoadVector128(ref searchSpace, (nuint)(offset + ch1ch2Distance)));
+                    Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, Vector128.LoadUnsafe(ref ushortSearchSpace, (nuint)offset));
+                    Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, Vector128.LoadUnsafe(ref ushortSearchSpace, (nuint)(offset + ch1ch2Distance)));
                     Vector128<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
 
                     // Early out: cmpAnd is all zeros
@@ -420,104 +421,13 @@ namespace System
             return lengthDelta;
         }
 
-        // Adapted from IndexOf(...)
+        // IndexOfNullCharacter processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
+        // This behavior is an implementation detail of the runtime and callers outside System.Private.CoreLib must not depend on it.
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe bool Contains(ref char searchSpace, char value, int length)
+        public static unsafe int IndexOfNullCharacter(ref char searchSpace)
         {
-            Debug.Assert(length >= 0);
-
-            fixed (char* pChars = &searchSpace)
-            {
-                nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-                nuint lengthToExamine = (uint)length;
-
-                if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
-                {
-                    // Figure out how many characters to read sequentially until we are vector aligned
-                    // This is equivalent to:
-                    //         unaligned = ((int)pCh % Unsafe.SizeOf<Vector<ushort>>()) / ElementsPerByte
-                    //         length = (Vector<ushort>.Count - unaligned) % Vector<ushort>.Count
-                    const int ElementsPerByte = sizeof(ushort) / sizeof(byte);
-                    int unaligned = (int)((uint)((int)pChars & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / ElementsPerByte);
-                    lengthToExamine = (uint)((Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1));
-                }
-
-                while (lengthToExamine >= 4)
-                {
-                    lengthToExamine -= 4;
-                    char* pStart = pChars + offset;
-
-                    if (value == pStart[0] ||
-                        value == pStart[1] ||
-                        value == pStart[2] ||
-                        value == pStart[3])
-                    {
-                        goto Found;
-                    }
-
-                    offset += 4;
-                }
-
-                while (lengthToExamine > 0)
-                {
-                    lengthToExamine--;
-
-                    if (value == pChars[offset])
-                        goto Found;
-
-                    offset++;
-                }
-
-                // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
-                // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware acceleration.
-                if (Vector.IsHardwareAccelerated && (offset < (uint)length))
-                {
-                    // Get the highest multiple of Vector<ushort>.Count that is within the search space.
-                    // That will be how many times we iterate in the loop below.
-                    // This is equivalent to: lengthToExamine = Vector<ushort>.Count + ((uint)length - offset) / Vector<ushort>.Count)
-                    lengthToExamine = ((uint)length - offset) & (nuint)~(Vector<ushort>.Count - 1);
-
-                    Vector<ushort> values = new(value);
-                    Vector<ushort> matches;
-
-                    while (offset < lengthToExamine)
-                    {
-                        // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always vector aligned
-                        Debug.Assert(((int)(pChars + offset) % Unsafe.SizeOf<Vector<ushort>>()) == 0);
-                        matches = Vector.Equals(values, Unsafe.Read<Vector<ushort>>(pChars + offset));
-                        if (matches == Vector<ushort>.Zero)
-                        {
-                            offset += (nuint)Vector<ushort>.Count;
-                            continue;
-                        }
-
-                        goto Found;
-                    }
-
-                    // The total length is at least Vector<ushort>.Count, so instead of falling back to a
-                    // sequential scan for the remainder, we check the vector read from the end -- note: unaligned read necessary.
-                    // We do this only if at least one element is left.
-                    if (offset < (uint)length)
-                    {
-                        matches = Vector.Equals(values, Unsafe.ReadUnaligned<Vector<ushort>>(pChars + (uint)length - (uint)Vector<ushort>.Count));
-                        if (matches != Vector<ushort>.Zero)
-                        {
-                            goto Found;
-                        }
-                    }
-                }
-
-                return false;
-
-            Found:
-                return true;
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe int IndexOf(ref char searchSpace, char value, int length)
-        {
-            Debug.Assert(length >= 0);
+            const char value = '\0';
+            const int length = int.MaxValue;
 
             nint offset = 0;
             nint lengthToExamine = length;
@@ -530,18 +440,12 @@ namespace System
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 // Needs to be double length to allow us to align the data first.
-                if (length >= Vector128<ushort>.Count * 2)
-                {
-                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
-                }
+                lengthToExamine = UnalignedCountVector128(ref searchSpace);
             }
             else if (Vector.IsHardwareAccelerated)
             {
                 // Needs to be double length to allow us to align the data first.
-                if (length >= Vector<ushort>.Count * 2)
-                {
-                    lengthToExamine = UnalignedCountVector(ref searchSpace);
-                }
+                lengthToExamine = UnalignedCountVector(ref searchSpace);
             }
 
         SequentialScan:
@@ -600,11 +504,10 @@ namespace System
                         // method, so the alignment only acts as best endeavour. The GC cost is likely to dominate over
                         // the misalignment that may occur after; to we default to giving the GC a free hand to relocate and
                         // its up to the caller whether they are operating over fixed data.
-                        Vector128<ushort> values = Vector128.Create((ushort)value);
                         Vector128<ushort> search = Vector128.LoadUnsafe(ref ushortSearchSpace, (nuint)offset);
 
                         // Same method as below
-                        uint matches = Vector128.Equals(values, search).AsByte().ExtractMostSignificantBits();
+                        uint matches = Vector128.Equals(Vector128<ushort>.Zero, search).AsByte().ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -620,13 +523,12 @@ namespace System
                     lengthToExamine = GetCharVector256SpanLength(offset, length);
                     if (lengthToExamine > 0)
                     {
-                        Vector256<ushort> values = Vector256.Create((ushort)value);
                         do
                         {
                             Debug.Assert(lengthToExamine >= Vector256<ushort>.Count);
 
                             Vector256<ushort> search = Vector256.LoadUnsafe(ref ushortSearchSpace, (nuint)offset);
-                            uint matches = Vector256.Equals(values, search).AsByte().ExtractMostSignificantBits();
+                            uint matches = Vector256.Equals(Vector256<ushort>.Zero, search).AsByte().ExtractMostSignificantBits();
                             // Note that MoveMask has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
                             if (matches == 0)
@@ -648,11 +550,10 @@ namespace System
                     {
                         Debug.Assert(lengthToExamine >= Vector128<ushort>.Count);
 
-                        Vector128<ushort> values = Vector128.Create((ushort)value);
                         Vector128<ushort> search = Vector128.LoadUnsafe(ref ushortSearchSpace, (nuint)offset);
 
                         // Same method as above
-                        uint matches = Vector128.Equals(values, search).AsByte().ExtractMostSignificantBits();
+                        uint matches = Vector128.Equals(Vector128<ushort>.Zero, search).AsByte().ExtractMostSignificantBits();
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -684,7 +585,6 @@ namespace System
                     lengthToExamine = GetCharVector128SpanLength(offset, length);
                     if (lengthToExamine > 0)
                     {
-                        Vector128<ushort> values = Vector128.Create((ushort)value);
                         do
                         {
                             Debug.Assert(lengthToExamine >= Vector128<ushort>.Count);
@@ -692,7 +592,7 @@ namespace System
                             Vector128<ushort> search = Vector128.LoadUnsafe(ref ushortSearchSpace, (uint)offset);
 
                             // Same method as above
-                            Vector128<ushort> compareResult = Vector128.Equals(values, search);
+                            Vector128<ushort> compareResult = Vector128.Equals(Vector128<ushort>.Zero, search);
                             if (compareResult == Vector128<ushort>.Zero)
                             {
                                 // Zero flags set so no matches
@@ -725,12 +625,11 @@ namespace System
 
                     if (lengthToExamine > 0)
                     {
-                        Vector<ushort> values = new Vector<ushort>((ushort)value);
                         do
                         {
                             Debug.Assert(lengthToExamine >= Vector<ushort>.Count);
 
-                            var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
+                            var matches = Vector.Equals(Vector<ushort>.Zero, LoadVector(ref searchSpace, offset));
                             if (Vector<ushort>.Zero.Equals(matches))
                             {
                                 offset += Vector<ushort>.Count;
@@ -750,7 +649,8 @@ namespace System
                     }
                 }
             }
-            return -1;
+
+            ThrowMustBeNullTerminatedString();
         Found3:
             return (int)(offset + 3);
         Found2:
@@ -759,1049 +659,6 @@ namespace System
             return (int)(offset + 1);
         Found:
             return (int)(offset);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe int IndexOfAny(ref char searchStart, char value0, char value1, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Vector128.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, rather than just testing as it used later, rather than doing it twice.
-                nint vectorDiff = (nint)length - Vector128<ushort>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // >= Vector128 is accelerated and length is enough to use them, so use that path.
-                    // We jump forward to the intrinsics at the end of them method so a naive branch predict
-                    // will choose the non-intrinsic path so short lengths which don't gain anything aren't
-                    // overly disadvantaged by having to jump over a lot of code. Whereas the longer lengths
-                    // more than make this back from the intrinsics.
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto IntrinsicsCompare;
-                }
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, rather than just testing as it used later, rather than doing it twice.
-                nint vectorDiff = (nint)length - Vector<ushort>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // Similar as above for Vector version
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto VectorCompare;
-                }
-            }
-
-            int lookUp;
-            while (lengthToExamine >= 4)
-            {
-                ref char current = ref Add(ref searchStart, offset);
-
-                lookUp = current;
-                if (value0 == lookUp || value1 == lookUp)
-                    goto Found;
-                lookUp = Unsafe.Add(ref current, 1);
-                if (value0 == lookUp || value1 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.Add(ref current, 2);
-                if (value0 == lookUp || value1 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.Add(ref current, 3);
-                if (value0 == lookUp || value1 == lookUp)
-                    goto Found3;
-
-                offset += 4;
-                lengthToExamine -= 4;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lookUp = Add(ref searchStart, offset);
-                if (value0 == lookUp || value1 == lookUp)
-                    goto Found;
-
-                offset += 1;
-                lengthToExamine -= 1;
-            }
-
-        NotFound:
-            return -1;
-        Found3:
-            return (int)(offset + 3);
-        Found2:
-            return (int)(offset + 2);
-        Found1:
-            return (int)(offset + 1);
-        Found:
-            return (int)offset;
-
-        IntrinsicsCompare:
-            // When we move into a Vectorized block, we process everything of Vector size;
-            // and then for any remainder we do a final compare of Vector size but starting at
-            // the end and forwards, which may overlap on an earlier compare.
-
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (Vector128.IsHardwareAccelerated)
-            {
-                uint matches;
-                ref ushort ushortSearchStart = ref Unsafe.As<char, ushort>(ref searchStart);
-                if (Vector256.IsHardwareAccelerated)
-                {
-                    Vector256<ushort> search;
-                    // Guard as we may only have a valid size for Vector128; when we will move to the Sse2
-                    // We have already subtracted Vector128<ushort>.Count from lengthToExamine so compare against that
-                    // to see if we have double the size for Vector256<ushort>.Count
-                    if (lengthToExamine >= (nuint)Vector128<ushort>.Count)
-                    {
-                        Vector256<ushort> values0 = Vector256.Create((ushort)value0);
-                        Vector256<ushort> values1 = Vector256.Create((ushort)value1);
-
-                        // Subtract Vector128<ushort>.Count so we have now subtracted Vector256<ushort>.Count
-                        lengthToExamine -= (nuint)Vector128<ushort>.Count;
-                        // First time this checks again against 0, however we will move into final compare if it fails.
-                        while (lengthToExamine > offset)
-                        {
-                            search = Vector256.LoadUnsafe(ref ushortSearchStart, offset);
-                            // Bitwise Or to combine the flagged matches for the second value to our match flags
-                            matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search))
-                                .AsByte().ExtractMostSignificantBits();
-
-                            // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
-                            if (matches == 0)
-                            {
-                                // None matched
-                                offset += (nuint)Vector256<ushort>.Count;
-                                continue;
-                            }
-
-                            goto IntrinsicsMatch;
-                        }
-
-                        // Move to Vector length from end for final compare
-                        search = Vector256.LoadUnsafe(ref ushortSearchStart, lengthToExamine);
-                        offset = lengthToExamine;
-                        // Same as method as above
-                        matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search))
-                            .AsByte().ExtractMostSignificantBits();
-                        if (matches == 0)
-                        {
-                            // None matched
-                            goto NotFound;
-                        }
-
-                        goto IntrinsicsMatch;
-                    }
-                }
-
-                // Initial size check was done on method entry.
-                Debug.Assert(length >= Vector128<ushort>.Count);
-                {
-                    Vector128<ushort> search, compareResult;
-                    Vector128<ushort> values0 = Vector128.Create((ushort)value0);
-                    Vector128<ushort> values1 = Vector128.Create((ushort)value1);
-                    // First time this checks against 0 and we will move into final compare if it fails.
-                    while (lengthToExamine > offset)
-                    {
-                        search = Vector128.LoadUnsafe(ref ushortSearchStart, offset);
-
-                        compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search);
-                        if (compareResult == Vector128<ushort>.Zero)
-                        {
-                            // None matched
-                            offset += (nuint)Vector128<ushort>.Count;
-                            continue;
-                        }
-
-                        // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                        // So the bit position in 'matches' corresponds to the element offset.
-                        matches = compareResult.AsByte().ExtractMostSignificantBits();
-                        goto IntrinsicsMatch;
-                    }
-                    // Move to Vector length from end for final compare
-                    search = Vector128.LoadUnsafe(ref ushortSearchStart, lengthToExamine);
-                    offset = lengthToExamine;
-                    // Same as method as above
-                    compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search);
-                    if (compareResult == Vector128<ushort>.Zero)
-                    {
-                        // None matched
-                        goto NotFound;
-                    }
-                    matches = compareResult.AsByte().ExtractMostSignificantBits();
-                }
-
-            IntrinsicsMatch:
-                // Find bitflag offset of first difference and add to current offset,
-                // flags are in bytes so divide by 2 for chars (shift right by 1)
-                offset += (nuint)(uint)BitOperations.TrailingZeroCount(matches) >> 1;
-                goto Found;
-            }
-
-        VectorCompare:
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (!Vector128.IsHardwareAccelerated && Vector.IsHardwareAccelerated)
-            {
-                Vector<ushort> values0 = new Vector<ushort>(value0);
-                Vector<ushort> values1 = new Vector<ushort>(value1);
-
-                Vector<ushort> search;
-                // First time this checks against 0 and we will move into final compare if it fails.
-                while (lengthToExamine > offset)
-                {
-                    search = LoadVector(ref searchStart, offset);
-                    search = Vector.BitwiseOr(
-                                    Vector.Equals(search, values0),
-                                    Vector.Equals(search, values1));
-                    if (Vector<ushort>.Zero.Equals(search))
-                    {
-                        // None matched
-                        offset += (nuint)Vector<ushort>.Count;
-                        continue;
-                    }
-
-                    goto VectorMatch;
-                }
-
-                // Move to Vector length from end for final compare
-                search = LoadVector(ref searchStart, lengthToExamine);
-                offset = lengthToExamine;
-                search = Vector.BitwiseOr(
-                                Vector.Equals(search, values0),
-                                Vector.Equals(search, values1));
-                if (Vector<ushort>.Zero.Equals(search))
-                {
-                    // None matched
-                    goto NotFound;
-                }
-
-            VectorMatch:
-                offset += (nuint)(uint)LocateFirstFoundChar(search);
-                goto Found;
-            }
-
-            Debug.Fail("Unreachable");
-            goto NotFound;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe int IndexOfAny(ref char searchStart, char value0, char value1, char value2, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Vector128.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, rather than just testing as it used later, rather than doing it twice.
-                nint vectorDiff = (nint)length - Vector128<ushort>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // >= Vector128 is accelerated and length is enough to use them, so use that path.
-                    // We jump forward to the intrinsics at the end of them method so a naive branch predict
-                    // will choose the non-intrinsic path so short lengths which don't gain anything aren't
-                    // overly disadvantaged by having to jump over a lot of code. Whereas the longer lengths
-                    // more than make this back from the intrinsics.
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto IntrinsicsCompare;
-                }
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, rather than just testing as it used later, rather than doing it twice.
-                nint vectorDiff = (nint)length - Vector<ushort>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // Similar as above for Vector version
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto VectorCompare;
-                }
-            }
-
-            int lookUp;
-            while (lengthToExamine >= 4)
-            {
-                ref char current = ref Add(ref searchStart, offset);
-
-                lookUp = current;
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp)
-                    goto Found;
-                lookUp = Unsafe.Add(ref current, 1);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.Add(ref current, 2);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.Add(ref current, 3);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp)
-                    goto Found3;
-
-                offset += 4;
-                lengthToExamine -= 4;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lookUp = Add(ref searchStart, offset);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp)
-                    goto Found;
-
-                offset += 1;
-                lengthToExamine -= 1;
-            }
-
-        NotFound:
-            return -1;
-        Found3:
-            return (int)(offset + 3);
-        Found2:
-            return (int)(offset + 2);
-        Found1:
-            return (int)(offset + 1);
-        Found:
-            return (int)offset;
-
-        IntrinsicsCompare:
-            // When we move into a Vectorized block, we process everything of Vector size;
-            // and then for any remainder we do a final compare of Vector size but starting at
-            // the end and forwards, which may overlap on an earlier compare.
-
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (Vector128.IsHardwareAccelerated)
-            {
-                uint matches;
-                ref ushort ushortSearchStart = ref Unsafe.As<char, ushort>(ref searchStart);
-                if (Vector256.IsHardwareAccelerated)
-                {
-                    Vector256<ushort> search;
-                    // Guard as we may only have a valid size for Vector128; when we will move to the Sse2
-                    // We have already subtracted Vector128<ushort>.Count from lengthToExamine so compare against that
-                    // to see if we have double the size for Vector256<ushort>.Count
-                    if (lengthToExamine >= (nuint)Vector128<ushort>.Count)
-                    {
-                        Vector256<ushort> values0 = Vector256.Create((ushort)value0);
-                        Vector256<ushort> values1 = Vector256.Create((ushort)value1);
-                        Vector256<ushort> values2 = Vector256.Create((ushort)value2);
-
-                        // Subtract Vector128<ushort>.Count so we have now subtracted Vector256<ushort>.Count
-                        lengthToExamine -= (nuint)Vector128<ushort>.Count;
-                        // First time this checks again against 0, however we will move into final compare if it fails.
-                        while (lengthToExamine > offset)
-                        {
-                            search = Vector256.LoadUnsafe(ref ushortSearchStart, offset);
-                            // Bitwise Or to combine the flagged matches for the second value to our match flags
-                            matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search) | Vector256.Equals(values2, search))
-                                    .AsByte().ExtractMostSignificantBits();
-                            // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
-                            if (matches == 0)
-                            {
-                                // None matched
-                                offset += (nuint)Vector256<ushort>.Count;
-                                continue;
-                            }
-
-                            goto IntrinsicsMatch;
-                        }
-
-                        // Move to Vector length from end for final compare
-                        search = Vector256.LoadUnsafe(ref ushortSearchStart, lengthToExamine);
-                        offset = lengthToExamine;
-                        // Same as method as above
-                        matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search) | Vector256.Equals(values2, search))
-                                .AsByte().ExtractMostSignificantBits();
-                        if (matches == 0)
-                        {
-                            // None matched
-                            goto NotFound;
-                        }
-
-                        goto IntrinsicsMatch;
-                    }
-                }
-
-                // Initial size check was done on method entry.
-                Debug.Assert(length >= Vector128<ushort>.Count);
-                {
-                    Vector128<ushort> search, compareResult;
-                    Vector128<ushort> values0 = Vector128.Create((ushort)value0);
-                    Vector128<ushort> values1 = Vector128.Create((ushort)value1);
-                    Vector128<ushort> values2 = Vector128.Create((ushort)value2);
-                    // First time this checks against 0 and we will move into final compare if it fails.
-                    while (lengthToExamine > offset)
-                    {
-                        search = Vector128.LoadUnsafe(ref ushortSearchStart, offset);
-
-                        compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search) | Vector128.Equals(values2, search);
-                        if (compareResult == Vector128<ushort>.Zero)
-                        {
-                            // None matched
-                            offset += (nuint)Vector128<ushort>.Count;
-                            continue;
-                        }
-
-                        // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                        // So the bit position in 'matches' corresponds to the element offset.
-                        matches = compareResult.AsByte().ExtractMostSignificantBits();
-                        goto IntrinsicsMatch;
-                    }
-                    // Move to Vector length from end for final compare
-                    search = Vector128.LoadUnsafe(ref ushortSearchStart, lengthToExamine);
-                    offset = lengthToExamine;
-                    // Same as method as above
-                    compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search) | Vector128.Equals(values2, search);
-                    if (compareResult == Vector128<ushort>.Zero)
-                    {
-                        // None matched
-                        goto NotFound;
-                    }
-                    matches = compareResult.AsByte().ExtractMostSignificantBits();
-                }
-
-            IntrinsicsMatch:
-                // Find bitflag offset of first difference and add to current offset,
-                // flags are in bytes so divide by 2 for chars (shift right by 1)
-                offset += (nuint)(uint)BitOperations.TrailingZeroCount(matches) >> 1;
-                goto Found;
-            }
-
-        VectorCompare:
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (!Vector128.IsHardwareAccelerated && Vector.IsHardwareAccelerated)
-            {
-                Vector<ushort> values0 = new Vector<ushort>(value0);
-                Vector<ushort> values1 = new Vector<ushort>(value1);
-                Vector<ushort> values2 = new Vector<ushort>(value2);
-
-                Vector<ushort> search;
-                // First time this checks against 0 and we will move into final compare if it fails.
-                while (lengthToExamine > offset)
-                {
-                    search = LoadVector(ref searchStart, offset);
-                    search = Vector.BitwiseOr(
-                                    Vector.BitwiseOr(
-                                        Vector.Equals(search, values0),
-                                        Vector.Equals(search, values1)),
-                                    Vector.Equals(search, values2));
-                    if (Vector<ushort>.Zero.Equals(search))
-                    {
-                        // None matched
-                        offset += (nuint)Vector<ushort>.Count;
-                        continue;
-                    }
-
-                    goto VectorMatch;
-                }
-
-                // Move to Vector length from end for final compare
-                search = LoadVector(ref searchStart, lengthToExamine);
-                offset = lengthToExamine;
-                search = Vector.BitwiseOr(
-                                    Vector.BitwiseOr(
-                                        Vector.Equals(search, values0),
-                                        Vector.Equals(search, values1)),
-                                    Vector.Equals(search, values2));
-                if (Vector<ushort>.Zero.Equals(search))
-                {
-                    // None matched
-                    goto NotFound;
-                }
-
-            VectorMatch:
-                offset += (nuint)(uint)LocateFirstFoundChar(search);
-                goto Found;
-            }
-
-            Debug.Fail("Unreachable");
-            goto NotFound;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe int IndexOfAny(ref char searchStart, char value0, char value1, char value2, char value3, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Vector128.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, rather than just testing as it used later, rather than doing it twice.
-                nint vectorDiff = (nint)length - Vector128<ushort>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // >= Vector128 is accelerated and length is enough to use them, so use that path.
-                    // We jump forward to the intrinsics at the end of them method so a naive branch predict
-                    // will choose the non-intrinsic path so short lengths which don't gain anything aren't
-                    // overly disadvantaged by having to jump over a lot of code. Whereas the longer lengths
-                    // more than make this back from the intrinsics.
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto IntrinsicsCompare;
-                }
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, rather than just testing as it used later, rather than doing it twice.
-                nint vectorDiff = (nint)length - Vector<ushort>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // Similar as above for Vector version
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto VectorCompare;
-                }
-            }
-
-            int lookUp;
-            while (lengthToExamine >= 4)
-            {
-                ref char current = ref Add(ref searchStart, offset);
-
-                lookUp = current;
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp)
-                    goto Found;
-                lookUp = Unsafe.Add(ref current, 1);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.Add(ref current, 2);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.Add(ref current, 3);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp)
-                    goto Found3;
-
-                offset += 4;
-                lengthToExamine -= 4;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lookUp = Add(ref searchStart, offset);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp)
-                    goto Found;
-
-                offset += 1;
-                lengthToExamine -= 1;
-            }
-
-        NotFound:
-            return -1;
-        Found3:
-            return (int)(offset + 3);
-        Found2:
-            return (int)(offset + 2);
-        Found1:
-            return (int)(offset + 1);
-        Found:
-            return (int)offset;
-
-        IntrinsicsCompare:
-            // When we move into a Vectorized block, we process everything of Vector size;
-            // and then for any remainder we do a final compare of Vector size but starting at
-            // the end and forwards, which may overlap on an earlier compare.
-
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (Vector128.IsHardwareAccelerated)
-            {
-                uint matches;
-                ref ushort ushortSearchStart = ref Unsafe.As<char, ushort>(ref searchStart);
-                if (Vector256.IsHardwareAccelerated)
-                {
-                    Vector256<ushort> search;
-                    // Guard as we may only have a valid size for Vector128; when we will move to the Sse2
-                    // We have already subtracted Vector128<ushort>.Count from lengthToExamine so compare against that
-                    // to see if we have double the size for Vector256<ushort>.Count
-                    if (lengthToExamine >= (nuint)Vector128<ushort>.Count)
-                    {
-                        Vector256<ushort> values0 = Vector256.Create((ushort)value0);
-                        Vector256<ushort> values1 = Vector256.Create((ushort)value1);
-                        Vector256<ushort> values2 = Vector256.Create((ushort)value2);
-                        Vector256<ushort> values3 = Vector256.Create((ushort)value3);
-
-                        // Subtract Vector128<ushort>.Count so we have now subtracted Vector256<ushort>.Count
-                        lengthToExamine -= (nuint)Vector128<ushort>.Count;
-                        // First time this checks again against 0, however we will move into final compare if it fails.
-                        while (lengthToExamine > offset)
-                        {
-                            search = Vector256.LoadUnsafe(ref ushortSearchStart, offset);
-                            matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search)
-                                     | Vector256.Equals(values2, search) | Vector256.Equals(values3, search))
-                                .AsByte().ExtractMostSignificantBits();
-                            // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
-                            if (matches == 0)
-                            {
-                                // None matched
-                                offset += (nuint)Vector256<ushort>.Count;
-                                continue;
-                            }
-
-                            goto IntrinsicsMatch;
-                        }
-
-                        // Move to Vector length from end for final compare
-                        search = Vector256.LoadUnsafe(ref ushortSearchStart, lengthToExamine);
-                        offset = lengthToExamine;
-                        // Same as method as above
-                        matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search)
-                                 | Vector256.Equals(values2, search) | Vector256.Equals(values3, search))
-                            .AsByte().ExtractMostSignificantBits();
-                        if (matches == 0)
-                        {
-                            // None matched
-                            goto NotFound;
-                        }
-
-                        goto IntrinsicsMatch;
-                    }
-                }
-
-                // Initial size check was done on method entry.
-                Debug.Assert(length >= Vector128<ushort>.Count);
-                {
-                    Vector128<ushort> search, compareResult;
-                    Vector128<ushort> values0 = Vector128.Create((ushort)value0);
-                    Vector128<ushort> values1 = Vector128.Create((ushort)value1);
-                    Vector128<ushort> values2 = Vector128.Create((ushort)value2);
-                    Vector128<ushort> values3 = Vector128.Create((ushort)value3);
-                    // First time this checks against 0 and we will move into final compare if it fails.
-                    while (lengthToExamine > offset)
-                    {
-                        search = Vector128.LoadUnsafe(ref ushortSearchStart, offset);
-
-                        compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search)
-                                      | Vector128.Equals(values2, search) | Vector128.Equals(values3, search);
-                        if (compareResult == Vector128<ushort>.Zero)
-                        {
-                            // None matched
-                            offset += (nuint)Vector128<ushort>.Count;
-                            continue;
-                        }
-
-                        // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                        // So the bit position in 'matches' corresponds to the element offset.
-                        matches = compareResult.AsByte().ExtractMostSignificantBits();
-                        goto IntrinsicsMatch;
-                    }
-                    // Move to Vector length from end for final compare
-                    search = Vector128.LoadUnsafe(ref ushortSearchStart, lengthToExamine);
-                    offset = lengthToExamine;
-                    // Same as method as above
-                    compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search)
-                                  | Vector128.Equals(values2, search) | Vector128.Equals(values3, search);
-                    if (compareResult == Vector128<ushort>.Zero)
-                    {
-                        // None matched
-                        goto NotFound;
-                    }
-                    matches = compareResult.AsByte().ExtractMostSignificantBits();
-                }
-
-            IntrinsicsMatch:
-                // Find bitflag offset of first difference and add to current offset,
-                // flags are in bytes so divide by 2 for chars (shift right by 1)
-                offset += (nuint)(uint)BitOperations.TrailingZeroCount(matches) >> 1;
-                goto Found;
-            }
-
-        VectorCompare:
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (!Vector128.IsHardwareAccelerated && Vector.IsHardwareAccelerated)
-            {
-                Vector<ushort> values0 = new Vector<ushort>(value0);
-                Vector<ushort> values1 = new Vector<ushort>(value1);
-                Vector<ushort> values2 = new Vector<ushort>(value2);
-                Vector<ushort> values3 = new Vector<ushort>(value3);
-
-                Vector<ushort> search;
-                // First time this checks against 0 and we will move into final compare if it fails.
-                while (lengthToExamine > offset)
-                {
-                    search = LoadVector(ref searchStart, offset);
-                    search = Vector.BitwiseOr(
-                                    Vector.BitwiseOr(
-                                        Vector.BitwiseOr(
-                                            Vector.Equals(search, values0),
-                                            Vector.Equals(search, values1)),
-                                        Vector.Equals(search, values2)),
-                                    Vector.Equals(search, values3));
-                    if (Vector<ushort>.Zero.Equals(search))
-                    {
-                        // None matched
-                        offset += (nuint)Vector<ushort>.Count;
-                        continue;
-                    }
-
-                    goto VectorMatch;
-                }
-
-                // Move to Vector length from end for final compare
-                search = LoadVector(ref searchStart, lengthToExamine);
-                offset = lengthToExamine;
-                search = Vector.BitwiseOr(
-                                Vector.BitwiseOr(
-                                    Vector.BitwiseOr(
-                                        Vector.Equals(search, values0),
-                                        Vector.Equals(search, values1)),
-                                    Vector.Equals(search, values2)),
-                                Vector.Equals(search, values3));
-                if (Vector<ushort>.Zero.Equals(search))
-                {
-                    // None matched
-                    goto NotFound;
-                }
-
-            VectorMatch:
-                offset += (nuint)(uint)LocateFirstFoundChar(search);
-                goto Found;
-            }
-
-            Debug.Fail("Unreachable");
-            goto NotFound;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe int IndexOfAny(ref char searchStart, char value0, char value1, char value2, char value3, char value4, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
-            nuint lengthToExamine = (nuint)(uint)length;
-
-            if (Vector128.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, rather than just testing as it used later, rather than doing it twice.
-                nint vectorDiff = (nint)length - Vector128<ushort>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // >= Vector128 is accelerated and length is enough to use them, so use that path.
-                    // We jump forward to the intrinsics at the end of them method so a naive branch predict
-                    // will choose the non-intrinsic path so short lengths which don't gain anything aren't
-                    // overly disadvantaged by having to jump over a lot of code. Whereas the longer lengths
-                    // more than make this back from the intrinsics.
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto IntrinsicsCompare;
-                }
-            }
-            else if (Vector.IsHardwareAccelerated)
-            {
-                // Calculate lengthToExamine here for test, rather than just testing as it used later, rather than doing it twice.
-                nint vectorDiff = (nint)length - Vector<ushort>.Count;
-                if (vectorDiff >= 0)
-                {
-                    // Similar as above for Vector version
-                    lengthToExamine = (nuint)vectorDiff;
-                    goto VectorCompare;
-                }
-            }
-
-            int lookUp;
-            while (lengthToExamine >= 4)
-            {
-                ref char current = ref Add(ref searchStart, offset);
-
-                lookUp = current;
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp || value4 == lookUp)
-                    goto Found;
-                lookUp = Unsafe.Add(ref current, 1);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp || value4 == lookUp)
-                    goto Found1;
-                lookUp = Unsafe.Add(ref current, 2);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp || value4 == lookUp)
-                    goto Found2;
-                lookUp = Unsafe.Add(ref current, 3);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp || value4 == lookUp)
-                    goto Found3;
-
-                offset += 4;
-                lengthToExamine -= 4;
-            }
-
-            while (lengthToExamine > 0)
-            {
-                lookUp = Add(ref searchStart, offset);
-                if (value0 == lookUp || value1 == lookUp || value2 == lookUp || value3 == lookUp || value4 == lookUp)
-                    goto Found;
-
-                offset += 1;
-                lengthToExamine -= 1;
-            }
-
-        NotFound:
-            return -1;
-        Found3:
-            return (int)(offset + 3);
-        Found2:
-            return (int)(offset + 2);
-        Found1:
-            return (int)(offset + 1);
-        Found:
-            return (int)offset;
-
-        IntrinsicsCompare:
-            // When we move into a Vectorized block, we process everything of Vector size;
-            // and then for any remainder we do a final compare of Vector size but starting at
-            // the end and forwards, which may overlap on an earlier compare.
-
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (Vector128.IsHardwareAccelerated)
-            {
-                uint matches;
-                ref ushort ushortSearchStart = ref Unsafe.As<char, ushort>(ref searchStart);
-                if (Vector256.IsHardwareAccelerated)
-                {
-                    Vector256<ushort> search;
-                    // Guard as we may only have a valid size for Vector128; when we will move to the Sse2
-                    // We have already subtracted Vector128<ushort>.Count from lengthToExamine so compare against that
-                    // to see if we have double the size for Vector256<ushort>.Count
-                    if (lengthToExamine >= (nuint)Vector128<ushort>.Count)
-                    {
-                        Vector256<ushort> values0 = Vector256.Create((ushort)value0);
-                        Vector256<ushort> values1 = Vector256.Create((ushort)value1);
-                        Vector256<ushort> values2 = Vector256.Create((ushort)value2);
-                        Vector256<ushort> values3 = Vector256.Create((ushort)value3);
-                        Vector256<ushort> values4 = Vector256.Create((ushort)value4);
-
-                        // Subtract Vector128<ushort>.Count so we have now subtracted Vector256<ushort>.Count
-                        lengthToExamine -= (nuint)Vector128<ushort>.Count;
-                        // First time this checks again against 0, however we will move into final compare if it fails.
-                        while (lengthToExamine > offset)
-                        {
-                            search = Vector256.LoadUnsafe(ref ushortSearchStart, offset);
-                            matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search) | Vector256.Equals(values2, search)
-                                     | Vector256.Equals(values3, search) | Vector256.Equals(values4, search))
-                                .AsByte().ExtractMostSignificantBits();
-                            // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
-                            if (matches == 0)
-                            {
-                                // None matched
-                                offset += (nuint)Vector256<ushort>.Count;
-                                continue;
-                            }
-
-                            goto IntrinsicsMatch;
-                        }
-
-                        // Move to Vector length from end for final compare
-                        search = Vector256.LoadUnsafe(ref ushortSearchStart, lengthToExamine);
-                        offset = lengthToExamine;
-                        // Same as method as above
-                        matches = (Vector256.Equals(values0, search) | Vector256.Equals(values1, search) | Vector256.Equals(values2, search)
-                                 | Vector256.Equals(values3, search) | Vector256.Equals(values4, search))
-                            .AsByte().ExtractMostSignificantBits();
-                        if (matches == 0)
-                        {
-                            // None matched
-                            goto NotFound;
-                        }
-
-                        goto IntrinsicsMatch;
-                    }
-                }
-
-                // Initial size check was done on method entry.
-                Debug.Assert(length >= Vector128<ushort>.Count);
-                {
-                    Vector128<ushort> search, compareResult;
-                    Vector128<ushort> values0 = Vector128.Create((ushort)value0);
-                    Vector128<ushort> values1 = Vector128.Create((ushort)value1);
-                    Vector128<ushort> values2 = Vector128.Create((ushort)value2);
-                    Vector128<ushort> values3 = Vector128.Create((ushort)value3);
-                    Vector128<ushort> values4 = Vector128.Create((ushort)value4);
-                    // First time this checks against 0 and we will move into final compare if it fails.
-                    while (lengthToExamine > offset)
-                    {
-                        search = Vector128.LoadUnsafe(ref ushortSearchStart, offset);
-
-                        compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search) | Vector128.Equals(values2, search)
-                                      | Vector128.Equals(values3, search) | Vector128.Equals(values4, search);
-                        if (compareResult == Vector128<ushort>.Zero)
-                        {
-                            // None matched
-                            offset += (nuint)Vector128<ushort>.Count;
-                            continue;
-                        }
-
-                        // Note that ExtractMostSignificantBits has converted the equal vector elements into a set of bit flags,
-                        // So the bit position in 'matches' corresponds to the element offset.
-                        matches = compareResult.AsByte().ExtractMostSignificantBits();
-                        goto IntrinsicsMatch;
-                    }
-                    // Move to Vector length from end for final compare
-                    search = Vector128.LoadUnsafe(ref ushortSearchStart, lengthToExamine);
-                    offset = lengthToExamine;
-                    // Same as method as above
-                    compareResult = Vector128.Equals(values0, search) | Vector128.Equals(values1, search) | Vector128.Equals(values2, search)
-                                  | Vector128.Equals(values3, search) | Vector128.Equals(values4, search);
-                    if (compareResult == Vector128<ushort>.Zero)
-                    {
-                        // None matched
-                        goto NotFound;
-                    }
-                    matches = compareResult.AsByte().ExtractMostSignificantBits();
-                }
-
-            IntrinsicsMatch:
-                // Find bitflag offset of first difference and add to current offset,
-                // flags are in bytes so divide by 2 for chars (shift right by 1)
-                offset += (nuint)(uint)BitOperations.TrailingZeroCount(matches) >> 1;
-                goto Found;
-            }
-
-        VectorCompare:
-            // We include the Supported check again here even though path will not be taken, so the asm isn't generated if not supported.
-            if (!Vector128.IsHardwareAccelerated && Vector.IsHardwareAccelerated)
-            {
-                Vector<ushort> values0 = new Vector<ushort>(value0);
-                Vector<ushort> values1 = new Vector<ushort>(value1);
-                Vector<ushort> values2 = new Vector<ushort>(value2);
-                Vector<ushort> values3 = new Vector<ushort>(value3);
-                Vector<ushort> values4 = new Vector<ushort>(value4);
-
-                Vector<ushort> search;
-                // First time this checks against 0 and we will move into final compare if it fails.
-                while (lengthToExamine > offset)
-                {
-                    search = LoadVector(ref searchStart, offset);
-                    search = Vector.BitwiseOr(
-                                Vector.BitwiseOr(
-                                    Vector.BitwiseOr(
-                                        Vector.BitwiseOr(
-                                            Vector.Equals(search, values0),
-                                            Vector.Equals(search, values1)),
-                                        Vector.Equals(search, values2)),
-                                    Vector.Equals(search, values3)),
-                                Vector.Equals(search, values4));
-                    if (Vector<ushort>.Zero.Equals(search))
-                    {
-                        // None matched
-                        offset += (nuint)Vector<ushort>.Count;
-                        continue;
-                    }
-
-                    goto VectorMatch;
-                }
-
-                // Move to Vector length from end for final compare
-                search = LoadVector(ref searchStart, lengthToExamine);
-                offset = lengthToExamine;
-                search = Vector.BitwiseOr(
-                            Vector.BitwiseOr(
-                                Vector.BitwiseOr(
-                                    Vector.BitwiseOr(
-                                        Vector.Equals(search, values0),
-                                        Vector.Equals(search, values1)),
-                                    Vector.Equals(search, values2)),
-                                Vector.Equals(search, values3)),
-                            Vector.Equals(search, values4));
-                if (Vector<ushort>.Zero.Equals(search))
-                {
-                    // None matched
-                    goto NotFound;
-                }
-
-            VectorMatch:
-                offset += (nuint)(uint)LocateFirstFoundChar(search);
-                goto Found;
-            }
-
-            Debug.Fail("Unreachable");
-            goto NotFound;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe int LastIndexOf(ref char searchSpace, char value, int length)
-        {
-            Debug.Assert(length >= 0);
-
-            fixed (char* pChars = &searchSpace)
-            {
-                char* pCh = pChars + length;
-                char* pEndCh = pChars;
-
-                if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
-                {
-                    // Figure out how many characters to read sequentially from the end until we are vector aligned
-                    // This is equivalent to: length = ((int)pCh % Unsafe.SizeOf<Vector<ushort>>()) / elementsPerByte
-                    const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                    length = ((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / elementsPerByte;
-                }
-
-            SequentialScan:
-                while (length >= 4)
-                {
-                    length -= 4;
-                    pCh -= 4;
-
-                    if (*(pCh + 3) == value)
-                        goto Found3;
-                    if (*(pCh + 2) == value)
-                        goto Found2;
-                    if (*(pCh + 1) == value)
-                        goto Found1;
-                    if (*pCh == value)
-                        goto Found;
-                }
-
-                while (length > 0)
-                {
-                    length--;
-                    pCh--;
-
-                    if (*pCh == value)
-                        goto Found;
-                }
-
-                // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
-                // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
-                if (Vector.IsHardwareAccelerated && pCh > pEndCh)
-                {
-                    // Get the highest multiple of Vector<ushort>.Count that is within the search space.
-                    // That will be how many times we iterate in the loop below.
-                    // This is equivalent to: length = Vector<ushort>.Count * ((int)(pCh - pEndCh) / Vector<ushort>.Count)
-                    length = (int)((pCh - pEndCh) & ~(Vector<ushort>.Count - 1));
-
-                    // Get comparison Vector
-                    Vector<ushort> vComparison = new Vector<ushort>(value);
-
-                    while (length > 0)
-                    {
-                        char* pStart = pCh - Vector<ushort>.Count;
-                        // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh (and hence pSart) is always vector aligned
-                        Debug.Assert(((int)pStart & (Unsafe.SizeOf<Vector<ushort>>() - 1)) == 0);
-                        Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.Read<Vector<ushort>>(pStart));
-                        if (Vector<ushort>.Zero.Equals(vMatches))
-                        {
-                            pCh -= Vector<ushort>.Count;
-                            length -= Vector<ushort>.Count;
-                            continue;
-                        }
-                        // Find offset of last match
-                        return (int)(pStart - pEndCh) + LocateLastFoundChar(vMatches);
-                    }
-
-                    if (pCh > pEndCh)
-                    {
-                        length = (int)(pCh - pEndCh);
-                        goto SequentialScan;
-                    }
-                }
-
-                return -1;
-            Found:
-                return (int)(pCh - pEndCh);
-            Found1:
-                return (int)(pCh - pEndCh) + 1;
-            Found2:
-                return (int)(pCh - pEndCh) + 2;
-            Found3:
-                return (int)(pCh - pEndCh) + 3;
-            }
         }
 
         // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
@@ -1829,35 +686,6 @@ namespace System
         private static int LocateFirstFoundChar(ulong match)
             => BitOperations.TrailingZeroCount(match) >> 4;
 
-        // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateLastFoundChar(Vector<ushort> match)
-        {
-            var vector64 = Vector.AsVectorUInt64(match);
-            ulong candidate = 0;
-            int i = Vector<ulong>.Count - 1;
-
-            // This pattern is only unrolled by the Jit if the limit is Vector<T>.Count
-            // As such, we need a dummy iteration variable for that condition to be satisfied
-            for (int j = 0; j < Vector<ulong>.Count; j++)
-            {
-                candidate = vector64[i];
-                if (candidate != 0)
-                {
-                    break;
-                }
-
-                i--;
-            }
-
-            // Single LEA instruction with jitted const (using function result)
-            return i * 4 + LocateLastFoundChar(candidate);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int LocateLastFoundChar(ulong match)
-            => BitOperations.Log2(match) >> 4;
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector<ushort> LoadVector(ref char start, nint offset)
             => Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, offset)));
@@ -1865,25 +693,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector<ushort> LoadVector(ref char start, nuint offset)
             => Unsafe.ReadUnaligned<Vector<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, (nint)offset)));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector128<ushort> LoadVector128(ref char start, nint offset)
-            => Unsafe.ReadUnaligned<Vector128<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, offset)));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector128<ushort> LoadVector128(ref char start, nuint offset)
-            => Unsafe.ReadUnaligned<Vector128<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, (nint)offset)));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector256<ushort> LoadVector256(ref char start, nint offset)
-            => Unsafe.ReadUnaligned<Vector256<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, offset)));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector256<ushort> LoadVector256(ref char start, nuint offset)
-            => Unsafe.ReadUnaligned<Vector256<ushort>>(ref Unsafe.As<char, byte>(ref Unsafe.Add(ref start, (nint)offset)));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ref char Add(ref char start, nuint offset) => ref Unsafe.Add(ref start, (nint)offset);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static nint GetCharVectorSpanLength(nint offset, nint length)
@@ -1920,21 +729,6 @@ namespace System
             // If a GC does occur and alignment is lost, the GC cost will outweigh any gains from alignment so it
             // isn't too important to pin to maintain the alignment.
             return (nint)(uint)(-(int)Unsafe.AsPointer(ref searchSpace) / ElementsPerByte) & (Vector128<ushort>.Count - 1);
-        }
-
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int FindFirstMatchedLane(Vector128<ushort> compareResult)
-        {
-            Debug.Assert(AdvSimd.Arm64.IsSupported);
-
-            Vector128<byte> pairwiseSelectedLane = AdvSimd.Arm64.AddPairwise(compareResult.AsByte(), compareResult.AsByte());
-            ulong selectedLanes = pairwiseSelectedLane.AsUInt64().ToScalar();
-
-            // It should be handled by compareResult != Vector.Zero
-            Debug.Assert(selectedLanes != 0);
-
-            return BitOperations.TrailingZeroCount(selectedLanes) >> 3;
         }
 
         public static void Reverse(ref char buf, nuint length)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -293,115 +293,6 @@ namespace System
             return true;
         }
 
-        internal static unsafe int IndexOfValueType<T>(ref T searchSpace, T value, int length) where T : struct, IEquatable<T>
-        {
-            Debug.Assert(length >= 0);
-
-            nint index = 0; // Use nint for arithmetic to avoid unnecessary 64->32->64 truncations
-            if (Vector.IsHardwareAccelerated && Vector<T>.IsSupported && (Vector<T>.Count * 2) <= length)
-            {
-                Vector<T> valueVector = new Vector<T>(value);
-                Vector<T> compareVector;
-                Vector<T> matchVector;
-                if ((uint)length % (uint)Vector<T>.Count != 0)
-                {
-                    // Number of elements is not a multiple of Vector<T>.Count, so do one
-                    // check and shift only enough for the remaining set to be a multiple
-                    // of Vector<T>.Count.
-                    compareVector = Unsafe.As<T, Vector<T>>(ref Unsafe.Add(ref searchSpace, index));
-                    matchVector = Vector.Equals(valueVector, compareVector);
-                    if (matchVector != Vector<T>.Zero)
-                    {
-                        goto VectorMatch;
-                    }
-                    index += length % Vector<T>.Count;
-                    length -= length % Vector<T>.Count;
-                }
-                while (length > 0)
-                {
-                    compareVector = Unsafe.As<T, Vector<T>>(ref Unsafe.Add(ref searchSpace, index));
-                    matchVector = Vector.Equals(valueVector, compareVector);
-                    if (matchVector != Vector<T>.Zero)
-                    {
-                        goto VectorMatch;
-                    }
-                    index += Vector<T>.Count;
-                    length -= Vector<T>.Count;
-                }
-                goto NotFound;
-            VectorMatch:
-                for (int i = 0; i < Vector<T>.Count; i++)
-                    if (compareVector[i].Equals(value))
-                        return (int)(index + i);
-            }
-
-            while (length >= 8)
-            {
-                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
-                    goto Found1;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 2)))
-                    goto Found2;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
-                    goto Found3;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 4)))
-                    goto Found4;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 5)))
-                    goto Found5;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 6)))
-                    goto Found6;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
-                    goto Found7;
-
-                length -= 8;
-                index += 8;
-            }
-
-            while (length >= 4)
-            {
-                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
-                    goto Found;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
-                    goto Found1;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 2)))
-                    goto Found2;
-                if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
-                    goto Found3;
-
-                length -= 4;
-                index += 4;
-            }
-
-            while (length > 0)
-            {
-                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
-                    goto Found;
-
-                index += 1;
-                length--;
-            }
-        NotFound:
-            return -1;
-
-        Found: // Workaround for https://github.com/dotnet/runtime/issues/8795
-            return (int)index;
-        Found1:
-            return (int)(index + 1);
-        Found2:
-            return (int)(index + 2);
-        Found3:
-            return (int)(index + 3);
-        Found4:
-            return (int)(index + 4);
-        Found5:
-            return (int)(index + 5);
-        Found6:
-            return (int)(index + 6);
-        Found7:
-            return (int)(index + 7);
-        }
-
         public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length) where T : IEquatable<T>?
         {
             Debug.Assert(length >= 0);
@@ -1162,7 +1053,7 @@ namespace System
             return -1; // not found
         }
 
-        public static int IndexOfAnyExcept<T>(ref T searchSpace, T value0, int length)
+        internal static int IndexOfAnyExcept<T>(ref T searchSpace, T value0, int length)
         {
             Debug.Assert(length >= 0, "Expected non-negative length");
 
@@ -1177,113 +1068,125 @@ namespace System
             return -1;
         }
 
-        public static int IndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, int length) where T : struct, IEquatable<T>
+        internal static int LastIndexOfAnyExcept<T>(ref T searchSpace, T value0, int length)
         {
             Debug.Assert(length >= 0, "Expected non-negative length");
-            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
 
-            if (!Vector128.IsHardwareAccelerated || length < Vector128<T>.Count)
+            for (int i = length -1; i >= 0; i--)
             {
-                for (int i = 0; i < length; i++)
+                if (!EqualityComparer<T>.Default.Equals(Unsafe.Add(ref searchSpace, i), value0))
                 {
-                    if (!Unsafe.Add(ref searchSpace, i).Equals(value0))
-                    {
-                        return i;
-                    }
-                }
-            }
-            else
-            {
-                Vector128<T> notEquals, value0Vector = Vector128.Create(value0);
-                ref T current = ref searchSpace;
-                ref T oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector128<T>.Count);
-
-                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
-                {
-                    notEquals = ~Vector128.Equals(value0Vector, Vector128.LoadUnsafe(ref current));
-                    if (notEquals != Vector128<T>.Zero)
-                    {
-                        return ComputeIndex(ref searchSpace, ref current, notEquals);
-                    }
-
-                    current = ref Unsafe.Add(ref current, Vector128<T>.Count);
-                }
-                while (!Unsafe.IsAddressGreaterThan(ref current, ref oneVectorAwayFromEnd));
-
-                // If any elements remain, process the last vector in the search space.
-                if ((uint)length % Vector128<T>.Count != 0)
-                {
-                    notEquals = ~Vector128.Equals(value0Vector, Vector128.LoadUnsafe(ref oneVectorAwayFromEnd));
-                    if (notEquals != Vector128<T>.Zero)
-                    {
-                        return ComputeIndex(ref searchSpace, ref oneVectorAwayFromEnd, notEquals);
-                    }
+                    return i;
                 }
             }
 
             return -1;
         }
 
-        internal static int IndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length) where T : struct, IEquatable<T>
+        internal static int IndexOfAnyExcept<T>(ref T searchSpace, T value0, T value1, int length)
         {
             Debug.Assert(length >= 0, "Expected non-negative length");
-            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
 
-            if (!Vector128.IsHardwareAccelerated || length < Vector128<T>.Count)
+            for (int i = 0; i < length; i++)
             {
-                for (int i = 0; i < length; i++)
+                ref T current = ref Unsafe.Add(ref searchSpace, i);
+                if (!EqualityComparer<T>.Default.Equals(current, value0) && !EqualityComparer<T>.Default.Equals(current, value1))
                 {
-                    T current = Unsafe.Add(ref searchSpace, i);
-                    if (!current.Equals(value0) && !current.Equals(value1) && !current.Equals(value2) && !current.Equals(value3))
-                    {
-                        return i;
-                    }
-                }
-            }
-            else
-            {
-                Vector128<T> notEquals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1), values2 = Vector128.Create(value2), values3 = Vector128.Create(value3);
-                ref T currentSearchSpace = ref searchSpace;
-                ref T oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector128<T>.Count);
-
-                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
-                {
-                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
-                    notEquals = ~(Vector128.Equals(values0, current) | Vector128.Equals(values1, current)
-                                | Vector128.Equals(values2, current) | Vector128.Equals(values3, current));
-                    if (notEquals != Vector128<T>.Zero)
-                    {
-                        return ComputeIndex(ref searchSpace, ref currentSearchSpace, notEquals);
-                    }
-
-                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<T>.Count);
-                }
-                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
-
-                // If any elements remain, process the last vector in the search space.
-                if ((uint)length % Vector128<T>.Count != 0)
-                {
-                    current = Vector128.LoadUnsafe(ref oneVectorAwayFromEnd);
-                    notEquals = ~(Vector128.Equals(values0, current) | Vector128.Equals(values1, current)
-                                | Vector128.Equals(values2, current) | Vector128.Equals(values3, current));
-                    if (notEquals != Vector128<T>.Zero)
-                    {
-                        return ComputeIndex(ref searchSpace, ref oneVectorAwayFromEnd, notEquals);
-                    }
+                    return i;
                 }
             }
 
             return -1;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int ComputeIndex<T>(ref T searchSpace, ref T current, Vector128<T> notEquals) where T : struct, IEquatable<T>
+        internal static int LastIndexOfAnyExcept<T>(ref T searchSpace, T value0, T value1, int length)
         {
-            uint notEqualsElements = notEquals.ExtractMostSignificantBits();
-            int index = BitOperations.TrailingZeroCount(notEqualsElements);
-            return index + (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / Unsafe.SizeOf<T>());
+            Debug.Assert(length >= 0, "Expected non-negative length");
+
+            for (int i = length - 1; i >= 0; i--)
+            {
+                ref T current = ref Unsafe.Add(ref searchSpace, i);
+                if (!EqualityComparer<T>.Default.Equals(current, value0) && !EqualityComparer<T>.Default.Equals(current, value1))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        internal static int IndexOfAnyExcept<T>(ref T searchSpace, T value0, T value1, T value2, int length)
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+
+            for (int i = 0; i < length; i++)
+            {
+                ref T current = ref Unsafe.Add(ref searchSpace, i);
+                if (!EqualityComparer<T>.Default.Equals(current, value0)
+                    && !EqualityComparer<T>.Default.Equals(current, value1)
+                    && !EqualityComparer<T>.Default.Equals(current, value2))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        internal static int LastIndexOfAnyExcept<T>(ref T searchSpace, T value0, T value1, T value2, int length)
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+
+            for (int i = length - 1; i >= 0; i--)
+            {
+                ref T current = ref Unsafe.Add(ref searchSpace, i);
+                if (!EqualityComparer<T>.Default.Equals(current, value0)
+                    && !EqualityComparer<T>.Default.Equals(current, value1)
+                    && !EqualityComparer<T>.Default.Equals(current, value2))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        internal static int IndexOfAnyExcept<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length)
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+
+            for (int i = 0; i < length; i++)
+            {
+                ref T current = ref Unsafe.Add(ref searchSpace, i);
+                if (!EqualityComparer<T>.Default.Equals(current, value0)
+                    && !EqualityComparer<T>.Default.Equals(current, value1)
+                    && !EqualityComparer<T>.Default.Equals(current, value2)
+                    && !EqualityComparer<T>.Default.Equals(current, value3))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        internal static int LastIndexOfAnyExcept<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length)
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+
+            for (int i = length - 1; i >= 0; i--)
+            {
+                ref T current = ref Unsafe.Add(ref searchSpace, i);
+                if (!EqualityComparer<T>.Default.Equals(current, value0)
+                    && !EqualityComparer<T>.Default.Equals(current, value1)
+                    && !EqualityComparer<T>.Default.Equals(current, value2)
+                    && !EqualityComparer<T>.Default.Equals(current, value3))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
         }
 
         public static bool SequenceEqual<T>(ref T first, ref T second, int length) where T : IEquatable<T>?
@@ -1394,6 +1297,1374 @@ namespace System
                     return result;
             }
             return firstLength.CompareTo(secondLength);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool CanVectorizeAndBenefit<T>(int length) where T : IEquatable<T>?
+        {
+            if (Vector128.IsHardwareAccelerated && RuntimeHelpers.IsBitwiseEquatable<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                {
+                    return length >= Vector128<byte>.Count;
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(short))
+                {
+                    return length >= Vector128<short>.Count;
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                {
+                    return length >= Vector128<int>.Count;
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(long))
+                {
+                    return length >= Vector128<long>.Count;
+                }
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        internal static bool ContainsValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<T>.Count)
+            {
+                nuint offset = 0;
+
+                while (length >= 8)
+                {
+                    length -= 8;
+
+                    if (Unsafe.Add(ref searchSpace, offset) == value
+                     || Unsafe.Add(ref searchSpace, offset + 1) == value
+                     || Unsafe.Add(ref searchSpace, offset + 2) == value
+                     || Unsafe.Add(ref searchSpace, offset + 3) == value
+                     || Unsafe.Add(ref searchSpace, offset + 4) == value
+                     || Unsafe.Add(ref searchSpace, offset + 5) == value
+                     || Unsafe.Add(ref searchSpace, offset + 6) == value
+                     || Unsafe.Add(ref searchSpace, offset + 7) == value)
+                    {
+                        return true;
+                    }
+
+                    offset += 8;
+                }
+
+                if (length >= 4)
+                {
+                    length -= 4;
+
+                    if (Unsafe.Add(ref searchSpace, offset) == value
+                     || Unsafe.Add(ref searchSpace, offset + 1) == value
+                     || Unsafe.Add(ref searchSpace, offset + 2) == value
+                     || Unsafe.Add(ref searchSpace, offset + 3) == value)
+                    {
+                        return true;
+                    }
+
+                    offset += 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    if (Unsafe.Add(ref searchSpace, offset) == value) return true;
+
+                    offset += 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
+            {
+                Vector256<T> equals, values = Vector256.Create(value);
+                ref T currentSearchSpace = ref searchSpace;
+                ref T oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector256<T>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    equals = Vector256.Equals(values, Vector256.LoadUnsafe(ref currentSearchSpace));
+                    if (equals == Vector256<T>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<T>.Count);
+                        continue;
+                    }
+
+                    return true;
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector256<T>.Count != 0)
+                {
+                    equals = Vector256.Equals(values, Vector256.LoadUnsafe(ref oneVectorAwayFromEnd));
+                    if (equals != Vector256<T>.Zero)
+                    {
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                Vector128<T> equals, values = Vector128.Create(value);
+                ref T currentSearchSpace = ref searchSpace;
+                ref T oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector128<T>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    equals = Vector128.Equals(values, Vector128.LoadUnsafe(ref currentSearchSpace));
+                    if (equals == Vector128<T>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<T>.Count);
+                        continue;
+                    }
+
+                    return true;
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<T>.Count != 0)
+                {
+                    equals = Vector128.Equals(values, Vector128.LoadUnsafe(ref oneVectorAwayFromEnd));
+                    if (equals != Vector128<T>.Zero)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfChar(ref char searchSpace, char value, int length)
+            => IndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
+            => IndexOfValueType<T, DontNegate<T>>(ref searchSpace, value, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfAnyExceptValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
+            => IndexOfValueType<T, Negate<T>>(ref searchSpace, value, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static int IndexOfValueType<TValue, TNegator>(ref TValue searchSpace, TValue value, int length)
+            where TValue : struct, INumber<TValue>
+            where TNegator : struct, INegator<TValue>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<TValue>.Count)
+            {
+                nuint offset = 0;
+
+                while (length >= 8)
+                {
+                    length -= 8;
+
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)offset;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 1) == value)) return (int)offset + 1;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 2) == value)) return (int)offset + 2;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 3) == value)) return (int)offset + 3;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 4) == value)) return (int)offset + 4;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 5) == value)) return (int)offset + 5;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 6) == value)) return (int)offset + 6;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 7) == value)) return (int)offset + 7;
+
+                    offset += 8;
+                }
+
+                if (length >= 4)
+                {
+                    length -= 4;
+
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)offset;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 1) == value)) return (int)offset + 1;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 2) == value)) return (int)offset + 2;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset + 3) == value)) return (int)offset + 3;
+
+                    offset += 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset).Equals(value))) return (int)offset;
+
+                    offset += 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
+            {
+                Vector256<TValue> equals, values = Vector256.Create(value);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref currentSearchSpace)));
+                    if (equals == Vector256<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector256<TValue>.Count != 0)
+                {
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref oneVectorAwayFromEnd)));
+                    if (equals != Vector256<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<TValue> equals, values = Vector128.Create(value);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref currentSearchSpace)));
+                    if (equals == Vector128<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<TValue>.Count != 0)
+                {
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref oneVectorAwayFromEnd)));
+                    if (equals != Vector128<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfAnyChar(ref char searchSpace, char value0, char value1, int length)
+            => IndexOfAnyValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfAnyValueType<T>(ref T searchSpace, T value0, T value1, int length) where T : struct, INumber<T>
+            => IndexOfAnyValueType<T, DontNegate<T>>(ref searchSpace, value0, value1, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, int length) where T : struct, INumber<T>
+            => IndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, length);
+
+        // having INumber<T> constraint here allows to use == operator and get better perf compared to .Equals
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static int IndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, int length)
+            where TValue : struct, INumber<TValue>
+            where TNegator : struct, INegator<TValue>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<TValue>.Count)
+            {
+                nuint offset = 0;
+                TValue lookUp;
+
+                if (typeof(TValue) == typeof(byte)) // this optimization is beneficial only to byte
+                {
+                    while (length >= 8)
+                    {
+                        length -= 8;
+
+                        ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                        lookUp = current;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset;
+                        lookUp = Unsafe.Add(ref current, 1);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 1;
+                        lookUp = Unsafe.Add(ref current, 2);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 2;
+                        lookUp = Unsafe.Add(ref current, 3);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 3;
+                        lookUp = Unsafe.Add(ref current, 4);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 4;
+                        lookUp = Unsafe.Add(ref current, 5);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 5;
+                        lookUp = Unsafe.Add(ref current, 6);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 6;
+                        lookUp = Unsafe.Add(ref current, 7);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 7;
+
+                        offset += 8;
+                    }
+                }
+
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                    lookUp = current;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset;
+                    lookUp = Unsafe.Add(ref current, 1);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 1;
+                    lookUp = Unsafe.Add(ref current, 2);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 2;
+                    lookUp = Unsafe.Add(ref current, 3);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset + 3;
+
+                    offset += 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    lookUp = Unsafe.Add(ref searchSpace, offset);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset;
+
+                    offset += 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
+            {
+                Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values0, current) | Vector256.Equals(values1, current));
+                    if (equals == Vector256<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector256<TValue>.Count != 0)
+                {
+                    current = Vector256.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values0, current) | Vector256.Equals(values1, current));
+                    if (equals != Vector256<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values0, current) | Vector128.Equals(values1, current));
+                    if (equals == Vector128<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<TValue>.Count != 0)
+                {
+                    current = Vector128.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values0, current) | Vector128.Equals(values1, current));
+                    if (equals != Vector128<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfAnyValueType<T>(ref T searchSpace, T value0, T value1, T value2, int length) where T : struct, INumber<T>
+            => IndexOfAnyValueType<T, DontNegate<T>>(ref searchSpace, value0, value1, value2, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, int length) where T : struct, INumber<T>
+            => IndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static int IndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, int length)
+            where TValue : struct, INumber<TValue>
+            where TNegator : struct, INegator<TValue>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<TValue>.Count)
+            {
+                nuint offset = 0;
+                TValue lookUp;
+
+                if (typeof(TValue) == typeof(byte)) // this optimization is beneficial only to byte
+                {
+                    while (length >= 8)
+                    {
+                        length -= 8;
+
+                        ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                        lookUp = current;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset;
+                        lookUp = Unsafe.Add(ref current, 1);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 1;
+                        lookUp = Unsafe.Add(ref current, 2);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 2;
+                        lookUp = Unsafe.Add(ref current, 3);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 3;
+                        lookUp = Unsafe.Add(ref current, 4);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 4;
+                        lookUp = Unsafe.Add(ref current, 5);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 5;
+                        lookUp = Unsafe.Add(ref current, 6);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 6;
+                        lookUp = Unsafe.Add(ref current, 7);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 7;
+
+                        offset += 8;
+                    }
+                }
+
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                    lookUp = current;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset;
+                    lookUp = Unsafe.Add(ref current, 1);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 1;
+                    lookUp = Unsafe.Add(ref current, 2);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 2;
+                    lookUp = Unsafe.Add(ref current, 3);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset + 3;
+
+                    offset += 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    lookUp = Unsafe.Add(ref searchSpace, offset);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset;
+
+                    offset += 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
+            {
+                Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1), values2 = Vector256.Create(value2);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values0, current) | Vector256.Equals(values1, current) | Vector256.Equals(values2, current));
+                    if (equals == Vector256<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector256<TValue>.Count != 0)
+                {
+                    current = Vector256.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values0, current) | Vector256.Equals(values1, current) | Vector256.Equals(values2, current));
+                    if (equals != Vector256<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1), values2 = Vector128.Create(value2);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values0, current) | Vector128.Equals(values1, current) | Vector128.Equals(values2, current));
+                    if (equals == Vector128<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<TValue>.Count != 0)
+                {
+                    current = Vector128.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values0, current) | Vector128.Equals(values1, current) | Vector128.Equals(values2, current));
+                    if (equals != Vector128<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfAnyValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length) where T : struct, INumber<T>
+            => IndexOfAnyValueType<T, DontNegate<T>>(ref searchSpace, value0, value1, value2, value3, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length) where T : struct, INumber<T>
+            => IndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, value3, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static int IndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, TValue value3, int length)
+            where TValue : struct, INumber<TValue>
+            where TNegator : struct, INegator<TValue>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<TValue>.Count)
+            {
+                nuint offset = 0;
+                TValue lookUp;
+
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                    lookUp = current;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset;
+                    lookUp = Unsafe.Add(ref current, 1);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset + 1;
+                    lookUp = Unsafe.Add(ref current, 2);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset + 2;
+                    lookUp = Unsafe.Add(ref current, 3);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset + 3;
+
+                    offset += 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    lookUp = Unsafe.Add(ref searchSpace, offset);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset;
+
+                    offset += 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
+            {
+                Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1), values2 = Vector256.Create(value2), values3 = Vector256.Create(value3);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values0, current) | Vector256.Equals(values1, current)
+                        | Vector256.Equals(values2, current) | Vector256.Equals(values3, current));
+                    if (equals == Vector256<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector256<TValue>.Count != 0)
+                {
+                    current = Vector256.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values0, current) | Vector256.Equals(values1, current)
+                        | Vector256.Equals(values2, current) | Vector256.Equals(values3, current));
+                    if (equals != Vector256<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1), values2 = Vector128.Create(value2), values3 = Vector128.Create(value3);
+                ref TValue currentSearchSpace = ref searchSpace;
+                ref TValue oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values0, current) | Vector128.Equals(values1, current)
+                        | Vector128.Equals(values2, current) | Vector128.Equals(values3, current));
+                    if (equals == Vector128<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<TValue>.Count != 0)
+                {
+                    current = Vector128.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values0, current) | Vector128.Equals(values1, current)
+                        | Vector128.Equals(values2, current) | Vector128.Equals(values3, current));
+                    if (equals != Vector128<TValue>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        internal static int IndexOfAnyValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, T value4, int length)
+            where T : struct, INumber<T>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<T>.Count)
+            {
+                nuint offset = 0;
+                T lookUp;
+
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    ref T current = ref Unsafe.Add(ref searchSpace, offset);
+                    lookUp = current;
+                    if (lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4) return (int)offset;
+                    lookUp = Unsafe.Add(ref current, 1);
+                    if (lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4) return (int)offset + 1;
+                    lookUp = Unsafe.Add(ref current, 2);
+                    if (lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4) return (int)offset + 2;
+                    lookUp = Unsafe.Add(ref current, 3);
+                    if (lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4) return (int)offset + 3;
+
+                    offset += 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    lookUp = Unsafe.Add(ref searchSpace, offset);
+                    if (lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3 || lookUp == value4) return (int)offset;
+
+                    offset += 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<T>.Count)
+            {
+                Vector256<T> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1),
+                    values2 = Vector256.Create(value2), values3 = Vector256.Create(value3), values4 = Vector256.Create(value4);
+                ref T currentSearchSpace = ref searchSpace;
+                ref T oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector256<T>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    equals = Vector256.Equals(values0, current) | Vector256.Equals(values1, current) | Vector256.Equals(values2, current)
+                           | Vector256.Equals(values3, current) | Vector256.Equals(values4, current);
+                    if (equals == Vector256<T>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<T>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the last vector in the search space.
+                if ((uint)length % Vector256<T>.Count != 0)
+                {
+                    current = Vector256.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = Vector256.Equals(values0, current) | Vector256.Equals(values1, current) | Vector256.Equals(values2, current)
+                           | Vector256.Equals(values3, current) | Vector256.Equals(values4, current);
+                    if (equals != Vector256<T>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<T> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1),
+                    values2 = Vector128.Create(value2), values3 = Vector128.Create(value3), values4 = Vector128.Create(value4);
+                ref T currentSearchSpace = ref searchSpace;
+                ref T oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, length - Vector128<T>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    equals = Vector128.Equals(values0, current) | Vector128.Equals(values1, current) | Vector128.Equals(values2, current)
+                           | Vector128.Equals(values3, current) | Vector128.Equals(values4, current);
+                    if (equals == Vector128<T>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<T>.Count);
+                        continue;
+                    }
+
+                    return ComputeFirstIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<T>.Count != 0)
+                {
+                    current = Vector128.LoadUnsafe(ref oneVectorAwayFromEnd);
+                    equals = Vector128.Equals(values0, current) | Vector128.Equals(values1, current) | Vector128.Equals(values2, current)
+                           | Vector128.Equals(values3, current) | Vector128.Equals(values4, current);
+                    if (equals != Vector128<T>.Zero)
+                    {
+                        return ComputeFirstIndex(ref searchSpace, ref oneVectorAwayFromEnd, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
+            => LastIndexOfValueType<T, DontNegate<T>>(ref searchSpace, value, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
+            => LastIndexOfValueType<T, Negate<T>>(ref searchSpace, value, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static int LastIndexOfValueType<TValue, TNegator>(ref TValue searchSpace, TValue value, int length)
+            where TValue : struct, INumber<TValue>
+            where TNegator : struct, INegator<TValue>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<TValue>.Count)
+            {
+                nuint offset = (nuint)length - 1;
+
+                while (length >= 8)
+                {
+                    length -= 8;
+
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)offset;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 1) == value)) return (int)offset - 1;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 2) == value)) return (int)offset - 2;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 3) == value)) return (int)offset - 3;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 4) == value)) return (int)offset - 4;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 5) == value)) return (int)offset - 5;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 6) == value)) return (int)offset - 6;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 7) == value)) return (int)offset - 7;
+
+                    offset -= 8;
+                }
+
+                if (length >= 4)
+                {
+                    length -= 4;
+
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)offset;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 1) == value)) return (int)offset - 1;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 2) == value)) return (int)offset - 2;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset - 3) == value)) return (int)offset - 3;
+
+                    offset -= 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset).Equals(value))) return (int)offset;
+
+                    offset -= 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
+            {
+                Vector256<TValue> equals, values = Vector256.Create(value);
+                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref currentSearchSpace)));
+                    if (equals == Vector256<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector256<TValue>.Count != 0)
+                {
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref searchSpace)));
+                    if (equals != Vector256<TValue>.Zero)
+                    {
+                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<TValue> equals, values = Vector128.Create(value);
+                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref currentSearchSpace)));
+                    if (equals == Vector128<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<TValue>.Count != 0)
+                {
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref searchSpace)));
+                    if (equals != Vector128<TValue>.Zero)
+                    {
+                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfAnyValueType<T>(ref T searchSpace, T value0, T value1, int length) where T : struct, INumber<T>
+            => LastIndexOfAnyValueType<T, DontNegate<T>>(ref searchSpace, value0, value1, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, int length) where T : struct, INumber<T>
+            => LastIndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static int LastIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, int length)
+            where TValue : struct, INumber<TValue>
+            where TNegator : struct, INegator<TValue>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<TValue>.Count)
+            {
+                nuint offset = (nuint)length - 1;
+                TValue lookUp;
+
+                if (typeof(TValue) == typeof(byte)) // this optimization is beneficial only to byte
+                {
+                    while (length >= 8)
+                    {
+                        length -= 8;
+
+                        ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                        lookUp = current;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset;
+                        lookUp = Unsafe.Add(ref current, -1);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 1;
+                        lookUp = Unsafe.Add(ref current, -2);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 2;
+                        lookUp = Unsafe.Add(ref current, -3);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 3;
+                        lookUp = Unsafe.Add(ref current, -4);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 4;
+                        lookUp = Unsafe.Add(ref current, -5);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 5;
+                        lookUp = Unsafe.Add(ref current, -6);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 6;
+                        lookUp = Unsafe.Add(ref current, -7);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 7;
+
+                        offset -= 8;
+                    }
+                }
+
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                    lookUp = current;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset;
+                    lookUp = Unsafe.Add(ref current, -1);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 1;
+                    lookUp = Unsafe.Add(ref current, -2);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 2;
+                    lookUp = Unsafe.Add(ref current, -3);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset - 3;
+
+                    offset -= 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    lookUp = Unsafe.Add(ref searchSpace, offset);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1)) return (int)offset;
+
+                    offset -= 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
+            {
+                Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1);
+                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1));
+                    if (equals == Vector256<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector256<TValue>.Count != 0)
+                {
+                    current = Vector256.LoadUnsafe(ref searchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1));
+                    if (equals != Vector256<TValue>.Zero)
+                    {
+                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1);
+                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1));
+                    if (equals == Vector128<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<TValue>.Count != 0)
+                {
+                    current = Vector128.LoadUnsafe(ref searchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1));
+                    if (equals != Vector128<TValue>.Zero)
+                    {
+                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfAnyValueType<T>(ref T searchSpace, T value0, T value1, T value2, int length) where T : struct, INumber<T>
+            => LastIndexOfAnyValueType<T, DontNegate<T>>(ref searchSpace, value0, value1, value2, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, int length) where T : struct, INumber<T>
+            => LastIndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static int LastIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, int length)
+            where TValue : struct, INumber<TValue>
+            where TNegator : struct, INegator<TValue>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<TValue>.Count)
+            {
+                nuint offset = (nuint)length - 1;
+                TValue lookUp;
+
+                if (typeof(TValue) == typeof(byte)) // this optimization is beneficial only to byte
+                {
+                    while (length >= 8)
+                    {
+                        length -= 8;
+
+                        ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                        lookUp = current;
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset;
+                        lookUp = Unsafe.Add(ref current, -1);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 1;
+                        lookUp = Unsafe.Add(ref current, -2);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 2;
+                        lookUp = Unsafe.Add(ref current, -3);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 3;
+                        lookUp = Unsafe.Add(ref current, -4);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 4;
+                        lookUp = Unsafe.Add(ref current, -5);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 5;
+                        lookUp = Unsafe.Add(ref current, -6);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 6;
+                        lookUp = Unsafe.Add(ref current, -7);
+                        if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 7;
+
+                        offset -= 8;
+                    }
+                }
+
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                    lookUp = current;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset;
+                    lookUp = Unsafe.Add(ref current, -1);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 1;
+                    lookUp = Unsafe.Add(ref current, -2);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 2;
+                    lookUp = Unsafe.Add(ref current, -3);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset - 3;
+
+                    offset -= 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    lookUp = Unsafe.Add(ref searchSpace, offset);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2)) return (int)offset;
+
+                    offset -= 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
+            {
+                Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1), values2 = Vector256.Create(value2);
+                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1) | Vector256.Equals(current, values2));
+                    if (equals == Vector256<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector256<TValue>.Count != 0)
+                {
+                    current = Vector256.LoadUnsafe(ref searchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1) | Vector256.Equals(current, values2));
+                    if (equals != Vector256<TValue>.Zero)
+                    {
+                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1), values2 = Vector128.Create(value2);
+                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2));
+                    if (equals == Vector128<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<TValue>.Count != 0)
+                {
+                    current = Vector128.LoadUnsafe(ref searchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2));
+                    if (equals != Vector128<TValue>.Zero)
+                    {
+                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfAnyValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length) where T : struct, INumber<T>
+            => LastIndexOfAnyValueType<T, DontNegate<T>>(ref searchSpace, value0, value1, value2, value3, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfAnyExceptValueType<T>(ref T searchSpace, T value0, T value1, T value2, T value3, int length) where T : struct, INumber<T>
+            => LastIndexOfAnyValueType<T, Negate<T>>(ref searchSpace, value0, value1, value2, value3, length);
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private static int LastIndexOfAnyValueType<TValue, TNegator>(ref TValue searchSpace, TValue value0, TValue value1, TValue value2, TValue value3, int length)
+            where TValue : struct, INumber<TValue>
+            where TNegator : struct, INegator<TValue>
+        {
+            Debug.Assert(length >= 0, "Expected non-negative length");
+            Debug.Assert(value0 is byte or short or int or long, "Expected caller to normalize to one of these types");
+
+            if (!Vector128.IsHardwareAccelerated || length < Vector128<TValue>.Count)
+            {
+                nuint offset = (nuint)length - 1;
+                TValue lookUp;
+
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    ref TValue current = ref Unsafe.Add(ref searchSpace, offset);
+                    lookUp = current;
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset;
+                    lookUp = Unsafe.Add(ref current, -1);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset - 1;
+                    lookUp = Unsafe.Add(ref current, -2);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset - 2;
+                    lookUp = Unsafe.Add(ref current, -3);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset - 3;
+
+                    offset -= 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    lookUp = Unsafe.Add(ref searchSpace, offset);
+                    if (TNegator.NegateIfNeeded(lookUp == value0 || lookUp == value1 || lookUp == value2 || lookUp == value3)) return (int)offset;
+
+                    offset -= 1;
+                }
+            }
+            else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
+            {
+                Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1), values2 = Vector256.Create(value2), values3 = Vector256.Create(value3);
+                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1)
+                                            | Vector256.Equals(current, values2) | Vector256.Equals(current, values3));
+                    if (equals == Vector256<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector256<TValue>.Count != 0)
+                {
+                    current = Vector256.LoadUnsafe(ref searchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1)
+                                            | Vector256.Equals(current, values2) | Vector256.Equals(current, values3));
+                    if (equals != Vector256<TValue>.Zero)
+                    {
+                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
+                    }
+                }
+            }
+            else
+            {
+                Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1), values2 = Vector128.Create(value2), values3 = Vector128.Create(value3);
+                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+
+                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
+                do
+                {
+                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1)
+                                            | Vector128.Equals(current, values2) | Vector128.Equals(current, values3));
+                    if (equals == Vector128<TValue>.Zero)
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<TValue>.Count);
+                        continue;
+                    }
+
+                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                }
+                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
+                // If any elements remain, process the first vector in the search space.
+                if ((uint)length % Vector128<TValue>.Count != 0)
+                {
+                    current = Vector128.LoadUnsafe(ref searchSpace);
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1)
+                                            | Vector128.Equals(current, values2) | Vector128.Equals(current, values3));
+                    if (equals != Vector128<TValue>.Zero)
+                    {
+                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeFirstIndex<T>(ref T searchSpace, ref T current, Vector128<T> equals) where T : struct
+        {
+            uint notEqualsElements = equals.ExtractMostSignificantBits();
+            int index = BitOperations.TrailingZeroCount(notEqualsElements);
+            return index + (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / Unsafe.SizeOf<T>());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeFirstIndex<T>(ref T searchSpace, ref T current, Vector256<T> equals) where T : struct
+        {
+            uint notEqualsElements = equals.ExtractMostSignificantBits();
+            int index = BitOperations.TrailingZeroCount(notEqualsElements);
+            return index + (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / Unsafe.SizeOf<T>());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeLastIndex<T>(ref T searchSpace, ref T current, Vector128<T> equals) where T : struct
+        {
+            uint notEqualsElements = equals.ExtractMostSignificantBits();
+            int index = 31 - BitOperations.LeadingZeroCount(notEqualsElements); // 31 = 32 (bits in Int32) - 1 (indexing from zero)
+            return (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / Unsafe.SizeOf<T>()) + index;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeLastIndex<T>(ref T searchSpace, ref T current, Vector256<T> equals) where T : struct
+        {
+            uint notEqualsElements = equals.ExtractMostSignificantBits();
+            int index = 31 - BitOperations.LeadingZeroCount(notEqualsElements); // 31 = 32 (bits in Int32) - 1 (indexing from zero)
+            return (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / Unsafe.SizeOf<T>()) + index;
+        }
+
+        private interface INegator<T> where T : struct
+        {
+            static abstract bool NegateIfNeeded(bool equals);
+            static abstract Vector128<T> NegateIfNeeded(Vector128<T> equals);
+            static abstract Vector256<T> NegateIfNeeded(Vector256<T> equals);
+        }
+
+        private readonly struct DontNegate<T> : INegator<T> where T : struct
+        {
+            public static bool NegateIfNeeded(bool equals) => equals;
+            public static Vector128<T> NegateIfNeeded(Vector128<T> equals) => equals;
+            public static Vector256<T> NegateIfNeeded(Vector256<T> equals) => equals;
+        }
+
+        private readonly struct Negate<T> : INegator<T> where T : struct
+        {
+            public static bool NegateIfNeeded(bool equals) => !equals;
+            public static Vector128<T> NegateIfNeeded(Vector128<T> equals) => ~equals;
+            public static Vector256<T> NegateIfNeeded(Vector256<T> equals) => ~equals;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -3,9 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 namespace System

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1067,7 +1067,7 @@ namespace System
                 int i = 0;
                 while (true)
                 {
-                    int pos = SpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, i), c, Length - i);
+                    int pos = SpanHelpers.IndexOfChar(ref Unsafe.Add(ref _firstChar, i), c, Length - i);
                     if (pos < 0)
                     {
                         break;

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -27,7 +27,8 @@ namespace System
 #pragma warning restore CA2249
         }
 
-        public bool Contains(char value) => SpanHelpers.Contains(ref _firstChar, value, Length);
+        public bool Contains(char value)
+            => SpanHelpers.ContainsValueType(ref Unsafe.As<char, short>(ref _firstChar), (short)value, Length);
 
         public bool Contains(char value, StringComparison comparisonType)
         {
@@ -36,8 +37,7 @@ namespace System
 
         // Returns the index of the first occurrence of a specified character in the current instance.
         // The search starts at startIndex and runs thorough the next count characters.
-        //
-        public int IndexOf(char value) => SpanHelpers.IndexOf(ref _firstChar, value, Length);
+        public int IndexOf(char value) => SpanHelpers.IndexOfChar(ref _firstChar, value, Length);
 
         public int IndexOf(char value, int startIndex)
         {
@@ -78,10 +78,10 @@ namespace System
             {
                 char valueUc = (char)(value | 0x20);
                 char valueLc = (char)(value & ~0x20);
-                return SpanHelpers.IndexOfAny(ref _firstChar, valueLc, valueUc, Length);
+                return SpanHelpers.IndexOfAnyChar(ref _firstChar, valueLc, valueUc, Length);
             }
 
-            return SpanHelpers.IndexOf(ref _firstChar, value, Length);
+            return SpanHelpers.IndexOfChar(ref _firstChar, value, Length);
         }
 
         public unsafe int IndexOf(char value, int startIndex, int count)
@@ -96,7 +96,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
             }
 
-            int result = SpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, startIndex), value, count);
+            int result = SpanHelpers.IndexOfChar(ref Unsafe.Add(ref _firstChar, startIndex), value, count);
 
             return result < 0 ? result : result + startIndex;
         }
@@ -280,8 +280,8 @@ namespace System
         // The search starts at startIndex and runs backwards to startIndex - count + 1.
         // The character at position startIndex is included in the search.  startIndex is the larger
         // index within the string.
-        //
-        public int LastIndexOf(char value) => SpanHelpers.LastIndexOf(ref _firstChar, value, Length);
+        public int LastIndexOf(char value)
+            => SpanHelpers.LastIndexOfValueType(ref Unsafe.As<char, short>(ref _firstChar), (short)value, Length);
 
         public int LastIndexOf(char value, int startIndex)
         {
@@ -306,7 +306,7 @@ namespace System
             }
 
             int startSearchAt = startIndex + 1 - count;
-            int result = SpanHelpers.LastIndexOf(ref Unsafe.Add(ref _firstChar, startSearchAt), value, count);
+            int result = SpanHelpers.LastIndexOfValueType(ref Unsafe.As<char, short>(ref Unsafe.Add(ref _firstChar, startSearchAt)), (short)value, count);
 
             return result < 0 ? result : result + startSearchAt;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -593,39 +593,9 @@ namespace System
             return new StringRuneEnumerator(this);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe int wcslen(char* ptr)
-        {
-            // IndexOf processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
-            // This IndexOf behavior is an implementation detail of the runtime and callers outside System.Private.CoreLib must not depend on it.
-            int length = SpanHelpers.IndexOf(ref *ptr, '\0', int.MaxValue);
-            if (length < 0)
-            {
-                ThrowMustBeNullTerminatedString();
-            }
+        internal static unsafe int wcslen(char* ptr) => SpanHelpers.IndexOfNullCharacter(ref *ptr);
 
-            return length;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe int strlen(byte* ptr)
-        {
-            // IndexOf processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
-            // This IndexOf behavior is an implementation detail of the runtime and callers outside System.Private.CoreLib must not depend on it.
-            int length = SpanHelpers.IndexOf(ref *ptr, (byte)'\0', int.MaxValue);
-            if (length < 0)
-            {
-                ThrowMustBeNullTerminatedString();
-            }
-
-            return length;
-        }
-
-        [DoesNotReturn]
-        private static void ThrowMustBeNullTerminatedString()
-        {
-            throw new ArgumentException(SR.Arg_MustBeNullTerminatedString);
-        }
+        internal static unsafe int strlen(byte* ptr) => SpanHelpers.IndexOfNullByte(ref *ptr);
 
         //
         // IConvertible implementation


### PR DESCRIPTION
Backport of #73768 to release/7.0-rc1

I'm backporting this as a special case (I missed the cutoff by hours), as discussed with @stephentoub, who discussed it with @danmoseley.

This PR gives us:
- great validation of the new `Vector128` and `Vector256` APIs.
- vectorization of all `Span.{Last}IndexOf{Any}{Except}` methods which translates to impressive performance improvements (the larger the input and more work needed, the better).

The performance has been verified on arm64 Windows and Linux, x64 Intel and AMD. Full results can be found [here](https://github.com/dotnet/runtime/pull/73768#issuecomment-1217106012)