### PR TITLE
[wasm][debugger] Fix chinese character in project name

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1469,12 +1469,12 @@ namespace Microsoft.WebAssembly.Diagnostics
                         continue;
                     try
                     {
-                        string decodedFileName = Uri.UnescapeDataString(file_name);
+                        string unescapedFileName = Uri.UnescapeDataString(file_name);
                         steps.Add(
                             new DebugItem
                             {
                                 Url = file_name,
-                                Data = context.SdbAgent.GetBytesFromAssemblyAndPdb(Path.GetFileName(decodedFileName), token)
+                                Data = context.SdbAgent.GetBytesFromAssemblyAndPdb(Path.GetFileName(unescapedFileName), token)
                             });
                     }
                     catch (Exception e)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -1469,11 +1469,12 @@ namespace Microsoft.WebAssembly.Diagnostics
                         continue;
                     try
                     {
+                        string decodedFileName = Uri.UnescapeDataString(file_name);
                         steps.Add(
                             new DebugItem
                             {
                                 Url = file_name,
-                                Data = context.SdbAgent.GetBytesFromAssemblyAndPdb(Path.GetFileName(file_name), token)
+                                Data = context.SdbAgent.GetBytesFromAssemblyAndPdb(Path.GetFileName(decodedFileName), token)
                             });
                     }
                     catch (Exception e)

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1086,5 +1086,17 @@ namespace DebuggerTests
                 }
             );
         }
+
+        [ConditionalFact(nameof(RunningOnChrome))]
+        public async Task SetBreakpointInProjectWithChineseCharactereInPath()
+        {
+            var bp = await SetBreakpointInMethod("debugger-test-chinese-char-in-path-ㄨ.dll", "DebuggerTests.CheckChineseCharacterInPath", "Evaluate", 1);
+            await EvaluateAndCheck(
+                $"window.setTimeout(function() {{ invoke_static_method ('[debugger-test-chinese-char-in-path-ㄨ] DebuggerTests.CheckChineseCharacterInPath:Evaluate'); }}, 1);",
+                "dotnet://debugger-test-chinese-char-in-path-ㄨ.dll/test.cs",
+                bp.Value["locations"][0]["lineNumber"].Value<int>(),
+                bp.Value["locations"][0]["columnNumber"].Value<int>(),
+                $"DebuggerTests.CheckChineseCharacterInPath.Evaluate");
+        }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -735,23 +735,25 @@ namespace DebuggerTests
                     ?.Where(f => f["functionName"]?.Value<string>() == function_name)
                     ?.FirstOrDefault();
 
-        [ConditionalFact(nameof(RunningOnChrome))]
-        public async Task DebugLazyLoadedAssemblyWithPdb()
+        [ConditionalTheory(nameof(RunningOnChrome))]
+        [InlineData("lazy-debugger-test")]
+        [InlineData("lazy-debugger-test-chinese-char-in-path-ㄨ")]
+        public async Task DebugLazyLoadedAssemblyWithPdb(string assembly_name)
         {
             Task<JObject> bpResolved = WaitForBreakpointResolvedEvent();
             int line = 9;
             await SetBreakpoint(".*/lazy-debugger-test.cs$", line, 0, use_regex: true);
             await LoadAssemblyDynamically(
-                    Path.Combine(DebuggerTestAppPath, "lazy-debugger-test.dll"),
-                    Path.Combine(DebuggerTestAppPath, "lazy-debugger-test.pdb"));
+                    Path.Combine(DebuggerTestAppPath, $"{assembly_name}.dll"),
+                    Path.Combine(DebuggerTestAppPath, $"{assembly_name}.pdb"));
 
