### PR TITLE
`DisableRuntimeMarshalling` block Vector types

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -411,7 +411,7 @@ namespace Internal.TypeSystem.Interop
                     return MarshallerKind.Invalid;
                 }
 
-                if (!IsValidForGenericMarshalling(type, context, isField))
+                if (!IsValidForGenericMarshalling(type, isField))
                 {
                     // Generic types cannot be marshalled.
                     return MarshallerKind.Invalid;
@@ -853,7 +853,6 @@ namespace Internal.TypeSystem.Interop
 
         private static bool IsValidForGenericMarshalling(
             TypeDesc type,
-            TypeSystemContext context,
             bool isFieldScenario,
             bool builtInMarshallingEnabled = true)
         {
@@ -877,18 +876,17 @@ namespace Internal.TypeSystem.Interop
             // * Vector128<T>: Represents the __m128 ABI primitive which requires currently unimplemented handling
             // * Vector256<T>: Represents the __m256 ABI primitive which requires currently unimplemented handling
             // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for interop scenarios
-            return !InteropTypes.IsSystemNullable(context, type)
-                && !InteropTypes.IsSystemSpan(context, type)
-                && !InteropTypes.IsSystemReadOnlySpan(context, type)
-                && !InteropTypes.IsSystemRuntimeIntrinsicsVector64T(context, type)
-                && !InteropTypes.IsSystemRuntimeIntrinsicsVector128T(context, type)
-                && !InteropTypes.IsSystemRuntimeIntrinsicsVector256T(context, type)
-                && !InteropTypes.IsSystemNumericsVectorT(context, type);
+            return !InteropTypes.IsSystemNullable(type.Context, type)
+                && !InteropTypes.IsSystemSpan(type.Context, type)
+                && !InteropTypes.IsSystemReadOnlySpan(type.Context, type)
+                && !InteropTypes.IsSystemRuntimeIntrinsicsVector64T(type.Context, type)
+                && !InteropTypes.IsSystemRuntimeIntrinsicsVector128T(type.Context, type)
+                && !InteropTypes.IsSystemRuntimeIntrinsicsVector256T(type.Context, type)
+                && !InteropTypes.IsSystemNumericsVectorT(type.Context, type);
         }
 
         internal static MarshallerKind GetDisabledMarshallerKind(
             TypeDesc type,
-            TypeSystemContext context,
             bool isFieldScenario)
         {
             // Get the underlying type for enum types.
@@ -916,7 +914,7 @@ namespace Internal.TypeSystem.Interop
                 if (!defType.ContainsGCPointers
                     && !defType.IsAutoLayoutOrHasAutoLayoutFields
                     && !defType.IsInt128OrHasInt128Fields
-                    && IsValidForGenericMarshalling(defType, context, isFieldScenario, builtInMarshallingEnabled: false))
+                    && IsValidForGenericMarshalling(defType, isFieldScenario, builtInMarshallingEnabled: false))
                 {
                     return MarshallerKind.BlittableValue;
                 }

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -344,9 +344,9 @@ namespace Internal.TypeSystem.Interop
             PInvokeFlags flags,
             bool isReturn)
         {
-            TypeSystemContext context = parameterType.Context;
-            MarshallerKind marshallerKind = MarshalHelpers.GetDisabledMarshallerKind(parameterType, context, marshallerType is MarshallerType.Field);
+            MarshallerKind marshallerKind = MarshalHelpers.GetDisabledMarshallerKind(parameterType, marshallerType is MarshallerType.Field);
 
+            TypeSystemContext context = parameterType.Context;
             // Create the marshaller based on MarshallerKind
             Marshaller marshaller = CreateMarshaller(marshallerKind);
             marshaller.Context = context;

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -344,9 +344,9 @@ namespace Internal.TypeSystem.Interop
             PInvokeFlags flags,
             bool isReturn)
         {
-            MarshallerKind marshallerKind = MarshalHelpers.GetDisabledMarshallerKind(parameterType);
-
             TypeSystemContext context = parameterType.Context;
+            MarshallerKind marshallerKind = MarshalHelpers.GetDisabledMarshallerKind(parameterType, context, marshallerType is MarshallerType.Field);
+
             // Create the marshaller based on MarshallerKind
             Marshaller marshaller = CreateMarshaller(marshallerKind);
             marshaller.Context = context;

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -1058,10 +1058,44 @@ OleColorMarshalingInfo *EEMarshalingData::GetOleColorMarshalingInfo()
 
 namespace
 {
+    bool IsValidForGenericMarshalling(MethodTable* pMT, bool isFieldScenario, bool builtInMarshallingEnabled = true)
+    {
+        _ASSERTE(pMT != NULL);
+
+        // Not generic, so passes "generic" test
+        if (!pMT->HasInstantiation())
+            return true;
+
+        // We can't block generic types for field scenarios for back-compat reasons.
+        if (isFieldScenario)
+            return true;
+
+        // Built-in marshalling considers the blittability for a generic type.
+        if (builtInMarshallingEnabled && !pMT->IsBlittable())
+            return false;
+
+        // Generics (blittable when built-in is enabled) are allowed to be marshalled with the following exceptions:
+        // * Nullable<T>: We don't want to be locked into the default behavior as we may want special handling later
+        // * Span<T>: Not supported by built-in marshalling
+        // * ReadOnlySpan<T>: Not supported by built-in marshalling
+        // * Vector64<T>: Represents the __m64 ABI primitive which requires currently unimplemented handling
+        // * Vector128<T>: Represents the __m128 ABI primitive which requires currently unimplemented handling
+        // * Vector256<T>: Represents the __m256 ABI primitive which requires currently unimplemented handling
+        // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for interop scenarios
+        return !pMT->HasSameTypeDefAs(g_pNullableClass)
+            && !pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__SPAN))
+            && !pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__READONLY_SPAN))
+            && !pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR64T))
+            && !pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR128T))
+            && !pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR256T))
+            && !pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTORT));
+    }
+
     MarshalInfo::MarshalType GetDisabledMarshallerType(
         Module* pModule,
         SigPointer sig,
-        const SigTypeContext * pTypeContext,
+        const SigTypeContext* pTypeContext,
+        bool isFieldScenario,
         MethodTable** pMTOut,
         UINT* errorResIDOut)
     {
@@ -1129,6 +1163,11 @@ namespace
                 if (pMT->IsAutoLayoutOrHasAutoLayoutField())
                 {
                     *errorResIDOut = IDS_EE_BADMARSHAL_AUTOLAYOUT;
+                    return MarshalInfo::MARSHAL_TYPE_UNKNOWN;
+                }
+                if (!IsValidForGenericMarshalling(pMT, isFieldScenario, false /* builtInMarshallingEnabled */))
+                {
+                    *errorResIDOut = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
                     return MarshalInfo::MARSHAL_TYPE_UNKNOWN;
                 }
                 if (pMT->IsInt128OrHasInt128Fields())
@@ -1273,6 +1312,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             pModule,
             sig,
             pTypeContext,
+            IsFieldScenario(),
             &m_pMT,
             &m_resID);
         m_args.m_pMT = m_pMT;
