### PR TITLE
Non-canonical NaN tests for Vector Equals method (Issue #68710)

### DIFF
--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -848,13 +848,6 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        public void VectorHalfEqualsNaNTest()
-        {
-            var nan = new Vector<Half>(Half.NaN);
-            Assert.True(nan.Equals(nan));
-        }
-
-        [Fact]
         public void VectorDoubleEqualsNonCanonicalNaNTest()
         {
             var cast = BitConverter.DoubleToUInt64Bits(double.NaN);
@@ -898,39 +891,6 @@ namespace System.Numerics.Tests
             var pnan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ sign));
             var snan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ mant));
             var psnan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ sign ^ mant));
-
-            Assert.True(nan.Equals(nan));
-            Assert.True(nan.Equals(pnan));
-            Assert.True(nan.Equals(snan));
-            Assert.True(nan.Equals(psnan));
-
-            Assert.True(pnan.Equals(nan));
-            Assert.True(pnan.Equals(pnan));
-            Assert.True(pnan.Equals(snan));
-            Assert.True(pnan.Equals(psnan));
-
-            Assert.True(snan.Equals(nan));
-            Assert.True(snan.Equals(pnan));
-            Assert.True(snan.Equals(snan));
-            Assert.True(snan.Equals(psnan));
-
-            Assert.True(psnan.Equals(nan));
-            Assert.True(psnan.Equals(pnan));
-            Assert.True(psnan.Equals(snan));
-            Assert.True(psnan.Equals(psnan));
-        }
-
-        [Fact]
-        public void VectorHalfEqualsNonCanonicalNaNTest()
-        {
-            ushort cast = BitConverter.HalfToUInt16Bits(Half.NaN);
-            ushort one = BitConverter.HalfToUInt16Bits(Half.One);
-            ushort sign = (ushort)(one ^ BitConverter.HalfToUInt16Bits((Half)(-1f)));
-            ushort mant = (ushort)(one ^ BitConverter.HalfToUInt16Bits((Half)1.2f));
-            var nan = new Vector<Half>(Half.NaN);
-            var pnan = new Vector<Half>(BitConverter.UInt16BitsToHalf((ushort)(cast ^ sign)));
-            var snan = new Vector<Half>(BitConverter.UInt16BitsToHalf((ushort)(cast ^ mant)));
-            var psnan = new Vector<Half>(BitConverter.UInt16BitsToHalf((ushort)(cast ^ sign ^ mant)));
 
             Assert.True(nan.Equals(nan));
             Assert.True(nan.Equals(pnan));

--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -850,67 +850,49 @@ namespace System.Numerics.Tests
         [Fact]
         public void VectorDoubleEqualsNonCanonicalNaNTest()
         {
-            var cast = BitConverter.DoubleToUInt64Bits(double.NaN);
-            var one = BitConverter.DoubleToUInt64Bits(1);
-            var sign = one ^ BitConverter.DoubleToUInt64Bits(-1);
-            var mant = one ^ BitConverter.DoubleToUInt64Bits(1.2);
-            var nan = new Vector<double>(double.NaN);
-            var pnan = new Vector<double>(BitConverter.UInt64BitsToDouble(cast ^ sign));
-            var snan = new Vector<double>(BitConverter.UInt64BitsToDouble(cast ^ mant));
-            var psnan = new Vector<double>(BitConverter.UInt64BitsToDouble(cast ^ sign ^ mant));
+            var maxSignificand = (1UL << 53) - 1;
+            // NaN with mantissa bits set
+            var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
+            var nans = new double[]
+            {
+                double.CopySign(double.NaN, -0.0), // -qnan
+                double.CopySign(double.NaN, +0.0), // +qnan
+                double.CopySign(snan, -0.0),       // -snan
+                double.CopySign(snan, +0.0),       // +snan
+            };
 
-            Assert.True(nan.Equals(nan));
-            Assert.True(nan.Equals(pnan));
-            Assert.True(nan.Equals(snan));
-            Assert.True(nan.Equals(psnan));
-
-            Assert.True(pnan.Equals(nan));
-            Assert.True(pnan.Equals(pnan));
-            Assert.True(pnan.Equals(snan));
-            Assert.True(pnan.Equals(psnan));
-
-            Assert.True(snan.Equals(nan));
-            Assert.True(snan.Equals(pnan));
-            Assert.True(snan.Equals(snan));
-            Assert.True(snan.Equals(psnan));
-
-            Assert.True(psnan.Equals(nan));
-            Assert.True(psnan.Equals(pnan));
-            Assert.True(psnan.Equals(snan));
-            Assert.True(psnan.Equals(psnan));
+            // all Vector<double> NaNs .Equals compare the same
+            foreach(var i in nans)
+            {
+                foreach(var j in nans)
+                {
+                    Assert.True(new Vector<double>(i).Equals(new Vector<double>(j)));
+                }
+            }
         }
 
         [Fact]
         public void VectorSingleEqualsNonCanonicalNaNTest()
         {
-            var cast = BitConverter.SingleToUInt32Bits(float.NaN);
-            var one = BitConverter.SingleToUInt32Bits(1f);
-            var sign = one ^ BitConverter.SingleToUInt32Bits(-1);
-            var mant = one ^ BitConverter.SingleToUInt32Bits(1.2f);
-            var nan = new Vector<float>(float.NaN);
-            var pnan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ sign));
-            var snan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ mant));
-            var psnan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ sign ^ mant));
+            var maxSignificand = (1U << 24) - 1;
+            // NaN with mantissa bits set
+            var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
+            var nans = new float[]
+            {
+                float.CopySign(float.NaN, -0.0f), // -qnan
+                float.CopySign(float.NaN, +0.0f), // +qnan
+                float.CopySign(snan, -0.0f),      // -snan
+                float.CopySign(snan, +0.0f),      // +snan
+            };
 
