### PR TITLE
Don't NativeAOT crossgen on ARM64

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -7,6 +7,10 @@
     <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 and we
          don't want to ship using NativeAOT on MacOS -->
     <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true' or '$(TargetOS)' == 'osx'">false</NativeAotSupported>
+
+    <!-- Work around https://github.com/dotnet/runtime/issues/72645 -->
+    <NativeAotSupported Condition="'$(TargetArchitecture)' == 'arm64'">false</NativeAotSupported>
+
     <!-- Trimming is not currently working, but set the appropriate feature flags for NativeAOT -->
     <PublishTrimmed Condition="'$(NativeAotSupported)' == 'true'">true</PublishTrimmed>
     <RuntimeIdentifiers Condition="'$(RunningPublish)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">linux-x64;linux-musl-x64;linux-arm;linux-musl-arm;linux-arm64;linux-musl-arm64;freebsd-x64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64;win-arm</RuntimeIdentifiers>


### PR DESCRIPTION
Lets us make #72645 a non-blocking-release issue.

We also set NativeAotSupported to false for Mac on the line above. Crossgen2 will still ship NativeAOT compiled on x64 Linux and Windows. R2R+SingleFile+Trimmed elsewhere.

Cc @dotnet/crossgen-contrib @dotnet/ilc-contrib 