### PR TITLE
[release/7.0-rc1] Disable VerifyXmlResolver test.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1593,6 +1593,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74115")]
         public void VerifyXmlResolver(bool provideResolver)
         {
             HttpListener listener;


### PR DESCRIPTION
Backports #74417 to release/7.0-rc1. Contributes to #74115.

## Customer Impact
None, this change disables a test that has been flaky in CI.

## Testing
N/A.

## Risk
Low. Only disables a flaky test.