### PR TITLE
Swallow ObjectDisposedException when aborting QuicStream from CancellationAction

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -70,9 +70,18 @@ public sealed partial class QuicStream
     {
         CancellationAction = target =>
         {
-            if (target is QuicStream stream)
+            try
             {
-                stream.Abort(QuicAbortDirection.Read, stream._defaultErrorCode);
+                if (target is QuicStream stream)
+                {
+                    stream.Abort(QuicAbortDirection.Read, stream._defaultErrorCode);
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // We collided with a Dispose in another thread. This can happen
+                // when using CancellationTokenSource.CancelAfter.
+                // Ignore the exception
             }
         }
     };
@@ -83,9 +92,18 @@ public sealed partial class QuicStream
     {
         CancellationAction = target =>
         {
-            if (target is QuicStream stream)
+            try
             {
-                stream.Abort(QuicAbortDirection.Write, stream._defaultErrorCode);
+                if (target is QuicStream stream)
+                {
+                    stream.Abort(QuicAbortDirection.Write, stream._defaultErrorCode);
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // We collided with a Dispose in another thread. This can happen
+                // when using CancellationTokenSource.CancelAfter.
+                // Ignore the exception
             }
         }
     };
@@ -475,8 +493,8 @@ public sealed partial class QuicStream
     private unsafe int HandleEventReceive(ref RECEIVE data)
     {
         ulong totalCopied = (ulong)_receiveBuffers.CopyFrom(
-            new ReadOnlySpan<QUIC_BUFFER>(data.Buffers, (int) data.BufferCount),
-            (int) data.TotalBufferLength,
+            new ReadOnlySpan<QUIC_BUFFER>(data.Buffers, (int)data.BufferCount),
+            (int)data.TotalBufferLength,
             data.Flags.HasFlag(QUIC_RECEIVE_FLAGS.FIN));
         if (totalCopied < data.TotalBufferLength)
         {


### PR DESCRIPTION
Fixes #73688.

Depends on #74669 (it changes the type of exception thrown).

When QuicStream.(Read|Write)Async is canceled via CancellationTokenSource.CancelAfter, the CancellationAction is invoked from different thread and therefore the Abort call races with Dispose on the original thread. #74669 will make the StreamClose/StreamAbort race safe by making sure we AddRef/Release the related MsQuicSafeHandle, thus converting the race to possible ObjectDisposedException which we can swallow.