### PR TITLE
Pass over interop tests with NativeAOT

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -95,6 +95,7 @@
     <_WillCLRTestProjectBuild Condition="'$(BuildAllProjects)' == 'true' And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)'">true</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(CLRTestBuildAllTargets)' != 'allTargets' And '$(CLRTestTargetUnsupported)' == 'true'">false</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(DisableProjectBuild)' == 'true'">false</_WillCLRTestProjectBuild>
+    <_WillCLRTestProjectBuild Condition="'$(NativeAotIncompatible)' == 'true' and '$(TestBuildMode)' == 'nativeaot'">false</_WillCLRTestProjectBuild>
   </PropertyGroup>
   <PropertyGroup>
     <_CopyNativeProjectBinaries Condition="'$(__CopyNativeTestBinaries)' != '1'">$(__CopyNativeProjectsAfterCombinedTestBuild)</_CopyNativeProjectBinaries>

--- a/src/tests/Interop/COM/Activator/Activator.csproj
+++ b/src/tests/Interop/COM/Activator/Activator.csproj
@@ -4,8 +4,8 @@
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
     <!-- The test fails casting from ClassFromA from the default ALC to type IGetTypeFromC from a custom ALC -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/Interop/COM/Activator/ActivatorBuiltInComDisabled.csproj
+++ b/src/tests/Interop/COM/Activator/ActivatorBuiltInComDisabled.csproj
@@ -4,8 +4,8 @@
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
     <!-- The test fails casting from ClassFromA from the default ALC to type IGetTypeFromC from a custom ALC -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
@@ -8,6 +8,7 @@ namespace ComWrappersTests
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
+    using TestLibrary;
     using Xunit;
 
     static class WeakReferenceNative
