### PR TITLE
[mono] fix Android sample AOT=true build

### DIFF
--- a/src/mono/sample/Android/AndroidSampleApp.csproj
+++ b/src/mono/sample/Android/AndroidSampleApp.csproj
@@ -47,7 +47,7 @@
 
     <PropertyGroup Condition="'$(ForceAOT)' == 'true' and '$(AOTWithLibraryFiles)' != 'true'">
       <_AotOutputType>AsmOnly</_AotOutputType>
-      <_AotModulesTablePath>$(BundleDir)\modules.c</_AotModulesTablePath>
+      <_AotModulesTablePath>$(ApkDir)\modules.c</_AotModulesTablePath>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(ForceAOT)' == 'true' and '$(AOTWithLibraryFiles)' == 'true'">


### PR DESCRIPTION
BundleDir isn't set in the sample.  the Apk builder task's cmake
template seems to expect the file in the ApkDir