### PR TITLE
Use Roslyn compiler with RefSafetyRulesAttribute support

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,7 +49,7 @@
     <!--
       TODO: Remove pinned version once arcade supplies a compiler that enables the repo to compile.
     -->
-    <MicrosoftNetCompilersToolsetVersion>4.4.0-2.22412.11</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.4.0-3.22431.10</MicrosoftNetCompilersToolsetVersion>
     <StaticCsVersion>0.2.0</StaticCsVersion>
     <!-- SDK dependencies -->
     <MicrosoftDotNetApiCompatTaskVersion>7.0.100-rc.1.22402.1</MicrosoftDotNetApiCompatTaskVersion>

--- a/src/libraries/System.Runtime/tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System/Attributes.cs
@@ -330,11 +330,14 @@ namespace System.Tests
         public static void customAttributeCount()
         {
             List<CustomAttributeData> customAttributes = typeof(GetCustomAttribute).Module.CustomAttributes.ToList();
+            Assert.Equal(1, customAttributes.Count(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.RefSafetyRulesAttribute"));
             // [System.Security.UnverifiableCodeAttribute()]
             // [TestAttributes.FooAttribute()]
             // [TestAttributes.ComplicatedAttribute((Int32)1, Stuff = 2)]
             // [System.Diagnostics.DebuggableAttribute((Boolean)True, (Boolean)False)]
-            Assert.Equal(4, customAttributes.Count);
+            // [System.Runtime.CompilerServices.RefSafetyRulesAttribute((Int32)11)]
+            Assert.Equal(5, customAttributes.Count);
+            Assert.Equal(4, customAttributes.FindIndex(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.RefSafetyRulesAttribute"));
         }
 
         [Fact]


### PR DESCRIPTION
Use Roslyn build from https://github.com/dotnet/roslyn/pull/63461/commits/48cf6659ca82ab9d53cf6f33c8188d6057d199fd with support for `RefSafetyRulesAttribute`.
