### PR TITLE
Fix XmlBinaryReader/XmlBinaryWriter on big-endian systems

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
@@ -1350,14 +1350,14 @@ namespace System.Xml
 
         public override int ReadArray(string localName, string namespaceUri, float[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
         public override int ReadArray(XmlDictionaryString localName, XmlDictionaryString namespaceUri, float[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
@@ -1373,14 +1373,14 @@ namespace System.Xml
 
         public override int ReadArray(string localName, string namespaceUri, double[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
         public override int ReadArray(XmlDictionaryString localName, XmlDictionaryString namespaceUri, double[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
@@ -1396,14 +1396,14 @@ namespace System.Xml
 
         public override int ReadArray(string localName, string namespaceUri, decimal[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
         public override int ReadArray(XmlDictionaryString localName, XmlDictionaryString namespaceUri, decimal[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Runtime.Serialization;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Buffers.Binary;
 
 namespace System.Xml
 {
@@ -757,12 +758,8 @@ namespace System.Xml
             {
                 int offset;
                 byte[] buffer = GetTextNodeBuffer(1 + sizeof(float), out offset);
-                byte* bytes = (byte*)&f;
                 buffer[offset + 0] = (byte)XmlBinaryNodeType.FloatText;
-                buffer[offset + 1] = bytes[0];
-                buffer[offset + 2] = bytes[1];
-                buffer[offset + 3] = bytes[2];
-                buffer[offset + 4] = bytes[3];
+                BinaryPrimitives.WriteSingleLittleEndian(buffer.AsSpan(offset + 1, 4), f);
                 Advance(1 + sizeof(float));
             }
         }
@@ -778,16 +775,8 @@ namespace System.Xml
             {
                 int offset;
                 byte[] buffer = GetTextNodeBuffer(1 + sizeof(double), out offset);
-                byte* bytes = (byte*)&d;
                 buffer[offset + 0] = (byte)XmlBinaryNodeType.DoubleText;
-                buffer[offset + 1] = bytes[0];
-                buffer[offset + 2] = bytes[1];
-                buffer[offset + 3] = bytes[2];
-                buffer[offset + 4] = bytes[3];
-                buffer[offset + 5] = bytes[4];
-                buffer[offset + 6] = bytes[5];
-                buffer[offset + 7] = bytes[6];
-                buffer[offset + 8] = bytes[7];
+                BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan(offset + 1, 8), d);
                 Advance(1 + sizeof(double));
             }
         }
@@ -798,10 +787,26 @@ namespace System.Xml
             byte[] buffer = GetTextNodeBuffer(1 + sizeof(decimal), out offset);
             byte* bytes = (byte*)&d;
             buffer[offset++] = (byte)XmlBinaryNodeType.DecimalText;
-            for (int i = 0; i < sizeof(decimal); i++)
+            if (BitConverter.IsLittleEndian)
             {
-                buffer[offset++] = bytes[i];
+                for (int i = 0; i < sizeof(decimal); i++)
+                {
+                    buffer[offset++] = bytes[i];
+                }
             }
+            else
+            {
+                Span<int> bits = stackalloc int[4];
+                decimal.TryGetBits(d, bits, out int intsWritten);
+                Debug.Assert(intsWritten == 4);
+
+                Span<byte> span = buffer.AsSpan(offset, sizeof(decimal));
+                BinaryPrimitives.WriteInt32LittleEndian(span, bits[3]);
+                BinaryPrimitives.WriteInt32LittleEndian(span.Slice(4), bits[2]);
+                BinaryPrimitives.WriteInt32LittleEndian(span.Slice(8), bits[0]);
+                BinaryPrimitives.WriteInt32LittleEndian(span.Slice(12), bits[1]);
+            }
+
             Advance(1 + sizeof(decimal));
         }
 
@@ -870,15 +875,146 @@ namespace System.Xml
             WriteMultiByteInt32(count);
         }
 
-        public unsafe void UnsafeWriteArray(XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
+        public unsafe void UnsafeWriteBoolArray(bool[] array, int offset, int count)
         {
-            WriteArrayInfo(nodeType, count);
-            UnsafeWriteArray(array, (int)(arrayMax - array));
+            WriteArrayInfo(XmlBinaryNodeType.BoolTextWithEndElement, count);
+            fixed (bool* items = &array[offset])
+            {
+                base.UnsafeWriteBytes((byte*)items, count);
+            }
         }
 
-        private unsafe void UnsafeWriteArray(byte* array, int byteCount)
+        public unsafe void UnsafeWriteInt16Array(short[] array, int offset, int count)
         {
-            base.UnsafeWriteBytes(array, byteCount);
+            WriteArrayInfo(XmlBinaryNodeType.Int16TextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (short* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, 2 * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(2, out int bufferOffset).AsSpan(bufferOffset, 2);
+                    BinaryPrimitives.WriteInt16LittleEndian(span, array[offset + i]);
+                    Advance(2);
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteInt32Array(int[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.Int32TextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (int* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, 4 * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(4, out int bufferOffset).AsSpan(bufferOffset, 4);
+                    BinaryPrimitives.WriteInt32LittleEndian(span, array[offset + i]);
+                    Advance(4);
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteInt64Array(long[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.Int64TextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (long* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, 8 * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(8, out int bufferOffset).AsSpan(bufferOffset, 8);
+                    BinaryPrimitives.WriteInt64LittleEndian(span, array[offset + i]);
+                    Advance(8);
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteFloatArray(float[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.FloatTextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (float* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, 4 * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(4, out int bufferOffset).AsSpan(bufferOffset, 4);
+                    BinaryPrimitives.WriteSingleLittleEndian(span, array[offset + i]);
+                    Advance(4);
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteDoubleArray(double[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.DoubleTextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (double* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, 8 * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(8, out int bufferOffset).AsSpan(bufferOffset, 8);
+                    BinaryPrimitives.WriteDoubleLittleEndian(span, array[offset + i]);
+                    Advance(8);
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteDecimalArray(decimal[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.DecimalTextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (decimal* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, 16 * count);
+                }
+            }
+            else
+            {
+                Span<int> bits = stackalloc int[4];
+                for (int i = 0; i < count; i++)
+                {
+                    decimal.TryGetBits(array[offset + i], bits, out int intsWritten);
+                    Debug.Assert(intsWritten == 4);
+
+                    Span<byte> span = GetBuffer(16, out int bufferOffset).AsSpan(bufferOffset, 16);
+                    BinaryPrimitives.WriteInt32LittleEndian(span, bits[3]);
+                    BinaryPrimitives.WriteInt32LittleEndian(span.Slice(4), bits[2]);
+                    BinaryPrimitives.WriteInt32LittleEndian(span.Slice(8), bits[0]);
+                    BinaryPrimitives.WriteInt32LittleEndian(span.Slice(12), bits[1]);
+                    Advance(16);
+                }
+            }
         }
 
         public void WriteDateTimeArray(DateTime[] array, int offset, int count)
@@ -1160,20 +1296,6 @@ namespace System.Xml
             WriteEndElement();
         }
 
-        private unsafe void UnsafeWriteArray(string? prefix, string localName, string? namespaceUri,
-                               XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
-        {
-            WriteStartArray(prefix, localName, namespaceUri, count);
-            _writer.UnsafeWriteArray(nodeType, count, array, arrayMax);
-        }
-
-        private unsafe void UnsafeWriteArray(string? prefix, XmlDictionaryString localName, XmlDictionaryString? namespaceUri,
-                               XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
-        {
-            WriteStartArray(prefix, localName, namespaceUri, count);
-            _writer.UnsafeWriteArray(nodeType, count, array, arrayMax);
-        }
-
         private static void CheckArray(Array array, int offset, int count)
         {
             ArgumentNullException.ThrowIfNull(array);
@@ -1199,10 +1321,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (bool* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.BoolTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteBoolArray(array, offset, count);
                 }
             }
         }
@@ -1218,10 +1338,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (bool* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.BoolTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteBoolArray(array, offset, count);
                 }
             }
         }
@@ -1237,10 +1355,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (short* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int16TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt16Array(array, offset, count);
                 }
             }
         }
@@ -1256,10 +1372,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (short* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int16TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt16Array(array, offset, count);
                 }
             }
         }
@@ -1275,10 +1389,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (int* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int32TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt32Array(array, offset, count);
                 }
             }
         }
@@ -1294,10 +1406,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (int* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int32TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt32Array(array, offset, count);
                 }
             }
         }
@@ -1313,10 +1423,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (long* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int64TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt64Array(array, offset, count);
                 }
             }
         }
@@ -1332,10 +1440,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (long* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int64TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt64Array(array, offset, count);
                 }
             }
         }
@@ -1351,10 +1457,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (float* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteFloatArray(array, offset, count);
                 }
             }
         }
@@ -1370,10 +1474,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (float* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteFloatArray(array, offset, count);
                 }
             }
         }
@@ -1389,10 +1491,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (double* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteDoubleArray(array, offset, count);
                 }
             }
         }
@@ -1408,10 +1508,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (double* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteDoubleArray(array, offset, count);
                 }
             }
         }
@@ -1427,10 +1525,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (decimal* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteDecimalArray(array, offset, count);
                 }
             }
         }
