### PR TITLE
[release/7.0-rc1] Improve DOTNET_JitDisasm and introduce DOTNET_JitDisasmSummary

### DIFF
--- a/docs/design/features/OsrDetailsAndDebugging.md
+++ b/docs/design/features/OsrDetailsAndDebugging.md
@@ -338,7 +338,7 @@ Note if a Tier0 method is recursive and has loops there can be some interesting 
 
 ### Seeing which OSR methods are created
 
-* `DOTNET_DumpJittedMethods=1` will specially mark OSR methods with the inspiring IL offsets.
+* `DOTNET_JitDisasmSummary=1` will specially mark OSR methods with the inspiring IL offsets.
 
 For example, running a libraries test with some stressful OSR settings, there ended up being 699 OSR methods jitted out of 160675 total methods. Grepping for OSR in the dump output, the last few lines were:
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1887,31 +1887,9 @@ void CodeGen::genGenerateMachineCode()
 
         if (compiler->fgHaveProfileData())
         {
-            const char* pgoKind;
-            switch (compiler->fgPgoSource)
-            {
-                case ICorJitInfo::PgoSource::Static:
-                    pgoKind = "Static";
-                    break;
-                case ICorJitInfo::PgoSource::Dynamic:
-                    pgoKind = "Dynamic";
-                    break;
-                case ICorJitInfo::PgoSource::Blend:
-                    pgoKind = "Blend";
-                    break;
-                case ICorJitInfo::PgoSource::Text:
-                    pgoKind = "Textual";
-                    break;
-                case ICorJitInfo::PgoSource::Sampling:
-                    pgoKind = "Sample-based";
-                    break;
-                default:
-                    pgoKind = "Unknown";
-                    break;
-            }
-
-            printf("; with %s PGO: edge weights are %s, and fgCalledCount is " FMT_WT "\n", pgoKind,
-                   compiler->fgHaveValidEdgeWeights ? "valid" : "invalid", compiler->fgCalledCount);
+            printf("; with %s: edge weights are %s, and fgCalledCount is " FMT_WT "\n",
+                   compiler->compGetPgoSourceName(), compiler->fgHaveValidEdgeWeights ? "valid" : "invalid",
+                   compiler->fgCalledCount);
         }
 
         if (compiler->fgPgoFailReason != nullptr)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4145,9 +4145,7 @@ private:
     regNumber getCallArgIntRegister(regNumber floatReg);
     regNumber getCallArgFloatRegister(regNumber intReg);
 
-#if defined(DEBUG)
     static unsigned jitTotalMethodCompiled;
-#endif
 
 #ifdef DEBUG
     static LONG jitNestingLevel;
@@ -9472,6 +9470,7 @@ public:
     }
 
     const char* compGetTieringName(bool wantShortName = false) const;
+    const char* compGetPgoSourceName() const;
     const char* compGetStressMessage() const;
 
     codeOptimize compCodeOpt() const

