### PR TITLE
[wasm-mt] Fix cross-origin headers when running the browser threads sample test

### DIFF
--- a/src/mono/sample/wasm/browser-threads/Wasm.Browser.Threads.Sample.csproj
+++ b/src/mono/sample/wasm/browser-threads/Wasm.Browser.Threads.Sample.csproj
@@ -6,7 +6,7 @@
     <DebugType>embedded</DebugType>
     <WasmDebugLevel>1</WasmDebugLevel>
     <GenerateRunScriptForSample Condition="'$(ArchiveTests)' == 'true'">true</GenerateRunScriptForSample>
-    <RunScriptCommand>$(ExecXHarnessCmd) wasm test-browser  --app=. --browser=Chrome $(XHarnessBrowserPathArg) --html-file=index.html --output-directory=$(XHarnessOutput) -- $(MSBuildProjectName).dll</RunScriptCommand>
+    <RunScriptCommand>$(ExecXHarnessCmd) wasm test-browser  --app=. --browser=Chrome $(XHarnessBrowserPathArg) --html-file=index.html --output-directory=$(XHarnessOutput) --web-server-use-cop -- $(MSBuildProjectName).dll</RunScriptCommand>
   </PropertyGroup>
   <ItemGroup>
     <WasmExtraFilesToDeploy Include="index.html" />
@@ -28,5 +28,5 @@
     <ProjectReference Include="$(LibrariesProjectRoot)\System.Threading.ThreadPool.WebAssembly.Threading\ref\System.Threading.ThreadPool.WebAssembly.Threading.csproj" IncludeAssets="compile" PrivateAssets="none" ExcludeAssets="runtime" Private="false" />
     <ProjectReference Include="$(LibrariesProjectRoot)\System.Diagnostics.Tracing.WebAssembly.PerfTracing\ref\System.Diagnostics.Tracing.WebAssembly.PerfTracing.csproj" IncludeAssets="compile" PrivateAssets="none" ExcludeAssets="runtime" Private="false" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
The work item `Wasm.Browser.Threads.Sample` fails when multi-threading is enabled with the following log output:
```
[17:30:39] fail: [out of order message from the browser]: http://127.0.0.1:35659/main.js 10:24 ReferenceError: SharedArrayBuffer is not defined
                     at http://127.0.0.1:35659/dotnet.js:14:13769
                     at http://127.0.0.1:35659/main.js:64:87
[17:30:39] info: WASM EXIT 2
[17:30:39] info: Waiting to flush log messages with a timeout of 120 secs ..
[17:30:39] fail: Application has finished with exit code HELP_SHOWN but 0 was expected
XHarness exit code: 71 (GENERAL_FAILURE)
```

This suggests that there is a problem with the `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers (see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)). We need to pass the `--web-server-use-cop` option to xharness to resolve this problem.

With this fix, the test succeeds:
```
...
[14:41:36] info: Hello, World!
[14:41:36] info: [MONO] Running class .cctor for System.Runtime.InteropServices.JavaScript.JavaScriptExports/<>c from 'System.Runtime.InteropServices.JavaScript.dll'
[14:41:36] info: WASM EXIT 0
...
[14:41:36] info: WaitForCompletion completed on thread 1
XHarness exit code: 0
```