### PR TITLE
Throw on incompatible WebSocket options

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.WebSockets.Client/src/Resources/Strings.resx
@@ -130,9 +130,9 @@
     <value>The WebSocket failed to negotiate max client window bits. The client requested {0} but the server responded with {1}.</value>
   </data>
   <data name="net_WebSockets_OptionsIncompatibleWithCustomInvoker" xml:space="preserve">
-    <value>UseDefaultCredentials, Credentials, Proxy, ClientCertificates, RemoteCertificateValidationCallback and Cookies must not be set on ClientWebSocketOptions when using a custom HttpMessageInvoker instance. These options should be set on the underlying HttpMessageHandler instead.</value>
+    <value>UseDefaultCredentials, Credentials, Proxy, ClientCertificates, RemoteCertificateValidationCallback and Cookies must not be set on ClientWebSocketOptions when an HttpMessageInvoker instance is also specified. These options should be set on the HttpMessageInvoker's underlying HttpMessageHandler instead.</value>
   </data>
   <data name="net_WebSockets_CustomInvokerRequiredForHttp2" xml:space="preserve">
-    <value>A custom HttpMessageInvoker instance must be passed to ConnectAsync when using HTTP/2.</value>
+    <value>An HttpMessageInvoker instance must be passed to ConnectAsync when using HTTP/2.</value>
   </data>
 </root>

--- a/src/libraries/System.Net.WebSockets.Client/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.WebSockets.Client/src/Resources/Strings.resx
@@ -129,4 +129,10 @@
   <data name="net_WebSockets_ClientWindowBitsNegotiationFailure" xml:space="preserve">
     <value>The WebSocket failed to negotiate max client window bits. The client requested {0} but the server responded with {1}.</value>
   </data>
+  <data name="net_WebSockets_OptionsIncompatibleWithCustomInvoker" xml:space="preserve">
+    <value>UseDefaultCredentials, Credentials, Proxy, ClientCertificates, RemoteCertificateValidationCallback and Cookies must not be set on ClientWebSocketOptions when using a custom HttpMessageInvoker instance. These options should be set on the underlying HttpMessageHandler instead.</value>
+  </data>
+  <data name="net_WebSockets_CustomInvokerRequiredForHttp2" xml:space="preserve">
+    <value>A custom HttpMessageInvoker instance must be passed to ConnectAsync when using HTTP/2.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
@@ -30,6 +30,14 @@ namespace System.Net.WebSockets
         private HttpVersionPolicy _versionPolicy = HttpVersionPolicy.RequestVersionOrLower;
         private bool _collectHttpResponseDetails;
 
