### PR TITLE
[wasm] CI: Trigger wasm jobs on some specific libraries

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -141,6 +141,9 @@ jobs:
       - eng/testing/scenarios/BuildWasmAppsJobsList.txt
       - eng/testing/workloads-testing.targets
       - src/libraries/sendtohelix*
+      - src/libraries/System.Net.WebSockets.Client/*
+      - src/libraries/System.Runtime.InteropServices/*
+      - src/libraries/System.Runtime.InteropServices.JavaScript/*
       - src/mono/mono/*
       - src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/*
       - src/mono/nuget/Microsoft.NET.Runtime.MonoTargets.Sdk/*
@@ -159,6 +162,8 @@ jobs:
     - subset: wasmdebuggertests
       include:
       - eng/testing/ProvisioningVersions.props
+      - src/libraries/System.Runtime.InteropServices/*
+      - src/libraries/System.Runtime.InteropServices.JavaScript/*
       - src/mono/mono/*
       - src/mono/wasm/debugger/*
       - src/mono/wasm/runtime/*
@@ -178,6 +183,26 @@ jobs:
       - ${{ parameters._const_paths._wasm_specific_only }}
       # other paths that should also trigger wasm jobs
       - src/mono/*
+
+    # libraries with some wasm specific code
+    - subset: wasm_libraries
+      - src/libraries/Common/*
+      - src/libraries/System.Console/*
+      - src/libraries/System.Diagnostics.FileVersionInfo/tests/*
+      - src/libraries/System.IO.Compression/*
+      - src/libraries/System.IO.MemoryMappedFiles/*
+      - src/libraries/System.Net.Http/*
+      - src/libraries/System.Net.Mail/*
+      - src/libraries/System.Net.Primitives/*
+      - src/libraries/System.Net.WebClient/*
+      - src/libraries/System.Net.WebProxy/*
+      - src/libraries/System.Net.WebSockets.Client/*
+      - src/libraries/System.Net.WebSockets/*
+      - src/libraries/System.Runtime.InteropServices.JavaScript/*
+      - src/libraries/System.Runtime.InteropServices/*
+      - src/libraries/System.Runtime.Serialization.Formatters/*
+      - src/libraries/System.Security.Cryptography/*
+      - src/libraries/System.Text.Encodings.Web/*
 
     # anything other than wasm-specific paths
     - subset: non_wasm

--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -186,6 +186,7 @@ jobs:
 
     # libraries with some wasm specific code
     - subset: wasm_libraries
+      include:
       - src/libraries/Common/*
       - src/libraries/System.Console/*
       - src/libraries/System.Diagnostics.FileVersionInfo/tests/*

--- a/eng/pipelines/common/templates/wasm-build-only.yml
+++ b/eng/pipelines/common/templates/wasm-build-only.yml
@@ -27,6 +27,7 @@ jobs:
             eq(variables['wasmDarcDependenciesChanged'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_libraries.containsChange'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true))
           ]
     jobParameters:

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -37,6 +37,7 @@ jobs:
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_libraries.containsChange'], true),
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm.containsChange'], true))))
           ]
       - name: onlyWBTOrDbgTestHaveChanges

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -314,6 +314,7 @@ jobs:
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_libraries.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -671,6 +672,7 @@ jobs:
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_libraries.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 


### PR DESCRIPTION
`subset: wasmbuildtests`:
- `src/libraries/System.Runtime.InteropServices/*`
    - this includes import generators
- `src/libraries/System.Runtime.InteropServices.JavaScript/*`

`subset: wasmdebuggertests`
- `src/libraries/System.Runtime.InteropServices/*`
- `src/libraries/System.Runtime.InteropServices.JavaScript/*`

And the following to trigger the wasm library tests:

       - src/libraries/Common/*
       - src/libraries/System.Console/*
       - src/libraries/System.Diagnostics.FileVersionInfo/tests/*
       - src/libraries/System.IO.Compression/*
       - src/libraries/System.IO.MemoryMappedFiles/*
       - src/libraries/System.Net.Http/*
       - src/libraries/System.Net.Mail/*
       - src/libraries/System.Net.Primitives/*
       - src/libraries/System.Net.WebClient/*
       - src/libraries/System.Net.WebProxy/*
       - src/libraries/System.Net.WebSockets.Client/*
       - src/libraries/System.Net.WebSockets/*
       - src/libraries/System.Runtime.InteropServices.JavaScript/*
       - src/libraries/System.Runtime.InteropServices/*
       - src/libraries/System.Runtime.Serialization.Formatters/*
       - src/libraries/System.Security.Cryptography/*
       - src/libraries/System.Text.Encodings.Web/*
