### PR TITLE
[mono] Assert that we don't need to inflate types when applying DIM overrides

### DIFF
--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1775,8 +1775,9 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 			if (mono_class_is_gtd (override->klass)) {
 				override = mono_class_inflate_generic_method_full_checked (override, ic, mono_class_get_context (ic), error);
 			} else if (decl->is_inflated) {
-				override = mono_class_inflate_generic_method_checked (override, mono_method_get_context (decl), error);
-				mono_error_assert_ok (error);
+				// there used to be code here to inflate decl, but in https://github.com/dotnet/runtime/pull/64102#discussion_r790019545 we
+				// think that this does not correspond to any real code.
+				g_assert_not_reached ();
 			}
 			if (!apply_override (klass, ic, vtable, decl, override, &override_map, &override_class_map, &conflict_map))
 				goto fail;

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1025,12 +1025,14 @@ apply_override (MonoClass *klass, MonoClass *override_class, MonoMethod **vtable
 		 * This is needed so the mono_class_is_assignable_from_internal () calls in the
 		 * conflict resolution work.
 		 */
-		if (mono_class_is_ginst (override_class)) {
+		g_assert (override_class == override->klass);
+		if (mono_class_is_ginst (override_class) && override->klass != override_class) {
 			override = mono_class_inflate_generic_method_checked (override, &mono_class_get_generic_class (override_class)->context, error);
 			mono_error_assert_ok (error);
 		}
 
-		if (mono_class_is_ginst (prev_override_class)) {
+		g_assert (prev_override->klass == prev_override_class);
+		if (mono_class_is_ginst (prev_override_class)  && prev_override->klass != prev_override_class) {
 			prev_override = mono_class_inflate_generic_method_checked (prev_override, &mono_class_get_generic_class (prev_override_class)->context, error);
 			mono_error_assert_ok (error);
 		}

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -932,7 +932,8 @@ mono_class_setup_vtable_full (MonoClass *klass, GList *in_setup)
 		context = mono_class_get_context (klass);
 		type_token = mono_class_get_generic_class (klass)->container_class->type_token;
 	} else {
-		context = (MonoGenericContext *) mono_class_try_get_generic_container (klass); //FIXME is this a case of a try?
+		MonoGenericContainer *container = mono_class_try_get_generic_container (klass); //FIXME is this a case of a try?
+		context = container ? &container->context : NULL;
 		type_token = klass->type_token;
 	}
 

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1018,8 +1018,6 @@ apply_override (MonoClass *klass, MonoClass *override_class, MonoMethod **vtable
 
 	/* Collect potentially conflicting overrides which are introduced by default interface methods */
 	if (prev_override) {
-		ERROR_DECL (error);
-
 		g_assert (prev_override->klass == prev_override_class);
 
 		if (!*conflict_map)

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1756,11 +1756,9 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 			MonoMethod *override = iface_overrides [i*2 + 1];
 			if (mono_class_is_gtd (override->klass)) {
 				override = mono_class_inflate_generic_method_full_checked (override, ic, mono_class_get_context (ic), error);
-			} else if (decl->is_inflated) {
-				// there used to be code here to inflate decl, but in https://github.com/dotnet/runtime/pull/64102#discussion_r790019545 we
-				// think that this does not correspond to any real code.
-				g_assert_not_reached ();
-			}
+			} 
+			// there used to be code here to inflate decl if decl->is_inflated, but in https://github.com/dotnet/runtime/pull/64102#discussion_r790019545 we
+			// think that this does not correspond to any real code.
 			if (!apply_override (klass, ic, vtable, decl, override, &override_map, &override_class_map, &conflict_map))
 				goto fail;
 		}

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github61244.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/github61244.cs
@@ -14,11 +14,19 @@ using System;
 // derived interface contexts, but the order is changed (or different.)
 // When this occurs the generic info is incorrect for the inflated method.
 
+// TestClass2 tests a regression due to the fix for the previous
+// regression that caused Mono to incorrectly instantiate generic
+// interfaces that appeared in the MethodImpl table
+
 class Program
 {
     static int Main(string[] args)
     {
-        return new TestClass().DoTest();
+        int result = new TestClass().DoTest();
+        if (result != 100)
+                return result;
+        result = new TestClass2().DoTest();
+        return result;
     }
 }
 
@@ -77,5 +85,34 @@ public class TestClass : SecondInterface<int, string>
 
         Console.WriteLine("Passed => 100");
         return 100;
+    }
+}
+
+public interface IA
+{
+    public int Foo();
+}
+
+public interface IB<T> : IA
+{
+        int IA.Foo() { return 104; }
+}
+
+public interface IC<H1, H2> : IB<H2>
+{
+        int IA.Foo() { return 105; }
+}
+
+public class C<U, V, W> : IC<V, W>
+{
+        int IA.Foo() { return 100; }
+}
+
+public class TestClass2
+{
+    public int DoTest()
+    {
+        IA c = new C<byte, short, int>();
+        return c.Foo();
     }
 }

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2022,10 +2022,10 @@
         <ExcludeList Include="$(XunitTestBinBase)/readytorun/**">
             <Issue>These tests are not supposed to be run with mono.</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/Emit/**">
+        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/Emit/**" Condition="false">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/InvokeConsumer/**">
+        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/InvokeConsumer/**" Condition="false">
             <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/reflection/Modifiers/modifiers/**">

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2022,11 +2022,11 @@
         <ExcludeList Include="$(XunitTestBinBase)/readytorun/**">
             <Issue>These tests are not supposed to be run with mono.</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/Emit/**" Condition="false">
-            <Issue>needs triage</Issue>
+        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/Emit/**">
+            <Issue>https://github.com/dotnet/runtime/issues/36113</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/InvokeConsumer/**" Condition="false">
-            <Issue>needs triage</Issue>
+        <ExcludeList Include="$(XunitTestBinBase)/reflection/DefaultInterfaceMethods/InvokeConsumer/**">
+            <Issue>https://github.com/dotnet/runtime/issues/36113</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/reflection/Modifiers/modifiers/**">
             <Issue>needs triage</Issue>


### PR DESCRIPTION
Due to rearranging the logic in https://github.com/dotnet/runtime/pull/64102 we already inflated the interfaces that are generic instances.  Inflating again is wrong and will use the wrong generic context.

Fixes https://github.com/dotnet/runtime/issues/70190
