### PR TITLE
Fix stack unwinding for NativeAOT on Unix

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -222,7 +222,7 @@ uintptr_t UnixNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Method
 
     UnixNativeMethodInfo * pNativeMethodInfo = (UnixNativeMethodInfo *)pMethodInfo;
 
-    PTR_UInt8 p = pNativeMethodInfo->pMainLSDA;
+    PTR_UInt8 p = pNativeMethodInfo->pLSDA;
 
     uint8_t unwindBlockFlags = *p++;
 
@@ -283,7 +283,7 @@ bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
 {
     UnixNativeMethodInfo * pNativeMethodInfo = (UnixNativeMethodInfo *)pMethodInfo;
 
-    PTR_UInt8 p = pNativeMethodInfo->pMainLSDA;
+    PTR_UInt8 p = pNativeMethodInfo->pLSDA;
 
     uint8_t unwindBlockFlags = *p++;
 
@@ -868,7 +868,7 @@ PTR_VOID UnixNativeCodeManager::GetAssociatedData(PTR_VOID ControlPC)
     if (!FindMethodInfo(ControlPC, (MethodInfo*)&methodInfo))
         return NULL;
 
-    PTR_UInt8 p = methodInfo.pMainLSDA;
+    PTR_UInt8 p = methodInfo.pLSDA;
 
     uint8_t unwindBlockFlags = *p++;
     if ((unwindBlockFlags & UBF_FUNC_HAS_ASSOCIATED_DATA) == 0)


### PR DESCRIPTION
Fix intermittent failures for running `./build.sh` on Unix:
```
  crossgen2 -> /runtime/artifacts/bin/coreclr/Linux.x64.Debug/crossgen2/linux-x64/publish/
  crossgen2: /runtime/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp:296: virtual bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *, REGDISPLAY *, PInvokeTransitionFrame **): Assertion `pNativeMethodInfo->pMainLSDA == pNativeMethodInfo->pLSDA' failed.
  Aborted
/runtime/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj(70,5): error MSB3073: The command "/runtime/artifacts/bin/coreclr/Linux.x64.Debug/crossgen2/linux-x64/publish/crossgen2 /runtime/artifacts/bin/coreclr/Linux.x64.Debug/IL/System.Private.CoreLib.dll --out /runtime/artifacts/obj/Microsoft.NETCore.App.Crossgen2/Debug/net7.0/linux-x64/S.P.C.tmp" exited with code 134.
```
Below is an example of the call stack that fails the assertion when being unwound:
```
#38 S_P_CoreLib_System_Exception__ToString ()
    at /runtime/src/libraries/System.Private.CoreLib/src/System/Exception.cs:124
#39 ILCompiler_ReadyToRun_Internal_JitInterface_CorInfoImpl__AllocException_0 ()
    at /runtime/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs:160
#40 ILCompiler_ReadyToRun_Internal_JitInterface_CorInfoImpl___canGetCookieForPInvokeCalliSig ()
    at /runtime/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs:2063
#41 RhpCallCatchFunclet ()
    at /runtime/src/coreclr/nativeaot/Runtime/amd64/ExceptionHandling.S:335
#42 S_P_CoreLib_System_Runtime_EH__DispatchEx ()
    at /runtime/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs:700
#43 S_P_CoreLib_System_Runtime_EH__RhThrowEx ()
    at /runtime/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs:570
#44 RhpThrowEx () at /runtime/src/coreclr/nativeaot/Runtime/amd64/ExceptionHandling.S:152
#45 ILCompiler_ReadyToRun_Internal_JitInterface_CorInfoImpl__canGetCookieForPInvokeCalliSig ()
    at /runtime/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs:2811
#46 ILCompiler_ReadyToRun_Internal_JitInterface_CorInfoImpl___canGetCookieForPInvokeCalliSig ()
    at /runtime/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs:2059
#47 ?? ()
   from /runtime/artifacts/bin/coreclr/Linux.x64.Debug/crossgen2/linux-x64/publish/libjitinterface_x64.so
```
Note that frame 40 above corresponds to the `catch` funclet of this reverse P/Invoke method:
https://github.com/dotnet/runtime/blob/b27b2988a6cd09b29af52d9d9c07608fbd860294/src/coreclr/tools/Common/JitInterface/CorInfoBase.cs#L2053-L2066

The fix is to use the funclet's LSDA instead of the main LSDA — similar to what we do on Windows.

Related changes: dotnet/corert#2157, dotnet/corert#4487.
Fixes #70543.