### PR TITLE
Add tests for exotic external tar asset archives, fix some more corner case bugs

### DIFF
--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -205,6 +205,9 @@
     <value>The entry is a symbolic link or a hard link but the LinkName field is null or empty.</value>
   </data>
   <data name="TarEntryTypeNotSupported" xml:space="preserve">
+    <value>Entry type '{0}' not supported.</value>
+  </data>
+  <data name="TarEntryTypeNotSupportedInFormat" xml:space="preserve">
     <value>Entry type '{0}' not supported in format '{1}'.</value>
   </data>
   <data name="TarEntryTypeNotSupportedForExtracting" xml:space="preserve">

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -199,6 +199,10 @@ namespace System.Formats.Tar
                 case TarEntryType.HardLink:
                 case TarEntryType.SymbolicLink:
                     // No data section
+                    if (_size > 0)
+                    {
+                        throw new FormatException(string.Format(SR.TarSizeFieldTooLargeForEntryType, _typeFlag));
+                    }
                     break;
                 case TarEntryType.RegularFile:
                 case TarEntryType.V7RegularFile: // Treated as regular file
@@ -257,6 +261,10 @@ namespace System.Formats.Tar
                 case TarEntryType.HardLink:
                 case TarEntryType.SymbolicLink:
                     // No data section
+                    if (_size > 0)
+                    {
+                        throw new FormatException(string.Format(SR.TarSizeFieldTooLargeForEntryType, _typeFlag));
+                    }
                     break;
                 case TarEntryType.RegularFile:
                 case TarEntryType.V7RegularFile: // Treated as regular file

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -311,6 +311,8 @@ namespace System.Formats.Tar
             {
                 MemoryStream copiedData = new MemoryStream();
                 TarHelpers.CopyBytes(archiveStream, copiedData, _size);
+                // Reset position pointer so the user can do the first DataStream read from the beginning
+                copiedData.Position = 0;
                 return copiedData;
             }
 
@@ -336,6 +338,8 @@ namespace System.Formats.Tar
             {
                 MemoryStream copiedData = new MemoryStream();
                 await TarHelpers.CopyBytesAsync(archiveStream, copiedData, size, cancellationToken).ConfigureAwait(false);
+                // Reset position pointer so the user can do the first DataStream read from the beginning
+                copiedData.Position = 0;
                 return copiedData;
             }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -20,7 +20,7 @@ namespace System.Formats.Tar
         // Attempts to retrieve the next header from the specified tar archive stream.
         // Throws if end of stream is reached or if any data type conversion fails.
         // Returns a valid TarHeader object if the attributes were read successfully, null otherwise.
