### PR TITLE
Avoid a crash when the debugger code fails to lookup the signature

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -8573,6 +8573,8 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 	}
 	case CMD_METHOD_GET_PARAM_INFO: {
 		MonoMethodSignature *sig = mono_method_signature_internal (method);
+		if (!sig)
+			return ERR_INVALID_ARGUMENT;
 		char **names;
 
 		/* FIXME: mono_class_from_mono_type_internal () and byrefs */


### PR DESCRIPTION
In this particular case, one of the method arguments has a type that
can not be resolved and the signature code returns null.

This is a cherry-pick from the the Unity Mono repo...
https://github.com/Unity-Technologies/mono/pull/1658
