### PR TITLE
Disallow TarWriter from writing link entries without LinkName set

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -391,6 +391,9 @@ namespace System.Formats.Tar
         // Writes all the common fields shared by all formats into the specified spans.
         private int WriteCommonFields(Span<byte> buffer, long actualLength, TarEntryType actualEntryType)
         {
+            // Don't write an empty LinkName if the entry is a hardlink or symlink
+            Debug.Assert(!string.IsNullOrEmpty(_linkName) ^ (_typeFlag is not TarEntryType.SymbolicLink and not TarEntryType.HardLink));
+
             int checksum = 0;
 
             if (_mode > 0)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -209,7 +209,7 @@ namespace System.Formats.Tar
         /// </item>
         /// </list>
         /// </remarks>
-        /// <exception cref="InvalidDataException">The entry type is <see cref="TarEntryType.HardLink"/> or <see cref="TarEntryType.SymbolicLink"/> and the <see cref="TarEntry.LinkName"/> is <see langword="null"/> or empty.</exception>
+        /// <exception cref="ArgumentException">The entry type is <see cref="TarEntryType.HardLink"/> or <see cref="TarEntryType.SymbolicLink"/> and the <see cref="TarEntry.LinkName"/> is <see langword="null"/> or empty.</exception>
         /// <exception cref="ObjectDisposedException">The archive stream is disposed.</exception>
         /// <exception cref="InvalidOperationException">The entry type of the <paramref name="entry"/> is not supported for writing.</exception>
         /// <exception cref="IOException">An I/O problem occurred.</exception>
@@ -252,7 +252,7 @@ namespace System.Formats.Tar
         /// </item>
         /// </list>
         /// </remarks>
-        /// <exception cref="InvalidDataException">The entry type is <see cref="TarEntryType.HardLink"/> or <see cref="TarEntryType.SymbolicLink"/> and the <see cref="TarEntry.LinkName"/> is <see langword="null"/> or empty.</exception>
+        /// <exception cref="ArgumentException">The entry type is <see cref="TarEntryType.HardLink"/> or <see cref="TarEntryType.SymbolicLink"/> and the <see cref="TarEntry.LinkName"/> is <see langword="null"/> or empty.</exception>
         /// <exception cref="ObjectDisposedException">The archive stream is disposed.</exception>
         /// <exception cref="InvalidOperationException">The entry type of the <paramref name="entry"/> is not supported for writing.</exception>
         /// <exception cref="IOException">An I/O problem occurred.</exception>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -376,7 +376,7 @@ namespace System.Formats.Tar
             {
                 if (string.IsNullOrEmpty(linkName))
                 {
-                    throw new InvalidDataException(SR.TarEntryHardLinkOrSymlinkLinkNameEmpty);
+                    throw new ArgumentException(SR.TarEntryHardLinkOrSymlinkLinkNameEmpty, "entry");
                 }
             }
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -216,6 +216,7 @@ namespace System.Formats.Tar
         {
             ObjectDisposedException.ThrowIf(_isDisposed, this);
             ArgumentNullException.ThrowIfNull(entry);
+            ValidateEntryLinkName(entry._header._typeFlag, entry._header._linkName);
             WriteEntryInternal(entry);
         }
 
@@ -262,6 +263,7 @@ namespace System.Formats.Tar
 
             ObjectDisposedException.ThrowIf(_isDisposed, this);
             ArgumentNullException.ThrowIfNull(entry);
+            ValidateEntryLinkName(entry._header._typeFlag, entry._header._linkName);
             return WriteEntryAsyncInternal(entry, cancellationToken);
         }
 
@@ -364,6 +366,17 @@ namespace System.Formats.Tar
             string? actualEntryName = string.IsNullOrEmpty(entryName) ? Path.GetFileName(fileName) : entryName;
 
             return (fullPath, actualEntryName);
