### PR TITLE
Backport: work around GitHub .patch URL issue

### DIFF
--- a/eng/actions/backport/index.js
+++ b/eng/actions/backport/index.js
@@ -67,7 +67,9 @@ async function run() {
     } catch { }
 
     // download and apply patch
-    await exec.exec(`curl -sSL "${github.context.payload.issue.pull_request.patch_url}" --output changes.patch`);
+    let patch_url = github.context.payload.issue.pull_request.patch_url;
+    patch_url = patch_url.replace("runtime", "RUNTIME");
+    await exec.exec(`curl -sSL "${patch_url}" --output changes.patch`);
 
     const git_am_command = "git am --3way --ignore-whitespace --keep-non-patch changes.patch";
     let git_am_output = `$ ${git_am_command}\n\n`;


### PR DESCRIPTION
`https://github.com/dotnet/RUNTIME/pull/74433.patch` works but `https://github.com/dotnet/runtime/pull/74433.patch` leads to 404, opened a ticket with GitHub: `#1757301`