### PR TITLE
Discourage using explicit package references to ILCompiler to publish

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -41,7 +41,7 @@
     <_PackageReferenceExceptILCompiler Include="@(PackageReference)" Exclude="Microsoft.DotNet.ILCompiler" />
     <_ILCompilerPackageReference Include="@(PackageReference)" Exclude="@(_PackageReferenceExceptILCompiler)" />
     <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler" Condition="@(_ILCompilerPackageReference->'%(Identity)')=='Microsoft.DotNet.ILCompiler'">
-        <Warning Text="Adding an explicit package reference to 'Microsoft.DotNet.ILCompiler' works only on a narrow set of scenarios and can run into version errors if not properly used." />
+        <Warning Text="Set PublishAot property to true and delete explicit `Microsoft.DotNet.ILCompiler` package reference in your project file. Explicit Microsoft.DotNet.ILCompiler package reference can run into version errors." />
         <ILCompilerPackVersion>@(_ILCompilerPackageReference->'%(Version)')</ILCompilerPackVersion>
     </KnownILCompilerPack>
   </ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <!-- Generate a warning if the non-SDK path is used  -->
-  <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true'" BeforeTargets="ImportRuntimeIlcPackageTarget">
+  <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true' and '$(ILCompilerTargetsPath)' != ''" BeforeTargets="ImportRuntimeIlcPackageTarget">
     <Warning Text="Set PublishAot property to true and delete explicit `Microsoft.DotNet.ILCompiler` package reference in your project file. Explicit Microsoft.DotNet.ILCompiler package reference can run into version errors." />
   </Target>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -39,13 +39,13 @@
   <!-- If called via package instead of the SDK, update the runtime package version to match the build package -->
   <ItemGroup Condition="'$(AotRuntimePackageLoadedViaSDK)' != 'true'">
     <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
-        <ILCompilerPackVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName($(ILCompilerTargetsPath)))))))</ILCompilerPackVersion>
+      <ILCompilerPackVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName($(ILCompilerTargetsPath)))))))</ILCompilerPackVersion>
     </KnownILCompilerPack>
   </ItemGroup>
 
   <!-- Generate a warning if the non-SDK path is used  -->
   <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true'" BeforeTargets="ImportRuntimeIlcPackageTarget">
-    <Warning Text="Set PublishAot property to true and delete explicit `Microsoft.DotNet.ILCompiler` package reference in your project file. Explicit Microsoft.DotNet.ILCompiler package reference can run into version errors." />
+    <Warning Text="Set PublishAot property to true and delete explicit 'Microsoft.DotNet.ILCompiler' package reference in your project file. Explicit 'Microsoft.DotNet.ILCompiler' package reference can run into version errors." />
   </Target>
 
   <!-- Locate the runtime package according to the current target runtime -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -41,6 +41,7 @@
     <_PackageReferenceExceptILCompiler Include="@(PackageReference)" Exclude="Microsoft.DotNet.ILCompiler" />
     <_ILCompilerPackageReference Include="@(PackageReference)" Exclude="@(_PackageReferenceExceptILCompiler)" />
     <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler" Condition="@(_ILCompilerPackageReference->'%(Identity)')=='Microsoft.DotNet.ILCompiler'">
+        <Warning Text="Adding an explicit package reference to 'Microsoft.DotNet.ILCompiler' works only on a narrow set of scenarios and can run into version errors if not properly used." />
         <ILCompilerPackVersion>@(_ILCompilerPackageReference->'%(Version)')</ILCompilerPackVersion>
     </KnownILCompilerPack>
   </ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -36,15 +36,17 @@
     <IlcDynamicBuildPropertyDependencies>SetupProperties</IlcDynamicBuildPropertyDependencies>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- If called via package instead of the SDK, update the runtime package version to match the build package -->
