### PR TITLE
[release/6.0] Mark `Unsafe.AsRef<T>(in T)` as `scoped`.

### DIFF
--- a/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
+++ b/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
@@ -300,10 +300,11 @@
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
         .param [1]
 #ifdef netcoreapp
-        .custom instance void [CORE_ASSEMBLY]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
+            .custom instance void [CORE_ASSEMBLY]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
 #else
-        .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
+            .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
 #endif
+            .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor() = ( 01 00 00 00 )
         .maxstack 1
         ldarg.0
         ret
@@ -577,6 +578,31 @@
 
 } // end of class System.Runtime.CompilerServices.IsReadOnlyAttribute
 #endif
+
+.class private auto ansi sealed beforefieldinit System.Runtime.CompilerServices.ScopedRefAttribute
+    extends [CORE_ASSEMBLY]System.Attribute
+{
+    .custom instance void [CORE_ASSEMBLY]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void [CORE_ASSEMBLY]System.AttributeUsageAttribute::.ctor(valuetype [CORE_ASSEMBLY]System.AttributeTargets) = (
+        01 00 00 08 00 00 02 00 54 02 0d 41 6c 6c 6f 77
+        4d 75 6c 74 69 70 6c 65 00 54 02 09 49 6e 68 65
+        72 69 74 65 64 00
+    )
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        .maxstack 8
+        IL_0000: ldarg.0
+        IL_0001: call instance void [CORE_ASSEMBLY]System.Attribute::.ctor()
+        IL_0007: ret
+    } // end of method ScopedRefAttribute::.ctor
+
+} // end of class System.Runtime.CompilerServices.ScopedRefAttribute
 
 .class private auto ansi sealed beforefieldinit Microsoft.CodeAnalysis.EmbeddedAttribute
     extends [CORE_ASSEMBLY]System.Attribute

--- a/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.IL">
+<Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>
     <!-- Make sure that the DebuggableAttribute is set properly. -->
@@ -8,6 +8,8 @@
     <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
     <IlasmFlags>$(IlasmFlags) -DEBUG=$(DebugOptimization)</IlasmFlags>
     <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides the System.Runtime.CompilerServices.Unsafe class, which provides generic, low-level functionality for manipulating pointers.
 
 Commonly Used Types:


### PR DESCRIPTION
Fixes Issue N/A

main PR: a tiny subset of #71265, as updated by #71498

# Description

The `ref` fields feature in C# 11 has brought some changes to the escape rules around byref-like parameters in static methods that return byref-like types, the most prominent method of which is `MemoryMarshal.CreateSpan`. In C# 11, a method with signature `Span<T> CreateSpan<T>(ref T reference, int length)` means that the returned span's lifetime is tied to the `ref` parameter, which is a reduced flexibility we don't want for such an unsafe method. To work around this, we introduced the `scoped` keyword which unties the lifetimes, and added it to `MemoryMarshal.CreateSpan`'s `ref` parameter.

However, when using C# 11 on frameworks earlier than .NET 7, `MemoryMarshal.CreateSpan` is not marked as `scoped` and code like the following starts failing to compile:

```csharp
public static Span<int> Test()
{
    int r = 0;
    return MemoryMarshal.CreateSpan(ref r, 1);
}
```

Users on earlier frameworks have no way out of this error; they need an API that "launders" away the scopedness of a reference. Updating `MemoryMarshal.CreateSpan` is non-trivial because it is distributed inbox, but an API that got `scoped` in .NET 7 and can be serviced is `Unsafe.AsRef<T>(in T)`.

In this PR I made the parameter of the `Unsafe.AsRef<T>(in T)` method scoped. The `System.Runtime.CompilerServices.Unsafe` package is distributed OOB, and once a new version gets released users will get a tiny way out of the scoped rules and could be unblocked by writing:

```csharp
public static Span<int> Test()
{
    int r = 0;
    return MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in r), 1);
}
```

# Customer Impact

C# 11 users on earlier frameworks might resort to dangerous measures such as:

```csharp
public unsafe static Span<int> Test()
{
    int r = 0;
    return MemoryMarshal.CreateSpan(ref Unsafe.AsRef<int>(Unsafe.AsPointer(ref r)), 1);
}
```

which would cause GC holes if the referece points to the heap (not in this case, just showing an example).

Granted, C# 11 on earlier frameworks is unsupported, but such users do exist and this PR provides the _minimal_ set of changes to open a tiny window to unblock them.

# Regression

Sort of, a regression technically exists, but on an unsupported scenario.

# Testing

Manual testing; I made the following project that targets .NET Standard 2.1 and uses C# 11. Before manually referencing the new `System.Runtime.CompilerServices.Unsafe` package it couldn't compile, afterwards it can:

```csharp
using System.Runtime.CompilerServices;
using System.Runtime.InteropServices;

public static class Class1
{
    public static Span<int> Test()
    {
        int r = 0;
        return MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in r), 1);
    }
}
```

# Risk

Low. This method's parameter is already `scoped` in .NET 7, and the only code change is adding a compile-time attribute that pre-C# 11 compilers ignore, the impact on C# 10 users on .NET 6 is expected to be zero. I don't think it would make any existing code fail.

# Package authoring signed off?


IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.