### PR TITLE
Unpin System.ValueTuple assembly version

### DIFF
--- a/src/libraries/System.ValueTuple/ref/System.ValueTuple.csproj
+++ b/src/libraries/System.ValueTuple/ref/System.ValueTuple.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <!-- Must match version supported by frameworks which support 4.0.* inbox.
-         Can be removed when API is added and this assembly is versioned to 4.1.* -->
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="System.ValueTuple.TypeForwards.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\ref\System.Runtime.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/libraries/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/libraries/System.ValueTuple/src/System.ValueTuple.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <!-- rev'ed to 4.0.1.0 even though 4.0.0.0 never shipped so that we can drop pre-release down to beta -->
-    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System.Runtime" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
System.ValueTuple's assembly version had to be pinned when it was consumable by .NET Framework which isn't true anymore. The library now only ships as part of the .NETCoreApp shared framework.