### PR TITLE
Move runtimeconfig.template.json stuff to csproj

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/System.Diagnostics.DiagnosticSource.Switches.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/System.Diagnostics.DiagnosticSource.Switches.Tests.csproj
@@ -4,6 +4,9 @@
     <TestRuntime>true</TestRuntime>
   </PropertyGroup>
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Diagnostics.DefaultActivityIdFormatIsHierarchial" Value="true" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="ActivityTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/runtimeconfig.template.json
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-  "configProperties": {
-    "System.Diagnostics.DefaultActivityIdFormatIsHierarchial": true
-  }
-}

--- a/src/libraries/System.Globalization.Extensions/tests/NlsTests/System.Globalization.Extensions.Nls.Tests.csproj
+++ b/src/libraries/System.Globalization.Extensions/tests/NlsTests/System.Globalization.Extensions.Nls.Tests.csproj
@@ -4,6 +4,9 @@
     <TestRuntime>true</TestRuntime>
   </PropertyGroup>
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\GetStringComparerTests.cs"
              Link="GetStringComparerTests.cs" />
     <Compile Include="..\IdnMapping\Data\ConformanceIdnaUnicodeTestResult.cs"

--- a/src/libraries/System.Globalization.Extensions/tests/NlsTests/runtimeconfig.template.json
+++ b/src/libraries/System.Globalization.Extensions/tests/NlsTests/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-  "configProperties": {
-    "System.Globalization.UseNls": true
-  }
-}

--- a/src/libraries/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
+++ b/src/libraries/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
@@ -63,6 +63,9 @@
     <!--Reference to System.Resources.Extensions is required in order to be able to embed a resource that requires a custom reader-->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Resources.Extensions\src\System.Resources.Extensions.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
+  </ItemGroup>
   <!--
     MSBuild on .NET Core doesn't support non-string resources. See https://github.com/Microsoft/msbuild/issues/2221
     Workaround this for now by invoking the desktop resgen.exe on Windows manually to regenerate the resource files.

--- a/src/libraries/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
+++ b/src/libraries/System.Resources.ResourceManager/tests/System.Resources.ResourceManager.Tests.csproj
@@ -63,9 +63,6 @@
     <!--Reference to System.Resources.Extensions is required in order to be able to embed a resource that requires a custom reader-->
     <ProjectReference Include="$(LibrariesProjectRoot)System.Resources.Extensions\src\System.Resources.Extensions.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
-  </ItemGroup>
   <!--
     MSBuild on .NET Core doesn't support non-string resources. See https://github.com/Microsoft/msbuild/issues/2221
     Workaround this for now by invoking the desktop resgen.exe on Windows manually to regenerate the resource files.

--- a/src/libraries/System.Resources.ResourceManager/tests/runtimeconfig.template.json
+++ b/src/libraries/System.Resources.ResourceManager/tests/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-    "configProperties": {
-        "System.Drawing.EnableUnixSupport": true
-    }
-}

--- a/src/libraries/System.Runtime/tests/NlsTests/System.Runtime.Nls.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/NlsTests/System.Runtime.Nls.Tests.csproj
@@ -7,6 +7,9 @@
     <NoWarn>$(NoWarn),SYSLIB0013</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\Helpers.cs"
              Link="Helpers.cs" />
     <Compile Include="..\System\ArrayTests.cs"

--- a/src/libraries/System.Runtime/tests/NlsTests/runtimeconfig.template.json
+++ b/src/libraries/System.Runtime/tests/NlsTests/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-    "configProperties": {
-        "System.Globalization.UseNls": true
-    }
-}


### PR DESCRIPTION
NativeAOT ignores this and emits a warning. This fails the test build.