### PR TITLE
[release/6.0] Fix VS component versions

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,8 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-emsdk -->
+    <add key="darc-pub-dotnet-emsdk-3f6c45a-2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3f6c45a2-2/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-emsdk-3f6c45a-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3f6c45a2-1/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-emsdk-3f6c45a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-3f6c45a2/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-emsdk -->
     <!--  Begin: Package sources from dotnet-wcf -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,77 +30,77 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201201-01">
       <Uri>https://github.com/microsoft/vstest</Uri>
@@ -222,9 +222,9 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>e9669dc84ecd668d3bbb748758103e23b394ffef</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="6.0.0-beta.22418.3">
+    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="6.0.0-beta.22457.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b851fe8fbf2be11e6554789187a5315e80667ebd</Sha>
+      <Sha>60eeccda4868d869c5995a5b68a6e47926b4342d</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.21416.5">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,21 +41,21 @@
     <!-- SDK dependencies -->
     <MicrosoftDotNetCompatibilityVersion>1.1.0-preview.22164.17</MicrosoftDotNetCompatibilityVersion>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.22418.3</MicrosoftDotNetApiCompatVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.22418.3</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.22418.3</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>6.0.0-beta.22418.3</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>6.0.0-beta.22418.3</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.22418.3</MicrosoftDotNetXUnitExtensionsVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22418.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.22418.3</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.22418.3</MicrosoftDotNetBuildTasksInstallersVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.22418.3</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.22418.3</MicrosoftDotNetBuildTasksTemplatingVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.22418.3</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.22418.3</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.22418.3</MicrosoftDotNetVersionToolsTasksVersion>
-    <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.22418.3</MicrosoftDotNetPackageTestingVersion>
+    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.22457.3</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.22457.3</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.22457.3</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>6.0.0-beta.22457.3</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>6.0.0-beta.22457.3</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.22457.3</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.22457.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.22457.3</MicrosoftDotNetBuildTasksArchivesVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.22457.3</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.22457.3</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.22457.3</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.22457.3</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.22457.3</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.22457.3</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.22457.3</MicrosoftDotNetPackageTestingVersion>
     <!-- NuGet dependencies -->
     <NuGetBuildTasksPackVersion>6.0.0-preview.1.102</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->

--- a/eng/common/templates/job/execute-sdl.yml
+++ b/eng/common/templates/job/execute-sdl.yml
@@ -53,7 +53,7 @@ jobs:
       demands: Cmd
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-      name: NetCore1ESPool-Internal
+      name: NetCore1ESPool-Svc-Internal
       demands: ImageOverride -equals windows.vs2019.amd64
   steps:
   - checkout: self

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -40,7 +40,7 @@ jobs:
         demands: Cmd
       # If it's not devdiv, it's dnceng
       ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-        name: NetCore1ESPool-Internal
+        name: NetCore1ESPool-Svc-Internal
         demands: ImageOverride -equals windows.vs2019.amd64
 
   variables:

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -46,10 +46,10 @@ jobs:
     # source-build builds run in Docker, including the default managed platform.
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Svc-Public
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: NetCore1ESPool-Internal
+        name: NetCore1ESPool-Svc-Internal
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
   ${{ if ne(parameters.platform.pool, '') }}:
     pool: ${{ parameters.platform.pool }}

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -89,7 +89,7 @@ jobs:
             demands: Cmd
           # If it's not devdiv, it's dnceng
           ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-            name: NetCore1ESPool-Internal
+            name: NetCore1ESPool-Svc-Internal
             demands: ImageOverride -equals windows.vs2019.amd64
 
         runAsPublic: ${{ parameters.runAsPublic }}

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -100,7 +100,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
 
       steps:
