### PR TITLE
[QUIC] Fix native crashes and heap corruption

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicBuffers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicBuffers.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.Quic;
+using System.Threading;
 
 namespace System.Net.Quic;
 
@@ -18,14 +20,27 @@ internal unsafe struct MsQuicBuffers : IDisposable
     private QUIC_BUFFER* _buffers;
     // Number of QUIC_BUFFER instance currently allocated in _buffers, so that we can reuse the memory instead of reallocating.
     private int _count;
+    private bool _initialized;
+    private bool _disposed;
 
     public MsQuicBuffers()
     {
         _buffers = null;
         _count = 0;
+        _initialized=false;
+        _disposed = false;
     }
 
-    public QUIC_BUFFER* Buffers => _buffers;
+    public QUIC_BUFFER* Buffers
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, typeof(MsQuicBuffers));
+            Debug.Assert(_initialized);
+            return _buffers;
+        }
+    }
+
     public int Count => _count;
 
     private void FreeNativeMemory()
@@ -48,6 +63,7 @@ internal unsafe struct MsQuicBuffers : IDisposable
 
     private void SetBuffer(int index, ReadOnlyMemory<byte> buffer)
     {
+        Debug.Assert(_buffers[index].Buffer == null);
         _buffers[index].Buffer = (byte*)NativeMemory.Alloc((nuint)buffer.Length, (nuint)sizeof(byte));
         _buffers[index].Length = (uint)buffer.Length;
         buffer.Span.CopyTo(_buffers[index].Span);
@@ -62,11 +78,14 @@ internal unsafe struct MsQuicBuffers : IDisposable
     /// <typeparam name="T">The type of the inputs.</typeparam>
     public void Initialize<T>(IList<T> inputs, Func<T, ReadOnlyMemory<byte>> toBuffer)
     {
+        ObjectDisposedException.ThrowIf(_disposed, typeof(MsQuicBuffers));
+        Debug.Assert(!_initialized);
         Reserve(inputs.Count);
         for (int i = 0; i < inputs.Count; ++i)
         {
             SetBuffer(i, toBuffer(inputs[i]));
         }
+        _initialized = true;
     }
 
     /// <summary>
@@ -76,15 +95,21 @@ internal unsafe struct MsQuicBuffers : IDisposable
     /// <param name="buffer">Buffer to be passed to MsQuic as QUIC_BUFFER*.</param>
     public void Initialize(ReadOnlyMemory<byte> buffer)
     {
+        ObjectDisposedException.ThrowIf(_disposed, typeof(MsQuicBuffers));
+        Debug.Assert(!_initialized);
         Reserve(1);
         SetBuffer(0, buffer);
+        _initialized = true;
     }
 
     /// <summary>
     /// Release the native memory of individual buffers and allows reuse of this struct.
     /// </summary>
-    public void Reset()
+    public void Reset() => Reset(disposing: false);
+
+    private void Reset(bool disposing)
     {
+        ObjectDisposedException.ThrowIf(_disposed && !disposing, typeof(MsQuicBuffers));
         for (int i = 0; i < _count; ++i)
         {
             if (_buffers[i].Buffer is null)
@@ -96,6 +121,7 @@ internal unsafe struct MsQuicBuffers : IDisposable
             NativeMemory.Free(buffer);
             _buffers[i].Length = 0;
         }
+        _initialized = false;
     }
 
     /// <summary>
@@ -103,7 +129,8 @@ internal unsafe struct MsQuicBuffers : IDisposable
     /// </summary>
     public void Dispose()
     {
-        Reset();
+        _disposed = true;
+        Reset(disposing: true);
         FreeNativeMemory();
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -162,6 +162,7 @@ public sealed partial class QuicListener : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
+        GCHandle keepObject = GCHandle.Alloc(this);
         try
         {
             PendingConnection pendingConnection = await _acceptQueue.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
@@ -174,6 +175,10 @@ public sealed partial class QuicListener : IAsyncDisposable
         {
             ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
             throw;
+        }
+        finally
+        {
+            keepObject.Free();
         }
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -90,6 +90,7 @@ public sealed partial class QuicStream
         }
     };
     private MsQuicBuffers _sendBuffers = new MsQuicBuffers();
+    private object _sendBuffersLock = new object();
 
     private readonly long _defaultErrorCode;
 
@@ -220,9 +221,9 @@ public sealed partial class QuicStream
         {
             unsafe
             {
-                int status = MsQuicApi.Api.ApiTable->StreamStart(
-                    _handle.QuicHandle,
-                    QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT);
+                int status = _handle.SafeCall(handle => MsQuicApi.Api.ApiTable->StreamStart(
+                    handle.QuicHandle,
+                    QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT));
                 if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception))
                 {
                     _startedTcs.TrySetException(exception);
@@ -297,9 +298,9 @@ public sealed partial class QuicStream
         {
             unsafe
             {
-                ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->StreamReceiveSetEnabled(
-                    _handle.QuicHandle,
-                    1),
+                ThrowHelper.ThrowIfMsQuicError(_handle.SafeCall(handle => MsQuicApi.Api.ApiTable->StreamReceiveSetEnabled(
+                    handle.QuicHandle,
+                    1)),
                 "StreamReceivedSetEnabled failed");
             }
         }
@@ -360,19 +361,23 @@ public sealed partial class QuicStream
             return valueTask;
         }
 
-        _sendBuffers.Initialize(buffer);
-        unsafe
+        lock (_sendBuffersLock)
         {
-            int status = MsQuicApi.Api.ApiTable->StreamSend(
-                _handle.QuicHandle,
-                _sendBuffers.Buffers,
-                (uint)_sendBuffers.Count,
-                completeWrites ? QUIC_SEND_FLAGS.FIN : QUIC_SEND_FLAGS.NONE,
-                null);
-            if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception))
+            ObjectDisposedException.ThrowIf(_disposed == 1, this);
+            _sendBuffers.Initialize(buffer);
+            unsafe
             {
-                _sendBuffers.Reset();
-                _sendTcs.TrySetException(exception, final: true);
+                int status = _handle.SafeCall(handle => MsQuicApi.Api.ApiTable->StreamSend(
+                    handle.QuicHandle,
+                    _sendBuffers.Buffers,
+                    (uint)_sendBuffers.Count,
+                    completeWrites ? QUIC_SEND_FLAGS.FIN : QUIC_SEND_FLAGS.NONE,
+                    null));
+                if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception))
+                {
+                    _sendBuffers.Reset();
+                    _sendTcs.TrySetException(exception, final: true);
+                }
             }
         }
 
