### PR TITLE
[release/7.0-rc1] Roll forward to the latest 6.0.x builds

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -48,13 +48,13 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>5618b2d243ccdeb5c7e50a298b33b13036b4351b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.0-rc.1.22418.6">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net6.Manifest-7.0.100" Version="7.0.0-rc.1.22418.9">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>eb3232eb90aac35a31134464fc498a5f1ddb239f</Sha>
+      <Sha>745113281de08619474a5e1c704290a4ed30a65d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.0-rc.1.22418.6">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.net7.Manifest-7.0.100" Version="7.0.0-rc.1.22418.9">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>eb3232eb90aac35a31134464fc498a5f1ddb239f</Sha>
+      <Sha>745113281de08619474a5e1c704290a4ed30a65d</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>7.0.100</SdkBandVersion>
-    <PackageVersionNet6>6.0.8</PackageVersionNet6>
+    <PackageVersionNet6>6.0.9</PackageVersionNet6>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Set assembly version to align with major and minor version,
@@ -22,8 +22,8 @@
     <UsingToolXliff>false</UsingToolXliff>
     <LastReleasedStableAssemblyVersion>$(AssemblyVersion)</LastReleasedStableAssemblyVersion>
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
-    <MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>7.0.0-rc.1.22418.6</MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>
-    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.0-rc.1.22418.6</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
+    <MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>7.0.0-rc.1.22418.9</MicrosoftNETWorkloadEmscriptennet6Manifest70100Version>
+    <MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>7.0.0-rc.1.22418.9</MicrosoftNETWorkloadEmscriptennet7Manifest70100Version>
   </PropertyGroup>
   <!--
     For source generator support we need to target multiple versions of Roslyn in order to be able to run on older versions of Roslyn.

--- a/eng/pipelines/mono/templates/workloads-build.yml
+++ b/eng/pipelines/mono/templates/workloads-build.yml
@@ -63,7 +63,8 @@ jobs:
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvos-*.nupkg
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvossimulator-*.nupkg
-          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.Manifest*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest*.nupkg
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoTargets.Sdk*.nupkg
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoAOTCompiler.Task*.nupkg
           IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Sdk*.nupkg

--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -155,8 +155,11 @@
                           />
 
     <WorkloadCombinationsToInstall Include="net7"   Variants="net7" />
+    <!-- Latest net6 6.0.x versions are not available in feed currently so don't install them -->
+    <!--
     <WorkloadCombinationsToInstall Include="net6"   Variants="net6" />
     <WorkloadCombinationsToInstall Include="net6+7" Variants="net6;net7" />
+    -->
     <!--<WorkloadCombinationsToInstall Include="none" />-->
 
     <WasmExtraFilesToDeploy Condition="'$(_UseWasmSymbolicator)' == 'true'" Include="$(MonoProjectRoot)wasm\data\wasm-symbol-patterns.txt" />

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.json.in
@@ -30,10 +30,10 @@
       "abstract": true,
       "description": "Android Mono AOT Workload",
       "packs": [
-        "Microsoft.NETCore.App.Runtime.AOT.Cross.android-x86",
-        "Microsoft.NETCore.App.Runtime.AOT.Cross.android-x64",
-        "Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm",
-        "Microsoft.NETCore.App.Runtime.AOT.Cross.android-arm64"
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.android-x86",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.android-x64",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.android-arm",
+        "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.android-arm64"
       ],
       "extends": [ "microsoft-net-runtime-android-net6" ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
@@ -90,8 +90,8 @@
       "packs": [
         "Microsoft.NETCore.App.Runtime.Mono.net6.osx-arm64",
         "Microsoft.NETCore.App.Runtime.Mono.net6.osx-x64",
-        "Microsoft.NETCore.App.Runtime.osx-arm64",
-        "Microsoft.NETCore.App.Runtime.osx-x64"
+        "Microsoft.NETCore.App.Runtime.net6.osx-arm64",
+        "Microsoft.NETCore.App.Runtime.net6.osx-x64"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling-net6" ],
       "platforms": [ "osx-arm64", "osx-x64" ]

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.json.in
@@ -141,49 +141,49 @@
       "kind": "Sdk",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NET.Runtime.MonoAOTCompiler.Task"
+        "any": "Microsoft.NET.Runtime.MonoAOTCompiler.Task"
       }
     },
     "Microsoft.NET.Runtime.MonoTargets.Sdk.net6": {
       "kind": "Sdk",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NET.Runtime.MonoTargets.Sdk"
+        "any": "Microsoft.NET.Runtime.MonoTargets.Sdk"
       }
     },
     "Microsoft.NET.Runtime.WebAssembly.Sdk.net6": {
       "kind": "Sdk",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NET.Runtime.WebAssembly.Sdk"
+        "any": "Microsoft.NET.Runtime.WebAssembly.Sdk"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.android-arm": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.android-arm"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.android-arm"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.android-arm64": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.android-arm"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.android-arm"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.android-x64": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.android-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.android-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.android-x86": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.android-x86"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.android-x86"
       }
     },
     "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.android-x86": {
@@ -230,77 +230,77 @@
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.maccatalyst-x64": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.osx-arm64": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.osx-x64": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.net6.osx-arm64": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.net6.osx-x64": {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.osx-x64"
+        "any": "Microsoft.NETCore.App.Runtime.osx-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.ios-arm" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.ios-arm"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.ios-arm"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.ios-arm64" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.ios-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.ios-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.iossimulator-arm64" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.iossimulator-x64" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.iossimulator-x86" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86"
       }
     },
     "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.tvos-arm64": {
@@ -315,21 +315,21 @@
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.tvossimulator-arm64" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net6.tvossimulator-x64" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.AOT.Cross.net6.maccatalyst-arm64": {
@@ -418,35 +418,35 @@
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.browser-wasm"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.browser-wasm"
       }
     },
     "Microsoft.NETCore.App.Runtime.net6.win-x64" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.win-x64"
