### PR TITLE
System.Net.Requests: Pick correct RemoteExecutor overload in test

### DIFF
--- a/src/libraries/System.Net.Requests/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Requests/tests/AssemblyInfo.cs
@@ -5,5 +5,4 @@ using System;
 using Xunit;
 
 [assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/74667", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoLinuxArm64))]
 [assembly: SkipOnPlatform(TestPlatforms.Browser, "System.Net.Requests is not supported on Browser.")]

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1978,12 +1978,12 @@ namespace System.Net.Tests
         }
 
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [InlineData(RequestCacheLevel.NoCacheNoStore, new string[] { "Pragma: no-cache", "Cache-Control: no-store, no-cache" })]
-        [InlineData(RequestCacheLevel.Reload, new string[] { "Pragma: no-cache", "Cache-Control: no-cache" })]
+        [InlineData(RequestCacheLevel.NoCacheNoStore, "Cache-Control: no-store, no-cache")]
+        [InlineData(RequestCacheLevel.Reload, "Cache-Control: no-cache")]
         public void SendHttpGetRequest_WithGlobalCachePolicy_AddCacheHeaders(
-            RequestCacheLevel requestCacheLevel, string[] expectedHeaders)
+            RequestCacheLevel requestCacheLevel, string expectedHeader)
         {
-            RemoteExecutor.Invoke(async (async, reqCacheLevel, eh0, eh1) =>
+            RemoteExecutor.Invoke(async (async, reqCacheLevel, eh) =>
             {
                 await LoopbackServer.CreateServerAsync(async (server, uri) =>
                 {
@@ -1994,8 +1994,8 @@ namespace System.Net.Tests
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         List<string> headers = await connection.ReadRequestHeaderAndSendResponseAsync();
-                        Assert.Contains(eh0, headers);
-                        Assert.Contains(eh1, headers);
+                        Assert.Contains("Pragma: no-cache", headers);
+                        Assert.Contains(eh, headers);
                     });
 
                     using (var response = (HttpWebResponse)await getResponse)
@@ -2003,7 +2003,7 @@ namespace System.Net.Tests
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     }
                 });
-            }, (this is HttpWebRequestTest_Async).ToString(), requestCacheLevel.ToString(), expectedHeaders[0], expectedHeaders[1]).Dispose();
+            }, (this is HttpWebRequestTest_Async).ToString(), requestCacheLevel.ToString(), expectedHeader).Dispose();
         }
 
         [Theory]


### PR DESCRIPTION
The test was using `RemoteExecutor.Invoke(Action<string, string, string, string> method, ...)` since there is no overload that takes `Func<string, string, string, string, Task>` (only one with three strings) and that means it's becoming an async void.

The delegate that gets invoked will return the moment the method awaits something not yet completed, so now there's a race condition, where `RemoteExecutor.Invoke` thinks all work is done, but there's still likely work running and it'll start doing all its cleanup stuff like killing child processes.

Fix by removing one string parameter so it picks the correct overload. I'll also open an arcade PR to add an overload with four string arguments.

Fixes https://github.com/dotnet/runtime/issues/74667