-    <_PackageReferenceExceptILCompiler Include="@(PackageReference)" Exclude="Microsoft.DotNet.ILCompiler" />
-    <_ILCompilerPackageReference Include="@(PackageReference)" Exclude="@(_PackageReferenceExceptILCompiler)" />
-    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler" Condition="@(_ILCompilerPackageReference->'%(Identity)')=='Microsoft.DotNet.ILCompiler'">
-        <Warning Text="Set PublishAot property to true and delete explicit `Microsoft.DotNet.ILCompiler` package reference in your project file. Explicit Microsoft.DotNet.ILCompiler package reference can run into version errors." />
-        <ILCompilerPackVersion>@(_ILCompilerPackageReference->'%(Version)')</ILCompilerPackVersion>
+  <!-- If called via package instead of the SDK, update the runtime package version to match the build package -->
+  <ItemGroup Condition="'$(AotRuntimePackageLoadedViaSDK)' != 'true'">
+    <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
+        <ILCompilerPackVersion>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName($(ILCompilerTargetsPath)))))))</ILCompilerPackVersion>
     </KnownILCompilerPack>
   </ItemGroup>
+
+  <!-- Generate a warning if the non-SDK path is used  -->
+  <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true'" BeforeTargets="ImportRuntimeIlcPackageTarget">
+    <Warning Text="Set PublishAot property to true and delete explicit `Microsoft.DotNet.ILCompiler` package reference in your project file. Explicit Microsoft.DotNet.ILCompiler package reference can run into version errors." />
+  </Target>
 
   <!-- Locate the runtime package according to the current target runtime -->
   <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' and '$(PublishAot)' == 'true' and $(IlcCalledViaPackage) == 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.props
@@ -11,8 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
   <PropertyGroup>
-    <!-- Set the publishAot property to true when imported from a package reference. -->
-    <PublishAot Condition="'$(PublishAot)' == '' And '$(AotRuntimePackageLoadedViaSDK)' != 'true'">true</PublishAot>
     <!-- N.B. The ILCompilerTargetsPath is used as a sentinel to indicate a version of this file has already been imported. It will also be the path
          used to import the targets later in the SDK. -->
     <ILCompilerTargetsPath>$(MSBuildThisFileDirectory)Microsoft.DotNet.ILCompiler.SingleEntry.targets</ILCompilerTargetsPath>

