### PR TITLE
Fix TransactionInterop.GetDtcTransaction()

### DIFF
--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransaction.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransaction.cs
@@ -11,9 +11,15 @@ namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 [ComImport, Guid(Guids.IID_ITransaction), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface ITransaction
 {
-    void Commit([MarshalAs(UnmanagedType.Bool)] bool fRetainingt, [MarshalAs(UnmanagedType.U4)] OletxXacttc grfTC, uint grfRM);
+    void Commit(
+        [MarshalAs(UnmanagedType.Bool)] bool fRetainingt,
+        [MarshalAs(UnmanagedType.U4)] OletxXacttc grfTC,
+        uint grfRM);
 
-    void Abort(IntPtr reason, [MarshalAs(UnmanagedType.Bool)] bool retaining, [MarshalAs(UnmanagedType.Bool)] bool async);
+    void Abort(
+        IntPtr reason,
+        [MarshalAs(UnmanagedType.Bool)] bool retaining,
+        [MarshalAs(UnmanagedType.Bool)] bool async);
 
     void GetTransactionInfo(out OletxXactTransInfo xactInfo);
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionCloner.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/ITransactionCloner.cs
@@ -10,5 +10,17 @@ namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 [ComImport, Guid("02656950-2152-11d0-944C-00A0C905416E"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface ITransactionCloner
 {
+    void Commit(
+        [MarshalAs(UnmanagedType.Bool)] bool fRetainingt,
+        [MarshalAs(UnmanagedType.U4)] OletxXacttc grfTC,
+        uint grfRM);
+
+    void Abort(
+        IntPtr reason,
+        [MarshalAs(UnmanagedType.Bool)] bool retaining,
+        [MarshalAs(UnmanagedType.Bool)] bool async);
+
+    void GetTransactionInfo(out OletxXactTransInfo xactInfo);
+
     void CloneWithCommitDisabled([MarshalAs(UnmanagedType.Interface)] out ITransaction ppITransaction);
 }

--- a/src/libraries/System.Transactions.Local/tests/OleTxTests.cs
+++ b/src/libraries/System.Transactions.Local/tests/OleTxTests.cs
@@ -433,8 +433,8 @@ public class OleTxTests : IClassFixture<OleTxTests.OleTxFixture>
             Assert.Equal(tx.TransactionInformation.DistributedIdentifier, tx2.TransactionInformation.DistributedIdentifier);
         });
 
-    // Test currently skipped, #74745
-    private void GetDtcTransaction()
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+    public void GetDtcTransaction()
         => Test(() =>
         {
             using var tx = new CommittableTransaction();


### PR DESCRIPTION
@AaronRobinsonMSFT can you review? The COM definition here was wrong ([ITransactionCloner](https://docs.microsoft.com/previous-versions/windows/desktop/ms684377(v=vs.85)) extends [ITransaction](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms686531(v=vs.85))).

Fixes #74745