### PR TITLE
Don't crash on recursive native layout

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1917,10 +1917,10 @@ namespace Internal.TypeSystem.Interop
             codeStream.Emit(ILOpcode.brfalse, lNullPointer);
 
             codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(
-                InteropTypes.GetPInvokeMarshal(Context).GetKnownMethod("GetFunctionPointerForDelegate",
-                new MethodSignature(MethodSignatureFlags.Static, 0, Context.GetWellKnownType(WellKnownType.IntPtr),
-                    new TypeDesc[] { Context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType }
-                ))));
+                InteropTypes.GetMarshal(Context).GetKnownMethod("GetFunctionPointerForDelegate",
+                new MethodSignature(MethodSignatureFlags.Static, 1, Context.GetWellKnownType(WellKnownType.IntPtr),
+                    new TypeDesc[] { Context.GetSignatureVariable(0, method: true) }
+                )).MakeInstantiatedMethod(ManagedType)));
 
             codeStream.Emit(ILOpcode.br, lDone);
 
@@ -1941,13 +1941,12 @@ namespace Internal.TypeSystem.Interop
             LoadNativeValue(codeStream);
             codeStream.Emit(ILOpcode.dup);
             codeStream.Emit(ILOpcode.brfalse, lNullPointer);
-            codeStream.Emit(ILOpcode.ldtoken, _ilCodeStreams.Emitter.NewToken(ManagedType));
 
             codeStream.Emit(ILOpcode.call, _ilCodeStreams.Emitter.NewToken(
-                InteropTypes.GetPInvokeMarshal(Context).GetKnownMethod("GetDelegateForFunctionPointer",
-                new MethodSignature(MethodSignatureFlags.Static, 0, Context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType,
-                    new TypeDesc[] { Context.GetWellKnownType(WellKnownType.IntPtr), Context.GetWellKnownType(WellKnownType.RuntimeTypeHandle) }
-                ))));
+                InteropTypes.GetMarshal(Context).GetKnownMethod("GetDelegateForFunctionPointer",
+                new MethodSignature(MethodSignatureFlags.Static, 1, Context.GetSignatureVariable(0, method: true),
+                    new TypeDesc[] { Context.GetWellKnownType(WellKnownType.IntPtr) }
+                )).MakeInstantiatedMethod(ManagedType)));
 
             codeStream.Emit(ILOpcode.br, lDone);
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -160,6 +160,9 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
+        [ThreadStatic]
+        static Stack<MetadataType> s_typesBeingLookedAt;
+
         public NativeStructType(ModuleDesc owningModule, MetadataType managedStructType, InteropStateManager interopStateManager)
         {
             Debug.Assert(!managedStructType.IsGenericDefinition);
@@ -168,7 +171,21 @@ namespace Internal.TypeSystem.Interop
             ManagedStructType = managedStructType;
             _interopStateManager = interopStateManager;
             _hasInvalidLayout = false;
-            CalculateFields();
+
+            Stack<MetadataType> typesBeingLookedAt = (s_typesBeingLookedAt ??= new Stack<MetadataType>());
+            if (typesBeingLookedAt.Contains(managedStructType))
+                ThrowHelper.ThrowTypeLoadException(managedStructType);
+
+            typesBeingLookedAt.Push(managedStructType);
+            try
+            {
+                CalculateFields();
+            }
+            finally
+            {
+                MetadataType popped = typesBeingLookedAt.Pop();
+                Debug.Assert(popped == managedStructType);
+            }
         }
 
         private void CalculateFields()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedInteropStubManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedInteropStubManager.cs
@@ -40,7 +40,7 @@ namespace ILCompiler
             }
         }
 
-        public override void AddDependenciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        public override void AddDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -22,7 +22,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             factory.MetadataManager.GetDependenciesDueToMethodCodePresence(ref dependencies, factory, method, methodIL);
 
