### PR TITLE
Add a way to suppress all trimming warnings

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -26,48 +26,13 @@
     <IlcBuildTasksPath>$(CoreCLRILCompilerDir)netstandard/ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
     <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
     <IlcFrameworkPath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkPath>
-    <NoWarn>$(NoWarn);IL3050;IL3051;IL3052;IL3054;IL3055;IL1005;IL3002</NoWarn>
+    <NoWarn>$(NoWarn);IL1005;IL3002</NoWarn>
     <TrimMode>partial</TrimMode>
-    <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <SuppressAotAnalysisWarnings>true</SuppressAotAnalysisWarnings>
 
     <!-- Forced by ILLink targets; we should fix the SDK -->
     <SelfContained>true</SelfContained>
-
-    <!-- Works around https://github.com/dotnet/runtime/issues/73926 -->
-    <!-- RequiresUnreferenceCodeAttribute method called -->
-    <NoWarn>$(NoWarn);IL2026;IL2116</NoWarn>
-    <!-- Invalid use of DynamicallyAccessedMembersAttribute -->
-    <NoWarn>$(NoWarn);IL2041;IL2042;IL2043;IL2056</NoWarn>
-    <!-- Reference to removed attribute type -->
-    <NoWarn>$(NoWarn);IL2045</NoWarn>
-    <!-- RequiresUnreferencedCodeAttribute mismatch on virtual override -->
-    <NoWarn>$(NoWarn);IL2046</NoWarn>
-    <!-- COM marshalling warning -->
-    <NoWarn>$(NoWarn);IL2050</NoWarn>
-    <!-- Reflection intrinsics with unknown arguments -->
-    <NoWarn>$(NoWarn);IL2032;IL2055;IL2057;IL2058;IL2059;IL2060;IL2061;IL2096</NoWarn>
-    <!-- Unknown values passed to locations with DynamicallyAccessedMemberTypes -->
-    <NoWarn>$(NoWarn);IL2062;IL2063;IL2064;IL2065;IL2066</NoWarn>
-    <!-- Unsatisfied DynamicallyAccessedMembers requirements -->
-    <NoWarn>$(NoWarn);IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;IL2087;IL2088;IL2089;IL2090;IL2091</NoWarn>
-    <!-- DynamicallyAccessedMembersAttribute mismatch on virtual override -->
-    <NoWarn>$(NoWarn);IL2092;IL2093;IL2094;IL2095</NoWarn>
-    <!-- DynamicallyAccessedMembersAttribute used on unsupported member -->
-    <NoWarn>$(NoWarn);IL2097;IL2098;IL2099;IL2106</NoWarn>
-    <!-- Unknown value passed to Expression.Property -->
-    <NoWarn>$(NoWarn);IL2103</NoWarn>
-    <!-- Multiple methods associated with state machine type or user method -->
-    <NoWarn>$(NoWarn);IL2107;IL2117</NoWarn>
-    <!-- Unannotated type derived from base type with RequiresUnreferencedCode -->
-    <NoWarn>$(NoWarn);IL2109</NoWarn>
-    <!-- Reflection access to members with DynamicallyAccessedMembers requirements -->
-    <NoWarn>$(NoWarn);IL2110;IL2111;IL2114;IL2115</NoWarn>
-    <!-- Reflection access to members with RequiresUnreferencedCode -->
-    <NoWarn>$(NoWarn);IL2112;IL2113</NoWarn>
-    <!-- Reflection access to compiler-generated code -->
-    <NoWarn>$(NoWarn);IL2118;IL2119;IL2120</NoWarn>
-
   </PropertyGroup>
 
   <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets" Condition="'$(TestNativeAot)' == 'true'" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -49,6 +49,10 @@ The .NET Foundation licenses this file to you under the MIT license.
     <EventSourceSupport Condition="$(IlcDisableReflection) == 'true'">false</EventSourceSupport>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(SuppressAotAnalysisWarnings)' == 'true'">
+    <EnableAotAnalyzer Condition="'$(EnableAotAnalyzer)' == ''">false</EnableAotAnalyzer>
+  </PropertyGroup>
+
   <PropertyGroup>
     <NativeObjectExt Condition="'$(TargetOS)' == 'windows'">.obj</NativeObjectExt>
     <NativeObjectExt Condition="'$(TargetOS)' != 'windows'">.o</NativeObjectExt>
@@ -241,6 +245,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
       <IlcArg Condition="$(NoWarn) != ''" Include='--nowarn:"$([MSBuild]::Escape($(NoWarn)))"' />
       <IlcArg Condition="$(TrimmerSingleWarn) == 'true'" Include="--singlewarn" />
+      <IlcArg Condition="$(ILLinkWarningLevel) == '0'" Include="--notrimwarn" />
+      <IlcArg Condition="$(SuppressAotAnalysisWarnings) == 'true'" Include="--noaotwarn" />
       <IlcArg Condition="$(IlcTrimMetadata) == 'false'" Include="--reflectiondata:all" />
       <IlcArg Condition="'$(ControlFlowGuard)' == 'Guard' and '$(TargetOS)' == 'windows'" Include="--guard:cf" />
       <IlcArg Include="@(_IlcRootedAssemblies->'--root:%(Identity)')" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -245,7 +245,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
       <IlcArg Condition="$(NoWarn) != ''" Include='--nowarn:"$([MSBuild]::Escape($(NoWarn)))"' />
       <IlcArg Condition="$(TrimmerSingleWarn) == 'true'" Include="--singlewarn" />
