### PR TITLE
Fix `fgNoStructParamPromotion`

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3886,13 +3886,6 @@ inline Compiler::lvaPromotionType Compiler::lvaGetPromotionType(const LclVarDsc*
         return PROMOTION_TYPE_INDEPENDENT;
     }
 
-    // Has struct promotion for arguments been disabled using COMPlus_JitNoStructPromotion=2
-    if (fgNoStructParamPromotion)
-    {
-        // The struct parameter is not enregistered
-        return PROMOTION_TYPE_DEPENDENT;
-    }
-
 // We have a parameter that could be enregistered
 #if defined(TARGET_ARM)
     // TODO-Cleanup: return INDEPENDENT for arm32.

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2038,6 +2038,12 @@ bool Compiler::StructPromotionHelper::CanPromoteStructVar(unsigned lclNum)
         return false;
     }
 
+    if (varDsc->lvIsParam && compiler->fgNoStructParamPromotion)
+    {
+        JITDUMP("  struct promotion of V%02u is disabled by fgNoStructParamPromotion\n", lclNum);
+        return false;
+    }
+
     if (!compiler->lvaEnregMultiRegVars && varDsc->lvIsMultiRegArgOrRet())
     {
         JITDUMP("  struct promotion of V%02u is disabled because lvIsMultiRegArgOrRet()\n", lclNum);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_74774/Runtime_74774.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74774/Runtime_74774.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+class Runtime_74774
+{
+    private static int Main()
+    {
+        return Problem(new() { FirstLngValue = 1, SecondLngValue = 2 }) != 3 ? 101 : 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long Problem(MultiRegStruct a)
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static long Call(MultiRegStruct a, MultiRegStruct b, MultiRegStruct c, MultiRegStruct d) => d.FirstLngValue + d.SecondLngValue;
+
+        return Call(default, default, default, a);
+    }
+
+    struct MultiRegStruct
+    {
+        public long FirstLngValue;
+        public long SecondLngValue;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_74774/Runtime_74774.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74774/Runtime_74774.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set DOTNET_JitNoStructPromotion=2
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export DOTNET_JitNoStructPromotion=2
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The setting didn't actually disallow promotion of parameters, only made it dependent. This broke some assumptions in morph that if a dependently promoted struct is encountered, it must have already been marked DNER.

Fix #74774.