### PR TITLE
[release/7.0-rc1] Set configureplatform.make prerelease to 0

### DIFF
--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
 
 # If set, indicates that this is not an officially supported release.
 # Release branches should set this to false.
-set(PRERELEASE 1)
+set(PRERELEASE 0)
 
 #----------------------------------------
 # Detect and set platform variable names


### PR DESCRIPTION
As explained here: https://github.com/dotnet/runtime/pull/72169#discussion_r921263308 by @jkotas:

> If we switch it to 0 in main, we will see C/C++ compiler warnings creep in. I do not think anybody wants to sign up for fixing them once we fork for .NET 8.

So I'm doing this directly in rc1. The maestro bot should get it backported to release/7.0 automatically.
