### PR TITLE
[release/6.0] Add signing infrastructure for diagnostic binaries

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,4 +1,4 @@
-<Project InitialTargets="SetupFilesToSign">
+<Project>
 
   <PropertyGroup>
     <!--
@@ -27,7 +27,12 @@
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Rocks.dll" CertificateName="3PartySHA2" />
 
-    <FileSignInfo Include="mscordaccore.dll" CertificateName="MicrosoftSHA2" />
+    <!--
+      The DAC and the DBI must go through special signing provisioning using a system separate
+      from MicroBuild.
+    -->
+    <FileSignInfo Include="mscordaccore.dll" CertificateName="None" />
+    <FileSignInfo Include="mscordbi.dll" CertificateName="None" />
 
     <!-- Exclude symbol packages from have a NuGet signature. These are never pushed to NuGet.org or
          other feeds (in fact, that have identical identity to their non-symbol variant) -->
@@ -56,33 +61,4 @@
     <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
     <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" />
   </ItemGroup>
-
-  <Target Name="SetupFilesToSign">
-    <!-- Ensure that we don't miss the DAC or DBI with the globbing below -->
-    <PropertyGroup Condition="'$(SignDiagnostics)' == 'true' or '$(SignDiagnosticsPackages)' == 'true'">
-      <AllowEmptySignList>false</AllowEmptySignList>
-    </PropertyGroup>
-
-    <ItemGroup Condition="'$(SignDiagnostics)' == 'true'">
-      <ItemsToSign Include="$(DiagnosticsFilesRoot)\**\mscordaccore*.dll" />
-      <ItemsToSign Include="$(DiagnosticsFilesRoot)\**\mscordbi.dll" />
-      <!--
-        The DAC should be signed with the SHA2 cert (both long and short name).
-        We already add the short-name DAC above, so add the long-name DAC here.
-      -->
-      <DacFileSignInfo Include="@(ItemsToSign->'%(FileName)%(Extension)')"
-                    Condition="$([System.String]::new('%(FileName)').StartsWith('mscordaccore'))" />
-      <FileSignInfo Include="@(DacFileSignInfo->ClearMetadata()->Distinct())"
-                    Exclude="mscordaccore.dll"
-                    CertificateName="MicrosoftSHA2" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="'$(SignDiagnosticsPackages)' == 'true'">
-      <!-- The cross OS diagnostics symbol packages need to be signed as they are the only packages
-      that have a specific version of assets that are only meant to be indexed in symbol servers.
-      Since only *symbols.nupkg get indexed, and installer doesn't produce these, we need to glob them for signing. -->
-      <ItemsToSign Include="$(PackagesFolder)\**\*CrossOsDiag*.nupkg" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -238,23 +238,11 @@ jobs:
 
     # Sign diagnostic files on Windows
     - ${{ if and(eq(parameters.osGroup, 'windows'), eq(parameters.signBinaries, true)) }}:
