### PR TITLE
Disable NegotiateAuthenticationKerberosTest on android

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateAuthenticationKerberosTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateAuthenticationKerberosTest.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 namespace System.Net.Security.Tests
 {
     [ConditionalClass(typeof(KerberosExecutor), nameof(KerberosExecutor.IsSupported))]
-    [SkipOnPlatform(TestPlatforms.Android, "Kerberos auth is not supported on Android")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/74224", TestPlatforms.Android)]
     public class NegotiateAuthenticationKerberosTest
     {
         private readonly ITestOutputHelper _testOutputHelper;

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateAuthenticationKerberosTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateAuthenticationKerberosTest.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 namespace System.Net.Security.Tests
 {
     [ConditionalClass(typeof(KerberosExecutor), nameof(KerberosExecutor.IsSupported))]
+    [SkipOnPlatform(TestPlatforms.Android, "Kerberos auth is not supported on Android")]
     public class NegotiateAuthenticationKerberosTest
     {
         private readonly ITestOutputHelper _testOutputHelper;


### PR DESCRIPTION
Contributes to #74224

Tests are failing reliably several times a day

```
                       Microsoft.DotNet.RemoteExecutor.RemoteExecutionException : Remote process failed with an unhandled exception.
                       Stack Trace:
                         
                         Child exception:
                           Xunit.Sdk.TrueException: Client authentication failed with Unsupported
                         Expected: True
                         Actual:   False
                         /_/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateAuthenticationKerberosTest.cs(48,0): at System.Net.Security.Tests.NegotiateAuthenticationKerberosTest.<>c.<Loopback_Success>b__2_0()
                         /_/src/mono/System.Private.CoreLib/src/System/Reflection/MethodInvoker.Mono.cs(33,0): at System.Reflection.MethodInvoker.InterpretedInvoke(Object obj, Span`1 args, BindingFlags invokeAttr)
                         
                         Child process:
                           System.Net.Security.Tests, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51 System.Net.Security.Tests.NegotiateAuthenticationKerberosTest+<>c Void <Loopback_Success>b__2_0()
                         
                         
                       Output:
                         GSSAPI trace:
                         
                     System.Net.Security.Tests.ServerAllowNoEncryptionTest.ServerAllowNoEncryption_ClientNoEncryption_ConnectWithNoEncryption [SKIP]
                       Condition(s) not met: "SupportsNullEncryption"
                       Microsoft.DotNet.RemoteExecutor.RemoteExecutionException : Remote process failed with an unhandled exception.
                       Stack Trace:
                         
                         Child exception:
                           Xunit.Sdk.EqualException: Assert.Equal() Failure
                         Expected: ContinueNeeded
                         Actual:   GenericFailure
                         /_/src/libraries/System.Net.Security/tests/FunctionalTests/NegotiateAuthenticationKerberosTest.cs(75,0): at System.Net.Security.Tests.NegotiateAuthenticationKerberosTest.<>c.<Invalid_Token>b__3_0()
                         /_/src/mono/System.Private.CoreLib/src/System/Reflection/MethodInvoker.Mono.cs(33,0): at System.Reflection.MethodInvoker.InterpretedInvoke(Object obj, Span`1 args, BindingFlags invokeAttr)
                         
                         Child process:
                           System.Net.Security.Tests, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51 System.Net.Security.Tests.NegotiateAuthenticationKerberosTest+<>c Void <Invalid_Token>b__3_0()
                         
                         
                       Output:
                         GSSAPI trace:
                         
```