### PR TITLE
Use System.Numerics.IEqualityOperators.op_Equality in SpanHelper.T.cs where possible.

### DIFF
--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -183,7 +183,6 @@ namespace System.Globalization.Tests
         [MemberData(nameof(IndexOf_TestData))]
         [MemberData(nameof(IndexOf_Aesc_Ligature_TestData))]
         [MemberData(nameof(IndexOf_U_WithDiaeresis_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/74179", TestRuntimes.Mono)]
         public void IndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected, int expectedMatchLength)
         {
             if (value.Length == 1)

--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -864,7 +864,6 @@ namespace System.Globalization.Tests
 
         [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(IndexOf_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/74179", TestRuntimes.Mono)]
         public void TestIndexOf(string source, string value, int startIndex, int count, CompareOptions options, int result)
         {
             foreach (string cul in s_cultureNames)
@@ -912,7 +911,6 @@ namespace System.Globalization.Tests
 
         [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(LastIndexOf_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/74179", TestRuntimes.Mono)]
         public void TestLastIndexOf(string source, string value, int startIndex, int count, CompareOptions options, int result)
         {
             foreach (string cul in s_cultureNames)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -1498,7 +1498,7 @@ namespace System
                 {
                     length -= 1;
 
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset).Equals(value))) return (int)offset;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)offset;
 
                     offset += 1;
                 }
@@ -2145,7 +2145,7 @@ namespace System
                 {
                     length -= 1;
 
-                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset).Equals(value))) return (int)offset;
+                    if (TNegator.NegateIfNeeded(Unsafe.Add(ref searchSpace, offset) == value)) return (int)offset;
 
                     offset -= 1;
                 }


### PR DESCRIPTION
Workaround crash hit by https://github.com/dotnet/runtime/issues/74179 making sure we avoid hitting codepath emitting this null pointer checks. The full fix includes codegen fixes as well, but will be performed in separate PR. There are still locations in SpanHelper.T.cs that uses Equal virtual call on value types that could be managed pointers to value types, but that code has remained the same for the last 4 years to 15 months and have not hit this issue in the past.

Fixes https://github.com/dotnet/runtime/issues/74179.

Full fix for underlying codegen issue, https://github.com/dotnet/runtime/pull/74638.