@@ -137,7 +137,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - template: setup-maestro-vars.yml
@@ -197,7 +197,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - template: setup-maestro-vars.yml
@@ -254,7 +254,7 @@ stages:
           demands: Cmd
         # If it's not devdiv, it's dnceng
         ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
     steps:
       - template: setup-maestro-vars.yml

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -121,7 +121,7 @@ jobs:
 
         # OSX Build Pool (we don't have on-prem OSX BuildPool
         ${{ if in(parameters.osGroup, 'OSX', 'MacCatalyst', 'iOS', 'iOSSimulator', 'tvOS', 'tvOSSimulator') }}:
-          vmImage: 'macOS-10.15'
+          vmImage: 'macOS-11'
 
         # Official Build Windows Pool
         ${{ if and(eq(parameters.osGroup, 'windows'), ne(variables['System.TeamProject'], 'public')) }}:

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -121,7 +121,7 @@ jobs:
 
         # OSX Build Pool (we don't have on-prem OSX BuildPool
         ${{ if in(parameters.osGroup, 'OSX', 'MacCatalyst', 'iOS', 'iOSSimulator', 'tvOS', 'tvOSSimulator') }}:
-          vmImage: 'macOS-11'
+          vmImage: 'macOS-10.15'
 
         # Official Build Windows Pool
         ${{ if and(eq(parameters.osGroup, 'windows'), ne(variables['System.TeamProject'], 'public')) }}:

--- a/global.json
+++ b/global.json
@@ -12,10 +12,10 @@
     "python3": "3.7.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.22418.3",
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.22418.3",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.22418.3",
-    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.22418.3",
+    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.22457.3",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.22457.3",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.22457.3",
+    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.22457.3",
     "Microsoft.Build.NoTargets": "3.1.0",
     "Microsoft.Build.Traversal": "3.0.23",
     "Microsoft.NET.Sdk.IL": "6.0.0-rc.1.21415.6"

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -149,7 +149,7 @@
       <MsiPackageProjects Include="%(Msis.PackageProject)" />
     </ItemGroup>
 
-    <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir)" Targets="restore;pack" />
+    <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir);IncludeSymbols=false" Targets="restore;pack" />
   </Target>
 
   <!-- Target to create a single wixpack for signing -->

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -48,38 +48,32 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <ItemDefinitionGroup>
-    <!-- Visual Studio components must be versioned. Build tasks will fall back to cobbling a version number from
-         the manifest information unless it's overridden. -->
-    <ComponentResources Version="$(FileVersion)" />
-  </ItemDefinitionGroup>
-
   <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
       <ComponentResources Include="microsoft-net-runtime-mono-tooling" Title=".NET Shared Mobile Build Tools"
-                          Description="Shared build tasks for mobile platform development."/>
+                          Description="Shared build tasks for mobile platform development." Version="$(FileVersion)"/>
       <ComponentResources Include="wasm-tools" Title=".NET WebAssembly Build Tools"
-                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
+                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking." Version="$(FileVersion)"/>
       <ComponentResources Include="microsoft-net-runtime-android" Title=".NET Android Build Tools"
-                          Description="Build tools for Android compilation and native linking."/>
+                          Description="Build tools for Android compilation and native linking." Version="$(FileVersion)"/>
       <ComponentResources Include="microsoft-net-runtime-android-aot" Title=".NET Android Build Tools (AoT)"
-                          Description="Build tools for Android ahead-of-time (AoT) compilation and native linking."/>
+                          Description="Build tools for Android ahead-of-time (AoT) compilation and native linking." Version="$(FileVersion)"/>
       <ComponentResources Include="microsoft-net-runtime-ios" Title=".NET iOS Build Tools"
-                          Description="Build tools for iOS compilation and native linking."/>
+                          Description="Build tools for iOS compilation and native linking." Version="$(FileVersion)"/>
       <ComponentResources Include="microsoft-net-runtime-tvos" Title=".NET tvOS Build Tools"
-                          Description="Build tools for tvOS compilation and native linking."/>
+                          Description="Build tools for tvOS compilation and native linking." Version="$(FileVersion)"/>
       <ComponentResources Include="microsoft-net-runtime-maccatalyst" Title=".NET Mac Catalyst Build Tools"
