### PR TITLE
Remove assert from Http3Connection.SendAsync

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -240,7 +240,7 @@ namespace System.Net.Http
             catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
             {
                 // This will happen if we aborted _connection somewhere and we have pending OpenOutboundStreamAsync call.
-                Debug.Assert(_abortException is not null);
+                // note that _abortException may be null if we closed the connection in response to a GOAWAY frame
                 throw new HttpRequestException(SR.net_http_client_execution_error, _abortException, RequestRetryType.RetryOnConnectionFailure);
             }
             finally
@@ -569,7 +569,14 @@ namespace System.Net.Http
             }
             catch (Exception ex)
             {
-                Abort(ex);
+                if (ex is QuicException qe && qe.QuicError == QuicError.OperationAborted)
+                {
+                    // ignore the exception, we have already closed the connection
+                }
+                else
+                {
+                    Abort(ex);
+                }
             }
             finally
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -567,16 +567,13 @@ namespace System.Net.Http
                     }
                 }
             }
+            catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
+            {
+                // ignore the exception, we have already closed the connection
+            }
             catch (Exception ex)
             {
-                if (ex is QuicException qe && qe.QuicError == QuicError.OperationAborted)
-                {
-                    // ignore the exception, we have already closed the connection
-                }
-                else
-                {
-                    Abort(ex);
-                }
+                Abort(ex);
             }
             finally
             {


### PR DESCRIPTION
Fixes #74162.

The assert in question was invalid, because we may close the connection gracefully without prior `Http3Connection.Abort` call when responding to a GOAWAY.

This PR also filters OperationAborted QuicExceptions from server-initiated streams since there is no need to call Abort when we already close the connection (and setting the _abortException in that case would be confusing).