### PR TITLE
Tar: Fix buffer is too small error when writing Prefix on large filenames 

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -374,12 +374,10 @@ namespace System.Formats.Tar
 
             if (_name.Length > FieldLengths.Name)
             {
-                int prefixBytesLength = Math.Min(_name.Length - FieldLengths.Name, FieldLengths.Name);
-                Span<byte> remaining = prefixBytesLength <= 256 ?
-                    stackalloc byte[prefixBytesLength] :
-                    new byte[prefixBytesLength];
-
-                int encoded = Encoding.ASCII.GetBytes(_name.AsSpan(FieldLengths.Name), remaining);
+                int prefixBytesLength = Math.Min(_name.Length - FieldLengths.Name, FieldLengths.Prefix);
+                Debug.Assert(prefixBytesLength <= 256);
+                Span<byte> remaining = stackalloc byte[prefixBytesLength];
+                int encoded = Encoding.ASCII.GetBytes(_name.AsSpan(FieldLengths.Name, prefixBytesLength), remaining);
                 Debug.Assert(encoded == remaining.Length);
 
                 checksum += WriteLeftAlignedBytesAndGetChecksum(remaining, buffer.Slice(FieldLocations.Prefix, FieldLengths.Prefix));

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -375,7 +375,6 @@ namespace System.Formats.Tar
             if (_name.Length > FieldLengths.Name)
             {
                 int prefixBytesLength = Math.Min(_name.Length - FieldLengths.Name, FieldLengths.Prefix);
-                Debug.Assert(prefixBytesLength <= 256);
                 Span<byte> remaining = stackalloc byte[prefixBytesLength];
                 int encoded = Encoding.ASCII.GetBytes(_name.AsSpan(FieldLengths.Name, prefixBytesLength), remaining);
                 Debug.Assert(encoded == remaining.Length);

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
@@ -270,13 +270,13 @@ namespace System.Formats.Tar.Tests
 
             string archivePath = GetTarFilePath(CompressionMethod.Uncompressed, TestTarFormat.gnu.ToString(), testCaseName);
             string tarExtractedPath = Path.Join(root.Path, "tarExtracted");
-            Directory.CreateDirectory(tarExtractedPath); // rename to gnuTarExtractedPath et al
+            Directory.CreateDirectory(tarExtractedPath);
 
             // extract with /usr/bin/tar
             ExtractWithTarTool(archivePath, tarExtractedPath);
 
             // create archive with TarFile
-            string dotnetTarArchive = Path.Join(root.Path, "dotnetTarArchive");
+            string dotnetTarArchive = Path.Join(root.Path, "dotnetTarArchive.tar");
             TarFile.CreateFromDirectory(tarExtractedPath, dotnetTarArchive, includeBaseDirectory: false);
 
             // extract TarFile's archive with /usr/bin/tar

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
@@ -264,12 +264,6 @@ namespace System.Formats.Tar.Tests
                 throw new SkipTestException("specialfiles is only supported on Unix and it needs sudo permissions for extraction.");
             }
 
-            string[] symlinkTestCases = { "file_symlink", "foldersymlink_folder_subfolder_file", "file_longsymlink" };
-            if (symlinkTestCases.Contains(testCaseName) && !MountHelper.CanCreateSymbolicLinks)
-            {
-                throw new SkipTestException("Symlinks are not supported on this platform.");
-            }
-
             using TempDirectory root = new TempDirectory();
 
             string archivePath = GetTarFilePath(CompressionMethod.Uncompressed, TestTarFormat.pax.ToString(), testCaseName);

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
@@ -264,6 +264,12 @@ namespace System.Formats.Tar.Tests
                 throw new SkipTestException("specialfiles is only supported on Unix and it needs sudo permissions for extraction.");
             }
 
+            string[] symlinkTestCases = { "file_symlink", "foldersymlink_folder_subfolder_file", "file_longsymlink" };
+            if (symlinkTestCases.Contains(testCaseName) && !MountHelper.CanCreateSymbolicLinks)
+            {
+                throw new SkipTestException("Symlinks are not supported on this platform.");
+            }
+
             using TempDirectory root = new TempDirectory();
 
             string archivePath = GetTarFilePath(CompressionMethod.Uncompressed, TestTarFormat.pax.ToString(), testCaseName);
@@ -285,11 +291,10 @@ namespace System.Formats.Tar.Tests
             // compare results
             Dictionary<string, FileSystemInfo> expectedEntries = GetFileSystemInfosRecursive(tarExtractedPath).ToDictionary(fsi => fsi.FullName.Substring(tarExtractedPath.Length));
 