+        internal bool AreCompatibleWithCustomInvoker() =>
+            !UseDefaultCredentials &&
+            Credentials is null &&
+            (_clientCertificates?.Count ?? 0) == 0 &&
+            RemoteCertificateValidationCallback is null &&
+            Cookies is null &&
+            (Proxy is null || Proxy == WebSocketHandle.DefaultWebProxy.Instance);
+
         internal ClientWebSocketOptions() { } // prevent external instantiation
 
         #region HTTP Settings

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -48,9 +48,22 @@ namespace System.Net.WebSockets
         public async Task ConnectAsync(Uri uri, HttpMessageInvoker? invoker, CancellationToken cancellationToken, ClientWebSocketOptions options)
         {
             bool disposeHandler = false;
-            invoker ??= new HttpMessageInvoker(SetupHandler(options, out disposeHandler));
-            HttpResponseMessage? response = null;
+            if (invoker is null)
+            {
+                if (options.HttpVersion.Major >= 2 || options.HttpVersionPolicy == HttpVersionPolicy.RequestVersionOrHigher)
+                {
+                    throw new ArgumentException(SR.net_WebSockets_CustomInvokerRequiredForHttp2, nameof(options));
+                }
 
+                invoker = new HttpMessageInvoker(SetupHandler(options, out disposeHandler));
+            }
+            else if (!options.AreCompatibleWithCustomInvoker())
+            {
+                // This will not throw if the Proxy is a DefaultWebProxy.
+                throw new ArgumentException(SR.net_WebSockets_OptionsIncompatibleWithCustomInvoker, nameof(options));
+            }
+
+            HttpResponseMessage? response = null;
             bool disposeResponse = false;
 
             // force non-secure request to 1.1 whenever it is possible as HttpClient does
@@ -237,12 +250,7 @@ namespace System.Net.WebSockets
             // Create the handler for this request and populate it with all of the options.
             // Try to use a shared handler rather than creating a new one just for this request, if
             // the options are compatible.
-            if (options.Credentials == null &&
-                !options.UseDefaultCredentials &&
-                options.Proxy == null &&
-                options.Cookies == null &&
-                options.RemoteCertificateValidationCallback == null &&
-                (options._clientCertificates?.Count ?? 0) == 0)
+            if (options.AreCompatibleWithCustomInvoker() && options.Proxy is null)
             {
                 disposeHandler = false;
                 handler = s_defaultHandler;
@@ -518,7 +526,7 @@ namespace System.Net.WebSockets
         }
 
         /// <summary>Used as a sentinel to indicate that ClientWebSocket should use the system's default proxy.</summary>
-        private sealed class DefaultWebProxy : IWebProxy
+        internal sealed class DefaultWebProxy : IWebProxy
         {
             public static DefaultWebProxy Instance { get; } = new DefaultWebProxy();
             public ICredentials? Credentials { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }

--- a/src/libraries/System.Net.WebSockets.Client/tests/AbortTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/AbortTest.cs
@@ -16,14 +16,14 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public InvokerAbortTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpMessageInvoker(new SocketsHttpHandler());
+        protected override bool UseCustomInvoker => true;
     }
 
     public sealed class HttpClientAbortTest : AbortTest
     {
         public HttpClientAbortTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseHttpClient => true;
     }
 
     public class AbortTest : ClientWebSocketTestBase

--- a/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -14,14 +14,14 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public InvokerCancelTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpMessageInvoker(new SocketsHttpHandler());
+        protected override bool UseCustomInvoker => true;
     }
 
     public sealed class HttpClientCancelTest : CancelTest
     {
         public HttpClientCancelTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseHttpClient => true;
     }
 
     public class CancelTest : ClientWebSocketTestBase

--- a/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Net.Test.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,13 +9,10 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using System.Net.Http;
-using System.Net.WebSockets.Client.Tests;
+using System.Diagnostics;
 
 namespace System.Net.WebSockets.Client.Tests
 {
-    /// <summary>
-    /// ClientWebSocket tests that do require a remote server.
-    /// </summary>
     public class ClientWebSocketTestBase
     {
         public static readonly object[][] EchoServers = System.Net.Test.Common.Configuration.WebSockets.EchoServers;
@@ -112,7 +108,36 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        protected virtual HttpMessageInvoker? GetInvoker() => null;
+        protected virtual bool UseCustomInvoker => false;
+
+        protected virtual bool UseHttpClient => false;
+
+        protected bool UseSharedHandler => !UseCustomInvoker && !UseHttpClient;
+
+        protected Action<HttpClientHandler>? ConfigureCustomHandler;
+
+        internal HttpMessageInvoker? GetInvoker()
+        {
+            var handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+            };
+
+            ConfigureCustomHandler?.Invoke(handler);
+
+            if (UseCustomInvoker)
+            {
+                Debug.Assert(!UseHttpClient);
+                return new HttpMessageInvoker(handler);
+            }
+
+            if (UseHttpClient)
+            {
+                return new HttpClient(handler);
+            }
+
+            return null;
+        }
 
         protected Task<ClientWebSocket> GetConnectedWebSocket(Uri uri, int TimeOutMilliseconds, ITestOutputHelper output) =>
             WebSocketHelper.GetConnectedWebSocket(uri, TimeOutMilliseconds, output, invoker: GetInvoker());

--- a/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
@@ -118,10 +118,12 @@ namespace System.Net.WebSockets.Client.Tests
 
         internal HttpMessageInvoker? GetInvoker()
         {
-            var handler = new HttpClientHandler
+            var handler = new HttpClientHandler();
+
+            if (PlatformDetection.IsNotBrowser)
             {
-                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-            };
+                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            }
 
             ConfigureCustomHandler?.Invoke(handler);
 

--- a/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -18,14 +18,14 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public InvokerCloseTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpMessageInvoker(new SocketsHttpHandler());
+        protected override bool UseCustomInvoker => true;
     }
 
     public sealed class HttpClientCloseTest : CloseTest
     {
         public HttpClientCloseTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseHttpClient => true;
     }
 
     public class CloseTest : ClientWebSocketTestBase

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
@@ -43,6 +43,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [Theory]
         [MemberData(nameof(ConnectAsync_Http2WithNoInvoker_ThrowsArgumentException_MemberData))]
