### PR TITLE
SkipBlockAlignmentPadding must be executed for all entries

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -225,10 +225,10 @@ namespace System.Formats.Tar
                     {
                         long bytesToSkip = _previouslyReadEntry._header._size - dataStream.Position;
                         TarHelpers.AdvanceStream(_archiveStream, bytesToSkip);
-                        TarHelpers.SkipBlockAlignmentPadding(_archiveStream, _previouslyReadEntry._header._size);
                         dataStream.HasReachedEnd = true; // Now the pointer is beyond the limit, so any read attempts should throw
                     }
                 }
+                TarHelpers.SkipBlockAlignmentPadding(_archiveStream, _previouslyReadEntry._header._size);
             }
         }
 
@@ -267,10 +267,10 @@ namespace System.Formats.Tar
                     {
                         long bytesToSkip = _previouslyReadEntry._header._size - dataStream.Position;
                         await TarHelpers.AdvanceStreamAsync(_archiveStream, bytesToSkip, cancellationToken).ConfigureAwait(false);
-                        await TarHelpers.SkipBlockAlignmentPaddingAsync(_archiveStream, _previouslyReadEntry._header._size, cancellationToken).ConfigureAwait(false);
                         dataStream.HasReachedEnd = true; // Now the pointer is beyond the limit, so any read attempts should throw
                     }
                 }
+                await TarHelpers.SkipBlockAlignmentPaddingAsync(_archiveStream, _previouslyReadEntry._header._size, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using Xunit;
 
@@ -144,6 +145,37 @@ namespace System.Formats.Tar.Tests
             TarFile.ExtractToDirectory(archive, baseDir, overwriteFiles: false);
 
             Assert.Equal(2, Directory.GetFileSystemEntries(baseDir).Count());
+        }
+
+        [Theory]
+        [InlineData(512)]
+        [InlineData(512 + 1)]
+        [InlineData(512 + 512 - 1)]
+        public void Extract_UnseekableStream_BlockAlignmentPadding_DoesNotAffectNextEntries(int contentSize)
+        {
+            byte[] fileContents = new byte[contentSize];
+            Array.Fill<byte>(fileContents, 0x1);
+
+            using var archive = new MemoryStream();
+            using (var compressor = new GZipStream(archive, CompressionMode.Compress, leaveOpen: true))
+            {
+                using var writer = new TarWriter(compressor);
+                var entry1 = new PaxTarEntry(TarEntryType.RegularFile, "file");
+                entry1.DataStream = new MemoryStream(fileContents);
+                writer.WriteEntry(entry1);
+
+                var entry2 = new PaxTarEntry(TarEntryType.RegularFile, "next-file");
+                writer.WriteEntry(entry2);
+            }
+
+            archive.Position = 0;
+            using var decompressor = new GZipStream(archive, CompressionMode.Decompress);
+            using var reader = new TarReader(decompressor);
+
+            using TempDirectory destination = new TempDirectory();
+            TarFile.ExtractToDirectory(decompressor, destination.Path, overwriteFiles: true);
+
+            Assert.Equal(2, Directory.GetFileSystemEntries(destination.Path, "*", SearchOption.AllDirectories).Count());
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -173,6 +174,37 @@ namespace System.Formats.Tar.Tests
                     Assert.Equal(2, Directory.GetFileSystemEntries(baseDir).Count());
                 }
             }
+        }
+
+        [Theory]
+        [InlineData(512)]
+        [InlineData(512 + 1)]
+        [InlineData(512 + 512 - 1)]
+        public async Task Extract_UnseekableStream_BlockAlignmentPadding_DoesNotAffectNextEntries_Async(int contentSize)
+        {
+            byte[] fileContents = new byte[contentSize];
+            Array.Fill<byte>(fileContents, 0x1);
+
+            using var archive = new MemoryStream();
+            using (var compressor = new GZipStream(archive, CompressionMode.Compress, leaveOpen: true))
+            {
+                using var writer = new TarWriter(compressor);
+                var entry1 = new PaxTarEntry(TarEntryType.RegularFile, "file");
+                entry1.DataStream = new MemoryStream(fileContents);
+                await writer.WriteEntryAsync(entry1);
+
+                var entry2 = new PaxTarEntry(TarEntryType.RegularFile, "next-file");
+                await writer.WriteEntryAsync(entry2);
+            }
+
+            archive.Position = 0;
+            using var decompressor = new GZipStream(archive, CompressionMode.Decompress);
+            using var reader = new TarReader(decompressor);
+
+            using TempDirectory destination = new TempDirectory();
+            await TarFile.ExtractToDirectoryAsync(decompressor, destination.Path, overwriteFiles: true);
+
+            Assert.Equal(2, Directory.GetFileSystemEntries(destination.Path, "*", SearchOption.AllDirectories).Count());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/74242

For entries that were not `_size % 512 == 0` we were not reading the block padding i.e: the zeroes after the entries' content was over and before the 512 block was completed. That was causing that the next entry was read with leading `0x0`s. 
FWIW: this only affected unseekable streams such as `GZipStream`.