### PR TITLE
[release/7.0-rc1] Remove assert from Http3Connection.SendAsync

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -240,7 +240,7 @@ namespace System.Net.Http
             catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
             {
                 // This will happen if we aborted _connection somewhere and we have pending OpenOutboundStreamAsync call.
-                Debug.Assert(_abortException is not null);
+                // note that _abortException may be null if we closed the connection in response to a GOAWAY frame
                 throw new HttpRequestException(SR.net_http_client_execution_error, _abortException, RequestRetryType.RetryOnConnectionFailure);
             }
             finally
@@ -566,6 +566,10 @@ namespace System.Net.Http
                             return;
                     }
                 }
+            }
+            catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
+            {
+                // ignore the exception, we have already closed the connection
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/74348 to release/7.0-rc1

## Customer Impact
None, this change affects only tests (Asserts don't run in Release configuration). We have seen an increased number of crashes on Debug runs on Alpine Linux where we recently enabled HTTP/3 test coverage. This PR serves to mainly de-noise CI reports.

## Testing
Functional tests pass on CI, and the affected test was run many times in a tight loop on the affected configuration.

## Risk
Low (or None even). The change does not affect the behavior of shipped product.