### PR TITLE
Remove unneeded references to JsonTypeInfo.PropertyInfoForTypeInfo.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -567,7 +567,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonSerializerOptions options,
             out JsonParameterInfo? jsonParameterInfo)
         {
-            Debug.Assert(state.Current.JsonTypeInfo.Converter.ConverterStrategy == ConverterStrategy.Object);
+            Debug.Assert(state.Current.JsonTypeInfo.Kind == JsonTypeInfoKind.Object);
 
             ReadOnlySpan<byte> unescapedPropertyName = JsonSerializer.GetPropertyName(ref state, ref reader, options);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -567,7 +567,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonSerializerOptions options,
             out JsonParameterInfo? jsonParameterInfo)
         {
-            Debug.Assert(state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
+            Debug.Assert(state.Current.JsonTypeInfo.Converter.ConverterStrategy == ConverterStrategy.Object);
 
             ReadOnlySpan<byte> unescapedPropertyName = JsonSerializer.GetPropertyName(ref state, ref reader, options);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json
             bool createExtensionProperty = true)
         {
 #if DEBUG
-            if (state.Current.JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy != ConverterStrategy.Object)
+            if (state.Current.JsonTypeInfo.Converter.ConverterStrategy != ConverterStrategy.Object)
             {
                 string objTypeName = obj?.GetType().FullName ?? "<null>";
                 Debug.Fail($"obj.GetType() => {objTypeName}; {state.Current.JsonTypeInfo.GetPropertyDebugInfo(unescapedPropertyName)}");

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json
             bool createExtensionProperty = true)
         {
 #if DEBUG
-            if (state.Current.JsonTypeInfo.Converter.ConverterStrategy != ConverterStrategy.Object)
+            if (state.Current.JsonTypeInfo.Kind != JsonTypeInfoKind.Object)
             {
                 string objTypeName = obj?.GetType().FullName ?? "<null>";
                 Debug.Fail($"obj.GetType() => {objTypeName}; {state.Current.JsonTypeInfo.GetPropertyDebugInfo(unescapedPropertyName)}");

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -20,8 +20,6 @@ namespace System.Text.Json.Serialization.Metadata
         internal JsonTypeInfo? ParentTypeInfo { get; private set; }
         private JsonTypeInfo? _jsonTypeInfo;
 
-        internal ConverterStrategy ConverterStrategy { get; private protected set; }
-
         /// <summary>
         /// Converter after applying CustomConverter (i.e. JsonConverterAttribute)
         /// </summary>
@@ -424,7 +422,7 @@ namespace System.Text.Json.Serialization.Metadata
                 return;
             }
 
-            if ((ConverterStrategy & (ConverterStrategy.Enumerable | ConverterStrategy.Dictionary)) != 0)
+            if ((EffectiveConverter.ConverterStrategy & (ConverterStrategy.Enumerable | ConverterStrategy.Dictionary)) != 0)
             {
                 // Properties of collections types that only have setters are not supported.
                 if (Get == null && Set != null && !_isUserSpecifiedSetter)
@@ -501,7 +499,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             Type potentialNumberType;
             if (!EffectiveConverter.IsInternalConverter ||
-                ((ConverterStrategy.Enumerable | ConverterStrategy.Dictionary) & ConverterStrategy) == 0)
+                ((ConverterStrategy.Enumerable | ConverterStrategy.Dictionary) & EffectiveConverter.ConverterStrategy) == 0)
             {
                 potentialNumberType = PropertyType;
             }
@@ -802,8 +800,6 @@ namespace System.Text.Json.Serialization.Metadata
             {
                 // This could potentially be double initialized
                 Debug.Assert(_jsonTypeInfo == null || _jsonTypeInfo == value);
-                // Ensure the right strategy is surfaced in PropertyInfoForTypeInfo early
-                ConverterStrategy = value?.Converter.ConverterStrategy ?? default;
                 _jsonTypeInfo = value;
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -10,8 +10,6 @@ namespace System.Text.Json.Serialization.Metadata
     /// <summary>
     /// Represents a strongly-typed property to prevent boxing and to create a direct delegate to the getter\setter.
     /// </summary>
-    /// <typeparamref name="T"/> is the <see cref="JsonConverter{T}.TypeToConvert"/> for either the property's converter,
-    /// or a type's converter, if the current instance is a <see cref="JsonTypeInfo.PropertyInfoForTypeInfo"/>.
     internal sealed class JsonPropertyInfo<T> : JsonPropertyInfo
     {
         private Func<object, T>? _typedGet;
@@ -221,7 +219,6 @@ namespace System.Text.Json.Serialization.Metadata
 
             _effectiveConverter = converter;
             _typedEffectiveConverter = converter;
-            ConverterStrategy = converter.ConverterStrategy;
         }
 
         internal override object? GetValueAsObject(object obj)
@@ -249,7 +246,7 @@ namespace System.Text.Json.Serialization.Metadata
                 value is not null &&
                 !state.IsContinuation &&
                 // .NET types that are serialized as JSON primitive values don't need to be tracked for cycle detection e.g: string.
-                ConverterStrategy != ConverterStrategy.Value &&
+                EffectiveConverter.ConverterStrategy != ConverterStrategy.Value &&
                 state.ReferenceResolver.ContainsReferenceForCycleDetection(value))
             {
                 // If a reference cycle is detected, treat value as null.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -538,7 +538,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             JsonConverter converter = Converter;
             Debug.Assert(PropertyInfoForTypeInfo.EffectiveConverter.ConverterStrategy == Converter.ConverterStrategy,
-                $"ConverterStrategy from PropertyInfoForTypeInfo.ConverterStrategy ({PropertyInfoForTypeInfo.EffectiveConverter.ConverterStrategy}) does not match converter's ({Converter.ConverterStrategy})");
+                $"ConverterStrategy from PropertyInfoForTypeInfo.EffectiveConverter.ConverterStrategy ({PropertyInfoForTypeInfo.EffectiveConverter.ConverterStrategy}) does not match converter's ({Converter.ConverterStrategy})");
             if (Kind == JsonTypeInfoKind.Object)
             {
                 InitializePropertyCache();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -410,7 +410,6 @@ namespace System.Text.Json.Serialization.Metadata
         /// 3. the property metadata for the root-level value.
         /// For example, for a property returning <see cref="List{T}"/> where T is a string,
         /// a JsonTypeInfo will be created with .Type=typeof(string) and .PropertyInfoForTypeInfo=JsonPropertyInfo{string}.
-        /// Without this property, methods that have a JsonPropertyInfo argument would also likely need to add an argument for JsonTypeInfo.
         /// </remarks>
         internal JsonPropertyInfo PropertyInfoForTypeInfo { get; }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -341,7 +341,7 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     if (KeyType != null)
                     {
-                        Debug.Assert(Converter.ConverterStrategy == ConverterStrategy.Dictionary);
+                        Debug.Assert(Kind == JsonTypeInfoKind.Dictionary);
 
                         // GetOrAddJsonTypeInfo already ensures JsonTypeInfo is configured
                         // also see comment on JsonPropertyInfo.JsonTypeInfo

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -341,7 +341,7 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     if (KeyType != null)
                     {
-                        Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Dictionary);
+                        Debug.Assert(Converter.ConverterStrategy == ConverterStrategy.Dictionary);
 
                         // GetOrAddJsonTypeInfo already ensures JsonTypeInfo is configured
                         // also see comment on JsonPropertyInfo.JsonTypeInfo
@@ -401,20 +401,16 @@ namespace System.Text.Json.Serialization.Metadata
         public JsonTypeInfoKind Kind { get; private set; }
 
         /// <summary>
-        /// The JsonPropertyInfo for this JsonTypeInfo. It is used to obtain the converter for the TypeInfo.
+        /// Dummy <see cref="JsonPropertyInfo"/> instance corresponding to the declaring type of this <see cref="JsonTypeInfo"/>.
         /// </summary>
         /// <remarks>
-        /// The returned JsonPropertyInfo does not represent a real property; instead it represents either:
-        /// a collection element type,
-        /// a generic type parameter,
-        /// a property type (if pushed to a new stack frame),
-        /// or the root type passed into the root serialization APIs.
-        /// For example, for a property returning <see cref="Collections.Generic.List{T}"/> where T is a string,
+        /// Used as convenience in cases where we want to serialize property-like values that do not define property metadata, such as:
+        /// 1. a collection element type,
+        /// 2. a dictionary key or value type or,
+        /// 3. the property metadata for the root-level value.
+        /// For example, for a property returning <see cref="List{T}"/> where T is a string,
         /// a JsonTypeInfo will be created with .Type=typeof(string) and .PropertyInfoForTypeInfo=JsonPropertyInfo{string}.
-        /// Without this property, a "Converter" property would need to be added to JsonTypeInfo and there would be several more
-        /// `if` statements to obtain the converter from either the actual JsonPropertyInfo (for a real property) or from the
-        /// TypeInfo (for the cases mentioned above). In addition, methods that have a JsonPropertyInfo argument would also likely
-        /// need to add an argument for JsonTypeInfo.
+        /// Without this property, methods that have a JsonPropertyInfo argument would also likely need to add an argument for JsonTypeInfo.
         /// </remarks>
         internal JsonPropertyInfo PropertyInfoForTypeInfo { get; }
 
@@ -456,7 +452,7 @@ namespace System.Text.Json.Serialization.Metadata
             PropertyInfoForTypeInfo = CreatePropertyInfoForTypeInfo();
             ElementType = converter.ElementType;
 
-            switch (PropertyInfoForTypeInfo.ConverterStrategy)
+            switch (converter.ConverterStrategy)
             {
                 case ConverterStrategy.Dictionary:
                     {
@@ -473,11 +469,11 @@ namespace System.Text.Json.Serialization.Metadata
                     }
                     break;
                 default:
-                    Debug.Fail($"Unexpected class type: {PropertyInfoForTypeInfo.ConverterStrategy}");
+                    Debug.Fail($"Unexpected class type: {converter.ConverterStrategy}");
                     throw new InvalidOperationException();
             }
 
-            Kind = GetTypeInfoKind(type, PropertyInfoForTypeInfo.ConverterStrategy);
+            Kind = GetTypeInfoKind(type, converter.ConverterStrategy);
         }
 
         internal void VerifyMutable()
@@ -542,9 +538,8 @@ namespace System.Text.Json.Serialization.Metadata
             CanUseSerializeHandler &= Options.SerializerContext?.CanUseSerializationLogic == true;
 
             JsonConverter converter = Converter;
-            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == Converter.ConverterStrategy,
-                $"ConverterStrategy from PropertyInfoForTypeInfo.ConverterStrategy ({PropertyInfoForTypeInfo.ConverterStrategy}) does not match converter's ({Converter.ConverterStrategy})");
-
+            Debug.Assert(PropertyInfoForTypeInfo.EffectiveConverter.ConverterStrategy == Converter.ConverterStrategy,
+                $"ConverterStrategy from PropertyInfoForTypeInfo.ConverterStrategy ({PropertyInfoForTypeInfo.EffectiveConverter.ConverterStrategy}) does not match converter's ({Converter.ConverterStrategy})");
             if (Kind == JsonTypeInfoKind.Object)
             {
                 InitializePropertyCache();
@@ -570,7 +565,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal string GetDebugInfo()
         {
-            ConverterStrategy strat = PropertyInfoForTypeInfo.ConverterStrategy;
+            ConverterStrategy converterStrategy = Converter.ConverterStrategy;
             string jtiTypeName = GetType().Name;
             string typeName = Type.FullName!;
             bool propCacheInitialized = PropertyCache != null;
@@ -579,7 +574,7 @@ namespace System.Text.Json.Serialization.Metadata
             sb.AppendLine("{");
             sb.AppendLine($"  GetType: {jtiTypeName},");
             sb.AppendLine($"  Type: {typeName},");
-            sb.AppendLine($"  ConverterStrategy: {strat},");
+            sb.AppendLine($"  ConverterStrategy: {converterStrategy},");
             sb.AppendLine($"  IsConfigured: {IsConfigured},");
             sb.AppendLine($"  HasPropertyCache: {propCacheInitialized},");
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -23,7 +23,7 @@ namespace System.Text.Json.Serialization.Metadata
             PopulatePolymorphismMetadata();
             MapInterfaceTypesToCallbacks();
 
-            if (PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object)
+            if (converter.ConverterStrategy == ConverterStrategy.Object)
             {
                 AddPropertiesAndParametersUsingReflection();
             }
@@ -41,7 +41,7 @@ namespace System.Text.Json.Serialization.Metadata
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         private void AddPropertiesAndParametersUsingReflection()
         {
-            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
+            Debug.Assert(Converter.ConverterStrategy == ConverterStrategy.Object);
 
             const BindingFlags BindingFlags =
                 BindingFlags.Instance |

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -216,8 +216,8 @@ namespace System.Text.Json
             Debug.Assert(Current.PolymorphicSerializationState == PolymorphicSerializationState.None);
 
             Current.PolymorphicJsonTypeInfo = Current.JsonTypeInfo;
-            Current.JsonTypeInfo = derivedJsonTypeInfo.PropertyInfoForTypeInfo.JsonTypeInfo;
-            Current.JsonPropertyInfo = Current.JsonTypeInfo.PropertyInfoForTypeInfo;
+            Current.JsonTypeInfo = derivedJsonTypeInfo;
+            Current.JsonPropertyInfo = derivedJsonTypeInfo.PropertyInfoForTypeInfo;
             Current.NumberHandling ??= Current.JsonPropertyInfo.NumberHandling;
             Current.PolymorphicSerializationState = PolymorphicSerializationState.PolymorphicReEntryStarted;
             SetConstructorArgumentState();
@@ -411,6 +411,6 @@ namespace System.Text.Json
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string DebuggerDisplay => $"Path:{JsonPath()} Current: ConverterStrategy.{Current.JsonTypeInfo?.PropertyInfoForTypeInfo.ConverterStrategy}, {Current.JsonTypeInfo?.Type.Name}";
+        private string DebuggerDisplay => $"Path:{JsonPath()} Current: ConverterStrategy.{Current.JsonTypeInfo?.Converter.ConverterStrategy}, {Current.JsonTypeInfo?.Type.Name}";
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -105,7 +105,7 @@ namespace System.Text.Json
         /// </summary>
         public bool IsProcessingDictionary()
         {
-            return (JsonTypeInfo.Converter.ConverterStrategy & ConverterStrategy.Dictionary) != 0;
+            return JsonTypeInfo.Kind is JsonTypeInfoKind.Dictionary;
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace System.Text.Json
         /// </summary>
         public bool IsProcessingEnumerable()
         {
-            return (JsonTypeInfo.Converter.ConverterStrategy & ConverterStrategy.Enumerable) != 0;
+            return JsonTypeInfo.Kind is JsonTypeInfoKind.Enumerable;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -105,7 +105,7 @@ namespace System.Text.Json
         /// </summary>
         public bool IsProcessingDictionary()
         {
-            return (JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy & ConverterStrategy.Dictionary) != 0;
+            return (JsonTypeInfo.Converter.ConverterStrategy & ConverterStrategy.Dictionary) != 0;
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace System.Text.Json
         /// </summary>
         public bool IsProcessingEnumerable()
         {
-            return (JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy & ConverterStrategy.Enumerable) != 0;
+            return (JsonTypeInfo.Converter.ConverterStrategy & ConverterStrategy.Enumerable) != 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -152,6 +152,6 @@ namespace System.Text.Json
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string DebuggerDisplay => $"ConverterStrategy.{JsonTypeInfo?.PropertyInfoForTypeInfo.ConverterStrategy}, {JsonTypeInfo?.Type.Name}";
+        private string DebuggerDisplay => $"ConverterStrategy.{JsonTypeInfo?.Converter.ConverterStrategy}, {JsonTypeInfo?.Type.Name}";
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -430,6 +430,6 @@ namespace System.Text.Json
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string DebuggerDisplay => $"Path:{PropertyPath()} Current: ConverterStrategy.{Current.JsonPropertyInfo?.ConverterStrategy}, {Current.JsonTypeInfo?.Type.Name}";
+        private string DebuggerDisplay => $"Path:{PropertyPath()} Current: ConverterStrategy.{Current.JsonPropertyInfo?.EffectiveConverter.ConverterStrategy}, {Current.JsonTypeInfo?.Type.Name}";
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -166,6 +166,6 @@ namespace System.Text.Json
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string DebuggerDisplay => $"ConverterStrategy.{JsonTypeInfo?.PropertyInfoForTypeInfo.ConverterStrategy}, {JsonTypeInfo?.Type.Name}";
+        private string DebuggerDisplay => $"ConverterStrategy.{JsonTypeInfo?.Converter.ConverterStrategy}, {JsonTypeInfo?.Type.Name}";
     }
 }


### PR DESCRIPTION
The internal `JsonTypeInfo.PropertyInfoForTypeInfo` property provides a placeholder implementation for `JsonPropertyInfo` in cases where real `JsonPropertyInfo` metadata is absent (e.g. when serializing the elements of a collection). This instance breaks a few invariants of the `JsonPropertyInfo` metadata and generally makes the internal serialization implementation harder to understand. Even though we would want to eventually remove it, this necessitates a deeper refactoring which we may or may not want to commit to in the near future. 

This PR on the other hand, removes quite a few superficial uses of `PropertyInfoForTypeInfo`, restricting the property to use cases where it is actually needed.