### PR TITLE
Pass /NOEXP /NOIMPLIB options to the linker when publishing native AOT .exes

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -80,7 +80,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- The runtime is not compatible with jump stubs inserted by incremental linking. -->
       <LinkerArg Include="/INCREMENTAL:NO" />
       <LinkerArg Condition="'$(LinkerSubsystem)' != ''" Include="/SUBSYSTEM:$(LinkerSubsystem)" />
-      <LinkerArg Condition="'$(OutputType)' == 'WinExe' or '$(OutputType)' == 'Exe'" Include="/ENTRY:$(EntryPointSymbol)" />
+      <LinkerArg Condition="'$(OutputType)' == 'WinExe' or '$(OutputType)' == 'Exe'" Include="/ENTRY:$(EntryPointSymbol) /NOEXP /NOIMPLIB" />
       <LinkerArg Condition="$(NativeLib) == 'Shared'" Include="/INCLUDE:NativeAOT_StaticInitialization" />
       <LinkerArg Include="/NATVIS:&quot;$(MSBuildThisFileDirectory)NativeAOT.natvis&quot;" />
       <LinkerArg Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />


### PR DESCRIPTION
VS2022 link.exe creates *.lib and *.exp files when linking .exes and prints a message like "Creating library bin\Release\net7.0\win-x64\native\repro.lib and object bin\Release\net7.0\win-x64\native\repro.exp" to the console. These files are not really useful for .exes and the message is unnecessary clutter in the dotnet publish output with NativeAOT.

Pass /NOEXP /NOIMPLIB to the linker to suppress this behavior.