### PR TITLE
Fix naming in interop code generation

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -434,9 +434,9 @@ namespace Internal.TypeSystem.Interop
                     return MarshallerKind.Invalid;
                 }
 
-                if (!isField && InteropTypes.IsInt128Type(context, type))
+                if (!isField && ((DefType)type).IsInt128OrHasInt128Fields)
                 {
-                    // Int128 types cannot be passed by value
+                    // Int128 types or structs that contain them cannot be passed by value
                     return MarshallerKind.Invalid;
                 }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/InteropTypes.cs
@@ -137,11 +137,6 @@ namespace Internal.TypeSystem.Interop
             return IsCoreNamedType(context, type, "System.Runtime.Intrinsics", "Vector64`1");
         }
 
-        public static bool IsInt128Type(TypeSystemContext context, TypeDesc type)
-        {
-            return type is DefType defType && defType.IsInt128OrHasInt128Fields;
-        }
-
         public static bool IsSystemRuntimeIntrinsicsVector128T(TypeSystemContext context, TypeDesc type)
         {
             return IsCoreNamedType(context, type, "System.Runtime.Intrinsics", "Vector128`1");


### PR DESCRIPTION
The name of the method was a lie. The comment was a lie.