### PR TITLE
Revert "Update S.R.Metadata in HostModel (#74009)"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -210,6 +210,14 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>e680411c22e33f45821f4ae64365a2970b2430a6</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="7.0.0-rc.1.22414.6">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>e680411c22e33f45821f4ae64365a2970b2430a6</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="7.0.0-rc.1.22414.6">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>e680411c22e33f45821f4ae64365a2970b2430a6</Sha>
+    </Dependency>
     <Dependency Name="runtime.native.System.IO.Ports" Version="7.0.0-rc.1.22414.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>e680411c22e33f45821f4ae64365a2970b2430a6</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,6 +74,8 @@
     <NuGetBuildTasksPackVersion>6.0.0-preview.1.102</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->
     <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-rc.1.22414.6</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCoreDotNetHostVersion>7.0.0-rc.1.22414.6</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>7.0.0-rc.1.22414.6</MicrosoftNETCoreDotNetHostPolicyVersion>
     <MicrosoftExtensionsDependencyModelVersion>6.0.0</MicrosoftExtensionsDependencyModelVersion>
     <!-- CoreClr dependencies -->
     <MicrosoftNETCoreILAsmVersion>7.0.0-rc.1.22414.6</MicrosoftNETCoreILAsmVersion>

--- a/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
+++ b/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.8.0" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Causing restore issues in https://github.com/dotnet/sdk/pull/27149#issuecomment-1218905897. I see the words "binding redirects" and that feels like won't be an easy fix. Open to other solutions, just want a PR ready if we need to unblock.

This reverts commit 7e4b3c10d5143a2cbf43bd9e6d1edb4f924cf9e9.