### PR TITLE
[Mono] Fix Mono Windows x86 build and runtime crash.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -16,6 +16,7 @@
     <SupportsArmIntrinsics Condition="'$(Platform)' == 'arm64'">true</SupportsArmIntrinsics>
     <SupportsWasmIntrinsics Condition="'$(Platform)' == 'wasm'">true</SupportsWasmIntrinsics>
     <SupportsX86Intrinsics Condition="'$(Platform)' == 'x64' or ('$(Platform)' == 'x86' and '$(TargetsUnix)' != 'true')">true</SupportsX86Intrinsics>
+    <SupportsX86Intrinsics Condition="'$(Platform)' == 'x86' and '$(TargetsWindows)' == 'true' and '$(FeatureMono)' == 'true'">false</SupportsX86Intrinsics>
     <ILLinkSharedDirectory>$(MSBuildThisFileDirectory)ILLink\</ILLinkSharedDirectory>
     <IsBigEndian Condition="'$(Platform)' == 's390x'">true</IsBigEndian>
     <Is64Bit Condition="'$(Platform)' == 'arm64' or '$(Platform)' == 'x64' or '$(Platform)' == 's390x' or '$(Platform)' == 'loongarch64' or '$(Platform)' == 'ppc64le'">true</Is64Bit>

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -1039,7 +1039,7 @@ socket_transport_connect (const char *address)
 	MonoAddressEntry *rp;
 	SOCKET sfd = INVALID_SOCKET;
 	int s = 0, res;
-	char *host;
+	char *host = NULL;
 	int port;
 
 	MONO_REQ_GC_SAFE_MODE;

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -2052,7 +2052,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	if (in_corlib && 
 		((!strcmp ("System.Numerics", cmethod_klass_name_space) && !strcmp ("Vector", cmethod_klass_name)) || 
 		!strncmp ("System.Runtime.Intrinsics", cmethod_klass_name_space, 25))) {
-		if (!strcmp (cmethod->name, "get_IsHardwareAccelerated") || !strcmp (cmethod->name, "get_IsSupported")) {
+		if (!strcmp (cmethod->name, "get_IsHardwareAccelerated")) {
 			EMIT_NEW_ICONST (cfg, ins, 0);
 			ins->type = STACK_I4;
 			return ins;

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -2052,7 +2052,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	if (in_corlib && 
 		((!strcmp ("System.Numerics", cmethod_klass_name_space) && !strcmp ("Vector", cmethod_klass_name)) || 
 		!strncmp ("System.Runtime.Intrinsics", cmethod_klass_name_space, 25))) {
-		if (!strcmp (cmethod->name, "get_IsHardwareAccelerated")) {
+		if (!strcmp (cmethod->name, "get_IsHardwareAccelerated") || !strcmp (cmethod->name, "get_IsSupported")) {
 			EMIT_NEW_ICONST (cfg, ins, 0);
 			ins->type = STACK_I4;
 			return ins;


### PR DESCRIPTION
When trying to validate a fix on Mono Windows x86, runtime crashed with stack overflow. After some investigation it turns out that Mono Windows x86 have SIMD disabled, but S.P.C was still build with `System.Runtime.Intrinsics` support and implementation of methods like `get_IsSupported` is implemented as follow:

```
.method public hidebysig specialname static
        bool  get_IsSupported() cil managed
{
  // Code size       6 (0x6)
  .maxstack  8
  IL_0000:  call       bool System.Runtime.Intrinsics.X86.Popcnt::get_IsSupported()
  IL_0005:  ret
} // end of method Popcnt::get_IsSupported
```

causing a stack overflow when called at runtime.

Fix make sure we won't add support for `System.Runtime.Intrinsics` in S.P.C for Mono Windows x86 builds.

There was also a warning in `debugger-agent.c` when building debug that caused build to fail, including fix for that as well.

NOTE, Mono Windows x86 is not an official supported configuration, but can still be used for testing and validation of x86 codegen and runtime behaviors (Mono x86 is still supported on other platforms), so there is still a value fixing it when needed. 