### PR TITLE
[RateLimiting] Handle Timer jitter

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -59,9 +59,9 @@ namespace System.Threading.RateLimiting
             {
                 throw new ArgumentException($"{nameof(options.QueueLimit)} must be set to a value greater than or equal to 0.", nameof(options));
             }
-            if (options.Window <= TimeSpan.Zero)
+            if (options.Window < TimeSpan.Zero)
             {
-                throw new ArgumentException($"{nameof(options.Window)} must be set to a value greater than TimeSpan.Zero.", nameof(options));
+                throw new ArgumentException($"{nameof(options.Window)} must be set to a value greater than or equal to TimeSpan.Zero.", nameof(options));
             }
 
             _options = new FixedWindowRateLimiterOptions

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -59,9 +59,9 @@ namespace System.Threading.RateLimiting
             {
                 throw new ArgumentException($"{nameof(options.QueueLimit)} must be set to a value greater than or equal to 0.", nameof(options));
             }
-            if (options.Window < TimeSpan.Zero)
+            if (options.Window <= TimeSpan.Zero)
             {
-                throw new ArgumentException($"{nameof(options.Window)} must be set to a value greater than or equal to TimeSpan.Zero.", nameof(options));
+                throw new ArgumentException($"{nameof(options.Window)} must be set to a value greater than TimeSpan.Zero.", nameof(options));
             }
 
             _options = new FixedWindowRateLimiterOptions
@@ -287,15 +287,14 @@ namespace System.Threading.RateLimiting
                     return;
                 }
 
-                long periods = (long)((nowTicks - _lastReplenishmentTick) * TickFrequency) / _options.Window.Ticks;
-                if (periods == 0)
+                if (((nowTicks - _lastReplenishmentTick) * TickFrequency) < _options.Window.Ticks && !_options.AutoReplenishment)
                 {
                     return;
                 }
 
                 // increment last tick by the number of replenish periods that occurred since the last replenish
                 // this way if replenish isn't being called every ReplenishmentPeriod we correctly track it so we know when replenishes should be occurring
-                _lastReplenishmentTick += (long)(periods * ReplenishmentPeriod.Ticks / TickFrequency);
+                _lastReplenishmentTick = nowTicks;
 
                 int availableRequestCounters = _requestCount;
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiter.cs
@@ -292,8 +292,6 @@ namespace System.Threading.RateLimiting
                     return;
                 }
 
