### PR TITLE
Revert change in StringBuilder.Append(char)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1052,10 +1052,10 @@ namespace System.Text
             int nextCharIndex = m_ChunkLength;
             char[] chars = m_ChunkChars;
 
-            if ((uint)nextCharIndex < (uint)chars.Length)
+            if ((uint)chars.Length > (uint)nextCharIndex)
             {
                 chars[nextCharIndex] = value;
-                m_ChunkLength = nextCharIndex + 1;
+                m_ChunkLength++;
             }
             else
             {


### PR DESCRIPTION
The change has a bad interaction with inlining heuristics.

Fixes #74158. Partial revert of #67448.