### PR TITLE
Allow address == g_gc_highest_address in get_skewed_basic_region_index_for_address

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3570,7 +3570,7 @@ sorted_table::clear()
 inline
 size_t get_skewed_basic_region_index_for_address (uint8_t* address)
 {
-    assert ((g_gc_lowest_address <= address) && (address < g_gc_highest_address));
+    assert ((g_gc_lowest_address <= address) && (address <= g_gc_highest_address));
     size_t skewed_basic_region_index = (size_t)address >> gc_heap::min_segment_size_shr;
     return skewed_basic_region_index;
 }


### PR DESCRIPTION
Some call sites, for example, the `set_region_gen_num` function, calls `get_basic_region_index_for_address` using the `heap_segment_reserved` value of a region. If it happens to be the last region in the global region allocator, that address would be exactly equal to `g_gc_highest_address`. therefore we need to relax the assert so that exactly equal to `g_gc_highest_address` is also allowed.