@@ -273,7 +274,7 @@ namespace ComWrappersTests
         {
             try
             {
-                if (OperatingSystem.IsWindows())
+                if (PlatformDetection.IsBuiltInComEnabled)
                 {
                     ValidateNonComWrappers();
 

--- a/src/tests/Interop/COM/Directory.Build.targets
+++ b/src/tests/Interop/COM/Directory.Build.targets
@@ -6,6 +6,8 @@
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
+    <!-- The tests are unhappy with where we lay out the executable -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseManagedCOMServer)' == 'true'">

--- a/src/tests/Interop/COM/ExtensionPoints/ExtensionPoints.csproj
+++ b/src/tests/Interop/COM/ExtensionPoints/ExtensionPoints.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExtensionPoints.cs" />

--- a/src/tests/Interop/COM/NativeClients/Directory.Build.props
+++ b/src/tests/Interop/COM/NativeClients/Directory.Build.props
@@ -8,6 +8,7 @@
     <!-- The entry point for these tests is native and the produced assembly is a no-op, so unloadability testing doesn't do anything here. -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestIsHosted>false</CLRTestIsHosted>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/Interop/COM/Reflection/Reflection.csproj
+++ b/src/tests/Interop/COM/Reflection/Reflection.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/ExecInDefAppDom/ExecInDefAppDom.csproj
+++ b/src/tests/Interop/ExecInDefAppDom/ExecInDefAppDom.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/ICastable/Castable.csproj
+++ b/src/tests/Interop/ICastable/Castable.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Castable.cs" />

--- a/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.csproj
+++ b/src/tests/Interop/IJW/CopyConstructorMarshaler/CopyConstructorMarshaler.csproj
@@ -1,13 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- IJW is Windows-only -->
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- IJW is not supported on ARM64 -->
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm64'">true</CLRTestTargetUnsupported>
-    <!-- Loading IJW assemblies into an unloadable context is not allowed -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/IJW/Directory.Build.props
+++ b/src/tests/Interop/IJW/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <!-- IJW is Windows-only -->
+    <!-- Test unsupported outside of windows -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- IJW is not supported on ARM64 -->
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm64'">true</CLRTestTargetUnsupported>
+    <!-- Loading IJW assemblies into an unloadable context is not allowed -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- C++/CLI not supported with NativeAOT -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.csproj
+++ b/src/tests/Interop/IJW/FixupCallsHostWhenLoaded/FixupCallsHostWhenLoaded.csproj
@@ -1,13 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- IJW is Windows-only -->
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- IJW is not supported on ARM64 -->
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm64'">true</CLRTestTargetUnsupported>
-    <!-- Loading IJW assemblies into an unloadable context is not allowed -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
+++ b/src/tests/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
@@ -1,13 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- IJW is Windows-only -->
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- IJW is not supported on ARM64 -->
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm64'">true</CLRTestTargetUnsupported>
-    <!-- Loading IJW assemblies into an unloadable context is not allowed -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
+++ b/src/tests/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
@@ -1,13 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- IJW is Windows-only -->
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- IJW is not supported on ARM64 -->
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm64'">true</CLRTestTargetUnsupported>
-    <!-- Loading IJW assemblies into an unloadable context is not allowed -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
+++ b/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
@@ -1,15 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- IJW is Windows-only -->
-    <!-- Test unsupported outside of windows -->
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- IJW is not supported on ARM64 -->
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm64'">true</CLRTestTargetUnsupported>
     <!-- Native varargs not supported on ARM -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'armel'">true</CLRTestTargetUnsupported>
-    <!-- Loading IJW assemblies into an unloadable context is not allowed -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="IUnknownTest.cs" />

--- a/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
+++ b/src/tests/Interop/MarshalAPI/IUnknown/IUnknownTestInALC.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestInALC.cs" />

--- a/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.csproj
+++ b/src/tests/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- CustomMarshalers unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyTrueTest.cs" />

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyWithoutComVisibleTest.cs" />

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTest.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTest.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DefaultTest.cs" />

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTestInALC.csproj
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/Default/DefaultTestInALC.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestInALC.cs" />

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -943,9 +943,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/RuntimeConfiguration/TestConfig/*">
             <Issue>Test expects being run with corerun</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/ICastable/Castable/*">
-            <Issue>ICastable is CoreCLR specific</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/debugging/debuginfo/tester/*">
             <Issue>Just-in-time compilation test</Issue>
         </ExcludeList>
@@ -1003,26 +1000,23 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ArrayMarshalling/SafeArray/SafeArrayTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: SAFEARRAY</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/**/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/155: COM</Issue>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/ComWrappers/API/ComWrappersTests/*">
+            <Issue>https://github.com/dotnet/runtime/issues/74620</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/ExecInDefAppDom/ExecInDefAppDom/*">
-            <Issue>Specific to CoreCLR</Issue>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/ComWrappers/API/ComWrappersTestsBuiltInComDisabled/*">
+            <Issue>https://github.com/dotnet/runtime/issues/74620</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest/*">
+            <Issue>https://github.com/dotnet/runtime/issues/74620</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: AssemblyLoadContext.LoadFromAssemblyPath</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/IJW/**/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/155: C++/CLI</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/LayoutClass/LayoutClassTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/163</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/164</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/MarshalAPI/IUnknown/**/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/155: COM</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/NativeLibrary/API/NativeLibraryTests/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/165</Issue>
@@ -1057,9 +1051,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/CriticalHandles/**/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/173</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/CustomMarshalers/CustomMarshalersTest/*">
-            <Issue>Specific to CoreCLR: Built-in COM Interop</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Decimal/DecimalTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/175</Issue>
         </ExcludeList>
@@ -1074,9 +1065,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: C++/CLI</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/NativeCallManagedComVisible/**/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/155: COM</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/SafeHandles/SafeHandleTests/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/168</Issue>


### PR DESCRIPTION
* Mark tests as NativeAotIncompatible in project file instead of disabling in issues.targets so that we don't even build them.
* Tweak for COM disabled
* Block some tests on a new issue

Cc @dotnet/interop-contrib 