-        internal static TarHeader? TryGetNextHeader(Stream archiveStream, bool copyData, TarEntryFormat initialFormat)
+        internal static TarHeader? TryGetNextHeader(Stream archiveStream, bool copyData, TarEntryFormat initialFormat, bool processDataBlock)
         {
             // The four supported formats have a header that fits in the default record size
             Span<byte> buffer = stackalloc byte[TarHelpers.RecordSize];
@@ -28,7 +28,7 @@ namespace System.Formats.Tar
             archiveStream.ReadExactly(buffer);
 
             TarHeader? header = TryReadAttributes(initialFormat, buffer);
-            if (header != null)
+            if (header != null && processDataBlock)
             {
                 header.ProcessDataBlock(archiveStream, copyData);
             }
@@ -39,7 +39,7 @@ namespace System.Formats.Tar
         // Asynchronously attempts read all the fields of the next header.
         // Throws if end of stream is reached or if any data type conversion fails.
         // Returns true if all the attributes were read successfully, false otherwise.
-        internal static async ValueTask<TarHeader?> TryGetNextHeaderAsync(Stream archiveStream, bool copyData, TarEntryFormat initialFormat, CancellationToken cancellationToken)
+        internal static async ValueTask<TarHeader?> TryGetNextHeaderAsync(Stream archiveStream, bool copyData, TarEntryFormat initialFormat, bool processDataBlock, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -50,7 +50,7 @@ namespace System.Formats.Tar
             await archiveStream.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
 
             TarHeader? header = TryReadAttributes(initialFormat, buffer.Span);
-            if (header != null)
+            if (header != null && processDataBlock)
             {
                 await header.ProcessDataBlockAsync(archiveStream, copyData, cancellationToken).ConfigureAwait(false);
             }
@@ -180,7 +180,7 @@ namespace System.Formats.Tar
         //   will get all the data section read and the stream pointer positioned at the beginning of the next header.
         // - Block, Character, Directory, Fifo, HardLink and SymbolicLink typeflag entries have no data section so the archive stream pointer will be positioned at the beginning of the next header.
         // - All other typeflag entries with a data section will generate a stream wrapping the data section: SeekableSubReadStream for seekable archive streams, and SubReadStream for unseekable archive streams.
-        private void ProcessDataBlock(Stream archiveStream, bool copyData)
+        internal void ProcessDataBlock(Stream archiveStream, bool copyData)
         {
             bool skipBlockAlignmentPadding = true;
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -408,11 +408,12 @@ namespace System.Formats.Tar
                     TarEntryType.LongPath or
                     TarEntryType.MultiVolume or
                     TarEntryType.RenamedOrSymlinked or
-                    TarEntryType.SparseFile or
                     TarEntryType.TapeVolume => TarEntryFormat.Gnu,
 
                     // V7 is the only one that uses 'V7RegularFile'.
                     TarEntryType.V7RegularFile => TarEntryFormat.V7,
+
+                    TarEntryType.SparseFile => throw new NotSupportedException(string.Format(SR.TarEntryTypeNotSupported, header._typeFlag)),
 
                     // We can quickly determine the *minimum* possible format if the entry type
                     // is the POSIX 'RegularFile', although later we could upgrade it to PAX or GNU

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -203,6 +203,12 @@ namespace System.Formats.Tar
         internal static T ParseOctal<T>(ReadOnlySpan<byte> buffer) where T : struct, INumber<T>
         {
             buffer = TrimEndingNullsAndSpaces(buffer);
+            buffer = TrimTrailingNullsAndSpaces(buffer);
+
+            if (buffer.Length == 0)
+            {
+                return T.Zero;
+            }
 
             T octalFactor = T.CreateTruncating(8u);
             T value = T.Zero;
@@ -241,6 +247,17 @@ namespace System.Formats.Tar
             }
 
             return buffer.Slice(0, trimmedLength);
+        }
+
+        private static ReadOnlySpan<byte> TrimTrailingNullsAndSpaces(ReadOnlySpan<byte> buffer)
+        {
+            int newStart = 0;
+            while (newStart < buffer.Length && buffer[newStart] is 0 or 32)
+            {
+                newStart++;
+            }
+
+            return buffer.Slice(newStart);
         }
 
         // Returns the ASCII string contained in the specified buffer of bytes,

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -203,7 +203,7 @@ namespace System.Formats.Tar
         internal static T ParseOctal<T>(ReadOnlySpan<byte> buffer) where T : struct, INumber<T>
         {
             buffer = TrimEndingNullsAndSpaces(buffer);
-            buffer = TrimTrailingNullsAndSpaces(buffer);
+            buffer = TrimLeadingNullsAndSpaces(buffer);
 
             if (buffer.Length == 0)
             {
@@ -249,7 +249,7 @@ namespace System.Formats.Tar
             return buffer.Slice(0, trimmedLength);
         }
 
-        private static ReadOnlySpan<byte> TrimTrailingNullsAndSpaces(ReadOnlySpan<byte> buffer)
+        private static ReadOnlySpan<byte> TrimLeadingNullsAndSpaces(ReadOnlySpan<byte> buffer)
         {
             int newStart = 0;
             while (newStart < buffer.Length && buffer[newStart] is 0 or 32)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -368,7 +368,7 @@ namespace System.Formats.Tar
                     throw new FormatException(string.Format(SR.TarInvalidFormat, archiveFormat));
             }
 
-            throw new InvalidOperationException(string.Format(SR.TarEntryTypeNotSupported, entryType, archiveFormat));
+            throw new InvalidOperationException(string.Format(SR.TarEntryTypeNotSupportedInFormat, entryType, archiveFormat));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -19,7 +19,6 @@ namespace System.Formats.Tar
         private readonly bool _leaveOpen;
         private TarEntry? _previouslyReadEntry;
         private List<Stream>? _dataStreamsToDispose;
-        private bool _readFirstEntry;
         private bool _reachedEndMarkers;
 
         internal Stream _archiveStream;
@@ -44,7 +43,6 @@ namespace System.Formats.Tar
 
             _previouslyReadEntry = null;
             _isDisposed = false;
-            _readFirstEntry = false;
             _reachedEndMarkers = false;
         }
 
@@ -124,11 +122,6 @@ namespace System.Formats.Tar
             TarHeader? header = TryGetNextEntryHeader(copyData);
             if (header != null)
             {
-                if (!_readFirstEntry)
-                {
-                    _readFirstEntry = true;
-                }
-
                 TarEntry entry = header._format switch
                 {
                     TarEntryFormat.Pax => header._typeFlag is TarEntryType.GlobalExtendedAttributes ?
@@ -282,11 +275,6 @@ namespace System.Formats.Tar
             TarHeader? header = await TryGetNextEntryHeaderAsync(copyData, cancellationToken).ConfigureAwait(false);
             if (header != null)
             {
-                if (!_readFirstEntry)
-                {
-                    _readFirstEntry = true;
-                }
-
                 TarEntry entry = header._format switch
                 {
                     TarEntryFormat.Pax => header._typeFlag is TarEntryType.GlobalExtendedAttributes ?

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -125,5 +126,163 @@ namespace System.Formats.Tar.Tests
         [InlineData(TarEntryFormat.Gnu, TestTarFormat.oldgnu)]
         public Task Read_Archive_LongPath_Over255_Async(TarEntryFormat format, TestTarFormat testFormat) =>
             Read_Archive_LongPath_Over255_Async_Internal(format, testFormat);
+
+        [Theory]
+        [MemberData(nameof(GetV7TestCaseNames))]
+        public Task ReadDataStreamOfTarGzV7Async(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.v7, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetUstarTestCaseNames))]
+        public Task ReadDataStreamOfTarGzUstarAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.ustar, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public Task ReadDataStreamOfTarGzPaxAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.pax, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public Task ReadDataStreamOfTarGzPaxGeaAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.pax_gea, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public Task ReadDataStreamOfTarGzOldGnuAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.oldgnu, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public Task ReadDataStreamOfTarGzGnuAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.gnu, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetV7TestCaseNames))]
+        public Task ReadCopiedDataStreamOfTarGzV7Async(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.v7, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetUstarTestCaseNames))]
+        public Task ReadCopiedDataStreamOfTarGzUstarAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.ustar, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public Task ReadCopiedDataStreamOfTarGzPaxAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.pax, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public Task ReadCopiedDataStreamOfTarGzPaxGeaAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.pax_gea, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public Task ReadCopiedDataStreamOfTarGzOldGnuAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.oldgnu, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public Task ReadCopiedDataStreamOfTarGzGnuAsync(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternalAsync(TestTarFormat.gnu, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetGoLangTarTestCaseNames))]
+        public Task ReadDataStreamOfExternalAssetsGoLangAsync(string testCaseName)
+        {
+            if (ShouldSkipGoLangAsset(testCaseName))
+            {
+                return Task.CompletedTask;
+            }
+            return VerifyDataStreamOfTarUncompressedInternalAsync("golang_tar", testCaseName, copyData: false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNodeTarTestCaseNames))]
+        public Task ReadDataStreamOfExternalAssetsNodeAsync(string testCaseName) =>
+            VerifyDataStreamOfTarUncompressedInternalAsync("node-tar", testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetRsTarTestCaseNames))]
+        public Task ReadDataStreamOfExternalAssetsRsAsync(string testCaseName)
+        {
+            if (testCaseName == "spaces")
+            {
+                // Tested separately
+                return Task.CompletedTask;
+            }
+            return VerifyDataStreamOfTarUncompressedInternalAsync("tar-rs", testCaseName, copyData: false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetGoLangTarTestCaseNames))]
+        public Task ReadCopiedDataStreamOfExternalAssetsGoLangAsync(string testCaseName)
+        {
+            if (ShouldSkipGoLangAsset(testCaseName))
+            {
+                return Task.CompletedTask;
+            }
+            return VerifyDataStreamOfTarUncompressedInternalAsync("golang_tar", testCaseName, copyData: true);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNodeTarTestCaseNames))]
+        public Task ReadCopiedDataStreamOfExternalAssetsNodeAsync(string testCaseName) =>
+            VerifyDataStreamOfTarUncompressedInternalAsync("node-tar", testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetRsTarTestCaseNames))]
+        public Task ReadCopiedDataStreamOfExternalAssetsRsAsync(string testCaseName)
+        {
+            if (testCaseName == "spaces")
+            {
+                // Tested separately
+                return Task.CompletedTask;
+            }
+            return VerifyDataStreamOfTarUncompressedInternalAsync("tar-rs", testCaseName, copyData: true);
+        }
+
+        private static async Task VerifyDataStreamOfTarUncompressedInternalAsync(string testFolderName, string testCaseName, bool copyData)
+        {
+            await using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, testFolderName, testCaseName);
+            await VerifyDataStreamOfTarInternalAsync(archiveStream, copyData);
+        }
+
+        private static async Task VerifyDataStreamOfTarGzInternalAsync(TestTarFormat testTarFormat, string testCaseName, bool copyData)
+        {
+            await using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.GZip, testTarFormat, testCaseName);
+            await using GZipStream decompressor = new GZipStream(archiveStream, CompressionMode.Decompress);
+            await VerifyDataStreamOfTarInternalAsync(decompressor, copyData);
+        }
+
+        private static async Task VerifyDataStreamOfTarInternalAsync(Stream archiveStream, bool copyData)
+        {
+            await using TarReader reader = new TarReader(archiveStream);
+
+            TarEntry entry;
+
+            await using MemoryStream ms = new MemoryStream();
+            while ((entry = await reader.GetNextEntryAsync(copyData)) != null)
+            {
+                if (entry.EntryType is TarEntryType.V7RegularFile or TarEntryType.RegularFile)
+                {
+                    if (entry.Length == 0)
+                    {
+                        Assert.Null(entry.DataStream);
+                    }
+                    else
+                    {
+                        Assert.NotNull(entry.DataStream);
+                        Assert.Equal(entry.DataStream.Length, entry.Length);
+                        if (copyData)
+                        {
+                            Assert.True(entry.DataStream.CanSeek);
+                            Assert.Equal(0, entry.DataStream.Position);
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -4,8 +4,10 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using Xunit;
+using static System.Formats.Tar.Tests.TarTestsBase;
 
 namespace System.Formats.Tar.Tests
 {
@@ -125,28 +127,159 @@ namespace System.Formats.Tar.Tests
         public void Read_Archive_LongPath_Over255(TarEntryFormat format, TestTarFormat testFormat) =>
             Read_Archive_LongPath_Over255_Internal(format, testFormat);
 
-        [Fact]
-        public void Read_NodeTarArchives_Successfully()
+        [Theory]
+        [MemberData(nameof(GetV7TestCaseNames))]
+        public void ReadDataStreamOfTarGzV7(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.v7, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetUstarTestCaseNames))]
+        public void ReadDataStreamOfTarGzUstar(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.ustar, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public void ReadDataStreamOfTarGzPax(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.pax, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public void ReadDataStreamOfTarGzPaxGea(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.pax_gea, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public void ReadDataStreamOfTarGzOldGnu(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.oldgnu, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public void ReadDataStreamOfTarGzGnu(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.gnu, testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetV7TestCaseNames))]
+        public void ReadCopiedDataStreamOfTarGzV7(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.v7, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetUstarTestCaseNames))]
+        public void ReadCopiedDataStreamOfTarGzUstar(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.ustar, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public void ReadCopiedDataStreamOfTarGzPax(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.pax, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public void ReadCopiedDataStreamOfTarGzPaxGea(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.pax_gea, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public void ReadCopiedDataStreamOfTarGzOldGnu(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.oldgnu, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
+        public void ReadCopiedDataStreamOfTarGzGnu(string testCaseName) =>
+            VerifyDataStreamOfTarGzInternal(TestTarFormat.gnu, testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetGoLangTarTestCaseNames))]
+        public void ReadDataStreamOfExternalAssetsGoLang(string testCaseName)
         {
-            string nodeTarPath = Path.Join(Directory.GetCurrentDirectory(), "tar", "node-tar");
-            foreach (string file in Directory.EnumerateFiles(nodeTarPath, "*.tar", SearchOption.AllDirectories))
+            if (ShouldSkipGoLangAsset(testCaseName))
             {
-                using FileStream sourceStream = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.Read);
-                using var reader = new TarReader(sourceStream);
+                return;
+            }
+            VerifyDataStreamOfTarUncompressedInternal("golang_tar", testCaseName, copyData: false);
+        }
 
-                TarEntry? entry = null;
-                while (true)
+        [Theory]
+        [MemberData(nameof(GetNodeTarTestCaseNames))]
+        public void ReadDataStreamOfExternalAssetsNode(string testCaseName) =>
+            VerifyDataStreamOfTarUncompressedInternal("node-tar", testCaseName, copyData: false);
+
+        [Theory]
+        [MemberData(nameof(GetRsTarTestCaseNames))]
+        public void ReadDataStreamOfExternalAssetsRs(string testCaseName)
+        {
+            if (testCaseName == "spaces")
+            {
+                // Tested separately
+                return;
+            }
+            VerifyDataStreamOfTarUncompressedInternal("tar-rs", testCaseName, copyData: false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetGoLangTarTestCaseNames))]
+        public void ReadCopiedDataStreamOfExternalAssetsGoLang(string testCaseName)
+        {
+            if (ShouldSkipGoLangAsset(testCaseName))
+            {
+                return;
+            }
+            VerifyDataStreamOfTarUncompressedInternal("golang_tar", testCaseName, copyData: true);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNodeTarTestCaseNames))]
+        public void ReadCopiedDataStreamOfExternalAssetsNode(string testCaseName) =>
+            VerifyDataStreamOfTarUncompressedInternal("node-tar", testCaseName, copyData: true);
+
+        [Theory]
+        [MemberData(nameof(GetRsTarTestCaseNames))]
+        public void ReadCopiedDataStreamOfExternalAssetsRs(string testCaseName)
+        {
+            if (testCaseName == "spaces")
+            {
+                // Tested separately
+                return;
+            }
+            VerifyDataStreamOfTarUncompressedInternal("tar-rs", testCaseName, copyData: true);
+        }
+
+        private static void VerifyDataStreamOfTarUncompressedInternal(string testFolderName, string testCaseName, bool copyData)
+        {
+            using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, testFolderName, testCaseName);
+            VerifyDataStreamOfTarInternal(archiveStream, copyData);
+        }
+
+        private static void VerifyDataStreamOfTarGzInternal(TestTarFormat testTarFormat, string testCaseName, bool copyData)
+        {
+            using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.GZip, testTarFormat, testCaseName);
+            using GZipStream decompressor = new GZipStream(archiveStream, CompressionMode.Decompress);
+            VerifyDataStreamOfTarInternal(decompressor, copyData);
+        }
+
+        private static void VerifyDataStreamOfTarInternal(Stream archiveStream, bool copyData)
+        {
+            using TarReader reader = new TarReader(archiveStream);
+
+            TarEntry entry;
+
+            while ((entry = reader.GetNextEntry(copyData)) != null)
+            {
+                if (entry.EntryType is TarEntryType.V7RegularFile or TarEntryType.RegularFile)
                 {
-                    Exception ex = Record.Exception(() => entry = reader.GetNextEntry());
-                    Assert.Null(ex);
-
-                    if (entry is null) break;
-
-                    ex = Record.Exception(() => entry.Name);
-                    Assert.Null(ex);
-
-                    ex = Record.Exception(() => entry.Length);
-                    Assert.Null(ex);
+                    if (entry.Length == 0)
+                    {
+                        Assert.Null(entry.DataStream);
+                    }
+                    else
+                    {
+                        Assert.NotNull(entry.DataStream);
+                        Assert.Equal(entry.DataStream.Length, entry.Length);
+                        if (copyData)
+                        {
+                            Assert.True(entry.DataStream.CanSeek);
+                            Assert.Equal(0, entry.DataStream.Position);
+                        }
+                    }
                 }
             }
         }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -252,10 +252,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(512)]