-      - powershell: >-
-          eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 $(officialBuildIdArg)
-          /p:DiagnosticsFilesRoot="$(buildProductRootFolderPath)"
-          /p:SignDiagnostics=true
-          /p:DotNetSignType=$(SignType)
-          -noBl
-          /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfig)/SignDiagnostics.binlog
-          -projects $(Build.SourcesDirectory)\eng\empty.csproj
-        displayName: Sign Diagnostic Binaries
-
-      - task: PublishPipelineArtifact@1
-        displayName: Publish Signing Logs
-        inputs:
-          targetPath: '$(Build.SourcesDirectory)/artifacts/log/'
-          artifactName: ${{ format('SignLogs_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        continueOnError: true
-        condition: always()
+      - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+        parameters:
+          basePath: $(buildProductRootFolderPath)
+          isOfficialBuild: ${{ parameters.isOfficialBuild }}
+          timeoutInMinutes: 30
 
     # Builds using gcc are not tested, and clrTools unitests do not publish the build artifacts
     - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools')) }}:
@@ -275,6 +263,7 @@ jobs:
           archType: ${{ parameters.archType }}
           osGroup: ${{ parameters.osGroup }}
           osSubgroup: ${{ parameters.osSubgroup }}
+          isOfficialBuild: ${{ parameters.isOfficialBuild }}
 
     - ${{ if and(ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, ''), ne(parameters.testGroup, 'clrTools')) }}:
       # Publish test native components for consumption by test execution.

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -2,6 +2,7 @@ parameters:
   archType: ''
   osGroup: ''
   osSubgroup: ''
+  isOfficialBuild: false
 
 steps:
   # Always build the crossdac, that way we know in CI/PR if things break to build.
@@ -29,6 +30,12 @@ steps:
           **/*
           !**/sharedFramework/**/*
         TargetFolder: '$(buildMuslDacStagingPath)'
+
+    - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+      parameters:
+        basePath: $(crossDacArtifactPath)
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        timeoutInMinutes: 30
 
   - ${{ if eq(parameters.osGroup, 'Linux') }}:
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/crossdac-pack.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-pack.yml
@@ -54,19 +54,6 @@ jobs:
         - ${{ parameters.runtimeFlavor }}_${{ parameters.runtimeVariant }}_product_build_${{ platform }}_${{ parameters.buildConfig }}
 
     steps:
-    # Install MicroBuild for signing the package
-    - ${{ if eq(parameters.isOfficialBuild, true) }}:
-      - template: /eng/pipelines/common/restore-internal-tools.yml
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
     - task: DownloadBuildArtifacts@0
       displayName: Download CrossDac artifacts
       inputs:
@@ -76,16 +63,6 @@ jobs:
 
     - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset crossdacpack -arch $(archType) $(osArg) -c $(buildConfig) $(officialBuildIdArg) $(crossDacArgs) -ci
       displayName: Build crossdac packaging
-
-    # Sign diagnostic files
-    - ${{ if eq(parameters.isOfficialBuild, true) }}:
-      - powershell: >-
-          eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 $(officialBuildIdArg)
-          /p:PackagesFolder="$(Build.SourcesDirectory)/artifacts/packages/$(buildConfig)"
-          /p:SignDiagnosticsPackages=true
-          /p:DotNetSignType=$(SignType)
-          -projects $(Build.SourcesDirectory)\eng\empty.csproj
-        displayName: Sign CrossDac package and contents
 
     # Save packages using the prepare-signed-artifacts format.
     - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml

--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -4,7 +4,7 @@ parameters:
   timeoutInMinutes: ''
 
 steps:
-- ${{ if and(eq(parameters.isOfficialBuild, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(eq(parameters.isOfficialBuild, true), ne(variables['Build.Reason'], 'PullRequest'), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
   - task: EsrpCodeSigning@1
     displayName: Sign Diagnostic Binaries
     inputs:

--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -1,0 +1,43 @@
+parameters:
+  basePath: ''
+  isOfficialBuild: ''
+  timeoutInMinutes: ''
+
+steps:
+- ${{ if and(eq(parameters.isOfficialBuild, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - task: EsrpCodeSigning@1
+    displayName: Sign Diagnostic Binaries
+    inputs:
+      ConnectedServiceName: 'dotnetesrp-diagnostics-dnceng'
+      FolderPath: ${{ parameters.basePath }}
+      Pattern: |
+        **/mscordaccore*.dll
+        **/mscordbi*.dll
+      UseMinimatch: true
+      signConfigType: 'inlineSignParams'
+      inlineOperation: >-
+        [
+          {
+            "keyCode": "CP-471322",
+            "operationCode": "SigntoolSign",
+            "parameters": {
+              "OpusName": "Microsoft",
+              "OpusInfo": "http://www.microsoft.com",
+              "PageHash": "/NPH",
+              "FileDigest": "/fd sha256",
+              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            },
+            "toolName": "sign",
+            "toolVersion": "1.0"
+          },
+          {
+            "KeyCode": "CP-471322",
+            "OperationCode": "SigntoolVerify",
+            "Parameters": {},
+            "ToolName": "sign",
+            "ToolVersion": "1.0"
+          }
+        ]
+      SessionTimeout: ${{ parameters.timeoutInMinutes }}
+      MaxConcurrency: '50'
+      MaxRetryAttempts: '5'

--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -41,3 +41,29 @@ steps:
       SessionTimeout: ${{ parameters.timeoutInMinutes }}
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
+
+  - powershell: |
+      $filesToSign = $(Get-ChildItem -Recurse ${{ parameters.basePath }} -Include mscordaccore*.dll, mscordbi*.dll)
+      foreach ($file in $filesToSign) {
+        $signingCert = $(Get-AuthenticodeSignature $file).SignerCertificate
+        if ($signingCert -eq $null)
+        {
+          throw "File $file does not contain a signature."
+        }
+
+        if ($signingCert.Subject -ne "CN=.NET DAC, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" `
+            -or $signingCert.Issuer -ne "CN=Microsoft Code Signing PCA 2010, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")
+        {
+          throw "File $file not in expected trust chain."
+        }
+
+        $certEKU = $signingCert.Extensions.Where({ $_.Oid.FriendlyName -eq "Enhanced Key Usage" }) | Select -First 1
+
+        if ($certEKU.EnhancedKeyUsages.Where({ $_.Value -eq "1.3.6.1.4.1.311.84.4.1" }).Count -ne 1)
+        {
+          throw "Signature for $file does not contain expected EKU."
+        }
+
+        Write-Host "$file is correctly signed."
+      }
+    displayName: Validate diagnostic signatures


### PR DESCRIPTION
Use a signing infrastructure orthogonal to microbuild to use other certs for diagnostic binaries.