### PR TITLE
Add custom comparer to use incremental generator caching for LoggerMessageGenerator and JsonSourceGenerator

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Roslyn4.0.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Roslyn4.0.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.Logging.Generators
     public partial class LoggerMessageGenerator : IIncrementalGenerator
     {
         private readonly CustomComparer comparer = new();
+
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
             IncrementalValuesProvider<ClassDeclarationSyntax> classDeclarations = context.SyntaxProvider


### PR DESCRIPTION
Related to issue https://github.com/dotnet/runtime/issues/74557, this is a proposed solution how to add caching to `LoggerMessageGenerator` and `JsonSourceGenerator`.