### PR TITLE
Fix issues found in recent Int128 ABI change

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/InteropTypes.cs
@@ -139,7 +139,7 @@ namespace Internal.TypeSystem.Interop
 
         public static bool IsInt128Type(TypeSystemContext context, TypeDesc type)
         {
-            return IsCoreNamedType(context, type, "System", "Int128") || IsCoreNamedType(context, type, "System", "UInt128");
+            return type is DefType defType && defType.IsInt128OrHasInt128Fields;
         }
 
         public static bool IsSystemRuntimeIntrinsicsVector128T(TypeSystemContext context, TypeDesc type)

--- a/src/tests/Interop/PInvoke/Int128/UInt128Native.cpp
+++ b/src/tests/Interop/PInvoke/Int128/UInt128Native.cpp
@@ -35,15 +35,15 @@ extern "C" DLL_EXPORT UInt128 STDMETHODCALLTYPE GetUInt128(uint64_t upper, uint6
     return result;
 }
 
-extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetUInt128Out(uint64_t upper, uint64_t lower, UInt128* pValue)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetUInt128Out(uint64_t upper, uint64_t lower, char* pValue /* This is a char*, as .NET does not currently guarantee that Int128 values are aligned */)
 {
     UInt128 value = GetUInt128(upper, lower);
-    *pValue = value;
+    memcpy(pValue, &value, sizeof(value));  // Perform unaligned write
 }
 
 extern "C" DLL_EXPORT const UInt128* STDMETHODCALLTYPE GetUInt128Ptr(uint64_t upper, uint64_t lower)
 {
-    GetUInt128Out(upper, lower, &UInt128Value);
+    GetUInt128Out(upper, lower, (char*)&UInt128Value);
     return &UInt128Value;
 }
 
@@ -62,13 +62,15 @@ extern "C" DLL_EXPORT UInt128 STDMETHODCALLTYPE AddUInt128(UInt128 lhs, UInt128 
     return result;
 }
 
-extern "C" DLL_EXPORT UInt128 STDMETHODCALLTYPE AddUInt128s(const UInt128* pValues, uint32_t count)
+extern "C" DLL_EXPORT UInt128 STDMETHODCALLTYPE AddUInt128s(const char* pValues /* These are char*, as .NET does not currently guarantee that Int128 values are aligned */, uint32_t count)
 {
     UInt128 result = {};
 
     for (uint32_t i = 0; i < count; i++)
     {
-        result = AddUInt128(result, pValues[i]);
+        UInt128 input;
+        memcpy(&input, pValues + (sizeof(UInt128) * i), sizeof(UInt128));  // Perform unaligned read
+        result = AddUInt128(result, input);
     }
 
     return result;


### PR DESCRIPTION
- Crossgen2 compiler was failing to detect that structs containing Int128 needed marshalling
- The contract we provide is that Int128 is aligned within a structure, but we do not provide guarantees around 128bit alignment itself, so the test needed updating for that.

Fixes #74318 