-            foreach (var actualEntry in GetFileSystemInfosRecursive(dotnetTarExtractedPath))
+            foreach (FileSystemInfo actualEntry in GetFileSystemInfosRecursive(dotnetTarExtractedPath))
             {
                 string keyPath = actualEntry.FullName.Substring(dotnetTarExtractedPath.Length);
-
-                Assert.True(expectedEntries.TryGetValue(keyPath, out FileSystemInfo expectedEntry), "Entry not expected.");
+                Assert.True(expectedEntries.TryGetValue(keyPath, out FileSystemInfo expectedEntry), $"Entry '{keyPath}' not expected.");
                 Assert.Equal(expectedEntry.Attributes, actualEntry.Attributes);
                 Assert.Equal(expectedEntry.LinkTarget, actualEntry.LinkTarget);
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
@@ -264,6 +264,12 @@ namespace System.Formats.Tar.Tests
                 throw new SkipTestException("specialfiles is only supported on Unix and it needs sudo permissions for extraction.");
             }
 
+            string[] symlinkTestCases = { "file_symlink", "foldersymlink_folder_subfolder_file", "file_longsymlink" };
+            if (symlinkTestCases.Contains(testCaseName) && PlatformDetection.IsWindowsNanoServer) // Tar version of Windows Nano Server does not support extracting symlinks.
+            {
+                throw new SkipTestException("Symlinks are not supported on this platform.");
+            }
+
             using TempDirectory root = new TempDirectory();
 
             string archivePath = GetTarFilePath(CompressionMethod.Uncompressed, TestTarFormat.pax.ToString(), testCaseName);

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Enumeration;
 using System.Linq;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
@@ -262,7 +261,7 @@ namespace System.Formats.Tar.Tests
         {
             if (testCaseName == "specialfiles" && !PlatformDetection.IsSuperUser)
             {
-                throw new SkipTestException("specialfiles is only supported on Unix and it needs sudo permissions for extraction");
+                throw new SkipTestException("specialfiles is only supported on Unix and it needs sudo permissions for extraction.");
             }
 
             using TempDirectory root = new TempDirectory();
@@ -299,12 +298,6 @@ namespace System.Formats.Tar.Tests
 
             // All expected entries should've been found and removed.
             Assert.Equal(0, expectedEntries.Count);
-        }
-
-        private static FileSystemEnumerable<FileSystemInfo> GetFileSystemInfosRecursive(string path)
-        {
-            var enumerationOptions = new EnumerationOptions { RecurseSubdirectories = true };
-            return new FileSystemEnumerable<FileSystemInfo>(path, (ref FileSystemEntry e) => e.ToFileSystemInfo(), enumerationOptions);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs
@@ -256,19 +256,18 @@ namespace System.Formats.Tar.Tests
             Assert.Null(reader.GetNextEntry());
         }
 
-        [ConditionalTheory]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [ConditionalTheory(nameof(CanExtractWithTarTool))]
         [MemberData(nameof(GetPaxAndGnuTestCaseNames))]
         public void ResultingArchive_CanBeExtractedByOtherTools(string testCaseName)
         {
             if (testCaseName == "specialfiles" && !PlatformDetection.IsSuperUser)
             {
-                throw new SkipTestException("specialfiles needs sudo permissions for extraction");
+                throw new SkipTestException("specialfiles is only supported on Unix and it needs sudo permissions for extraction");
             }
 
             using TempDirectory root = new TempDirectory();
 
-            string archivePath = GetTarFilePath(CompressionMethod.Uncompressed, TestTarFormat.gnu.ToString(), testCaseName);
+            string archivePath = GetTarFilePath(CompressionMethod.Uncompressed, TestTarFormat.pax.ToString(), testCaseName);
             string tarExtractedPath = Path.Join(root.Path, "tarExtracted");
             Directory.CreateDirectory(tarExtractedPath);
 

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -613,12 +613,27 @@ namespace System.Formats.Tar.Tests
             }
         }
 
