### PR TITLE
Enable linux arm/arm64 superpmi benchmarks collection

### DIFF
--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -162,7 +162,6 @@ jobs:
     # Linux tests are built on the OSX machines.
     # - OSX_x64
     - OSX_arm64
-    #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
     - Linux_arm
     - Linux_arm64
     - Linux_x64

--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -163,8 +163,8 @@ jobs:
     # - OSX_x64
     - OSX_arm64
     #TODO: Need special handling of running "benchmark build" from inside TMP folder on helix machine.
-    # - Linux_arm
-    # - Linux_arm64
+    - Linux_arm
+    - Linux_arm64
     - Linux_x64
     - windows_x64
     - windows_x86

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -185,7 +185,7 @@ def build_and_run(coreclr_args, output_mch_name):
     collection_command = f"{dotnet_exe} {benchmarks_dll}  --filter \"*\" --corerun {os.path.join(core_root, corerun_exe)} --partition-count {partition_count} " \
                          f"--partition-index {partition_index} --envVars COMPlus_JitName:{shim_name} " \
                          " COMPlus_ZapDisable:1  COMPlus_ReadyToRun:0 " \
-                         "--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart"
+                         "--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --logBuildOutput"
 
     # Generate the execution script in Temp location
     with TempDir() as temp_location:


### PR DESCRIPTION
We were not able to get the benchmark collection for linux arm/arm64 because they run under docker on helix and `BDN` tries to write in a folder that is "read-only". @adamsitnik helped to add fallback to copy to a `tmp` folder in https://github.com/dotnet/BenchmarkDotNet/pull/2073 and that unblocked the collection. The successful collection is https://dev.azure.com/dnceng/internal/_build/results?buildId=1950953&view=logs&j=7f33e5bd-7764-5d8a-ba2e-506e078b9c3f&t=5f980cba-253f-56da-0cba-c1322a20cb47.