### PR TITLE
Update public pool names

### DIFF
--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -46,7 +46,7 @@ jobs:
     # source-build builds run in Docker, including the default managed platform.
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Public
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Internal

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -111,7 +111,7 @@ jobs:
       pool:
         # Public Linux Build Pool
         ${{ if and(or(in(parameters.osGroup, 'Linux', 'FreeBSD', 'Android'), eq(parameters.hostedOs, 'Linux')), eq(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore1ESPool-Svc-Public
+          name: NetCore-Svc-Public
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         # Official Build Linux Pool
@@ -130,7 +130,7 @@ jobs:
 
         # Public Windows Build Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')), eq(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore1ESPool-Svc-Public
+          name: NetCore-Svc-Public
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
 
 

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -31,7 +31,7 @@ jobs:
 - job: EnterpriseLinuxTests
   timeoutInMinutes: 120
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore-Svc-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
   steps:
   - bash: |

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -28,7 +28,7 @@ jobs:
   displayName: Docker Linux
   timeoutInMinutes: 180
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore-Svc-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
   steps:
@@ -76,7 +76,7 @@ jobs:
   displayName: Docker NanoServer
   timeoutInMinutes: 150
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore-Svc-Public
     demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
 
   steps:

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -29,7 +29,7 @@ jobs:
   displayName: Docker Linux
   timeoutInMinutes: 120
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore-Svc-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
   steps:
@@ -54,7 +54,7 @@ jobs:
   displayName: Docker NanoServer
   timeoutInMinutes: 120
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore-Svc-Public
     demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
 
   steps:


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.