### PR TITLE
[WASM] Fix deadlock when instantiating pthread worker pool

### DIFF
--- a/src/mono/wasm/runtime/pthreads/browser/index.ts
+++ b/src/mono/wasm/runtime/pthreads/browser/index.ts
@@ -135,12 +135,14 @@ export function preAllocatePThreadWorkerPool(defaultPthreadPoolSize: number, con
 export async function instantiateWasmPThreadWorkerPool(): Promise<void> {
     // this is largely copied from emscripten's "receiveInstance" in "createWasm" in "src/preamble.js"
     const workers = Internals.getUnusedWorkerPool();
-    const allLoaded = createPromiseController<void>();
-    let leftToLoad = workers.length;
-    workers.forEach((w) => {
-        Internals.loadWasmModuleToWorker(w, function () {
-            if (!--leftToLoad) allLoaded.promise_control.resolve();
+    if (workers.length > 0) {
+        const allLoaded = createPromiseController<void>();
+        let leftToLoad = workers.length;
+        workers.forEach((w) => {
+            Internals.loadWasmModuleToWorker(w, function () {
+                if (!--leftToLoad) allLoaded.promise_control.resolve();
+            });
         });
-    });
-    await allLoaded.promise;
+        await allLoaded.promise;
+    }
 }


### PR DESCRIPTION
I ran into an issue with app initialization with WASM threads enabled. When the number of workers in the pool is set to 0 (which is a valid value), the app awaits a promise that will never resolve. This PR fixes it.