### PR TITLE
Fix some corner cases in TarReader

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -134,9 +134,9 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>77acd39a813579e1e9b12cd98466787e7f90e059</Sha>
     </Dependency>
-    <Dependency Name="System.Formats.Tar.TestData" Version="7.0.0-beta.22409.1">
+    <Dependency Name="System.Formats.Tar.TestData" Version="7.0.0-beta.22421.2">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
-      <Sha>77acd39a813579e1e9b12cd98466787e7f90e059</Sha>
+      <Sha>9d8fad5f0614bee808083308a3729084b681f7e7</Sha>
     </Dependency>
     <Dependency Name="System.IO.Compression.TestData" Version="7.0.0-beta.22409.1">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -120,7 +120,7 @@
     <SystemRuntimeNumericsTestDataVersion>7.0.0-beta.22409.1</SystemRuntimeNumericsTestDataVersion>
     <SystemComponentModelTypeConverterTestDataVersion>7.0.0-beta.22409.1</SystemComponentModelTypeConverterTestDataVersion>
     <SystemDrawingCommonTestDataVersion>7.0.0-beta.22409.1</SystemDrawingCommonTestDataVersion>
-    <SystemFormatsTarTestDataVersion>7.0.0-beta.22409.1</SystemFormatsTarTestDataVersion>
+    <SystemFormatsTarTestDataVersion>7.0.0-beta.22421.2</SystemFormatsTarTestDataVersion>
     <SystemIOCompressionTestDataVersion>7.0.0-beta.22409.1</SystemIOCompressionTestDataVersion>
     <SystemIOPackagingTestDataVersion>7.0.0-beta.22409.1</SystemIOPackagingTestDataVersion>
     <SystemNetTestDataVersion>7.0.0-beta.22409.1</SystemNetTestDataVersion>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -461,18 +461,36 @@ namespace System.Formats.Tar
                     // The POSIX formats have a 6 byte Magic "ustar\0", followed by a 2 byte Version "00"
                     if (!version.SequenceEqual(UstarVersionBytes))
                     {
-                        throw new FormatException(string.Format(SR.TarPosixFormatExpected, _name));
+                        // Check for gnu version header for mixed case
+                        if (!version.SequenceEqual(GnuVersionBytes))
+                        {
+                            throw new FormatException(string.Format(SR.TarPosixFormatExpected, _name));
+                        }
+
+                        _version = GnuVersion;
                     }
-                    _version = UstarVersion;
+                    else
+                    {
+                        _version = UstarVersion;
+                    }
                     break;
 
                 case TarEntryFormat.Gnu:
                     // The GNU format has a Magic+Version 8 byte string "ustar  \0"
                     if (!version.SequenceEqual(GnuVersionBytes))
                     {
-                        throw new FormatException(string.Format(SR.TarGnuFormatExpected, _name));
+                        // Check for ustar or pax version header for mixed case
+                        if (!version.SequenceEqual(UstarVersionBytes))
+                        {
+                            throw new FormatException(string.Format(SR.TarGnuFormatExpected, _name));
+                        }
+
+                        _version = UstarVersion;
                     }
-                    _version = GnuVersion;
+                    else
+                    {
+                        _version = GnuVersion;
+                    }
                     break;
 
                 default:

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -138,6 +138,11 @@ namespace System.Formats.Tar
                     TarEntryFormat.V7 or TarEntryFormat.Unknown or _ => new V7TarEntry(header, this),
                 };
 
+                if (_archiveStream.CanSeek && _archiveStream.Length == _archiveStream.Position)
+                {
+                    _reachedEndMarkers = true;
+                }
+
                 _previouslyReadEntry = entry;
                 PreserveDataStreamForDisposalIfNeeded(entry);
                 return entry;
@@ -290,6 +295,11 @@ namespace System.Formats.Tar
                     TarEntryFormat.Ustar => new UstarTarEntry(header, this),
                     TarEntryFormat.V7 or TarEntryFormat.Unknown or _ => new V7TarEntry(header, this),
                 };
+
+                if (_archiveStream.CanSeek && _archiveStream.Length == _archiveStream.Position)
+                {
+                    _reachedEndMarkers = true;
+                }
 
                 _previouslyReadEntry = entry;
                 PreserveDataStreamForDisposalIfNeeded(entry);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -124,5 +124,31 @@ namespace System.Formats.Tar.Tests
         [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
         public void Read_Archive_LongPath_Over255(TarEntryFormat format, TestTarFormat testFormat) =>
             Read_Archive_LongPath_Over255_Internal(format, testFormat);
+
+        [Fact]
+        public void Read_NodeTarArchives_Successfully()
+        {
+            string nodeTarPath = Path.Join(Directory.GetCurrentDirectory(), "tar", "node-tar");
+            foreach (string file in Directory.EnumerateFiles(nodeTarPath, "*.tar", SearchOption.AllDirectories))
+            {
+                using FileStream sourceStream = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var reader = new TarReader(sourceStream);
+
+                TarEntry? entry = null;
+                while (true)
+                {
+                    Exception ex = Record.Exception(() => entry = reader.GetNextEntry());
+                    Assert.Null(ex);
+
+                    if (entry is null) break;
+
+                    ex = Record.Exception(() => entry.Name);
+                    Assert.Null(ex);
+
+                    ex = Record.Exception(() => entry.Length);
+                    Assert.Null(ex);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
* Fix reading of tar file with hardlinks.
* Fix reading of tar files with mixed formats (gnu with ustar or pax entries and vice versa).
* Add node-tar fixtures test added in dotnet/runtime-assets repo.

Contributes to #74316.