### PR TITLE
Mark certain compiler-created locals as aliased

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21992,6 +21992,8 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
                     //
                     // Ideally, we then inline the boxed method and and if it turns out not to modify
                     // the copy, we can undo the copy too.
+                    GenTree* localCopyThis = nullptr;
+
                     if (requiresInstMethodTableArg)
                     {
                         // Perform a trial box removal and ask for the type handle tree that fed the box.
@@ -22005,7 +22007,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
                             // If that worked, turn the box into a copy to a local var
                             //
                             JITDUMP("Found suitable method table arg tree [%06u]\n", dspTreeID(methodTableArg));
-                            GenTree* localCopyThis = gtTryRemoveBoxUpstreamEffects(thisObj, BR_MAKE_LOCAL_COPY);
+                            localCopyThis = gtTryRemoveBoxUpstreamEffects(thisObj, BR_MAKE_LOCAL_COPY);
 
                             if (localCopyThis != nullptr)
                             {
@@ -22046,7 +22048,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
                     else
                     {
                         JITDUMP("Found unboxed entry point, trying to simplify box to a local copy\n");
-                        GenTree* localCopyThis = gtTryRemoveBoxUpstreamEffects(thisObj, BR_MAKE_LOCAL_COPY);
+                        localCopyThis = gtTryRemoveBoxUpstreamEffects(thisObj, BR_MAKE_LOCAL_COPY);
 
                         if (localCopyThis != nullptr)
                         {
@@ -22069,6 +22071,11 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
 
                     if (optimizedTheBox)
                     {
+                        assert(localCopyThis->OperIs(GT_ADDR));
+
+                        // We may end up inlining this call, so the local copy must be marked as "aliased",
+                        // making sure the inlinee importer will know when to spill references to its value.
+                        lvaGetDesc(localCopyThis->AsUnOp()->gtOp1->AsLclVar())->lvHasLdAddrOp = true;
 
 #if FEATURE_TAILCALL_OPT
                         if (call->IsImplicitTailCall())

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -16617,6 +16617,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                                         stackallocAsLocal);
                                 lvaTable[stackallocAsLocal].lvType           = TYP_BLK;
                                 lvaTable[stackallocAsLocal].lvExactSize      = (unsigned)allocSize;
+                                lvaTable[stackallocAsLocal].lvHasLdAddrOp    = true;
                                 lvaTable[stackallocAsLocal].lvIsUnsafeBuffer = true;
                                 op1              = gtNewLclvNode(stackallocAsLocal, TYP_BLK);
                                 op1              = gtNewOperNode(GT_ADDR, TYP_I_IMPL, op1);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -15603,6 +15603,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             compSuppressedZeroInit       = true;
                         }
 
+                        // The constructor may store "this", with subsequent code mutating the underlying local
+                        // through the captured reference. To correctly spill the node we'll push onto the stack
+                        // in such a case, we must mark the temp as potentially aliased.
+                        lclDsc->lvHasLdAddrOp = true;
+
                         // Obtain the address of the temp
                         newObjThisPtr =
                             gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(lclNum, lvaTable[lclNum].TypeGet()));

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1378,6 +1378,7 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         // Codegen will need it for x86 scope info.
         varDsc->lvImplicitlyReferenced = 1;
 #endif // TARGET_X86
+        varDsc->lvHasLdAddrOp = 1;
 
         lvaSetVarDoNotEnregister(lvaVarargsHandleArg DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.il
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime { }
+.assembly extern System.Console { }
+
+.assembly Runtime_74635.dll { }
+
+#define TRUE "1"
+#define FALSE "0"
+#define THIS "0"
+
+#define EXPECTED "0"
+#define THRASHED "1"
+
+.class Runtime_74635 extends [System.Runtime]System.Object
+{
+  .method public static int32 Main()
+  {
+    .entrypoint
+
+    call bool .this::ProblemWithDevirtualization()
+    brtrue DEVIRT_FAILED
+
+    ldc.i4 100
+    ret
+
+  DEVIRT_FAILED:
+    ldc.i4 101
+    ret
+  }
+
+  .method private static bool ProblemWithDevirtualization() noinlining
+  {
+    ldc.i4 EXPECTED
+    newobj instance void Struct::.ctor(int32)
+    box valuetype Struct
+    callvirt instance int32 Interface::ReturnSelf()
+    ldc.i4 EXPECTED
+    bne.un FAILED
+
+    ldc.i4 FALSE
+    ret
+
+  FAILED:
+    ldc.i4 TRUE
+    ret
+  }
+}
+
+.class interface Interface
+{
+  .method public abstract virtual int32 ReturnSelf() { }
+}
+
+.class sealed sequential Struct extends [System.Runtime]System.ValueType implements Interface
+{
+  .field public int32 Value
+
+  .method public specialname void .ctor(int32 val)
+  {
+    ldarg THIS
+    ldarg val
+    stfld int32 .this::Value
+    ret
+  }
+
+  .method public virtual int32 ReturnSelf()
+  {
+    ldarg THIS
+    ldfld int32 .this::Value
+    ldarg THIS
+    ldc.i4 THRASHED
+    stind.i4
+    ret
+  }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.il
@@ -25,6 +25,9 @@
     call bool .this::ProblemWithCtors()
     brtrue CTORS_FAILED
 
+    call bool .this::ProblemWithLocAlloc()
+    brtrue LOCALLOC_FAILED
+
     ldc.i4 100
     ret
 
@@ -34,6 +37,10 @@
 
   CTORS_FAILED:
     ldc.i4 102
+    ret
+
+  LOCALLOC_FAILED:
+    ldc.i4 103
     ret
   }
 
@@ -70,6 +77,36 @@
 
   FAILED:
     ldc.i4 TRUE
+    ret
+  }
+
+  .method private static bool ProblemWithLocAlloc() noinlining
+  {
+    sizeof valuetype Struct
+    localloc
+    call int32 .this::ReturnExpectedWithLocAlloc(void*)
+    ldc.i4 EXPECTED
+    bne.un FAILED
+
+    ldc.i4 FALSE
+    ret
+
+  FAILED:
+    ldc.i4 TRUE
+    ret
+  }
+
+  .method private static int32 ReturnExpectedWithLocAlloc(void* pLocAlloc)
+  {
+    ldarg pLocAlloc
+    ldc.i4 EXPECTED
+    stind.i4
+
+    ldarg pLocAlloc
+    ldfld int32 Struct::Value
+    ldarg pLocAlloc
+    ldc.i4 THRASHED
+    stind.i4
     ret
   }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.il
@@ -22,11 +22,18 @@
     call bool .this::ProblemWithDevirtualization()
     brtrue DEVIRT_FAILED
 
+    call bool .this::ProblemWithCtors()
+    brtrue CTORS_FAILED
+
     ldc.i4 100
     ret
 
   DEVIRT_FAILED:
     ldc.i4 101
+    ret
+
+  CTORS_FAILED:
+    ldc.i4 102
     ret
   }
 
@@ -46,6 +53,25 @@
     ldc.i4 TRUE
     ret
   }