+        [SkipOnPlatform(TestPlatforms.Browser, "HTTP/2 WebSockets aren't supported on Browser")]
         public async Task ConnectAsync_Http2WithNoInvoker_ThrowsArgumentException(Action<ClientWebSocketOptions> configureOptions)
         {
             using var ws = new ClientWebSocket();

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.Http2.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Net.Test.Common;
 using System.Threading;
@@ -11,34 +10,58 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-using static System.Net.Http.Functional.Tests.TestHelper;
-
 namespace System.Net.WebSockets.Client.Tests
 {
     public sealed class InvokerConnectTest_Http2 : ConnectTest_Http2
     {
         public InvokerConnectTest_Http2(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseCustomInvoker => true;
     }
 
     public sealed class HttpClientConnectTest_Http2 : ConnectTest_Http2
     {
         public HttpClientConnectTest_Http2(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseHttpClient => true;
     }
 
-    public class ConnectTest_Http2 : ClientWebSocketTestBase
+    public sealed class HttpClientConnectTest_Http2_NoInvoker : ClientWebSocketTestBase
+    {
+        public HttpClientConnectTest_Http2_NoInvoker(ITestOutputHelper output) : base(output) { }
+
+        public static IEnumerable<object[]> ConnectAsync_Http2WithNoInvoker_ThrowsArgumentException_MemberData()
+        {
+            yield return Options(options => options.HttpVersion = HttpVersion.Version20);
+            yield return Options(options => options.HttpVersion = HttpVersion.Version30);
+            yield return Options(options => options.HttpVersion = new Version(2, 1));
+            yield return Options(options => options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher);
+
+            static object[] Options(Action<ClientWebSocketOptions> configureOptions) =>
+                new object[] { configureOptions };
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectAsync_Http2WithNoInvoker_ThrowsArgumentException_MemberData))]
+        public async Task ConnectAsync_Http2WithNoInvoker_ThrowsArgumentException(Action<ClientWebSocketOptions> configureOptions)
+        {
+            using var ws = new ClientWebSocket();
+            configureOptions(ws.Options);
+
+            Task connectTask = ws.ConnectAsync(new Uri("wss://dummy"), CancellationToken.None);
+
+            Assert.Equal(TaskStatus.Faulted, connectTask.Status);
+            await Assert.ThrowsAsync<ArgumentException>("options", () => connectTask);
+        }
+    }
+
+    public abstract class ConnectTest_Http2 : ClientWebSocketTestBase
     {
         public ConnectTest_Http2(ITestOutputHelper output) : base(output) { }
 
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform")]
-        public async Task ConnectAsync_VersionNotSupported_NoSsl_Throws(bool useHandler)
+        public async Task ConnectAsync_VersionNotSupported_NoSsl_Throws()
         {
             await Http2LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
@@ -46,17 +69,10 @@ namespace System.Net.WebSockets.Client.Tests
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
                     cws.Options.HttpVersion = HttpVersion.Version20;
-                    cws.Options.HttpVersionPolicy = Http.HttpVersionPolicy.RequestVersionExact;
-                    Task t;
-                    if (useHandler)
-                    {
-                        var handler = new SocketsHttpHandler();
-                        t = cws.ConnectAsync(uri, new HttpMessageInvoker(handler), cts.Token);
-                    }
-                    else
-                    {
-                        t = cws.ConnectAsync(uri, cts.Token);
-                    }
+                    cws.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+                    Task t = cws.ConnectAsync(uri, GetInvoker(), cts.Token);
+
                     var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
                     Assert.IsType<HttpRequestException>(ex.InnerException);
                     Assert.True(ex.InnerException.Data.Contains("SETTINGS_ENABLE_CONNECT_PROTOCOL"));
@@ -65,8 +81,7 @@ namespace System.Net.WebSockets.Client.Tests
             async server =>
             {
                 Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.EnableConnect, Value = 0 });
-            }, new Http2Options() { WebSocketEndpoint = true, UseSsl = false }
-            );
+            }, new Http2Options() { WebSocketEndpoint = true, UseSsl = false });
         }
 
         [Fact]
@@ -79,10 +94,9 @@ namespace System.Net.WebSockets.Client.Tests
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
                     cws.Options.HttpVersion = HttpVersion.Version20;
