### PR TITLE
Attempt to reduce test build cost

### DIFF
--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+ // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // ===========================================================================
 // File: zapsig.cpp

--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -1,4 +1,4 @@
- // Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // ===========================================================================
 // File: zapsig.cpp

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -565,7 +565,7 @@ $(BashCLRTestExitCodeCheck)
       File="$(ExecutionBashScriptPath)"
       Lines="$(_CLRTestExecutionScriptText)"
       Overwrite="true" />
-<!--     <Exec Command="chmod +x $(ExecutionBashScriptPath)" EchoOff="true" /> -->
+    <Exec Condition="'$(SkipChmodOfGeneratedCommandScript)' != 'true'" Command="chmod +x $(ExecutionBashScriptPath)" EchoOff="true" />
   </Target>
 
 </Project>

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -565,7 +565,7 @@ $(BashCLRTestExitCodeCheck)
       File="$(ExecutionBashScriptPath)"
       Lines="$(_CLRTestExecutionScriptText)"
       Overwrite="true" />
-    <Exec Command="chmod +x $(ExecutionBashScriptPath)" EchoOff="true" />
+<!--     <Exec Command="chmod +x $(ExecutionBashScriptPath)" EchoOff="true" /> -->
   </Target>
 
 </Project>

--- a/src/tests/Common/dir.traversal.targets
+++ b/src/tests/Common/dir.traversal.targets
@@ -93,7 +93,7 @@
     <MSBuild Targets="$(DefaultCopyAllNativeTestProjectBinariesTarget)"
              Projects="@(Project)"
              Condition="'$(SerializeProjects)'!='true'"
-             Properties="BuildAllProjects=true"
+             Properties="BuildAllProjects=true;SkipChmodOfGeneratedCommandScript=true"
              BuildInParallel="true"
              ContinueOnError="ErrorAndContinue" />
 

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -49,7 +49,9 @@
          Each of the test groups is meant to be built by a separate MSBuild invocation with specified $(__TestGroupToBuild) property. -->
     <ItemGroup Condition=" '$(CLRTestPriorityToBuild)' == '0' ">
 
-      <!-- Fast filter to avoid files with Pri1 projects, this isn't completely accurate, but its close -->
+      <!-- Fast filter to avoid files with Pri1 projects, this isn't completely accurate, but its close. Any Pri1 tests not caught by this will be skipped,
+           and any tests intended as Pri0 will end up running as Pri1, which isn't terrible. This trick allows us to avoid loading each project into msbuild
+           and evaluating it, which is a substantial improvement to the performance of the "Copy native test components to test output folder" task in our test runs  -->
       <Pri1Projects Include="@(AllProjects)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($([System.IO.File]::ReadAllText('%(AllProjects.FullPath)')), '&lt;CLRTestPriority&gt;1&lt;/CLRTestPriority&gt;'))" />
 
       <AllProjects Remove="@(Pri1Projects)" />

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -45,11 +45,15 @@
       <AllProjects Include="$(TestRoot)**\*.fsproj" Exclude="@(DisabledProjects)" />
       <AllProjects Include="$(TestRoot)**\*.ilproj" Exclude="@(DisabledProjects)" />
     </ItemGroup>
-
     <!-- All the test projects are partitioned into the test groups as defined below.
          Each of the test groups is meant to be built by a separate MSBuild invocation with specified $(__TestGroupToBuild) property. -->
-
     <ItemGroup Condition=" '$(CLRTestPriorityToBuild)' == '0' ">
+
+      <!-- Fast filter to avoid files with Pri1 projects, this isn't completely accurate, but its close -->
+      <Pri1Projects Include="@(AllProjects)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($([System.IO.File]::ReadAllText('%(AllProjects.FullPath)')), '&lt;CLRTestPriority&gt;1&lt;/CLRTestPriority&gt;'))" />
+
+      <AllProjects Remove="@(Pri1Projects)" />
+
       <!-- Group number k consists of all the test projects P such that _GroupStartsWith(k) <= P.Identity < _GroupStartsWith(k+1).
            In other words, ItemGroup _GroupStartsWith defines boundaries between the test groups. -->
 


### PR DESCRIPTION
An evaluation of the cost of "Copy native test components to test output folder" indicates that there are 2 major performance bottlenecks in that routine.

There are the findings I had
1. The routine spends significant time loading every test project into msbuild to determine what to do. This processing takes as much as 400ms per test on hardware which has slow IO performance.
2. On Unix platforms, when producing the test script binaries, we make the scripts executable by using chmod. This ALSO takes as long as 400ms on the slowest platforms.
3. Actually copying the native binaries around is extremely cheap and fast, and the cost to generate the test scripts is also fairly low.

This change addresses both of these issues.
1. For the issue that we look into each test project to determine what to do, I observed that for tests which are pri1 tests, when running a pri0 only job, we don't need to even examine any of the tests marked as exclusively pri1. This is a bit of a hack, but it does seem to work quite well.
2. For the chmod issue, since we don't actually maintain the executable bit when sent to helix, I set an msbuild property when generating the scripts during the "Copy native test components to test output folder" to just not set that flag.

Results:
Mac OSX test run jobs take ~8 minutes to run this portion of the build, down from ~27 minutes. Performance improvements are visible on all architectures/OS pairings, but they aren't as dramatic.