### PR TITLE
Fix to skip adding self as next unrelated code list

### DIFF
--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -619,7 +619,7 @@ void ReadyToRunInfo::RegisterUnrelatedR2RModule()
         {
             ReadyToRunInfo* oldGlobalValue;
             oldGlobalValue = s_pGlobalR2RModules;
-            if (InterlockedCompareExchangeT(&m_pNextR2RForUnrelatedCode, oldGlobalValue, NULL) != NULL)
+            if (InterlockedCompareExchangeT(&m_pNextR2RForUnrelatedCode, dac_cast<PTR_ReadyToRunInfo>(dac_cast<TADDR>(oldGlobalValue) | 0x1), NULL) != NULL)
             {
                 // Some other thread is registering or has registered this R2R image for unrelated generics
                 // ReadyToRun code loading. we can simply return, as this process cannot fail.
@@ -629,7 +629,7 @@ void ReadyToRunInfo::RegisterUnrelatedR2RModule()
             while (InterlockedCompareExchangeT(&s_pGlobalR2RModules, this, oldGlobalValue) != oldGlobalValue)
             {
                 oldGlobalValue = s_pGlobalR2RModules;
-                m_pNextR2RForUnrelatedCode = oldGlobalValue;
+                m_pNextR2RForUnrelatedCode = dac_cast<PTR_ReadyToRunInfo>(dac_cast<TADDR>(oldGlobalValue) | 0x1);
             }
         }
     }

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -94,7 +94,7 @@ public:
 
     static PTR_ReadyToRunInfo ComputeAlternateGenericLocationForR2RCode(MethodDesc *pMethod);
     static PTR_ReadyToRunInfo GetUnrelatedR2RModules();
-    PTR_ReadyToRunInfo GetNextUnrelatedR2RModule() { LIMITED_METHOD_CONTRACT; return m_pNextR2RForUnrelatedCode; }
+    PTR_ReadyToRunInfo GetNextUnrelatedR2RModule() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_ReadyToRunInfo>(dac_cast<TADDR>(m_pNextR2RForUnrelatedCode) & ~0x1); }
     void RegisterUnrelatedR2RModule();
 
     static PTR_ReadyToRunInfo Initialize(Module * pModule, AllocMemTracker *pamTracker);


### PR DESCRIPTION
It makes an infinite loop searching for entry point when `crossgen2` option `--compilebubblegenerics` is given with reference to system dlls and target dll as below command.

```
./corerun ./crossgen2/crossgen2.dll ./test/hello.dll --compilebubblegenerics --codegenopt DumpJittedMethods=1 --inputbubble -o ./hello.dll --r:"*.dll" -r:"test/*.dll" -O
```

The result `hello.dll` makes coreclr keep circling inside `MethodDesc::GetPrecompiledR2RCode()` to find the entry point.
```cpp
Thread 1 "corerun" hit Breakpoint 3, ReadyToRunInfo::GetEntryPoint (this=0x7fff7918d848, pMD=0x7fff79384468, pConfig=0x7fffffffca28, fFixups=1) at /home/leee/dotnet/runtime/src/coreclr/vm/readytoruninfo.cpp:1103
(gdb) bt
#0  ReadyToRunInfo::GetEntryPoint (this=0x7fff7918d848, pMD=0x7fff79384468, pConfig=0x7fffffffca28, fFixups=1) at /home/leee/dotnet/runtime/src/coreclr/vm/readytoruninfo.cpp:1103
#1  0x00007ffff6f01c2b in MethodDesc::GetPrecompiledR2RCode (this=0x7fff79384468, pConfig=0x7fffffffca28) at /home/leee/dotnet/runtime/src/coreclr/vm/prestub.cpp:528
#2  0x00007ffff6f01cd0 in MethodDesc::GetPrecompiledCode (this=0x7fff79384468, pConfig=0x7fffffffca28, shouldTier=false) at /home/leee/dotnet/runtime/src/coreclr/vm/prestub.cpp:442
#3  0x00007ffff6f01843 in MethodDesc::PrepareILBasedCode (this=0x7fff79384468, pConfig=0x7fffffffca28) at /home/leee/dotnet/runtime/src/coreclr/vm/prestub.cpp:407
#4  0x00007ffff6f014e6 in MethodDesc::PrepareCode (this=0x7fff79384468, pConfig=0x7fffffffca28) at /home/leee/dotnet/runtime/src/coreclr/vm/prestub.cpp:323
#5  0x00007ffff6dcb40b in CodeVersionManager::PublishVersionableCodeIfNecessary (this=0x55555562e200, pMethodDesc=0x7fff79384468, callerGCMode=CallerGCMode::Coop, doBackpatchRef=0x7fffffffcbd7, doFullBackpatchRef=0x7fffffffcbd6) at /home/leee/dotnet/runtime/src/coreclr/vm/codeversion.cpp:1698
#6  0x00007ffff6f0753b in MethodDesc::DoPrestub (this=0x7fff79384468, pDispatchingMT=0x0, callerGCMode=CallerGCMode::Coop) at /home/leee/dotnet/runtime/src/coreclr/vm/prestub.cpp:2109
#7  0x00007ffff6f068df in PreStubWorker (pTransitionBlock=0x7fffffffcef8, pMD=0x7fff79384468) at /home/leee/dotnet/runtime/src/coreclr/vm/prestub.cpp:1938
#8  0x00007ffff734b474 in ThePreStub () at /home/leee/dotnet/runtime/src/coreclr/vm/amd64/theprestubamd64.S:16
#9  0x00007fff78fe517b in ?? ()
#10 0x0000000000000000 in ?? ()
```

This is because `ReadyToRunInfo::RegisterUnrelatedR2RModule()` registers self as `m_pNextR2RForUnrelatedCode` and the linked list is lost.
The registration first occurs at https://github.com/dotnet/runtime/blob/21041fa89f94ebbde36a07d2ffa34118036ec9a6/src/coreclr/vm/assembly.cpp#L1549 and later at https://github.com/dotnet/runtime/blob/21041fa89f94ebbde36a07d2ffa34118036ec9a6/src/coreclr/vm/domainassembly.cpp#L609
This PR fixes this by checking if this is already registered.