-                    cws.Options.HttpVersionPolicy = Http.HttpVersionPolicy.RequestVersionExact;
-                    Task t;
-                    var handler = CreateSocketsHttpHandler(allowAllCertificates: true);
-                    t = cws.ConnectAsync(uri, new HttpMessageInvoker(handler), cts.Token);
+                    cws.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+                    Task t = cws.ConnectAsync(uri, GetInvoker(), cts.Token);
 
                     var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
                     Assert.IsType<HttpRequestException>(ex.InnerException);
@@ -92,31 +106,22 @@ namespace System.Net.WebSockets.Client.Tests
             async server =>
             {
                 Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.EnableConnect, Value = 0 });
-            }, new Http2Options() { WebSocketEndpoint = true }
-            );
+            }, new Http2Options() { WebSocketEndpoint = true });
         }
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
-        [Theory]
-        [MemberData(nameof(SecureEchoServersAndBoolean))]
+        [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform")]
-        public async Task ConnectAsync_Http11Server_DowngradeFail(Uri server, bool useHandler)
+        public async Task ConnectAsync_Http11Server_DowngradeFail()
         {
             using (var cws = new ClientWebSocket())
             using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
             {
                 cws.Options.HttpVersion = HttpVersion.Version20;
-                cws.Options.HttpVersionPolicy = Http.HttpVersionPolicy.RequestVersionExact;
-                Task t;
-                if (useHandler)
-                {
-                    var handler = new SocketsHttpHandler();
-                    t = cws.ConnectAsync(server, new HttpMessageInvoker(handler), cts.Token);
-                }
-                else
-                {
-                    t = cws.ConnectAsync(server, cts.Token);
-                }
+                cws.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+                Task t = cws.ConnectAsync(Test.Common.Configuration.WebSockets.SecureRemoteEchoServer, GetInvoker(), cts.Token);
+
                 var ex = await Assert.ThrowsAnyAsync<WebSocketException>(() => t);
                 Assert.IsType<HttpRequestException>(ex.InnerException);
                 Assert.True(ex.InnerException.Data.Contains("HTTP2_ENABLED"));
@@ -126,34 +131,23 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory]
-        [MemberData(nameof(EchoServersAndBoolean))]
+        [MemberData(nameof(EchoServers))]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform")]
-        public async Task ConnectAsync_Http11Server_DowngradeSuccess(Uri server, bool useHandler)
+        public async Task ConnectAsync_Http11Server_DowngradeSuccess(Uri server)
         {
             using (var cws = new ClientWebSocket())
             using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
             {
                 cws.Options.HttpVersion = HttpVersion.Version20;
-                cws.Options.HttpVersionPolicy = Http.HttpVersionPolicy.RequestVersionOrLower;
-                if (useHandler)
-                {
-                    var handler = new SocketsHttpHandler();
-                    await cws.ConnectAsync(server, new HttpMessageInvoker(handler), cts.Token);
-                }
-                else
-                {
-                    await cws.ConnectAsync(server, cts.Token);
-                }
+                cws.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+                await cws.ConnectAsync(server, GetInvoker(), cts.Token);
                 Assert.Equal(WebSocketState.Open, cws.State);
             }
         }
 
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform")]
-        public async Task ConnectAsync_VersionSupported_NoSsl_Success(bool useHandler)
+        public async Task ConnectAsync_VersionSupported_NoSsl_Success()
         {
             await Http2LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
@@ -161,16 +155,8 @@ namespace System.Net.WebSockets.Client.Tests
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
                     cws.Options.HttpVersion = HttpVersion.Version20;
-                    cws.Options.HttpVersionPolicy = Http.HttpVersionPolicy.RequestVersionExact;
-                    if (useHandler)
-                    {
-                        var handler = new SocketsHttpHandler();
-                        await cws.ConnectAsync(uri, new HttpMessageInvoker(handler), cts.Token);
-                    }
-                    else
-                    {
-                        await cws.ConnectAsync(uri, cts.Token);
-                    }
+                    cws.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                    await cws.ConnectAsync(uri, GetInvoker(), cts.Token);
                 }
             },
             async server =>
@@ -178,8 +164,7 @@ namespace System.Net.WebSockets.Client.Tests
                 Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.EnableConnect, Value = 1 });
                 (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
                 await connection.SendResponseHeadersAsync(streamId, endStream: false, HttpStatusCode.OK);
-            }, new Http2Options() { WebSocketEndpoint = true, UseSsl = false }
-            );
+            }, new Http2Options() { WebSocketEndpoint = true, UseSsl = false });
         }
 
         [Fact]
