### PR TITLE
Do not create `ADDR(HWI/SIMD)` in the inliner

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5881,15 +5881,6 @@ private:
     Statement* fgInlinePrependStatements(InlineInfo* inlineInfo);
     void fgInlineAppendStatements(InlineInfo* inlineInfo, BasicBlock* block, Statement* stmt);
 
-#if FEATURE_MULTIREG_RET
-    GenTree* fgGetStructAsStructPtr(GenTree* tree);
-    GenTree* fgAssignStructInlineeToVar(GenTree* child, CORINFO_CLASS_HANDLE retClsHnd);
-    void fgAttachStructInlineeToAsg(GenTree* tree, GenTree* child, CORINFO_CLASS_HANDLE retClsHnd);
-#endif // FEATURE_MULTIREG_RET
-
-    static fgWalkPreFn  fgUpdateInlineReturnExpressionPlaceHolder;
-    static fgWalkPostFn fgLateDevirtualization;
-
 #ifdef DEBUG
     static fgWalkPreFn fgDebugCheckInlineCandidates;
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -328,8 +328,9 @@ private:
         // We need to force all assignments from multi-reg nodes into the "lcl = node()" form.
         if (inlinee->IsMultiRegNode())
         {
-            // Special case: we already have a local, the only thing to do is mark it appropriately.
-            if (dst->OperIs(GT_LCL_VAR))
+            // Special case: we already have a local, the only thing to do is mark it appropriately. Except
+            // if it may turn into an indirection.
+            if (dst->OperIs(GT_LCL_VAR) && !m_compiler->lvaIsImplicitByRefLocal(dst->AsLclVar()->GetLclNum()))
             {
                 m_compiler->lvaGetDesc(dst->AsLclVar())->lvIsMultiRegRet = true;
             }

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -251,7 +251,7 @@ private:
 
         // If an inline was rejected and the call returns a struct, we may
         // have deferred some work when importing call for cases where the
-        // struct is returned in register(s).
+        // struct is returned in multiple registers.
         //
         // See the bail-out clauses in impFixupCallStructReturn for inline
         // candidates.
@@ -265,21 +265,18 @@ private:
 
             switch (howToReturnStruct)
             {
-
 #if FEATURE_MULTIREG_RET
-
-                // Is this a type that is returned in multiple registers
-                // or a via a primitive type that is larger than the struct type?
-                // if so we need to force into into a form we accept.
-                // i.e. LclVar = call()
+                // Force multi-reg nodes into the "lcl = node()" form if necessary.
+                //
                 case Compiler::SPK_ByValue:
                 case Compiler::SPK_ByValueAsHfa:
                 {
                     // See assert below, we only look one level above for an asg parent.
-                    if (parent->gtOper == GT_ASG)
+                    if (parent->OperIs(GT_ASG))
                     {
-                        // Either lhs is a call V05 = call(); or lhs is addr, and asg becomes a copyBlk.
-                        AttachStructInlineeToAsg(parent, tree, retClsHnd);
+                        // The inlinee can only be the RHS.
+                        assert(parent->gtGetOp2() == tree);
+                        AttachStructInlineeToAsg(parent->AsOp(), retClsHnd);
                     }
                     else
                     {
@@ -310,141 +307,98 @@ private:
     }
 
 #if FEATURE_MULTIREG_RET
-
-    /***************************************************************************************************
-     * child     - The inlinee of the retExpr node.
-     * retClsHnd - The struct class handle of the type of the inlinee.
-     *
-     * Assign the inlinee to a tmp, if it is a call, just assign it to a lclVar, else we can
-     * use a copyblock to do the assignment.
-     */
-    GenTree* AssignStructInlineeToVar(GenTree* child, CORINFO_CLASS_HANDLE retClsHnd)
+    //------------------------------------------------------------------------
+    // AttachStructInlineeToAsg: Update an "ASG(..., inlinee)" tree.
+    //
+    // Morphs inlinees that are multi-reg nodes into the (only) supported shape
+    // of "lcl = node()", either by marking the LHS local "lvIsMultiRegRet" or
+    // assigning the node into a temp and using that as the RHS.
+    //
+    // Arguments:
+    //    asg       - The assignment with the inlinee on the RHS
+    //    retClsHnd - The struct handle for the inlinee
+    //
+    void AttachStructInlineeToAsg(GenTreeOp* asg, CORINFO_CLASS_HANDLE retClsHnd)
     {
-        assert(child->gtOper != GT_RET_EXPR && child->gtOper != GT_MKREFANY);
+        assert(asg->OperIs(GT_ASG));
 
-        unsigned tmpNum = m_compiler->lvaGrabTemp(false DEBUGARG("RetBuf for struct inline return candidates."));
-        m_compiler->lvaSetStruct(tmpNum, retClsHnd, false);
-        var_types structType = m_compiler->lvaGetDesc(tmpNum)->lvType;
+        GenTree* dst     = asg->gtGetOp1();
+        GenTree* inlinee = asg->gtGetOp2();
 
-        GenTree* dst = m_compiler->gtNewLclvNode(tmpNum, structType);
+        // We need to force all assignments from multi-reg nodes into the "lcl = node()" form.
+        if (inlinee->IsMultiRegNode())
+        {
+            // Special case: we already have a local, the only thing to do is mark it appropriately.
+            if (dst->OperIs(GT_LCL_VAR))
+            {
+                m_compiler->lvaGetDesc(dst->AsLclVar())->lvIsMultiRegRet = true;
+            }
+            else
+            {
+                // Here, we assign our node into a fresh temp and then use that temp as the new value.
+                asg->gtOp2 = AssignStructInlineeToVar(inlinee, retClsHnd);
+            }
+        }
+        else if (dst->IsMultiRegLclVar())
+        {
+            // This is no longer a multi-reg assignment -- clear the flag.
+            dst->AsLclVar()->ClearMultiReg();
+        }
+    }
 
-        // If we have a call, we'd like it to be: V00 = call(), but first check if
-        // we have a ", , , call()" -- this is very defensive as we may never get
-        // an inlinee that is made of commas. If the inlinee is not a call, then
-        // we use a copy block to do the assignment.
-        GenTree* src       = child;
+    //------------------------------------------------------------------------
+    // AssignStructInlineeToVar: Assign the struct inlinee to a temp local.
+    //
+    // Arguments:
+    //    inlinee   - The inlinee of the RET_EXPR node
+    //    retClsHnd - The struct class handle of the type of the inlinee.
+    //
+    // Return Value:
+    //    Value representing the freshly assigned temp.
+    //
+    GenTree* AssignStructInlineeToVar(GenTree* inlinee, CORINFO_CLASS_HANDLE retClsHnd)
+    {
+        assert(!inlinee->OperIs(GT_MKREFANY, GT_RET_EXPR));
+
+        unsigned   lclNum = m_compiler->lvaGrabTemp(false DEBUGARG("RetBuf for struct inline return candidates."));
+        LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
+        m_compiler->lvaSetStruct(lclNum, retClsHnd, false);
+
+        // Sink the assignment below any COMMAs: this is required for multi-reg nodes.
+        GenTree* src       = inlinee;
         GenTree* lastComma = nullptr;
-        while (src->gtOper == GT_COMMA)
+        while (src->OperIs(GT_COMMA))
         {
             lastComma = src;
             src       = src->AsOp()->gtOp2;
         }
 
-        GenTree* newInlinee = nullptr;
-        if (src->gtOper == GT_CALL)
+        // When assigning a multi-register value to a local var, make sure the variable is marked as lvIsMultiRegRet.
+        if (src->IsMultiRegNode())
         {
-            // If inlinee was just a call, new inlinee is v05 = call()
-            newInlinee = m_compiler->gtNewAssignNode(dst, src);
-
-            // When returning a multi-register value in a local var, make sure the variable is
-            // marked as lvIsMultiRegRet, so it does not get promoted.
-            if (src->AsCall()->HasMultiRegRetVal())
-            {
-                m_compiler->lvaGetDesc(tmpNum)->lvIsMultiRegRet = true;
-            }
-
-            // If inlinee was comma, but a deeper call, new inlinee is (, , , v05 = call())
-            if (child->gtOper == GT_COMMA)
-            {
-                lastComma->AsOp()->gtOp2 = newInlinee;
-                newInlinee               = child;
-            }
-        }
-        else
-        {
-            // Inlinee is not a call, so just create a copy block to the tmp.
-            src              = child;
-            GenTree* dstAddr = GetStructAsStructPtr(dst);
-            GenTree* srcAddr = GetStructAsStructPtr(src);
-            newInlinee       = m_compiler->gtNewCpObjNode(dstAddr, srcAddr, retClsHnd, false);
+            varDsc->lvIsMultiRegRet = true;
         }
 
-        GenTree* production = m_compiler->gtNewLclvNode(tmpNum, structType);
-        return m_compiler->gtNewOperNode(GT_COMMA, structType, newInlinee, production);
+        GenTree* dst = m_compiler->gtNewLclvNode(lclNum, varDsc->TypeGet());
+        GenTree* asg = m_compiler->gtNewBlkOpNode(dst, src, /* isVolatile */ false, /* isCopyBlock */ true);
+
+        // If inlinee was comma, new inlinee is (, , , lcl = inlinee).
+        if (inlinee->OperIs(GT_COMMA))
+        {
+            lastComma->AsOp()->gtOp2 = asg;
+            asg                      = inlinee;
+        }
+
+        // Block morphing does not support (promoted) locals under commas, as such, instead of "COMMA(asg, lcl)" we
+        // do "OBJ(COMMA(asg, ADDR(LCL)))". TODO-1stClassStructs: improve block morphing and delete this workaround.
+        //
+        GenTree* lcl  = m_compiler->gtNewLclvNode(lclNum, varDsc->TypeGet());
+        GenTree* addr = m_compiler->gtNewOperNode(GT_ADDR, TYP_I_IMPL, lcl);
+        addr          = m_compiler->gtNewOperNode(GT_COMMA, addr->TypeGet(), asg, addr);
+        GenTree* obj  = m_compiler->gtNewObjNode(varDsc->GetLayout(), addr);
+
+        return obj;
     }
-
-    /***************************************************************************************************
-     * tree      - The tree pointer that has one of its child nodes as retExpr.
-     * child     - The inlinee child.
-     * retClsHnd - The struct class handle of the type of the inlinee.
-     *
-     * V04 = call() assignments are okay as we codegen it. Everything else needs to be a copy block or
-     * would need a temp. For example, a cast(ldobj) will then be, cast(v05 = ldobj, v05); But it is
-     * a very rare (or impossible) scenario that we'd have a retExpr transform into a ldobj other than
-     * a lclVar/call. So it is not worthwhile to do pattern matching optimizations like addr(ldobj(op1))
-     * can just be op1.
-     */
-    void AttachStructInlineeToAsg(GenTree* tree, GenTree* child, CORINFO_CLASS_HANDLE retClsHnd)
-    {
-        // We are okay to have:
-        // 1. V02 = call();
-        // 2. copyBlk(dstAddr, srcAddr);
-        assert(tree->gtOper == GT_ASG);
-
-        // We have an assignment, we codegen only V05 = call().
-        if (child->gtOper == GT_CALL && tree->AsOp()->gtOp1->gtOper == GT_LCL_VAR)
-        {
-            // If it is a multireg return on x64/ux, the local variable should be marked as lvIsMultiRegRet
-            if (child->AsCall()->HasMultiRegRetVal())
-            {
-                unsigned lclNum                                 = tree->AsOp()->gtOp1->AsLclVarCommon()->GetLclNum();
-                m_compiler->lvaGetDesc(lclNum)->lvIsMultiRegRet = true;
-            }
-            return;
-        }
-
-        GenTree* dstAddr = GetStructAsStructPtr(tree->AsOp()->gtOp1);
-        GenTree* srcAddr = GetStructAsStructPtr(
-            (child->gtOper == GT_CALL)
-                ? AssignStructInlineeToVar(child, retClsHnd) // Assign to a variable if it is a call.
-                : child);                                    // Just get the address, if not a call.
-
-        tree->ReplaceWith(m_compiler->gtNewCpObjNode(dstAddr, srcAddr, retClsHnd, false), m_compiler);
-    }
-
-    /*********************************************************************************
-     *
-     * tree - The node which needs to be converted to a struct pointer.
-     *
-     *  Return the pointer by either __replacing__ the tree node with a suitable pointer
-     *  type or __without replacing__ and just returning a subtree or by __modifying__
-     *  a subtree.
-     */
-    GenTree* GetStructAsStructPtr(GenTree* tree)
-    {
-        noway_assert(tree->OperIs(GT_LCL_VAR, GT_FIELD, GT_IND, GT_BLK, GT_OBJ, GT_COMMA) ||
-                     tree->OperIsSimdOrHWintrinsic() || tree->IsCnsVec());
-        // GT_CALL,     cannot get address of call.
-        // GT_MKREFANY, inlining should've been aborted due to mkrefany opcode.
-        // GT_RET_EXPR, cannot happen after fgUpdateInlineReturnExpressionPlaceHolder
-
-        switch (tree->OperGet())
-        {
-            case GT_BLK:
-            case GT_OBJ:
-            case GT_IND:
-                return tree->AsOp()->gtOp1;
-
-            case GT_COMMA:
-                tree->AsOp()->gtOp2 = GetStructAsStructPtr(tree->AsOp()->gtOp2);
-                tree->gtType        = TYP_BYREF;
-                return tree;
-
-            default:
-                return m_compiler->gtNewOperNode(GT_ADDR, TYP_BYREF, tree);
-        }
-    }
-
 #endif // FEATURE_MULTIREG_RET
 
     //------------------------------------------------------------------------
@@ -1454,7 +1408,7 @@ _Done:
 
         // Replace the call with the return expression. Note that iciCall won't be part of the IR
         // but may still be referenced from a GT_RET_EXPR node. We will replace GT_RET_EXPR node
-        // in fgUpdateInlineReturnExpressionPlaceHolder. At that time we will also update the flags
+        // in UpdateInlineReturnExpressionPlaceHolder. At that time we will also update the flags
         // on the basic block of GT_RET_EXPR node.
         if (iciCall->gtInlineCandidateInfo->retExpr->OperGet() == GT_RET_EXPR)
         {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7151,6 +7151,15 @@ GenTree* Compiler::gtNewZeroConNode(var_types type)
             zero = gtNewDconNode(0.0);
             break;
 
+#ifdef FEATURE_SIMD
+        case TYP_SIMD8:
+        case TYP_SIMD12:
+        case TYP_SIMD16:
+        case TYP_SIMD32:
+            zero = gtNewZeroConNode(type, CORINFO_TYPE_FLOAT);
+            break;
+#endif // FEATURE_SIMD
+
         default:
             noway_assert(!"Bad type in gtNewZeroConNode");
             zero = nullptr;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8666,12 +8666,6 @@ GenTree* Compiler::fgMorphConst(GenTree* tree)
 // Return value:
 //    GenTreeLclVar if the obj can be replaced by it, null otherwise.
 //
-// Notes:
-//    TODO-CQ: currently this transformation is done only under copy block,
-//    but it is beneficial to do for each OBJ node. However, `PUT_ARG_STACK`
-//    for some platforms does not expect struct `LCL_VAR` as a source, so
-//    it needs more work.
-//
 GenTreeLclVar* Compiler::fgMorphTryFoldObjAsLclVar(GenTreeObj* obj, bool destroyNodes)
 {
     if (opts.OptimizationEnabled())

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6918,32 +6918,8 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
             // if the root node was an `ASG`, `RET` or `CAST`.
             // Return a zero con node to exit morphing of the old trees without asserts
             // and forbid POST_ORDER morphing doing something wrong with our call.
-            var_types callType;
-            if (varTypeIsStruct(origCallType))
-            {
-                CORINFO_CLASS_HANDLE        retClsHnd = call->gtRetClsHnd;
-                Compiler::structPassingKind howToReturnStruct;
-                callType = getReturnTypeForStruct(retClsHnd, call->GetUnmanagedCallConv(), &howToReturnStruct);
-                assert((howToReturnStruct != SPK_Unknown) && (howToReturnStruct != SPK_ByReference));
-                if (howToReturnStruct == SPK_ByValue)
-                {
-                    callType = TYP_I_IMPL;
-                }
-                else if (howToReturnStruct == SPK_ByValueAsHfa || varTypeIsSIMD(callType))
-                {
-                    callType = TYP_FLOAT;
-                }
-                assert((callType != TYP_UNKNOWN) && !varTypeIsStruct(callType));
-            }
-            else
-            {
-                callType = origCallType;
-            }
-            assert((callType != TYP_UNKNOWN) && !varTypeIsStruct(callType));
-            callType = genActualType(callType);
-
-            GenTree* zero = gtNewZeroConNode(callType);
-            result        = fgMorphTree(zero);
+            var_types zeroType = (origCallType == TYP_STRUCT) ? TYP_INT : genActualType(origCallType);
+            result             = fgMorphTree(gtNewZeroConNode(zeroType));
         }
         else
         {

--- a/src/tests/JIT/Directed/arglist/vararg.cs
+++ b/src/tests/JIT/Directed/arglist/vararg.cs
@@ -4441,6 +4441,26 @@ namespace NativeVarargTest
             return equal;
         }
 
+        // Miscellaneous tests
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool TestEchoFourDoubleStructViaParameterAssign()
+        {
+            FourDoubleStruct arg = new FourDoubleStruct();
+            arg.a = 1.0;
+            arg.b = 2.0;
+            arg.c = 3.0;
+            arg.d = 4.0;
+
+            FourDoubleStruct returnValue = ManagedNativeVarargTests.TestEchoFourDoubleStructViaParameterAssign(arg, __arglist());
+            bool equal = arg.a == returnValue.a &&
+                         arg.b == returnValue.b &&
+                         arg.c == returnValue.c &&
+                         arg.d == returnValue.d;
+
+            return equal;
+        }
+
         ////////////////////////////////////////////////////////////////////////
         // Report Failure
         ////////////////////////////////////////////////////////////////////////
@@ -5064,6 +5084,9 @@ namespace NativeVarargTest
 
             // Parameter address tests
             success = ReportFailure(TestEchoFourDoubleStructManagedViaAddress(), "TestEchoFourDoubleStructManagedViaAddress()", success, 155);
+
+            // Miscellaneous tests
+            success = ReportFailure(TestEchoFourDoubleStructViaParameterAssign(), "TestEchoFourDoubleStructViaParameterAssign()", success, 156);
 
             printf("\n", __arglist());
             printf("%d Tests run. %d Passed, %d Failed.\n", __arglist(m_testCount, m_passCount, m_failCount));

--- a/src/tests/JIT/Directed/arglist/varargmanaged.cs
+++ b/src/tests/JIT/Directed/arglist/varargmanaged.cs
@@ -1331,5 +1331,31 @@ namespace NativeVarargTest
         {
             return new FourDoubleStruct { a = a, b = b, c = c, d = d };
         }
+
+        // Miscellaneous tests
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static FourDoubleStruct TestEchoFourDoubleStructViaParameterAssign(FourDoubleStruct a, __arglist)
+        {
+            // Tests that a multi-reg return from an inline candidate can be assigned successfully to a by-reference
+            // parameter on Windows ARM64.
+            a = ReturnDoubleStructInlineCandidate(a);
+
+            return a;
+        }
+
+        private static FourDoubleStruct ReturnDoubleStructInlineCandidate(FourDoubleStruct a)
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void Call() { }
+
+            Call();
+            Call();
+            Call();
+            Call();
+            Call();
+
+            return a;
+        }
     }
 }


### PR DESCRIPTION
When inserting return expressions in the inliner, we do some IR munging to maintain the invariant that multi-reg nodes are only used by multi-reg stores. This procedure was creating some illegal `ADDR`s, which only "worked out" because block morphing would later always discard them. This change avoids that by creating simple stores from the beginning.

We're expecting sizeable positive diffs due to unblocking a number of forward substitutions that would otherwise fail on the "multi-reg state must match" checks.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1958256&view=results) - with some regressions due to the usual consequences of more propagations.