-                          Description="Build tools for Mac Catalyst compilation and native linking."/>
+                          Description="Build tools for Mac Catalyst compilation and native linking." Version="$(FileVersion)"/>
       <ComponentResources Include="runtimes-ios" Title=".NET iOS Runtimes"
-                          Description=".NET runtime components for iOS execution."/>
+                          Description=".NET runtime components for iOS execution." Version="$(FileVersion)"/>
       <ComponentResources Include="runtimes-tvos" Title=".NET tvOS Build Tools"
-                          Description=".NET runtime components for tvOS execution."/>
+                          Description=".NET runtime components for tvOS execution." Version="$(FileVersion)"/>
       <ComponentResources Include="runtimes-maccatalyst" Title=".NET Mac Catalyst Build Tools"
-                          Description=".NET runtime components for Mac Catalyst execution."/>
+                          Description=".NET runtime components for Mac Catalyst execution." Version="$(FileVersion)"/>
       <ComponentResources Include="runtimes-windows" Title=".NET Windows Runtimes"
-                          Description=".NET runtime components for Windows execution."/>
+                          Description=".NET runtime components for Windows execution." Version="$(FileVersion)"/>
     </ItemGroup>
 
     <!-- BAR requires having version information in blobs -->

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -1,4 +1,4 @@
-﻿<Project DefaultTargets="Restore;Build">
+<Project DefaultTargets="Restore;Build">
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
@@ -53,27 +53,27 @@
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
       <_ComponentResources Include="microsoft-net-runtime-mono-tooling" Title=".NET Shared Mobile Build Tools"
-                          Description="Shared build tasks for mobile platform development."/>
+                           Description="Shared build tasks for mobile platform development."/>
       <_ComponentResources Include="wasm-tools" Title=".NET WebAssembly Build Tools"
-                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
+                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
       <_ComponentResources Include="microsoft-net-runtime-android" Title=".NET Android Build Tools"
-                          Description="Build tools for Android compilation and native linking."/>
+                           Description="Build tools for Android compilation and native linking."/>
       <_ComponentResources Include="microsoft-net-runtime-android-aot" Title=".NET Android Build Tools (AoT)"
-                          Description="Build tools for Android ahead-of-time (AoT) compilation and native linking."/>
+                           Description="Build tools for Android ahead-of-time (AoT) compilation and native linking."/>
       <_ComponentResources Include="microsoft-net-runtime-ios" Title=".NET iOS Build Tools"
-                          Description="Build tools for iOS compilation and native linking."/>
+                           Description="Build tools for iOS compilation and native linking."/>
       <_ComponentResources Include="microsoft-net-runtime-tvos" Title=".NET tvOS Build Tools"
-                          Description="Build tools for tvOS compilation and native linking."/>
+                           Description="Build tools for tvOS compilation and native linking."/>
       <_ComponentResources Include="microsoft-net-runtime-maccatalyst" Title=".NET Mac Catalyst Build Tools"
-                          Description="Build tools for Mac Catalyst compilation and native linking."/>
+                           Description="Build tools for Mac Catalyst compilation and native linking."/>
       <_ComponentResources Include="runtimes-ios" Title=".NET iOS Runtimes"
-                          Description=".NET runtime components for iOS execution."/>
+                           Description=".NET runtime components for iOS execution."/>
       <_ComponentResources Include="runtimes-tvos" Title=".NET tvOS Build Tools"
-                          Description=".NET runtime components for tvOS execution."/>
+                           Description=".NET runtime components for tvOS execution."/>
       <_ComponentResources Include="runtimes-maccatalyst" Title=".NET Mac Catalyst Build Tools"
-                          Description=".NET runtime components for Mac Catalyst execution."/>
+                           Description=".NET runtime components for Mac Catalyst execution."/>
       <_ComponentResources Include="runtimes-windows" Title=".NET Windows Runtimes"
-                          Description=".NET runtime components for Windows execution."/>
+                           Description=".NET runtime components for Windows execution."/>
 
       <ComponentResources Include="@(_ComponentResources)" Version="$(FileVersion)" />
     </ItemGroup>