+        "any": "Microsoft.NETCore.App.Runtime.win-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.net6.win-x86" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.win-x86"
+        "any": "Microsoft.NETCore.App.Runtime.win-x86"
       }
     },
     "Microsoft.NETCore.App.Runtime.net6.win-arm" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.win-arm"
+        "any": "Microsoft.NETCore.App.Runtime.win-arm"
       }
     },
     "Microsoft.NETCore.App.Runtime.net6.win-arm64" : {
       "kind": "framework",
       "version": "${PackageVersionNet6}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.win-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.win-arm64"
       }
     }
   }

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.targets.in
@@ -97,13 +97,6 @@
         <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.net6" />
     </ImportGroup>
 
-    <!-- HACK: -->
-    <ImportGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '6.0'))">
-      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Python.net6" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
-      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Node.net6" />
-      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Sdk.net6" />
-    </ImportGroup>
-
     <PropertyGroup Condition="'$(TargetsNet6)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'macOS' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'maccatalyst' or '$(TargetPlatformIdentifier)' == 'tvos' or ('$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true'))">
       <_MonoWorkloadTargetsMobile>true</_MonoWorkloadTargetsMobile>
       <_MonoWorkloadRuntimePackPackageVersion>$(_RuntimePackInWorkloadVersion6)</_MonoWorkloadRuntimePackPackageVersion>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.json.in
@@ -17,9 +17,9 @@
     "wasm-experimental": {
       "description": ".NET WebAssembly experimental tooling",
       "packs": [
-        "Microsoft.NET.Runtime.WebAssembly.Templates",
-        "Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm",
-        "Microsoft.NETCore.App.Runtime.Mono.perftrace.browser-wasm"
+        "Microsoft.NET.Runtime.WebAssembly.Templates.net7",
+        "Microsoft.NETCore.App.Runtime.Mono.multithread.net7.browser-wasm",
+        "Microsoft.NETCore.App.Runtime.Mono.perftrace.net7.browser-wasm"
       ],
       "extends": [ "wasm-tools" ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
@@ -151,53 +151,56 @@
       "kind": "Sdk",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NET.Runtime.MonoAOTCompiler.Task"
+        "any": "Microsoft.NET.Runtime.MonoAOTCompiler.Task"
       }
     },
     "Microsoft.NET.Runtime.MonoTargets.Sdk.net7": {
       "kind": "Sdk",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NET.Runtime.MonoTargets.Sdk"
+        "any": "Microsoft.NET.Runtime.MonoTargets.Sdk"
       }
     },
     "Microsoft.NET.Runtime.WebAssembly.Sdk.net7": {
       "kind": "Sdk",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NET.Runtime.WebAssembly.Sdk"
+        "any": "Microsoft.NET.Runtime.WebAssembly.Sdk"
       }
     },