-            var source_location = "dotnet://lazy-debugger-test.dll/lazy-debugger-test.cs";
+            var source_location = $"dotnet://{assembly_name}.dll/lazy-debugger-test.cs";
             Assert.Contains(source_location, scripts.Values);
 
             await bpResolved;
 
             var pause_location = await EvaluateAndCheck(
-               "window.setTimeout(function () { invoke_static_method('[lazy-debugger-test] LazyMath:IntAdd', 5, 10); }, 1);",
+               "window.setTimeout(function () { invoke_static_method('[" + assembly_name + "] LazyMath:IntAdd', 5, 10); }, 1);",
                source_location, line, 8,
                "LazyMath.IntAdd");
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ.csproj
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="EnableAggressiveTrimming;PublishTrimmed">
+  <PropertyGroup>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+    <OutputType>library</OutputType>
+    <IsTestProject>false</IsTestProject>
+    <IsTestSupportProject>true</IsTestSupportProject>
+    <!-- to call AsssemblyExtensions.ApplyUpdate we need Optimize=false, EmitDebugInformation=true in all configurations -->
+    <Optimize>false</Optimize>
+    <EmitDebugInformation>true</EmitDebugInformation>
+    <!-- hot reload is not compatible with trimming -->
+    <EnableAggressiveTrimming>false</EnableAggressiveTrimming>
+    <PublishTrimmed>false</PublishTrimmed>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EmbedAllSources>true</EmbedAllSources>
+
+    <!-- FIXME: issue -->
+    <DisableSourceLink>true</DisableSourceLink>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="MethodBody0.cs" />
+    <Compile Include="MethodBody1.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- This package from https://github.com/dotnet/hotreload-utils provides
+         targets that read the json delta script and generates deltas based on the baseline assembly and the modified sources.
+
+         Projects must define the DeltaScript property that specifies the (relative) path to the json script.
+         Deltas will be emitted next to the output assembly.  Deltas will be copied when the current
+         project is referenced from other other projects.
+    -->
+    <PackageReference Include="Microsoft.DotNet.HotReload.Utils.Generator.BuildTool" Version="$(MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/MethodBody0.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/MethodBody0.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+
+namespace ApplyUpdateReferencedAssembly
+{
+    public class MethodBodyUnchangedAssembly {
+        public static string StaticMethod1 () {
+            Console.WriteLine("original");
+            return "ok";
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/MethodBody1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/MethodBody1.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class MethodBody1 {
+        public static string StaticMethod1 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+    }
+
+    public class MethodBody2 {
+        public static string StaticMethod1 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+    }
+
+    public class MethodBody3 {
+        public static string StaticMethod3 () {
+            int a = 10;
+            Console.WriteLine("original");
+            return "OLD STRING";
+        }
+    }
+
+
+
+    public class MethodBody4 {
+        public static void StaticMethod4 () {
+        }
+    }
+
+
+
+
+
+
+    public class MethodBody5 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a line that will not be changed");
+            Console.WriteLine("original");
+        }
+    }
+
+    public class MethodBody6 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a line that will not be changed");
+            Console.WriteLine("original");
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/MethodBody1_v1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/MethodBody1_v1.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class MethodBody1 {
+        public static string StaticMethod1 () {
+                Console.WriteLine("v1");
+                double b = 15;
+                Debugger.Break();
+                return "NEW STRING";
+        }
+    }
+
+    public class MethodBody2 {
+        public static string StaticMethod1 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+    }
+
+    public class MethodBody3 {
+        public static string StaticMethod3 () {
+            float b = 15;
+            Console.WriteLine("v1");
+            return "NEW STRING";
+        }
+    }
+
+
+
+    public class MethodBody4 {
+        public static void StaticMethod4 () {
+            int a = 10;
+            int b = 20;
+            Console.WriteLine(a + b);
+            Console.WriteLine(a + b);
+            Console.WriteLine(a + b);
+        }
+    }
+
+    public class MethodBody5 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a line that will not be changed");
+            Console.WriteLine("beforeoriginal");
+            Console.WriteLine("original");
+        }
+    }
+    public class MethodBody6 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a line that will not be changed");
+            Console.WriteLine("original");
+        }
+        public static void NewMethodStatic () {
+            int i = 20;
+            newStaticField = 10;
+            Console.WriteLine($"add a breakpoint in the new static method, look at locals {newStaticField}");
+            /*var newvar = new MethodBody6();
+            newvar.NewMethodInstance (10);*/
+        }
+        public static int newStaticField;
+    }
+
+    public class MethodBody7 {
+        public static int staticField;
+        int attr1;
+        string attr2;
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a method in a new class");
+            Console.WriteLine("original");
+            MethodBody7 newvar = new MethodBody7();
+            staticField = 80;            
+            newvar.InstanceMethod();
+        }
+        public void InstanceMethod () {
+            int aLocal = 50;
+            attr1 = 15;
+            attr2 = "20";
+            Console.WriteLine($"add a breakpoint the instance method of the new class");
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/MethodBody1_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/MethodBody1_v2.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class MethodBody1 {
+        public static string StaticMethod1 ()
+        {
+            Console.WriteLine("v2");
+            bool c = true;
+            Debugger.Break();
+            return "NEWEST STRING";
+        }
+    }
+
+    public class MethodBody2 {
+        public static string StaticMethod1 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+    }
+
+    public class MethodBody3 {
+        public static string StaticMethod3 () {
+            bool c = true;
+            int d = 10;
+            int e = 20;
+            int f = 50;
+            return "NEWEST STRING";
+        }
+    }
+
+    public class MethodBody4 {
+        public static void StaticMethod4 () {
+        }
+    }
+
+
+
+
+
+
+    public class MethodBody5 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("beforeoriginal");
+            Console.WriteLine("original");
+        }
+    }
+
+    public class MethodBody6 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a line that will not be changed");
+            Console.WriteLine("original");
+        }
+        public static void NewMethodStatic () {
+            int i = 20;
+            newStaticField = 10;
+            Console.WriteLine($"add a breakpoint in the new static method, look at locals {newStaticField}");
+            /*var newvar = new MethodBody6();
+            newvar.NewMethodInstance (10);*/
+        }
+        public static int newStaticField;
+    }
+
+    public class MethodBody7 {
+        public static int staticField;
+        int attr1;
+        string attr2;
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a method in a new class");
+            Console.WriteLine("original");
+            MethodBody7 newvar = new MethodBody7();
+            staticField = 80;            
+            newvar.InstanceMethod();
+        }
+        public void InstanceMethod () {
+            int aLocal = 50;
+            attr1 = 15;
+            attr2 = "20";
+            Console.WriteLine($"add a breakpoint the instance method of the new class");
+        }
+    }
+
+    public class MethodBody8 {
+        public static int staticField;
+        int attr1;
+        string attr2;
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a method in a new class");
+            Console.WriteLine("original");
+            MethodBody8 newvar = new MethodBody8();
+            staticField = 80;            
+            newvar.InstanceMethod();
+        }
+        public void InstanceMethod () {
+            int aLocal = 50;
+            attr1 = 15;
+            attr2 = "20";
+            Console.WriteLine($"add a breakpoint the instance method of the new class");
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/deltascript.json
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssemblyChineseCharInPathㄨ/deltascript.json
@@ -1,0 +1,7 @@
+{
+    "changes": [
+        {"document": "MethodBody1.cs", "update": "MethodBody1_v1.cs"},
+        {"document": "MethodBody1.cs", "update": "MethodBody1_v2.cs"},
+    ]
+}
+

--- a/src/mono/wasm/debugger/tests/debugger-test-chinese-char-in-path-ㄨ/debugger-test-chinese-char-in-path-ㄨ.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-chinese-char-in-path-ㄨ/debugger-test-chinese-char-in-path-ㄨ.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PublishWindowsPdb>false</PublishWindowsPdb>
+  </PropertyGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-chinese-char-in-path-ㄨ/debugger-test-chinese-char-in-path-ㄨ.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-chinese-char-in-path-ㄨ/debugger-test-chinese-char-in-path-ㄨ.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- pdb2pdb.exe does not seem to support special characters in the path, and exits with -1 -->
     <PublishWindowsPdb>false</PublishWindowsPdb>
   </PropertyGroup>
 </Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-chinese-char-in-path-ㄨ/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-chinese-char-in-path-ㄨ/test.cs
@@ -1,0 +1,10 @@
+namespace DebuggerTests
+{
+    public class CheckChineseCharacterInPath
+    {
+        public static void Evaluate()
+        {
+            var a = 123;
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -20,6 +20,7 @@
 
     <!-- We want to bundle these assemblies, so build them first -->
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
+    <ProjectReference Include="..\ApplyUpdateReferencedAssemblyChineseCharInPathㄨ\ApplyUpdateReferencedAssemblyChineseCharInPathㄨ.csproj" />
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\debugger-test-chinese-char-in-path-ㄨ\debugger-test-chinese-char-in-path-ㄨ.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" ReferenceOutputAssembly="false" Private="true" />
@@ -30,6 +31,7 @@
 
     <!-- These are only loaded dynamically -->
     <_AssemblyForDynamicLoading Include="lazy-debugger-test" />
+    <_AssemblyForDynamicLoading Include="lazy-debugger-test-chinese-char-in-path-ㄨ" />
     <_AssemblyForDynamicLoading Include="debugger-test-with-full-debug-type" />
     <_AssemblyForDynamicLoading Include="debugger-test-with-pdb-deleted" />
     <_AssemblyForDynamicLoading Include="debugger-test-without-debug-symbols" />
@@ -79,6 +81,9 @@
       <!-- Don't modify EnC test assemblies -->
       <TrimmerRootAssembly
           Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('ApplyUpdateReferencedAssembly.dll'))"
+          Include="%(ResolvedFileToPublish.FullPath)" />
+      <TrimmerRootAssembly
+          Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('ApplyUpdateReferencedAssemblyChineseCharInPathㄨ.dll'))"
           Include="%(ResolvedFileToPublish.FullPath)" />
     </ItemGroup>
   </Target>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -21,6 +21,7 @@
     <!-- We want to bundle these assemblies, so build them first -->
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\debugger-test-chinese-char-in-path-ㄨ\debugger-test-chinese-char-in-path-ㄨ.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" ReferenceOutputAssembly="false" Private="true" />
     <ProjectReference Include="..\debugger-test-without-debug-symbols-to-load\debugger-test-without-debug-symbols-to-load.csproj" Private="true" />
     <ProjectReference Include="..\debugger-test-with-non-user-code-class\debugger-test-with-non-user-code-class.csproj" Private="true" />
@@ -53,6 +54,7 @@
     <ItemGroup>
       <WasmAssembliesToBundle Include="$(OutDir)\$(TargetFileName)" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-special-char-in-path.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-chinese-char-in-path-ㄨ.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-without-debug-symbols-to-load.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-non-user-code-class.dll" />

--- a/src/mono/wasm/debugger/tests/lazy-debugger-test-chinese-char-in-path-ㄨ/lazy-debugger-test-chinese-char-in-path-ㄨ.csproj
+++ b/src/mono/wasm/debugger/tests/lazy-debugger-test-chinese-char-in-path-ㄨ/lazy-debugger-test-chinese-char-in-path-ㄨ.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>

--- a/src/mono/wasm/debugger/tests/lazy-debugger-test-chinese-char-in-path-ㄨ/lazy-debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/lazy-debugger-test-chinese-char-in-path-ㄨ/lazy-debugger-test.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+public partial class LazyMath
+{
+    public static int IntAdd(int a, int b)
+    {
+        int c = a + b;
+        return c;
+    }
+}
+
+namespace DebuggerTests
+{
+    public class ClassToCheckFieldValue
+    {
+        public int valueToCheck;
+        public ClassToCheckFieldValue()
+        {
+            valueToCheck = 20;
+        }
+    }
+}


### PR DESCRIPTION
The test case does not simulate the real case from blazor, but I added it anyway.

From blaze we receive from the loaded_files variable file names like this:
http://localhost:5168/_framework/%E3%84%A8U1U2U3.Shared.dll
Then we need to convert to: http://localhost:5168/_framework/ㄨU1U2U3.Shared.dll to find it in our assemblies by name.

In the debugger-tests in the mono-config.json, the file name is like this, we add and search with this name, so we don't need the UnescapeDataString.
```
{
      "behavior": "assembly",
      "name": "debugger-test-chinese-char-in-path-\u3128.dll"
}
```