-            Assert.True(nan.Equals(nan));
-            Assert.True(nan.Equals(pnan));
-            Assert.True(nan.Equals(snan));
-            Assert.True(nan.Equals(psnan));
-
-            Assert.True(pnan.Equals(nan));
-            Assert.True(pnan.Equals(pnan));
-            Assert.True(pnan.Equals(snan));
-            Assert.True(pnan.Equals(psnan));
-
-            Assert.True(snan.Equals(nan));
-            Assert.True(snan.Equals(pnan));
-            Assert.True(snan.Equals(snan));
-            Assert.True(snan.Equals(psnan));
-
-            Assert.True(psnan.Equals(nan));
-            Assert.True(psnan.Equals(pnan));
-            Assert.True(psnan.Equals(snan));
-            Assert.True(psnan.Equals(psnan));
+            // all Vector<float> NaNs .Equals compare the same
+            foreach(var i in nans)
+            {
+                foreach(var j in nans)
+                {
+                    Assert.True(new Vector<float>(i).Equals(new Vector<float>(j)));
+                }
+            }
         }
         #endregion
 

--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -846,6 +846,112 @@ namespace System.Numerics.Tests
             var nan = new Vector<float>(float.NaN);
             Assert.True(nan.Equals(nan));
         }
+
+        [Fact]
+        public void VectorHalfEqualsNaNTest()
+        {
+            var nan = new Vector<Half>(Half.NaN);
+            Assert.True(nan.Equals(nan));
+        }
+
+        [Fact]
+        public void VectorDoubleEqualsNonCanonicalNaNTest()
+        {
+            var cast = BitConverter.DoubleToUInt64Bits(double.NaN);
+            var one = BitConverter.DoubleToUInt64Bits(1);
+            var sign = one ^ BitConverter.DoubleToUInt64Bits(-1);
+            var mant = one ^ BitConverter.DoubleToUInt64Bits(1.2);
+            var nan = new Vector<double>(double.NaN);
+            var pnan = new Vector<double>(BitConverter.UInt64BitsToDouble(cast ^ sign));
+            var snan = new Vector<double>(BitConverter.UInt64BitsToDouble(cast ^ mant));
+            var psnan = new Vector<double>(BitConverter.UInt64BitsToDouble(cast ^ sign ^ mant));
+
+            Assert.True(nan.Equals(nan));
+            Assert.True(nan.Equals(pnan));
+            Assert.True(nan.Equals(snan));
+            Assert.True(nan.Equals(psnan));
+
+            Assert.True(pnan.Equals(nan));
+            Assert.True(pnan.Equals(pnan));
+            Assert.True(pnan.Equals(snan));
+            Assert.True(pnan.Equals(psnan));
+
+            Assert.True(snan.Equals(nan));
+            Assert.True(snan.Equals(pnan));
+            Assert.True(snan.Equals(snan));
+            Assert.True(snan.Equals(psnan));
+
+            Assert.True(psnan.Equals(nan));
+            Assert.True(psnan.Equals(pnan));
+            Assert.True(psnan.Equals(snan));
+            Assert.True(psnan.Equals(psnan));
+        }
+
+        [Fact]
+        public void VectorSingleEqualsNonCanonicalNaNTest()
+        {
+            var cast = BitConverter.SingleToUInt32Bits(float.NaN);
+            var one = BitConverter.SingleToUInt32Bits(1f);
+            var sign = one ^ BitConverter.SingleToUInt32Bits(-1);
+            var mant = one ^ BitConverter.SingleToUInt32Bits(1.2f);
+            var nan = new Vector<float>(float.NaN);
+            var pnan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ sign));
+            var snan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ mant));
+            var psnan = new Vector<float>(BitConverter.UInt32BitsToSingle(cast ^ sign ^ mant));
+
+            Assert.True(nan.Equals(nan));
+            Assert.True(nan.Equals(pnan));
+            Assert.True(nan.Equals(snan));
+            Assert.True(nan.Equals(psnan));
+
+            Assert.True(pnan.Equals(nan));
+            Assert.True(pnan.Equals(pnan));
+            Assert.True(pnan.Equals(snan));
+            Assert.True(pnan.Equals(psnan));
+
+            Assert.True(snan.Equals(nan));
+            Assert.True(snan.Equals(pnan));
+            Assert.True(snan.Equals(snan));
+            Assert.True(snan.Equals(psnan));
+
+            Assert.True(psnan.Equals(nan));
+            Assert.True(psnan.Equals(pnan));
+            Assert.True(psnan.Equals(snan));
+            Assert.True(psnan.Equals(psnan));
+        }
+
+        [Fact]
+        public void VectorHalfEqualsNonCanonicalNaNTest()
+        {
+            ushort cast = BitConverter.HalfToUInt16Bits(Half.NaN);
+            ushort one = BitConverter.HalfToUInt16Bits(Half.One);
+            ushort sign = (ushort)(one ^ BitConverter.HalfToUInt16Bits((Half)(-1f)));
+            ushort mant = (ushort)(one ^ BitConverter.HalfToUInt16Bits((Half)1.2f));
+            var nan = new Vector<Half>(Half.NaN);
+            var pnan = new Vector<Half>(BitConverter.UInt16BitsToHalf((ushort)(cast ^ sign)));
+            var snan = new Vector<Half>(BitConverter.UInt16BitsToHalf((ushort)(cast ^ mant)));
+            var psnan = new Vector<Half>(BitConverter.UInt16BitsToHalf((ushort)(cast ^ sign ^ mant)));
+
+            Assert.True(nan.Equals(nan));
+            Assert.True(nan.Equals(pnan));
+            Assert.True(nan.Equals(snan));
+            Assert.True(nan.Equals(psnan));
+
+            Assert.True(pnan.Equals(nan));
+            Assert.True(pnan.Equals(pnan));
+            Assert.True(pnan.Equals(snan));
+            Assert.True(pnan.Equals(psnan));
+
+            Assert.True(snan.Equals(nan));
+            Assert.True(snan.Equals(pnan));
+            Assert.True(snan.Equals(snan));
+            Assert.True(snan.Equals(psnan));
+
+            Assert.True(psnan.Equals(nan));
+            Assert.True(psnan.Equals(pnan));
+            Assert.True(psnan.Equals(snan));
+            Assert.True(psnan.Equals(psnan));
+        }
         #endregion
 
         #region System.Object Overloads

