### PR TITLE
[release/6.0] App does not Run as a service in a Windows Container

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/Microsoft.Extensions.Hosting.WindowsServices.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/Microsoft.Extensions.Hosting.WindowsServices.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <PackageDescription>.NET hosting infrastructure for Windows Services.</PackageDescription>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceHelpers.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             {
                 return false;
             }
-            return parent.SessionId == 0 && string.Equals("services", parent.ProcessName, StringComparison.OrdinalIgnoreCase);
+            return string.Equals("services", parent.ProcessName, StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
Backport of #62452 to release/6.0

## Customer Impact
When an ASP.NET service or a "generic hosted" app is executed as a Windows Service inside a Windows Container, it isn't getting the right lifetime. This makes the app not start correctly.

The reason is because inside a Windows Container, the Windows "SessionId" isn't set to `0`.

## Testing
Manually tested in a Windows Service on a normal machine, plus inside a Windows Container. As well as tested the method still produces `false` when not running as a Windows Service in both "normal" and containers.

There are no automated tests for this scenario since:

1. We would need to install the service on the CI machine in order to run it as a service
2. We would need to be running in a Windows Container

## Risk
Low Risk. The change has been in `main`/7.0 since December without any complaints/concerns popping up.

Fix #70751