### PR TITLE
Change signature for diagnostic binaries

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,5 +1,4 @@
-<Project InitialTargets="SetupFilesToSign">
-
+<Project>
   <PropertyGroup>
     <!--
       Windows arm/arm64 jobs don't have MSIs to sign. Keep it simple: allow not finding any matches

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -20,6 +20,13 @@
     <!-- apphost and comhost template files are not signed, by design. -->
     <FileSignInfo Include="apphost.exe;singlefilehost.exe;comhost.dll" CertificateName="None" />
 
+    <!--
+      The DAC and the DBI must go through special signing provisioning using a system separate
+      from MicroBuild.
+    -->
+    <FileSignInfo Include="mscordaccore.dll" CertificateName="None" />
+    <FileSignInfo Include="mscordbi.dll" CertificateName="None" />
+
     <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
     <!-- WARNING: Needs to happed outside of any target -->
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
@@ -30,8 +37,6 @@
     <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="3PartySHA2" />
-
-    <FileSignInfo Include="mscordaccore.dll" CertificateName="MicrosoftSHA2" />
 
     <!-- Exclude symbol packages from have a NuGet signature. These are never pushed to NuGet.org or
          other feeds (in fact, that have identical identity to their non-symbol variant) -->
@@ -61,33 +66,4 @@
     <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" Condition="'$(PostBuildSign)' == 'true'" />
     <ItemsToSign Include="@(ItemsToSignWithPaths->Distinct())" Condition="'$(PostBuildSign)' != 'true'" />
   </ItemGroup>
-
-  <Target Name="SetupFilesToSign">
-    <!-- Ensure that we don't miss the DAC or DBI with the globbing below -->
-    <PropertyGroup Condition="'$(SignDiagnostics)' == 'true' or '$(SignDiagnosticsPackages)' == 'true'">
-      <AllowEmptySignList>false</AllowEmptySignList>
-    </PropertyGroup>
-
-    <ItemGroup Condition="'$(SignDiagnostics)' == 'true'">
-      <ItemsToSign Include="$(DiagnosticsFilesRoot)\**\mscordaccore*.dll" />
-      <ItemsToSign Include="$(DiagnosticsFilesRoot)\**\mscordbi.dll" />
-      <!--
-        The DAC should be signed with the SHA2 cert (both long and short name).
-        We already add the short-name DAC above, so add the long-name DAC here.
-      -->
-      <DacFileSignInfo Include="@(ItemsToSign->'%(FileName)%(Extension)')"
-                    Condition="$([System.String]::new('%(FileName)').StartsWith('mscordaccore'))" />
-      <FileSignInfo Include="@(DacFileSignInfo->ClearMetadata()->Distinct())"
-                    Exclude="mscordaccore.dll"
-                    CertificateName="MicrosoftSHA2" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="'$(SignDiagnosticsPackages)' == 'true'">
-      <!-- The cross OS diagnostics symbol packages need to be signed as they are the only packages
-      that have a specific version of assets that are only meant to be indexed in symbol servers.
-      Since only *symbols.nupkg get indexed, and installer doesn't produce these, we need to glob them for signing. -->
-      <ItemsToSign Include="$(PackagesFolder)\**\*CrossOsDiag*.nupkg" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -261,11 +261,12 @@ jobs:
             targetFolder: $(buildProductRootFolderPath)/sharedFramework
             overWrite: true
 
-    - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
-      parameters:
-        basePath: $(buildProductRootFolderPath)
-        isOfficialBuild: ${{ parameters.signBinaries }}
-        timeoutInMinutes: 30
+    - ${{ if and(eq(parameters.osGroup, 'windows'), eq(parameters.signBinaries, true)) }}:
+      - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+        parameters:
+          basePath: $(buildProductRootFolderPath)
+          isOfficialBuild: ${{ parameters.signBinaries }}
+          timeoutInMinutes: 30
 
     # Builds using gcc are not tested, and clrTools unitests do not publish the build artifacts
     - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -261,25 +261,11 @@ jobs:
             targetFolder: $(buildProductRootFolderPath)/sharedFramework
             overWrite: true
 