--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -855,18 +855,19 @@ namespace System.Numerics.Tests
             var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
             var nans = new double[]
             {
-                double.CopySign(double.NaN, -0.0), // -qnan
+                double.CopySign(double.NaN, -0.0), // -qnan same as double.NaN
                 double.CopySign(double.NaN, +0.0), // +qnan
                 double.CopySign(snan, -0.0),       // -snan
                 double.CopySign(snan, +0.0),       // +snan
             };
 
-            // all Vector<double> NaNs .Equals compare the same
+            // all Vector<double> NaNs .Equals compare the same, but == compare as different
             foreach(var i in nans)
             {
                 foreach(var j in nans)
                 {
                     Assert.True(new Vector<double>(i).Equals(new Vector<double>(j)));
+                    Assert.False(new Vector<double>(i) == new Vector<double>(j));
                 }
             }
         }
@@ -879,18 +880,19 @@ namespace System.Numerics.Tests
             var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
             var nans = new float[]
             {
-                float.CopySign(float.NaN, -0.0f), // -qnan
+                float.CopySign(float.NaN, -0.0f), // -qnan same as float.NaN
                 float.CopySign(float.NaN, +0.0f), // +qnan
                 float.CopySign(snan, -0.0f),      // -snan
                 float.CopySign(snan, +0.0f),      // +snan
             };
 
