### PR TITLE
[wasm-ep] Fix missing cross-origin headers when running the browser-eventpipe sample

### DIFF
--- a/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
+++ b/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
@@ -7,7 +7,7 @@
     <WasmDebugLevel>1</WasmDebugLevel>
     <WasmBuildNative>true</WasmBuildNative>
     <GenerateRunScriptForSample Condition="'$(ArchiveTests)' == 'true'">true</GenerateRunScriptForSample>
-    <RunScriptCommand>$(ExecXHarnessCmd) wasm test-browser  --app=. --browser=Chrome $(XHarnessBrowserPathArg) --html-file=index.html --output-directory=$(XHarnessOutput) -- $(MSBuildProjectName).dll</RunScriptCommand>
+    <RunScriptCommand>$(ExecXHarnessCmd) wasm test-browser  --app=. --browser=Chrome $(XHarnessBrowserPathArg) --html-file=index.html --output-directory=$(XHarnessOutput) --web-server-use-cop -- $(MSBuildProjectName).dll</RunScriptCommand>
     <FeatureWasmPerfTracing>true</FeatureWasmPerfTracing>
     <FeatureWasmThreads Condition="false">true</FeatureWasmThreads>
     <NoWarn>$(NoWarn);CA2007</NoWarn> <!-- consider ConfigureAwait() -->


### PR DESCRIPTION
The same issue that was fixed in #74342 is ocurring in the `browser-eventpipe` sample.

See [test console log](https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-74342-merge-8726f949d3714745b6/Wasm.Browser.EventPipe.Sample/1/console.269c771d.log?helixlogtype=result):
```
[1.0.0-prerelease.22411.1+5ebf69650b9f7b4ecab485be840b3022420f7812] XHarness command issued: wasm test-browser --app=. --browser=Chrome --html-file=index.html --output-directory=/datadisks/disk1/work/9EF008BC/w/8F620802/uploads/xharness-output -- Wasm.Browser.EventPipe.Sample.dll
[14:49:00] info: Starting chromedriver with args: --headless --incognito --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-renderer-backgrounding --enable-features=NetworkService,NetworkServiceInProcess --allow-insecure-localhost --disable-breakpad --disable-component-extensions-with-background-pages --disable-dev-shm-usage --disable-extensions --disable-features=TranslateUI --disable-ipc-flooding-protection --force-color-profile=srgb --metrics-recording-only
Starting ChromeDriver 100.0.4896.0 (ecbece54737a3df72a99f07de4850663ea5a48d3-refs/heads/main@{#972765}) on port 45003
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
[14:49:09] fail: [out of order message from the browser]: http://127.0.0.1:35833/dotnet.js 13:13768 Uncaught ReferenceError: SharedArrayBuffer is not defined
[15:04:01] fail: Tests timed out. Killing driver service pid 7945
[15:04:01] fail: Application has finished with exit code TIMED_OUT but 0 was expected
XHarness exit code: 71 (GENERAL_FAILURE)
```