### PR TITLE
use msquic bits on all Windows platforms

### DIFF
--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -138,6 +138,7 @@
   </ItemGroup>
 
   <!-- Support for deploying msquic -->
+  <!-- dotnet/msquic transport package
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' and
                         ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86') and '$(DotNetBuildFromSource)' != 'true'">
     <BinPlaceDir Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)" ItemName="NativeBinPlaceItem" />
@@ -146,8 +147,8 @@
     <BinPlaceDir Include="$(LibrariesNativeArtifactsPath)" ItemName="NativeBinPlaceItem" />
     <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\*" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' and
-                        ('$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm') and '$(DotNetBuildFromSource)' != 'true'">
+  -->
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' and '$(DotNetBuildFromSource)' != 'true'">
     <BinPlaceDir Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)" ItemName="NativeBinPlaceItem" />
     <BinPlaceDir Include="$(NetCoreAppCurrentTestHostSharedFrameworkPath)" ItemName="NativeBinPlaceItem" />
     <BinPlaceDir Include="$(LibrariesAllBinArtifactsPath)" ItemName="NativeBinPlaceItem" />


### PR DESCRIPTION
We currently consume msquic bits for `ARM` and we consume msquic/dotnet transport package for `x64` and `x86`. 
That was done to limit risk but it is going to create maintenance hassle on updated. 
This change uses MsQuic bits on all Windows platforms.
We may switch back to transport package when we need pre-release features and fixes but for now this will allow us too validate their binaries in main branch.  

