### PR TITLE
Fix use of uninitialized memory for Vector3 constants

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2412,10 +2412,12 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                         // Get a temp integer register to compute long address.
                         regNumber addrReg = tree->GetSingleTempReg();
 
-                        simd16_t constValue = vecCon->gtSimd16Val;
+                        simd16_t constValue = {};
 
-                        if (tree->TypeGet() == TYP_SIMD12)
-                            constValue.u32[3] = 0;
+                        if (vecCon->TypeIs(TYP_SIMD12))
+                            memcpy(&constValue, &vecCon->gtSimd12Val, sizeof(simd12_t));
+                        else
+                            constValue = vecCon->gtSimd16Val;
 
                         CORINFO_FIELD_HANDLE hnd = emit->emitSimd16Const(constValue);
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2412,12 +2412,12 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                         // Get a temp integer register to compute long address.
                         regNumber addrReg = tree->GetSingleTempReg();
 
-                        simd16_t             constValue = vecCon->gtSimd16Val;
+                        simd16_t constValue = vecCon->gtSimd16Val;
 
                         if (tree->TypeGet() == TYP_SIMD12)
                             constValue.u32[3] = 0;
 
-                        CORINFO_FIELD_HANDLE hnd        = emit->emitSimd16Const(constValue);
+                        CORINFO_FIELD_HANDLE hnd = emit->emitSimd16Const(constValue);
 
                         emit->emitIns_R_C(INS_ldr, attr, targetReg, addrReg, hnd, 0);
                     }

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2413,6 +2413,10 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                         regNumber addrReg = tree->GetSingleTempReg();
 
                         simd16_t             constValue = vecCon->gtSimd16Val;
+
+                        if (tree->TypeGet() == TYP_SIMD12)
+                            constValue.u32[3] = 0;
+
                         CORINFO_FIELD_HANDLE hnd        = emit->emitSimd16Const(constValue);
 
                         emit->emitIns_R_C(INS_ldr, attr, targetReg, addrReg, hnd, 0);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -561,10 +561,12 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                 case TYP_SIMD12:
                 case TYP_SIMD16:
                 {
-                    simd16_t constValue = vecCon->gtSimd16Val;
+                    simd16_t constValue = {};
 
-                    if (tree->TypeGet() == TYP_SIMD12)
-                        constValue.u32[3] = 0;
+                    if (vecCon->TypeIs(TYP_SIMD12))
+                        memcpy(&constValue, &vecCon->gtSimd12Val, sizeof(simd12_t));
+                    else
+                        constValue = vecCon->gtSimd16Val;
 
                     CORINFO_FIELD_HANDLE hnd = emit->emitSimd16Const(constValue);
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -561,12 +561,12 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                 case TYP_SIMD12:
                 case TYP_SIMD16:
                 {
-                    simd16_t             constValue = vecCon->gtSimd16Val;
+                    simd16_t constValue = vecCon->gtSimd16Val;
 
                     if (tree->TypeGet() == TYP_SIMD12)
                         constValue.u32[3] = 0;
 
-                    CORINFO_FIELD_HANDLE hnd        = emit->emitSimd16Const(constValue);
+                    CORINFO_FIELD_HANDLE hnd = emit->emitSimd16Const(constValue);
 
                     emit->emitIns_R_C(ins_Load(targetType), attr, targetReg, hnd, 0);
                     break;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -562,6 +562,10 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
                 case TYP_SIMD16:
                 {
                     simd16_t             constValue = vecCon->gtSimd16Val;
+
+                    if (tree->TypeGet() == TYP_SIMD12)
+                        constValue.u32[3] = 0;
+
                     CORINFO_FIELD_HANDLE hnd        = emit->emitSimd16Const(constValue);
 
                     emit->emitIns_R_C(ins_Load(targetType), attr, targetReg, hnd, 0);

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -765,7 +765,13 @@ CodeGen::OperandDesc CodeGen::genOperandDesc(GenTree* op)
                     case TYP_SIMD12:
                     case TYP_SIMD16:
                     {
-                        simd16_t constValue = op->AsVecCon()->gtSimd16Val;
+                        simd16_t constValue = {};
+
+                        if (op->TypeIs(TYP_SIMD12))
+                            memcpy(&constValue, &op->AsVecCon()->gtSimd12Val, sizeof(simd12_t));
+                        else
+                            constValue = op->AsVecCon()->gtSimd16Val;
+
                         return OperandDesc(emit->emitSimd16Const(constValue));
                     }
 


### PR DESCRIPTION
Found while investigating #72149. 

In a good case, it made the size and content of readonly data non-deterministic.
In a bad case, it exposed downstream bugs like #72149 intermittently.