### PR TITLE
Cleanup current directory tests

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
@@ -23,16 +23,18 @@ namespace Microsoft.VisualBasic.Tests
             base.Dispose(disposing);
         }
 
-        // On OSX/MacCatalyst, the temp directory /tmp/ is a symlink to /private/tmp, so setting the current
-        // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
-        // path that followed the symlink.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX), nameof(PlatformDetection.IsNotMacCatalyst))]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         public void ChDir()
         {
             var savedDirectory = System.IO.Directory.GetCurrentDirectory();
             FileSystem.ChDir(TestDirectory);
-            Assert.Equal(TestDirectory, System.IO.Directory.GetCurrentDirectory());
+
+            // If the test directory has symlinks, setting the current directory to a symlinked path will result
+            // in GetCurrentDirectory returning the absolute path that followed the symlink. We can only verify
+            // the test directory name in that case.
+            Assert.Equal(System.IO.Path.GetFileName(TestDirectory), System.IO.Path.GetFileName(System.IO.Directory.GetCurrentDirectory()));
+
             FileSystem.ChDir(savedDirectory);
             Assert.Equal(savedDirectory, System.IO.Directory.GetCurrentDirectory());
         }
@@ -82,8 +84,7 @@ namespace Microsoft.VisualBasic.Tests
             }
         }
 
-        // Can't get current directory on OSX before setting it.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         public void CurDir()
         {

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
@@ -285,24 +285,25 @@ namespace Microsoft.VisualBasic.FileIO.Tests
             }
         }
 
-        // Can't get current directory on OSX before setting it.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [Fact]
         public void CurrentDirectoryGet()
         {
             var CurrentDirectory = System.IO.Directory.GetCurrentDirectory();
             Assert.Equal(FileIO.FileSystem.CurrentDirectory, CurrentDirectory);
         }
 
-        // On OSX/MacCatalyst, the temp directory /tmp/ is a symlink to /private/tmp, so setting the current
-        // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
-        // path that followed the symlink.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX), nameof(PlatformDetection.IsNotMacCatalyst))]
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50572", TestPlatforms.Android)]
         public void CurrentDirectorySet()
         {
             var SavedCurrentDirectory = System.IO.Directory.GetCurrentDirectory();
             FileIO.FileSystem.CurrentDirectory = TestDirectory;
-            Assert.Equal(TestDirectory, FileIO.FileSystem.CurrentDirectory);
+
+            // If the test directory has symlinks, setting the current directory to a symlinked path will result
+            // in GetCurrentDirectory returning the absolute path that followed the symlink. We can only verify
+            // the test directory name in that case.
+            Assert.Equal(System.IO.Path.GetFileName(TestDirectory), System.IO.Path.GetFileName(FileIO.FileSystem.CurrentDirectory));
+
             FileIO.FileSystem.CurrentDirectory = SavedCurrentDirectory;
             Assert.Equal(FileIO.FileSystem.CurrentDirectory, SavedCurrentDirectory);
         }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
