### PR TITLE
Revert "Don't NativeAOT crossgen on ARM64 (#74211)"

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -7,10 +7,6 @@
     <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 and we
          don't want to ship using NativeAOT on MacOS -->
     <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true' or '$(TargetOS)' == 'osx'">false</NativeAotSupported>
-
-    <!-- Work around https://github.com/dotnet/runtime/issues/72645 -->
-    <NativeAotSupported Condition="'$(TargetArchitecture)' == 'arm64'">false</NativeAotSupported>
-
     <!-- Trimming is not currently working, but set the appropriate feature flags for NativeAOT -->
     <PublishTrimmed Condition="'$(NativeAotSupported)' == 'true'">true</PublishTrimmed>
     <RuntimeIdentifiers Condition="'$(RunningPublish)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">linux-x64;linux-musl-x64;linux-arm;linux-musl-arm;linux-arm64;linux-musl-arm64;freebsd-x64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64;win-arm</RuntimeIdentifiers>


### PR DESCRIPTION
This reverts commit 02c2ba0eb79a3895782267a00108c0c5c657b3ff.

Makes crossgen2 NativeAOT-compiled on ARM64.

@dotnet/crossgen-contrib would it be okay to switch back to NativeAOT-compiled crossgen2 in 7.0?