+        }
+
+        private static void ValidateEntryLinkName(TarEntryType entryType, string? linkName)
+        {
+            if (entryType is TarEntryType.HardLink or TarEntryType.SymbolicLink)
+            {
+                if (string.IsNullOrEmpty(linkName))
+                {
+                    throw new InvalidDataException(SR.TarEntryHardLinkOrSymlinkLinkNameEmpty);
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -209,6 +209,7 @@ namespace System.Formats.Tar
         /// </item>
         /// </list>
         /// </remarks>
+        /// <exception cref="InvalidDataException">The entry type is <see cref="TarEntryType.HardLink"/> or <see cref="TarEntryType.SymbolicLink"/> and the <see cref="TarEntry.LinkName"/> is <see langword="null"/> or empty.</exception>
         /// <exception cref="ObjectDisposedException">The archive stream is disposed.</exception>
         /// <exception cref="InvalidOperationException">The entry type of the <paramref name="entry"/> is not supported for writing.</exception>
         /// <exception cref="IOException">An I/O problem occurred.</exception>
@@ -251,6 +252,7 @@ namespace System.Formats.Tar
         /// </item>
         /// </list>
         /// </remarks>
+        /// <exception cref="InvalidDataException">The entry type is <see cref="TarEntryType.HardLink"/> or <see cref="TarEntryType.SymbolicLink"/> and the <see cref="TarEntry.LinkName"/> is <see langword="null"/> or empty.</exception>
         /// <exception cref="ObjectDisposedException">The archive stream is disposed.</exception>
         /// <exception cref="InvalidOperationException">The entry type of the <paramref name="entry"/> is not supported for writing.</exception>
         /// <exception cref="IOException">An I/O problem occurred.</exception>

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Gnu.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Gnu.Tests.cs
@@ -243,7 +243,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archiveStream = new MemoryStream();
             using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            Assert.Throws<InvalidDataException>(() => writer.WriteEntry(new GnuTarEntry(entryType, "link")));
+            Assert.Throws<ArgumentException>(() => writer.WriteEntry(new GnuTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Gnu.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Gnu.Tests.cs
@@ -243,7 +243,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archiveStream = new MemoryStream();
             using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            Assert.Throws<ArgumentException>(() => writer.WriteEntry(new GnuTarEntry(entryType, "link")));
+            Assert.Throws<ArgumentException>("entry", () => writer.WriteEntry(new GnuTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Gnu.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Gnu.Tests.cs
@@ -167,6 +167,10 @@ namespace System.Formats.Tar.Tests
             using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(entryType, longName);
+                if (entryType is TarEntryType.HardLink or TarEntryType.SymbolicLink)
+                {
+                    entry.LinkName = "linktarget";
+                }
                 writer.WriteEntry(entry);
             }
 
@@ -230,6 +234,16 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(longName, entry.Name);
                 Assert.Equal(longLinkName, entry.LinkName);
             }
+        }
+
+        [Theory]
+        [InlineData(TarEntryType.HardLink)]
+        [InlineData(TarEntryType.SymbolicLink)]
+        public void Write_LinkEntry_EmptyLinkName_Throws(TarEntryType entryType)
+        {
+            using MemoryStream archiveStream = new MemoryStream();
+            using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
+            Assert.Throws<InvalidDataException>(() => writer.WriteEntry(new GnuTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
@@ -493,7 +493,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archiveStream = new MemoryStream();
             using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            Assert.Throws<InvalidDataException>(() => writer.WriteEntry(new PaxTarEntry(entryType, "link")));
+            Assert.Throws<ArgumentException>(() => writer.WriteEntry(new PaxTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
@@ -493,7 +493,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archiveStream = new MemoryStream();
             using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            Assert.Throws<ArgumentException>(() => writer.WriteEntry(new PaxTarEntry(entryType, "link")));
+            Assert.Throws<ArgumentException>("entry", () => writer.WriteEntry(new PaxTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
@@ -485,5 +485,15 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(overLimitTimestamp, actualCTime);
             }
         }
+
+        [Theory]
+        [InlineData(TarEntryType.HardLink)]
+        [InlineData(TarEntryType.SymbolicLink)]
+        public void Write_LinkEntry_EmptyLinkName_Throws(TarEntryType entryType)
+        {
+            using MemoryStream archiveStream = new MemoryStream();
+            using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
+            Assert.Throws<InvalidDataException>(() => writer.WriteEntry(new PaxTarEntry(entryType, "link")));
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Ustar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Ustar.Tests.cs
@@ -160,7 +160,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archiveStream = new MemoryStream();
             using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            Assert.Throws<InvalidDataException>(() => writer.WriteEntry(new UstarTarEntry(entryType, "link")));
+            Assert.Throws<ArgumentException>(() => writer.WriteEntry(new UstarTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Ustar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Ustar.Tests.cs
@@ -152,5 +152,15 @@ namespace System.Formats.Tar.Tests
                 VerifyFifo(fifo);
             }
         }
+
+        [Theory]
+        [InlineData(TarEntryType.HardLink)]
+        [InlineData(TarEntryType.SymbolicLink)]
+        public void Write_LinkEntry_EmptyLinkName_Throws(TarEntryType entryType)
+        {
+            using MemoryStream archiveStream = new MemoryStream();
+            using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
+            Assert.Throws<InvalidDataException>(() => writer.WriteEntry(new UstarTarEntry(entryType, "link")));
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Ustar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Ustar.Tests.cs
@@ -160,7 +160,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archiveStream = new MemoryStream();
             using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            Assert.Throws<ArgumentException>(() => writer.WriteEntry(new UstarTarEntry(entryType, "link")));
+            Assert.Throws<ArgumentException>("entry", () => writer.WriteEntry(new UstarTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.V7.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.V7.Tests.cs
@@ -92,5 +92,15 @@ namespace System.Formats.Tar.Tests
                 VerifyDirectory(directory);
             }
         }
+
+        [Theory]
+        [InlineData(TarEntryType.HardLink)]
+        [InlineData(TarEntryType.SymbolicLink)]
+        public void Write_LinkEntry_EmptyLinkName_Throws(TarEntryType entryType)
+        {
+            using MemoryStream archiveStream = new MemoryStream();
+            using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
+            Assert.Throws<InvalidDataException>(() => writer.WriteEntry(new V7TarEntry(entryType, "link")));
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.V7.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.V7.Tests.cs
@@ -100,7 +100,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archiveStream = new MemoryStream();
             using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            Assert.Throws<ArgumentException>(() => writer.WriteEntry(new V7TarEntry(entryType, "link")));
+            Assert.Throws<ArgumentException>("entry", () => writer.WriteEntry(new V7TarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.V7.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.V7.Tests.cs
@@ -100,7 +100,7 @@ namespace System.Formats.Tar.Tests
         {
             using MemoryStream archiveStream = new MemoryStream();
             using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            Assert.Throws<InvalidDataException>(() => writer.WriteEntry(new V7TarEntry(entryType, "link")));
+            Assert.Throws<ArgumentException>(() => writer.WriteEntry(new V7TarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Gnu.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Gnu.Tests.cs
@@ -264,7 +264,7 @@ namespace System.Formats.Tar.Tests
         {
             await using MemoryStream archiveStream = new MemoryStream();
             await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            await Assert.ThrowsAsync<ArgumentException>(async () => await writer.WriteEntryAsync(new GnuTarEntry(entryType, "link")));
+            await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(new GnuTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Gnu.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Gnu.Tests.cs
@@ -183,6 +183,10 @@ namespace System.Formats.Tar.Tests
                 await using (TarWriter writer = new TarWriter(archiveStream, TarEntryFormat.Gnu, leaveOpen: true))
                 {
                     GnuTarEntry entry = new GnuTarEntry(entryType, longName);
+                    if (entryType is TarEntryType.HardLink or TarEntryType.SymbolicLink)
+                    {
+                        entry.LinkName = "linktarget";
+                    }
                     await writer.WriteEntryAsync(entry);
                 }
 
@@ -251,6 +255,16 @@ namespace System.Formats.Tar.Tests
                     Assert.Equal(longLinkName, entry.LinkName);
                 }
             }
+        }
+
+        [Theory]
+        [InlineData(TarEntryType.HardLink)]
+        [InlineData(TarEntryType.SymbolicLink)]
+        public async Task Write_LinkEntry_EmptyLinkName_Throws_Async(TarEntryType entryType)
+        {
+            await using MemoryStream archiveStream = new MemoryStream();
+            await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
+            await Assert.ThrowsAsync<InvalidDataException>(async () => await writer.WriteEntryAsync(new GnuTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Gnu.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Gnu.Tests.cs
@@ -264,7 +264,7 @@ namespace System.Formats.Tar.Tests
         {
             await using MemoryStream archiveStream = new MemoryStream();
             await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            await Assert.ThrowsAsync<InvalidDataException>(async () => await writer.WriteEntryAsync(new GnuTarEntry(entryType, "link")));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await writer.WriteEntryAsync(new GnuTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
@@ -513,7 +513,7 @@ namespace System.Formats.Tar.Tests
         {
             await using MemoryStream archiveStream = new MemoryStream();
             await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            await Assert.ThrowsAsync<ArgumentException>(async () => await writer.WriteEntryAsync(new PaxTarEntry(entryType, "link")));
+            await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(new PaxTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
@@ -513,7 +513,7 @@ namespace System.Formats.Tar.Tests
         {
             await using MemoryStream archiveStream = new MemoryStream();
             await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            await Assert.ThrowsAsync<InvalidDataException>(async () => await writer.WriteEntryAsync(new PaxTarEntry(entryType, "link")));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await writer.WriteEntryAsync(new PaxTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
@@ -505,5 +505,15 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(overLimitTimestamp, actualCTime);
             }
         }
+
+        [Theory]
+        [InlineData(TarEntryType.HardLink)]
+        [InlineData(TarEntryType.SymbolicLink)]
+        public async Task Write_LinkEntry_EmptyLinkName_Throws_Async(TarEntryType entryType)
+        {
+            await using MemoryStream archiveStream = new MemoryStream();
+            await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
+            await Assert.ThrowsAsync<InvalidDataException>(async () => await writer.WriteEntryAsync(new PaxTarEntry(entryType, "link")));
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Ustar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Ustar.Tests.cs
@@ -161,7 +161,7 @@ namespace System.Formats.Tar.Tests
         {
             await using MemoryStream archiveStream = new MemoryStream();
             await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            await Assert.ThrowsAsync<ArgumentException>(async () => await writer.WriteEntryAsync(new UstarTarEntry(entryType, "link")));
+            await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(new UstarTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Ustar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Ustar.Tests.cs
@@ -161,7 +161,7 @@ namespace System.Formats.Tar.Tests
         {
             await using MemoryStream archiveStream = new MemoryStream();
             await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            await Assert.ThrowsAsync<InvalidDataException>(async () => await writer.WriteEntryAsync(new UstarTarEntry(entryType, "link")));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await writer.WriteEntryAsync(new UstarTarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Ustar.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Ustar.Tests.cs
@@ -153,5 +153,15 @@ namespace System.Formats.Tar.Tests
                 VerifyFifo(fifo);
             }
         }
+
+        [Theory]
+        [InlineData(TarEntryType.HardLink)]
+        [InlineData(TarEntryType.SymbolicLink)]
+        public async Task Write_LinkEntry_EmptyLinkName_Throws_Async(TarEntryType entryType)
+        {
+            await using MemoryStream archiveStream = new MemoryStream();
+            await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
+            await Assert.ThrowsAsync<InvalidDataException>(async () => await writer.WriteEntryAsync(new UstarTarEntry(entryType, "link")));
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.V7.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.V7.Tests.cs
@@ -101,7 +101,7 @@ namespace System.Formats.Tar.Tests
         {
             await using MemoryStream archiveStream = new MemoryStream();
             await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            await Assert.ThrowsAsync<ArgumentException>(async () => await writer.WriteEntryAsync(new V7TarEntry(entryType, "link")));
+            await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(new V7TarEntry(entryType, "link")));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.V7.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.V7.Tests.cs
@@ -93,5 +93,15 @@ namespace System.Formats.Tar.Tests
                 VerifyDirectory(directory);
             }
         }
+
+        [Theory]
+        [InlineData(TarEntryType.HardLink)]
+        [InlineData(TarEntryType.SymbolicLink)]
+        public async Task Write_LinkEntry_EmptyLinkName_Throws_Async(TarEntryType entryType)
+        {
+            await using MemoryStream archiveStream = new MemoryStream();
+            await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
+            await Assert.ThrowsAsync<InvalidDataException>(async () => await writer.WriteEntryAsync(new V7TarEntry(entryType, "link")));
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.V7.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.V7.Tests.cs
@@ -101,7 +101,7 @@ namespace System.Formats.Tar.Tests
         {
             await using MemoryStream archiveStream = new MemoryStream();
             await using TarWriter writer = new TarWriter(archiveStream, leaveOpen: false);
-            await Assert.ThrowsAsync<InvalidDataException>(async () => await writer.WriteEntryAsync(new V7TarEntry(entryType, "link")));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await writer.WriteEntryAsync(new V7TarEntry(entryType, "link")));
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/74887