### PR TITLE
Optimize AwayFromZero rounding

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1320,9 +1320,14 @@ namespace System
                     return Round(value);
 
                 // For ARM/ARM64 we can lower it down to a single instruction FRINTA
-                // For XARCH we have to use the common path
-                if (AdvSimd.IsSupported && mode == MidpointRounding.AwayFromZero)
-                    return AdvSimd.RoundAwayFromZeroScalar(Vector64.CreateScalar(value)).ToScalar();
+                // For other platforms we use a fast managed implementation
+                if (mode == MidpointRounding.AwayFromZero)
+                {
+                    if (AdvSimd.IsSupported)
+                        return AdvSimd.RoundAwayFromZeroScalar(Vector64.CreateScalar(value)).ToScalar();
+                    // manually fold BitDecrement(0.5)
+                    return Truncate(value + CopySign(0.49999999999999994, value));
+                }
             }
 
             return Round(value, 0, mode);
@@ -1359,13 +1364,8 @@ namespace System
                     // it is rounded to the nearest value above (for positive numbers) or below (for negative numbers)
                     case MidpointRounding.AwayFromZero:
                     {
-                        double fraction = ModF(value, &value);
-
-                        if (Abs(fraction) >= 0.5)
-                        {
-                            value += Sign(fraction);
-                        }
-
+                        // manually fold BitDecrement(0.5)
+                        value = Truncate(value + CopySign(0.49999999999999994, value));
                         break;
                     }
                     // Directed rounding: Round to the nearest value, toward to zero

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -442,7 +442,7 @@ namespace System
                     if (AdvSimd.IsSupported)
                         return AdvSimd.RoundAwayFromZeroScalar(Vector64.CreateScalarUnsafe(x)).ToScalar();
                     // manually fold BitDecrement(0.5f)
-                    return Truncate(value + CopySign(0.49999997f, x));
+                    return Truncate(x + CopySign(0.49999997f, x));
                 }
             }
 
@@ -481,7 +481,7 @@ namespace System
                     case MidpointRounding.AwayFromZero:
                     {
                         // manually fold BitDecrement(0.5f)
-                        value = Truncate(value + CopySign(0.49999997f, x));
+                        value = Truncate(x + CopySign(0.49999997f, x));
                         break;
                     }
                     // Directed rounding: Round to the nearest value, toward to zero

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -442,7 +442,7 @@ namespace System
                     if (AdvSimd.IsSupported)
                         return AdvSimd.RoundAwayFromZeroScalar(Vector64.CreateScalarUnsafe(x)).ToScalar();
                     // manually fold BitDecrement(0.5f)
-                    return Truncate(value + CopySign(0.49999997f, value));
+                    return Truncate(value + CopySign(0.49999997f, x));
                 }
             }
 
@@ -481,7 +481,7 @@ namespace System
                     case MidpointRounding.AwayFromZero:
                     {
                         // manually fold BitDecrement(0.5f)
-                        value = Truncate(value + CopySign(0.49999997f, value));
+                        value = Truncate(value + CopySign(0.49999997f, x));
                         break;
                     }
                     // Directed rounding: Round to the nearest value, toward to zero

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -481,7 +481,7 @@ namespace System
                     case MidpointRounding.AwayFromZero:
                     {
                         // manually fold BitDecrement(0.5f)
-                        value = Truncate(x + CopySign(0.49999997f, x));
+                        x = Truncate(x + CopySign(0.49999997f, x));
                         break;
                     }
                     // Directed rounding: Round to the nearest value, toward to zero

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -436,9 +436,14 @@ namespace System
                     return Round(x);
 
                 // For ARM/ARM64 we can lower it down to a single instruction FRINTA
-                // For XARCH we have to use the common path
-                if (AdvSimd.IsSupported && mode == MidpointRounding.AwayFromZero)
-                    return AdvSimd.RoundAwayFromZeroScalar(Vector64.CreateScalarUnsafe(x)).ToScalar();
+                // For other platforms we use a fast managed implementation
+                if (mode == MidpointRounding.AwayFromZero)
+                {
+                    if (AdvSimd.IsSupported)
+                        return AdvSimd.RoundAwayFromZeroScalar(Vector64.CreateScalarUnsafe(x)).ToScalar();
+                    // manually fold BitDecrement(0.5f)
+                    return Truncate(value + CopySign(0.49999997f, value));
+                }
             }
 
             return Round(x, 0, mode);
@@ -475,13 +480,8 @@ namespace System
                     // it is rounded to the nearest value above (for positive numbers) or below (for negative numbers)
                     case MidpointRounding.AwayFromZero:
                     {
-                        float fraction = ModF(x, &x);
-
-                        if (Abs(fraction) >= 0.5f)
-                        {
-                            x += Sign(fraction);
-                        }
-
+                        // manually fold BitDecrement(0.5f)
+                        value = Truncate(value + CopySign(0.49999997f, value));
                         break;
                     }
                     // Directed rounding: Round to the nearest value, toward to zero


### PR DESCRIPTION
Makes AwayFromZero use a fast managed
implementation instead of an FCall.

The code is not fully optimal due to
CopySign not being optimized for constant inputs,
it could be workarounded with direct Sse usage
but propely fixing CopySign would be better.