### PR TITLE
Add host trace message to indicate runtimeconfig was not found

### DIFF
--- a/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
@@ -68,6 +68,7 @@ namespace HostActivation.Tests
             File.Delete(fixture.TestProject.RuntimeConfigJson);
             File.Delete(fixture.TestProject.DepsJson);
 
+            // Make sure normal run succeeds and doesn't print any errors
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
@@ -76,6 +77,15 @@ namespace HostActivation.Tests
                 // Note that this is an exact match - we don't expect any output from the host itself
                 .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
                 .And.NotHaveStdErr();
+
+            // Make sure tracing indicates there is no runtime config and no deps json
+            Command.Create(appExe)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
+                .And.HaveStdErrContaining($"Runtime config does not exist at [{fixture.TestProject.RuntimeConfigJson}]")
+                .And.HaveStdErrContaining($"Could not locate the dependencies manifest file [{fixture.TestProject.DepsJson}]");
         }
 
         [Fact]

--- a/src/native/corehost/runtime_config.cpp
+++ b/src/native/corehost/runtime_config.cpp
@@ -396,15 +396,16 @@ bool runtime_config_t::read_framework_array(const json_parser_t::value_t& framew
 
 bool runtime_config_t::ensure_parsed()
 {
-    trace::verbose(_X("Attempting to read runtime config: %s"), m_path.c_str());
     if (!ensure_dev_config_parsed())
     {
         trace::verbose(_X("Did not successfully parse the runtimeconfig.dev.json"));
     }
 
+    trace::verbose(_X("Attempting to read runtime config: %s"), m_path.c_str());
     if (!bundle::info_t::config_t::probe(m_path) && !pal::realpath(&m_path, true))
     {
         // Not existing is not an error.
+        trace::verbose(_X("Runtime config does not exist at [%s]"), m_path.c_str());
         return true;
     }
 


### PR DESCRIPTION
Not having a `runtimeconfig.json` is valid and we just assume the app is self-contained. The host tracing for not having runtime config versus having a valid one is currently identical. This just adds a log message to make it clear when we don't find a runtime config.