### PR TITLE
[release/6.0] Drop 6.0.200 workload manifests

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,10 +12,6 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>3f6c45a2580cd9387b643163de8136a9691764c8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.200" Version="6.0.9">
-      <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>3f6c45a2580cd9387b643163de8136a9691764c8</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.9">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>3f6c45a2580cd9387b643163de8136a9691764c8</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- The bands we want to produce workload manifests for -->
-    <WorkloadSdkBandVersions Include="6.0.100;6.0.200;6.0.300;6.0.400" />
+    <WorkloadSdkBandVersions Include="6.0.100;6.0.300;6.0.400" />
   </ItemGroup>
   <PropertyGroup>
     <!-- For source generator support we need to target multiple versions of Rolsyn in order to be able to run on older versions of Roslyn -->
@@ -172,7 +172,6 @@
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21416.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
     <!-- emscripten / Node -->
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.9</MicrosoftNETWorkloadEmscriptenManifest60100Version>
-    <MicrosoftNETWorkloadEmscriptenManifest60200Version>6.0.9</MicrosoftNETWorkloadEmscriptenManifest60200Version>
     <MicrosoftNETWorkloadEmscriptenManifest60300Version>6.0.9</MicrosoftNETWorkloadEmscriptenManifest60300Version>
     <MicrosoftNETWorkloadEmscriptenManifest60400Version>6.0.9</MicrosoftNETWorkloadEmscriptenManifest60400Version>
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</MicrosoftNETRuntimeEmscriptenVersion>


### PR DESCRIPTION
goes along with https://github.com/dotnet/emsdk/pull/195