### PR TITLE
JIT: Mark an F# test as GC stress incompatible

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_72845/Runtime_72845.fsproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72845/Runtime_72845.fsproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <NoStandardLib>True</NoStandardLib>
     <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <GCStressIncompatible>True</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Runtime_72845.fs" />


### PR DESCRIPTION
Fix #73808