@@ -419,10 +424,10 @@ public sealed partial class QuicStream
 
         unsafe
         {
-            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->StreamShutdown(
-                _handle.QuicHandle,
+            ThrowHelper.ThrowIfMsQuicError(_handle.SafeCall(handle => MsQuicApi.Api.ApiTable->StreamShutdown(
+                handle.QuicHandle,
                 flags,
-                (ulong)errorCode),
+                (ulong)errorCode)),
                 "StreamShutdown failed");
         }
     }
@@ -442,10 +447,10 @@ public sealed partial class QuicStream
         {
             unsafe
             {
-                ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->StreamShutdown(
-                    _handle.QuicHandle,
+                ThrowHelper.ThrowIfMsQuicError(_handle.SafeCall(handle => MsQuicApi.Api.ApiTable->StreamShutdown(
+                    handle.QuicHandle,
                     QUIC_STREAM_SHUTDOWN_FLAGS.GRACEFUL,
-                    default),
+                    default)),
                     "StreamShutdown failed");
             }
         }
@@ -490,7 +495,10 @@ public sealed partial class QuicStream
     }
     private unsafe int HandleEventSendComplete(ref SEND_COMPLETE data)
     {
-        _sendBuffers.Reset();
+        lock (_sendBuffersLock)
+        {
+            _sendBuffers.Reset();
+        }
         if (data.Canceled == 0)
         {
             _sendTcs.TrySetResult();
@@ -653,15 +661,18 @@ public sealed partial class QuicStream
         await valueTask.ConfigureAwait(false);
         _handle.Dispose();
 
-        // TODO: memory leak if not disposed
-        _sendBuffers.Dispose();
+        lock (_sendBuffersLock)
+        {
+            // TODO: memory leak if not disposed
+            _sendBuffers.Dispose();
+        }
 
         unsafe void StreamShutdown(QUIC_STREAM_SHUTDOWN_FLAGS flags, long errorCode)
         {
-            int status = MsQuicApi.Api.ApiTable->StreamShutdown(
-                _handle.QuicHandle,
+            int status = _handle.SafeCall(handle => MsQuicApi.Api.ApiTable->StreamShutdown(
+                handle.QuicHandle,
                 flags,
-                (ulong)errorCode);
+                (ulong)errorCode));
             if (StatusFailed(status))
             {
                 if (NetEventSource.Log.IsEnabled())


### PR DESCRIPTION
There were races between disposing SendBuffers and MsQuic handles and using them from parallel threads. Most prominent in stress tests in configuration `-cancelRate 1 -ops 9` (POST Duplex Dispose).

After the change, I didn't see any crashes in stress in a couple of hours, will keep them running in the meantime.

Change has no impact on perf.

Fixes #72696