### PR TITLE
[debugger][wasm] Fixes trying to evaluate a debugger helper function in a non-wasm page.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1539,8 +1539,9 @@ namespace Microsoft.WebAssembly.Diagnostics
             ExecutionContext context = GetContext(sessionId);
             if (Interlocked.CompareExchange(ref context.ready, new TaskCompletionSource<DebugStore>(), null) != null)
                 return await context.ready.Task;
-
-            await context.SdbAgent.SendDebuggerAgentCommand(CmdEventRequest.ClearAllBreakpoints, null, token);
+            var res = await context.SdbAgent.SendDebuggerAgentCommand(CmdEventRequest.ClearAllBreakpoints, null, token, false);
+            if (res.HasError) //it's not a wasm page then the command returns an error
+                return null;
 
             if (context.PauseOnExceptions != PauseOnExceptionsKind.None && context.PauseOnExceptions != PauseOnExceptionsKind.Unset)
                 await context.SdbAgent.EnableExceptions(context.PauseOnExceptions, token);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -470,8 +470,10 @@ namespace DebuggerTests
                 });
         }
 
-        [ConditionalFact(nameof(RunningOnChrome))]
-        public async Task CreateGoodBreakpointAndHitGoToNonWasmPageComeBackAndHitAgain()
+        [ConditionalTheory(nameof(RunningOnChrome))]
+        [InlineData("load_non_wasm_page")]
+        [InlineData("load_non_wasm_page_forcing_runtime_ready")] //to simulate the same behavior that has when debugging from VS and OnDefaultContextCreated is called
+        public async Task CreateGoodBreakpointAndHitGoToNonWasmPageComeBackAndHitAgain(string func_name)
         {
             var bp = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 10, 8);
             var pause_location = await EvaluateAndCheck(
@@ -500,7 +502,7 @@ namespace DebuggerTests
 
             var run_method = JObject.FromObject(new
             {
-                expression = "window.setTimeout(function() { load_non_wasm_page(); }, 1);"
+                expression = "window.setTimeout(function() { " + func_name + "(); }, 1);"
             });
             await cli.SendCommand("Runtime.evaluate", run_method, token);
             await Task.Delay(1000, token);

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html
@@ -92,6 +92,10 @@
 			console.log("load_wasm_page_without_assets")
 			window.location.replace("http://localhost:9400/wasm-page-without-assets.html");
 		}
+		function load_non_wasm_page_forcing_runtime_ready () {
+			console.log("load_non_wasm_page_forcing_runtime_ready")
+			window.location.replace("http://localhost:9400/non-wasm-page-forcing-runtime-ready.html");
+		}
 		</script>
 
 		<script type="text/javascript" src="other.js"></script>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <WasmExtraFilesToDeploy Include="debugger-driver.html" />
     <WasmExtraFilesToDeploy Include="non-wasm-page.html" />
+    <WasmExtraFilesToDeploy Include="non-wasm-page-forcing-runtime-ready.html" />
     <WasmExtraFilesToDeploy Include="wasm-page-without-assets.html" />
     <WasmExtraFilesToDeploy Include="other.js" />
     <WasmExtraFilesToDeploy Include="weather.json" />

--- a/src/mono/wasm/debugger/tests/debugger-test/non-wasm-page-forcing-runtime-ready.html
+++ b/src/mono/wasm/debugger/tests/debugger-test/non-wasm-page-forcing-runtime-ready.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en-us">
+	<head>
+	</head>
+	<body>
+	<script type='text/javascript'>
+		console.debug ("#debugger-app-ready#");
+		console.debug("mono_wasm_runtime_ready", "fe00e07a-5519-4dfe-b35a-f867dbaf2e28");
+		function reload_wasm_page () {
+			window.location.replace("http://localhost:9400/debugger-driver.html");
+		}
+	</script>
+	</body>
+</html>


### PR DESCRIPTION
This will only happen when debugging from VS because we receive a Runtime.executionContextCreated and try to check RuntimeReady, then we call SendDebuggerAgentCommand and this was throwing an exception.

To force this behavior in the test case I created a new test case that will force a call to RuntimeReady in a non-wasm-page.

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/1557
Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/1559
Fixes https://github.com/dotnet/runtime/issues/74064