### PR TITLE
Move distributed transaction test to OleTxTests

### DIFF
--- a/src/libraries/System.Transactions.Local/tests/OleTxNonWindowsUnsupportedTests.cs
+++ b/src/libraries/System.Transactions.Local/tests/OleTxNonWindowsUnsupportedTests.cs
@@ -55,10 +55,15 @@ public class OleTxNonWindowsUnsupportedTests
 
     [Fact]
     public void GetWhereabouts()
-        => Assert.Throws<PlatformNotSupportedException>(() => TransactionInterop.GetWhereabouts());
+        => Assert.Throws<PlatformNotSupportedException>(TransactionInterop.GetWhereabouts);
 
     [Fact]
     public void GetExportCookie()
-        => Assert.Throws<PlatformNotSupportedException>(() => TransactionInterop.GetExportCookie(
-            new CommittableTransaction(), new byte[200]));
+        => Assert.Throws<PlatformNotSupportedException>(() =>
+            TransactionInterop.GetExportCookie(new CommittableTransaction(), new byte[200]));
+
+    [Fact]
+    public void GetDtcTransaction()
+        => Assert.Throws<PlatformNotSupportedException>(() =>
+            TransactionInterop.GetDtcTransaction(new CommittableTransaction()));
 }

--- a/src/libraries/System.Transactions.Local/tests/OleTxTests.cs
+++ b/src/libraries/System.Transactions.Local/tests/OleTxTests.cs
@@ -433,6 +433,34 @@ public class OleTxTests : IClassFixture<OleTxTests.OleTxFixture>
             Assert.Equal(tx.TransactionInformation.DistributedIdentifier, tx2.TransactionInformation.DistributedIdentifier);
         });
 
+    // Test currently skipped, #74745
+    private void GetDtcTransaction()
+        => Test(() =>
+        {
+            using var tx = new CommittableTransaction();
+
+            var outcomeReceived = new AutoResetEvent(false);
+
+            var enlistment = new TestEnlistment(
+                Phase1Vote.Prepared, EnlistmentOutcome.Committed, outcomeReceived: outcomeReceived);
+
+            Assert.Equal(Guid.Empty, tx.PromoterType);
+
+            tx.EnlistVolatile(enlistment, EnlistmentOptions.None);
+
+            // Forces promotion to MSDTC, returns an ITransaction for use only with System.EnterpriseServices.
+            _ = TransactionInterop.GetDtcTransaction(tx);
+
+            Assert.Equal(TransactionStatus.Active, tx.TransactionInformation.Status);
+            Assert.Equal(TransactionInterop.PromoterTypeDtc, tx.PromoterType);
+
+            tx.Commit();
+
+            Assert.True(outcomeReceived.WaitOne(Timeout));
+            Assert.Equal(EnlistmentOutcome.Committed, enlistment.Outcome);
+            Retry(() => Assert.Equal(TransactionStatus.Committed, tx.TransactionInformation.Status));
+        });
+
     private static void Test(Action action)
     {
         // Temporarily skip on 32-bit where we have an issue.


### PR DESCRIPTION
Test-only PR to stabilize the CI builds. The skipped test is because of #74745, the fix for that is ready as well (but separated from this unrelated test-only stabilization).

NonMsdtcPromoterTests.PSPENonMsdtcGetPromoterTypeMSDTC was triggering an MSDTC distributed transaction on Windows, but without the proper checks/resiliency. Moved to OleTxTests.

Fixes #74170