### PR TITLE
[release/7.0] [QUIC] Root listener/connection while waiting on new connection/stream event

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -392,6 +392,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             throw new InvalidOperationException(SR.net_quic_accept_not_allowed);
         }
 
+        GCHandle keepObject = GCHandle.Alloc(this);
         try
         {
             return await _acceptQueue.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
@@ -400,6 +401,10 @@ public sealed partial class QuicConnection : IAsyncDisposable
         {
             ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
             throw;
+        }
+        finally
+        {
+            keepObject.Free();
         }
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -162,6 +162,7 @@ public sealed partial class QuicListener : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
+        GCHandle keepObject = GCHandle.Alloc(this);
         try
         {
             PendingConnection pendingConnection = await _acceptQueue.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
@@ -174,6 +175,10 @@ public sealed partial class QuicListener : IAsyncDisposable
         {
             ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
             throw;
+        }
+        finally
+        {
+            keepObject.Free();
         }
     }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicListenerTests.cs
@@ -106,7 +106,7 @@ namespace System.Net.Quic.Tests
             QuicListenerOptions listenerOptions = CreateQuicListenerOptions();
             listenerOptions.ListenEndPoint = listener1.LocalEndPoint;
             listenerOptions.ApplicationProtocols[0] = new SslApplicationProtocol("someprotocol");
-            listenerOptions.ConnectionOptionsCallback = (_, _, _) => 
+            listenerOptions.ConnectionOptionsCallback = (_, _, _) =>
             {
                 var options = CreateQuicServerOptions();
                 options.ServerAuthenticationOptions.ApplicationProtocols[0] = listenerOptions.ApplicationProtocols[0];
@@ -143,6 +143,28 @@ namespace System.Net.Quic.Tests
             // [ActiveIssue("https://github.com/dotnet/runtime/issues/73045")]
             //
             await AssertThrowsQuicExceptionAsync(QuicError.InternalError, async () => await CreateQuicListener(listener.LocalEndPoint));
+        }
+
+        [Fact]
+        public async Task Listener_AwaitsConnection_ListenerSurvivesGC()
+        {
+            TaskCompletionSource<IPEndPoint> listenerEndpointTcs = new TaskCompletionSource<IPEndPoint>();
+            await Task.WhenAll(
+                Task.Run(async () =>
+                {
+                    await using var listener = await CreateQuicListener();
+                    listenerEndpointTcs.SetResult(listener.LocalEndPoint);
+                    var connection = await listener.AcceptConnectionAsync();
+                    await connection.DisposeAsync();
+                }).WaitAsync(TimeSpan.FromSeconds(5)),
+                Task.Run(async () =>
+                {
+                    var endpoint = await listenerEndpointTcs.Task;
+                    await Task.Delay(TimeSpan.FromSeconds(0.5));
+                    GC.Collect();
+                    var connection = await CreateQuicConnection(endpoint);
+                    await connection.DisposeAsync();
+                }).WaitAsync(TimeSpan.FromSeconds(5)));
         }
     }
 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -102,7 +102,7 @@ namespace System.Net.Quic.Tests
                         }
                         catch (Exception ex)
                         {
-                            _output?.WriteLine($"Failed to {ex.Message}");
+                            _output?.WriteLine($"Failed to connect: {ex.Message}");
                             throw;
                         }
                     }));
@@ -152,15 +152,6 @@ namespace System.Net.Quic.Tests
                     disposable.DisposeAsync().GetAwaiter().GetResult();
                 }
             }
-        }
-
-        [OuterLoop("May take several seconds")]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73377")]
-        public override Task Parallel_ReadWriteMultipleStreamsConcurrently()
-        {
-            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Backport of the first commit of https://github.com/dotnet/runtime/pull/74450 to release/7.0

Fixes https://github.com/dotnet/runtime/issues/73377.

### Root cause

When awaiting reading from `Channel` (whether it's channel of connections in listener or channel of stream in connection) we're technically awaiting a native event from msquic. During this awaiting we were hitting another instance of the problem stated in https://devblogs.microsoft.com/pfxteam/keeping-async-methods-alive/. In other words, GC would collect listener/connection while we were waiting for NEW_CONNECTION/NEW_STREAM events.

### Fix

Added rooting of listener/connection in `AcceptIncoming...` methods. Also added tests directly targeted at this problem (they were consistently failing before the fix, always on the first run).

## Customer Impact

The error manifests as a hang. A hang about which a user is not able to do anything. And it might lead to a false suspicion that a dead-lock is happening.
Note that we did have the same problem before (in 6.0), even with more places where GC had an opportunity to collect Listener/Connection/Stream. My suspicion is timing changes due to API changes and/or other changes elsewhere just uncovered this.


## Testing

Re-enable failing tests as part of fix. Also added 2 more targeted tests that were failing before the fix and now are passing.

## Risk

Low since Quic is in preview mode. Should not have impact on HTTP/3.