@@ -1446,10 +1542,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (decimal* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteDecimalArray(array, offset, count);
                 }
             }
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -759,7 +759,7 @@ namespace System.Xml
                 int offset;
                 byte[] buffer = GetTextNodeBuffer(1 + sizeof(float), out offset);
                 buffer[offset + 0] = (byte)XmlBinaryNodeType.FloatText;
-                BinaryPrimitives.WriteSingleLittleEndian(buffer.AsSpan(offset + 1, 4), f);
+                BinaryPrimitives.WriteSingleLittleEndian(buffer.AsSpan(offset + 1, sizeof(float)), f);
                 Advance(1 + sizeof(float));
             }
         }
@@ -776,7 +776,7 @@ namespace System.Xml
                 int offset;
                 byte[] buffer = GetTextNodeBuffer(1 + sizeof(double), out offset);
                 buffer[offset + 0] = (byte)XmlBinaryNodeType.DoubleText;
-                BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan(offset + 1, 8), d);
+                BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan(offset + 1, sizeof(double)), d);
                 Advance(1 + sizeof(double));
             }
         }
@@ -891,16 +891,16 @@ namespace System.Xml
             {
                 fixed (short* items = &array[offset])
                 {
-                    base.UnsafeWriteBytes((byte*)items, 2 * count);
+                    base.UnsafeWriteBytes((byte*)items, sizeof(short) * count);
                 }
             }
             else
             {
                 for (int i = 0; i < count; i++)
                 {
-                    Span<byte> span = GetBuffer(2, out int bufferOffset).AsSpan(bufferOffset, 2);
+                    Span<byte> span = GetBuffer(sizeof(short), out int bufferOffset).AsSpan(bufferOffset, sizeof(short));
                     BinaryPrimitives.WriteInt16LittleEndian(span, array[offset + i]);
-                    Advance(2);
+                    Advance(sizeof(short));
                 }
             }
         }
