### PR TITLE
Bump Kerberos.NET version in tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Security/Kerberos/System.Net.Security.Kerberos.Shared.projitems
+++ b/src/libraries/Common/tests/System/Net/Security/Kerberos/System.Net.Security.Kerberos.Shared.projitems
@@ -36,6 +36,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Kerberos.NET" Version="4.5.174" />
+    <PackageReference Include="Kerberos.NET" Version="4.5.178" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes tests on big endian platforms.

Fixes #73343