### PR TITLE
Bump intellisense package version to Preview7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -169,7 +169,7 @@
     <!--<SdkVersionForWorkloadTesting>7.0.100-rc.1.22402.35</SdkVersionForWorkloadTesting>-->
     <CompilerPlatformTestingVersion>1.1.2-beta1.22403.2</CompilerPlatformTestingVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220721.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220822.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>7.0.100-1.22415.4</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>


### PR DESCRIPTION
Pipeline result: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=314423&view=results
Job step that pushed the package: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=314423&view=logs&j=92a4755a-6173-591e-5c07-8dbe1165e937&t=3415eb6a-646d-5f62-84ed-e011fa74e199 
This needs a backport to RC1.