### PR TITLE
[release/6.0][mono][jit] Don't memset memory in increments lower than word size

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/String.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/String.Mono.cs
@@ -47,16 +47,27 @@ namespace System
                 }
                 return;
             }
-            if (val != 0)
+#if TARGET_64BIT
+            const int word_size = 8;
+            long word_val;
+#else
+            const int word_size = 4;
+            int word_val;
+#endif
+            word_val = val;
+            if (word_val != 0)
             {
-                val = val | (val << 8);
-                val = val | (val << 16);
+                word_val |= (word_val << 8);
+                word_val |= (word_val << 16);
+#if TARGET_64BIT
+                word_val |= (word_val << 32);
+#endif
             }
-            // align to 4
-            int rest = (int)dest & 3;
+            // align to word_size
+            int rest = (int)dest & (word_size - 1);
             if (rest != 0)
             {
-                rest = 4 - rest;
+                rest = word_size - rest;
                 len -= rest;
                 do
                 {
@@ -65,20 +76,30 @@ namespace System
                     --rest;
                 } while (rest != 0);
             }
+
             while (len >= 16)
             {
-                ((int*)dest)[0] = val;
-                ((int*)dest)[1] = val;
-                ((int*)dest)[2] = val;
-                ((int*)dest)[3] = val;
+#if TARGET_64BIT
+                ((long*)dest)[0] = word_val;
+                ((long*)dest)[1] = word_val;
+#else
+                ((int*)dest)[0] = word_val;
+                ((int*)dest)[1] = word_val;
+                ((int*)dest)[2] = word_val;
+                ((int*)dest)[3] = word_val;
+#endif
                 dest += 16;
                 len -= 16;
             }
-            while (len >= 4)
+            while (len >= word_size)
             {
-                ((int*)dest)[0] = val;
-                dest += 4;
-                len -= 4;
+#if TARGET_64BIT
+                ((long*)dest)[0] = word_val;
+#else
+                ((int*)dest)[0] = word_val;
+#endif
+                dest += word_size;
+                len -= word_size;
             }
             // tail bytes
             while (len > 0)


### PR DESCRIPTION
If we memset a vt containing references, then, in order for preemptive GC and concurrent GC to work, writing to reference slots must happen atomically, otherwise GC might encounter a garbage ref.

This was uncovered by crashes in CI in the System.Text.Json.Tests running on Mono(https://github.com/dotnet/runtime/issues/58828)

**Customer Impact**
Infrequent crashes in the GC are possible on 64 bit targets where we use preemptive suspend or concurrent GC. (Desktop and mobile targets) without the fix.
Also speeds up memset by about 15% for smaller valuetypes hitting this path on 64bit. More for extra large valuetypes.

**Testing**
This was tested as part of our CI test suites on main for last 2 weeks without any detected failures. The changed code is hit very frequently, as part of clearing of medium sized / large valuetypes (initobj opcode). 
Manual validation done prior to submission to main.

**Risk**
Low Risk. The change itself is very basic and it got tested over the last few weeks as part of our test suites.




Backport of https://github.com/dotnet/runtime/pull/73480