### PR TITLE
Fix SharedLibrary smoke test build on osx-arm64

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm64/InteropThunksHelpers.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/InteropThunksHelpers.S
@@ -27,7 +27,7 @@ POINTER_SIZE = 0x08
         // need to save and restore them, too
         GETTHUNKDATA_ETLS_9
 #else
-        INLINE_GET_TLS_VAR x9, tls_thunkData
+        INLINE_GET_TLS_VAR x9, C_FUNC(tls_thunkData)
 #endif
 
         // x9  = base address of TLS data
@@ -58,7 +58,7 @@ POINTER_SIZE = 0x08
     //
     LEAF_ENTRY RhGetCurrentThunkContext, _TEXT
 
-        INLINE_GET_TLS_VAR x1, tls_thunkData
+        INLINE_GET_TLS_VAR x1, C_FUNC(tls_thunkData)
 
         ldr x0, [x1]
 


### PR DESCRIPTION
Fixes this error:

```sh
ld : warning : can't parse dwarf compilation unit info in /Users/adeel/projects/runtime/artifacts/tests/coreclr/obj/OSX.arm64.Release/Managed/nativeaot/SmokeTests/SharedLibrary/SharedLibrary/native/SharedLibrary.o [/Users/adeel/projects/runtime/src/tests/build.proj]
    Undefined symbols for architecture arm64:
      "tls_thunkData", referenced from:
          _RhCommonStub in libRuntime.WorkstationGC.a(InteropThunksHelpers.S.o)
          _RhGetCurrentThunkContext in libRuntime.WorkstationGC.a(InteropThunksHelpers.S.o)
         (maybe you meant: _tls_thunkData)
    ld: symbol(s) not found for architecture arm64
```
after that `src/tests/build.sh -nativeaot Release -tree:nativeaot` succeeds.