### PR TITLE
[LoongArch64] supporting `src/tests/run.sh` on LA64.

### DIFF
--- a/eng/native/init-os-and-arch.sh
+++ b/eng/native/init-os-and-arch.sh
@@ -13,7 +13,7 @@ FreeBSD|Linux|NetBSD|OpenBSD|SunOS|Android)
 Darwin)
     os=OSX ;;
 *)
-    echo "Unsupported OS $OSName detected !"
+    echo "Unsupported OS $OSName detected!"
     exit 1 ;;
 esac
 

--- a/eng/native/init-os-and-arch.sh
+++ b/eng/native/init-os-and-arch.sh
@@ -13,8 +13,8 @@ FreeBSD|Linux|NetBSD|OpenBSD|SunOS|Android)
 Darwin)
     os=OSX ;;
 *)
-    echo "Unsupported OS $OSName detected, configuring as if for Linux"
-    os=Linux ;;
+    echo "Unsupported OS $OSName detected !"
+    exit 1 ;;
 esac
 
 # On Solaris, `uname -m` is discouraged, see https://docs.oracle.com/cd/E36784_01/html/E36870/uname-1.html
@@ -74,7 +74,7 @@ case "$CPUName" in
 	arch=ppc64le
 	;;
     *)
-        echo "Unknown CPU $CPUName detected, configuring as if for x64"
-        arch=x64
+        echo "Unknown CPU $CPUName detected!"
+        exit 1
         ;;
 esac

--- a/src/coreclr/scripts/coreclr_arguments.py
+++ b/src/coreclr/scripts/coreclr_arguments.py
@@ -63,7 +63,7 @@ class CoreclrArguments:
         self.require_built_core_root = require_built_core_root
         self.require_built_test_dir = require_built_test_dir
 
-        self.valid_arches = ["x64", "x86", "arm", "arm64", "wasm"]
+        self.valid_arches = ["x64", "x86", "arm", "arm64", "loongarch64", "wasm"]
         self.valid_build_types = ["Debug", "Checked", "Release"]
         self.valid_host_os = ["windows", "OSX", "Linux", "illumos", "Solaris", "Browser", "Android"]
 

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -11,7 +11,7 @@ function print_usage {
     echo 'Optional arguments:'
     echo '  -h|--help                        : Show usage information.'
     echo '  -v, --verbose                    : Show output from each test.'
-    echo '  <arch>                           : One of x64, x86, arm, arm64, loongarch64, riscv64, wasm. Defaults to x64.'
+    echo '  <arch>                           : One of x64, x86, arm, arm64, loongarch64, riscv64, wasm. Defaults to current architecture.'
     echo '  Android                          : Set build OS to Android.'
     echo '  --test-env=<path>                : Script to set environment variables for tests'
     echo '  --testRootDir=<path>             : Root directory of the test build (e.g. runtime/artifacts/tests/windows.x64.Debug).'
@@ -39,55 +39,14 @@ function print_usage {
     echo '  --limitedDumpGeneration          : '
 }
 
-function check_cpu_architecture {
-    local CPUName=$(uname -m)
-    local __arch=
-
-    if [[ "$(uname -s)" == "SunOS" ]]; then
-        CPUName=$(isainfo -n)
-    fi
-
-    case $CPUName in
-        i686)
-            __arch=x86
-            ;;
-        amd64|x86_64)
-            __arch=x64
-            ;;
-        armv7l)
-            __arch=arm
-            ;;
-        aarch64|arm64)
-            __arch=arm64
-            ;;
-        loongarch64)
-            __arch=loongarch64
-            ;;
-        riscv64)
-            __arch=riscv64
-            ;;
-        *)
-            echo "Unknown CPU $CPUName detected, configuring as if for x64"
-            __arch=x64
-            ;;
-    esac
-
-    echo "$__arch"
-}
-
-################################################################################
-# Handle Arguments
-################################################################################
-
-ARCH=$(check_cpu_architecture)
-
 # Exit code constants
 readonly EXIT_CODE_SUCCESS=0       # Script ran normally.
 readonly EXIT_CODE_EXCEPTION=1     # Script exited because something exceptional happened (e.g. bad arguments, Ctrl-C interrupt).
 readonly EXIT_CODE_TEST_FAILURE=2  # Script completed successfully, but one or more tests failed.
 
 # Argument variables
-buildArch=$ARCH
+source "$repoRootDir/eng/native/init-os-and-arch.sh"
+buildArch="$arch"
 buildOS=
 buildConfiguration="Debug"
 testRootDir=

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -11,7 +11,7 @@ function print_usage {
     echo 'Optional arguments:'
     echo '  -h|--help                        : Show usage information.'
     echo '  -v, --verbose                    : Show output from each test.'
-    echo '  <arch>                           : One of x64, x86, arm, arm64, loongarch64, riscv64, wasm. Defaults to current architecture.'
+    echo '  <arch>                           : One of x64, x86, arm, arm64, loongarch64, riscv64, wasm. Defaults to x64.'
     echo '  Android                          : Set build OS to Android.'
     echo '  --test-env=<path>                : Script to set environment variables for tests'
     echo '  --testRootDir=<path>             : Root directory of the test build (e.g. runtime/artifacts/tests/windows.x64.Debug).'
@@ -128,6 +128,9 @@ do
             ;;
         arm64)
             buildArch="arm64"
+            ;;
+        loongarch64)
+            buildArch="loongarch64"
             ;;
         wasm)
             buildArch="wasm"


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

supporting the `src/tests/run.sh` on LA64.