@@ -192,10 +177,8 @@ namespace System.Net.WebSockets.Client.Tests
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
                     cws.Options.HttpVersion = HttpVersion.Version20;
-                    cws.Options.HttpVersionPolicy = Http.HttpVersionPolicy.RequestVersionExact;
-
-                    var handler = CreateSocketsHttpHandler(allowAllCertificates: true);
-                    await cws.ConnectAsync(uri, new HttpMessageInvoker(handler), cts.Token);
+                    cws.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                    await cws.ConnectAsync(uri, GetInvoker(), cts.Token);
                 }
             },
             async server =>
@@ -203,8 +186,39 @@ namespace System.Net.WebSockets.Client.Tests
                 Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.EnableConnect, Value = 1 });
                 (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
                 await connection.SendResponseHeadersAsync(streamId, endStream: false, HttpStatusCode.OK);
-            }, new Http2Options() { WebSocketEndpoint = true }
-            );
+            }, new Http2Options() { WebSocketEndpoint = true });
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "HTTP/2 WebSockets aren't supported on Browser")]
+        public async Task ConnectAsync_SameHttp2ConnectionUsedForMultipleWebSocketConnection()
+        {
+            await Http2LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using var cws1 = new ClientWebSocket();
+                cws1.Options.HttpVersion = HttpVersion.Version20;
+                cws1.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+                using var cws2 = new ClientWebSocket();
+                cws2.Options.HttpVersion = HttpVersion.Version20;
+                cws2.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+                using var cts = new CancellationTokenSource(TimeOutMilliseconds);
+                HttpMessageInvoker? invoker = GetInvoker();
+
+                await cws1.ConnectAsync(uri, invoker, cts.Token);
+                await cws2.ConnectAsync(uri, invoker, cts.Token);
+            },
+            async server =>
+            {
+                await using Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.EnableConnect, Value = 1 });
+
+                (int streamId1, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+                await connection.SendResponseHeadersAsync(streamId1, endStream: false, HttpStatusCode.OK);
+
+                (int streamId2, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+                await connection.SendResponseHeadersAsync(streamId2, endStream: false, HttpStatusCode.OK);
+            }, new Http2Options() { WebSocketEndpoint = true, UseSsl = false });
         }
     }
 }

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -3,12 +3,11 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Test.Common;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,14 +16,78 @@ namespace System.Net.WebSockets.Client.Tests
     public sealed class InvokerConnectTest : ConnectTest
     {
         public InvokerConnectTest(ITestOutputHelper output) : base(output) { }
-        protected override HttpMessageInvoker? GetInvoker() => new HttpMessageInvoker(new SocketsHttpHandler());
+
+        protected override bool UseCustomInvoker => true;
+
+        public static IEnumerable<object[]> ConnectAsync_CustomInvokerWithIncompatibleWebSocketOptions_ThrowsArgumentException_MemberData()
+        {
+            yield return Throw(options => options.UseDefaultCredentials = true);
+            yield return NoThrow(options => options.UseDefaultCredentials = false);
+            yield return Throw(options => options.Credentials = new NetworkCredential());
+            yield return Throw(options => options.Proxy = new WebProxy());
+            yield return Throw(options => options.ClientCertificates.Add(Test.Common.Configuration.Certificates.GetClientCertificate()));
+            yield return NoThrow(options => options.ClientCertificates = new X509CertificateCollection());
+            yield return Throw(options => options.RemoteCertificateValidationCallback = delegate { return true; });
+            yield return Throw(options => options.Cookies = new CookieContainer());
+
+            // We allow no proxy or the default proxy to be used
+            yield return NoThrow(options => { });
+            yield return NoThrow(options => options.Proxy = null);
+
+            // These options don't conflict with the custom invoker
+            yield return NoThrow(options => options.HttpVersion = new Version(2, 0));
+            yield return NoThrow(options => options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher);
+            yield return NoThrow(options => options.SetRequestHeader("foo", "bar"));
+            yield return NoThrow(options => options.AddSubProtocol("foo"));
+            yield return NoThrow(options => options.KeepAliveInterval = TimeSpan.FromSeconds(42));
+            yield return NoThrow(options => options.DangerousDeflateOptions = new WebSocketDeflateOptions());
+            yield return NoThrow(options => options.CollectHttpResponseDetails = true);
+
+            static object[] Throw(Action<ClientWebSocketOptions> configureOptions) =>
+                new object[] { configureOptions, true };
+
+            static object[] NoThrow(Action<ClientWebSocketOptions> configureOptions) =>
+                new object[] { configureOptions, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectAsync_CustomInvokerWithIncompatibleWebSocketOptions_ThrowsArgumentException_MemberData))]
+        [SkipOnPlatform(TestPlatforms.Browser, "Custom invoker is ignored on Browser")]
+        public async Task ConnectAsync_CustomInvokerWithIncompatibleWebSocketOptions_ThrowsArgumentException(Action<ClientWebSocketOptions> configureOptions, bool shouldThrow)
+        {
+            using var invoker = new HttpMessageInvoker(new SocketsHttpHandler
+            {
+                ConnectCallback = (_, _) => ValueTask.FromException<Stream>(new Exception("ConnectCallback"))
+            });
+
+            using var ws = new ClientWebSocket();
+            configureOptions(ws.Options);
+
+            Task connectTask = ws.ConnectAsync(new Uri("wss://dummy"), invoker, CancellationToken.None);
+            if (shouldThrow)
+            {
+                Assert.Equal(TaskStatus.Faulted, connectTask.Status);
+                await Assert.ThrowsAsync<ArgumentException>("options", () => connectTask);
+            }
+            else
+            {
+                WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(() => connectTask);
+                Assert.NotNull(ex.InnerException);
+                Assert.Contains("ConnectCallback", ex.InnerException.Message);
+            }
+
+            foreach (X509Certificate cert in ws.Options.ClientCertificates)
+            {
+                cert.Dispose();
+            }
+        }
     }
 
     public sealed class HttpClientConnectTest : ConnectTest
     {
         public HttpClientConnectTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseHttpClient => true;
     }
 
     public class ConnectTest : ClientWebSocketTestBase
