### PR TITLE
Clean up remnants of Crossgen1 from test scripts and pipelines

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -9,7 +9,6 @@ parameters:
   crossrootfsDir: ''
   readyToRun: false
   liveLibrariesBuildConfig: ''
-  crossgen2: false
   compositeBuildMode: false
   useCodeFlowEnforcement: ''
   helixQueues: ''
@@ -127,15 +126,9 @@ jobs:
 
     - ${{ if eq(parameters.readyToRun, true) }}:
       - name: crossgenArg
-      # Switch R2R to use cg2 by default
         value: 'crossgen2'
       - name: LogNamePrefix
-        value: TestRunLogs_R2R
-      - ${{ if eq(parameters.crossgen2, true) }}:
-        - name: crossgenArg
-          value: 'crossgen2'
-        - name: LogNamePrefix
-          value: TestRunLogs_R2R_CG2
+        value: TestRunLogs_R2R_CG2
       - ${{ if eq(parameters.compositeBuildMode, true) }}:
         - name: crossgenArg
           value: 'composite'
@@ -166,8 +159,8 @@ jobs:
     # Note that "timeoutInMinutes" is an Azure DevOps Pipelines parameter for a "job" that specifies the
     # total time allowed for a job, and is specified lower down. Make sure you set it properly for any new testGroup.
     #
-    # Please note that for Crossgen / Crossgen2 R2R runs, the "test running time" also includes the
-    # time needed to compile the test into native code with the Crossgen compiler.
+    # Please note that for Crossgen2 R2R runs, the "test running time" also includes the
+    # time needed to compile the test into native code with the Crossgen2 compiler.
 
     - name: timeoutPerTestInMinutes
       value: 10
@@ -176,7 +169,7 @@ jobs:
     - ${{ if in(parameters.testGroup, 'outerloop') }}:
       - name: timeoutPerTestCollectionInMinutes
         value: 120
-    - ${{ if eq(parameters.crossgen2, true) }}:
+    - ${{ if eq(parameters.readyToRun, true) }}:
         - name: timeoutPerTestCollectionInMinutes
           value: 90
         - name: timeoutPerTestInMinutes
@@ -320,7 +313,7 @@ jobs:
 
 
     # Compose the Core_Root folder containing all artifacts needed for running
-    # CoreCLR tests. This step also compiles the framework using Crossgen / Crossgen2
+    # CoreCLR tests. This step also compiles the framework using Crossgen2
     # in ReadyToRun jobs.
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) generatelayoutonly $(logRootNameArg)Layout $(runtimeFlavorArgs) $(crossgenArg) $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(librariesOverrideArg) $(runtimeVariantArg)
       displayName: Generate CORE_ROOT
@@ -385,8 +378,7 @@ jobs:
         timeoutPerTestInMinutes: $(timeoutPerTestInMinutes)
         timeoutPerTestCollectionInMinutes: $(timeoutPerTestCollectionInMinutes)
 
-        runCrossGen: ${{ and(eq(parameters.readyToRun, true), ne(parameters.crossgen2, true)) }}
-        runCrossGen2: ${{ and(eq(parameters.readyToRun, true), eq(parameters.crossgen2, true)) }}
+        runCrossGen2: ${{ eq(parameters.readyToRun, true) }}
         ${{ if and(ne(parameters.testGroup, 'innerloop'), eq(parameters.runtimeFlavor, 'coreclr')) }}:
           runPALTestsDir: '$(coreClrProductRootFolderPath)/paltests'
 

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -15,7 +15,6 @@ parameters:
   scenarios: ''
   timeoutPerTestCollectionInMinutes: ''
   timeoutPerTestInMinutes: ''
-  runCrossGen: ''
   runCrossGen2: ''
   runPALTestsDir: ''
   compositeBuildMode: false
@@ -46,7 +45,6 @@ steps:
       _HelixSource: ${{ parameters.helixSource }}
       _HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
       _HelixType: ${{ parameters.helixType }}
-      _RunCrossGen: ${{ parameters.runCrossGen }}
       _RunCrossGen2: ${{ parameters.runCrossGen2 }}
       _CompositeBuildMode: ${{ parameters.compositeBuildMode }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}

