### PR TITLE
#52851 skip CurrentDirectorySet on MacCatalyst

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
@@ -293,12 +293,11 @@ namespace Microsoft.VisualBasic.FileIO.Tests
             Assert.Equal(FileIO.FileSystem.CurrentDirectory, CurrentDirectory);
         }
 
-        // On OSX, the temp directory /tmp/ is a symlink to /private/tmp, so setting the current
+        // On OSX/MacCatalyst, the temp directory /tmp/ is a symlink to /private/tmp, so setting the current
         // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
         // path that followed the symlink.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX), nameof(PlatformDetection.IsNotMacCatalyst))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52851", TestPlatforms.MacCatalyst)]
         public void CurrentDirectorySet()
         {
             var SavedCurrentDirectory = System.IO.Directory.GetCurrentDirectory();


### PR DESCRIPTION
Forgot to change this test in https://github.com/dotnet/runtime/pull/74070 PR.