@@ -258,7 +321,13 @@ namespace System.Net.WebSockets.Client.Tests
             using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
             using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create())
             {
-                cws.Options.Proxy = new WebProxy(proxyServer.Uri);
+                ConfigureCustomHandler = handler => handler.Proxy = new WebProxy(proxyServer.Uri);
+
+                if (UseSharedHandler)
+                {
+                    cws.Options.Proxy = new WebProxy(proxyServer.Uri);
+                }
+
                 await ConnectAsync(cws, server, cts.Token);
 
                 string expectedCloseStatusDescription = "Client close status";
@@ -267,6 +336,7 @@ namespace System.Net.WebSockets.Client.Tests
                 Assert.Equal(WebSocketState.Closed, cws.State);
                 Assert.Equal(WebSocketCloseStatus.NormalClosure, cws.CloseStatus);
                 Assert.Equal(expectedCloseStatusDescription, cws.CloseStatusDescription);
+                Assert.Equal(1, proxyServer.Connections);
             }
         }
 

--- a/src/libraries/System.Net.WebSockets.Client/tests/DeflateTests.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/DeflateTests.cs
@@ -18,14 +18,14 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public InvokerDeflateTests(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpMessageInvoker(new SocketsHttpHandler());
+        protected override bool UseCustomInvoker => true;
     }
 
     public sealed class HttpClientDeflateTests : DeflateTests
     {
         public HttpClientDeflateTests(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseHttpClient => true;
     }
 
     [PlatformSpecific(~TestPlatforms.Browser)]

--- a/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.Http2.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.Http2.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using System.Net.Http;
-using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,19 +10,29 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-using static System.Net.Http.Functional.Tests.TestHelper;
-
 namespace System.Net.WebSockets.Client.Tests
 {
-    public class SendReceiveTest_Http2 : ClientWebSocketTestBase
+    public sealed class HttpClientSendReceiveTest_Http2 : SendReceiveTest_Http2
+    {
+        public HttpClientSendReceiveTest_Http2(ITestOutputHelper output) : base(output) { }
+
+        protected override bool UseHttpClient => true;
+    }
+
+    public sealed class InvokerSendReceiveTest_Http2 : SendReceiveTest_Http2
+    {
+        public InvokerSendReceiveTest_Http2(ITestOutputHelper output) : base(output) { }
+
+        protected override bool UseCustomInvoker => true;
+    }
+
+    public abstract class SendReceiveTest_Http2 : ClientWebSocketTestBase
     {
         public SendReceiveTest_Http2(ITestOutputHelper output) : base(output) { }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Fact]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform")]
-        public async Task ReceiveNoThrowAfterSend_NoSsl(bool useHandler)
+        public async Task ReceiveNoThrowAfterSend_NoSsl()
         {
             var serverMessage = new byte[] { 4, 5, 6 };
             await Http2LoopbackServer.CreateClientAndServerAsync(async uri =>
@@ -32,16 +41,9 @@ namespace System.Net.WebSockets.Client.Tests
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
                     cws.Options.HttpVersion = HttpVersion.Version20;
-                    cws.Options.HttpVersionPolicy = Http.HttpVersionPolicy.RequestVersionExact;
-                    if (useHandler)
-                    {
-                        var handler = new SocketsHttpHandler();
-                        await cws.ConnectAsync(uri, new HttpMessageInvoker(handler), cts.Token);
-                    }
-                    else
-                    {
-                        await cws.ConnectAsync(uri, cts.Token);
-                    }
+                    cws.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+                    await cws.ConnectAsync(uri, GetInvoker(), cts.Token);
 
                     await cws.SendAsync(new byte[] { 2, 3, 4 }, WebSocketMessageType.Binary, true, cts.Token);
 
@@ -63,8 +65,7 @@ namespace System.Net.WebSockets.Client.Tests
                 byte[] constructMessage = prefix.Concat(serverMessage).ToArray();
                 await connection.SendResponseDataAsync(streamId, constructMessage, endStream: false);
 
-            }, new Http2Options() { WebSocketEndpoint = true, UseSsl = false }
-            );
+            }, new Http2Options() { WebSocketEndpoint = true, UseSsl = false });
         }
 
         [Fact]
