### PR TITLE
[Android] Update gRPC client tests pipeline

### DIFF
--- a/eng/pipelines/runtime-android-grpc-client-tests.yml
+++ b/eng/pipelines/runtime-android-grpc-client-tests.yml
@@ -8,12 +8,12 @@
 trigger: none
 
 schedules:
-  - cron: "0 9,21 * * *" # run at 9:00 and 21:00 (UTC) which is 1:00 and 13:00 (PST).
+  - cron: "0 9 * * *" # run at 9:00 (UTC) which is 1:00 (PST).
     displayName: grpc-dotnet Android client test schedule
     branches:
       include:
       - main
-    always: true
+    always: false
 
 variables:
   - template: /eng/pipelines/common/variables.yml

--- a/eng/pipelines/runtime-android-grpc-client-tests.yml
+++ b/eng/pipelines/runtime-android-grpc-client-tests.yml
@@ -24,22 +24,23 @@ jobs:
 # Android emulators
 # Build the whole product using Mono and run libraries tests
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Android_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_gRPC
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunGrpcTestsOnly=true /p:BuildGrpcServerDockerImage=true
-      timeoutInMinutes: 180
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        extraHelixArguments: /p:RunGrpcTestsOnly=true /p:BuildGrpcServerDockerImage=true
-        testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+- ${{ if eq(variables.isRollingBuild, true) }}:
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+      buildConfig: Release
+      runtimeFlavor: mono
+      platforms:
+      - Android_x64
+      jobParameters:
+        testGroup: innerloop
+        nameSuffix: AllSubsets_Mono_gRPC
+        buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunGrpcTestsOnly=true /p:BuildGrpcServerDockerImage=true
+        timeoutInMinutes: 180
+        # extra steps, run tests
+        extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+        extraStepsParameters:
+          creator: dotnet-bot
+          extraHelixArguments: /p:RunGrpcTestsOnly=true /p:BuildGrpcServerDockerImage=true
+          testRunNamePrefixSuffix: Mono_$(_BuildConfig)


### PR DESCRIPTION
- reduce the frequency of scheduled runs to just 1 per day
- make sure the job doesn't run for PRs