--- a/src/coreclr/nativeaot/docs/compiling.md
+++ b/src/coreclr/nativeaot/docs/compiling.md
@@ -2,7 +2,7 @@
 
 Please consult [documentation](https://docs.microsoft.com/dotnet/core/deploying/native-aot) for instructions how to compile and publish application.
 
-The rest of this document covers advanced topics only. Adding an explicit package references to 'Microsoft.DotNet.ILCompile' can generate warnings when publishing and is only supported on a narrow set of scenarios. When possible, use the SDK options to publish a native AOT application.
+The rest of this document covers advanced topics only. Adding an explicit package references to 'Microsoft.DotNet.ILCompile' will generate warning when publishing and it can run into version errors. When possible, use the PublishAot property to publish a native AOT application.
 
 ## Using daily builds
 

--- a/src/coreclr/nativeaot/docs/compiling.md
+++ b/src/coreclr/nativeaot/docs/compiling.md
@@ -2,7 +2,7 @@
 
 Please consult [documentation](https://docs.microsoft.com/dotnet/core/deploying/native-aot) for instructions how to compile and publish application.
 
-The rest of this document covers advanced topics only. Adding an explicit package references to 'Microsoft.DotNet.ILCompile' will generate warning when publishing and it can run into version errors. When possible, use the PublishAot property to publish a native AOT application.
+The rest of this document covers advanced topics only. Adding an explicit package reference to `Microsoft.DotNet.ILCompiler` will generate warning when publishing and it can run into version errors. When possible, use the PublishAot property to publish a native AOT application.
 
 ## Using daily builds
 

--- a/src/coreclr/nativeaot/docs/compiling.md
+++ b/src/coreclr/nativeaot/docs/compiling.md
@@ -2,8 +2,7 @@
 
 Please consult [documentation](https://docs.microsoft.com/dotnet/core/deploying/native-aot) for instructions how to compile and publish application.
 
-The rest of this document covers advanced topics only.
-
+The rest of this document covers advanced topics only. Adding an explicit package references to 'Microsoft.DotNet.ILCompile' can generate warnings when publishing and is only supported on a narrow set of scenarios. When possible, use the SDK options to publish a native AOT application.
 
 ## Using daily builds
 
@@ -34,7 +33,7 @@ or by adding the following element to the project file:
 
 ## Cross-architecture compilation
 
-Native AOT toolchain allows targeting ARM64 on an x64 host and vice versa for both Windows and Linux. Cross-OS compilation, such as targeting Linux on a Windows host, is not supported. To target win-arm64 on a Windows x64 host, in addition to the `Microsoft.DotNet.ILCompiler` package reference, also add the `runtime.win-x64.Microsoft.DotNet.ILCompiler` package reference to get the x64-hosted compiler:
+Native AOT toolchain allows targeting ARM64 on an x64 host and vice versa for both Windows and Linux and is now supported in the SDK. Cross-OS compilation, such as targeting Linux on a Windows host, is not supported. To target win-arm64 on a Windows x64 host on an advanced scenario where the SDK support is not sufficient, in addition to the `Microsoft.DotNet.ILCompiler` package reference, also add the `runtime.win-x64.Microsoft.DotNet.ILCompiler` package reference to get the x64-hosted compiler:
 ```xml
 <PackageReference Include="Microsoft.DotNet.ILCompiler; runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="7.0.0-preview.2.22103.2" />
 ```

--- a/src/coreclr/nativeaot/docs/compiling.md
+++ b/src/coreclr/nativeaot/docs/compiling.md
@@ -33,7 +33,21 @@ or by adding the following element to the project file:
 
 ## Cross-architecture compilation
 
-Native AOT toolchain allows targeting ARM64 on an x64 host and vice versa for both Windows and Linux and is now supported in the SDK. Cross-OS compilation, such as targeting Linux on a Windows host, is not supported. To target win-arm64 on a Windows x64 host on an advanced scenario where the SDK support is not sufficient, in addition to the `Microsoft.DotNet.ILCompiler` package reference, also add the `runtime.win-x64.Microsoft.DotNet.ILCompiler` package reference to get the x64-hosted compiler:
+Native AOT toolchain allows targeting ARM64 on an x64 host and vice versa for both Windows and Linux and is now supported in the SDK. Cross-OS compilation, such as targeting Linux on a Windows host, is not supported. For SDK support, add the following to your project file,
+
+```xml
+    <PropertyGroup>
+        <PublishAot>true</PublishAot>
+    </PropertyGroup>
+```
+
+Targeting win-arm64 on a Windows x64 host machine,
+
+```bash
+> dotnet publish -r win-arm64 -c Release
+```
+
+To target win-arm64 on a Windows x64 host on an advanced scenario where the SDK support is not sufficient (note that these scenarios will generate warnings for using explicit package references), in addition to the `Microsoft.DotNet.ILCompiler` package reference, also add the `runtime.win-x64.Microsoft.DotNet.ILCompiler` package reference to get the x64-hosted compiler:
 ```xml
 <PackageReference Include="Microsoft.DotNet.ILCompiler; runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="7.0.0-preview.2.22103.2" />
 ```


### PR DESCRIPTION
Fixes #74387 and https://github.com/dotnet/sdk/issues/27239

Publishing a `NativeAOT` application is supported via the SDK and the 'old' unsupported way that we started via adding explicit package reference is discouraged. The explicit support is for very narrow scenarios like getting the latest fix on native AOT issues before the SDK exposes the fix via its official `ILCompiler `packages. 

We also no longer support publishing an AOT application if the SDK property, `PublishAOT`, is not set and only the explicit package reference exists. We allowed this behavior (no `PublishAOT` specified) early in 7.0 when SDK support was not enabled but do not want to continue to support the old way now. SDK path is the only we way want to support except for the narrow scenario described above where `PublishAOT` is still required for that scenario to work.