+
+  .method private static bool ProblemWithCtors() noinlining
+  {
+    ldc.i4 EXPECTED
+    ldc.i4 THRASHED
+    newobj instance void Struct::.ctor(int32, int32)
+    pop
+
+    ldsfld int32 Struct::StaticValue
+    ldc.i4 EXPECTED
+    bne.un FAILED
+
+    ldc.i4 FALSE
+    ret
+
+  FAILED:
+    ldc.i4 TRUE
+    ret
+  }
 }
 
 .class interface Interface
@@ -55,6 +81,8 @@
 
 .class sealed sequential Struct extends [System.Runtime]System.ValueType implements Interface
 {
+  .field public static int32 StaticValue
+
   .field public int32 Value
 
   .method public specialname void .ctor(int32 val)
@@ -62,6 +90,23 @@
     ldarg THIS
     ldarg val
     stfld int32 .this::Value
+
+    ret
+  }
+
+  .method public specialname void .ctor(int32 expected, int32 thrashed)
+  {
+    ldarg THIS
+    ldarg expected
+    stfld int32 .this::Value
+
+    ldarg THIS
+    ldfld int32 .this::Value
+    ldarg THIS
+    ldarg thrashed
+    stind.i4
+    stsfld int32 .this::StaticValue
+
     ret
   }
 
