### PR TITLE
Use BOOL (vs. bool) in event pipe qcall signatures

### DIFF
--- a/src/coreclr/vm/eventpipeinternal.cpp
+++ b/src/coreclr/vm/eventpipeinternal.cpp
@@ -60,7 +60,7 @@ extern "C" void QCALLTYPE EventPipeInternal_Disable(UINT64 sessionID)
     END_QCALL;
 }
 
-extern "C" bool QCALLTYPE EventPipeInternal_GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo)
+extern "C" BOOL QCALLTYPE EventPipeInternal_GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo)
 {
     QCALL_CONTRACT;
 
@@ -229,7 +229,7 @@ extern "C" void QCALLTYPE EventPipeInternal_WriteEventData(
     END_QCALL;
 }
 
-extern "C" bool QCALLTYPE EventPipeInternal_GetNextEvent(UINT64 sessionID, EventPipeEventInstanceData *pInstance)
+extern "C" BOOL QCALLTYPE EventPipeInternal_GetNextEvent(UINT64 sessionID, EventPipeEventInstanceData *pInstance)
 {
     QCALL_CONTRACT;
 
@@ -255,7 +255,7 @@ extern "C" bool QCALLTYPE EventPipeInternal_GetNextEvent(UINT64 sessionID, Event
     return pNextInstance != NULL;
 }
 
-extern "C" bool QCALLTYPE EventPipeInternal_SignalSession(UINT64 sessionID)
+extern "C" BOOL QCALLTYPE EventPipeInternal_SignalSession(UINT64 sessionID)
 {
     QCALL_CONTRACT;
 
@@ -268,7 +268,7 @@ extern "C" bool QCALLTYPE EventPipeInternal_SignalSession(UINT64 sessionID)
     return result;
 }
 
-extern "C" bool QCALLTYPE EventPipeInternal_WaitForSessionSignal(UINT64 sessionID, INT32 timeoutMs)
+extern "C" BOOL QCALLTYPE EventPipeInternal_WaitForSessionSignal(UINT64 sessionID, INT32 timeoutMs)
 {
     QCALL_CONTRACT;
 

--- a/src/coreclr/vm/eventpipeinternal.h
+++ b/src/coreclr/vm/eventpipeinternal.h
@@ -51,7 +51,7 @@ extern "C" UINT64 QCALLTYPE EventPipeInternal_Enable(
 //!
 extern "C" void QCALLTYPE EventPipeInternal_Disable(UINT64 sessionID);
 
-extern "C" bool QCALLTYPE EventPipeInternal_GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo);
+extern "C" BOOL QCALLTYPE EventPipeInternal_GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo);
 
 extern "C" INT_PTR QCALLTYPE EventPipeInternal_CreateProvider(
     _In_z_ LPCWSTR providerName,
@@ -82,14 +82,14 @@ extern "C" void QCALLTYPE EventPipeInternal_WriteEventData(
     UINT32 eventDataCount,
     LPCGUID pActivityId, LPCGUID pRelatedActivityId);
 
-extern "C" bool QCALLTYPE EventPipeInternal_GetNextEvent(
+extern "C" BOOL QCALLTYPE EventPipeInternal_GetNextEvent(
     UINT64 sessionID,
     EventPipeEventInstanceData *pInstance);
 
-extern "C" bool QCALLTYPE EventPipeInternal_SignalSession(
+extern "C" BOOL QCALLTYPE EventPipeInternal_SignalSession(
     UINT64 sessionID);
 
-extern "C" bool QCALLTYPE EventPipeInternal_WaitForSessionSignal(
+extern "C" BOOL QCALLTYPE EventPipeInternal_WaitForSessionSignal(
     UINT64 sessionID,
     INT32 timeoutMs);
 


### PR DESCRIPTION

`BOOL` is preferred in QCALL signatures since it has well defined size (int32) while c++ `bool` is implementation specific and is typically 1 byte.
It looks like we expect `int32` (`UnmanagedType.Bool`) on the managed side as well.
https://github.com/dotnet/runtime/blob/e67e4da2843c0ef69f213177f1013a3f3b8bcd77/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.CoreCLR.cs#L57

This fixes https://github.com/dotnet/runtime/issues/62145 for me.

I am not sure why this is not causing failures in non-singlefile case. It should though. 
Perhaps some differences in initialization or how calls are bound have a mitigating effect on non-singlefile.