### PR TITLE
[wasm] Test, and app host fixes

### DIFF
--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -126,7 +126,7 @@
   <PropertyGroup Condition="'$(WasmGenerateAppBundle)' == 'true'">
     <RunCommand Condition="'$(DOTNET_HOST_PATH)' != '' and Exists($(DOTNET_HOST_PATH))">$(DOTNET_HOST_PATH)</RunCommand>
     <RunCommand Condition="'$(RunCommand)' == ''">dotnet</RunCommand>
-    <RunArguments Condition="'$(RunArguments)' == ''">exec $([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll')) --runtime-config $(_AppBundleDirForRunCommand)/$(AssemblyName).runtimeconfig.json $(WasmHostArguments)</RunArguments>
+    <RunArguments Condition="'$(RunArguments)' == ''">exec &quot;$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll'))&quot; --runtime-config &quot;$(_AppBundleDirForRunCommand)/$(AssemblyName).runtimeconfig.json&quot; $(WasmHostArguments)</RunArguments>
     <RunWorkingDirectory Condition="'$(RunWorkingDirectory)' == ''">$(_AppBundleDirForRunCommand)</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BrowserRunner.cs
@@ -77,12 +77,12 @@ internal class BrowserRunner : IAsyncDisposable
 
         var url = new Uri(urlAvailable.Task.Result);
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+        string[] chromeArgs = new[] { $"--explicitly-allowed-ports={url.Port}" };
+        Console.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', args)}");
         Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions{
             ExecutablePath = s_chromePath.Value,
             Headless = headless,
-            Args = OperatingSystem.IsWindows()
-                        ? new[] { $"--explicitly-allowed-ports={url.Port}" }
-                        : Array.Empty<string>()
+            Args = chromeArgs
         });
 
         IPage page = await Browser.NewPageAsync();

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BrowserRunner.cs
@@ -78,7 +78,7 @@ internal class BrowserRunner : IAsyncDisposable
         var url = new Uri(urlAvailable.Task.Result);
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         string[] chromeArgs = new[] { $"--explicitly-allowed-ports={url.Port}" };
-        Console.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', args)}");
+        Console.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', chromeArgs)}");
         Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions{
             ExecutablePath = s_chromePath.Value,
             Headless = headless,


### PR DESCRIPTION
-  Use explicity allowed ports with playwright, on linux too
- Quote path, and arguments for wasm app host, to fix running with app host on windows

Fixes #72436 .