@@ -2266,23 +2306,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                 if (m_pMT == NULL)
                     break;
 
-                // Blittable generics are allowed to be marshalled with the following exceptions:
-                // * Nullable<T>: We don't want to be locked into the default behavior as we may want special handling later
-                // * Vector64<T>: Represents the __m64 ABI primitive which requires currently unimplemented handling
-                // * Vector128<T>: Represents the __m128 ABI primitive which requires currently unimplemented handling
-                // * Vector256<T>: Represents the __m256 ABI primitive which requires currently unimplemented handling
-                // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for interop scenarios
-                // We can't block these types for field scenarios for back-compat reasons.
-                if (m_pMT->HasInstantiation() && !IsFieldScenario()
-                    && (!m_pMT->IsBlittable()
-                        || (m_pMT->HasSameTypeDefAs(g_pNullableClass)
-                        || m_pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__SPAN))
-                        || m_pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__READONLY_SPAN))
-                        || m_pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR64T))
-                        || m_pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR128T))
-                        || m_pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR256T))
-                        || m_pMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTORT))
-                    )))
+                if (!IsValidForGenericMarshalling(m_pMT, IsFieldScenario()))
                 {
                     m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
                     IfFailGoto(E_FAIL, lFail);

--- a/src/tests/Interop/DisabledRuntimeMarshalling/Native_DisabledMarshalling/DisabledRuntimeMarshallingNative.cs
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/Native_DisabledMarshalling/DisabledRuntimeMarshallingNative.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using Xunit;
 
 public unsafe class DisabledRuntimeMarshallingNative
@@ -177,6 +179,21 @@ public unsafe class DisabledRuntimeMarshallingNative
     [DllImport(nameof(DisabledRuntimeMarshallingNative), EntryPoint = "CheckStructWithShortAndBoolWithVariantBool")]
     [return:MarshalAs(UnmanagedType.U1)]
     public static extern bool CheckStructWithShortAndBoolWithVariantBool_FailureExpected(StructWithShortAndBool str, short s, [MarshalAs(UnmanagedType.VariantBool)] bool b);
+
+    [DllImport(nameof(DisabledRuntimeMarshallingNative), EntryPoint = "Invalid")]
+    public static extern void CallWith(Nullable<int> s);
+    [DllImport(nameof(DisabledRuntimeMarshallingNative), EntryPoint = "Invalid")]
+    public static extern void CallWith(Span<int> s);
+    [DllImport(nameof(DisabledRuntimeMarshallingNative), EntryPoint = "Invalid")]
+    public static extern void CallWith(ReadOnlySpan<int> ros);
+    [DllImport(nameof(DisabledRuntimeMarshallingNative), EntryPoint = "Invalid")]
+    public static extern void CallWith(Vector64<int> v);
+    [DllImport(nameof(DisabledRuntimeMarshallingNative), EntryPoint = "Invalid")]
+    public static extern void CallWith(Vector128<int> v);
+    [DllImport(nameof(DisabledRuntimeMarshallingNative), EntryPoint = "Invalid")]
+    public static extern void CallWith(Vector256<int> v);
+    [DllImport(nameof(DisabledRuntimeMarshallingNative), EntryPoint = "Invalid")]
+    public static extern void CallWith(Vector<int> v);
 
     // Apply the UnmanagedFunctionPointer attributes with the default calling conventions so that Mono's AOT compiler
     // recognizes that these delegate types are used in interop and should have managed->native thunks generated for them.

--- a/src/tests/Interop/DisabledRuntimeMarshalling/PInvokeAssemblyMarshallingDisabled/Generics.cs
+++ b/src/tests/Interop/DisabledRuntimeMarshalling/PInvokeAssemblyMarshallingDisabled/Generics.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+using static DisabledRuntimeMarshallingNative;
+
+namespace DisabledRuntimeMarshalling;
+
+public unsafe class Generics
+{
+    [Fact]
+    public static void BlittableGeneric_NotSupported()
+    {
+        Assert.Throws<MarshalDirectiveException>(() =>
+        {
+            Nullable<int> s = default;
+            DisabledRuntimeMarshallingNative.CallWith(s);
+        });
+        Assert.Throws<MarshalDirectiveException>(() =>
+        {
+            Span<int> s = default;
+            DisabledRuntimeMarshallingNative.CallWith(s);
+        });
+        Assert.Throws<MarshalDirectiveException>(() =>
+        {
+            ReadOnlySpan<int> ros = default;
+            DisabledRuntimeMarshallingNative.CallWith(ros);
+        });
+        Assert.Throws<MarshalDirectiveException>(() =>
+        {
+            Vector64<int> v = default;
+            DisabledRuntimeMarshallingNative.CallWith(v);
+        });
+        Assert.Throws<MarshalDirectiveException>(() =>
+        {
+            Vector128<int> v = default;
+            DisabledRuntimeMarshallingNative.CallWith(v);
+        });
+        Assert.Throws<MarshalDirectiveException>(() =>
+        {
+            Vector256<int> v = default;
+            DisabledRuntimeMarshallingNative.CallWith(v);
+        });
+        Assert.Throws<MarshalDirectiveException>(() =>
+        {
+            Vector<int> v = default;
+            DisabledRuntimeMarshallingNative.CallWith(v);
+        });
+    }
+}


### PR DESCRIPTION
When `DisableRuntimeMarshalling` is set, the runtime should block
a bad-list for blittable types.

This doesn't address the case where the P/Invoke is inlined.

Contributes to #74269 

/cc @davidwrighton @dotnet/interop-contrib 