@@ -912,16 +912,16 @@ namespace System.Xml
             {
                 fixed (int* items = &array[offset])
                 {
-                    base.UnsafeWriteBytes((byte*)items, 4 * count);
+                    base.UnsafeWriteBytes((byte*)items, sizeof(int) * count);
                 }
             }
             else
             {
                 for (int i = 0; i < count; i++)
                 {
-                    Span<byte> span = GetBuffer(4, out int bufferOffset).AsSpan(bufferOffset, 4);
+                    Span<byte> span = GetBuffer(sizeof(int), out int bufferOffset).AsSpan(bufferOffset, sizeof(int));
                     BinaryPrimitives.WriteInt32LittleEndian(span, array[offset + i]);
-                    Advance(4);
+                    Advance(sizeof(int));
                 }
             }
         }
@@ -933,16 +933,16 @@ namespace System.Xml
             {
                 fixed (long* items = &array[offset])
                 {
-                    base.UnsafeWriteBytes((byte*)items, 8 * count);
+                    base.UnsafeWriteBytes((byte*)items, sizeof(long) * count);
                 }
             }
             else
             {
                 for (int i = 0; i < count; i++)
                 {
-                    Span<byte> span = GetBuffer(8, out int bufferOffset).AsSpan(bufferOffset, 8);
+                    Span<byte> span = GetBuffer(sizeof(long), out int bufferOffset).AsSpan(bufferOffset, sizeof(long));
                     BinaryPrimitives.WriteInt64LittleEndian(span, array[offset + i]);
-                    Advance(8);
+                    Advance(sizeof(long));
                 }
             }
         }
