### PR TITLE
#50575 colorbehavior default should disable colors in android/applemobile

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Extensions.Logging.Console
         private const string LoglevelPadding = ": ";
         private static readonly string _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length);
         private static readonly string _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
+        private static readonly bool _isAndroidOrAppleMobile = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))
+                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))
+                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))
+                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
         private IDisposable? _optionsReloadToken;
 
         public SimpleConsoleFormatter(IOptionsMonitor<SimpleConsoleFormatterOptions> options)
@@ -158,12 +162,8 @@ namespace Microsoft.Extensions.Logging.Console
 
         private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
         {
-            bool isAndroidOrAppleMobile = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))
-                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))
-                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))
-                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
             bool disableColors = (FormatterOptions.ColorBehavior == LoggerColorBehavior.Disabled) ||
-                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && (!ConsoleUtils.EmitAnsiColorCodes || isAndroidOrAppleMobile));
+                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && (!ConsoleUtils.EmitAnsiColorCodes || _isAndroidOrAppleMobile));
             if (disableColors)
             {
                 return new ConsoleColors(null, null);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -162,6 +162,8 @@ namespace Microsoft.Extensions.Logging.Console
 
         private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
         {
+            // We shouldn't be outputting color codes for Android/Apple mobile platforms,
+            // they have no shell (adb shell is not meant for running apps) and all the output gets redirected to some log file.
             bool disableColors = (FormatterOptions.ColorBehavior == LoggerColorBehavior.Disabled) ||
                 (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && (!ConsoleUtils.EmitAnsiColorCodes || _isAndroidOrAppleMobile));
             if (disableColors)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Extensions.Logging.Console
         private static readonly string _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length);
         private static readonly string _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
         private static readonly bool _isAndroidOrAppleMobile = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))
-                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))
-                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))
-                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
+                                                            || RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))
+                                                            || RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))
+                                                            || RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
         private IDisposable? _optionsReloadToken;
 
         public SimpleConsoleFormatter(IOptionsMonitor<SimpleConsoleFormatterOptions> options)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Extensions.Logging.Console
 {
@@ -157,8 +158,12 @@ namespace Microsoft.Extensions.Logging.Console
 
         private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
         {
+            bool isAndroidOrAppleMobile = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))
+                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))
+                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))
+                                          || RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
             bool disableColors = (FormatterOptions.ColorBehavior == LoggerColorBehavior.Disabled) ||
-                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && !ConsoleUtils.EmitAnsiColorCodes);
+                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && (!ConsoleUtils.EmitAnsiColorCodes || isAndroidOrAppleMobile));
             if (disableColors)
             {
                 return new ConsoleColors(null, null);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
         [InlineData(LoggerColorBehavior.Default)]
         [InlineData(LoggerColorBehavior.Enabled)]
         [InlineData(LoggerColorBehavior.Disabled)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50575", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51398", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73436", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void Log_WritingScopes_LogsWithCorrectColorsWhenColorEnabled(LoggerColorBehavior colorBehavior)
         {


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/50575 and https://github.com/dotnet/runtime/issues/51398