### PR TITLE
Improve HTTP/1 response header parsing

### DIFF
--- a/src/libraries/Common/tests/System/IO/DelegateDelegatingStream.cs
+++ b/src/libraries/Common/tests/System/IO/DelegateDelegatingStream.cs
@@ -9,6 +9,8 @@ namespace System.IO
     /// <summary>Provides a stream whose implementation is supplied by delegates or by an inner stream.</summary>
     internal sealed class DelegateDelegatingStream : DelegatingStream
     {
+        public delegate int ReadSpanDelegate(Span<byte> buffer);
+
         public static DelegateDelegatingStream NopDispose(Stream innerStream) =>
             new DelegateDelegatingStream(innerStream)
             {
@@ -27,6 +29,7 @@ namespace System.IO
         public Func<long> GetPositionFunc { get; set; }
         public Action<long> SetPositionFunc { get; set; }
         public Func<byte[], int, int, int> ReadFunc { get; set; }
+        public ReadSpanDelegate ReadSpanFunc { get; set; }
         public Func<byte[], int, int, CancellationToken, Task<int>> ReadAsyncArrayFunc { get; set; }
         public Func<Memory<byte>, CancellationToken, ValueTask<int>> ReadAsyncMemoryFunc { get; set; }
         public Func<long, SeekOrigin, long> SeekFunc { get; set; }
@@ -48,6 +51,7 @@ namespace System.IO
         public override long Position => GetPositionFunc != null ? GetPositionFunc() : base.Position;
 
         public override int Read(byte[] buffer, int offset, int count) => ReadFunc != null ? ReadFunc(buffer, offset, count) : base.Read(buffer, offset, count);
+        public override int Read(Span<byte> buffer) => ReadSpanFunc != null ? ReadSpanFunc(buffer) : base.Read(buffer);
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => ReadAsyncArrayFunc != null ? ReadAsyncArrayFunc(buffer, offset, count, cancellationToken) : base.ReadAsync(buffer, offset, count, cancellationToken);
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => ReadAsyncMemoryFunc != null ? ReadAsyncMemoryFunc(buffer, cancellationToken) : base.ReadAsync(buffer, cancellationToken);
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1290,6 +1290,7 @@ namespace System.Net.Http.Functional.Tests
                 : "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nLong-Header: ");
 
             bool streamDisposed = false;
+            bool responseComplete = false;
             int readCount = 0;
             int fastFillLength = 64 * 1024 * 1024; // 64 MB
 
@@ -1298,6 +1299,11 @@ namespace System.Net.Http.Functional.Tests
                 if (streamDisposed)
                 {
                     throw new ObjectDisposedException("Foo");
+                }
+
+                if (responseComplete)
+                {
+                    return 0;
                 }
 
                 Span<byte> buffer = memory.Span;
@@ -1343,6 +1349,8 @@ namespace System.Net.Http.Functional.Tests
                         return 1;
                     }
                 }
+
+                responseComplete = true;
 
                 Debug.Assert(buffer.Length >= 4);
                 return Encoding.ASCII.GetBytes("\r\n\r\n", buffer);


### PR DESCRIPTION
Based on the "portable" implementation from @scalablecory's PR https://github.com/dotnet/runtime/pull/63295.
This PR does not include the Avx2-vectorized parsing code.

Sending in-memory (no I/O) requests and parsing the response:

|    Method | Toolchain | ResponseHeaders |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |
|---------- |---------- |---------------- |----------:|----------:|----------:|----------:|------:|--------:|
| SendAsync |      main |               1 |  1.701 μs | 0.0075 μs | 0.0373 μs |  1.689 μs |  1.00 |    0.00 |
| SendAsync |        pr |               1 |  1.481 μs | 0.0014 μs | 0.0071 μs |  1.480 μs |  0.87 |    0.02 |
|           |           |                 |           |           |           |           |       |         |
| SendAsync |      main |               2 |  1.880 μs | 0.0085 μs | 0.0428 μs |  1.863 μs |  1.00 |    0.00 |
| SendAsync |        pr |               2 |  1.674 μs | 0.0044 μs | 0.0225 μs |  1.673 μs |  0.89 |    0.02 |
|           |           |                 |           |           |           |           |       |         |
| SendAsync |      main |               3 |  2.129 μs | 0.0037 μs | 0.0184 μs |  2.126 μs |  1.00 |    0.00 |
| SendAsync |        pr |               3 |  1.751 μs | 0.0018 μs | 0.0092 μs |  1.749 μs |  0.82 |    0.01 |
|           |           |                 |           |           |           |           |       |         |
| SendAsync |      main |               4 |  2.302 μs | 0.0050 μs | 0.0248 μs |  2.296 μs |  1.00 |    0.00 |
| SendAsync |        pr |               4 |  1.883 μs | 0.0044 μs | 0.0218 μs |  1.886 μs |  0.82 |    0.02 |
|           |           |                 |           |           |           |           |       |         |
| SendAsync |      main |               8 |  3.257 μs | 0.0049 μs | 0.0246 μs |  3.258 μs |  1.00 |    0.00 |
| SendAsync |        pr |               8 |  2.647 μs | 0.0114 μs | 0.0577 μs |  2.628 μs |  0.81 |    0.02 |
|           |           |                 |           |           |           |           |       |         |
| SendAsync |      main |              16 |  5.871 μs | 0.0129 μs | 0.0666 μs |  5.882 μs |  1.00 |    0.00 |
| SendAsync |        pr |              16 |  4.472 μs | 0.0226 μs | 0.1145 μs |  4.409 μs |  0.76 |    0.02 |
|           |           |                 |           |           |           |           |       |         |
| SendAsync |      main |              32 | 11.995 μs | 0.0314 μs | 0.1611 μs | 11.958 μs |  1.00 |    0.00 |
| SendAsync |        pr |              32 |  9.302 μs | 0.0153 μs | 0.0783 μs |  9.306 μs |  0.78 |    0.01 |
|           |           |                 |           |           |           |           |       |         |
| SendAsync |      main |              64 | 27.980 μs | 0.0543 μs | 0.2808 μs | 27.870 μs |  1.00 |    0.00 |
| SendAsync |        pr |              64 | 22.456 μs | 0.0496 μs | 0.2555 μs | 22.358 μs |  0.80 |    0.01 |