### PR TITLE
Initialize Volatile value

### DIFF
--- a/src/coreclr/gc/env/volatile.h
+++ b/src/coreclr/gc/env/volatile.h
@@ -302,9 +302,9 @@ private:
 
 public:
     //
-    // Default constructor.  Results in an uninitialized value!
+    // Default constructor.
     //
-    inline Volatile()
+    inline Volatile() : m_val {}
     {
     }
 

--- a/src/coreclr/inc/volatile.h
+++ b/src/coreclr/inc/volatile.h
@@ -342,9 +342,9 @@ private:
 
 public:
     //
-    // Default constructor.  Results in an uninitialized value!
+    // Default constructor.
     //
-    inline Volatile()
+    inline Volatile() : m_val {}
     {
         STATIC_CONTRACT_SUPPORTS_DAC;
     }

--- a/src/tests/GC/API/GC/GetTotalPauseDuration.csproj
+++ b/src/tests/GC/API/GC/GetTotalPauseDuration.csproj
@@ -8,7 +8,7 @@
         correctly under GCStress.
      -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/GC/API/GC/GetTotalPauseDuration.csproj
+++ b/src/tests/GC/API/GC/GetTotalPauseDuration.csproj
@@ -8,7 +8,7 @@
         correctly under GCStress.
      -->
     <GCStressIncompatible>true</GCStressIncompatible>
-    <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -562,12 +562,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929/test45929/*">
             <Issue>https://github.com/dotnet/runtime/issues/60152</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetTotalPauseDuration/*">
-            <Issue>https://github.com/dotnet/runtime/issues/74631</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetGCMemoryInfo/*">
-            <Issue>https://github.com/dotnet/runtime/issues/74902</Issue>
-        </ExcludeList>    
     </ItemGroup>
 
     <!-- The following are x64 Unix failures on CoreCLR. -->


### PR DESCRIPTION
In #74363, we changed the code in `gc.cpp` such that `memset (&last_ephemeral_gc_info, 0, sizeof (last_ephemeral_gc_info));` is replaced by `last_ephemeral_gc_info = {};`

`last_ephemeral_gc_info` has type `Volatile<size_t>` and the default constructor of `Volatile` leave the underlying value uninitialized, this is causing the issue. In the old code, the volatile field was zero-initialized but in the new code, it isn't.

This change added back the default initialization for the volatile field and the issue associated with #74631 is fixed.

All GC code related to this change is reviewed and I confirm volatile is the only issue.