### PR TITLE
enable SendMailAsync_CanBeCanceled_CancellationToken test

### DIFF
--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -458,7 +458,6 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73447", TestPlatforms.AnyUnix)]
         public async Task SendMailAsync_CanBeCanceled_CancellationToken()
         {
             using var server = new LoopbackSmtpServer();
@@ -480,10 +479,10 @@ namespace System.Net.Mail.Tests
             await Task.Delay(500);
             serverMre.Set();
 
-            await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask).WaitAsync(TestHelper.PassingTestTimeout);
 
             // We should still be able to send mail on the SmtpClient instance
-            await client.SendMailAsync(message);
+            await client.SendMailAsync(message).WaitAsync(TestHelper.PassingTestTimeout);
 
             Assert.Equal("<foo@internet.com>", server.MailFrom);
             Assert.Equal("<bar@internet.com>", server.MailTo);

--- a/src/libraries/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="MailAddressTest.cs" />
     <Compile Include="MailMessageTest.cs" />
     <Compile Include="SmtpExceptionTest.cs" />
+    <Compile Include="TestHelper.cs" />
     <Compile Include="$(CommonTestPath)System\Diagnostics\Tracing\TestEventListener.cs"
              Link="Common\System\Diagnostics\Tracing\TestEventListener.cs" />
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs"

--- a/src/libraries/System.Net.Mail/tests/Functional/TestHelper.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/TestHelper.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.Mail.Tests
+{
+    public static class TestHelper
+    {
+        public const int PassingTestTimeoutMilliseconds = 1 * 60 * 1000;
+        public static TimeSpan PassingTestTimeout => TimeSpan.FromMilliseconds(PassingTestTimeoutMilliseconds);
+    }
+}


### PR DESCRIPTION
contributes to #73447

I could not reproduce it. so I'm enabling the test again with limit on execution. 
If something fails we should not hang the whole suite and hopefully we would get some insight. 
I can instrument the test more if we see failures. 