### PR TITLE
CI: Fix helix test results reporting

### DIFF
--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -848,6 +848,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74781", TestRuntimes.Mono)]
         public void VectorDoubleEqualsNonCanonicalNaNTest()
         {
             // max 8 bit exponent, just under half max mantissa
@@ -872,6 +873,7 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74781", TestRuntimes.Mono)]
         public void VectorSingleEqualsNonCanonicalNaNTest()
         {
             // max 11 bit exponent, just under half max mantissa

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -172,8 +172,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
-      <HelixPostCommands>@(HelixPostCommand)</HelixPostCommands>
+      <HelixPreCommands>$(HelixPreCommands);@(HelixPreCommand)</HelixPreCommands>
+      <HelixPostCommands>$(HelixPostCommands);@(HelixPostCommand)</HelixPostCommands>
       <HelixCommandPrefix Condition="'$(WindowsShell)' == 'true' and @(HelixCommandPrefixItem->Count()) > 0" >$(HelixCommandPrefix) @(HelixCommandPrefixItem -> 'set &quot;%(Identity)&quot;', ' &amp; ')</HelixCommandPrefix>
       <HelixCommandPrefix Condition="'$(WindowsShell)' != 'true' and @(HelixCommandPrefixItem->Count()) > 0 ">$(HelixCommandPrefix) @(HelixCommandPrefixItem, ' ')</HelixCommandPrefix>
       <IncludeHelixCorrelationPayload Condition="'$(IncludeHelixCorrelationPayload)' == '' and '$(HelixCorrelationPayload)' != ''">true</IncludeHelixCorrelationPayload>


### PR DESCRIPTION
PR #73060 broke uploading of helix test results. This was caused by the
change:

```xml
      <HelixPostCommands>@(HelixPostCommand)</HelixPostCommands>
```

This is overwriting the existing value of `$(HelixPostCommands)`, which
gets set to have the upload script invocation in https://github.com/dotnet/arcade/blob/34dff939b4a91e4693f78a856e0e055c1a3f3fba/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/AzurePipelines.MonoQueue.targets#L8-L15 at evaluation time.

Fix by *appending* to the property.

Thanks to ChadNedzlek for finding the cause!

Fixes https://github.com/dotnet/runtime/issues/74699 .