### PR TITLE
[NativeAOT] Fix conservative stack reporting

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -152,7 +152,7 @@ static int InitializeRuntime()
     if (!RhInitialize())
         return -1;
 
-    RhpEnableConservativeStackReporting();
+    // RhpEnableConservativeStackReporting();
 
     void * osModule = PalGetModuleHandleFromPointer((void*)&NATIVEAOT_ENTRYPOINT);
 

--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -152,7 +152,7 @@ static int InitializeRuntime()
     if (!RhInitialize())
         return -1;
 
-    // RhpEnableConservativeStackReporting();
+    RhpEnableConservativeStackReporting();
 
     void * osModule = PalGetModuleHandleFromPointer((void*)&NATIVEAOT_ENTRYPOINT);
 

--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -221,6 +221,14 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
 #endif // UNIX_AMD64_ABI
     uintptr_t GetIp() { return Rip; }
     uintptr_t GetSp() { return Rsp; }
+
+    template <typename F>
+    void ForEachPossibleObjectRef(F lambda)
+    {
+        for (size_t* pReg = &Rax; pReg < &Rip; pReg++)
+            lambda(pReg);
+    }
+
 } CONTEXT, *PCONTEXT;
 #elif defined(HOST_ARM)
 
@@ -406,6 +414,16 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
     uintptr_t GetIp() { return Pc; }
     uintptr_t GetLr() { return Lr; }
     uintptr_t GetSp() { return Sp; }
+
+    template <typename F>
+    void ForEachPossibleObjectRef(F lambda)
+    {
+        for (size_t* pReg = &X0; pReg <= &X28; pReg++)
+            lambda(pReg);
+
+        // Lr can be used as a scratch register
+        lambda(&Lr);
+    }
 } CONTEXT, *PCONTEXT;
 
 #elif defined(HOST_WASM)

--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -225,8 +225,8 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
     template <typename F>
     void ForEachPossibleObjectRef(F lambda)
     {
-        for (size_t* pReg = &Rax; pReg < &Rip; pReg++)
-            lambda(pReg);
+        for (uint64_t* pReg = &Rax; pReg < &Rip; pReg++)
+            lambda((size_t*)pReg);
     }
 
 } CONTEXT, *PCONTEXT;
@@ -418,11 +418,11 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
     template <typename F>
     void ForEachPossibleObjectRef(F lambda)
     {
-        for (size_t* pReg = &X0; pReg <= &X28; pReg++)
-            lambda(pReg);
+        for (uint64_t* pReg = &X0; pReg <= &X28; pReg++)
+            lambda((size_t*)pReg);
 
         // Lr can be used as a scratch register
-        lambda(&Lr);
+        lambda((size_t*)&Lr);
     }
 } CONTEXT, *PCONTEXT;
 

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -405,6 +405,12 @@ void RedhawkGCInterface::EnumGcRef(PTR_RtuObjectRef pRef, GCRefKind kind, void *
     GcEnumObject((PTR_OBJECTREF)pRef, flags, (EnumGcRefCallbackFunc *)pfnEnumCallback, (EnumGcRefScanContext *)pvCallbackData);
 }
 
+// static
+void RedhawkGCInterface::EnumGcRefConservatively(PTR_RtuObjectRef pRef, void* pfnEnumCallback, void* pvCallbackData)
+{
+    GcEnumObject((PTR_OBJECTREF)pRef, GC_CALL_INTERIOR | GC_CALL_PINNED, (EnumGcRefCallbackFunc*)pfnEnumCallback, (EnumGcRefScanContext*)pvCallbackData);
+}
+
 #ifndef DACCESS_COMPILE
 
 // static

--- a/src/coreclr/nativeaot/Runtime/gcrhinterface.h
+++ b/src/coreclr/nativeaot/Runtime/gcrhinterface.h
@@ -112,6 +112,7 @@ public:
     static void WaitForGCCompletion();
 
     static void EnumGcRef(PTR_RtuObjectRef pRef, GCRefKind kind, void * pfnEnumCallback, void * pvCallbackData);
