### PR TITLE
avoid allocation X509Chain if there is no certificate

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -43,11 +43,13 @@ namespace System.Net
             {
                 QueryContextRemoteCertificate(securityContext, out remoteContext);
 
-                if (remoteContext != null && !remoteContext.IsInvalid)
+                if (remoteContext == null || remoteContext.IsInvalid)
                 {
-                    remoteContext.DangerousAddRef(ref gotReference);
-                    result = new X509Certificate2(remoteContext.DangerousGetHandle());
+                    return null;
                 }
+
+                remoteContext.DangerousAddRef(ref gotReference);
+                result = new X509Certificate2(remoteContext.DangerousGetHandle());
 
                 if (retrieveChainCertificates)
                 {


### PR DESCRIPTION
Introduced by #68188. macOS and Windows check for validity but on Linux it would just fall-through even if there is no peer's certificate. 