### PR TITLE
#50575 default case color behaviour is enabled

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
@@ -32,11 +32,13 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 logger.Log(LogLevel.Information, 0, _state, null, _defaultFormatter);
             }
 
+            // For Android/iOS/tvOS/MacCatalyst default color behavior, enables the color
+            var colBehavior = colorBehavior == LoggerColorBehavior.Default && (PlatformDetection.IsAndroid || PlatformDetection.IsAppleMobile) ? LoggerColorBehavior.Enabled : colorBehavior;
+
             // Assert
-            switch (colorBehavior)
+            switch (colBehavior)
             {
                 case LoggerColorBehavior.Enabled:
-                case LoggerColorBehavior.Default:
                     Assert.Equal(2, sink.Writes.Count);
                     var write = sink.Writes[0];
                     Assert.Equal(ConsoleColor.Black, write.BackgroundColor);
@@ -46,6 +48,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                     Assert.Equal(TestConsole.DefaultForegroundColor, write.ForegroundColor);
                     break;
                 case LoggerColorBehavior.Disabled:
+                case LoggerColorBehavior.Default:
                     Assert.Equal(1, sink.Writes.Count);
                     write = sink.Writes[0];
                     Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
@@ -33,10 +33,10 @@ namespace Microsoft.Extensions.Logging.Console.Test
             }
 
             // For Android/iOS/tvOS/MacCatalyst default color behavior, enables the color
-            var colBehavior = colorBehavior == LoggerColorBehavior.Default && (PlatformDetection.IsAndroid || PlatformDetection.IsAppleMobile) ? LoggerColorBehavior.Enabled : colorBehavior;
+            colorBehavior = colorBehavior == LoggerColorBehavior.Default && (PlatformDetection.IsAndroid || PlatformDetection.IsAppleMobile) ? LoggerColorBehavior.Enabled : colorBehavior;
 
             // Assert
-            switch (colBehavior)
+            switch (colorBehavior)
             {
                 case LoggerColorBehavior.Enabled:
                     Assert.Equal(2, sink.Writes.Count);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Extensions.Logging.Console.Test
                     Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
                     Assert.Equal(TestConsole.DefaultForegroundColor, write.ForegroundColor);
                     break;
-                case LoggerColorBehavior.Disabled:
                 case LoggerColorBehavior.Default:
+                case LoggerColorBehavior.Disabled:
                     Assert.Equal(1, sink.Writes.Count);
                     write = sink.Writes[0];
                     Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
         [InlineData(LoggerColorBehavior.Default)]
         [InlineData(LoggerColorBehavior.Enabled)]
         [InlineData(LoggerColorBehavior.Disabled)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50575", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51398", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73436", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void Log_WritingScopes_LogsWithCorrectColorsWhenColorEnabled(LoggerColorBehavior colorBehavior)
         {
@@ -38,6 +36,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             switch (colorBehavior)
             {
                 case LoggerColorBehavior.Enabled:
+                case LoggerColorBehavior.Default:
                     Assert.Equal(2, sink.Writes.Count);
                     var write = sink.Writes[0];
                     Assert.Equal(ConsoleColor.Black, write.BackgroundColor);
@@ -46,7 +45,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
                     Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
                     Assert.Equal(TestConsole.DefaultForegroundColor, write.ForegroundColor);
                     break;
-                case LoggerColorBehavior.Default:
                 case LoggerColorBehavior.Disabled:
                     Assert.Equal(1, sink.Writes.Count);
                     write = sink.Writes[0];


### PR DESCRIPTION
 Microsoft.Extensions.Logging.Console.LoggerColorBehavior.Default 
    -  Use the default color behavior, enabling color except when the console output is redirected.
           
Default case should behave as enabled in this test case.
Fix #50575 and #51398