### PR TITLE
Fix mono package versions during stabilization

### DIFF
--- a/src/mono/nuget/Directory.Build.props
+++ b/src/mono/nuget/Directory.Build.props
@@ -12,10 +12,6 @@
 
     <!-- mono doesn't currently use the index so don't force it to be in sync -->
     <SkipIndexCheck>true</SkipIndexCheck>
-    
-    <!-- Central place to set the versions of all nuget packages produced in the repo -->
-    <PackageVersion Condition="'$(ProductVersion)' == ''">7.0.0</PackageVersion>
-    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/nuget/Directory.Build.targets
+++ b/src/mono/nuget/Directory.Build.targets
@@ -1,5 +1,13 @@
 <Project>
   <UsingTask TaskName="GenerateFileFromTemplate" AssemblyFile="$(WorkloadTasksAssemblyPath)" />
   <Import Project="..\Directory.Build.targets" />
+  
+  <PropertyGroup>
+    <!-- Central place to set the versions of all mono pkgprojs. -->
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
+    <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == ''">$(PackageVersion)</StableVersion>
+    <StableVersion Condition="'$(IsShippingPackage)' != 'true' and '$(MSBuildProjectExtension)' == '.pkgproj'" />
+  </PropertyGroup>
+  
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />
 </Project>


### PR DESCRIPTION
The issues that are being fixed via this PR happened and were fixed during the 7.0 stabilization release exercise.

This will also need to be backported into release/7.0-rc1.