@@ -33,10 +33,15 @@ namespace System.IO.Tests
             RemoteExecutor.Invoke(() =>
             {
                 Directory.SetCurrentDirectory(TestDirectory);
-                // On OSX, the temp directory /tmp/ is a symlink to /private/tmp, so setting the current
-                // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
-                // path that followed the symlink.
-                if (!OperatingSystem.IsMacOS())
+
+                if ((File.GetAttributes(Path.GetDirectoryName(TestDirectory)) & FileAttributes.ReparsePoint) != 0)
+                {
+                    // If the temp directory is symlink, setting the current directory to a symlinked path will result
+                    // in GetCurrentDirectory returning the absolute path that followed the symlink. We can only verify
+                    // the test directory name in that case.
+                    Assert.Equal(Path.GetFileName(TestDirectory), Path.GetFileName(Directory.GetCurrentDirectory()));
+                }
+                else
                 {
                     Assert.Equal(TestDirectory, Directory.GetCurrentDirectory());
                 }
@@ -70,13 +75,19 @@ namespace System.IO.Tests
                     {
                         Assert.Equal(linkPath, Directory.GetCurrentDirectory());
                     }
-                    else if (OperatingSystem.IsMacOS())
-                    {
-                        Assert.Equal("/private" + path, Directory.GetCurrentDirectory());
-                    }
                     else
                     {
-                        Assert.Equal(path, Directory.GetCurrentDirectory());
+                        if ((File.GetAttributes(Path.GetDirectoryName(TestDirectory)) & FileAttributes.ReparsePoint) != 0)
+                        {
+                            // If the temp directory is symlink, setting the current directory to a symlinked path will result
+                            // in GetCurrentDirectory returning the absolute path that followed the symlink. We can only verify
+                            // the test directory name in that case.
+                            Assert.Equal(Path.GetFileName(path), Path.GetFileName(Directory.GetCurrentDirectory()));
+                        }
+                        else
+                        {
+                            Assert.Equal(path, Directory.GetCurrentDirectory());
+                        }
                     }
 
                     Directory.SetCurrentDirectory(Path.GetTempPath());

--- a/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
@@ -33,13 +33,12 @@ namespace System.IO.Tests
             RemoteExecutor.Invoke(() =>
             {
                 Directory.SetCurrentDirectory(TestDirectory);
-
-                if ((File.GetAttributes(Path.GetDirectoryName(TestDirectory)) & FileAttributes.ReparsePoint) != 0)
+                if (OperatingSystem.IsMacOS())
                 {
-                    // If the temp directory is symlink, setting the current directory to a symlinked path will result
-                    // in GetCurrentDirectory returning the absolute path that followed the symlink. We can only verify
-                    // the test directory name in that case.
-                    Assert.Equal(Path.GetFileName(TestDirectory), Path.GetFileName(Directory.GetCurrentDirectory()));
+                    // On OSX, the temp directory /tmp/ is a symlink to /private/tmp, so setting the current
+                    // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
+                    // path that followed the symlink.
+                    Assert.Equal("/private" + TestDirectory, Directory.GetCurrentDirectory());
                 }
                 else
                 {
@@ -75,19 +74,13 @@ namespace System.IO.Tests
                     {
                         Assert.Equal(linkPath, Directory.GetCurrentDirectory());
                     }
+                    else if (OperatingSystem.IsMacOS())
+                    {
+                        Assert.Equal("/private" + path, Directory.GetCurrentDirectory());
+                    }
                     else
                     {
-                        if ((File.GetAttributes(Path.GetDirectoryName(TestDirectory)) & FileAttributes.ReparsePoint) != 0)
-                        {
-                            // If the temp directory is symlink, setting the current directory to a symlinked path will result
-                            // in GetCurrentDirectory returning the absolute path that followed the symlink. We can only verify
-                            // the test directory name in that case.
-                            Assert.Equal(Path.GetFileName(path), Path.GetFileName(Directory.GetCurrentDirectory()));
-                        }
-                        else
-                        {
-                            Assert.Equal(path, Directory.GetCurrentDirectory());
-                        }
+                        Assert.Equal(path, Directory.GetCurrentDirectory());
                     }
 
                     Directory.SetCurrentDirectory(Path.GetTempPath());

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -62,8 +62,7 @@ namespace System.IO
                 path = Combine(Interop.Sys.GetCwd(), path);
             }
 
-            // We would ideally use realpath to do this, but it resolves symlinks, requires that the file actually exist,
-            // and turns it into a full path, which we only want if fullCheck is true.
+            // We would ideally use realpath to do this, but it resolves symlinks and requires that the file actually exist.
             string collapsedString = PathInternal.RemoveRelativeSegments(path, PathInternal.GetRootLength(path));
 
             Debug.Assert(collapsedString.Length < path.Length || collapsedString.ToString() == path,

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -44,13 +44,11 @@ namespace System.Tests
                 Environment.CurrentDirectory = TestDirectory;
                 Assert.Equal(Directory.GetCurrentDirectory(), Environment.CurrentDirectory);
 
-                if (!OperatingSystem.IsMacOS())
-                {
-                    // On OSX, the temp directory /tmp/ is a symlink to /private/tmp, so setting the current
-                    // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
-                    // path that followed the symlink.
-                    Assert.Equal(TestDirectory, Directory.GetCurrentDirectory());
-                }
+                // If the temp directory is symlink, setting the current directory to a symlinked path will result
+                // in GetCurrentDirectory returning the absolute path that followed the symlink. We can only verify
+                // the test directory name in that case.
+                Assert.Equal(Path.GetFileName(TestDirectory), Path.GetFileName(Environment.CurrentDirectory));
+
             }).Dispose();
         }
 


### PR DESCRIPTION
Replace hardcoded list of platforms with symlinked temp directory with a relaxed condition that allows the test to pass even when the temp directory is symlinked.