### PR TITLE
Make special_sweep_p a per heap member

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -2756,8 +2756,6 @@ BOOL gc_heap::fgn_last_gc_was_concurrent = FALSE;
 
 VOLATILE(bool) gc_heap::full_gc_approach_event_set;
 
-bool gc_heap::special_sweep_p = false;
-
 size_t gc_heap::full_gc_counts[gc_type_max];
 
 bool gc_heap::maxgen_size_inc_p = false;
@@ -2855,6 +2853,8 @@ size_t     gc_heap::expand_mechanisms_per_heap[max_expand_mechanisms_count];
 size_t     gc_heap::interesting_mechanism_bits_per_heap[max_gc_mechanism_bits_count];
 
 mark_queue_t gc_heap::mark_queue;
+
+bool gc_heap::special_sweep_p = false;
 
 #endif // MULTIPLE_HEAPS
 
@@ -14118,6 +14118,8 @@ gc_heap::init_gc_heap (int h_number)
 #ifdef RECORD_LOH_STATE
     loh_state_index = 0;
 #endif //RECORD_LOH_STATE
+
+    special_sweep_p = false;
 #endif //MULTIPLE_HEAPS
 
 #ifdef MULTIPLE_HEAPS

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3852,7 +3852,7 @@ public:
     PER_HEAP_ISOLATED
     VOLATILE(bool) full_gc_approach_event_set;
 
-    PER_HEAP_ISOLATED
+    PER_HEAP
     bool special_sweep_p;
 
 #ifdef BACKGROUND_GC


### PR DESCRIPTION
In `process_last_np_surv_region`, we set the `special_sweep_p` flag when we don't have a region after `next_region = heap_segment_next (alloc_region)` is null together with some other conditions that is irrelevant here.

Later, in `process_remaining_regions`, we assert that `heap_segment_next_rw (current_region) == 0`. I assume that it is checking the same thing, which is okay.

But `special_sweep_p` is a `PER_HEAP_ISOLATED` member, which means if one heap has that condition, it will set the flag for other heaps. On the other heaps, it is possible that the corresponding `next_region` is not null, thus triggering the assert.

Changing the flag from `PER_HEAP_ISOLATED` to a `PER_HEAP` member solved the issue.