-                // increment last tick by the number of replenish periods that occurred since the last replenish
-                // this way if replenish isn't being called every ReplenishmentPeriod we correctly track it so we know when replenishes should be occurring
                 _lastReplenishmentTick = nowTicks;
 
                 int availableRequestCounters = _requestCount;

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
@@ -10,8 +10,9 @@ namespace System.Threading.RateLimiting
     {
         /// <summary>
         /// Specifies the time window that takes in the requests.
-        /// Must be set to a value > <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="FixedWindowRateLimiter"/>.
+        /// Must be set to a value >= <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="FixedWindowRateLimiter"/>.
         /// </summary>
+        /// <remarks><see cref="TimeSpan.Zero"/> means the limiter will never replenish.</remarks>
         public TimeSpan Window { get; set; } = TimeSpan.Zero;
 
         /// <summary>

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/FixedWindowRateLimiterOptions.cs
@@ -10,7 +10,7 @@ namespace System.Threading.RateLimiting
     {
         /// <summary>
         /// Specifies the time window that takes in the requests.
-        /// Must be set to a value >= <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="FixedWindowRateLimiter"/>.
+        /// Must be set to a value > <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="FixedWindowRateLimiter"/>.
         /// </summary>
         public TimeSpan Window { get; set; } = TimeSpan.Zero;
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiter.cs
@@ -63,9 +63,9 @@ namespace System.Threading.RateLimiting
             {
                 throw new ArgumentException($"{nameof(options.QueueLimit)} must be set to a value greater than or equal to 0.", nameof(options));
             }
-            if (options.Window <= TimeSpan.Zero)
+            if (options.Window < TimeSpan.Zero)
             {
-                throw new ArgumentException($"{nameof(options.Window)} must be set to a value greater than TimeSpan.Zero.", nameof(options));
+                throw new ArgumentException($"{nameof(options.Window)} must be set to a value greater than or equal to TimeSpan.Zero.", nameof(options));
             }
 
             _options = new SlidingWindowRateLimiterOptions

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
@@ -10,7 +10,7 @@ namespace System.Threading.RateLimiting
     {
         /// <summary>
         /// Specifies the minimum period between replenishments.
-        /// Must be set to a value >= <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="SlidingWindowRateLimiter"/>.
+        /// Must be set to a value > <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="SlidingWindowRateLimiter"/>.
         /// </summary>
         public TimeSpan Window { get; set; } = TimeSpan.Zero;
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/SlidingWindowRateLimiterOptions.cs
@@ -10,8 +10,9 @@ namespace System.Threading.RateLimiting
     {
         /// <summary>
         /// Specifies the minimum period between replenishments.
-        /// Must be set to a value > <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="SlidingWindowRateLimiter"/>.
+        /// Must be set to a value >= <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="SlidingWindowRateLimiter"/>.
         /// </summary>
+        /// <remarks><see cref="TimeSpan.Zero"/> means the limiter will never replenish.</remarks>
         public TimeSpan Window { get; set; } = TimeSpan.Zero;
 
         /// <summary>

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiter.cs
@@ -61,9 +61,9 @@ namespace System.Threading.RateLimiting
             {
                 throw new ArgumentException($"{nameof(options.QueueLimit)} must be set to a value greater than or equal to 0.", nameof(options));
             }
-            if (options.ReplenishmentPeriod <= TimeSpan.Zero)
+            if (options.ReplenishmentPeriod < TimeSpan.Zero)
             {
-                throw new ArgumentException($"{nameof(options.ReplenishmentPeriod)} must be set to a value greater than TimeSpan.Zero.", nameof(options));
+                throw new ArgumentException($"{nameof(options.ReplenishmentPeriod)} must be set to a value greater than or equal to TimeSpan.Zero.", nameof(options));
             }
 
             _options = new TokenBucketRateLimiterOptions

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
@@ -10,7 +10,7 @@ namespace System.Threading.RateLimiting
     {
         /// <summary>
         /// Specifies the minimum period between replenishments.
-        /// Must be set to a value >= <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="TokenBucketRateLimiter"/>.
+        /// Must be set to a value > <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="TokenBucketRateLimiter"/>.
         /// </summary>
         public TimeSpan ReplenishmentPeriod { get; set; } = TimeSpan.Zero;
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TokenBucketRateLimiterOptions.cs
@@ -10,8 +10,9 @@ namespace System.Threading.RateLimiting
     {
         /// <summary>
         /// Specifies the minimum period between replenishments.
-        /// Must be set to a value > <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="TokenBucketRateLimiter"/>.
+        /// Must be set to a value >= <see cref="TimeSpan.Zero" /> by the time these options are passed to the constructor of <see cref="TokenBucketRateLimiter"/>.
         /// </summary>
+        /// <remarks><see cref="TimeSpan.Zero"/> means the limiter will never replenish.</remarks>
         public TimeSpan ReplenishmentPeriod { get; set; } = TimeSpan.Zero;
 
         /// <summary>

--- a/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/FixedWindowRateLimiterTests.cs
@@ -37,31 +37,31 @@ namespace System.Threading.RateLimiting.Test
         {
             Assert.Throws<ArgumentException>(
                 () => new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = -1,
-                QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                QueueLimit = 1,
-                Window = TimeSpan.FromMinutes(2),
-                AutoReplenishment = false
-            }));
+                {
+                    PermitLimit = -1,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 1,
+                    Window = TimeSpan.FromMinutes(2),
+                    AutoReplenishment = false
+                }));
             Assert.Throws<ArgumentException>(
                 () => new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = 1,
-                QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                QueueLimit = -1,
-                Window = TimeSpan.FromMinutes(2),
-                AutoReplenishment = false
-            }));
+                {
+                    PermitLimit = 1,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = -1,
+                    Window = TimeSpan.FromMinutes(2),
+                    AutoReplenishment = false
+                }));
             Assert.Throws<ArgumentException>(
                 () => new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
-            {
-                PermitLimit = 1,
-                QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                QueueLimit = 1,
-                Window = TimeSpan.MinValue,
-                AutoReplenishment = false
-            }));
+                {
+                    PermitLimit = 1,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 1,
+                    Window = TimeSpan.MinValue,
+                    AutoReplenishment = false
+                }));
             Assert.Throws<ArgumentException>(
                 () => new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
                 {
@@ -70,15 +70,6 @@ namespace System.Threading.RateLimiting.Test
                     QueueLimit = 1,
                     Window = TimeSpan.FromMinutes(-2),
                     AutoReplenishment = false,
-                }));
-            Assert.Throws<ArgumentException>(
-                () => new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
-                {
-                    PermitLimit = 1,
-                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                    QueueLimit = 1,
-                    Window = TimeSpan.Zero,
-                    AutoReplenishment = false
                 }));
         }
 