-    # Sign diagnostic files on Windows
-    - ${{ if and(eq(parameters.osGroup, 'windows'), eq(parameters.signBinaries, true)) }}:
-      - powershell: >-
-          eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 $(officialBuildIdArg)
-          /p:DiagnosticsFilesRoot="$(buildProductRootFolderPath)"
-          /p:SignDiagnostics=true
-          /p:DotNetSignType=$(SignType)
-          -noBl
-          /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfig)/SignDiagnostics.binlog
-          -projects $(Build.SourcesDirectory)\eng\empty.csproj
-        displayName: Sign Diagnostic Binaries
-
-      - task: PublishPipelineArtifact@1
-        displayName: Publish Signing Logs
-        inputs:
-          targetPath: '$(Build.SourcesDirectory)/artifacts/log/'
-          artifactName: ${{ format('SignLogs_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        continueOnError: true
-        condition: always()
+    - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+      parameters:
+        basePath: $(buildProductRootFolderPath)
+        isOfficialBuild: ${{ parameters.signBinaries }}
+        timeoutInMinutes: 30
 
     # Builds using gcc are not tested, and clrTools unitests do not publish the build artifacts
     - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools'), ne(parameters.disableClrTest, true)) }}:
@@ -300,6 +286,7 @@ jobs:
             archType: ${{ parameters.archType }}
             osGroup: ${{ parameters.osGroup }}
             osSubgroup: ${{ parameters.osSubgroup }}
+            isOfficialBuild: ${{ parameters.signBinaries }}
             ${{ if eq(parameters.archType, 'arm') }}:
               hostArchType: x86
             ${{ else }}:

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -1,5 +1,6 @@
 parameters:
   archType: ''
+  isOfficialBuild: false
   osGroup: ''
   osSubgroup: ''
   hostArchType: ''

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -52,6 +52,12 @@ steps:
 
       displayName: Gather CrossDac Artifacts
 
+  - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+    parameters:
+      basePath: $(crossDacArtifactPath)
+      isOfficialBuild: ${{ parameters.isOfficialBuild }}
+      timeoutInMinutes: 30
+
   - ${{ if eq(parameters.osGroup, 'Linux') }}:
     - task: CopyFiles@2
       displayName: Gather runtime for CrossDac

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -53,11 +53,11 @@ steps:
 
       displayName: Gather CrossDac Artifacts
 
-  - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
-    parameters:
-      basePath: $(crossDacArtifactPath)
-      isOfficialBuild: ${{ parameters.isOfficialBuild }}
-      timeoutInMinutes: 30
+    - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+      parameters:
+        basePath: $(crossDacArtifactPath)
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        timeoutInMinutes: 30
 
   - ${{ if eq(parameters.osGroup, 'Linux') }}:
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/crossdac-pack.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-pack.yml
@@ -77,16 +77,6 @@ jobs:
     - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset crossdacpack -arch $(archType) $(osArg) -c $(buildConfig) $(officialBuildIdArg) $(crossDacArgs) -ci
       displayName: Build crossdac packaging
 
-    # Sign diagnostic files
-    - ${{ if eq(parameters.isOfficialBuild, true) }}:
-      - powershell: >-
-          eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 $(officialBuildIdArg)
-          /p:PackagesFolder="$(Build.SourcesDirectory)/artifacts/packages/$(buildConfig)"
-          /p:SignDiagnosticsPackages=true
-          /p:DotNetSignType=$(SignType)
-          -projects $(Build.SourcesDirectory)\eng\empty.csproj
-        displayName: Sign CrossDac package and contents
-
     # Save packages using the prepare-signed-artifacts format.
     - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
       parameters:

--- a/eng/pipelines/coreclr/templates/crossdac-pack.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-pack.yml
@@ -54,19 +54,6 @@ jobs:
         - ${{ parameters.runtimeFlavor }}_${{ parameters.runtimeVariant }}_product_build_${{ platform }}_${{ parameters.buildConfig }}
 
     steps:
-    # Install MicroBuild for signing the package
-    - ${{ if eq(parameters.isOfficialBuild, true) }}:
-      - template: /eng/pipelines/common/restore-internal-tools.yml
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
     - task: DownloadBuildArtifacts@0
       displayName: Download CrossDac artifacts
       inputs:

--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -52,3 +52,29 @@ steps:
       DOTNET_MULTILEVEL_LOOKUP: 0
       DOTNET_ROOT: '$(Agent.TempDirectory)/dotnet'
       DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR: '$(Agent.TempDirectory)/dotnet'
+
+  - powershell: |
+      $filesToSign = $(Get-ChildItem -Recurse ${{ parameters.basePath }} -Include mscordaccore*.dll, mscordbi*.dll)
+      foreach ($file in $filesToSign) {
+        $signingCert = $(Get-AuthenticodeSignature $file).SignerCertificate
+        if ($signingCert -eq $null)
+        {
+          throw "File $file does not contain a signature."
+        }
+
+        if ($signingCert.Subject -ne "CN=.NET DAC, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" `
+            -or $signingCert.Issuer -ne "CN=Microsoft Code Signing PCA 2010, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")
+        {
+          throw "File $file not in expected trust chain."
+        }
+
+        $certEKU = $signingCert.Extensions.Where({ $_.Oid.FriendlyName -eq "Enhanced Key Usage" }) | Select -First 1
+
+        if ($certEKU.EnhancedKeyUsages.Where({ $_.Value -eq "1.3.6.1.4.1.311.84.4.1" }).Count -ne 1)
+        {
+          throw "Signature for $file does not contain expected EKU."
+        }
+
+        Write-Host "$file is correctly signed."
+      }
+    displayName: Validate diagnostic signatures

--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -1,0 +1,43 @@
+parameters:
+  basePath: ''
+  isOfficialBuild: ''
+  timeoutInMinutes: ''
+
+steps:
+- ${{ if and(eq(parameters.isOfficialBuild, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - task: EsrpCodeSigning@1
+    displayName: Sign Diagnostic Binaries
+    inputs:
+      ConnectedServiceName: 'dotnetesrp-diagnostics-dnceng'
+      FolderPath: ${{ parameters.basePath }}
+      Pattern: |
+        **/mscordaccore*.dll
+        **/mscordbi*.dll
+      UseMinimatch: true
+      signConfigType: 'inlineSignParams'
+      inlineOperation: >-
+        [
+          {
+            "keyCode": "CP-471322",
+            "operationCode": "SigntoolSign",
+            "parameters": {
+              "OpusName": "Microsoft",
+              "OpusInfo": "http://www.microsoft.com",
+              "PageHash": "/NPH",
+              "FileDigest": "/fd sha256",
+              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "toolName": "sign",
+            "toolVersion": "1.0"
+          },
+          {
+            "KeyCode": "CP-471322",
+            "OperationCode": "SigntoolVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          }
+        ]
+      SessionTimeout: ${{ parameters.timeoutInMinutes }}
+      MaxConcurrency: '50'
+      MaxRetryAttempts: '5'

--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -5,6 +5,13 @@ parameters:
 
 steps:
 - ${{ if and(eq(parameters.isOfficialBuild, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - task: UseDotNet@2
+    displayName: Install .NET 6 SDK for signing.
+    inputs:
+      packageType: 'sdk'
+      version: '6.0.x'
+      installationPath: '$(Agent.TempDirectory)/dotnet'
+
   - task: EsrpCodeSigning@1
     displayName: Sign Diagnostic Binaries
     inputs:
@@ -41,3 +48,7 @@ steps:
       SessionTimeout: ${{ parameters.timeoutInMinutes }}
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 0
+      DOTNET_ROOT: '$(Agent.TempDirectory)/dotnet'
+      DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR: '$(Agent.TempDirectory)/dotnet'


### PR DESCRIPTION
- Add DAC signature infrastructure
- Try using a .NET 6 SDK to enable signing

Use a signing infrastructure orthogonal to microbuild to use other certs for diagnostic binaries.

cc: @dotnet/dotnet-diag @leculver 

