### PR TITLE
Add Fedora 38 RID

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
@@ -3454,6 +3454,38 @@
     "any",
     "base"
   ],
+  "fedora.38": [
+    "fedora.38",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.38-arm64": [
+    "fedora.38-arm64",
+    "fedora.38",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.38-x64": [
+    "fedora.38-x64",
+    "fedora.38",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "freebsd": [
     "freebsd",
     "unix",
@@ -4285,22 +4317,22 @@
     "any",
     "base"
   ],
+  "linux-musl-ppc64le": [
+    "linux-musl-ppc64le",
+    "linux-musl",
+    "linux-ppc64le",
+    "linux",
+    "unix-ppc64le",
+    "unix",
+    "any",
+    "base"
+  ],
   "linux-musl-s390x": [
     "linux-musl-s390x",
     "linux-musl",
     "linux-s390x",
     "linux",
     "unix-s390x",
-    "unix",
-    "any",
-    "base"
-  ],
-   "linux-musl-ppc64le": [
-    "linux-musl-ppc64le",
-    "linux-musl",
-    "linux-ppc64le",
-    "linux",
-    "unix-ppc64le",
     "unix",
     "any",
     "base"
@@ -4325,18 +4357,18 @@
     "any",
     "base"
   ],
-  "linux-s390x": [
-    "linux-s390x",
-    "linux",
-    "unix-s390x",
-    "unix",
-    "any",
-    "base"
-  ],
   "linux-ppc64le": [
     "linux-ppc64le",
     "linux",
     "unix-ppc64le",
+    "unix",
+    "any",
+    "base"
+  ],
+  "linux-s390x": [
+    "linux-s390x",
+    "linux",
+    "unix-s390x",
     "unix",
     "any",
     "base"
@@ -8895,14 +8927,14 @@
     "any",
     "base"
   ],
-  "unix-s390x": [
-    "unix-s390x",
+  "unix-ppc64le": [
+    "unix-ppc64le",
     "unix",
     "any",
     "base"
   ],
-  "unix-ppc64le": [
-    "unix-ppc64le",
+  "unix-s390x": [
+    "unix-s390x",
     "unix",
     "any",
     "base"

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -1215,6 +1215,23 @@
         "fedora-x64"
       ]
     },
+    "fedora.38": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.38-arm64": {
+      "#import": [
+        "fedora.38",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.38-x64": {
+      "#import": [
+        "fedora.38",
+        "fedora-x64"
+      ]
+    },
     "freebsd": {
       "#import": [
         "unix"
@@ -1637,16 +1654,16 @@
         "linux-armel"
       ]
     },
-    "linux-musl-s390x": {
-      "#import": [
-        "linux-musl",
-        "linux-s390x"
-      ]
-    },
     "linux-musl-ppc64le": {
       "#import": [
         "linux-musl",
         "linux-ppc64le"
+      ]
+    },
+    "linux-musl-s390x": {
+      "#import": [
+        "linux-musl",
+        "linux-s390x"
       ]
     },
     "linux-musl-x64": {
@@ -1661,16 +1678,16 @@
         "linux-x86"
       ]
     },
-    "linux-s390x": {
-      "#import": [
-        "linux",
-        "unix-s390x"
-      ]
-    },
     "linux-ppc64le": {
       "#import": [
         "linux",
         "unix-ppc64le"
+      ]
+    },
+    "linux-s390x": {
+      "#import": [
+        "linux",
+        "unix-s390x"
       ]
     },
     "linux-x64": {
@@ -3636,12 +3653,12 @@
         "unix"
       ]
     },
-    "unix-s390x": {
+    "unix-ppc64le": {
       "#import": [
         "unix"
       ]
     },
-    "unix-ppc64le": {
+    "unix-s390x": {
       "#import": [
         "unix"
       ]

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -81,7 +81,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35;36;37</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35;36;37;38</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
Fedora 38 is now in development:

    $ podman run -it registry.fedoraproject.org/fedora:rawhide
    [root@d3934d2b267b /]# cat /etc/os-release
    NAME="Fedora Linux"
    VERSION="38 (Container Image Prerelease)"
    ID=fedora
    VERSION_ID=38
    VERSION_CODENAME=""
    PLATFORM_ID="platform:f38"
    PRETTY_NAME="Fedora Linux 38 (Container Image Prerelease)"
    ANSI_COLOR="0;38;2;60;110;180"
    LOGO=fedora-logo-icon
    CPE_NAME="cpe:/o:fedoraproject:fedora:38"
    DEFAULT_HOSTNAME="fedora"
    HOME_URL="https://fedoraproject.org/"
    DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/"
    SUPPORT_URL="https://ask.fedoraproject.org/"
    BUG_REPORT_URL="https://bugzilla.redhat.com/"
    REDHAT_BUGZILLA_PRODUCT="Fedora"
    REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide
    REDHAT_SUPPORT_PRODUCT="Fedora"
    REDHAT_SUPPORT_PRODUCT_VERSION=rawhide
    VARIANT="Container Image"
    VARIANT_ID=container

The changes to runtime.compatibility.json and runtime.json were automated and made by `dotnet pack -p:UpdateRuntimeFiles=true`