### PR TITLE
fix MaxResponseHeadersLength tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -92,7 +92,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.HandleRequestAsync(headers: new[] { new HttpHeaderData("Foo", new string('a', handler.MaxResponseHeadersLength * 1024)) });
                 }
-                // Ignore errors caused by the client
+                // Client can respond by closing/aborting the underlying stream while we are still sending the headers, ignore these exceptions
                 catch (IOException ex) when (ex.InnerException is SocketException se && se.SocketErrorCode == SocketError.Shutdown) { }
 #if !WINHTTPHANDLER_TEST
                 catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted && ex.ApplicationErrorCode == Http3ExcessiveLoad) {}
@@ -144,7 +144,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.HandleRequestAsync(headers: headers);
                 }
-                // Ignore errors caused by the client
+                // Client can respond by closing/aborting the underlying stream while we are still sending the headers, ignore these exceptions
                 catch (IOException ex) when (ex.InnerException is SocketException se && se.SocketErrorCode == SocketError.Shutdown) { }
 #if !WINHTTPHANDLER_TEST
                 catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted && ex.ApplicationErrorCode == Http3ExcessiveLoad) {}

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -4,7 +4,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Test.Common;
+#if !WINHTTPHANDLER_TEST
 using System.Net.Quic;
+#endif
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -91,8 +93,10 @@ namespace System.Net.Http.Functional.Tests
                     await server.HandleRequestAsync(headers: new[] { new HttpHeaderData("Foo", new string('a', handler.MaxResponseHeadersLength * 1024)) });
                 }
                 // Ignore errors caused by the client
-                catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted && ex.ApplicationErrorCode == Http3ExcessiveLoad) {}
                 catch (IOException ex) when (ex.InnerException is SocketException se && se.SocketErrorCode == SocketError.Shutdown) { }
+#if !WINHTTPHANDLER_TEST
+                catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted && ex.ApplicationErrorCode == Http3ExcessiveLoad) {}
+#endif
             });
         }
 
@@ -141,8 +145,10 @@ namespace System.Net.Http.Functional.Tests
                     await server.HandleRequestAsync(headers: headers);
                 }
                 // Ignore errors caused by the client
-                catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted && ex.ApplicationErrorCode == Http3ExcessiveLoad) { }
                 catch (IOException ex) when (ex.InnerException is SocketException se && se.SocketErrorCode == SocketError.Shutdown) { }
+#if !WINHTTPHANDLER_TEST
+                catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted && ex.ApplicationErrorCode == Http3ExcessiveLoad) {}
+#endif
             });
         }
     }

