### PR TITLE
[release/6.0][wasm][debugger] Ignoring all protocol extension messages that are not supported on .net6

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -535,7 +535,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
 
             //ignore all protocol extension messages not supported on .net6
-            if (method.StartsWith("DotnetDebugger."))
+            if (method.StartsWith("DotnetDebugger.", StringComparison.Ordinal))
                 return true;
 
             return false;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -534,6 +534,10 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
             }
 
+            //ignore all protocol extension messages not supported on .net6
+            if (method.StartsWith("DotnetDebugger."))
+                return true;
+
             return false;
         }
         private async Task<bool> CallOnFunction(MessageId id, JObject args, CancellationToken token)


### PR DESCRIPTION
## Customer Impact
New features were implemented on vscode-js-debug extension repo, so the customers were getting messages like this on console:
`fail: Microsoft.WebAssembly.Diagnostics.DevToolsProxy[0] sending error response for id: msg-B7CCCEF5694F2EF11713AE7F86743A45:::1017 -> [Result: IsOk: False, IsErr: True, Value: , Error: {   "code": -32601,   "message": "'DotnetDebugger.setDebuggerProperty' wasn't found" } ]`

## Testing
Manually tested

## Risk
Low risk, only ignoring the messages that starts with `DotnetDebugger.`

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1600783