### PR TITLE
Add server1.pfx to CredScanSuppressions.json

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -14,6 +14,12 @@
                 "-----BEGIN PRIVATE KEY-----",
                 "-----BEGIN * PRIVATE KEY-----"
             ]
+        },
+        {
+            "_justification": "Suppression approved. Private key for testing purpose.",
+            "file": [
+                "src/tests/FunctionalTests/Android/Device_Emulator/gRPC/grpc-dotnet/testassets/Certs/InteropTests/server1.pfx"
+            ]
         }
     ]
 }


### PR DESCRIPTION
The internal mirror is currently blocked on some new CredScan false positives for test keys that were merged as part of https://github.com/dotnet/runtime/pull/73060. We suppressed one file but missed this one.

I made a separate section in the file since the other one looks for a placeholder that doesn't apply to the .pfx.