### PR TITLE
Re-enable MemoryCacheTest.Contains.

### DIFF
--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -49,12 +49,6 @@ namespace MonoTests.System.Runtime.Caching
 {
     public class MemoryCacheTest
     {
-        private readonly ITestOutputHelper _output;
-        public MemoryCacheTest(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         public static bool SupportsPhysicalMemoryMonitor
         {
             get
@@ -1324,12 +1318,6 @@ namespace MonoTests.System.Runtime.Caching
 
     public class MemoryCacheTestExpires11
     {
-        private readonly ITestOutputHelper _output;
-        public MemoryCacheTestExpires11(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         [Fact]
         [OuterLoop] // makes long wait
         public async Task TimedExpirationAsync()


### PR DESCRIPTION
Addresses #1429 in a way.

The test doesn't look like it should fail. And it doesn't fail locally. This issue is quite old, so I can't easily tell see what the history of this test case was when it was disabled. I suspect there was a transient timing issue that triggered this that has long since disappeared.

To protect against such an issue in the future though, I changed the timing used in this test to be a little more forgiving, and also added a little logging to give some information if we see this test start failing again in the future.