### PR TITLE
Initialize GetExactClasses in repGetExactClasses

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -2727,6 +2727,9 @@ void MethodContext::dmpGetExactClasses(DLD key, DLD value)
 }
 int MethodContext::repGetExactClasses(CORINFO_CLASS_HANDLE baseType, int maxExactClasses, CORINFO_CLASS_HANDLE* exactClsRet)
 {
+    if (GetExactClasses == nullptr)
+        GetExactClasses = new LightWeightMap<DLD, DLD>();
+
     DLD key;
     ZeroMemory(&key, sizeof(key));
     key.A = CastHandle(baseType);


### PR DESCRIPTION
superpmi-replay is still failing with AV. Initialize `GetExactClass` at one more place.