@@ -78,10 +79,9 @@ namespace System.Net.WebSockets.Client.Tests
                 using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
                 {
                     cws.Options.HttpVersion = HttpVersion.Version20;
-                    cws.Options.HttpVersionPolicy = Http.HttpVersionPolicy.RequestVersionExact;
+                    cws.Options.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
 
-                    var handler = CreateSocketsHttpHandler(allowAllCertificates: true);
-                    await cws.ConnectAsync(uri, new HttpMessageInvoker(handler), cts.Token);
+                    await cws.ConnectAsync(uri, GetInvoker(), cts.Token);
 
                     await cws.SendAsync(new byte[] { 2, 3, 4 }, WebSocketMessageType.Binary, true, cts.Token);
 
@@ -103,8 +103,7 @@ namespace System.Net.WebSockets.Client.Tests
                 byte[] constructMessage = prefix.Concat(serverMessage).ToArray();
                 await connection.SendResponseDataAsync(streamId, constructMessage, endStream: false);
 
-            }, new Http2Options() { WebSocketEndpoint = true }
-            );
+            }, new Http2Options() { WebSocketEndpoint = true });
         }
     }
 }

--- a/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -17,28 +17,28 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public InvokerMemorySendReceiveTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpMessageInvoker(new SocketsHttpHandler());
+        protected override bool UseCustomInvoker => true;
     }
 
     public sealed class HttpClientMemorySendReceiveTest : MemorySendReceiveTest
     {
         public HttpClientMemorySendReceiveTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseHttpClient => true;
     }
 
     public sealed class InvokerArraySegmentSendReceiveTest : ArraySegmentSendReceiveTest
     {
         public InvokerArraySegmentSendReceiveTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpMessageInvoker(new SocketsHttpHandler());
+        protected override bool UseCustomInvoker => true;
     }
 
     public sealed class HttpClientArraySegmentSendReceiveTest : ArraySegmentSendReceiveTest
     {
         public HttpClientArraySegmentSendReceiveTest(ITestOutputHelper output) : base(output) { }
 
-        protected override HttpMessageInvoker? GetInvoker() => new HttpClient(new HttpClientHandler());
+        protected override bool UseHttpClient => true;
     }
 
     public class MemorySendReceiveTest : SendReceiveTest


### PR DESCRIPTION
Fixes #74415
Fixes #74416

For #74415, we now throw if HTTP/2 has been requested but a custom invoker wasn't specified.

For #74416, I added a simple check for any options that can't be honored when using a custom invoker instance, and we now throw an `ArgumentException`.
The only exception is the default `Proxy` - we don't throw if the user doesn't overwrite it (as that would impact all default use cases). Given that `SocketsHttpHandler` shares the same default (default proxy is used unless explicitly disabled), I don't think this is a big deal.