### PR TITLE
[mono][llvm] Disable simd intrinsics when we might be interoping between jit and llvmaot

### DIFF
--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3027,7 +3027,7 @@ static gboolean
 is_simd_supported (MonoCompile *cfg)
 {
 #ifdef DISABLE_SIMD
-    return FALSE;
+	return FALSE;
 #endif
 	// FIXME: Clean this up
 #ifdef TARGET_WASM
@@ -3035,6 +3035,10 @@ is_simd_supported (MonoCompile *cfg)
 		return FALSE;
 #else
 	if (cfg->llvm_only)
+		return FALSE;
+	// FIXME We disable simd intrinsics when mixing between llvmaot and jit since the llvm backend could
+	// see that certain simd operations are supported while with jit we fail to emit correct code.
+	if (cfg->compile_aot && cfg->compile_llvm && !cfg->full_aot)
 		return FALSE;
 #endif
 	return TRUE;

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -719,12 +719,6 @@ emit_hardware_intrinsics (
 			goto support_probe_complete;
 		id = info->id;
 
-#ifdef TARGET_ARM64
-		if (!(cfg->compile_aot && cfg->full_aot && !cfg->interp) && !intrin_group->jit_supported) {
-			goto support_probe_complete;
-		}
-#endif
-
 		// Hardware intrinsics are LLVM-only.
 		if (!COMPILE_LLVM (cfg) && !intrin_group->jit_supported)
 			goto support_probe_complete;


### PR DESCRIPTION
Revert previous partial disabling of simd intrinsics.

If we have a method that checkes if some hardware functionality `IsSupported` and then calls another method making use of this functionality if so, we have a problem if the method using the actual intrinsic is not also aot compiled and the intrisic is not supported by the jit. This issue is exposed inside bcl code, where this pattern is very common, by use of profiled aot on android. This change goes for the most conservative approach, by disabling all simd if we are not fullaot-ing and we use llvm.