-        [InlineData(512 + 1)]
-        [InlineData(512 + 512 - 1)]
-        public void BlockAlignmentPadding_DoesNotAffectNextEntries(int contentSize)
+        [InlineData(512, false)]
+        [InlineData(512, true)]
+        [InlineData(512 + 1, false)]
+        [InlineData(512 + 1, true)]
+        [InlineData(512 + 512 - 1, false)]
+        [InlineData(512 + 512 - 1, true)]
+        public void BlockAlignmentPadding_DoesNotAffectNextEntries(int contentSize, bool copyData)
         {
             byte[] fileContents = new byte[contentSize];
             Array.Fill<byte>(fileContents, 0x1);
@@ -275,17 +278,17 @@ namespace System.Formats.Tar.Tests
             using var unseekable = new WrappedStream(archive, archive.CanRead, archive.CanWrite, canSeek: false);
             using var reader = new TarReader(unseekable);
 
-            TarEntry e = reader.GetNextEntry();
+            TarEntry e = reader.GetNextEntry(copyData);
             Assert.Equal(contentSize, e.Length);
 
             byte[] buffer = new byte[contentSize];
             while (e.DataStream.Read(buffer) > 0) ;
             AssertExtensions.SequenceEqual(fileContents, buffer);
 
-            e = reader.GetNextEntry();
+            e = reader.GetNextEntry(copyData);
             Assert.Equal(0, e.Length);
 
-            e = reader.GetNextEntry();
+            e = reader.GetNextEntry(copyData);
             Assert.Null(e);
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
@@ -290,10 +290,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData(512)]
-        [InlineData(512 + 1)]
-        [InlineData(512 + 512 - 1)]
-        public async Task BlockAlignmentPadding_DoesNotAffectNextEntries_Async(int contentSize)
+        [InlineData(512, false)]
+        [InlineData(512, true)]
+        [InlineData(512 + 1, false)]
+        [InlineData(512 + 1, true)]
+        [InlineData(512 + 512 - 1, false)]
+        [InlineData(512 + 512 - 1, true)]
+        public async Task BlockAlignmentPadding_DoesNotAffectNextEntries_Async(int contentSize, bool copyData)
         {
             byte[] fileContents = new byte[contentSize];
             Array.Fill<byte>(fileContents, 0x1);
@@ -313,17 +316,17 @@ namespace System.Formats.Tar.Tests
             using var unseekable = new WrappedStream(archive, archive.CanRead, archive.CanWrite, canSeek: false);
             using var reader = new TarReader(unseekable);
 
-            TarEntry e = await reader.GetNextEntryAsync();
+            TarEntry e = await reader.GetNextEntryAsync(copyData);
             Assert.Equal(contentSize, e.Length);
 
             byte[] buffer = new byte[contentSize];
             while (e.DataStream.Read(buffer) > 0) ;
             AssertExtensions.SequenceEqual(fileContents, buffer);
 
-            e = await reader.GetNextEntryAsync();
+            e = await reader.GetNextEntryAsync(copyData);
             Assert.Equal(0, e.Length);
 
-            e = await reader.GetNextEntryAsync();
+            e = await reader.GetNextEntryAsync(copyData);
             Assert.Null(e);
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -118,45 +118,25 @@ namespace System.Formats.Tar.Tests
         {
             "empty",
             "file-and-dir",
-            "gnu-incremental",
             "gnu-long-nul",
-            "gnu-multi-hdrs",
-            "gnu-nil-sparse-data",
-            "gnu-nil-sparse-hole",
             "gnu-not-utf8",
-            "gnu-sparse-big",
             "gnu-utf8",
             "gnu",
             "hardlink",
-            "hdr-only",
-            "invalid-go17",
-            "issue10968",
-            "issue11169",
-            "issue12435",
-            "neg-size",
             "nil-uid",
             "pax-bad-hdr-file",
             "pax-bad-mtime-file",
             "pax-global-records",
-            "pax-multi-hdrs",
-            "pax-nil-sparse-data",
-            "pax-nil-sparse-hole",
             "pax-nul-path",
             "pax-nul-xattrs",
-            "pax-path-hdr",
             "pax-pos-size-file",
             "pax-records",
-            "pax-sparse-big",
             "pax",
-            "sparse-formats",
             "star",
             "trailing-slash",
             "ustar-file-devs",
             "ustar-file-reg",
             "ustar",
-            "v7",
-            "writer-big-long",
-            "writer-big",
             "writer",
             "xattrs"
         };
@@ -195,9 +175,6 @@ namespace System.Formats.Tar.Tests
             "reading_files",
             "simple_missing_last_header",
             "simple",
-            "spaces",
-            "sparse-1",
-            "sparse",
             "xattrs"
         };
 
