### PR TITLE
Fold field offsets into array addresses

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18243,25 +18243,11 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
                 GenTree*       nonConst = nullptr;
                 if (tree->AsOp()->gtOp1->IsCnsIntOrI())
                 {
-                    // If the other arg is an int constant, and is a "not-a-field", choose
-                    // that as the multiplier, thus preserving constant index offsets...
-                    if (tree->AsOp()->gtOp2->OperGet() == GT_CNS_INT &&
-                        tree->AsOp()->gtOp2->AsIntCon()->gtFieldSeq == nullptr)
-                    {
-                        assert(!tree->AsOp()->gtOp2->AsIntCon()->ImmedValNeedsReloc(comp));
-                        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntConCommon::gtIconVal had
-                        // target_ssize_t type.
-                        subMul   = (target_ssize_t)tree->AsOp()->gtOp2->AsIntConCommon()->IconValue();
-                        nonConst = tree->AsOp()->gtOp1;
-                    }
-                    else
-                    {
-                        assert(!tree->AsOp()->gtOp1->AsIntCon()->ImmedValNeedsReloc(comp));
-                        // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntConCommon::gtIconVal had
-                        // target_ssize_t type.
-                        subMul   = (target_ssize_t)tree->AsOp()->gtOp1->AsIntConCommon()->IconValue();
-                        nonConst = tree->AsOp()->gtOp2;
-                    }
+                    assert(!tree->AsOp()->gtOp1->AsIntCon()->ImmedValNeedsReloc(comp));
+                    // TODO-CrossBitness: we wouldn't need the cast below if GenTreeIntConCommon::gtIconVal had
+                    // target_ssize_t type.
+                    subMul   = (target_ssize_t)tree->AsOp()->gtOp1->AsIntConCommon()->IconValue();
+                    nonConst = tree->AsOp()->gtOp2;
                 }
                 else if (tree->AsOp()->gtOp2->IsCnsIntOrI())
                 {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18326,36 +18326,6 @@ void GenTreeArrAddr::ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum*
 }
 
 //------------------------------------------------------------------------
-// IsArrayAddr: Is "this" an expression for an array address?
-//
-// Recognizes the following patterns:
-//    this: ARR_ADDR
-//    this: ADD(ARR_ADDR, CONST)
-//
-// Arguments:
-//    pArrAddr - [out] parameter for the found ARR_ADDR node
-//
-// Return Value:
-//    Whether "this" matches the pattern denoted above.
-//
-bool GenTree::IsArrayAddr(GenTreeArrAddr** pArrAddr)
-{
-    GenTree* addr = this;
-    if (addr->OperIs(GT_ADD) && addr->AsOp()->gtGetOp2()->IsCnsIntOrI())
-    {
-        addr = addr->AsOp()->gtGetOp1();
-    }
-
-    if (addr->OperIs(GT_ARR_ADDR))
-    {
-        *pArrAddr = addr->AsArrAddr();
-        return true;
-    }
-
-    return false;
-}
-
-//------------------------------------------------------------------------
 // Create: Create or retrieve a field sequence for the given field handle.
 //
 // The field sequence instance contains some cached information relevant to

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6485,10 +6485,9 @@ public:
         return m_fieldOffset;
     }
 
-    void AddField(unsigned offset)
+    void AddOffset(ssize_t offset)
     {
-        assert((m_fieldOffset + offset) < m_elemSize);
-        m_fieldOffset += offset;
+        m_fieldOffset = (m_fieldOffset + static_cast<size_t>(offset)) % m_elemSize;
     }
 
     void ParseArrayAddress(Compiler* comp, GenTree** pArr, ValueNum* pInxVN);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2013,8 +2013,6 @@ public:
 
     bool IsFieldAddr(Compiler* comp, GenTree** pBaseAddr, FieldSeq** pFldSeq, ssize_t* pOffset);
 
-    bool IsArrayAddr(GenTreeArrAddr** pArrAddr);
-
     // These are only used for dumping.
     // The GetRegNum() is only valid in LIR, but the dumping methods are not easily
     // modified to check this.

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -8473,17 +8473,14 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                     }
                     else
                     {
-                        GenTreeArrAddr* arrAddr  = nullptr;
-                        GenTree*        baseAddr = nullptr;
-                        FieldSeq*       fldSeq   = nullptr;
-                        ssize_t         offset   = 0;
+                        GenTree*  baseAddr = nullptr;
+                        FieldSeq* fldSeq   = nullptr;
+                        ssize_t   offset   = 0;
 
-                        if (arg->IsArrayAddr(&arrAddr))
+                        if (arg->OperIs(GT_ARR_ADDR))
                         {
-                            // We will not collect "fldSeq" -- any modification to an S[], at
-                            // any field of "S", will lose all information about the array type.
                             CORINFO_CLASS_HANDLE elemTypeEq =
-                                EncodeElemType(arrAddr->GetElemType(), arrAddr->GetElemClassHandle());
+                                EncodeElemType(arg->AsArrAddr()->GetElemType(), arg->AsArrAddr()->GetElemClassHandle());
                             AddModifiedElemTypeAllContainingLoops(mostNestedLoop, elemTypeEq);
                             // Conservatively assume byrefs may alias this array element
                             memoryHavoc |= memoryKindSet(ByrefExposed);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9173,7 +9173,7 @@ void Compiler::fgValueNumberArrIndexAddr(GenTreeArrAddr* arrAddr)
 
     ValueNum arrVN    = vnStore->VNNormalValue(arr->GetVN(VNK_Liberal));
     inxVN             = vnStore->VNNormalValue(inxVN);
-    ValueNum offsetVN = vnStore->VNForIntPtrCon(0);
+    ValueNum offsetVN = vnStore->VNForIntPtrCon(arrAddr->GetFieldOffset());
 
     ValueNum     arrAddrVN  = vnStore->VNForFunc(TYP_BYREF, VNF_PtrToArrElem, elemTypeEqVN, arrVN, inxVN, offsetVN);
     ValueNumPair arrAddrVNP = ValueNumPair(arrAddrVN, arrAddrVN);


### PR DESCRIPTION
That is:

```
 ADD
   ARR_ADDR T[]
     ADD
       LCL_VAR array
       CNS_INT 40
   8

 =>

 ARR_ADDR T[] [+8]
   ADD
     ADD
       LCL_VAR array
       CNS_INT 40
     8

 =>

 ARR_ADDR T[] [+8]
   ADD
     LCL_VAR array
     CNS_INT 48
```
We're expecting some positive diffs.

This should also help get rid of regressions seen over at #72725.