### PR TITLE
Make sure we at least sweep the loh even when we wanted to compact it

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -4217,7 +4217,7 @@ protected:
     PER_HEAP
     size_t      loh_pinned_queue_length;
 
-    PER_HEAP_ISOLATED
+    PER_HEAP
     int         loh_pinned_queue_decay;
 
     PER_HEAP


### PR DESCRIPTION
For regions, it is possible for `special_sweep_p` to override the behavior of `is_compaction_mandatory` when all heaps are joining to make the decision whether to sweep or to compact.

This is causing a problem for LOH compaction because we are expecting the LOH is already swept at this point or it will be compacted in the `compact_phase`, but neither will happen if `loh_compacted_p` is `true` but got overridden by  `special_sweep_p`.

This fix will make sure the LOH is swept if that happened. This is important to make sure the mark bits are reset for LOH.

> As a side effect, this will walk the LOH survivor after the POH survivors - not sure if the profilers are happy with that.