### PR TITLE
Expose JsonSerializer.IsReadOnly and MakeReadOnly() APIs.

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -350,6 +350,7 @@ namespace System.Text.Json
         public bool IgnoreReadOnlyFields { get { throw null; } set { } }
         public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
         public bool IncludeFields { get { throw null; } set { } }
+        public bool IsReadOnly { get { throw null; } }
         public int MaxDepth { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonNumberHandling NumberHandling { get { throw null; } set { } }
         public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
@@ -364,6 +365,7 @@ namespace System.Text.Json
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Getting a converter for a type may require reflection which depends on unreferenced code.")]
         public System.Text.Json.Serialization.JsonConverter GetConverter(System.Type typeToConvert) { throw null; }
         public System.Text.Json.Serialization.Metadata.JsonTypeInfo GetTypeInfo(System.Type type) { throw null; }
+        public void MakeReadOnly() { }
     }
     public enum JsonTokenType : byte
     {

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -336,7 +336,7 @@
   <data name="TrailingCommaNotAllowedBeforeObjectEnd" xml:space="preserve">
     <value>The JSON object contains a trailing comma at the end which is not supported in this mode. Change the reader options.</value>
   </data>
-  <data name="SerializerOptionsImmutable" xml:space="preserve">
+  <data name="SerializerOptionsReadOnly" xml:space="preserve">
     <value>Serializer options cannot be changed once serialization or deserialization has occurred.</value>
   </data>
   <data name="StreamNotWritable" xml:space="preserve">
@@ -578,7 +578,7 @@
   <data name="NodeDuplicateKey" xml:space="preserve">
     <value>An item with the same key has already been added. Key: {0}</value>
   </data>
-  <data name="SerializerContextOptionsImmutable" xml:space="preserve">
+  <data name="SerializerContextOptionsReadOnly" xml:space="preserve">
     <value>JsonSerializerOptions instances cannot be modified once encapsulated by a JsonSerializerContext. Such encapsulation can happen either when calling 'JsonSerializerOptions.AddContext' or when passing the options instance to a JsonSerializerContext constructor.</value>
   </data>
   <data name="ConverterForPropertyMustBeValid" xml:space="preserve">
@@ -659,8 +659,8 @@
   <data name="JsonPropertyInfoBoundToDifferentParent" xml:space="preserve">
     <value>JsonPropertyInfo with name '{0}' for type '{1}' is already bound to different JsonTypeInfo.</value>
   </data>
-  <data name="JsonTypeInfoUsedButTypeInfoResolverNotSet" xml:space="preserve">
-    <value>JsonTypeInfo metadata references a JsonSerializerOptions instance that doesn't specify a TypeInfoResolver.</value>
+  <data name="JsonSerializerOptionsNoTypeInfoResolverSpecified" xml:space="preserve">
+    <value>JsonSerializerOptions instance must specify a TypeInfoResolver setting before being marked as read-only.</value>
   </data>
   <data name="JsonPolymorphismOptionsAssociatedWithDifferentJsonTypeInfo" xml:space="preserve">
     <value>Parameter already associated with a different JsonTypeInfo instance.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -24,13 +24,25 @@ namespace System.Text.Json.Serialization
         /// </remarks>
         public JsonSerializerOptions Options
         {
-            get => _options ??= new JsonSerializerOptions { TypeInfoResolver = this, IsImmutable = true };
+            get
+            {
+                JsonSerializerOptions? options = _options;
+
+                if (options is null)
+                {
+                    options = new JsonSerializerOptions { TypeInfoResolver = this };
+                    options.MakeReadOnly();
+                    _options = options;
+                }
+
+                return options;
+            }
 
             internal set
             {
-                Debug.Assert(!value.IsImmutable);
+                Debug.Assert(!value.IsReadOnly);
                 value.TypeInfoResolver = this;
-                value.IsImmutable = true;
+                value.MakeReadOnly();
                 _options = value;
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -57,7 +57,7 @@ namespace System.Text.Json
         {
             JsonTypeInfo? typeInfo = null;
 
-            if (IsImmutable)
+            if (IsReadOnly)
             {
                 typeInfo = GetCachingContext()?.GetOrAddJsonTypeInfo(type);
                 if (ensureConfigured)
@@ -111,7 +111,7 @@ namespace System.Text.Json
         {
             get
             {
-                Debug.Assert(IsImmutable);
+                Debug.Assert(IsReadOnly);
                 return _objectTypeInfo ??= GetTypeInfoInternal(JsonTypeInfo.ObjectType);
             }
         }
@@ -127,7 +127,7 @@ namespace System.Text.Json
 
         private CachingContext? GetCachingContext()
         {
-            Debug.Assert(IsImmutable);
+            Debug.Assert(IsReadOnly);
 
             return _cachingContext ??= TrackedCachingContexts.GetOrCreate(this);
         }
@@ -178,7 +178,7 @@ namespace System.Text.Json
 
             public static CachingContext GetOrCreate(JsonSerializerOptions options)
             {
-                Debug.Assert(options.IsImmutable, "Cannot create caching contexts for mutable JsonSerializerOptions instances");
+                Debug.Assert(options.IsReadOnly, "Cannot create caching contexts for mutable JsonSerializerOptions instances");
                 Debug.Assert(options._typeInfoResolver != null);
 
                 ConcurrentDictionary<JsonSerializerOptions, WeakReference<CachingContext>> cache = s_cache;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -531,9 +531,9 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(Monitor.IsEntered(_configureLock), "Configure called directly, use EnsureConfigured which locks this method");
 
-            if (!Options.IsImmutable)
+            if (!Options.IsReadOnly)
             {
-                Options.InitializeForMetadataGeneration();
+                Options.MakeReadOnly();
             }
 
             PropertyInfoForTypeInfo.EnsureChildOf(this);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -139,9 +139,9 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_JsonTypeInfoUsedButTypeInfoResolverNotSet()
+        public static void ThrowInvalidOperationException_JsonSerializerOptionsNoTypeInfoResolverSpecified()
         {
-            throw new InvalidOperationException(SR.JsonTypeInfoUsedButTypeInfoResolverNotSet);
+            throw new InvalidOperationException(SR.JsonSerializerOptionsNoTypeInfoResolverSpecified);
         }
 
         [DoesNotReturn]
@@ -170,11 +170,11 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_SerializerOptionsImmutable(JsonSerializerContext? context)
+        public static void ThrowInvalidOperationException_SerializerOptionsReadOnly(JsonSerializerContext? context)
         {
             string message = context == null
-                ? SR.SerializerOptionsImmutable
-                : SR.SerializerContextOptionsImmutable;
+                ? SR.SerializerOptionsReadOnly
+                : SR.SerializerContextOptionsReadOnly;
 
             throw new InvalidOperationException(message);
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -144,6 +144,7 @@ namespace System.Text.Json.Serialization.Tests
             options.MakeReadOnly();
             Assert.True(options.IsReadOnly);
             options.MakeReadOnly(); // Is idempotent operation
+            Assert.True(options.IsReadOnly);
 
             Assert.Throws<InvalidOperationException>(() => options.MaxDepth = 13);
             Assert.Throws<InvalidOperationException>(() => options.Converters.Add(new JsonStringEnumConverter()));
@@ -151,6 +152,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<InvalidOperationException>(() => options.TypeInfoResolver = null);
 
             options.MakeReadOnly(); // Is still idempotent operation
+            Assert.True(options.IsReadOnly);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -136,10 +136,46 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void NewDefaultOptions_IsNotReadOnly()
+        {
+            var options = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+            Assert.False(options.IsReadOnly);
+
+            options.MakeReadOnly();
+            Assert.True(options.IsReadOnly);
+            options.MakeReadOnly(); // Is idempotent operation
+
+            Assert.Throws<InvalidOperationException>(() => options.MaxDepth = 13);
+            Assert.Throws<InvalidOperationException>(() => options.Converters.Add(new JsonStringEnumConverter()));
+            Assert.Throws<InvalidOperationException>(() => options.AddContext<JsonContext>());
+            Assert.Throws<InvalidOperationException>(() => options.TypeInfoResolver = null);
+
+            options.MakeReadOnly(); // Is still idempotent operation
+        }
+
+        [Fact]
+        public static void NewDefaultOptions_MakeReadOnly_NoTypeInfoResolver_ThrowsInvalidOperation()
+        {
+            var options = new JsonSerializerOptions();
+            Assert.False(options.IsReadOnly);
+
+            Assert.Throws<InvalidOperationException>(() => options.MakeReadOnly());
+            Assert.False(options.IsReadOnly);
+
+            options.TypeInfoResolver = new DefaultJsonTypeInfoResolver();
+            options.MakeReadOnly();
+            Assert.True(options.IsReadOnly);
+        }
+
+        [Fact]
         public static void TypeInfoResolverCannotBeSetAfterAddingContext()
         {
             var options = new JsonSerializerOptions();
+            Assert.False(options.IsReadOnly);
+
             options.AddContext<JsonContext>();
+            Assert.True(options.IsReadOnly);
+
             Assert.IsType<JsonContext>(options.TypeInfoResolver);
             Assert.Throws<InvalidOperationException>(() => options.TypeInfoResolver = new DefaultJsonTypeInfoResolver());
         }
@@ -614,12 +650,16 @@ namespace System.Text.Json.Serialization.Tests
         public static void CopyConstructor_OriginalLocked()
         {
             JsonSerializerOptions options = new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+            Assert.False(options.IsReadOnly);
 
             // Perform serialization with options, after which it will be locked.
             JsonSerializer.Serialize("1", options);
+
+            Assert.True(options.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => options.ReferenceHandler = ReferenceHandler.Preserve);
 
             var newOptions = new JsonSerializerOptions(options);
+            Assert.False(newOptions.IsReadOnly);
             VerifyOptionsEqual(options, newOptions);
 
             // No exception is thrown on mutating the new options instance because it is "unlocked".
@@ -710,6 +750,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void JsonSerializerOptions_Default_IsReadOnly()
         {
             var optionsSingleton = JsonSerializerOptions.Default;
+            Assert.True(optionsSingleton.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => optionsSingleton.IncludeFields = true);
             Assert.Throws<InvalidOperationException>(() => optionsSingleton.Converters.Add(new JsonStringEnumConverter()));
             Assert.Throws<InvalidOperationException>(() => optionsSingleton.AddContext<JsonContext>());
@@ -719,6 +760,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<InvalidOperationException>(() => resolver.Modifiers.Clear());
             Assert.Throws<InvalidOperationException>(() => resolver.Modifiers.Add(ti => { }));
             Assert.Throws<InvalidOperationException>(() => resolver.Modifiers.Insert(0, ti => { }));
+
+            optionsSingleton.MakeReadOnly(); // MakeReadOnly is idempontent.
         }
 
         [Fact]
@@ -726,6 +769,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             var options = new JsonSerializerOptions();
             var newOptions = new JsonSerializerOptions(JsonSerializerDefaults.General);
+            Assert.False(newOptions.IsReadOnly);
             VerifyOptionsEqual(options, newOptions);
         }
 
@@ -757,8 +801,8 @@ namespace System.Text.Json.Serialization.Tests
 
                 if (propertyType == typeof(bool))
                 {
-                    // IgnoreNullValues and DefaultIgnoreCondition cannot be active at the same time.
-                    if (property.Name != "IgnoreNullValues")
+                    if (property.Name is not nameof(JsonSerializerOptions.IgnoreNullValues) // IgnoreNullValues and DefaultIgnoreCondition cannot be active at the same time.
+                                        and not nameof(JsonSerializerOptions.IsReadOnly)) // Property is not structural and cannot be set.
                     {
                         property.SetValue(options, true);
                     }
@@ -815,6 +859,11 @@ namespace System.Text.Json.Serialization.Tests
 
                 if (propertyType == typeof(bool))
                 {
+                    if (property.Name == nameof(JsonSerializerOptions.IsReadOnly))
+                    {
+                        break; // readonly-ness is not a structural property of JsonSerializerOptions.
+                    }
+
                     Assert.Equal((bool)property.GetValue(options), (bool)property.GetValue(newOptions));
                 }
                 else if (propertyType == typeof(int))
@@ -834,19 +883,19 @@ namespace System.Text.Json.Serialization.Tests
                 }
                 else if (propertyType.IsValueType)
                 {
-                    if (property.Name == "ReadCommentHandling")
+                    if (property.Name == nameof(JsonSerializerOptions.ReadCommentHandling))
                     {
                         Assert.Equal(options.ReadCommentHandling, newOptions.ReadCommentHandling);
                     }
-                    else if (property.Name == "DefaultIgnoreCondition")
+                    else if (property.Name == nameof(JsonSerializerOptions.DefaultIgnoreCondition))
                     {
                         Assert.Equal(options.DefaultIgnoreCondition, newOptions.DefaultIgnoreCondition);
                     }
-                    else if (property.Name == "NumberHandling")
+                    else if (property.Name == nameof(JsonSerializerOptions.NumberHandling))
                     {
                         Assert.Equal(options.NumberHandling, newOptions.NumberHandling);
                     }
-                    else if (property.Name == "UnknownTypeHandling")
+                    else if (property.Name == nameof(JsonSerializerOptions.UnknownTypeHandling))
                     {
                         Assert.Equal(options.UnknownTypeHandling, newOptions.UnknownTypeHandling);
                     }
@@ -988,10 +1037,13 @@ namespace System.Text.Json.Serialization.Tests
             jti.Properties.Clear();
 
             var value = new TestClassForEncoding { MyString = "SomeValue" };
+            Assert.False(options.IsReadOnly);
+
             string json = JsonSerializer.Serialize(value, jti);
             Assert.Equal("{}", json);
 
             // Using JsonTypeInfo will lock JsonSerializerOptions
+            Assert.True(options.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => options.IncludeFields = false);
 
             // Getting JsonTypeInfo now should return a fresh immutable instance


### PR DESCRIPTION
Fix #54482.