### PR TITLE
[wasm] Add new javascript API types

### DIFF
--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -269,6 +269,8 @@ declare global {
     function getDotnetRuntime(runtimeId: number): RuntimeAPI | undefined;
 }
 
+declare const dotnet: ModuleAPI["dotnet"];
+declare const exit: ModuleAPI["exit"];
 /**
  * Span class is JS wrapper for System.Span<T>. This view doesn't own the memory, nor pin the underlying array.
  * It's ideal to be used on call from C# with the buffer pinned there or with unmanaged memory.
@@ -315,4 +317,4 @@ declare class ManagedObject implements IDisposable {
     toString(): string;
 }
 
-export { ArraySegment, AssetBehaviours, AssetEntry, CreateDotnetRuntimeType, DotnetModuleConfig, EmscriptenModule, IMemoryView, LoadingResource, ManagedError, ManagedObject, MemoryViewType, ModuleAPI, MonoConfig, NativePointer, ResourceRequest, RuntimeAPI, Span, createDotnetRuntime as default };
+export { ArraySegment, AssetBehaviours, AssetEntry, CreateDotnetRuntimeType, DotnetModuleConfig, EmscriptenModule, IMemoryView, LoadingResource, ManagedError, ManagedObject, MemoryViewType, ModuleAPI, MonoConfig, NativePointer, ResourceRequest, RuntimeAPI, Span, createDotnetRuntime as default, dotnet, exit };

--- a/src/mono/wasm/runtime/export-types.ts
+++ b/src/mono/wasm/runtime/export-types.ts
@@ -17,6 +17,8 @@ declare global {
 
 export default createDotnetRuntime;
 
+declare const dotnet: ModuleAPI["dotnet"];
+declare const exit: ModuleAPI["exit"];
 
 /**
  * Span class is JS wrapper for System.Span<T>. This view doesn't own the memory, nor pin the underlying array.
@@ -71,6 +73,7 @@ export {
     EmscriptenModule, NativePointer,
     RuntimeAPI, ModuleAPI, DotnetModuleConfig, CreateDotnetRuntimeType, MonoConfig,
     AssetEntry, ResourceRequest, LoadingResource, AssetBehaviours,
-    IMemoryView, MemoryViewType, ManagedObject, ManagedError, Span, ArraySegment
+    IMemoryView, MemoryViewType, ManagedObject, ManagedError, Span, ArraySegment,
+    dotnet, exit
 };
 


### PR DESCRIPTION
With #73785 , `dotnet` and `exit` are now public APIs with named exports.

When developing in TypeScript, importing `dotnet` did not work for type completion.
So I added those to d.ts .