@@ -954,16 +954,16 @@ namespace System.Xml
             {
                 fixed (float* items = &array[offset])
                 {
-                    base.UnsafeWriteBytes((byte*)items, 4 * count);
+                    base.UnsafeWriteBytes((byte*)items, sizeof(float) * count);
                 }
             }
             else
             {
                 for (int i = 0; i < count; i++)
                 {
-                    Span<byte> span = GetBuffer(4, out int bufferOffset).AsSpan(bufferOffset, 4);
+                    Span<byte> span = GetBuffer(sizeof(float), out int bufferOffset).AsSpan(bufferOffset, sizeof(float));
                     BinaryPrimitives.WriteSingleLittleEndian(span, array[offset + i]);
-                    Advance(4);
+                    Advance(sizeof(float));
                 }
             }
         }
@@ -975,16 +975,16 @@ namespace System.Xml
             {
                 fixed (double* items = &array[offset])
                 {
-                    base.UnsafeWriteBytes((byte*)items, 8 * count);
+                    base.UnsafeWriteBytes((byte*)items, sizeof(double) * count);
                 }
             }
             else
             {
                 for (int i = 0; i < count; i++)
                 {
-                    Span<byte> span = GetBuffer(8, out int bufferOffset).AsSpan(bufferOffset, 8);
+                    Span<byte> span = GetBuffer(sizeof(double), out int bufferOffset).AsSpan(bufferOffset, sizeof(double));
                     BinaryPrimitives.WriteDoubleLittleEndian(span, array[offset + i]);
-                    Advance(8);
+                    Advance(sizeof(double));
                 }
             }
         }
@@ -996,7 +996,7 @@ namespace System.Xml
             {
                 fixed (decimal* items = &array[offset])
                 {
-                    base.UnsafeWriteBytes((byte*)items, 16 * count);
+                    base.UnsafeWriteBytes((byte*)items, sizeof(decimal) * count);
                 }
             }
             else

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -373,10 +373,10 @@ namespace System.Xml
             => BitConverter.IsLittleEndian ? ReadRawBytes<long>() : BinaryPrimitives.ReverseEndianness(ReadRawBytes<long>());
 
         public float ReadSingle()
-            => BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(4, out int offset).AsSpan(offset, 4));
+            => BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(sizeof(float), out int offset).AsSpan(offset, sizeof(float)));
 
         public double ReadDouble()