--- a/src/coreclr/jit/jitconfig.cpp
+++ b/src/coreclr/jit/jitconfig.cpp
@@ -44,14 +44,15 @@ void JitConfigValues::MethodSet::initialize(const WCHAR* list, ICorJitHost* host
     bool         isQuoted  = false;    // true while parsing inside a quote "this-is-a-quoted-region"
     MethodName   currentName;          // Buffer used while parsing the current entry
 
-    currentName.m_next                    = nullptr;
-    currentName.m_methodNameStart         = -1;
-    currentName.m_methodNameLen           = -1;
-    currentName.m_methodNameWildcardAtEnd = false;
-    currentName.m_classNameStart          = -1;
-    currentName.m_classNameLen            = -1;
-    currentName.m_classNameWildcardAtEnd  = false;
-    currentName.m_numArgs                 = -1;
+    currentName.m_next                      = nullptr;
+    currentName.m_methodNameStart           = -1;
+    currentName.m_methodNameLen             = -1;
+    currentName.m_methodNameWildcardAtStart = false;
+    currentName.m_methodNameWildcardAtEnd   = false;
+    currentName.m_classNameStart            = -1;
+    currentName.m_classNameLen              = -1;
+    currentName.m_classNameWildcardAtEnd    = false;
+    currentName.m_numArgs                   = -1;
 
     enum State
     {
@@ -202,21 +203,31 @@ void JitConfigValues::MethodSet::initialize(const WCHAR* list, ICorJitHost* host
                     }
 
                     // Is the first character a wildcard?
-                    if (m_list[currentName.m_methodNameStart] == WILD_CHAR)
+                    if (m_list[currentName.m_methodNameStart] == WILD_CHAR && currentName.m_methodNameLen == 1)
                     {
                         // The method name is a full wildcard; mark it as such.
                         currentName.m_methodNameStart = -1;
                         currentName.m_methodNameLen   = -1;
                     }
-                    // Is there a wildcard at the end of the method name?
-                    //
-                    else if (m_list[currentName.m_methodNameStart + currentName.m_methodNameLen - 1] == WILD_CHAR)
+                    else
                     {
-                        // i.e. class:foo*, will match any method that starts with "foo"
-
-                        // Remove the trailing WILD_CHAR from method name
-                        currentName.m_methodNameLen--; // backup for WILD_CHAR
-                        currentName.m_methodNameWildcardAtEnd = true;
+                        // Is there a wildcard at the start of the method name?
+                        if (m_list[currentName.m_methodNameStart] == WILD_CHAR)
+                        {
+                            // i.e. class:*foo, will match any method that ends with "foo"
+                            // Remove the leading WILD_CHAR from method name
+                            currentName.m_methodNameStart++;
+                            currentName.m_methodNameLen--;
+                            currentName.m_methodNameWildcardAtStart = true;
+                        }
+                        // Is there a wildcard at the end of the method name?
+                        if (m_list[currentName.m_methodNameStart + currentName.m_methodNameLen - 1] == WILD_CHAR)
+                        {
+                            // i.e. class:foo*, will match any method that starts with "foo"
+                            // Remove the trailing WILD_CHAR from method name
+                            currentName.m_methodNameLen--; // backup for WILD_CHAR
+                            currentName.m_methodNameWildcardAtEnd = true;
+                        }
                     }
 
                     // should we expect an ARG_LIST?
@@ -309,11 +320,30 @@ void JitConfigValues::MethodSet::destroy(ICorJitHost* host)
     m_names = nullptr;
 }
 
-static bool matchesName(const char* const name, int nameLen, bool wildcardAtEnd, const char* const s2)
+// strstr that is length-limited, this implementation is not intended to be used on hot paths
+static size_t strnstr(const char* pSrc, size_t srcSize, const char* needle, size_t needleSize)
 {
-    // 's2' must start with 'nameLen' characters of 'name'
-    if (strncmp(name, s2, nameLen) != 0)
+    for (size_t srcPos = 0; srcPos <= srcSize - needleSize; srcPos++)
     {
+        if (strncmp(pSrc + srcPos, needle, needleSize) == 0)
+        {
+            return srcPos;
+        }
+    }
+    return -1;
+}
+
+static bool matchesName(
+    const char* const name, int nameLen, bool wildcardAtStart, bool wildcardAtEnd, const char* const s2)
+{
+    if (wildcardAtStart && (int)strnstr(s2, strlen(s2), name, nameLen) == -1)
+    {
+        return false;
+    }
+
+    if (!wildcardAtStart && strncmp(name, s2, nameLen) != 0)
+    {
+        // 's2' must start with 'nameLen' characters of 'name'
         return false;
     }
 
@@ -346,12 +376,14 @@ bool JitConfigValues::MethodSet::contains(const char*       methodName,
         if (name->m_methodNameStart != -1)
         {
             const char* expectedMethodName = &m_list[name->m_methodNameStart];
-            if (!matchesName(expectedMethodName, name->m_methodNameLen, name->m_methodNameWildcardAtEnd, methodName))
+            if (!matchesName(expectedMethodName, name->m_methodNameLen, name->m_methodNameWildcardAtStart,
+                             name->m_methodNameWildcardAtEnd, methodName))
             {
                 // C++ embeds the class name into the method name; deal with that here.
                 const char* colon = strchr(methodName, ':');
                 if (colon != nullptr && colon[1] == ':' &&
-                    matchesName(expectedMethodName, name->m_methodNameLen, name->m_methodNameWildcardAtEnd, methodName))
+                    matchesName(expectedMethodName, name->m_methodNameLen, name->m_methodNameWildcardAtStart,
+                                name->m_methodNameWildcardAtEnd, methodName))
                 {
                     int classLen = (int)(colon - methodName);
                     if (name->m_classNameStart == -1 ||
@@ -367,8 +399,7 @@ bool JitConfigValues::MethodSet::contains(const char*       methodName,
 
         // If m_classNameStart is valid, check for a mismatch
         if (className == nullptr || name->m_classNameStart == -1 ||
-            matchesName(&m_list[name->m_classNameStart], name->m_classNameLen, name->m_classNameWildcardAtEnd,
-                        className))
+            matchesName(&m_list[name->m_classNameStart], name->m_classNameLen, false, false, className))
         {
             return true;
         }
@@ -379,8 +410,8 @@ bool JitConfigValues::MethodSet::contains(const char*       methodName,
         if (nsSep != nullptr && nsSep != className)
         {
             const char* onlyClass = nsSep[-1] == '.' ? nsSep : &nsSep[1];
-            if (matchesName(&m_list[name->m_classNameStart], name->m_classNameLen, name->m_classNameWildcardAtEnd,
-                            onlyClass))
+            if (matchesName(&m_list[name->m_classNameStart], name->m_classNameLen, false,
+                            name->m_classNameWildcardAtEnd, onlyClass))
             {
                 return true;
             }

--- a/src/coreclr/jit/jitconfig.cpp
+++ b/src/coreclr/jit/jitconfig.cpp
@@ -323,6 +323,11 @@ void JitConfigValues::MethodSet::destroy(ICorJitHost* host)
 // strstr that is length-limited, this implementation is not intended to be used on hot paths
 static size_t strnstr(const char* pSrc, size_t srcSize, const char* needle, size_t needleSize)
 {
+    if (srcSize < needleSize)
+    {
+        return -1;
+    }
+
     for (size_t srcPos = 0; srcPos <= srcSize - needleSize; srcPos++)
     {
         if (strncmp(pSrc + srcPos, needle, needleSize) == 0)

--- a/src/coreclr/jit/jitconfig.h
+++ b/src/coreclr/jit/jitconfig.h
@@ -20,6 +20,7 @@ public:
             MethodName* m_next;
             int         m_methodNameStart;
             int         m_methodNameLen;
+            bool        m_methodNameWildcardAtStart;
             bool        m_methodNameWildcardAtEnd;
             int         m_classNameStart;
             int         m_classNameLen;

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -26,15 +26,14 @@ CONFIG_INTEGER(DiffableDasm, W("JitDiffableDasm"), 0)          // Make the disas
 CONFIG_INTEGER(JitDasmWithAddress, W("JitDasmWithAddress"), 0) // Print the process address next to each instruction of
                                                                // the disassembly
 CONFIG_INTEGER(DisplayLoopHoistStats, W("JitLoopHoistStats"), 0) // Display JIT loop hoisting statistics
-CONFIG_INTEGER(DisplayLsraStats, W("JitLsraStats"), 0)       // Display JIT Linear Scan Register Allocator statistics
-                                                             // If set to "1", display the stats in textual format.
-                                                             // If set to "2", display the stats in csv format.
-                                                             // If set to "3", display the stats in summarize format.
-                                                             // Recommended to use with JitStdOutFile flag.
-CONFIG_STRING(JitLsraOrdering, W("JitLsraOrdering"))         // LSRA heuristics ordering
-CONFIG_INTEGER(DumpJittedMethods, W("DumpJittedMethods"), 0) // Prints all jitted methods to the console
-CONFIG_INTEGER(EnablePCRelAddr, W("JitEnablePCRelAddr"), 1)  // Whether absolute addr be encoded as PC-rel offset by
-                                                             // RyuJIT where possible
+CONFIG_INTEGER(DisplayLsraStats, W("JitLsraStats"), 0)      // Display JIT Linear Scan Register Allocator statistics
+                                                            // If set to "1", display the stats in textual format.
+                                                            // If set to "2", display the stats in csv format.
+                                                            // If set to "3", display the stats in summarize format.
+                                                            // Recommended to use with JitStdOutFile flag.
+CONFIG_STRING(JitLsraOrdering, W("JitLsraOrdering"))        // LSRA heuristics ordering
+CONFIG_INTEGER(EnablePCRelAddr, W("JitEnablePCRelAddr"), 1) // Whether absolute addr be encoded as PC-rel offset by
+                                                            // RyuJIT where possible
 CONFIG_INTEGER(JitAssertOnMaxRAPasses, W("JitAssertOnMaxRAPasses"), 0)
 CONFIG_INTEGER(JitBreakEmitOutputInstr, W("JitBreakEmitOutputInstr"), -1)
 CONFIG_INTEGER(JitBreakMorphTree, W("JitBreakMorphTree"), 0xffffffff)
@@ -256,6 +255,8 @@ CONFIG_INTEGER(EnableIncompleteISAClass, W("EnableIncompleteISAClass"), 0) // En
 // JitDisasm is supported in Release too
 CONFIG_METHODSET(JitDisasm, W("JitDisasm"))
 #endif // !defined(DEBUG)
+
+CONFIG_INTEGER(JitDisasmSummary, W("JitDisasmSummary"), 0) // Prints all jitted methods to the console
 
 CONFIG_INTEGER(RichDebugInfo, W("RichDebugInfo"), 0) // If 1, keep rich debug info and report it back to the EE
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/74090 to .NET 7.0 rc1 on @stephentoub's [request](https://github.com/dotnet/runtime/pull/74090#issuecomment-1219471050).

This PR improves UX of a recently added feature to .NET 7.0 - `DOTNET_JitDisasm=method` (https://github.com/dotnet/runtime/pull/73365) which gives users ability to print rich assembly code for any function.

Namely, this PR improves wildcard support (e.g. `DOTNET_JitDisasm=*foo*` or `DOTNET_JitDisasm=MyType:*foo*()`) and, what is more important, introduces `DOTNET_JitDisasmSummary=1` command to print all functions JIT compiles with a short summary (which tier, does it use PGO, etc) - it serves two purposes:
1) It gives users ability to copy-paste a function name to use in JitDisasm (it's especially important for top-level statements, nested functions and dynamically emitted IL functions -- all those names are machine-generated)
2) It can be used to quickly validate if PGO works as expected

Example of its output:
```
  1: JIT compiled SubStringCountTest:Foo():int [Instrumented Tier0, IL size=29, code size=156]
  2: JIT compiled SubStringCountTest:Foo():int [Instrumented Tier1-OSR @0x13 with Dynamic PGO, IL size=29, code size=63]
  3: JIT compiled SubStringCountTest:Foo():int [Tier1 with Dynamic PGO, IL size=29, code size=22]
  4: JIT compiled Thread:Sleep(int) [Tier1 with Static PGO, IL size=33, code size=148]
  ...
```
_(btw, in this specific example `SubStringCountTest:Foo` is compiled 3 times (3 tiers basically))_

## Customer Impact
No impact, JitDisasm and JitDisasmSummary are new configuration knobs in .NET7.0

## Testing
Tested locally and by SuperPMI jobs

## Risk
Low
