### PR TITLE
JIT: local assertion prop and redundant zeroing

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1969,12 +1969,12 @@ ValueNum ValueNumStore::VNZeroForType(var_types typ)
     }
 }
 
-ValueNum ValueNumStore::VNForZeroObj(CORINFO_CLASS_HANDLE structHnd)
+ValueNum ValueNumStore::VNForZeroObj(ClassLayout* layout)
 {
-    assert(structHnd != NO_CLASS_HANDLE);
+    assert(layout != nullptr);
 
-    ValueNum structHndVN = VNForHandle(ssize_t(structHnd), GTF_ICON_CLASS_HDL);
-    ValueNum zeroObjVN   = VNForFunc(TYP_STRUCT, VNF_ZeroObj, structHndVN);
+    ValueNum layoutVN  = VNForIntPtrCon(reinterpret_cast<ssize_t>(layout));
+    ValueNum zeroObjVN = VNForFunc(TYP_STRUCT, VNF_ZeroObj, layoutVN);
 
     return zeroObjVN;
 }
@@ -7465,7 +7465,7 @@ PhaseStatus Compiler::fgValueNumber()
                     if (isZeroed)
                     {
                         // By default we will zero init these LclVars
-                        initVal = (typ == TYP_STRUCT) ? vnStore->VNForZeroObj(varDsc->GetStructHnd())
+                        initVal = (typ == TYP_STRUCT) ? vnStore->VNForZeroObj(varDsc->GetLayout())
                                                       : vnStore->VNZeroForType(typ);
                     }
                     else
@@ -8327,20 +8327,23 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
             {
                 ValueNum   initObjVN  = ValueNumStore::NoVN;
                 bool const isZeroInit = rhs->IsIntegralConst(0);
-                if (isEntire && isZeroInit)
+                if (isZeroInit && isEntire)
                 {
                     // Note that it is possible to see pretty much any kind of type for the local
                     // (not just TYP_STRUCT) here because of the ASG(BLK(ADDR(LCL_VAR/FLD)), 0) form.
-                    initObjVN = (lhsVarDsc->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(lhsVarDsc->GetStructHnd())
+                    initObjVN = (lhsVarDsc->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(lhsVarDsc->GetLayout())
                                                                      : vnStore->VNZeroForType(lhsVarDsc->TypeGet());
                 }
                 else if (isZeroInit)
                 {
-                    initObjVN = (lhs->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(layout->GetClassHandle())
+                    // Non-entire zeroing
+                    initObjVN = (lhs->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(layout)
                                                                : vnStore->VNZeroForType(lhs->TypeGet());
                 }
                 else
                 {
+                    // Non-zero init, or non-entire block zero init
+                    //
                     // Non-zero block init is very rare so we'll use a simple, unique VN here.
                     initObjVN = vnStore->VNForExpr(compCurBB, lhsVarDsc->TypeGet());
                 }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8325,29 +8325,17 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
             ValueNumPair rhsVNPair = ValueNumPair();
             if (tree->OperIsInitBlkOp())
             {
-                ValueNum   initObjVN  = ValueNumStore::NoVN;
-                bool const isZeroInit = rhs->IsIntegralConst(0);
-                if (isZeroInit && isEntire)
+                ValueNum initObjVN = ValueNumStore::NoVN;
+                if (rhs->IsIntegralConst(0))
                 {
-                    // Note that it is possible to see pretty much any kind of type for the local
-                    // (not just TYP_STRUCT) here because of the ASG(BLK(ADDR(LCL_VAR/FLD)), 0) form.
-                    initObjVN = (lhsVarDsc->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(lhsVarDsc->GetLayout())
-                                                                     : vnStore->VNZeroForType(lhsVarDsc->TypeGet());
-                }
-                else if (isZeroInit)
-                {
-                    // Non-entire zeroing
                     initObjVN = (lhs->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(layout)
                                                                : vnStore->VNZeroForType(lhs->TypeGet());
                 }
                 else
                 {
-                    // Non-zero init, or non-entire block zero init
-                    //
                     // Non-zero block init is very rare so we'll use a simple, unique VN here.
-                    initObjVN = vnStore->VNForExpr(compCurBB, lhsVarDsc->TypeGet());
+                    initObjVN = vnStore->VNForExpr(compCurBB, lhs->TypeGet());
                 }
-
                 rhsVNPair.SetBoth(initObjVN);
             }
             else

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -500,7 +500,7 @@ public:
     ValueNum VNZeroForType(var_types typ);
 
     // Returns the value number for a zero-initialized struct.
-    ValueNum VNForZeroObj(CORINFO_CLASS_HANDLE structHnd);
+    ValueNum VNForZeroObj(ClassLayout* layout);
 
     // Returns the value number for one of the given "typ".
     // It returns NoVN for a "typ" that has no one value, such as TYP_REF.


### PR DESCRIPTION
In local assertion prop, optimize out stores of zeros to locations that are
already known to be zero. Don't do this for integer locals as it can lead to
excessive loop cloning.

If we succeed in a LCL_FLD copy prop, try and find a knock-on zero prop.

Update VN to handle the `struct LCL_FLD = 0` case better.

[diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=7552&view=ms.vss-build-web.run-extensions-tab)