### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/src/native/external/cgmanifest.json
+++ b/src/native/external/cgmanifest.json
@@ -1,64 +1,65 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "git",
-                "Git": {
-                    "RepositoryUrl": "https://github.com/google/brotli",
-                    "CommitHash": "e61745a6b7add50d380cfd7d3883dd6c62fc2c71"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "Git": {
-                    "RepositoryUrl": "https://github.com/libunwind/libunwind",
-                    "CommitHash": "b3ca1b59a795a617877c01fe5d299ab7a07ff29d"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "Git": {
-                    "RepositoryUrl": "https://github.com/llvm/llvm-project",
-                    "CommitHash": "f28c006a5895fc0e329fe15fead81e37457cb1d1"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "Git": {
-                    "RepositoryUrl": "https://github.com/Tencent/rapidjson",
-                    "CommitHash": "d87b698d0fcc10a5f632ecbc80a9cb2a8fa094a5"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "Git": {
-                    "RepositoryUrl": "https://github.com/madler/zlib",
-                    "CommitHash": "21767c654d31d2dccdde4330529775c6c5fd5389"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": {
-                "Type": "git",
-                "Git": {
-                    "RepositoryUrl": "https://github.com/jtkukunas/zlib",
-                    "CommitHash": "bf55d56b068467329f5a6f29bee31bc80d694023"
-                }
-            },
-            "DevelopmentDependency": false
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/google/brotli",
+          "CommitHash": "e61745a6b7add50d380cfd7d3883dd6c62fc2c71"
         }
-    ]
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/libunwind/libunwind",
+          "CommitHash": "b3ca1b59a795a617877c01fe5d299ab7a07ff29d"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/llvm/llvm-project",
+          "CommitHash": "f28c006a5895fc0e329fe15fead81e37457cb1d1"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/Tencent/rapidjson",
+          "CommitHash": "d87b698d0fcc10a5f632ecbc80a9cb2a8fa094a5"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/madler/zlib",
+          "CommitHash": "21767c654d31d2dccdde4330529775c6c5fd5389"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/jtkukunas/zlib",
+          "CommitHash": "bf55d56b068467329f5a6f29bee31bc80d694023"
+        }
+      },
+      "DevelopmentDependency": false
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.