### PR TITLE
Make System.Transactions.Local trimmable

### DIFF
--- a/src/libraries/System.Transactions.Local/src/System.Transactions.Local.csproj
+++ b/src/libraries/System.Transactions.Local/src/System.Transactions.Local.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)</TargetFrameworks>
     <NoWarn>CA1805;IDE0059;CS1591</NoWarn>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
-    <IsTrimmable>false</IsTrimmable>
+    <IsTrimmable Condition="'$(TargetPlatformIdentifier)' == 'windows'">false</IsTrimmable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Transactions\CommittableTransaction.cs" />


### PR DESCRIPTION
On other target platforms than windows.

This fixes https://github.com/dotnet/runtime/issues/74506

The reason to make it non-trimmable is that it uses COM interop
on windows. So we can make it trimmable again on other target platforms.
https://github.com/dotnet/runtime/issues/74506#issuecomment-1231917923