### PR TITLE
[mono] Disable failing Globalization and Transactions tests

### DIFF
--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -183,6 +183,7 @@ namespace System.Globalization.Tests
         [MemberData(nameof(IndexOf_TestData))]
         [MemberData(nameof(IndexOf_Aesc_Ligature_TestData))]
         [MemberData(nameof(IndexOf_U_WithDiaeresis_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74179", TestRuntimes.Mono)]
         public void IndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected, int expectedMatchLength)
         {
             if (value.Length == 1)

--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -864,6 +864,7 @@ namespace System.Globalization.Tests
 
         [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(IndexOf_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74179", TestRuntimes.Mono)]
         public void TestIndexOf(string source, string value, int startIndex, int count, CompareOptions options, int result)
         {
             foreach (string cul in s_cultureNames)
@@ -911,6 +912,7 @@ namespace System.Globalization.Tests
 
         [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(LastIndexOf_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74179", TestRuntimes.Mono)]
         public void TestLastIndexOf(string source, string value, int startIndex, int count, CompareOptions options, int result)
         {
             foreach (string cul in s_cultureNames)

--- a/src/libraries/System.Transactions.Local/tests/OleTxTests.cs
+++ b/src/libraries/System.Transactions.Local/tests/OleTxTests.cs
@@ -13,6 +13,7 @@ namespace System.Transactions.Tests;
 #nullable enable
 
 [PlatformSpecific(TestPlatforms.Windows)]
+[SkipOnMono("COM Interop not supported on Mono")]
 public class OleTxTests : IClassFixture<OleTxTests.OleTxFixture>
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(1);


### PR DESCRIPTION
The System.Transactions.Tests.OleTxTests aren't supported by Mono on Windows: #74187
Fixes #74187

The System.Globalization test failure is a real issue that is being investigated: #74179
Disable tests against #74179