--- a/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/SlidingWindowRateLimiterTests.cs
@@ -39,53 +39,43 @@ namespace System.Threading.RateLimiting.Test
         {
             Assert.Throws<ArgumentException>(
                 () => new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
-            {
-                PermitLimit = -1,
-                QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                QueueLimit = 1,
-                Window = TimeSpan.FromMinutes(2),
-                SegmentsPerWindow = 1,
-                AutoReplenishment = false
-            }));
+                {
+                    PermitLimit = -1,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 1,
+                    Window = TimeSpan.FromMinutes(2),
+                    SegmentsPerWindow = 1,
+                    AutoReplenishment = false
+                }));
             Assert.Throws<ArgumentException>(
                 () => new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
-            {
-                PermitLimit = 1,
-                QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                QueueLimit = -1,
-                Window = TimeSpan.FromMinutes(2),
-                SegmentsPerWindow = 1,
-                AutoReplenishment = false
-            }));
-            Assert.Throws<ArgumentException>(
-                () => new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
-            {
-                PermitLimit = 1,
-                QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                QueueLimit = 1,
-                Window = TimeSpan.FromMinutes(2),
-                SegmentsPerWindow = -1,
-                AutoReplenishment = false
-            }));
-            Assert.Throws<ArgumentException>(
-                () => new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
-            {
-                PermitLimit = 1,
-                QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                QueueLimit = 1,
-                Window = TimeSpan.MinValue,
-                SegmentsPerWindow = 1,
-                AutoReplenishment = false
-            }));
+                {
+                    PermitLimit = 1,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = -1,
+                    Window = TimeSpan.FromMinutes(2),
+                    SegmentsPerWindow = 1,
+                    AutoReplenishment = false
+                }));
             Assert.Throws<ArgumentException>(
                 () => new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
                 {
                     PermitLimit = 1,
                     QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                     QueueLimit = 1,
-                    Window = TimeSpan.Zero,
+                    Window = TimeSpan.FromMinutes(2),
+                    SegmentsPerWindow = -1,
+                    AutoReplenishment = false
+                }));
+            Assert.Throws<ArgumentException>(
+                () => new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
+                {
+                    PermitLimit = 1,
+                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                    QueueLimit = 1,
+                    Window = TimeSpan.MinValue,
                     SegmentsPerWindow = 1,
-                    AutoReplenishment = false,
+                    AutoReplenishment = false
                 }));
             Assert.Throws<ArgumentException>(
                 () => new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -83,16 +83,6 @@ namespace System.Threading.RateLimiting.Test
                     TokenLimit = 1,
                     QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
                     QueueLimit = 1,
-                    ReplenishmentPeriod = TimeSpan.Zero,
-                    TokensPerPeriod = 1,
-                    AutoReplenishment = false
-                }));
-            Assert.Throws<ArgumentException>(
-                () => new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
-                {
-                    TokenLimit = 1,
-                    QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
-                    QueueLimit = 1,
                     ReplenishmentPeriod = TimeSpan.FromMilliseconds(-1),
                     TokensPerPeriod = 1,
                     AutoReplenishment = false

--- a/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/TokenBucketRateLimiterTests.cs
@@ -1361,7 +1361,7 @@ namespace System.Threading.RateLimiting.Test
         }
 
         [Fact]
-        public void AutoReplenishIgnoresTimerJitter()
+        public void AutoReplenishPreservesTimeWithTimerJitter()
         {
             var replenishmentPeriod = TimeSpan.FromMinutes(10);
             using var limiter = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
@@ -1382,7 +1382,9 @@ namespace System.Threading.RateLimiting.Test
             // Replenish 1 millisecond less than ReplenishmentPeriod while AutoReplenishment is enabled
             Replenish(limiter, (long)replenishmentPeriod.TotalMilliseconds - 1);
 
-            Assert.Equal(8, limiter.GetStatistics().CurrentAvailablePermits);
+            // Timer ran faster than ReplenishmentPeriod so a full token wasn't added.
+            // Internally the limiter is tracking that so the next timer call will add to the previous partial token
+            Assert.Equal(7, limiter.GetStatistics().CurrentAvailablePermits);
 
             // Replenish 1 millisecond longer than ReplenishmentPeriod while AutoReplenishment is enabled
             Replenish(limiter, (long)replenishmentPeriod.TotalMilliseconds + 1);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/74056

Two approaches are used here, we "trust the timer" when auto replenish is enabled so FixedWindow and SlidingWindow will always move the window when the timer fires. And in the token bucket case we change to use a fill rate internally and update with partial tokens when replenish is called, no matter how frequently.

~Also added validation for not passing TimeSpan.Zero to the limiters, but we could revert that if we just want TimeSpan.Zero to mean never replenish (Timer already uses TimeSpan.Zero as never run the timer).~