### PR TITLE
Fix RegexOptions.NonBacktracking matching end anchors at timeout check boundaries

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1270,7 +1270,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
-        public void Nonbacktracking_TimeoutCheckNotEOF()
+        public void NonBacktracking_NoEndAnchorMatchAtTimeoutCheck()
         {
             // First figure out how many characters the innermost matching loop of NonBacktracking looks at between
             // timeout checks. This makes the test more robust, as the value isn't exposed and we'd have to set it as

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1304,9 +1304,9 @@ namespace System.Text.RegularExpressions.Tests
             Assert.True(charsPerTimeoutCheck >= 0);
 
             // Now that the limit is known, do the actual test
-            Regex testPattern = new Regex("^a*b$", RegexHelpers.RegexOptionNonBacktracking, TimeSpan.FromHours(1));
-            string input = string.Concat(new string('a', charsPerTimeoutCheck - 1), "bc");
-            // Checking for timeout just before the 'c' shouldn't allow the $ anchor to match
+            Regex testPattern = new Regex("^a*$", RegexHelpers.RegexOptionNonBacktracking, TimeSpan.FromHours(1));
+            string input = string.Concat(new string('a', charsPerTimeoutCheck), 'b');
+            // Checking for timeout just before the 'b' shouldn't allow the $ anchor to match
             Assert.False(testPattern.IsMatch(input));
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1300,7 +1300,7 @@ namespace System.Text.RegularExpressions.Tests
                     return 1;
                 }
             }
-            int charsPerTimeoutCheck = Array.BinarySearch(Enumerable.Range(0, 2048).ToArray(), -1, Comparer<int>.Create(IsCharsPerTimeoutCheck));
+            int charsPerTimeoutCheck = Array.BinarySearch(Enumerable.Range(0, 16_000).ToArray(), -1, Comparer<int>.Create(IsCharsPerTimeoutCheck));
             Assert.True(charsPerTimeoutCheck >= 0);
 
             // Now that the limit is known, do the actual test

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1269,6 +1269,47 @@ namespace System.Text.RegularExpressions.Tests
             Assert.InRange(sw.Elapsed.TotalSeconds, 0, 10); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        public void Nonbacktracking_TimeoutCheckNotEOF()
+        {
+            // First figure out how many characters the innermost matching loop of NonBacktracking looks at between
+            // timeout checks. This makes the test more robust, as the value isn't exposed and we'd have to set it as
+            // a constant here.
+            Regex timeoutPattern = new Regex("a*", RegexHelpers.RegexOptionNonBacktracking, TimeSpan.FromTicks(1));
+            // Function for comparing the left hand side to the internal chars matched per timeout check in NonBacktracking
+            int IsCharsPerTimeoutCheck(int candidate, int dummy)
+            {
+                try
+                {
+                    timeoutPattern.Match(new string('a', candidate));
+                    try
+                    {
+                        timeoutPattern.Match(new string('a', candidate + 1));
+                    }
+                    catch (RegexMatchTimeoutException)
+                    {
+                        // Only the higher check timed out, number of chars per timeout check found
+                        return 0;
+                    }
+                    // Neither check timed out, chars per timeout check is higher
+                    return -1;
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    // Candidate times out, chars per timeout check is lower
+                    return 1;
+                }
+            }
+            int charsPerTimeoutCheck = Array.BinarySearch(Enumerable.Range(0, 2048).ToArray(), -1, Comparer<int>.Create(IsCharsPerTimeoutCheck));
+            Assert.True(charsPerTimeoutCheck >= 0);
+
+            // Now that the limit is known, do the actual test
+            Regex testPattern = new Regex("^a*b$", RegexHelpers.RegexOptionNonBacktracking, TimeSpan.FromHours(1));
+            string input = string.Concat(new string('a', charsPerTimeoutCheck - 1), "bc");
+            // Checking for timeout just before the 'c' shouldn't allow the $ anchor to match
+            Assert.False(testPattern.IsMatch(input));
+        }
+
         public static IEnumerable<object[]> Match_Advanced_TestData()
         {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)


### PR DESCRIPTION
This PR adds a test for and fixes https://github.com/dotnet/runtime/issues/74467.

The test is the more complicated part, as it needs to find how many characters the innermost matching loop is processing at a time. Since that value is not public it first does a binary search over different input lengths with a 1-tick timeout to find the minimum input length to trigger the timeout. Then with that a pattern of `^a*$` needs to not match an input of form `"aaa...ab"` where there are exactly enough `a`'s to pop out of the loop right before the `b`.

Including the test in the unit test project would have been another option, but the matcher's sources aren't built into that currently.

The fix itself is quite simple, with an integer bound passed in instead of slicing the input (since the slice length is used to indicate where the whole input ends for anchors).