### PR TITLE
Fix building CLR test tree

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -537,13 +537,17 @@
     <_UsingDefaultForHasRuntimeOutput>false</_UsingDefaultForHasRuntimeOutput>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TestBuildMode)' == 'nativeaot'">
+    <IlcReference Include="$(TargetingPackPath)/*.dll" />
+  </ItemGroup>
+
   <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.NETCore.Native.targets" Condition="'$(TestBuildMode)' == 'nativeaot'" />
 
   <Target Name="BuildNativeAot"
           DependsOnTargets="Build;LinkNativeIfBuildAndRun" />
 
   <Target Name="LinkNativeIfBuildAndRun"
-          Condition="'$(CLRTestTargetUnsupported)' != 'true' and '$(CLRTestKind)' == 'BuildAndRun'"
+          Condition="'$(_WillCLRTestProjectBuild)' == 'true' and '$(CLRTestKind)' == 'BuildAndRun'"
           DependsOnTargets="ComputeResolvedFilesToPublishList;LinkNative" />
 
 </Project>


### PR DESCRIPTION
* If we're only building Pri-0 tests, don't try to AOT compile Pri-1 tests. `_WillCLRTestProjectBuild` is the property that checks for that.
* Targeting pack references get injected in a way that the compiler targets don't see. The compiler targets are written for publish scenarios but we're not doing a publish.

Fixes #68394