### PR TITLE
Fix ObjectStackAllocationTests JitStress failure

### DIFF
--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -16,6 +16,7 @@ $(CLRTestBatchPreCommands)
 set COMPlus_TieredCompilation=0
 set COMPlus_ProfApi_RejitOnAttach=0
 set COMPlus_JITMinOpts=0
+set COMPlus_JitNoForceFallback=1
 set COMPlus_JitDebuggable=0
 set COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE,STRESS_MIN_OPTS
 set COMPlus_JitObjectStackAllocation=1
@@ -25,6 +26,7 @@ $(BashCLRTestPreCommands)
 export COMPlus_TieredCompilation=0
 export COMPlus_ProfApi_RejitOnAttach=0
 export COMPlus_JITMinOpts=0
+export COMPlus_JitNoForceFallback=1
 export COMPlus_JitDebuggable=0
 export COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE,STRESS_MIN_OPTS
 export COMPlus_JitObjectStackAllocation=1


### PR DESCRIPTION
Disable noway_assert testing, which falls back to MinOpts.
This test specifically disables MinOpts and fails if code is
not optimized.

Fixes #57910