@@ -633,24 +610,6 @@ namespace System.Formats.Tar.Tests
             {
                 yield return new object[] { name };
             }
-        }
-
-        public static bool ShouldSkipGoLangAsset(string testCaseName)
-        {
-            return testCaseName is
-                "gnu-multi-hdrs" or // More than one consecutive LongPath metadata entry found
-                "hdr-only" or //
-                "invalid-go17" or //
-                "issue10968" or //
-                "issue11169" or //
-                "issue12435" or //
-                "neg-size" or //
-                "pax-multi-hdrs" or // More than one consecutive extended attributes header found
-                "pax-path-hdr" or //
-                "sparse-formats" or //
-                "v7" or //
-                "writer-big-long" or //
-                "writer-big";
         }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/74316 (excludes libarchive, which were not added as assets)

src changes:
- Remove unused `_readFirstEntry` field in `TarReader`.
- Add `processDataBlock` bool argument to `TryGetNextHeader` so that in the case of Pax, we don't read the data block until after we process the extended attributes, in case `size` is encountered among them and we override the original value.
- Throw more clearly when encountering a sparse entry. We won't support it for 7.0.
- Throw when encountering a size field > 0 in entries where data is not expected.
- When copying data, make sure that the freshly created memory stream is rewinded so that the user's first call of `DataStream` returns a stream positioned in the first byte, instead of the last byte.
- For octal fields, trim leading nulls and whitespaces. We already trim trailing nulls and whitespaces. @am11 https://github.com/dotnet/runtime/pull/74358 my changes would conflict a lot with yours. I kept the change as simple and clear as possible, and only confined it to those two characters.

test changes:
- Cover all the new external exotic assets, with added explanations for those that had to be special cased.
- Make sure to test copyData as much as possible, both in uncompressed and gzipped archives.
- Added the copyData argument to the recently added tests in https://github.com/dotnet/runtime/pull/74396 cc @Jozkee .
- Sync and async.
