### PR TITLE
Bump timout in NativeAOT extra-platforms

### DIFF
--- a/eng/pipelines/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/runtime-extra-platforms-other.yml
@@ -92,7 +92,7 @@ jobs:
       isSingleFile: true
       nameSuffix: NativeAOT_Libs
       buildArgs: -s clr.aot+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:ArchiveTests=true
-      timeoutInMinutes: 240
+      timeoutInMinutes: 300 # doesn't normally take this long, but I've seen Helix queues backed up for 160 minutes
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:


### PR DESCRIPTION
#74045 has these legs failing because the Helix queue wait time was two hours and forty minutes...

@dotnet/ilc-contrib PTAL