@@ -94,6 +94,8 @@
     </ItemGroup>
 
     <ItemGroup>
+      <!-- Set SupportsMachineArch metadata to true if a specific manifest needs to support arm64 for Visual Studio. DO NOT set if for all feature bands as
+           it changes the SWIX authoring and older versions of Visual Studio will fail to install. -->
       <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Mono.ToolChain.Manifest-*.nupkg" MsiVersion="$(MsiVersion)"/>
     </ItemGroup>
 
@@ -109,17 +111,35 @@
       <Output TaskParameter="Msis" ItemName="Msis" />
     </CreateVisualStudioWorkload>
 
-    <!-- Build all the SWIX projects. This requires full framework MSBuild-->
-    <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VSTemp)%(SwixProjects.SdkFeatureBand)" />
+    <!-- Split SWIX projects for packs and components/manifests and build them into separate folders. This allows us to consume pack-only drops
+         across multiple VS builds to support multi-targeting. -->
+    <ItemGroup>
+      <SwixWorkloadPackProjects Include="@(SwixProjects)" Condition="'%(PackageType)' == 'msi-pack'"
+                                ManifestOutputPath="$(VStemp)\p\%(SwixProjects.SdkFeatureBand)"
+                                ZipFile="Workload.VSDrop.mono.net.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand).packs.zip"/>
+      <SwixComponentsAndManifests Include="@(SwixProjects)" Condition="'%(PackageType)' == 'msi-manifest' Or '%(PackageType)' == 'component'"
+                                  ManifestOutputPath="$(VStemp)\c\%(SwixProjects.SdkFeatureBand)"
+                                  ZipFile="Workload.VSDrop.mono.net.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand).components.zip"/>
+      <PartitionedSwixProjects Include="@(SwixWorkloadPackProjects);@(SwixComponentsAndManifests)" />
+    </ItemGroup>
 
-    <!-- Create payload package for VSDROP creation -->
+    <!-- Can't build in parallel to the same output folder because of a shared file from the SWIX compiler. -->
+    <MSBuild Projects="@(PartitionedSwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=%(ManifestOutputPath)"/>
+
+    <!-- Create the zip files used for VSDROP creation. -->
     <ItemGroup>
       <SdkFeatureBand Include="%(SwixProjects.SdkFeatureBand)" />
     </ItemGroup>
-    
+
+    <ItemGroup>
+      <VSDrop Include="%(PartitionedSwixProjects.ZipFile)" SourceDirectory="%(ManifestOutputPath)" />
+    </ItemGroup>
+
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" />
     <MakeDir Directories="$(VisualStudioSetupInsertionPath)" />
