### PR TITLE
Update Xunit to 2.4.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -158,8 +158,8 @@
     <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.22411.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.22411.1</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>1.1.0-alpha.0.22408.2</MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>
-    <XUnitVersion>2.4.2-pre.22</XUnitVersion>
-    <XUnitAnalyzersVersion>0.12.0-pre.20</XUnitAnalyzersVersion>
+    <XUnitVersion>2.4.2</XUnitVersion>
+    <XUnitAnalyzersVersion>1.0.0</XUnitAnalyzersVersion>
     <XUnitRunnerVisualStudioVersion>2.4.5</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>3.1.2</CoverletCollectorVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>


### PR DESCRIPTION
2.4.2 stable released ~2 weeks ago and we have at least one shipping library that depends on it. For releasing 7.0.0, we must not depend on prerelease versions.

Manual backport of https://github.com/dotnet/runtime/pull/74262

@danmoseley I assume this is tell-mode as it's necessary for shipping.