### PR TITLE
Set modified timestamps on files being extracted from tar archives

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -529,7 +529,7 @@ namespace System.Formats.Tar
                 DataStream?.CopyTo(fs);
             }
 
-            ArchivingUtils.AttemptSetLastWriteTime(destinationFileName, ModificationTime);
+            AttemptSetLastWriteTime(destinationFileName, ModificationTime);
         }
 
         // Asynchronously extracts the current entry as a regular file into the specified destination.
@@ -551,7 +551,19 @@ namespace System.Formats.Tar
                 }
             }
 
-            ArchivingUtils.AttemptSetLastWriteTime(destinationFileName, ModificationTime);
+            AttemptSetLastWriteTime(destinationFileName, ModificationTime);
+        }
+
+        private static void AttemptSetLastWriteTime(string destinationFileName, DateTimeOffset lastWriteTime)
+        {
+            try
+            {
+                File.SetLastWriteTime(destinationFileName, lastWriteTime.LocalDateTime); // SetLastWriteTime expects local time
+            }
+            catch
+            {
+                // Some OSes like Android might not support setting the last write time, the extraction should not fail because of that
+            }
         }
 
         private FileStreamOptions CreateFileStreamOptions(bool isAsync)

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
@@ -194,7 +194,7 @@ namespace System.Formats.Tar.Tests
             Assert.Null(reader.GetNextEntry());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public void SkipRecursionIntoDirectorySymlinks()
         {
             using TempDirectory root = new TempDirectory();
@@ -225,7 +225,7 @@ namespace System.Formats.Tar.Tests
             Assert.Null(reader.GetNextEntry()); // file.txt should not be found
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public void SkipRecursionIntoBaseDirectorySymlink()
         {
             using TempDirectory root = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectoryAsync.File.Tests.cs
@@ -238,7 +238,7 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public async Task SkipRecursionIntoDirectorySymlinksAsync()
         {
             using TempDirectory root = new TempDirectory();
@@ -269,7 +269,7 @@ namespace System.Formats.Tar.Tests
             Assert.Null(await reader.GetNextEntryAsync()); // file.txt should not be found
         }
 
-        [Fact]
+        [ConditionalFact(typeof(MountHelper), nameof(MountHelper.CanCreateSymbolicLinks))]
         public async Task SkipRecursionIntoBaseDirectorySymlinkAsync()
         {
             using TempDirectory root = new TempDirectory();

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.File.Tests.cs
@@ -44,6 +44,33 @@ namespace System.Formats.Tar.Tests
             Assert.Throws<DirectoryNotFoundException>(() => TarFile.ExtractToDirectory(sourceFileName: filePath, destinationDirectoryName: dirPath, overwriteFiles: false));
         }
 
+        [Fact]
+        public void SetsLastModifiedTimeOnExtractedFiles()
+        {
+            using TempDirectory root = new TempDirectory();
+
+            string inDir = Path.Join(root.Path, "indir");
+            string inFile = Path.Join(inDir, "file");
+
+            string tarFile = Path.Join(root.Path, "file.tar");
+
+            string outDir = Path.Join(root.Path, "outdir");
+            string outFile = Path.Join(outDir, "file");
+
+            Directory.CreateDirectory(inDir);
+            File.Create(inFile).Dispose();
+            var dt = new DateTime(2001, 1, 2, 3, 4, 5, DateTimeKind.Local);
+            File.SetLastWriteTime(inFile, dt);
+
+            TarFile.CreateFromDirectory(sourceDirectoryName: inDir, destinationFileName: tarFile, includeBaseDirectory: false);
+
+            Directory.CreateDirectory(outDir);
+            TarFile.ExtractToDirectory(sourceFileName: tarFile, destinationDirectoryName: outDir, overwriteFiles: false);
+
+            Assert.True(File.Exists(outFile));
+            Assert.InRange(File.GetLastWriteTime(outFile).Ticks, dt.AddSeconds(-3).Ticks, dt.AddSeconds(3).Ticks); // include some slop for filesystem granularity
+        }
+
         [Theory]
         [InlineData(TestTarFormat.v7)]
         [InlineData(TestTarFormat.ustar)]

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.File.Tests.cs
@@ -56,6 +56,33 @@ namespace System.Formats.Tar.Tests
             }
         }
 
+        [Fact]
+        public async Task SetsLastModifiedTimeOnExtractedFiles()
+        {
+            using TempDirectory root = new TempDirectory();
+
+            string inDir = Path.Join(root.Path, "indir");
+            string inFile = Path.Join(inDir, "file");
+
+            string tarFile = Path.Join(root.Path, "file.tar");
+
+            string outDir = Path.Join(root.Path, "outdir");
+            string outFile = Path.Join(outDir, "file");
+
+            Directory.CreateDirectory(inDir);
+            File.Create(inFile).Dispose();
+            var dt = new DateTime(2001, 1, 2, 3, 4, 5, DateTimeKind.Local);
+            File.SetLastWriteTime(inFile, dt);
+
+            await TarFile.CreateFromDirectoryAsync(sourceDirectoryName: inDir, destinationFileName: tarFile, includeBaseDirectory: false);
+
+            Directory.CreateDirectory(outDir);
+            await TarFile.ExtractToDirectoryAsync(sourceFileName: tarFile, destinationDirectoryName: outDir, overwriteFiles: false);
+
+            Assert.True(File.Exists(outFile));
+            Assert.InRange(File.GetLastWriteTime(outFile).Ticks, dt.AddSeconds(-3).Ticks, dt.AddSeconds(3).Ticks); // include some slop for filesystem granularity
+        }
+
         [Theory]
         [InlineData(TestTarFormat.v7)]
         [InlineData(TestTarFormat.ustar)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/73825

Also fix some new tests which wouldn't pass un-elevated on Windows. 