### PR TITLE
Enable caching of writeable W^X mappings

### DIFF
--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -259,7 +259,7 @@ bool ExecutableAllocator::Initialize()
     return true;
 }
 
-//#define ENABLE_CACHED_MAPPINGS
+#define ENABLE_CACHED_MAPPINGS
 
 void ExecutableAllocator::UpdateCachedMapping(BlockRW* pBlock)
 {


### PR DESCRIPTION
This change enables caching of the last used writeable mapping for
W^X. It was originally disabled by an ifdef, but after we've turned W^X
on by default, performance tests have shown a regression in some regex
tests. I have investigated those and found that they do excessive amount
of jitting (around 50000 methods). Enabling the caching of the last used
writeable mapping fixes the regression completely.
The caching implementation was present in the sources ever since I've
implemented the W^X stuff, but if was disabled by an ifdef. So this
change just defines the related symbol and enables the code.

The caching basically just keeps a writeable mapping after unmapping
until the next mapping request arrives, so it gives an opportunity to
reuse it in case of series of mappings of sequential range of executable
memory, which happens e.g. in the case mentioned.