### PR TITLE
[wasm] Disable firefox debugger tests for rolling builds

### DIFF
--- a/eng/pipelines/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/runtime-extra-platforms-wasm.yml
@@ -47,15 +47,15 @@ jobs:
       alwaysRun: true
 
   # Wasm Debugger tests - firefox
-  - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
-    parameters:
-      platforms:
-        - Browser_wasm_firefox
-      browser: firefox
-      # ff tests are unstable currently
-      shouldContinueOnError: true
-      alwaysRun: true
-
+  #  - disabled from rolling builds
+  #- template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
+    #parameters:
+      #platforms:
+        #- Browser_wasm_firefox
+      #browser: firefox
+      ## ff tests are unstable currently
+      #shouldContinueOnError: true
+      #alwaysRun: true
 
   # Disabled for now
   #- template: /eng/pipelines/coreclr/perf-wasm-jobs.yml


### PR DESCRIPTION
.. because they are unstable right now. They will still be run on PRs
though.

Fixes https://github.com/dotnet/runtime/issues/74640 .