### PR TITLE
[Android] Skip VectorSingle and VectorDoubleEqualsNonCanonicalNaNTest on x64

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -38,6 +38,8 @@ namespace System
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsAndroid => RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
         public static bool IsNotAndroid => !IsAndroid;
+        public static bool IsAndroidX64 => IsAndroid && Is64BitProcess;
+        public static bool IsNotAndroidX64 => !IsAndroidX64;
         public static bool IsAndroidX86 => IsAndroid && IsX86Process;
         public static bool IsNotAndroidX86 => !IsAndroidX86;
         public static bool IsiOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));

--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -848,6 +848,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74781", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX64))]
         public void VectorDoubleEqualsNonCanonicalNaNTest()
         {
             // max 8 bit exponent, just under half max mantissa
@@ -872,6 +873,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74781", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX64))]
         public void VectorSingleEqualsNonCanonicalNaNTest()
         {
             // max 11 bit exponent, just under half max mantissa


### PR DESCRIPTION
These tests are failing on Android x64 and need to be skipped to avoid blocking clean ci.

https://github.com/dotnet/runtime/issues/74781