-            => BinaryPrimitives.ReadDoubleLittleEndian(GetBuffer(8, out int offset).AsSpan(offset, 8));
+            => BinaryPrimitives.ReadDoubleLittleEndian(GetBuffer(sizeof(double), out int offset).AsSpan(offset, sizeof(double)));
 
         public decimal ReadDecimal()
         {
@@ -964,10 +964,10 @@ namespace System.Xml
             => (ulong)GetInt64(offset);
 
         public float GetSingle(int offset)
-            => BinaryPrimitives.ReadSingleLittleEndian(_buffer.AsSpan(offset, 4));
+            => BinaryPrimitives.ReadSingleLittleEndian(_buffer.AsSpan(offset, sizeof(float)));
 
         public double GetDouble(int offset)
-            => BinaryPrimitives.ReadDoubleLittleEndian(_buffer.AsSpan(offset, 8));
+            => BinaryPrimitives.ReadDoubleLittleEndian(_buffer.AsSpan(offset, sizeof(double)));
 
         public decimal GetDecimal(int offset)
         {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -373,10 +373,10 @@ namespace System.Xml
             => BitConverter.IsLittleEndian ? ReadRawBytes<long>() : BinaryPrimitives.ReverseEndianness(ReadRawBytes<long>());
 
         public float ReadSingle()
-            => ReadRawBytes<float>();
+            => BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(4, out int offset).AsSpan(offset, 4));
 
         public double ReadDouble()
-            => ReadRawBytes<double>();
+            => BinaryPrimitives.ReadDoubleLittleEndian(GetBuffer(8, out int offset).AsSpan(offset, 8));
 
         public decimal ReadDecimal()
         {
@@ -964,10 +964,10 @@ namespace System.Xml
             => (ulong)GetInt64(offset);
 
         public float GetSingle(int offset)
-            => ReadRawBytes<float>(offset);
+            => BinaryPrimitives.ReadSingleLittleEndian(_buffer.AsSpan(offset, 4));
 
         public double GetDouble(int offset)
-            => ReadRawBytes<double>(offset);
+            => BinaryPrimitives.ReadDoubleLittleEndian(_buffer.AsSpan(offset, 8));
 
         public decimal GetDecimal(int offset)
         {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
@@ -166,7 +166,6 @@ namespace System.Runtime.Serialization.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/74494", typeof(PlatformDetection), nameof(PlatformDetection.IsS390xProcess))]
         public static void BinaryXml_ReadPrimitiveTypes()
         {
             float f = 1.23456788f;
@@ -206,7 +205,6 @@ namespace System.Runtime.Serialization.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/74494", typeof(PlatformDetection), nameof(PlatformDetection.IsS390xProcess))]
         public static void BinaryXml_Array_RoundTrip()
         {
             int[] ints = new int[] { -1, 0x01020304, 0x11223344, -1 };

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
@@ -195,12 +195,10 @@ namespace System.Runtime.Serialization.Xml.Tests
             AssertReadContentFromBinary(8.20788039913184E-304, XmlBinaryNodeType.DoubleText, new byte[] { 8, 7, 6, 5, 4, 3, 2, 1 });
             AssertReadContentFromBinary(guid, XmlBinaryNodeType.GuidText, guid.ToByteArray());
             AssertReadContentFromBinary(new TimeSpan(0x0807060504030201), XmlBinaryNodeType.TimeSpanText, new byte[] { 01, 02, 03, 04, 05, 06, 07, 08 });
-            AssertReadContentFromBinary(new decimal(0x20212223, 0x10111213, 0x01020304, true, scale: 0x1b), XmlBinaryNodeType.DecimalText
-                , new byte[] { 0x0, 0x0, 0x1b, 0x80, 0x4, 0x3, 0x2, 0x1, 0x23, 0x22, 0x21, 0x20, 0x13, 0x12, 0x11, 0x10 });
-            DateTime datetime = new DateTime(2022, 8, 26, 12, 34, 56, DateTimeKind.Utc);
-            Span<byte> datetimeBytes = stackalloc byte[8];
-            BinaryPrimitives.WriteInt64LittleEndian(datetimeBytes, datetime.ToBinary());
-            AssertReadContentFromBinary(datetime, XmlBinaryNodeType.DateTimeText, datetimeBytes);
+            AssertReadContentFromBinary(new decimal(0x20212223, 0x10111213, 0x01020304, true, scale: 0x1b), XmlBinaryNodeType.DecimalText,
+                new byte[] { 0x0, 0x0, 0x1b, 0x80, 0x4, 0x3, 0x2, 0x1, 0x23, 0x22, 0x21, 0x20, 0x13, 0x12, 0x11, 0x10 });
+            AssertReadContentFromBinary(new DateTime(2022, 8, 26, 12, 34, 56, DateTimeKind.Utc), XmlBinaryNodeType.DateTimeText,
+                new byte[] { 0x00, 0x18, 0xdf, 0x61, 0x5f, 0x87, 0xda, 0x48 });
 
             // Double can be represented as float or inte as long as no detail is lost
             AssertReadContentFromBinary((double)0x0100, XmlBinaryNodeType.Int16Text, new byte[] { 0x00, 0x01 });

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -196,6 +197,10 @@ namespace System.Runtime.Serialization.Xml.Tests
             AssertReadContentFromBinary(new TimeSpan(0x0807060504030201), XmlBinaryNodeType.TimeSpanText, new byte[] { 01, 02, 03, 04, 05, 06, 07, 08 });
             AssertReadContentFromBinary(new decimal(0x20212223, 0x10111213, 0x01020304, true, scale: 0x1b), XmlBinaryNodeType.DecimalText
                 , new byte[] { 0x0, 0x0, 0x1b, 0x80, 0x4, 0x3, 0x2, 0x1, 0x23, 0x22, 0x21, 0x20, 0x13, 0x12, 0x11, 0x10 });
+            DateTime datetime = new DateTime(2022, 8, 26, 12, 34, 56, DateTimeKind.Utc);
+            Span<byte> datetimeBytes = stackalloc byte[8];
+            BinaryPrimitives.WriteInt64LittleEndian(datetimeBytes, datetime.ToBinary());
+            AssertReadContentFromBinary(datetime, XmlBinaryNodeType.DateTimeText, datetimeBytes);
 
             // Double can be represented as float or inte as long as no detail is lost
             AssertReadContentFromBinary((double)0x0100, XmlBinaryNodeType.Int16Text, new byte[] { 0x00, 0x01 });
@@ -207,6 +212,16 @@ namespace System.Runtime.Serialization.Xml.Tests
         public static void BinaryXml_Array_RoundTrip()
         {
             int[] ints = new int[] { -1, 0x01020304, 0x11223344, -1 };
+            float[] floats = new float[] { 1.2345f, 2.3456f };
+            double[] doubles = new double[] { 1.2345678901, 2.3456789012 };
+            decimal[] decimals = new[] {
+                new decimal(0x20212223, 0x10111213, 0x01020304, true, scale: 0x1b),
+                new decimal(0x50515253, 0x40414243, 0x31323334, false, scale: 0x1c)
+            };
+            DateTime[] datetimes = new[] {
+                new DateTime(2022, 8, 26, 12, 34, 56, DateTimeKind.Utc),
+                new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Local)
+            };
             TimeSpan[] timespans = new[] { TimeSpan.FromTicks(0x0102030405060708), TimeSpan.FromTicks(0x1011121314151617) };
             // Write more than 4 kb in a single call to ensure we hit path for reading (and writing happens on 512b) large arrays
             long[] longs = Enumerable.Range(0x01020304, 513).Select(i => (long)i | (long)(~i << 32)).ToArray();
@@ -219,6 +234,10 @@ namespace System.Runtime.Serialization.Xml.Tests
             using var writer = XmlDictionaryWriter.CreateBinaryWriter(ms);
             writer.WriteStartElement("root");
             writer.WriteArray(null, "ints", null, ints, 1, 2);
+            writer.WriteArray(null, "floats", null, floats, 0, floats.Length);
+            writer.WriteArray(null, "doubles", null, doubles, 0, doubles.Length);
+            writer.WriteArray(null, "decimals", null, decimals, 0, decimals.Length);
+            writer.WriteArray(null, "datetimes", null, datetimes, 0, datetimes.Length);
             writer.WriteArray(null, "timespans", null, timespans, 0, timespans.Length);
             writer.WriteArray(null, "longs", null, longs, 0, longs.Length);
             writer.WriteArray(null, "guids", null, guids, 0, guids.Length);
@@ -232,6 +251,10 @@ namespace System.Runtime.Serialization.Xml.Tests
             using var reader = XmlDictionaryReader.CreateBinaryReader(ms, XmlDictionaryReaderQuotas.Max);
             reader.ReadStartElement("root");
             int intsRead = reader.ReadArray("ints", string.Empty, actualInts, 1, 3);
+            float[] actualFloats = reader.ReadSingleArray("floats", string.Empty);
+            double[] actualDoubles = reader.ReadDoubleArray("doubles", string.Empty);
+            decimal[] actualDecimals = reader.ReadDecimalArray("decimals", string.Empty);
+            DateTime[] actualDateTimes = reader.ReadDateTimeArray("datetimes", string.Empty);
             TimeSpan[] actualTimeSpans = reader.ReadTimeSpanArray("timespans", string.Empty);
             long[] actualLongs = reader.ReadInt64Array("longs", string.Empty);
             Guid[] actualGuids = reader.ReadGuidArray("guids", string.Empty);
@@ -242,6 +265,10 @@ namespace System.Runtime.Serialization.Xml.Tests
             Assert.Equal(2, intsRead);
             AssertExtensions.SequenceEqual(ints, actualInts);
             AssertExtensions.SequenceEqual(actualLongs, longs);
+            AssertExtensions.SequenceEqual(actualFloats, floats);
+            AssertExtensions.SequenceEqual(actualDoubles, doubles);
+            AssertExtensions.SequenceEqual(actualDecimals, decimals);
+            AssertExtensions.SequenceEqual(actualDateTimes, datetimes);
             AssertExtensions.SequenceEqual(actualTimeSpans, timespans);
             AssertExtensions.SequenceEqual(actualGuids, guids);
         }


### PR DESCRIPTION
Properly byte-swap float/double/decimal types.
Handle array types correctly on big-endian systems.
Added test case for array-of-decimal types.

Fixes #74494

CC @StephenMolloy @Daniel-Svensson @jkotas 