--- a/eng/pipelines/common/templates/runtimes/wasm-runtime-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/wasm-runtime-and-send-to-helix.yml
@@ -9,7 +9,6 @@ parameters:
   crossrootfsDir: ''
   readyToRun: false
   liveLibrariesBuildConfig: ''
-  crossgen2: false
   compositeBuildMode: false
   helixQueues: ''
   stagedBuild: false
@@ -66,8 +65,7 @@ steps:
         timeoutPerTestInMinutes: $(timeoutPerTestInMinutes)
         timeoutPerTestCollectionInMinutes: $(timeoutPerTestCollectionInMinutes)
 
-        runCrossGen: ${{ and(eq(parameters.readyToRun, true), ne(parameters.crossgen2, true)) }}
-        runCrossGen2: ${{ and(eq(parameters.readyToRun, true), eq(parameters.crossgen2, true)) }}
+        runCrossGen2: ${{ eq(parameters.readyToRun, true) }}
         compositeBuildMode: ${{ parameters.compositeBuildMode }}
         runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
 

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -150,7 +150,6 @@ jobs:
     jobParameters:
       testGroup: outerloop
       readyToRun: true
-      crossgen2: true
       displayNameArgs: R2R_CG2
       liveLibrariesBuildConfig: Release
 

--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -53,7 +53,6 @@ jobs:
     jobParameters:
       testGroup: innerloop
       readyToRun: true
-      crossgen2: true
       compositeBuildMode: true
       displayNameArgs: Composite
       liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -51,7 +51,6 @@ jobs:
     jobParameters:
       testGroup: gcstress-extra
       readyToRun: true
-      crossgen2: true
       compositeBuildMode: true
       displayNameArgs: Composite
       liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -49,6 +49,5 @@ jobs:
     jobParameters:
       testGroup: innerloop
       readyToRun: true
