### PR TITLE
Unload MsQuic after checking for QUIC support to free resources.

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -48,7 +48,7 @@ internal sealed unsafe class MsQuicApi
         }
     }
 
-    internal static Lazy<MsQuicApi> _api = new Lazy<MsQuicApi>(AllocateMsQuicApi);
+    private static readonly Lazy<MsQuicApi> _api = new Lazy<MsQuicApi>(AllocateMsQuicApi);
     internal static MsQuicApi Api => _api.Value;
 
     internal static bool IsQuicSupported { get; }
@@ -74,7 +74,7 @@ internal sealed unsafe class MsQuicApi
 
             try
             {
-                // check version
+                // Check version
                 int arraySize = 4;
                 uint* libVersion = stackalloc uint[arraySize];
                 uint size = (uint)arraySize * sizeof(uint);
@@ -132,7 +132,7 @@ internal sealed unsafe class MsQuicApi
         }
     }
 
-    internal static MsQuicApi AllocateMsQuicApi()
+    private static MsQuicApi AllocateMsQuicApi()
     {
         Debug.Assert(IsQuicSupported);
 
@@ -145,11 +145,11 @@ internal sealed unsafe class MsQuicApi
         throw new Exception("Failed to create MsQuicApi instance");
     }
 
-    internal static bool TryLoadMsQuic(out IntPtr msQuicHandle) =>
+    private static bool TryLoadMsQuic(out IntPtr msQuicHandle) =>
         NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) ||
         NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
 
-    internal static bool TryOpenMsQuic(IntPtr msQuicHandle, out QUIC_API_TABLE* apiTable)
+    private static bool TryOpenMsQuic(IntPtr msQuicHandle, out QUIC_API_TABLE* apiTable)
     {
         apiTable = null;
         if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
@@ -168,7 +168,7 @@ internal sealed unsafe class MsQuicApi
         return true;
     }
 
-    internal static bool TryCloseMsQuic(IntPtr msQuicHandle, QUIC_API_TABLE* apiTable)
+    private static bool TryCloseMsQuic(IntPtr msQuicHandle, QUIC_API_TABLE* apiTable)
     {
         if (NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
         {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -127,10 +127,8 @@ internal sealed unsafe class MsQuicApi
         }
         finally
         {
-            if (!IsQuicSupported)
-            {
-                NativeLibrary.Free(msQuicHandle);
-            }
+            // Unload the library, we will load it again when we actually use QUIC
+            NativeLibrary.Free(msQuicHandle);
         }
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Quic;
@@ -47,7 +48,8 @@ internal sealed unsafe class MsQuicApi
         }
     }
 
-    internal static MsQuicApi Api { get; } = null!;
+    internal static Lazy<MsQuicApi> _api = new Lazy<MsQuicApi>(AllocateMsQuicApi);
+    internal static MsQuicApi Api => _api.Value;
 
     internal static bool IsQuicSupported { get; }
 
@@ -58,29 +60,21 @@ internal sealed unsafe class MsQuicApi
 
     static MsQuicApi()
     {
-        IntPtr msQuicHandle;
-        if (!NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) &&
-            !NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
+        if (!TryLoadMsQuic(out IntPtr msQuicHandle))
         {
             return;
         }
 
         try
         {
-            if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
-            {
-                return;
-            }
-
-            QUIC_API_TABLE* apiTable = null;
-            delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> msQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)msQuicOpenVersionAddress;
-            if (StatusFailed(msQuicOpenVersion((uint)MsQuicVersion.Major, &apiTable)))
+            if (!TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable))
             {
                 return;
             }
 
             try
             {
+                // check version
                 int arraySize = 4;
                 uint* libVersion = stackalloc uint[arraySize];
                 uint size = (uint)arraySize * sizeof(uint);
@@ -99,7 +93,7 @@ internal sealed unsafe class MsQuicApi
                     return;
                 }
 
-                // Assume SChannel is being used on windows and query for the actual provider from the library
+                // Assume SChannel is being used on windows and query for the actual provider from the library if querying is supported
                 QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
                 size = sizeof(QUIC_TLS_PROVIDER);
                 apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
@@ -122,18 +116,14 @@ internal sealed unsafe class MsQuicApi
                     Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
                 }
 
-                Api = new MsQuicApi(apiTable);
                 IsQuicSupported = true;
             }
             finally
             {
-                if (!IsQuicSupported && NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
-                {
-                    // Gracefully close the API table
-                    ((delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)msQuicClose)(apiTable);
-                }
+                // Gracefully close the API table to free resources. The API table will be allocated lazily again if needed
+                bool closed = TryCloseMsQuic(msQuicHandle, apiTable);
+                Debug.Assert(closed, "Failed to close MsQuic");
             }
-
         }
         finally
         {
@@ -142,6 +132,53 @@ internal sealed unsafe class MsQuicApi
                 NativeLibrary.Free(msQuicHandle);
             }
         }
+    }
+
+    internal static MsQuicApi AllocateMsQuicApi()
+    {
+        Debug.Assert(IsQuicSupported);
+
+        if (TryLoadMsQuic(out IntPtr msQuicHandle) &&
+            TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable))
+        {
+            return new MsQuicApi(apiTable);
+        }
+
+        throw new Exception("Failed to create MsQuicApi instance");
+    }
+
+    internal static bool TryLoadMsQuic(out IntPtr msQuicHandle) =>
+        NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) ||
+        NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
+
+    internal static bool TryOpenMsQuic(IntPtr msQuicHandle, out QUIC_API_TABLE* apiTable)
+    {
+        apiTable = null;
+        if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
+        {
+            return false;
+        }
+
+        QUIC_API_TABLE* table = null;
+        delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> msQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)msQuicOpenVersionAddress;
+        if (StatusFailed(msQuicOpenVersion((uint)MsQuicVersion.Major, &table)))
+        {
+            return false;
+        }
+
+        apiTable = table;
+        return true;
+    }
+
+    internal static bool TryCloseMsQuic(IntPtr msQuicHandle, QUIC_API_TABLE* apiTable)
+    {
+        if (NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
+        {
+            ((delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)msQuicClose)(apiTable);
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsWindowsVersionSupported() => OperatingSystem.IsWindowsVersionAtLeast(MinWindowsVersion.Major,


### PR DESCRIPTION
Fixes #74629.

This PR unloads MsQuic library from the process after we check whether it is supported. This saves some resources when HTTP3 is not used (e.g. the server does not advertise HTTP3)

Test app:
```cs
using System.Net.Http;

HttpClient client = new HttpClient();

await client.GetAsync("https://www.microsoft.com");

System.Console.WriteLine("Done");
System.Console.ReadLine();
```
Results on Windows11
Diff | Before | After
:----|----:|---:
Threads | 62 | 23
PrivateMemorySize | 13385728 | 12083200