+        public static bool CanExtractWithTarTool = CanExtractWithTarTool_Method();
+
+        private static bool CanExtractWithTarTool_Method()
+        {
+            using Process tarToolProcess = new Process();
+            tarToolProcess.StartInfo.FileName = OperatingSystem.IsWindows() ? "tar" : "/usr/bin/tar";
+            tarToolProcess.StartInfo.Arguments = "--help";
+
+            tarToolProcess.StartInfo.RedirectStandardOutput = true;
+            tarToolProcess.Start();
+
+            tarToolProcess.StandardOutput.ReadToEnd();
+            tarToolProcess.WaitForExit();
+
+            return (tarToolProcess.ExitCode == 0);
+        }
+
         public static void ExtractWithTarTool(string source, string destination)
         {
-            Assert.True(!OperatingSystem.IsWindows(), "This method is unsupported on Windows.");
-
             using Process tarToolProcess = new Process();
-            tarToolProcess.StartInfo.FileName = "/usr/bin/tar";
+            tarToolProcess.StartInfo.FileName = OperatingSystem.IsWindows() ? "tar" : "/usr/bin/tar";
             tarToolProcess.StartInfo.Arguments = $"-xf {source} -C {destination}";
 
             tarToolProcess.StartInfo.RedirectStandardOutput = true;

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -624,7 +624,7 @@ namespace System.Formats.Tar.Tests
 
         private static readonly Lazy<bool> s_canExtractWithTarTool = new Lazy<bool>(() =>
         {
-            if (PlatformDetection.IsAndroid) // Android reports tar: chown 7913:3579 'file.txt': Operation not permitted.
+            if (PlatformDetection.IsAndroid || PlatformDetection.IsLinuxBionic) // Android reports tar: chown 7913:3579 'file.txt': Operation not permitted.
             {
                 return false;
             }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -621,10 +621,10 @@ namespace System.Formats.Tar.Tests
             tarToolProcess.StartInfo.FileName = "/usr/bin/tar";
             tarToolProcess.StartInfo.Arguments = $"-xf {source} -C {destination}";
 
-            tarToolProcess.StartInfo.UseShellExecute = false;
             tarToolProcess.StartInfo.RedirectStandardOutput = true;
             tarToolProcess.Start();
 
+            tarToolProcess.StandardOutput.ReadToEnd();
             tarToolProcess.WaitForExit();
 
             Assert.Equal(0, tarToolProcess.ExitCode);

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -624,6 +624,11 @@ namespace System.Formats.Tar.Tests
 
         private static readonly Lazy<bool> s_canExtractWithTarTool = new Lazy<bool>(() =>
         {
+            if (PlatformDetection.IsAndroid || PlatformDetection.IsWindowsNanoServer)
+            {
+                return false;
+            }
+
             if (PlatformDetection.IsWindows)
             {
                 Version osVersion = Environment.OSVersion.Version;
@@ -656,10 +661,10 @@ namespace System.Formats.Tar.Tests
             tarToolProcess.StartInfo.RedirectStandardOutput = true;
             tarToolProcess.Start();
 
-            tarToolProcess.StandardOutput.ReadToEnd();
+            string output = tarToolProcess.StandardOutput.ReadToEnd();
             tarToolProcess.WaitForExit();
 
-            Assert.Equal(0, tarToolProcess.ExitCode);
+            Assert.True(tarToolProcess.ExitCode == 0, "Tar process output: " + output);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -624,7 +624,7 @@ namespace System.Formats.Tar.Tests
 
         private static readonly Lazy<bool> s_canExtractWithTarTool = new Lazy<bool>(() =>
         {
-            if (PlatformDetection.IsAndroid || PlatformDetection.IsWindowsNanoServer)
+            if (PlatformDetection.IsAndroid) // Android reports tar: chown 7913:3579 'file.txt': Operation not permitted.
             {
                 return false;
             }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -618,7 +618,7 @@ namespace System.Formats.Tar.Tests
         private static bool CanExtractWithTarTool_Method()
         {
             using Process tarToolProcess = new Process();
-            tarToolProcess.StartInfo.FileName = OperatingSystem.IsWindows() ? "tar" : "/usr/bin/tar";
+            tarToolProcess.StartInfo.FileName = "tar"; // location varies: find it on the PATH.
             tarToolProcess.StartInfo.Arguments = "--help";
 
             tarToolProcess.StartInfo.RedirectStandardOutput = true;
@@ -633,7 +633,7 @@ namespace System.Formats.Tar.Tests
         public static void ExtractWithTarTool(string source, string destination)
         {
             using Process tarToolProcess = new Process();
-            tarToolProcess.StartInfo.FileName = OperatingSystem.IsWindows() ? "tar" : "/usr/bin/tar";
+            tarToolProcess.StartInfo.FileName = "tar"; // location varies: find it on the PATH.
             tarToolProcess.StartInfo.Arguments = $"-xf {source} -C {destination}";
 
             tarToolProcess.StartInfo.RedirectStandardOutput = true;

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -610,6 +611,23 @@ namespace System.Formats.Tar.Tests
             {
                 yield return new object[] { name };
             }
+        }
+
+        public static void ExtractWithTarTool(string source, string destination)
+        {
+            Assert.True(!OperatingSystem.IsWindows(), "This method is unsupported on Windows.");
+
+            using Process tarToolProcess = new Process();
+            tarToolProcess.StartInfo.FileName = "/usr/bin/tar";
+            tarToolProcess.StartInfo.Arguments = $"-xf {source} -C {destination}";
+
+            tarToolProcess.StartInfo.UseShellExecute = false;
+            tarToolProcess.StartInfo.RedirectStandardOutput = true;
+            tarToolProcess.Start();
+
+            tarToolProcess.WaitForExit();
+
+            Assert.Equal(0, tarToolProcess.ExitCode);
         }
     }
 }


### PR DESCRIPTION
Found while addressing https://github.com/dotnet/runtime/issues/74316#issuecomment-1229194357.
```
System.Formats.Tar.Tests.TarFile_CreateFromDirectory_File_Tests.ResultingArchive_CanBeExtractedByOtherTools(testCaseName: "file_longsymlink") [FAIL]
  System.ArgumentException : The output byte buffer is too small to contain the encoded data, encoding codepage '20127' and fallback 'System.Text.EncoderReplacementFallback'. (Parameter 'bytes')
  Stack Trace:
    /home/david/runtime/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs(1090,0): at System.Text.Encoding.ThrowBytesOverflow()
    /home/david/runtime/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs(1101,0): at System.Text.Encoding.ThrowBytesOverflow(EncoderNLS encoder, Boolean nothingEncoded)
    /home/david/runtime/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.Internal.cs(682,0): at System.Text.Encoding.GetBytesWithFallback(ReadOnlySpan`1 chars, Int32 originalCharsLength, Span`1 bytes, Int32 originalBytesLength, EncoderNLS encoder)
    /home/david/runtime/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs(411,0): at System.Text.ASCIIEncoding.GetBytesWithFallback(ReadOnlySpan`1 chars, Int32 originalCharsLength, Span`1 bytes, Int32 originalBytesLength, EncoderNLS encoder)
    /home/david/runtime/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.Internal.cs(497,0): at System.Text.Encoding.GetBytesWithFallback(Char* pOriginalChars, Int32 originalCharCount, Byte* pOriginalBytes, Int32 originalByteCount, Int32 charsConsumedSoFar, Int32 bytesWrittenSoFar)
    /home/david/runtime/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs(320,0): at System.Text.ASCIIEncoding.GetBytes(ReadOnlySpan`1 chars, Span`1 bytes)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs(382,0): at System.Formats.Tar.TarHeader.WritePosixName(Span`1 buffer)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs(353,0): at System.Formats.Tar.TarHeader.WriteAsPaxSharedInternal(Span`1 buffer, Int64& actualLength)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs(322,0): at System.Formats.Tar.TarHeader.WriteAsPaxInternal(Stream archiveStream, Span`1 buffer)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs(153,0): at System.Formats.Tar.TarHeader.WriteAsPax(Stream archiveStream, Span`1 buffer)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs(291,0): at System.Formats.Tar.TarWriter.WriteEntryInternal(TarEntry entry)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs(219,0): at System.Formats.Tar.TarWriter.WriteEntry(TarEntry entry)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs(164,0): at System.Formats.Tar.TarWriter.ReadFileFromDiskAndWriteToArchiveStreamAsEntry(String fullPath, String entryName)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs(135,0): at System.Formats.Tar.TarWriter.WriteEntry(String fileName, String entryName)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs(297,0): at System.Formats.Tar.TarFile.CreateFromDirectoryInternal(String sourceDirectoryName, Stream destination, Boolean includeBaseDirectory, Boolean leaveOpen)
    /home/david/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs(102,0): at System.Formats.Tar.TarFile.CreateFromDirectory(String sourceDirectoryName, String destinationFileName, Boolean includeBaseDirectory)
    /home/david/runtime/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.CreateFromDirectory.File.Tests.cs(280,0): at System.Formats.Tar.Tests.TarFile_CreateFromDirectory_File_Tests.ResultingArchive_CanBeExtractedByOtherTools(String testCaseName)
       at InvokeStub_TarFile_CreateFromDirectory_File_Tests.ResultingArchive_CanBeExtractedByOtherTools(Object, Object, IntPtr*)
       at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```

TODO:
Add similar test with TarWriter, async, and Stream. 

Since this may be backport-worthy, consider merging without the aforementioned.