+    static void EnumGcRefConservatively(PTR_RtuObjectRef pRef, void* pfnEnumCallback, void* pvCallbackData);
 
     static void BulkEnumGcObjRef(PTR_RtuObjectRef pRefs, uint32_t cRefs, void * pfnEnumCallback, void * pvCallbackData);
 

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -661,11 +661,13 @@ void Thread::HijackCallback(NATIVE_CONTEXT* pThreadContext, void* pThreadToHijac
     // we may be able to do GC stack walk right where the threads is now,
     // as long as the location is a GC safe point.
     ICodeManager* codeManager = runtime->GetCodeManagerForAddress(pvAddress);
-    if (codeManager->IsSafePoint(pvAddress))
+    if (runtime->IsConservativeStackReportingEnabled() ||
+        codeManager->IsSafePoint(pvAddress))
     {
         // we may not be able to unwind in some locations, such as epilogs.
         // such locations should not contain safe points.
-        ASSERT(codeManager->IsUnwindable(pvAddress));
+        // when scanning conservatively we do not need to unwind
+        ASSERT(codeManager->IsUnwindable(pvAddress) || runtime->IsConservativeStackReportingEnabled());
 
         // if we are not given a thread to hijack
         // perform in-line wait on the current thread

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -476,6 +476,18 @@ void Thread::GcScanRootsWorker(void * pfnEnumCallback, void * pvCallbackData, St
             // Transition frame may contain callee saved registers that need to be reported as well
             PInvokeTransitionFrame* pTransitionFrame = GetTransitionFrame();
             ASSERT(pTransitionFrame != NULL);
+
+            if (pTransitionFrame == INTERRUPTED_THREAD_MARKER)
+            {
+                GetInterruptedContext()->ForEachPossibleObjectRef
+                (
+                    [&](size_t* pRef)
+                    {
+                        RedhawkGCInterface::EnumGcRefConservatively((PTR_RtuObjectRef)pRef, pfnEnumCallback, pvCallbackData);
+                    }
+                );
+            }
+
             if (pTransitionFrame < pLowerBound)
                 pLowerBound = pTransitionFrame;
 

--- a/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
@@ -76,11 +76,11 @@ struct UNIX_CONTEXT
         ASSERT(&X0() + 10 == &X10());
         ASSERT(&X0() + 20 == &X20());
 
-        for (size_t* pReg = &X0(); pReg <= &X28(); pReg++)
-            lambda(pReg);
+        for (uint64_t* pReg = &X0(); pReg <= &X28(); pReg++)
+            lambda((size_t*)pReg);
 
         // Lr can be used as a scratch register
-        lambda(&Lr());
+        lambda((size_t*)&Lr());
     }
 
 #elif defined(TARGET_AMD64)
@@ -108,22 +108,22 @@ struct UNIX_CONTEXT
     template <typename F>
     void ForEachPossibleObjectRef(F lambda)
     {
-        lambda(&Rax());
-        lambda(&Rcx());
-        lambda(&Rdx());
-        lambda(&Rbx());
-        lambda(&Rsp());
-        lambda(&Rbp());
-        lambda(&Rsi());
-        lambda(&Rdi());
-        lambda(&R8());
-        lambda(&R9());
-        lambda(&R10());
-        lambda(&R11());
-        lambda(&R12());
-        lambda(&R13());
-        lambda(&R14());
-        lambda(&R15());
+        lambda((size_t*)&Rax());
+        lambda((size_t*)&Rcx());
+        lambda((size_t*)&Rdx());
+        lambda((size_t*)&Rbx());
+        lambda((size_t*)&Rsp());
+        lambda((size_t*)&Rbp());
+        lambda((size_t*)&Rsi());
+        lambda((size_t*)&Rdi());
+        lambda((size_t*)&R8());
+        lambda((size_t*)&R9());
+        lambda((size_t*)&R10());
+        lambda((size_t*)&R11());
+        lambda((size_t*)&R12());
+        lambda((size_t*)&R13());
+        lambda((size_t*)&R14());
+        lambda((size_t*)&R15());
     }
 #else
     PORTABILITY_ASSERT("UNIX_CONTEXT");

--- a/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
@@ -67,6 +67,22 @@ struct UNIX_CONTEXT
     uintptr_t GetIp() { return (uintptr_t)Pc(); }
     uintptr_t GetSp() { return (uintptr_t)Sp(); }
 
+    template <typename F>
+    void ForEachPossibleObjectRef(F lambda)
+    {
+        // it is doubtful anyone would implement X0-X28 not as a contiguous array
+        // just in case - here are some asserts.
+        ASSERT(&X0() + 1 == &X1());
+        ASSERT(&X0() + 10 == &X10());
+        ASSERT(&X0() + 20 == &X20());
+
+        for (size_t* pReg = &X0(); pReg <= &X28(); pReg++)
+            lambda(pReg);
+
+        // Lr can be used as a scratch register
+        lambda(&Lr());
+    }
+
 #elif defined(TARGET_AMD64)
     uint64_t& Rax();
     uint64_t& Rcx();
@@ -88,6 +104,27 @@ struct UNIX_CONTEXT
 
     uintptr_t GetIp() { return (uintptr_t)Rip(); }
     uintptr_t GetSp() { return (uintptr_t)Rsp(); }
+
+    template <typename F>
+    void ForEachPossibleObjectRef(F lambda)
+    {
+        lambda(&Rax());
+        lambda(&Rcx());
+        lambda(&Rdx());
+        lambda(&Rbx());
+        lambda(&Rsp());
+        lambda(&Rbp());
+        lambda(&Rsi());
+        lambda(&Rdi());
+        lambda(&R8());
+        lambda(&R9());
+        lambda(&R10());
+        lambda(&R11());
+        lambda(&R12());
+        lambda(&R13());
+        lambda(&R14());
+        lambda(&R15());
+    }
 #else
     PORTABILITY_ASSERT("UNIX_CONTEXT");
 #endif // TARGET_ARM


### PR DESCRIPTION
Conservative stack reporting is an unsupported, but occasionally useful mode. I have just tried it and realized that it is broken since after the asynchronous suspension was introduced. 

In conservative mode we report all stack locations that can possibly contain managed ref as possible roots, however for stacks suspended asynchronously the interrupted context must also be reported, since it is not necessarily stored on the stack.