--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/System.Net.Http.WinHttpHandler.Functional.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;net48</TargetFrameworks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <DefineConstants>$(DefineConstants);WINHTTPHANDLER_TEST</DefineConstants>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Net\Configuration.cs"

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -842,7 +842,7 @@ namespace System.Net.Http
             // https://tools.ietf.org/html/draft-ietf-quic-http-24#section-4.1.1
             if (headersLength > _headerBudgetRemaining)
             {
-                _stream.Abort(QuicAbortDirection.Write, (long)Http3ErrorCode.ExcessiveLoad);
+                _stream.Abort(QuicAbortDirection.Read, (long)Http3ErrorCode.ExcessiveLoad);
                 throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection.Pool.Settings.MaxResponseHeadersByteLength));
             }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1240,7 +1240,6 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version20;
     }
 
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/73930")]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpClientHandler_MaxResponseHeadersLength_Http3 : HttpClientHandler_MaxResponseHeadersLength_Test
     {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -447,7 +447,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
         if (NetEventSource.Log.IsEnabled())
         {
-            NetEventSource.Error(this, $"{this} Received event CONNECTED {LocalEndPoint} -> {RemoteEndPoint}");
+            NetEventSource.Info(this, $"{this} Received event CONNECTED {LocalEndPoint} -> {RemoteEndPoint}");
         }
 
         _connectedTcs.TrySetResult();
@@ -558,7 +558,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     {
         if (NetEventSource.Log.IsEnabled())
         {
-                NetEventSource.Info(this, $"{this} Received event {type}");
+            NetEventSource.Info(this, $"{this} Received event {type}");
         }
 
         return QUIC_STATUS_SUCCESS;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -460,7 +460,7 @@ public sealed partial class QuicStream
     {
         if (NetEventSource.Log.IsEnabled())
         {
-            NetEventSource.Info(this, $"{this} Received event START_COMPLETE with {nameof(data.Status)}={data.Status} and {nameof(data.PeerAccepted)}={data.PeerAccepted}");
+            NetEventSource.Info(this, $"{this} Received event START_COMPLETE with {nameof(data.ID)}={data.ID}, {nameof(data.Status)}={data.Status} and {nameof(data.PeerAccepted)}={data.PeerAccepted}");
         }
 
         _id = unchecked((long)data.ID);
@@ -614,7 +614,7 @@ public sealed partial class QuicStream
     {
         if (NetEventSource.Log.IsEnabled())
         {
-                NetEventSource.Info(this, $"{this} Received event {type}");
+            NetEventSource.Info(this, $"{this} Received event {type}");
         }
 
         return QUIC_STATUS_SUCCESS;


### PR DESCRIPTION
This is mostly test problem. I saw occasional failures also on HTTP/1.1
```

System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_MaxResponseHeadersLength_Http11.ThresholdExceeded_ThrowsException

      System.IO.IOException : Unable to write data to the transport connection: Broken pipe.
      ---- System.Net.Sockets.SocketException : Broken pipe
      Stack Trace:
        /home/furt/github/wfurt-runtime2/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs(739,0): at System.Net.Test.Common.LoopbackServer.Connection.SendResponseAsync(Byte[] response)
        /home/furt/github/wfurt-runtime2/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs(983,0): at System.Net.Test.Common.LoopbackServer.Connection.SendResponseBodyAsync(Byte[] content, Boolean isFinal)
        /home/furt/github/wfurt-runtime2/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs(161,0): at System.Net.Test.Common.GenericLoopbackConnection.SendResponseBodyAsync(String content, Boolean isFinal)
```

now, there are some significant differences and reasons why HTTP/3 fails often:

https://github.com/dotnet/runtime/blob/4734ee0ae9055e722cbe6184e561cc9f29936482/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs#L165-L169

and then on receiving side something like 
```c#
        (frameType, payloadLength) = await ReadFrameEnvelopeAsync(cancellationToken).ConfigureAwait(false);

        private async ValueTask ReadHeadersAsync(long headersLength, CancellationToken cancellationToken)
        {
            // TODO: this header budget is sent as SETTINGS_MAX_HEADER_LIST_SIZE, so it should not use frame payload but rather 32 bytes + uncompressed size per entry.
            // https://tools.ietf.org/html/draft-ietf-quic-http-24#section-4.1.1
            if (headersLength > _headerBudgetRemaining)
            {
                _stream.Abort(QuicAbortDirection.Read, (long)Http3ErrorCode.ExcessiveLoad);
                throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection.Pool.Settings.MaxResponseHeadersByteLength));
            }
```
we  get header length from the frame header and we can fail and Abort without even waiting for the headers (and sending task to complete)

The fix for this is to simply swallow transport errors. 


Now looking at it, it seems like we are aborting wrong side. It somewhat does not matter as we will fail and abort both sides immediately but that delivers wrong application code to the peer. 


Lastly I was trying to use tracing to figure out what is happening I finally succeeded but I had to improve it somewhat. 
The current log is way to crude and it does not include useful information. So I split the generic log to each event handler so we can log also some specific parts. With that following fragments was creation for solving this:

```
Sender:
        01:06:54.7569379[Info] thisOrContextObject: QuicStream#64628464, memberName: WriteAsync, message: [strm][0x7F3464004F80] Stream writing memory of '3' bytes while not completing writes.
        01:06:54.7569734[Info] thisOrContextObject: QuicStream#64628464, memberName: NativeCallback, message: [strm][0x7F3464004F80] Received event SEND_COMPLETE
        01:06:54.7569903[Info] thisOrContextObject: QuicStream#64628464, memberName: WriteAsync, message: [strm][0x7F3464004F80] Stream writing memory of '15400' bytes while not completing writes.
        01:06:54.7584017[Info] thisOrContextObject: QuicStream#64628464, memberName: NativeCallback, message: [strm][0x7F3464004F80] Received event IDEAL_SEND_BUFFER_SIZE
        01:06:54.7584457[Info] thisOrContextObject: QuicStream#64628464, memberName: NativeCallback, message: [strm][0x7F3464004F80] Received event PEER_RECEIVE_ABORTED
        01:06:54.7594386[Info] thisOrContextObject: QuicStream#64628464, memberName: NativeCallback, message: [strm][0x7F3464004F80] Received event SEND_COMPLETE

Receiver:
        01:40:10.3530872[Info] thisOrContextObject: QuicStream#41727345, memberName: NativeCallback, message: [strm][0x7FA554013E40] Received event RECEIVE
        01:40:10.3531404[Info] thisOrContextObject: QuicStream#41727345, memberName: HandleEventReceive, message: [strm][0x7FA554013E40] Received 1 buffers, Total count of 3. totalCopied=3
        01:40:10.3532103[HandlerMessage] poolId: 34868631, workerId: 49584532, requestId: 0, memberName: ReadFrameEnvelopeAsync, message: Received frame 1 of length 15400.
        01:40:10.3532604[Info] thisOrContextObject: QuicStream#41727345, memberName: Abort, message: [strm][0x7FA554013E40] Aborting Read with 263.
        01:40:10.3546351[Info] thisOrContextObject: QuicStream#41727345, memberName: Abort, message: [strm][0x7FA554013E40] Aborting Write with 258.
        01:40:10.3547886[Info] thisOrContextObject: QuicStream#41727345, memberName: Abort, message: [strm][0x7FA554013E40] Aborting Read with 268.
        01:40:10.3588480[Info] thisOrContextObject: QuicStream#41727345, memberName: NativeCallback, message: [strm][0x7FA554013E40] Received event SHUTDOWN_COMPLETE
```

so it is clear we received 3 bytes out of promised 15400 and aborted immediately. Peer (e.g. LoopBack server) will get PEER_RECEIVE_ABORTED before completing write. 

fixes #73930

