### PR TITLE
Microsoft.Extensions.Configuration.Binder: Fix complex types in constructors

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -924,6 +924,12 @@ namespace Microsoft.Extensions.Configuration
 
             var propertyBindingPoint = new BindingPoint(initialValue: config.GetSection(parameterName).Value, isReadOnly: false);
 
+            BindInstance(
+                parameter.ParameterType,
+                propertyBindingPoint,
+                config.GetSection(parameterName),
+                options);
+
             if (propertyBindingPoint.Value is null)
             {
                 if (ParameterDefaultValue.TryGetDefaultValue(parameter, out object? defaultValue))
@@ -935,12 +941,6 @@ namespace Microsoft.Extensions.Configuration
                     throw new InvalidOperationException(SR.Format(SR.Error_ParameterHasNoMatchingConfig, type, parameterName));
                 }
             }
-
-            BindInstance(
-                parameter.ParameterType,
-                propertyBindingPoint,
-                config.GetSection(parameterName),
-                options);
 
             return propertyBindingPoint.Value;
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -250,6 +250,12 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
         public record struct RecordStructTypeOptions(string Color, int Length);
 
+        public record RecordOptionsWithNesting(int Number, RecordOptionsWithNesting.RecordNestedOptions Nested1,
+            RecordOptionsWithNesting.RecordNestedOptions Nested2 = null!)
+        {
+            public record RecordNestedOptions(string ValueA, int ValueB);
+        }
+
         // Here, the constructor has three parameters, but not all of those match
         // match to a property or field
         public class ClassWhereParametersDoNotMatchProperties
@@ -2354,6 +2360,29 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var options = config.Get<RecordStructTypeOptions>();
             Assert.Equal(42, options.Length);
             Assert.Equal("Green", options.Color);
+        }
+
+        [Fact]
+        public void CanBindNestedRecordOptions()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Number", "1"},
+                {"Nested1:ValueA", "Cool"},
+                {"Nested1:ValueB", "42"},
+                {"Nested2:ValueA", "Uncool"},
+                {"Nested2:ValueB", "24"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = config.Get<RecordOptionsWithNesting>();
+            Assert.Equal(1, options.Number);
+            Assert.Equal("Cool", options.Nested1.ValueA);
+            Assert.Equal(42, options.Nested1.ValueB);
+            Assert.Equal("Uncool", options.Nested2.ValueA);
+            Assert.Equal(24, options.Nested2.ValueB);
         }
 
         [Fact]


### PR DESCRIPTION
Currently, the following code:
```cs
var dic = new Dictionary<string, string>
{
    {"BaseInt", "42"},
    {"Nested:String", "ABC"},
    {"Nested:Int", "1"},
};

var test = new ConfigurationBuilder()
    .AddInMemoryCollection(dic)
    .Build()
    .Get<Test>();

Console.WriteLine(test.ToString());

record Nested(string String, int Int);
record Test(int BaseInt, Nested Nested);
```
produces:
**System.InvalidOperationException:** 'Cannot create instance of type 'Test' because parameter 'Nested' has no matching config. Each parameter in the constructor that does not have a default value must have a corresponding config entry.'

However, when giving the `Nested` property a default value of `null!` everything works as expected, including the correct values being printed, suggesting a bug.

The issue is caused by `BindParameter` prematurely cancelling the binding operator when neither `GetSection` nor a possible default assignment manage to produce a value. This ignores the possibility of a parameter first acquiring a value via the `BindInstance` call, as is the case - e.g. - with basic record types (among many others).

An unintended side effect is that `BindInstance` will no longer be called after the value has been provided by a defaulted parameter. However, since in that case the types have to match anyways I think the call was previously redundant in that case anyways.