### PR TITLE
Extensions.Logging.Console: Only check for Android/Apple mobile on netcoreapp configs

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Extensions.Logging.Console
             // We shouldn't be outputting color codes for Android/Apple mobile platforms,
             // they have no shell (adb shell is not meant for running apps) and all the output gets redirected to some log file.
             bool disableColors = (FormatterOptions.ColorBehavior == LoggerColorBehavior.Disabled) ||
-                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && (!ConsoleUtils.EmitAnsiColorCodes || _isAndroidOrAppleMobile));
+                (FormatterOptions.ColorBehavior == LoggerColorBehavior.Default && (!ConsoleUtils.EmitAnsiColorCodes || IsAndroidOrAppleMobile));
             if (disableColors)
             {
                 return new ConsoleColors(null, null);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Extensions.Logging.Console
         private static readonly string _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length);
         private static readonly string _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
 #if NETCOREAPP
-        private static readonly bool _isAndroidOrAppleMobile => OperatingSystem.IsAndroid()
+        private static bool IsAndroidOrAppleMobile => OperatingSystem.IsAndroid()
                                                             || OperatingSystem.IsTvOS()
                                                             || OperatingSystem.IsIOS(); // returns true on MacCatalyst
 #else
-        private const bool _isAndroidOrAppleMobile = false;
+        private static bool IsAndroidOrAppleMobile => false;
 #endif
         private IDisposable? _optionsReloadToken;
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -15,10 +15,13 @@ namespace Microsoft.Extensions.Logging.Console
         private const string LoglevelPadding = ": ";
         private static readonly string _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length);
         private static readonly string _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
-        private static readonly bool _isAndroidOrAppleMobile = RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"))
-                                                            || RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"))
-                                                            || RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"))
-                                                            || RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
+#if NETCOREAPP
+        private static readonly bool _isAndroidOrAppleMobile = OperatingSystem.IsAndroid()
+                                                            || OperatingSystem.IsTvOS()
+                                                            || OperatingSystem.IsIOS();
+#else
+        private const bool _isAndroidOrAppleMobile = false;
+#endif
         private IDisposable? _optionsReloadToken;
 
         public SimpleConsoleFormatter(IOptionsMonitor<SimpleConsoleFormatterOptions> options)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Extensions.Logging.Console
         private static readonly string _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length);
         private static readonly string _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
 #if NETCOREAPP
-        private static bool IsAndroidOrAppleMobile => OperatingSystem.IsAndroid()
-                                                            || OperatingSystem.IsTvOS()
-                                                            || OperatingSystem.IsIOS(); // returns true on MacCatalyst
+        private static bool IsAndroidOrAppleMobile => OperatingSystem.IsAndroid() ||
+                                                      OperatingSystem.IsTvOS() ||
+                                                      OperatingSystem.IsIOS(); // returns true on MacCatalyst
 #else
         private static bool IsAndroidOrAppleMobile => false;
 #endif

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Extensions.Logging.Console
         private static readonly string _messagePadding = new string(' ', GetLogLevelString(LogLevel.Information).Length + LoglevelPadding.Length);
         private static readonly string _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
 #if NETCOREAPP
-        private static readonly bool _isAndroidOrAppleMobile = OperatingSystem.IsAndroid()
+        private static readonly bool _isAndroidOrAppleMobile => OperatingSystem.IsAndroid()
                                                             || OperatingSystem.IsTvOS()
-                                                            || OperatingSystem.IsIOS();
+                                                            || OperatingSystem.IsIOS(); // returns true on MacCatalyst
 #else
         private const bool _isAndroidOrAppleMobile = false;
 #endif


### PR DESCRIPTION
We can keep the previous behavior before https://github.com/dotnet/runtime/pull/74496 on non-netcoreapp configs since they only apply to legacy Xamarin.iOS/Android.
That allows us to use the more efficient `OperatingSystem.Is*()` APIs.