-    <ZipDirectory Overwrite="true" DestinationFile="$(VisualStudioSetupInsertionPath)Workloads.VSDrop.%(SdkFeatureBand.Identity).$(PackageVersion).zip" SourceDirectory="$(VSTemp)%(SdkFeatureBand.Identity)"/>
+
+    <ZipDirectory Overwrite="true" SourceDirectory="%(SourceDirectory)"
+                  DestinationFile="$(VisualStudioSetupInsertionPath)%(VSDrop.Identity)" />
 
     <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
     <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -52,28 +52,30 @@
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
-      <ComponentResources Include="microsoft-net-runtime-mono-tooling" Title=".NET Shared Mobile Build Tools"
-                          Description="Shared build tasks for mobile platform development." Version="$(FileVersion)"/>
-      <ComponentResources Include="wasm-tools" Title=".NET WebAssembly Build Tools"
-                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking." Version="$(FileVersion)"/>
-      <ComponentResources Include="microsoft-net-runtime-android" Title=".NET Android Build Tools"
-                          Description="Build tools for Android compilation and native linking." Version="$(FileVersion)"/>
-      <ComponentResources Include="microsoft-net-runtime-android-aot" Title=".NET Android Build Tools (AoT)"
-                          Description="Build tools for Android ahead-of-time (AoT) compilation and native linking." Version="$(FileVersion)"/>
-      <ComponentResources Include="microsoft-net-runtime-ios" Title=".NET iOS Build Tools"
-                          Description="Build tools for iOS compilation and native linking." Version="$(FileVersion)"/>
-      <ComponentResources Include="microsoft-net-runtime-tvos" Title=".NET tvOS Build Tools"
-                          Description="Build tools for tvOS compilation and native linking." Version="$(FileVersion)"/>
-      <ComponentResources Include="microsoft-net-runtime-maccatalyst" Title=".NET Mac Catalyst Build Tools"
-                          Description="Build tools for Mac Catalyst compilation and native linking." Version="$(FileVersion)"/>
-      <ComponentResources Include="runtimes-ios" Title=".NET iOS Runtimes"
-                          Description=".NET runtime components for iOS execution." Version="$(FileVersion)"/>
-      <ComponentResources Include="runtimes-tvos" Title=".NET tvOS Build Tools"
-                          Description=".NET runtime components for tvOS execution." Version="$(FileVersion)"/>
-      <ComponentResources Include="runtimes-maccatalyst" Title=".NET Mac Catalyst Build Tools"
-                          Description=".NET runtime components for Mac Catalyst execution." Version="$(FileVersion)"/>
-      <ComponentResources Include="runtimes-windows" Title=".NET Windows Runtimes"
-                          Description=".NET runtime components for Windows execution." Version="$(FileVersion)"/>
+      <_ComponentResources Include="microsoft-net-runtime-mono-tooling" Title=".NET Shared Mobile Build Tools"
+                          Description="Shared build tasks for mobile platform development."/>
+      <_ComponentResources Include="wasm-tools" Title=".NET WebAssembly Build Tools"
+                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-android" Title=".NET Android Build Tools"
+                          Description="Build tools for Android compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-android-aot" Title=".NET Android Build Tools (AoT)"
+                          Description="Build tools for Android ahead-of-time (AoT) compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-ios" Title=".NET iOS Build Tools"
+                          Description="Build tools for iOS compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-tvos" Title=".NET tvOS Build Tools"
+                          Description="Build tools for tvOS compilation and native linking."/>
+      <_ComponentResources Include="microsoft-net-runtime-maccatalyst" Title=".NET Mac Catalyst Build Tools"
+                          Description="Build tools for Mac Catalyst compilation and native linking."/>
+      <_ComponentResources Include="runtimes-ios" Title=".NET iOS Runtimes"
+                          Description=".NET runtime components for iOS execution."/>
+      <_ComponentResources Include="runtimes-tvos" Title=".NET tvOS Build Tools"
+                          Description=".NET runtime components for tvOS execution."/>
+      <_ComponentResources Include="runtimes-maccatalyst" Title=".NET Mac Catalyst Build Tools"
+                          Description=".NET runtime components for Mac Catalyst execution."/>
+      <_ComponentResources Include="runtimes-windows" Title=".NET Windows Runtimes"
+                          Description=".NET runtime components for Windows execution."/>
+
+      <ComponentResources Include="@(_ComponentResources)" Version="$(FileVersion)" />
     </ItemGroup>
 
     <!-- BAR requires having version information in blobs -->


### PR DESCRIPTION
This update contains multiple fixes for issues that were identified during the last servicing release.

- `ItemDefinitionGroup` is evaluated globally while the `FileVersion` property is only set after the `GetAssemblyVersion` target runs. This causes the VS components to assume the default workload version, which doesn't play well with upgrades in VS. The assembly file version value is preferred because it can change between builds, allow consecutive insertions into VS that can be upgraded.
- The updated task now provides metadata that will allow us to split the VSDROP generation into two separate archives. One which only contains workload packs (needed to share DROPs across VS versions to support multi-targeting) and another that only contains the manifest installers and workload components.
- The ZIP archive names have been updated to disambiguate its contents and support automatic drop creation during staging.