### PR TITLE
Only widen short local stores

### DIFF
--- a/src/coreclr/jit/lowerloongarch64.cpp
+++ b/src/coreclr/jit/lowerloongarch64.cpp
@@ -176,54 +176,6 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 //
 void Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
 {
-    // Try to widen the ops if they are going into a local var.
-    GenTree* op1 = storeLoc->gtGetOp1();
-    if ((storeLoc->gtOper == GT_STORE_LCL_VAR) && (op1->gtOper == GT_CNS_INT))
-    {
-        GenTreeIntCon* con    = op1->AsIntCon();
-        ssize_t        ival   = con->gtIconVal;
-        unsigned       varNum = storeLoc->GetLclNum();
-        LclVarDsc*     varDsc = comp->lvaGetDesc(varNum);
-
-        if (varDsc->lvIsSIMDType())
-        {
-            noway_assert(storeLoc->gtType != TYP_STRUCT);
-        }
-        unsigned size = genTypeSize(storeLoc);
-        // If we are storing a constant into a local variable
-        // we extend the size of the store here
-        if ((size < 4) && !varTypeIsStruct(varDsc))
-        {
-            if (!varTypeIsUnsigned(varDsc))
-            {
-                if (genTypeSize(storeLoc) == 1)
-                {
-                    if ((ival & 0x7f) != ival)
-                    {
-                        ival = ival | 0xffffff00;
-                    }
-                }
-                else
-                {
-                    assert(genTypeSize(storeLoc) == 2);
-                    if ((ival & 0x7fff) != ival)
-                    {
-                        ival = ival | 0xffff0000;
-                    }
-                }
-            }
-
-            // A local stack slot is at least 4 bytes in size, regardless of
-            // what the local var is typed as, so auto-promote it here
-            // unless it is a field of a promoted struct
-            // TODO-CQ: if the field is promoted shouldn't we also be able to do this?
-            if (!varDsc->lvIsStructField)
-            {
-                storeLoc->gtType = TYP_INT;
-                con->SetIconValue(ival);
-            }
-        }
-    }
     if (storeLoc->OperIs(GT_STORE_LCL_FLD))
     {
         // We should only encounter this for lclVars that are lvDoNotEnregister.

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -41,20 +41,18 @@ void Lowering::LowerRotate(GenTree* tree)
 // Notes:
 //    This involves:
 //    - Handling of contained immediates.
-//    - Widening operations of unsigneds.
+//    - Widening some small stores.
 //
 void Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
 {
     // Most small locals (the exception is dependently promoted fields) have 4 byte wide stack slots, so
-    // we can widen the store, if profitable. This optimization is not relevant for register candidates.
-    //
-    // The widening is only (largely) profitable for 2 byte stores. We could widen bytes too but that
-    // would only be better when the constant is zero and reused, which we presume is not common enough.
+    // we can widen the store, if profitable. The widening is only (largely) profitable for 2 byte stores.
+    // We could widen bytes too but that would only be better when the constant is zero and reused, which
+    // we presume is not common enough.
     //
     if (storeLoc->OperIs(GT_STORE_LCL_VAR) && (genTypeSize(storeLoc) == 2) && storeLoc->Data()->IsCnsIntOrI())
     {
-        LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
-        if (varDsc->lvDoNotEnregister && !varDsc->lvIsStructField)
+        if (!comp->lvaGetDesc(storeLoc)->lvIsStructField)
         {
             storeLoc->gtType = TYP_INT;
         }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -56,13 +56,7 @@ void Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
         LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
         if (varDsc->lvDoNotEnregister && !varDsc->lvIsStructField)
         {
-            GenTreeIntCon* constNode  = storeLoc->Data()->AsIntCon();
-            ssize_t        constValue = constNode->IconValue();
-            constValue =
-                varTypeIsUnsigned(varDsc) ? static_cast<uint16_t>(constValue) : static_cast<int16_t>(constValue);
-
             storeLoc->gtType = TYP_INT;
-            constNode->SetIconValue(constValue);
         }
     }
     if (storeLoc->OperIs(GT_STORE_LCL_FLD))


### PR DESCRIPTION
As the commit message points out, widening byte stores is not profitable most of the time.

This change is meant to minimize the amount of regressions for the upcoming enablement of folding primitives in local morph.

[Diffs](https://github.com/dotnet/runtime/pull/74685/checks?check_run_id=8337332205).