@@ -72,6 +117,7 @@
     ldarg THIS
     ldc.i4 THRASHED
     stind.i4
+
     ret
   }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.il
@@ -28,6 +28,9 @@
     call bool .this::ProblemWithLocAlloc()
     brtrue LOCALLOC_FAILED
 
+    call bool .this::ProblemWithCapturingCtors()
+    brtrue CAPTURING_CTORS_FAILED
+
     ldc.i4 100
     ret
 
@@ -41,6 +44,10 @@
 
   LOCALLOC_FAILED:
     ldc.i4 103
+    ret
+
+  CAPTURING_CTORS_FAILED:
+    ldc.i4 104
     ret
   }
 
@@ -109,6 +116,29 @@
     stind.i4
     ret
   }
+
+  .method private static bool ProblemWithCapturingCtors() noinlining
+  {
+    .locals (valuetype Closure closure)
+
+    ldc.i4 EXPECTED
+    ldloca closure
+    newobj instance void Struct::.ctor(int32, valuetype Closure&)
+    ldloc closure
+    ldfld valuetype Struct& Closure::StructRef
+    ldc.i4 THRASHED
+    stfld int32 Struct::Value
+    ldfld int32 Struct::Value
+    ldc.i4 EXPECTED
+    bne.un FAILED
+
+    ldc.i4 FALSE
+    ret
+
+  FAILED:
+    ldc.i4 TRUE
+    ret
+  }
 }
 
 .class interface Interface
@@ -122,7 +152,7 @@
 
   .field public int32 Value
 
-  .method public specialname void .ctor(int32 val)
+  .method public void .ctor(int32 val)
   {
     ldarg THIS
     ldarg val
@@ -131,7 +161,7 @@
     ret
   }
 
-  .method public specialname void .ctor(int32 expected, int32 thrashed)
+  .method public void .ctor(int32 expected, int32 thrashed)
   {
     ldarg THIS
     ldarg expected
@@ -147,6 +177,19 @@
     ret
   }
 
+  .method public void .ctor(int32 val, valuetype Closure& closureRef) noinlining
+  {
+    ldarg THIS
+    ldarg val
+    stfld int32 .this::Value
+
+    ldarg closureRef
+    ldarg THIS
+    stfld valuetype Struct& Closure::StructRef
+
+    ret
+  }
+
   .method public virtual int32 ReturnSelf()
   {
     ldarg THIS
@@ -157,4 +200,11 @@
 
     ret
   }
+}
+
+.class sealed Closure extends [System.Runtime]System.ValueType
+{
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (01 00 00 00)
+
+  .field public valuetype Struct& StructRef
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635.ilproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2693,6 +2693,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_64125/Runtime_64125/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635/**">
+            <Issue>https://github.com/dotnet/runtime/issues/74687</Issue>
+        </ExcludeList>
         <!-- End interpreter issues -->
     </ItemGroup>
 


### PR DESCRIPTION
In the importer, an invariant is observed that if a local can be modified indirectly, it must be marked either address-exposed, or "address-taken". A number of compiler-produced temps were violating this invariant, which means that the spilling logic would miss references to them, ultimately (potentially) caused silent bad codegen.

This change fixes the problem by marking said locals as "address-taken".

We are expecting sizeable regressions. There are two sources:
1) Tailcall restrictions in morph. These could actually be worked around, but when I tried that, the regression only got worse (this is due to the fact not all tailcalls are size wins).
2) More aggressive spilling. In particular, if we have a sequence like the following:
```
newobj <...>
call
```
We will now spill the `newobj`-produced local. This is a correctness requirement that cannot be worked around without early interprocedural analysis as the last added test case shows.

Fixes #74635.