### PR TITLE
use Task.Run to execute SmtpClient

### DIFF
--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -482,7 +482,7 @@ namespace System.Net.Mail.Tests
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask).WaitAsync(TestHelper.PassingTestTimeout);
 
             // We should still be able to send mail on the SmtpClient instance
-            await Task.Run(() => client.SendMailAsync(message).GetAwaiter().GetResult()).WaitAsync(TestHelper.PassingTestTimeout);
+            await Task.Run(() => client.SendMailAsync(message)).WaitAsync(TestHelper.PassingTestTimeout);
 
             Assert.Equal("<foo@internet.com>", server.MailFrom);
             Assert.Equal("<bar@internet.com>", server.MailTo);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -482,7 +482,7 @@ namespace System.Net.Mail.Tests
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask).WaitAsync(TestHelper.PassingTestTimeout);
 
             // We should still be able to send mail on the SmtpClient instance
-            await client.SendMailAsync(message).WaitAsync(TestHelper.PassingTestTimeout);
+            await Task.Run(() => client.SendMailAsync(message).GetAwaiter().GetResult()).WaitAsync(TestHelper.PassingTestTimeout);
 
             Assert.Equal("<foo@internet.com>", server.MailFrom);
             Assert.Equal("<bar@internet.com>", server.MailTo);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -473,7 +473,7 @@ namespace System.Net.Mail.Tests
 
             var message = new MailMessage("foo@internet.com", "bar@internet.com", "Foo", "Bar");
 
-            Task sendTask = client.SendMailAsync(message, cts.Token);
+            Task sendTask = Task.Run(() => client.SendMailAsync(message, cts.Token));
 
             cts.Cancel();
             await Task.Delay(500);


### PR DESCRIPTION
I'm not sure why #74545 did not work. we got one more test hanging instance after it. 
After looking at the Mail code the `SendMailAsync` actually does fair amount of synchronous processing before returning the `Task`. 
I'm not sure if there is better way to do it @stephentoub but I'm pushing that to the thread-pool to be sure the code before it and final `await` can execute.

This is only one test in `Mail` test suite using the `ManualResetEvent`. I did look at and it seems ok to me. We basically block completion so the client has chance to cancel. 
 
contributes to https://github.com/dotnet/runtime/issues/73447