### PR TITLE
[wasm-mt] Log exit codes in browser samples to prevent tests from timeouting

### DIFF
--- a/src/mono/sample/wasm/browser-eventpipe/main.js
+++ b/src/mono/sample/wasm/browser-eventpipe/main.js
@@ -44,7 +44,11 @@ function getOnClickHandler(startWork, stopWork, getIterationsDone) {
 }
 
 async function main() {
-    const { MONO, Module, getAssemblyExports } = await dotnet.create()
+    const { MONO, Module, getAssemblyExports } = await dotnet
+        .withElementOnExit()
+        .withExitCodeLogging()
+        .create();
+
     globalThis.__Module = Module;
     globalThis.MONO = MONO;
 

--- a/src/mono/sample/wasm/browser-eventpipe/main.js
+++ b/src/mono/sample/wasm/browser-eventpipe/main.js
@@ -53,6 +53,9 @@ async function main() {
     const btn = document.getElementById("startWork");
     btn.style.backgroundColor = "rgb(192,255,192)";
     btn.onclick = getOnClickHandler(exports.Sample.Test.StartAsyncWork, exports.Sample.Test.StopWork, exports.Sample.Test.GetIterationsDone);
+
+    // only for CI purposes
+    console.log("WASM EXIT 0");
 }
 
 main();

--- a/src/mono/sample/wasm/browser-eventpipe/main.js
+++ b/src/mono/sample/wasm/browser-eventpipe/main.js
@@ -3,15 +3,6 @@
 
 import { dotnet } from "./dotnet.js";
 
-function wasm_exit(exit_code) {
-    var tests_done_elem = document.createElement("label");
-    tests_done_elem.id = "tests_done";
-    tests_done_elem.innerHTML = exit_code.toString();
-    document.body.appendChild(tests_done_elem);
-
-    console.log(`WASM EXIT ${exit_code}`);
-}
-
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 async function doWork(startWork, stopWork, getIterationsDone) {
@@ -62,9 +53,6 @@ async function main() {
     const btn = document.getElementById("startWork");
     btn.style.backgroundColor = "rgb(192,255,192)";
     btn.onclick = getOnClickHandler(exports.Sample.Test.StartAsyncWork, exports.Sample.Test.StopWork, exports.Sample.Test.GetIterationsDone);
-
-    // only for CI purposes
-    wasm_exit(0);
 }
 
 main();

--- a/src/mono/sample/wasm/browser-eventpipe/main.js
+++ b/src/mono/sample/wasm/browser-eventpipe/main.js
@@ -3,6 +3,15 @@
 
 import { dotnet } from "./dotnet.js";
 
+function wasm_exit(exit_code) {
+    var tests_done_elem = document.createElement("label");
+    tests_done_elem.id = "tests_done";
+    tests_done_elem.innerHTML = exit_code.toString();
+    document.body.appendChild(tests_done_elem);
+
+    console.log(`WASM EXIT ${exit_code}`);
+}
+
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 async function doWork(startWork, stopWork, getIterationsDone) {
@@ -55,7 +64,7 @@ async function main() {
     btn.onclick = getOnClickHandler(exports.Sample.Test.StartAsyncWork, exports.Sample.Test.StopWork, exports.Sample.Test.GetIterationsDone);
 
     // only for CI purposes
-    console.log("WASM EXIT 0");
+    wasm_exit(0);
 }
 
 main();

--- a/src/mono/sample/wasm/browser-eventpipe/main.js
+++ b/src/mono/sample/wasm/browser-eventpipe/main.js
@@ -44,11 +44,7 @@ function getOnClickHandler(startWork, stopWork, getIterationsDone) {
 }
 
 async function main() {
-    const { MONO, Module, getAssemblyExports } = await dotnet
-        .withElementOnExit()
-        .withExitCodeLogging()
-        .create();
-
+    const { MONO, Module, getAssemblyExports } = await dotnet.create()
     globalThis.__Module = Module;
     globalThis.MONO = MONO;
 

--- a/src/mono/sample/wasm/browser-threads/main.js
+++ b/src/mono/sample/wasm/browser-threads/main.js
@@ -3,13 +3,13 @@
 
 import { dotnet, exit } from './dotnet.js'
 
-function wasmExit(exitCode, error) {
-    try {
-        exit(exitCode, error);
-    } finally {
-        // we need to log the 'WASM EXIT' for CI
-        console.log(`WASM EXIT ${exitCode}`);
-    }
+function wasm_exit(exit_code) {
+    var tests_done_elem = document.createElement("label");
+    tests_done_elem.id = "tests_done";
+    tests_done_elem.innerHTML = exit_code.toString();
+    document.body.appendChild(tests_done_elem);
+
+    console.log(`WASM EXIT ${exit_code}`);
 }
 
 let progressElement = null;
@@ -79,8 +79,10 @@ try {
     setEditable(inputElement, true);
     inputElement.addEventListener("change", onInputValueChanged(exports, inputElement));
 
-    let exitCode = await runMain(assemblyName, []);
-    wasmExit(exitCode);
+    let exit_code = await runMain(assemblyName, []);
+    wasm_exit(exit_code);
+    exit(exit_code);
 } catch (err) {
-    wasmExit(2, err);
+    wasm_exit(2);
+    exit(exit_code, err);
 }

--- a/src/mono/sample/wasm/browser-threads/main.js
+++ b/src/mono/sample/wasm/browser-threads/main.js
@@ -3,6 +3,15 @@
 
 import { dotnet, exit } from './dotnet.js'
 
+function wasmExit(exitCode, error) {
+    try {
+        exit(exitCode, error);
+    } finally {
+        // we need to log the 'WASM EXIT' for CI
+        console.log(`WASM EXIT ${exitCode}`);
+    }
+}
+
 let progressElement = null;
 
 function updateProgress(status) {
@@ -70,8 +79,8 @@ try {
     setEditable(inputElement, true);
     inputElement.addEventListener("change", onInputValueChanged(exports, inputElement));
 
-    let exit_code = await runMain(assemblyName, []);
-    exit(exit_code);
+    let exitCode = await runMain(assemblyName, []);
+    wasmExit(exitCode);
 } catch (err) {
-    exit(2, err);
+    wasmExit(2, err);
 }

--- a/src/mono/sample/wasm/browser-threads/main.js
+++ b/src/mono/sample/wasm/browser-threads/main.js
@@ -3,15 +3,6 @@
 
 import { dotnet, exit } from './dotnet.js'
 
-function wasm_exit(exit_code) {
-    var tests_done_elem = document.createElement("label");
-    tests_done_elem.id = "tests_done";
-    tests_done_elem.innerHTML = exit_code.toString();
-    document.body.appendChild(tests_done_elem);
-
-    console.log(`WASM EXIT ${exit_code}`);
-}
-
 let progressElement = null;
 
 function updateProgress(status) {
@@ -63,6 +54,8 @@ try {
     const inputElement = document.getElementById("inputN");
     const { setModuleImports, getAssemblyExports, runMain } = await dotnet
         .withEnvironmentVariable("MONO_LOG_LEVEL", "debug")
+        .withElementOnExit()
+        .withExitCodeLogging()
         .create();
 
     setModuleImports("main.js", {
@@ -80,9 +73,7 @@ try {
     inputElement.addEventListener("change", onInputValueChanged(exports, inputElement));
 
     let exit_code = await runMain(assemblyName, []);
-    wasm_exit(exit_code);
     exit(exit_code);
 } catch (err) {
-    wasm_exit(2);
-    exit(exit_code, err);
+    exit(2, err);
 }


### PR DESCRIPTION
**WIP** - don't reveiw.

After recent changes the `src/mono/sample/wasm/browser-threads/main.js` script stopped printing `WASM EXIT <exit code>` that xharness is looking for. The CI test then fails:

```
[17:40:59] info: Hello, World!
[17:40:59] info: [MONO] Running class .cctor for System.Runtime.InteropServices.JavaScript.JavaScriptExports/<>c from 'System.Runtime.InteropServices.JavaScript.dll'
[17:55:52] info: Waiting to flush log messages with a timeout of 120 secs ..
[17:55:52] fail: Flushing log messages failed with: System.OperationCanceledException: The operation was canceled.
                    at System.Threading.Channels.AsyncOperation`1.GetResult(Int16 token)
                    at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+MoveNext()
                    at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestMessagesProcessor.RunAsync(CancellationToken token) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs:line 66
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestMessagesProcessor.RunAsync(CancellationToken token) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs:line 66
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestMessagesProcessor.CompleteAndFlushAsync(Nullable`1 timeout) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs:line 106. Ignoring.
[17:55:52] fail: Tests timed out. Killing driver service pid 15988
[17:55:52] fail: Application has finished with exit code TIMED_OUT but 0 was expected
XHarness exit code: 71 (GENERAL_FAILURE)
```

see https://dev.azure.com/dnceng/public/_build/results?buildId=1961582&view=logs&j=5e0663a6-779c-5be5-6d4c-61295b043a58&t=a6da8bfe-2e5e-5d0c-f321-5907e9da992a

The `browser-eventpipe` sample also runs in CI and it doesn't exit at any point (#74487). That makes sense when it runs in the browser but it doesn't work in CI (see https://dev.azure.com/dnceng/public/_build/results?buildId=1961582&view=logs&j=92c81310-cb26-5923-f96e-b7c73963fa3d&t=0aa9a844-8701-5b62-3bc4-3a39f7c23650). I tried adding the `wasm_exit` code into the sample, but it didn't solve the issue. The sample's probably gonna require a bit more restructuring or replacing with a tailored functional test.