### PR TITLE
add ability to set GCName via runtimeconfig.

### DIFF
--- a/src/coreclr/gc/gcconfig.h
+++ b/src/coreclr/gc/gcconfig.h
@@ -135,7 +135,8 @@ public:
     INT_CONFIG   (GCHeapHardLimitPOHPercent, "GCHeapHardLimitPOHPercent", "System.GC.HeapHardLimitPOHPercent", 0,                  "Specifies the GC heap POH usage as a percentage of the total memory")                    \
     INT_CONFIG   (GCEnabledInstructionSets,  "GCEnabledInstructionSets",  NULL,                                -1,                 "Specifies whether GC can use AVX2 or AVX512F - 0 for neither, 1 for AVX2, 3 for AVX512F")\
     INT_CONFIG   (GCConserveMem,             "GCConserveMemory",          "System.GC.ConserveMemory",          0,                  "Specifies how hard GC should try to conserve memory - values 0-9")                       \
-    INT_CONFIG   (GCWriteBarrier,            "GCWriteBarrier",            NULL,                                0,                  "Specifies whether GC should use more precise but slower write barrier")
+    INT_CONFIG   (GCWriteBarrier,            "GCWriteBarrier",            NULL,                                0,                  "Specifies whether GC should use more precise but slower write barrier")                  \
+    STRING_CONFIG(GCName,                    "GCName",                    "System.GC.Name",                                        "Specifies the path of the standalone GC implementation.")                                
 // This class is responsible for retreiving configuration information
 // for how the GC should operate.
 class GCConfig

--- a/src/coreclr/vm/gcheaputilities.cpp
+++ b/src/coreclr/vm/gcheaputilities.cpp
@@ -335,7 +335,7 @@ HRESULT GCHeapUtilities::LoadAndInitialize()
     assert(g_gc_load_status == GC_LOAD_STATUS_BEFORE_START);
     g_gc_load_status = GC_LOAD_STATUS_START;
 
-    LPCWSTR standaloneGcLocation = Configuration::GetKnobStringValue(W("System.GC.GCName"), CLRConfig::EXTERNAL_GCName);
+    LPCWSTR standaloneGcLocation = Configuration::GetKnobStringValue(W("System.GC.Name"), CLRConfig::EXTERNAL_GCName);
     if (!standaloneGcLocation)
     {
         return InitializeDefaultGC();

--- a/src/coreclr/vm/gcheaputilities.cpp
+++ b/src/coreclr/vm/gcheaputilities.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "common.h"
+#include "configuration.h"
 #include "gcheaputilities.h"
 #include "gcenv.ee.h"
 #include "appdomain.hpp"
@@ -179,7 +180,7 @@ HMODULE LoadStandaloneGc(LPCWSTR libFileName)
 //
 // See Documentation/design-docs/standalone-gc-loading.md for details
 // on the loading protocol in use here.
-HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
+HRESULT LoadAndInitializeGC(LPCWSTR standaloneGcLocation)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -334,8 +335,7 @@ HRESULT GCHeapUtilities::LoadAndInitialize()
     assert(g_gc_load_status == GC_LOAD_STATUS_BEFORE_START);
     g_gc_load_status = GC_LOAD_STATUS_START;
 
-    LPWSTR standaloneGcLocation = nullptr;
-    CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_GCName, &standaloneGcLocation);
+    LPCWSTR standaloneGcLocation = Configuration::GetKnobStringValue(W("System.GC.GCName"), CLRConfig::EXTERNAL_GCName);
     if (!standaloneGcLocation)
     {
         return InitializeDefaultGC();


### PR DESCRIPTION
gcname was only enabled via `DOTNET_GCName`, this change enables setting it via `System.GC.GCName` in runtimeconfig.json. 