### PR TITLE
More timeout checks in RegexOptions.NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Automata.cs
@@ -82,7 +82,7 @@ namespace System.Text.RegularExpressions.Symbolic
         private int[]?[] _nfaDelta = Array.Empty<int[]>();
 
         /// <summary>
-        /// The transition function for <see cref="FindSubcaptures(ReadOnlySpan{char}, int, int, PerThreadData)"/>,
+        /// The transition function for <see cref="FindSubcaptures(ReadOnlySpan{char}, int, long, int, PerThreadData)"/>,
         /// which is an NFA mode with additional state to track capture start and end positions.
         /// Each entry is an array of pairs of target state and effects to be applied when taking the transition.
         /// If the entry is null then the transition has not been computed yet.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexThresholds.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexThresholds.cs
@@ -58,5 +58,25 @@ namespace System.Text.RegularExpressions.Symbolic
                 DefaultSymbolicRegexSafeSizeThreshold :
                 safeSizeThresholdInt;
         }
+
+        /// <summary>
+        /// The number of characters the match start and end finding phases loop over between timeout checks.
+        /// </summary>
+        /// <remarks>
+        /// The timeout exists not to provide perfect guarantees around execution time but rather as a mitigation against
+        /// catastrophic backtracking.  Catastrophic backtracking is not an issue for the NonBacktracking engine, but we
+        /// still check the timeout now and again to provide some semblance of the behavior a developer experiences with
+        /// the backtracking engines.  We can, however, choose a large number here, since it's not actually needed for security.
+        /// </remarks>
+        internal const int CharsPerTimeoutCheckStartEnd = 1_000;
+
+        /// <summary>
+        /// The number of characters the subcapture finding phase loops over between timeout checks.
+        /// </summary>
+        /// <remarks>
+        /// Finding subcaptures is slower than finding the start and end of the top level match. To give better accuracy this
+        /// number is set lower than <see cref="CharsPerTimeoutCheckStartEnd"/>.
+        /// </remarks>
+        internal const int CharsPerTimeoutCheckSubcaptures = 100;
     }
 }


### PR DESCRIPTION
This PR adds timeout checking into matching loops in all phases of `RegexOptions.NonBacktracking`, while previously only the first "find the end position" phase had the check. The second "find the start position by walking backwards" phase uses the same number of innermost loop iterations between cheks as the first one. However, the third phase for finding subcaptures uses a lower one to account for the phase being slower in general. I measured that the 100 characters per timeout check gives around a 15ms resolution in the third phase.

The constants configuring those numbers of iterations are moved into `SymbolicRegexThresholds`.

This PR includes the bug fix from https://github.com/dotnet/runtime/pull/74525 to avoid a conflict after that one is merged.