-            factory.InteropStubManager.AddDependenciesDueToPInvoke(ref dependencies, factory, method);
+            factory.InteropStubManager.AddDependenciesDueToMethodCodePresence(ref dependencies, factory, method);
 
             if (method.OwningType is MetadataType mdType)
                 ModuleUseBasedDependencyAlgorithm.AddDependenciesDueToModuleUse(ref dependencies, factory, mdType.Module);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/EmptyInteropStubManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/EmptyInteropStubManager.cs
@@ -21,7 +21,7 @@ namespace ILCompiler
             return null;
         }
 
-        public override void AddDependenciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        public override void AddDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/InteropStubManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/InteropStubManager.cs
@@ -16,7 +16,7 @@ namespace ILCompiler
     /// </summary>
     public abstract class InteropStubManager : ICompilationRootProvider
     {
-        public abstract void AddDependenciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method);
+        public abstract void AddDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method);
 
         public abstract void AddInterestingInteropConstructedTypeDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedInteropStubManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedInteropStubManager.cs
@@ -28,67 +28,12 @@ namespace ILCompiler
             _logger = logger;
         }
 
-        public override void AddDependenciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        public override void AddDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            if (method.IsPInvoke && method.OwningType is MetadataType type && MarshalHelpers.IsRuntimeMarshallingEnabled(type.Module))
-            {
-                dependencies = dependencies ?? new DependencyList();
-
-                MethodSignature methodSig = method.Signature;
-                AddParameterMarshallingDependencies(ref dependencies, factory, method, methodSig.ReturnType);
-
-                for (int i = 0; i < methodSig.Length; i++)
-                {
-                    AddParameterMarshallingDependencies(ref dependencies, factory, method, methodSig[i]);
-                }
-            }
-
             if (method.HasInstantiation)
             {
                 dependencies = dependencies ?? new DependencyList();
                 AddMarshalAPIsGenericDependencies(ref dependencies, factory, method);
-            }
-        }
-
-        private void AddParameterMarshallingDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, TypeDesc type)
-        {
-            if (type.IsDelegate)
-            {
-                dependencies.Add(factory.DelegateMarshallingData((DefType)type), "Delegate marshaling");
-            }
-
-            TypeSystemContext context = type.Context;
-            if ((type.IsWellKnownType(WellKnownType.MulticastDelegate)
-                    || type == context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType))
-            {
-                // If we hit this p/invoke as part of delegate marshalling (i.e. this is a delegate
-                // that has another delegate in the signature), blame the delegate type, not the marshalling thunk.
-                // This should ideally warn from the use site (e.g. where GetDelegateForFunctionPointer
-                // is called) but it's currently hard to get a warning from those spots and this guarantees
-                // we won't miss a spot (e.g. a p/invoke that has a delegate and that delegate contains
-                // a System.Delegate parameter).
-                MethodDesc reportedMethod = method;
-                if (reportedMethod is Internal.IL.Stubs.DelegateMarshallingMethodThunk delegateThunkMethod)
-                {
-                    reportedMethod = delegateThunkMethod.InvokeMethod;
-                }
-
-                _logger.LogWarning(reportedMethod, DiagnosticId.CorrectnessOfAbstractDelegatesCannotBeGuaranteed, DiagnosticUtilities.GetMethodSignatureDisplayName(method));
-            }
-
-            // struct may contain delegate fields, hence we need to add dependencies for it
-            if (type.IsByRef)
-                type = ((ParameterizedType)type).ParameterType;
-
-            if (MarshalHelpers.IsStructMarshallingRequired(type))
-            {
-                foreach (FieldDesc field in type.GetFields())
-                {
-                    if (field.IsStatic)
-                        continue;
-
-                    AddParameterMarshallingDependencies(ref dependencies, factory, method, field.FieldType);
-                }
             }
         }
 


### PR DESCRIPTION
Fixes dotnet/runtimelab#163.

* We don't have a nice way to pass context around when computing the native type. Use a threadstatic. This is pretty rare.
* We had one more spot where we ran out of stack when we were trying to look for delegates. Remove the need for that code by using the generic `Marshal` API (that we recognize elsewhere). Move the code responsible for warnings to dataflow analysis.

Cc @dotnet/ilc-contrib 