### PR TITLE
#50878 enable StringSegment tests on Android

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -806,7 +806,6 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50878", TestPlatforms.Android)]
         public void StringSegment_Substring_InvalidOffsetAndLength()
         {
             // Arrange
@@ -818,7 +817,6 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50878", TestPlatforms.Android)]
         public void StringSegment_Substring_OffsetAndLengthOverflows()
         {
             // Arrange
@@ -899,7 +897,6 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50878", TestPlatforms.Android)]
         public void StringSegment_Subsegment_InvalidOffsetAndLength()
         {
             // Arrange
@@ -911,7 +908,6 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50878", TestPlatforms.Android)]
         public void StringSegment_Subsegment_OffsetAndLengthOverflows()
         {
             // Arrange


### PR DESCRIPTION
Tests are passing now, removed active issues.
Fixes #50878