### PR TITLE
[ARM64] - `IsValidCompareChain` should return `false` if both operands are not integral types

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2122,8 +2122,7 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
         return true;
     }
     // Can the child be contained.
-    else if (IsSafeToContainMem(parent, child) && (child->OperIs(GT_AND) || child->OperIsCmpCompare()) &&
-             varTypeIsIntegral(child->gtGetOp1()) && varTypeIsIntegral(child->gtGetOp2()))
+    else if (IsSafeToContainMem(parent, child))
     {
         if (child->OperIs(GT_AND))
         {
@@ -2150,7 +2149,8 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
             child->SetContained();
             return true;
         }
-        else if (child->OperIsCmpCompare())
+        else if (child->OperIsCmpCompare() && varTypeIsIntegral(child->gtGetOp1()) &&
+                 varTypeIsIntegral(child->gtGetOp2()))
         {
             child->AsOp()->SetContained();
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2086,7 +2086,8 @@ bool Lowering::IsValidCompareChain(GenTree* child, GenTree* parent)
             return IsValidCompareChain(child->AsOp()->gtGetOp2(), child) &&
                    IsValidCompareChain(child->AsOp()->gtGetOp1(), child);
         }
-        else if (child->OperIsCmpCompare())
+        else if (child->OperIsCmpCompare() && varTypeIsIntegral(child->gtGetOp1()) &&
+                 varTypeIsIntegral(child->gtGetOp2()))
         {
             // Can the child compare be contained.
             return IsSafeToContainMem(parent, child);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2122,8 +2122,8 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
         return true;
     }
     // Can the child be contained.
-    else if (IsSafeToContainMem(parent, child) && varTypeIsIntegral(child->gtGetOp1()) &&
-             varTypeIsIntegral(child->gtGetOp2()))
+    else if (IsSafeToContainMem(parent, child) && (child->OperIs(GT_AND) || child->OperIsCmpCompare()) &&
+             varTypeIsIntegral(child->gtGetOp1()) && varTypeIsIntegral(child->gtGetOp2()))
     {
         if (child->OperIs(GT_AND))
         {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2122,7 +2122,8 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
         return true;
     }
     // Can the child be contained.
-    else if (IsSafeToContainMem(parent, child))
+    else if (IsSafeToContainMem(parent, child) && varTypeIsIntegral(child->gtGetOp1()) &&
+             varTypeIsIntegral(child->gtGetOp2()))
     {
         if (child->OperIs(GT_AND))
         {


### PR DESCRIPTION
**Description**
Should resolve this assert: https://github.com/dotnet/runtime/issues/74172

The assert was this in `genCodeForConditionalCompare`:
```cpp
    // No float support or swapping op1 and op2 to generate cmp reg, imm.
    assert(!varTypeIsFloating(op2Type));
```
Seems like float types are not supported on conditional compares, `ccmp`.

The PR, https://github.com/dotnet/runtime/pull/71705, introduced compare chains.
Compare chains will generate conditional compares, but the checks to see if an op is a valid compare chain did not include any type checks. This PR adds the checks; if the operands are integral types, op is a valid compare chain.

**Acceptance Criteria**
- [x] CI Passes
