### PR TITLE
Add NuGet package for System.Runtime.Serialization.Schema

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Schema/src/System.Runtime.Serialization.Schema.csproj
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System.Runtime.Serialization.Schema.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IsPackable>true</IsPackable>
     <!-- TODO: Remove this setting when the package shipped with .NET 7. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <PackageDescription>Provides support for importing and exporting xsd schemas for DataContractSerializer.


### PR DESCRIPTION
System.Runtime.Serialization.Schema isn't getting a NuGet package created for it because it doesn't set IsPackable=true.