### PR TITLE
Working with StressLogAnalyzer I found yet another issue where we are…

### DIFF
--- a/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
+++ b/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
@@ -1227,6 +1227,10 @@ int ProcessStressLog(void* baseAddress, int argc, char* argv[])
     s_fPrintFormatStrings = false;
     s_showAllMessages = false;
     s_maxHeapNumberSeen = -1;
+    for (int i = IS_INTERESTING; i < s_interestingStringCount; i++)
+    {
+        s_interestingStringTable[i] = nullptr;
+    }
     s_interestingStringCount = IS_INTERESTING;
     s_levelFilterCount = 0;
     s_gcFilterStart = 0;


### PR DESCRIPTION
… missing an initialization when re-running the analysis - when you add a format string to look for via the -f option, and then later remove it, it's not actually removed, but is still found.

The fix is simply to clear the s_interestingStringTable above the fixed entries.