### PR TITLE
[wasm] Speedup Vector128.Shuffle with SIMD

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -937,6 +937,7 @@ static guint16 sri_vector_methods [] = {
 	SN_Narrow,
 	SN_Negate,
 	SN_OnesComplement,
+	SN_Shuffle,
 	SN_Sqrt,
 	SN_Subtract,
 	SN_Sum,
@@ -1370,6 +1371,15 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 			return NULL;
 		return emit_simd_ins_for_unary_op (cfg, klass, fsig, args, arg0_type, id);
 	} 
+	case SN_Shuffle: {
+		if (!is_element_type_primitive (fsig->params [0]))
+			return NULL;
+#ifdef TARGET_WASM
+		return emit_simd_ins_for_sig (cfg, klass, OP_WASM_SIMD_SWIZZLE, -1, -1, fsig, args);
+#else
+		return NULL;
+#endif
+	}
 	case SN_Sum: {
 #ifdef TARGET_ARM64
 		if (!is_element_type_primitive (fsig->params [0]))


### PR DESCRIPTION
Example speedup result in `Span.Reverse` with `WasmSIMD=true`

Firefox/amd64

| measurement | before | after | delta |
|-:|-:|-:|-:|
|                    Span, Reverse bytes |     0.0857ms |     0.0022ms | 39x faster  |
|                    Span, Reverse chars |     0.0987ms |     0.0042ms | 23.5x faster|

Chrome/amd64

| measurement | before | after | delta |
|-:|-:|-:|-:|
|                    Span, Reverse bytes |     0.0768ms |     0.0028ms | 27.4x faster |
|                    Span, Reverse chars |     0.0975ms |     0.0061ms | 16x faster   |