-      crossgen2: true
       displayNameArgs: R2R_CG2
       liveLibrariesBuildConfig: Release

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -42,7 +42,6 @@ WARNING:   When setting properties based on their current state (for example:
         <![CDATA[
 
 if [ "$(AlwaysUseCrossGen2)" == "true" ]; then
-    unset RunCrossGen
     export RunCrossGen2=1
     export CompositeBuildMode=1
 fi
@@ -162,7 +161,6 @@ fi
         <![CDATA[
 
 if /i "$(AlwaysUseCrossGen2)" == "true" (
-    set RunCrossGen=
     set RunCrossGen2=1
     set CompositeBuildMode=1
 )

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -313,7 +313,7 @@ fi
 
 $(BashIlrtTestLaunchCmds)
 
-if [ ! -z ${RunCrossGen+x} ]%3B then
+if [ ! -z ${RunCrossGen2+x} ]%3B then
   TakeLock
 fi
 
@@ -322,7 +322,7 @@ $LAUNCHER $ExePath "${CLRTestExecutionArguments[@]}"
 
 CLRTestExitCode=$?
 
-if [ ! -z ${RunCrossGen+x} ]%3B then
+if [ ! -z ${RunCrossGen2+x} ]%3B then
   ReleaseLock
 fi
 
@@ -341,7 +341,7 @@ fi
 
 $(BashIlrtTestLaunchCmds)
 
-if [ ! -z ${RunCrossGen+x} ]%3B then
+if [ ! -z ${RunCrossGen2+x} ]%3B then
   TakeLock
 fi
 
@@ -350,7 +350,7 @@ $LAUNCHER $ExePath "${CLRTestExecutionArguments[@]}"
 
 CLRTestExitCode=$?
 
-if [ ! -z ${RunCrossGen+x} ]%3B then
+if [ ! -z ${RunCrossGen2+x} ]%3B then
   ReleaseLock
 fi
 

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -298,13 +298,13 @@ IF NOT "%CLRCustomTestLauncher%"=="" (
 
 $(BatchIlrtTestLaunchCmds)
 
-if defined RunCrossGen (
+if defined RunCrossGen2 (
   call :TakeLock
 )
 ECHO %LAUNCHER% %ExePath% %CLRTestExecutionArguments%
 %LAUNCHER% %ExePath% %CLRTestExecutionArguments%
 set CLRTestExitCode=!ERRORLEVEL!
-if defined RunCrossGen (
+if defined RunCrossGen2 (
   call :ReleaseLock
 )
 $(BatchLinkerTestCleanupCmds)

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -33,7 +33,6 @@
         HelixTargetQueues=$(_HelixTargetQueues);
         HelixType=$(_HelixType);
         PublishTestResults=$(_PublishTestResults);
-        RunCrossGen=$(_RunCrossGen);
         RunCrossGen2=$(_RunCrossGen2);
         CompositeBuildMode=$(_CompositeBuildMode);
         LongRunningGCTests=$(_LongRunningGCTests);
@@ -489,12 +488,10 @@
     <HelixArchitecture>$(TargetArchitecture)</HelixArchitecture>
     <HelixConfiguration Condition=" '$(Scenario)' == 'normal' ">$(Configuration)</HelixConfiguration>
     <HelixConfiguration Condition=" '$(Scenario)' != 'normal' ">$(Configuration)-$(Scenario)</HelixConfiguration>
-    <RunCrossGen Condition=" '$(RunCrossGen)' != 'true' ">false</RunCrossGen>
     <RunCrossGen2 Condition=" '$(RunCrossGen2)' != 'true' ">false</RunCrossGen2>
     <LongRunningGCTests Condition=" '$(LongRunningGCTests)' != 'true' ">false</LongRunningGCTests>
     <GcSimulatorTests Condition=" '$(GcSimulatorTests)' != 'true' ">false</GcSimulatorTests>
     <TestRunNamePrefix Condition="'$(RuntimeFlavor)' != ''">$(RuntimeFlavor) </TestRunNamePrefix>
-    <TestRunNamePrefix Condition=" '$(RunCrossGen)' == 'true' ">R2R </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(RunCrossGen2)' == 'true' ">R2R-CG2 </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(TestRunNamePrefix)$(TargetOS) $(TargetArchitecture) $(Configuration) @ </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(TargetOS) $(TargetArchitecture) $(Configuration) $(Scenario) @ </TestRunNamePrefix>
@@ -514,7 +511,6 @@
     <HelixPreCommand Include="set CORE_ROOT=%HELIX_CORRELATION_PAYLOAD%" />
     <!-- Set _NT_SYMBOL_PATH so VM _ASSERTE() asserts can find the symbol files when doing stack walks -->
     <HelixPreCommand Include="set _NT_SYMBOL_PATH=%HELIX_CORRELATION_PAYLOAD%\PDB" />
-    <HelixPreCommand Include="set RunCrossGen2=1" Condition=" '$(RunCrossGen)' == 'true' " />
     <HelixPreCommand Include="set RunCrossGen2=1" Condition=" '$(RunCrossGen2)' == 'true' " />
     <HelixPreCommand Include="set CompositeBuildMode=1" Condition=" '$(CompositeBuildMode)' == 'true' " />
     <HelixPreCommand Include="set RunningLongGCTests=1" Condition=" '$(LongRunningGCTests)' == 'true' " />
@@ -536,7 +532,6 @@
 
   <ItemGroup Condition=" '$(TestWrapperTargetsWindows)' != 'true' ">
     <HelixPreCommand Include="export CORE_ROOT=$HELIX_CORRELATION_PAYLOAD" />
-    <HelixPreCommand Include="export RunCrossGen2=1" Condition=" '$(RunCrossGen)' == 'true' " />
     <HelixPreCommand Include="export RunCrossGen2=1" Condition=" '$(RunCrossGen2)' == 'true' " />
     <HelixPreCommand Include="export CompositeBuildMode=1" Condition=" '$(CompositeBuildMode)' == 'true' " />
     <HelixPreCommand Include="export RunningLongGCTests=1" Condition=" '$(LongRunningGCTests)' == 'true' " />

--- a/src/tests/Common/scripts/bringup_runtest.sh
+++ b/src/tests/Common/scripts/bringup_runtest.sh
@@ -1111,7 +1111,7 @@ do
             ((disableEventLogging = 1))
             ;;
         --runcrossgentests)
-            export RunCrossGen=1
+            export RunCrossGen2=1
             ;;
         --sequential)
             ((maxProcesses = 1))


### PR DESCRIPTION
During my work on improving Crossgen2 PDB testing I noticed that
we still have a bunch of places containing obsolete provisions
for choosing between Crossgen1 and Crossgen2 (Crossgen1 was
deleted from the codebase about a year ago). This change cleans
them up.

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 