### PR TITLE
[wasm] Unwrap exception when calling entrypoint

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -85,6 +85,9 @@ namespace System.Runtime.InteropServices.JavaScript
             }
             catch (Exception ex)
             {
+                if (ex is TargetInvocationException refEx && refEx.InnerException != null)
+                    ex = refEx.InnerException;
+
                 arg_exc.ToJS(ex);
             }
         }


### PR DESCRIPTION
Introduced in the new entrypoint API. `TargetInvocationException` should be unwrapped to get the real error message to the client.