-      <IlcArg Condition="$(ILLinkWarningLevel) == '0'" Include="--notrimwarn" />
+      <IlcArg Condition="$(SuppressTrimAnalysisWarnings) == 'true'" Include="--notrimwarn" />
       <IlcArg Condition="$(SuppressAotAnalysisWarnings) == 'true'" Include="--noaotwarn" />
       <IlcArg Condition="$(IlcTrimMetadata) == 'false'" Include="--reflectiondata:all" />
       <IlcArg Condition="'$(ControlFlowGuard)' == 'Guard' and '$(TargetOS)' == 'windows'" Include="--guard:cf" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logger.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logger.cs
@@ -26,6 +26,7 @@ namespace ILCompiler
         private readonly CompilerGeneratedState _compilerGeneratedState;
 
         private readonly HashSet<int> _suppressedWarnings;
+        private readonly HashSet<string> _suppressedCategories;
 
         private readonly bool _isSingleWarn;
         private readonly HashSet<string> _singleWarnEnabledAssemblies;
@@ -44,7 +45,8 @@ namespace ILCompiler
             IEnumerable<int> suppressedWarnings,
             bool singleWarn,
             IEnumerable<string> singleWarnEnabledModules,
-            IEnumerable<string> singleWarnDisabledModules)
+            IEnumerable<string> singleWarnDisabledModules,
+            IEnumerable<string> suppressedCategories)
         {
             _logWriter = writer;
             _compilerGeneratedState = ilProvider == null ? null : new CompilerGeneratedState(ilProvider, this);
@@ -53,15 +55,16 @@ namespace ILCompiler
             _isSingleWarn = singleWarn;
             _singleWarnEnabledAssemblies = new HashSet<string>(singleWarnEnabledModules, StringComparer.OrdinalIgnoreCase);
             _singleWarnDisabledAssemblies = new HashSet<string>(singleWarnDisabledModules, StringComparer.OrdinalIgnoreCase);
+            _suppressedCategories = new HashSet<string>(suppressedCategories, StringComparer.Ordinal);
         }
 
-        public Logger(TextWriter writer, ILProvider ilProvider, bool isVerbose, IEnumerable<int> suppressedWarnings, bool singleWarn, IEnumerable<string> singleWarnEnabledModules, IEnumerable<string> singleWarnDisabledModules)
-            : this(new TextLogWriter(writer), ilProvider, isVerbose, suppressedWarnings, singleWarn, singleWarnEnabledModules, singleWarnDisabledModules)
+        public Logger(TextWriter writer, ILProvider ilProvider, bool isVerbose, IEnumerable<int> suppressedWarnings, bool singleWarn, IEnumerable<string> singleWarnEnabledModules, IEnumerable<string> singleWarnDisabledModules, IEnumerable<string> suppressedCategories)
+            : this(new TextLogWriter(writer), ilProvider, isVerbose, suppressedWarnings, singleWarn, singleWarnEnabledModules, singleWarnDisabledModules, suppressedCategories)
         {
         }
 
         public Logger(ILogWriter writer, ILProvider ilProvider, bool isVerbose)
-            : this(writer, ilProvider, isVerbose, Array.Empty<int>(), singleWarn: false, Array.Empty<string>(), Array.Empty<string>())
+            : this(writer, ilProvider, isVerbose, Array.Empty<int>(), singleWarn: false, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>())
         {
         }
 
@@ -140,6 +143,8 @@ namespace ILCompiler
 
         public void LogError(TypeSystemEntity origin, DiagnosticId id, params string[] args) =>
             LogError(new MessageOrigin(origin), id, args);
+
+        internal bool IsWarningSubcategorySuppressed(string category) => _suppressedCategories.Contains(category);
 
         internal bool IsWarningSuppressed(int code, MessageOrigin origin)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/MessageContainer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/MessageContainer.cs
@@ -125,6 +125,9 @@ namespace ILCompiler.Logging
             if (context.IsWarningSuppressed(code, origin))
                 return null;
 
+            if (context.IsWarningSubcategorySuppressed(subcategory))
+                return null;
+
             if (TryLogSingleWarning(context, code, origin, subcategory))
                 return null;
 
@@ -137,6 +140,9 @@ namespace ILCompiler.Logging
         private static MessageContainer? CreateWarningMessageContainer(Logger context, MessageOrigin origin, DiagnosticId id, string subcategory, params string[] args)
         {
             if (context.IsWarningSuppressed((int)id, origin))
+                return null;
+
+            if (context.IsWarningSubcategorySuppressed(subcategory))
                 return null;
 
             if (TryLogSingleWarning(context, (int)id, origin, subcategory))


### PR DESCRIPTION
Fixes #73926.

Also adding AOT analysis suppression for parity.

I didn't port the warning level support because the compat kind of goes beyond that. We can revisit later if needed.

Cc @dotnet/ilc-contrib 