### PR TITLE
Skip mode check on Android tests when extracting tar files

### DIFF
--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -409,7 +409,8 @@ namespace System.Formats.Tar.Tests
 
         protected static void AssertFileModeEquals(string path, UnixFileMode mode)
         {
-            if (!PlatformDetection.IsWindows)
+            if (!PlatformDetection.IsWindows &&
+                !PlatformDetection.IsAndroid) // Android may change the requested permissions.)
             {
                 Assert.Equal(mode, File.GetUnixFileMode(path));
             }


### PR DESCRIPTION
Test fix on Android platforms.
Originally written by @tmds in this PR commit: https://github.com/dotnet/runtime/pull/74002/commits/daed79e774ddcf5d1ce02ab03087fda45a01f7a7
We discovered this failure in runtime-extra-platforms, which doesn't get executed often. Android is changing the mode and we cannot reliably compare it.
Will backport it to RC1 after merging.