### PR TITLE
Don't track current field of state machines

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedNames.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedNames.cs
@@ -36,6 +36,19 @@ namespace ILCompiler.Dataflow
             return typeName.Length > i + 1 && typeName[i + 1] == 'd';
         }
 
+        internal static bool IsStateMachineCurrentField(string fieldName)
+        {
+            if (!IsGeneratedMemberName(fieldName))
+                return false;
+
+            int i = fieldName.LastIndexOf('>');
+            if (i == -1)
+                return false;
+
+            // Current field is <>2__current
+            return fieldName.Length > i + 1 && fieldName[i + 1] == '2';
+        }
+
         internal static bool IsGeneratedType(string name) => IsStateMachineType(name) || IsLambdaDisplayClass(name);
 
         internal static bool IsLambdaOrLocalFunction(string methodName) => IsLambdaMethod(methodName) || IsLocalFunction(methodName);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
@@ -500,10 +500,17 @@ namespace ILCompiler.Dataflow
 
         public static bool IsHoistedLocal(FieldDesc field)
         {
-            // Treat all fields on compiler-generated types as hoisted locals.
-            // This avoids depending on the name mangling scheme for hoisted locals.
-            var declaringTypeName = field.OwningType.Name;
-            return CompilerGeneratedNames.IsLambdaDisplayClass(declaringTypeName) || CompilerGeneratedNames.IsStateMachineType(declaringTypeName);
+            if (CompilerGeneratedNames.IsLambdaDisplayClass(field.OwningType.Name))
+                return true;
+
+            if (CompilerGeneratedNames.IsStateMachineType(field.OwningType.Name))
+            {
+                // Don't track the "current" field which is used for state machine return values,
+                // because this can be expensive to track.
+                return !CompilerGeneratedNames.IsStateMachineCurrentField(field.Name);
+            }
+
+            return false;
         }
 
         // "Nested function" refers to lambdas and local functions.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/CompilerGeneratedNames.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/CompilerGeneratedNames.cs
@@ -34,6 +34,19 @@ namespace Mono.Linker.Dataflow
 			return typeName.Length > i + 1 && typeName[i + 1] == 'd';
 		}
 
+		internal static bool IsStateMachineCurrentField (string fieldName)
+		{
+			if (!IsGeneratedMemberName (fieldName))
+				return false;
+
+			int i = fieldName.LastIndexOf ('>');
+			if (i == -1)
+				return false;
+
+			// Current field is <>2__current
+			return fieldName.Length > i + 1 && fieldName[i + 1] == '2';
+		}
+
 		internal static bool IsGeneratedType (string name) => IsStateMachineType (name) || IsLambdaDisplayClass (name);
 
 		internal static bool IsLambdaOrLocalFunction (string methodName) => IsLambdaMethod (methodName) || IsLocalFunction (methodName);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/CompilerGeneratedState.cs
@@ -55,10 +55,16 @@ namespace Mono.Linker.Dataflow
 
 		public static bool IsHoistedLocal (FieldDefinition field)
 		{
-			// Treat all fields on compiler-generated types as hoisted locals.
-			// This avoids depending on the name mangling scheme for hoisted locals.
-			var declaringTypeName = field.DeclaringType.Name;
-			return CompilerGeneratedNames.IsLambdaDisplayClass (declaringTypeName) || CompilerGeneratedNames.IsStateMachineType (declaringTypeName);
+			if (CompilerGeneratedNames.IsLambdaDisplayClass (field.DeclaringType.Name))
+				return true;
+
+			if (CompilerGeneratedNames.IsStateMachineType (field.DeclaringType.Name)) {
+				// Don't track the "current" field which is used for state machine return values,
+				// because this can be expensive to track.
+				return !CompilerGeneratedNames.IsStateMachineCurrentField (field.Name);
+			}
+
+			return false;
 		}
 
 		// "Nested function" refers to lambdas and local functions.


### PR DESCRIPTION
Port of https://github.com/dotnet/linker/pull/2979

Fixes #73048.

The files under ReferenceSource match what's in linker repo main branch. We don't have any other diffs in these files.

I didn't do a full integration from the linker repo because I would like to get this into RC1.