-            // all Vector<float> NaNs .Equals compare the same
+            // all Vector<float> NaNs .Equals compare the same, but == compare as different
             foreach(var i in nans)
             {
                 foreach(var j in nans)
                 {
                     Assert.True(new Vector<float>(i).Equals(new Vector<float>(j)));
+                    Assert.False(new Vector<float>(i) == new Vector<float>(j));
                 }
             }
         }

--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -850,9 +850,8 @@ namespace System.Numerics.Tests
         [Fact]
         public void VectorDoubleEqualsNonCanonicalNaNTest()
         {
-            var maxSignificand = (1UL << 53) - 1;
-            // NaN with mantissa bits set
-            var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
+            // max 8 bit exponent, just under half max mantissa
+            var snan = BitConverter.UInt64BitsToDouble(0x7FF7_FFFF_FFFF_FFFF);
             var nans = new double[]
             {
                 double.CopySign(double.NaN, -0.0), // -qnan same as double.NaN
@@ -875,9 +874,8 @@ namespace System.Numerics.Tests
         [Fact]
         public void VectorSingleEqualsNonCanonicalNaNTest()
         {
-            var maxSignificand = (1U << 24) - 1;
-            // NaN with mantissa bits set
-            var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
+            // max 11 bit exponent, just under half max mantissa
+            var snan = BitConverter.UInt32BitsToSingle(0x7FBF_FFFF);
             var nans = new float[]
             {
                 float.CopySign(float.NaN, -0.0f), // -qnan same as float.NaN

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
@@ -4459,6 +4459,56 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Fact]
+        public void Vector128DoubleEqualsNonCanonicalNaNTest()
+        {
+            var maxSignificand = (1UL << 53) - 1;
+            // NaN with mantissa bits set
+            var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
+            var nans = new double[]
+            {
+                double.CopySign(double.NaN, -0.0), // -qnan same as double.NaN
+                double.CopySign(double.NaN, +0.0), // +qnan
+                double.CopySign(snan, -0.0),       // -snan
+                double.CopySign(snan, +0.0),       // +snan
+            };
+
+            // all Vector<double> NaNs .Equals compare the same, but == compare as different
+            foreach(var i in nans)
+            {
+                foreach(var j in nans)
+                {
+                    Assert.True(Vector128.Create(i).Equals(Vector128.Create(j)));
+                    Assert.False(Vector128.Create(i) == Vector128.Create(j));
+                }
+            }
+        }
+
+        [Fact]
+        public void Vector128SingleEqualsNonCanonicalNaNTest()
+        {
+            var maxSignificand = (1U << 24) - 1;
+            // NaN with mantissa bits set
+            var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
+            var nans = new float[]
+            {
+                float.CopySign(float.NaN, -0.0f), // -qnan same as float.NaN
+                float.CopySign(float.NaN, +0.0f), // +qnan
+                float.CopySign(snan, -0.0f),      // -snan
+                float.CopySign(snan, +0.0f),      // +snan
+            };
+
+            // all Vector<float> NaNs .Equals compare the same, but == compare as different
+            foreach(var i in nans)
+            {
+                foreach(var j in nans)
+                {
+                    Assert.True(Vector128.Create(i).Equals(Vector128.Create(j)));
+                    Assert.False(Vector128.Create(i) == Vector128.Create(j));
+                }
+            }
+        }
+
+        [Fact]
         public void IsSupportedByte() => TestIsSupported<byte>();
 
         [Fact]

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
@@ -4461,9 +4461,8 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         [Fact]
         public void Vector128DoubleEqualsNonCanonicalNaNTest()
         {
-            var maxSignificand = (1UL << 53) - 1;
-            // NaN with mantissa bits set
-            var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
+            // max 8 bit exponent, just under half max mantissa
+            var snan = BitConverter.UInt64BitsToDouble(0x7FF7_FFFF_FFFF_FFFF);
             var nans = new double[]
             {
                 double.CopySign(double.NaN, -0.0), // -qnan same as double.NaN
@@ -4486,9 +4485,8 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         [Fact]
         public void Vector128SingleEqualsNonCanonicalNaNTest()
         {
-            var maxSignificand = (1U << 24) - 1;
-            // NaN with mantissa bits set
-            var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
+            // max 11 bit exponent, just under half max mantissa
+            var snan = BitConverter.UInt32BitsToSingle(0x7FBF_FFFF);
             var nans = new float[]
             {
                 float.CopySign(float.NaN, -0.0f), // -qnan same as float.NaN

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector256Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector256Tests.cs
@@ -5484,6 +5484,56 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Fact]
+        public void Vector256DoubleEqualsNonCanonicalNaNTest()
+        {
+            var maxSignificand = (1UL << 53) - 1;
+            // NaN with mantissa bits set
+            var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
+            var nans = new double[]
+            {
+                double.CopySign(double.NaN, -0.0), // -qnan same as double.NaN
+                double.CopySign(double.NaN, +0.0), // +qnan
+                double.CopySign(snan, -0.0),       // -snan
+                double.CopySign(snan, +0.0),       // +snan
+            };
+
+            // all Vector<double> NaNs .Equals compare the same, but == compare as different
+            foreach(var i in nans)
+            {
+                foreach(var j in nans)
+                {
+                    Assert.True(Vector256.Create(i).Equals(Vector256.Create(j)));
+                    Assert.False(Vector256.Create(i) == Vector256.Create(j));
+                }
+            }
+        }
+
+        [Fact]
+        public void Vector256SingleEqualsNonCanonicalNaNTest()
+        {
+            var maxSignificand = (1U << 24) - 1;
+            // NaN with mantissa bits set
+            var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
+            var nans = new float[]
+            {
+                float.CopySign(float.NaN, -0.0f), // -qnan same as float.NaN
+                float.CopySign(float.NaN, +0.0f), // +qnan
+                float.CopySign(snan, -0.0f),      // -snan
+                float.CopySign(snan, +0.0f),      // +snan
+            };
+
+            // all Vector<float> NaNs .Equals compare the same, but == compare as different
+            foreach(var i in nans)
+            {
+                foreach(var j in nans)
+                {
+                    Assert.True(Vector256.Create(i).Equals(Vector256.Create(j)));
+                    Assert.False(Vector256.Create(i) == Vector256.Create(j));
+                }
+            }
+        }
+
+        [Fact]
         public void IsSupportedByte() => TestIsSupported<byte>();
 
         [Fact]

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector256Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector256Tests.cs
@@ -5486,9 +5486,8 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         [Fact]
         public void Vector256DoubleEqualsNonCanonicalNaNTest()
         {
-            var maxSignificand = (1UL << 53) - 1;
-            // NaN with mantissa bits set
-            var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
+            // max 8 bit exponent, just under half max mantissa
+            var snan = BitConverter.UInt64BitsToDouble(0x7FF7_FFFF_FFFF_FFFF);
             var nans = new double[]
             {
                 double.CopySign(double.NaN, -0.0), // -qnan same as double.NaN
@@ -5511,9 +5510,8 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         [Fact]
         public void Vector256SingleEqualsNonCanonicalNaNTest()
         {
-            var maxSignificand = (1U << 24) - 1;
-            // NaN with mantissa bits set
-            var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
+            // max 11 bit exponent, just under half max mantissa
+            var snan = BitConverter.UInt32BitsToSingle(0x7FBF_FFFF);
             var nans = new float[]
             {
                 float.CopySign(float.NaN, -0.0f), // -qnan same as float.NaN

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
@@ -3883,6 +3883,56 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Fact]
+        public void Vector64DoubleEqualsNonCanonicalNaNTest()
+        {
+            var maxSignificand = (1UL << 53) - 1;
+            // NaN with mantissa bits set
+            var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
+            var nans = new double[]
+            {
+                double.CopySign(double.NaN, -0.0), // -qnan same as double.NaN
+                double.CopySign(double.NaN, +0.0), // +qnan
+                double.CopySign(snan, -0.0),       // -snan
+                double.CopySign(snan, +0.0),       // +snan
+            };
+
+            // all Vector<double> NaNs .Equals compare the same, but == compare as different
+            foreach(var i in nans)
+            {
+                foreach(var j in nans)
+                {
+                    Assert.True(Vector64.Create(i).Equals(Vector64.Create(j)));
+                    Assert.False(Vector64.Create(i) == Vector64.Create(j));
+                }
+            }
+        }
+
+        [Fact]
+        public void Vector64SingleEqualsNonCanonicalNaNTest()
+        {
+            var maxSignificand = (1U << 24) - 1;
+            // NaN with mantissa bits set
+            var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
+            var nans = new float[]
+            {
+                float.CopySign(float.NaN, -0.0f), // -qnan same as float.NaN
+                float.CopySign(float.NaN, +0.0f), // +qnan
+                float.CopySign(snan, -0.0f),      // -snan
+                float.CopySign(snan, +0.0f),      // +snan
+            };
+
+            // all Vector<float> NaNs .Equals compare the same, but == compare as different
+            foreach(var i in nans)
+            {
+                foreach(var j in nans)
+                {
+                    Assert.True(Vector64.Create(i).Equals(Vector64.Create(j)));
+                    Assert.False(Vector64.Create(i) == Vector64.Create(j));
+                }
+            }
+        }
+
+        [Fact]
         public void IsSupportedByte() => TestIsSupported<byte>();
 
         [Fact]

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
@@ -3885,9 +3885,8 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         [Fact]
         public void Vector64DoubleEqualsNonCanonicalNaNTest()
         {
-            var maxSignificand = (1UL << 53) - 1;
-            // NaN with mantissa bits set
-            var snan = BitConverter.UInt64BitsToDouble(BitConverter.DoubleToUInt64Bits(double.NaN) | maxSignificand);
+            // max 8 bit exponent, just under half max mantissa
+            var snan = BitConverter.UInt64BitsToDouble(0x7FF7_FFFF_FFFF_FFFF);
             var nans = new double[]
             {
                 double.CopySign(double.NaN, -0.0), // -qnan same as double.NaN
@@ -3910,9 +3909,8 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         [Fact]
         public void Vector64SingleEqualsNonCanonicalNaNTest()
         {
-            var maxSignificand = (1U << 24) - 1;
-            // NaN with mantissa bits set
-            var snan = BitConverter.UInt32BitsToSingle(BitConverter.SingleToUInt32Bits(float.NaN) | maxSignificand);
+            // max 11 bit exponent, just under half max mantissa
+            var snan = BitConverter.UInt32BitsToSingle(0x7FBF_FFFF);
             var nans = new float[]
             {
                 float.CopySign(float.NaN, -0.0f), // -qnan same as float.NaN


### PR DESCRIPTION
Fixes #68710