### PR TITLE
Fix GUID interop in distributed transactions and block ARM

### DIFF
--- a/src/libraries/System.Transactions.Local/src/Resources/Strings.resx
+++ b/src/libraries/System.Transactions.Local/src/Resources/Strings.resx
@@ -420,7 +420,10 @@
   <data name="TraceSourceBase" xml:space="preserve">
     <value>[Base]</value>
   </data>
-  <data name="DistributedNotSupportOn32Bits" xml:space="preserve">
+  <data name="DistributedNotSupportedOn32Bits" xml:space="preserve">
     <value>Distributed transactions are currently unsupported in 32-bit processes.</value>
+  </data>
+  <data name="DistributedNotSupportedOnArm" xml:space="preserve">
+    <value>Distributed transactions are currently unsupported on ARM.</value>
   </data>
 </root>

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/IPrepareInfo.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/IPrepareInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/IResourceManagerFactory2.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/IResourceManagerFactory2.cs
@@ -10,15 +10,15 @@ namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 internal interface IResourceManagerFactory2
 {
     internal void Create(
-        Guid pguidRM,
+        in Guid pguidRM,
         [MarshalAs(UnmanagedType.LPStr)] string pszRMName,
         [MarshalAs(UnmanagedType.Interface)] IResourceManagerSink pIResMgrSink,
         [MarshalAs(UnmanagedType.Interface)] out IResourceManager rm);
 
     internal void CreateEx(
-        Guid pguidRM,
+        in Guid pguidRM,
         [MarshalAs(UnmanagedType.LPStr)] string pszRMName,
         [MarshalAs(UnmanagedType.Interface)] IResourceManagerSink pIResMgrSink,
-        Guid riidRequested,
+        in Guid riidRequested,
         [MarshalAs(UnmanagedType.Interface)] out object rm);
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransaction.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransaction.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
-using System.Transactions.Oletx;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 
@@ -12,7 +10,7 @@ namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 internal interface ITransaction
 {
     void Commit(
-        [MarshalAs(UnmanagedType.Bool)] bool fRetainingt,
+        [MarshalAs(UnmanagedType.Bool)] bool fRetaining,
         [MarshalAs(UnmanagedType.U4)] OletxXacttc grfTC,
         uint grfRM);
 

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionCloner.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionCloner.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionDispenser.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionDispenser.cs
@@ -7,7 +7,7 @@ using System.Transactions.Oletx;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 
-// https://docs.microsoft.com/previous-versions/windows/desktop/ms679525(v=vs.85)
+// https://docs.microsoft.com/previous-versions/windows/desktop/ms687604(v=vs.85)
 [ComImport, Guid(Guids.IID_ITransactionDispenser), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface ITransactionDispenser
 {

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionEnlistmentAsync.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionEnlistmentAsync.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionExport.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionExport.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionExportFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionExportFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionImport.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionImport.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;
@@ -13,6 +12,6 @@ internal interface ITransactionImport
     void Import(
         uint cbTransactionCookie,
         [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] byte[] rgbTransactionCookie,
-        Guid piid,
+        in Guid piid,
         [MarshalAs(UnmanagedType.Interface)] out object ppvTransaction);
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionOptions.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionOptions.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionOutcomeEvents.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionOutcomeEvents.cs
@@ -10,11 +10,21 @@ namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 [ComImport, Guid("3A6AD9E2-23B9-11cf-AD60-00AA00A74CCD"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface ITransactionOutcomeEvents
 {
-    void Committed([MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW /* always null? */, int hresult);
+    void Committed(
+        [MarshalAs(UnmanagedType.Bool)] bool fRetaining,
+        IntPtr pNewUOW,
+        int hresult);
 
-    void Aborted(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW, int hresult);
+    void Aborted(
+        IntPtr pboidReason,
+        [MarshalAs(UnmanagedType.Bool)] bool fRetaining,
+        IntPtr pNewUOW,
+        int hresult);
 
-    void HeuristicDecision([MarshalAs(UnmanagedType.U4)] OletxTransactionHeuristic dwDecision, IntPtr pboidReason, int hresult);
+    void HeuristicDecision(
+        [MarshalAs(UnmanagedType.U4)] OletxTransactionHeuristic dwDecision,
+        IntPtr pboidReason,
+        int hresult);
 
     void Indoubt();
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionReceiver.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionReceiver.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionReceiverFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionReceiverFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionResourceAsync.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionResourceAsync.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
-using System.Transactions.Oletx;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 
@@ -19,7 +17,10 @@ internal interface ITransactionResourceAsync
 
     void CommitRequest(OletxXactRm grfRM, IntPtr pNewUOW);
 
-    void AbortRequest(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW);
+    void AbortRequest(
+        IntPtr pboidReason,
+        [MarshalAs(UnmanagedType.Bool)] bool fRetaining,
+        IntPtr pNewUOW);
 
     void TMDown();
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionTransmitter.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionTransmitter.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionTransmitterFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionTransmitterFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace System.Transactions.DtcProxyShim.DtcInterfaces;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionVoterNotifyAsync2.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionVoterNotifyAsync2.cs
@@ -10,11 +10,21 @@ namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 [ComImport, Guid("5433376B-414D-11d3-B206-00C04FC2F3EF"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface ITransactionVoterNotifyAsync2
 {
-    void Committed([MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW /* always null? */, uint hresult);
+    void Committed(
+        [MarshalAs(UnmanagedType.Bool)] bool fRetaining,
+        IntPtr pNewUOW,
+        uint hresult);
 
-    void Aborted(IntPtr pboidReason, [MarshalAs(UnmanagedType.Bool)] bool fRetaining, IntPtr pNewUOW, uint hresult);
+    void Aborted(
+        IntPtr pboidReason,
+        [MarshalAs(UnmanagedType.Bool)] bool fRetaining,
+        IntPtr pNewUOW,
+        uint hresult);
 
-    void HeuristicDecision([MarshalAs(UnmanagedType.U4)] OletxTransactionHeuristic dwDecision, IntPtr pboidReason, uint hresult);
+    void HeuristicDecision(
+        [MarshalAs(UnmanagedType.U4)] OletxTransactionHeuristic dwDecision,
+        IntPtr pboidReason,
+        uint hresult);
 
     void Indoubt();
 

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
@@ -55,9 +55,14 @@ internal sealed class DtcProxyShimFactory
         out byte[] whereabouts,
         out ResourceManagerShim resourceManagerShim)
     {
-        if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
+        switch (RuntimeInformation.ProcessArchitecture)
         {
-            throw new PlatformNotSupportedException(SR.DistributedNotSupportOn32Bits);
+            case Architecture.X86:
+                throw new PlatformNotSupportedException(SR.DistributedNotSupportedOn32Bits);
+
+            case Architecture.Armv6: // #74170
+            case Architecture.Arm64:
+                throw new PlatformNotSupportedException(SR.DistributedNotSupportedOnArm);
         }
 
         lock (_proxyInitLock)


### PR DESCRIPTION
Fixes #74170

@AaronRobinsonMSFT went through all the interop and added `in` to GUIDs where relevant.
@kunalspathak you indicated you're able to repro this, any chance you can give this PR a try to see if it fixes the issue?