-    "Microsoft.NET.Runtime.WebAssembly.Templates": {
+    "Microsoft.NET.Runtime.WebAssembly.Templates.net7": {
       "kind": "template",
-      "version": "${PackageVersion}"
+      "version": "${PackageVersion}",
+      "alias-to": {
+        "any": "Microsoft.NET.Runtime.WebAssembly.Templates"
+      }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.android-arm": {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.android-arm"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.android-arm"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.android-arm64": {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.android-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.android-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.android-x64": {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.android-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.android-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.android-x86": {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.android-x86"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.android-x86"
       }
     },
     "Microsoft.NETCore.App.Runtime.AOT.Cross.net7.android-x86": {
@@ -244,35 +247,35 @@
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.maccatalyst-x64": {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.osx-arm64": {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.osx-x64": {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.net7.osx-arm64": {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.net7.osx-x64": {
@@ -286,21 +289,21 @@
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.ios-arm"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.ios-arm"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.ios-arm64" : {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.ios-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.ios-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.iossimulator-arm64" : {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.iossimulator-x64" : {
@@ -314,7 +317,7 @@
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86"
       }
     },
     "Microsoft.NETCore.App.Runtime.AOT.Cross.net7.tvos-arm64": {
@@ -329,21 +332,21 @@
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.tvossimulator-arm64" : {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.net7.tvossimulator-x64" : {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.AOT.Cross.net7.maccatalyst-arm64": {
@@ -432,43 +435,49 @@
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.Mono.browser-wasm"
+        "any": "Microsoft.NETCore.App.Runtime.Mono.browser-wasm"
       }
     },
-    "Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm" : {
+    "Microsoft.NETCore.App.Runtime.Mono.multithread.net7.browser-wasm" : {
       "kind": "framework",
-      "version": "${PackageVersion}"
+      "version": "${PackageVersion}",
+      "alias-to: {
+        "any": "Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm"
+      }
     },
-    "Microsoft.NETCore.App.Runtime.Mono.perftrace.browser-wasm" : {
+    "Microsoft.NETCore.App.Runtime.Mono.perftrace.net7.browser-wasm" : {
       "kind": "framework",
-      "version": "${PackageVersion}"
+      "version": "${PackageVersion}",
+      "alias-to: {
+        "any": "Microsoft.NETCore.App.Runtime.Mono.perftrace.browser-wasm"
+      }
     },
     "Microsoft.NETCore.App.Runtime.net7.win-x64" : {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.win-x64"
+        "any": "Microsoft.NETCore.App.Runtime.win-x64"
       }
     },
     "Microsoft.NETCore.App.Runtime.net7.win-x86" : {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.win-x86"
+        "any": "Microsoft.NETCore.App.Runtime.win-x86"
       }
     },
     "Microsoft.NETCore.App.Runtime.net7.win-arm" : {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.win-arm"
+        "any": "Microsoft.NETCore.App.Runtime.win-arm"
       }
     },
     "Microsoft.NETCore.App.Runtime.net7.win-arm64" : {
       "kind": "framework",
       "version": "${PackageVersion}",
       "alias-to": {
-          "any": "Microsoft.NETCore.App.Runtime.win-arm64"
+        "any": "Microsoft.NETCore.App.Runtime.win-arm64"
       }
     }
   }

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.json.in
@@ -441,14 +441,14 @@
     "Microsoft.NETCore.App.Runtime.Mono.multithread.net7.browser-wasm" : {
       "kind": "framework",
       "version": "${PackageVersion}",
-      "alias-to: {
+      "alias-to": {
         "any": "Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm"
       }
     },
     "Microsoft.NETCore.App.Runtime.Mono.perftrace.net7.browser-wasm" : {
       "kind": "framework",
       "version": "${PackageVersion}",
-      "alias-to: {
+      "alias-to": {
         "any": "Microsoft.NETCore.App.Runtime.Mono.perftrace.browser-wasm"
       }
     },

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.targets.in
@@ -103,8 +103,8 @@
       <KnownRuntimePack Update="@(KnownRuntimePack)">
         <LatestRuntimeFrameworkVersion Condition="'%(KnownRuntimePack.TargetFramework)' == 'net7.0' and '%(KnownRuntimePack.RuntimePackLabels)' == 'Mono'">$(_MonoWorkloadRuntimePackPackageVersion)</LatestRuntimeFrameworkVersion>
         <!-- Overrides for wasm threading support -->
-        <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnableThreading)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.multithread.**RID**</RuntimePackNamePatterns>
-        <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnablePerfTrace)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.perftrace.**RID**</RuntimePackNamePatterns>
+        <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnableThreading)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.multithread.net7.**RID**</RuntimePackNamePatterns>
+        <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnablePerfTrace)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.perftrace.net7.**RID**</RuntimePackNamePatterns>
       </KnownRuntimePack>
     </ItemGroup>
 

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.targets.in
@@ -94,13 +94,6 @@
         <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.net7" />
     </ImportGroup>
 
-    <!-- HACK: -->
-    <ImportGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '7.0'))">
-      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Python.net7" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
-      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Node.net7" />
-      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Sdk.net7" />
-    </ImportGroup>
-
     <PropertyGroup Condition="'$(TargetsNet7)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'macOS' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'maccatalyst' or '$(TargetPlatformIdentifier)' == 'tvos' or ('$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true'))">
       <_MonoWorkloadTargetsMobile>true</_MonoWorkloadTargetsMobile>
       <_MonoWorkloadRuntimePackPackageVersion>$(_RuntimePackInWorkloadVersion7)</_MonoWorkloadRuntimePackPackageVersion>


### PR DESCRIPTION
~Staging the updates to [net7-workload-changes](https://github.com/dotnet/runtime/tree/net7-workload-changes) once it is complete in https://github.com/dotnet/runtime/pull/74018~

This bumps the 6.0.x builds to 6.0.9 which aren't in a feed CI can use, disables the tests that would fail as a result, and removes a workaround for the older manifests.