### PR TITLE
Add WaitAsync functionality to Background Service

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.Hosting
                 await _executeTask.WaitAsync(cancellationToken).ConfigureAwait(false);
 #else
                 var tcs = new TaskCompletionSource<object>();
-                using var registration = cancellationToken.Register(tcs.SetCanceled);
+                using CancellationTokenRegistration registration = cancellationToken.Register(s => ((TaskCompletionSource<object>)s).SetCanceled(), tcs);
                 await (await Task.WhenAny(_executeTask, tcs.Task).ConfigureAwait(false)).ConfigureAwait(false);
 #endif
             }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -74,13 +74,17 @@ namespace Microsoft.Extensions.Hosting
             finally
             {
                 // Wait until the task completes or the stop token triggers
+                try
+                {
 #if NETCOREAPP
-                await _executeTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    await _executeTask.WaitAsync(cancellationToken).ConfigureAwait(false);
 #else
-                var tcs = new TaskCompletionSource<object>();
-                using CancellationTokenRegistration registration = cancellationToken.Register(s => ((TaskCompletionSource<object>)s).SetCanceled(), tcs);
-                await (await Task.WhenAny(_executeTask, tcs.Task).ConfigureAwait(false)).ConfigureAwait(false);
+                    var tcs = new TaskCompletionSource<object>();
+                    using CancellationTokenRegistration registration = cancellationToken.Register(s => ((TaskCompletionSource<object>)s).SetCanceled(), tcs);
+                    await Task.WhenAny(_executeTask, tcs.Task).ConfigureAwait(false);
 #endif
+                }
+                catch (OperationCanceledException) { }
             }
 
         }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -74,17 +74,10 @@ namespace Microsoft.Extensions.Hosting
             finally
             {
                 // Wait until the task completes or the stop token triggers
-                try
-                {
-#if NETCOREAPP
-                    await _executeTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-#else
-                    var tcs = new TaskCompletionSource<object>();
-                    using CancellationTokenRegistration registration = cancellationToken.Register(s => ((TaskCompletionSource<object>)s).SetCanceled(), tcs);
-                    await Task.WhenAny(_executeTask, tcs.Task).ConfigureAwait(false);
-#endif
-                }
-                catch (OperationCanceledException) { }
+                var tcs = new TaskCompletionSource<object>();
+                using CancellationTokenRegistration registration = cancellationToken.Register(s => ((TaskCompletionSource<object>)s!).SetCanceled(), tcs);
+                // Do not await the _executeTask because cancelling it will throw an OperationCanceledException which we are explicitly ignoring
+                await Task.WhenAny(_executeTask, tcs.Task).ConfigureAwait(false);
             }
 
         }


### PR DESCRIPTION
Resolves problem in #36380 where `Microsoft.Extensions.Hosting.Abstractions\src\BackgroundService.cs` can create Tasks that appear likely to never complete. New functionality in .NET 6.0 allowed this to be cleaned up with `Task.WaitAsync`. Since this API does not exist in all configurations that the Extensions libraries target, the new desired behavior is simulated by [a fix](https://github.com/dotnet/runtime/issues/36380#issuecomment-517352681) proposed by @Zenexer in versions without it.

The nested `ConfigureAwait()` calls don't look pretty, but they were required in order to be compliant with [CA2007](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007).