### PR TITLE
Disallow `ASG(..., IND<struct>)` before morph

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3909,8 +3909,14 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 GenTree*  lclVar     = gtNewLclvNode(rawHandleSlot, TYP_I_IMPL);
                 GenTree*  lclVarAddr = gtNewOperNode(GT_ADDR, TYP_I_IMPL, lclVar);
                 var_types resultType = JITtype2varType(sig->retType);
-                retNode              = gtNewOperNode(GT_IND, resultType, lclVarAddr);
-
+                if (resultType == TYP_STRUCT)
+                {
+                    retNode = gtNewObjNode(sig->retTypeClass, lclVarAddr);
+                }
+                else
+                {
+                    retNode = gtNewIndir(resultType, lclVarAddr);
+                }
                 break;
             }
 

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1015,19 +1015,6 @@ private:
             return IndirTransform::None;
         }
 
-        if (indir->OperIs(GT_IND)) // IND<struct>
-        {
-            // TODO-ADDR: add this case to the "don't expect" assert above; it requires updating
-            // "cpblk" import to not create such nodes for block copies of known size.
-            return IndirTransform::None;
-        }
-
-        if (!user->OperIs(GT_ASG, GT_CALL, GT_RETURN))
-        {
-            // TODO-ADDR: define the contract for "COMMA(..., LCL<struct>)".
-            return IndirTransform::None;
-        }
-
         ClassLayout* indirLayout = nullptr;
 
         if (indir->OperIs(GT_FIELD))


### PR DESCRIPTION
Requires fixing-up some NativeAOT-specific intrinsics.

`IND<struct>` after morph must still be allowed because `FIELD` nodes are morphed as such. There is also the case of `STORE_DYN_BLK`, but that will not reach local morphing code because it is a "wide" indirection.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1971930&view=ms.vss-build-web.run-extensions-tab).