### PR TITLE
Fix argument validation in RuntimeType.InvokeMember

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -459,8 +459,6 @@ namespace System
             string name, BindingFlags bindingFlags, Binder? binder, object? target,
             object?[]? providedArgs, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParams)
         {
-            ArgumentNullException.ThrowIfNull(name);
-
             const BindingFlags MemberBindingMask = (BindingFlags)0x000000FF;
             const BindingFlags InvocationMask = (BindingFlags)0x0000FF00;
             const BindingFlags BinderGetSetField = BindingFlags.GetField | BindingFlags.SetField;
@@ -567,10 +565,12 @@ namespace System
             // PutDispProperty and\or PutRefDispProperty ==> SetProperty.
             if ((bindingFlags & (BindingFlags.PutDispProperty | BindingFlags.PutRefDispProperty)) != 0)
                 bindingFlags |= BindingFlags.SetProperty;
+
+            ArgumentNullException.ThrowIfNull(name);
             if (name.Length == 0 || name.Equals("[DISPID=0]"))
             {
                 // in InvokeMember we always pretend there is a default member if none is provided and we make it ToString
-                name = GetDefaultMemberName()! ?? "ToString";
+                name = GetDefaultMemberName() ?? "ToString";
             }
 
             // GetField or SetField

--- a/src/libraries/System.Reflection/tests/DefaultBinderTests.cs
+++ b/src/libraries/System.Reflection/tests/DefaultBinderTests.cs
@@ -167,6 +167,14 @@ namespace System.Reflection.Tests
             Assert.Equal(8, result);
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public static void InvokeWithCreateInstance(string name)
+        {
+            Assert.IsType<Sample>(typeof(Sample).InvokeMember(name, BindingFlags.CreateInstance, null, null, null));
+        }
+
         public class Test
         {
             public void TestMethod(int param1) { }


### PR DESCRIPTION
The rollout of `!!` erroneously moved an ArgumentNullException to be thrown earlier in the method, preventing a null name from being used (which is valid with BindingFlags.CreateInstance).

(Separately, we should consider fixing the nullable reference type annotation on `string name`, since null is allowed in some circumstances.)

Fixes https://github.com/dotnet/runtime/discussions/74977#discussioncomment-3536448
cc: @AaronRobinsonMSFT, @steveharter 