### PR TITLE
[wasm][debugger] Disable new tests about JMC in Firefox

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1040,7 +1040,7 @@ namespace DebuggerTests
             );
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(RunningOnChrome))]
         [InlineData("ClassInheritsFromClassWithoutDebugSymbols", 1287, true)]
         [InlineData("ClassInheritsFromClassWithoutDebugSymbols", 1287, false)]
         [InlineData("ClassInheritsFromNonUserCodeClass", 1335, true)]


### PR DESCRIPTION
JMC is not supported on firefox yet.