### PR TITLE
[wasm] Avoid duplicate jobs in `runtime-wasm` 

### DIFF
--- a/eng/pipelines/common/templates/wasm-build-only.yml
+++ b/eng/pipelines/common/templates/wasm-build-only.yml
@@ -27,20 +27,36 @@ jobs:
         value: ${{ parameters.alwaysRun }}
       - name: allWasmContainsChange
         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'] ]
+      - name: isDefaultPipeline
+        # default pipeline, so not runtime-wasm, and not
+        # runtime-extra-platforms+rolling build
+        value: ${{
+            and(
+              ne(parameters.isWasmOnlyBuild, true),
+              or(
+                ne(parameters.isExtraPlatformsBuild, true),
+                eq(variables['isRollingBuild'], true)))
+          }}
+      - name: shouldRunOnDefaultPipelines
+        value: $[
+          or(
+            eq(variables['wasmDarcDependenciesChanged'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true))
+          ]
     jobParameters:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       testGroup: innerloop
       nameSuffix: ${{ parameters.nameSuffix }}_BuildOnly
       buildArgs: -s mono+libs+host -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs) ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 240
-      # always run for runtime-wasm builds (triggered manually)
-      # Always run for rolling builds
-      # Else run on path changes
+      # if !alwaysRun, then:
+      #   if this is runtime-wasm (isWasmOnlyBuild):
+      #     - then run only if it would not have run on default pipelines (based
+      #       on path changes)
+      #     - else run based on path changes
       condition: >-
         or(
           eq(variables['alwaysRunVar'], true),
-          eq(variables['wasmDarcDependenciesChanged'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true))
-
+          eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']))

--- a/eng/pipelines/common/templates/wasm-build-tests.yml
+++ b/eng/pipelines/common/templates/wasm-build-tests.yml
@@ -1,6 +1,7 @@
 parameters:
   alwaysRun: false
   isExtraPlatformsBuild: false
+  isWasmOnlyBuild: false
   platforms: []
   shouldContinueOnError: false
 
@@ -25,18 +26,38 @@ jobs:
         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'] ]
       - name: alwaysRunVar
         value: ${{ parameters.alwaysRun }}
+      - name: isDefaultPipeline
+        # default pipeline, so not runtime-wasm, and not
+        # runtime-extra-platforms+rolling build
+        value: ${{
+            and(
+              ne(parameters.isWasmOnlyBuild, true),
+              or(
+                ne(parameters.isExtraPlatformsBuild, true),
+                eq(variables['isRollingBuild'], true)))
+          }}
+      - name: shouldRunOnDefaultPipelines
+        value: $[
+          or(
+            eq(variables['wasmDarcDependenciesChanged'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_wasmbuildtests.containsChange'], true))
+          ]
     jobParameters:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       testGroup: innerloop
       nameSuffix: WasmBuildTests
       buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmBuildTests=true /p:TestAssemblies=false /p:BrowserHost=$(_hostedOs)
       timeoutInMinutes: 180
+      # if !alwaysRun, then:
+      #   if this is runtime-wasm (isWasmOnlyBuild):
+      #     - then run only if it would not have run on default pipelines (based
+      #       on path changes)
+      #     - else run based on path changes
       condition: >-
         or(
           eq(variables['alwaysRunVar'], true),
-          eq(variables['wasmDarcDependenciesChanged'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasmbuildtests.containsChange'], true))
+          eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']))
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:

--- a/eng/pipelines/common/templates/wasm-debugger-tests.yml
+++ b/eng/pipelines/common/templates/wasm-debugger-tests.yml
@@ -1,6 +1,7 @@
 parameters:
   alwaysRun: false
   isExtraPlatformsBuild: false
+  isWasmOnlyBuild: false
   browser: 'chrome'
   shouldContinueOnError: false
   platforms: []
@@ -24,19 +25,38 @@ jobs:
         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'] ]
       - name: alwaysRunVar
         value: ${{ parameters.alwaysRun }}
+      - name: isDefaultPipeline
+        # default pipeline, so not runtime-wasm, and not
+        # runtime-extra-platforms+rolling build
+        value: ${{
+            and(
+              ne(parameters.isWasmOnlyBuild, true),
+              or(
+                ne(parameters.isExtraPlatformsBuild, true),
+                eq(variables['isRollingBuild'], true)))
+          }}
+      - name: shouldRunOnDefaultPipelines
+        value: $[
+          or(
+            eq(variables['wasmDarcDependenciesChanged'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_wasmdebuggertests.containsChange'], true))
+          ]
     jobParameters:
       testGroup: innerloop
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       nameSuffix: Mono_DebuggerTests_${{ parameters.browser }}
       buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmDebuggerTests=true /p:TestAssemblies=false /p:BrowserHost=$(_hostedOs) /p:DebuggerHost=${{ parameters.browser }}
       timeoutInMinutes: 180
+      # if !alwaysRun, then:
+      #   if this is runtime-wasm (isWasmOnlyBuild):
+      #     - then run only if it would not have run on default pipelines (based
+      #       on path changes)
+      #     - else run based on path changes
       condition: >-
         or(
           eq(variables['alwaysRunVar'], true),
-          eq(variables['wasmDarcDependenciesChanged'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasmdebuggertests.containsChange'], true))
-      # extra steps, run tests
+          eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']))
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:
         creator: dotnet-bot

--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -3,6 +3,7 @@ parameters:
   extraBuildArgs: ''
   extraHelixArgs: ''
   isExtraPlatformsBuild: false
+  isWasmOnlyBuild: false
   buildAOTOnHelix: true
   nameSuffix: ''
   platforms: []
@@ -22,7 +23,8 @@ jobs:
       platforms:
         - Browser_wasm
       nameSuffix: ${{ parameters.nameSuffix }}
-      isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       extraBuildArgs: /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=${{ parameters.buildAOTOnHelix }} /p:RunAOTCompilation=${{ parameters.runAOT }} ${{ parameters.extraBuildArgs }}
       extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true ${{ parameters.extraHelixArgs }}
       alwaysRun: ${{ parameters.alwaysRun }}
@@ -38,7 +40,8 @@ jobs:
       platforms:
         - Browser_wasm_win
       nameSuffix: ${{ parameters.nameSuffix }}
-      isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       extraBuildArgs: /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=${{ parameters.buildAOTOnHelix }} /p:RunAOTCompilation=${{ parameters.runAOT }} ${{ parameters.extraBuildArgs }}
       extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true ${{ parameters.extraHelixArgs }}
       alwaysRun: ${{ parameters.alwaysRun }}

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -4,6 +4,7 @@ parameters:
   extraBuildArgs: ''
   extraHelixArgs: ''
   isExtraPlatformsBuild: false
+  isWasmOnlyBuild: false
   nameSuffix: ''
   platforms: []
   runSmokeOnlyArg: ''
@@ -33,22 +34,39 @@ jobs:
         value: ${{ parameters.alwaysRun }}
       - name: allWasmContainsChange
         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'] ]
+      - name: isDefaultPipeline
+        # default pipeline, so not runtime-wasm, and not
+        # runtime-extra-platforms+rolling build
+        value: ${{
+            and(
+              ne(parameters.isWasmOnlyBuild, true),
+              or(
+                ne(parameters.isExtraPlatformsBuild, true),
+                eq(variables['isRollingBuild'], true)))
+          }}
+      - name: shouldRunOnDefaultPipelines
+        value: $[
+          or(
+            eq(variables['wasmDarcDependenciesChanged'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true))
+          ]
     jobParameters:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       testGroup: innerloop
       nameSuffix: LibraryTests${{ parameters.nameSuffix }}
       buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:BrowserHost=$(_hostedOs) ${{ parameters.runSmokeOnlyArg }} ${{ parameters.extraBuildArgs }}
       timeoutInMinutes: 240
-      # always run for runtime-wasm builds (triggered manually)
-      # Always run for rolling builds
-      # Else run on path changes
+      # if !alwaysRun, then:
+      #   if this is runtime-wasm (isWasmOnlyBuild):
+      #     - then run only if it would not have run on default pipelines (based
+      #       on path changes)
+      #     - else run based on path changes
       condition: >-
         or(
           eq(variables['alwaysRunVar'], true),
-          eq(variables['wasmDarcDependenciesChanged'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true))
+          eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']))
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/common/templates/additional-steps-then-helix.yml
       extraStepsParameters:

--- a/eng/pipelines/common/templates/wasm-runtime-tests.yml
+++ b/eng/pipelines/common/templates/wasm-runtime-tests.yml
@@ -1,6 +1,7 @@
 parameters:
   alwaysRun: false
   isExtraPlatformsBuild: false
+  isWasmOnlyBuild: false
   platforms: []
 
 jobs:
@@ -24,20 +25,39 @@ jobs:
         value: 10
       - name: timeoutPerTestCollectionInMinutes
         value: 200
+      - name: isDefaultPipeline
+        # default pipeline, so not runtime-wasm, and not
+        # runtime-extra-platforms+!rolling build
+        value: ${{
+            and(
+              ne(parameters.isWasmOnlyBuild, true),
+              or(
+                ne(parameters.isExtraPlatformsBuild, true),
+                eq(variables['isRollingBuild'], true)))
+          }}
+      - name: shouldRunOnDefaultPipelines
+        value: $[
+          or(
+            eq(variables['wasmDarcDependenciesChanged'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true))
+          ]
     jobParameters:
       testGroup: innerloop
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       nameSuffix: AllSubsets_Mono_RuntimeTests
       runtimeVariant: monointerpreter
       buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 180
+      # if !alwaysRun, then:
+      #   if this is runtime-wasm (isWasmOnlyBuild):
+      #     - then run only if it would not have run on default pipelines (based
+      #       on path changes)
+      #     - else run based on path changes
       condition: >-
         or(
           eq(variables['alwaysRunVar'], true),
-          eq(variables['wasmDarcDependenciesChanged'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_allwasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true))
+          eq(variables['isDefaultPipeline'], variables['shouldRunOnDefaultPipelines']))
       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/wasm-runtime-and-send-to-helix.yml
       extraStepsParameters:
         creator: dotnet-bot

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -27,7 +27,7 @@ variables:
 # We only run evaluate paths on runtime, runtime-staging and runtime-community pipelines on PRs
 # keep in sync with /eng/pipelines/common/xplat-setup.yml
 - name: dependOnEvaluatePaths
-  value: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community', 'runtime-extra-platforms')) }}
+  value: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community', 'runtime-extra-platforms', 'runtime-wasm')) }}
 - name: debugOnPrReleaseOnRolling
   ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     value: Release

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -18,7 +18,7 @@ jobs:
     shouldContinueOnError: ${{ or(eq(parameters.shouldContinueOnError, true), and(ne(parameters.shouldContinueOnError, 'forceFalse'), endsWith(variables['Build.DefinitionName'], 'staging'), eq(variables['Build.Reason'], 'PullRequest'))) }}
 
     # keep in sync with /eng/pipelines/common/variables.yml
-    dependOnEvaluatePaths: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community', 'runtime-extra-platforms')) }}
+    dependOnEvaluatePaths: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community', 'runtime-extra-platforms', 'runtime-wasm')) }}
 
     variables:
       # Disable component governance in our CI builds. These builds are not shipping nor

--- a/eng/pipelines/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/runtime-extra-platforms-wasm.yml
@@ -4,6 +4,7 @@
 #   /azp run runtime-wasm
 
 parameters:
+  isExtraPlatformsBuild: false
   isWasmOnlyBuild: false
   isRollingBuild: false
 
@@ -15,15 +16,6 @@ jobs:
 # - rest are covered by runtime, and runtime-staging
 #
 - ${{ if eq(parameters.isRollingBuild, true) }}:
-  # EAT Library tests - only run on linux
-  - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-    parameters:
-      platforms:
-        - Browser_wasm
-      nameSuffix: _EAT
-      runAOT: false
-      alwaysRun: true
-
   # AOT Library tests
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
     parameters:
@@ -70,15 +62,28 @@ jobs:
 #
 - ${{ if ne(parameters.isRollingBuild, true) }}:
   # Library tests
+  # these run on runtime also
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
     parameters:
       platforms:
         - Browser_wasm
       # Don't run for rolling builds, as this is covered
-      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       scenarios:
         - normal
         - WasmTestOnBrowser
+
+  # this only runs on the extra pipeline
+  - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+    parameters:
+      platforms:
+        - Browser_wasm
+      nameSuffix: _NodeJs
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      scenarios:
         - WasmTestOnNodeJs
 
   # Library tests - Windows
@@ -87,7 +92,8 @@ jobs:
       platforms:
         - Browser_wasm_win
       # Don't run for rolling builds, as this is covered
-      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       scenarios:
         - WasmTestOnBrowser
         - WasmTestOnNodeJs
@@ -100,8 +106,11 @@ jobs:
         #- Browser_wasm_win
       nameSuffix: _Threading
       extraBuildArgs: /p:WasmEnableThreads=true
-      # Don't run for rolling builds, as this is covered
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      # Always run for runtime-wasm because tests are not run in runtime
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+
       # NOTE - Since threading is experimental, we don't want to block mainline work
       shouldContinueOnError: true
       scenarios:
@@ -117,8 +126,11 @@ jobs:
         #- Browser_wasm_win
       nameSuffix: _Threading_PerfTracing
       extraBuildArgs: /p:WasmEnablePerfTracing=true
-      # Don't run for rolling builds, as this is covered
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+      # Always run for runtime-wasm because tests are not run in runtime
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+
       # NOTE - Since threading is experimental, we don't want to block mainline work
       shouldContinueOnError: true
       scenarios:
@@ -133,7 +145,8 @@ jobs:
         - Browser_wasm
       nameSuffix: _EAT
       runAOT: false
-      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
   # AOT Library tests
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -143,6 +156,8 @@ jobs:
         - Browser_wasm_win
       nameSuffix: _AOT
       runAOT: true
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
 
   # High resource AOT Library tests
@@ -155,6 +170,8 @@ jobs:
       extraBuildArgs: /p:TestAssemblies=false /p:RunHighAOTResourceRequiringTestsOnly=true
       buildAOTOnHelix: false
       runAOT: true
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
 
   # Wasm.Build.Tests
@@ -163,7 +180,8 @@ jobs:
       platforms:
         - Browser_wasm
         - Browser_wasm_win
-      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
   # Debugger tests
   - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
@@ -171,19 +189,23 @@ jobs:
       platforms:
         - Browser_wasm
         - Browser_wasm_win
-      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
   - template: /eng/pipelines/common/templates/wasm-runtime-tests.yml
     parameters:
       platforms:
         - Browser_wasm
-      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
 
   - template: /eng/pipelines/common/templates/wasm-debugger-tests.yml
     parameters:
       platforms:
         - Browser_wasm_firefox
       browser: firefox
+      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
       # ff tests are unstable currently
       shouldContinueOnError: true

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -34,11 +34,13 @@ jobs:
 - ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
   - template: /eng/pipelines/common/evaluate-default-paths.yml
 
-# include this unconditionally, because it has per job conditions
-- template: /eng/pipelines/runtime-extra-platforms-wasm.yml
-  parameters:
-    isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
-    isRollingBuild: ${{ variables.isRollingBuild }}
+# Add wasm jobs only for rolling builds
+- ${{ if eq(variables.isRollingBuild, true) }}:
+  - template: /eng/pipelines/runtime-extra-platforms-wasm.yml
+    parameters:
+      isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+      isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
+      isRollingBuild: ${{ variables.isRollingBuild }}
 
 # Any jobs that are not specific to any platform
 - ${{ if eq(variables.isNotSpecificPlatformOnlyBuild, true) }}:

--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -12,10 +12,10 @@ jobs:
 #
 # Evaluate paths
 #
-- ${{ if eq(variables.dependOnEvaluatePaths, true) }}:
-  - template: /eng/pipelines/common/evaluate-default-paths.yml
+- template: /eng/pipelines/common/evaluate-default-paths.yml
 
 - template: /eng/pipelines/runtime-extra-platforms-wasm.yml
   parameters:
+    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
     isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
     isRollingBuild: ${{ variables.isRollingBuild }}


### PR DESCRIPTION
- In `runtime-wasm`, skip the jobs that already run in `runtime` pipeline
- Add wasm jobs to `runtime-extra-platforms` only in rolling builds
- Remove EAT from `runtime-extra-platforms` on rolling builds, because it is already in `runtime`

This will help remove duplication of `Wasm.Build.Tests`, among others, which is helix-heavy.