### PR TITLE
Fix NCL stress tests after ProductVersion upgrade

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Directory.Build.props
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Directory.Build.props
@@ -7,7 +7,7 @@
         <RepositoryRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, global.json))/</RepositoryRoot>
         
         <TargetingPacksTargetsLocation Condition="'$(TargetingPacksTargetsLocation)' == ''">$(RepositoryRoot)eng/targetingpacks.targets</TargetingPacksTargetsLocation>
-        <ProductVersion>7.0.0</ProductVersion>
+        <ProductVersion>8.0.0</ProductVersion>
         <NetCoreAppCurrent>net7.0</NetCoreAppCurrent>
         <NetCoreAppCurrentVersion>7.0</NetCoreAppCurrentVersion>
         <MicrosoftNetCoreAppFrameworkName>Microsoft.NETCore.App</MicrosoftNetCoreAppFrameworkName>

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -42,5 +42,5 @@ EXPOSE 5001
 ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
 ENV HTTPSTRESS_ARGS=''
-CMD /live-runtime-artifacts/testhost/net$VERSION-Linux-$CONFIGURATION-x64/dotnet exec \
+CMD /live-runtime-artifacts/testhost/net$VERSION-Linux-$CONFIGURATION-x64/dotnet exec --roll-forward Major \
     ./bin/$CONFIGURATION/net$VERSION/HttpStress.dll $HTTPSTRESS_ARGS

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.ps1
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.ps1
@@ -56,7 +56,7 @@ dotnet build -c $StressConfiguration
 $Runscript=".\run-stress-$LibrariesConfiguration-$StressConfiguration.ps1"
 if (-not (Test-Path $Runscript)) {
     Write-Host "Generating Runscript."
-    Add-Content -Path $Runscript -Value "& '$TestHostRoot/dotnet' exec ./bin/$StressConfiguration/net$Version/HttpStress.dll `$args"
+    Add-Content -Path $Runscript -Value "& '$TestHostRoot/dotnet' exec --roll-forward Major ./bin/$StressConfiguration/net$Version/HttpStress.dll `$args"
 }
 
 Write-Host "To run tests type:"

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.sh
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.sh
@@ -59,7 +59,7 @@ dotnet build -c $stress_configuration
 runscript=./run-stress-${stress_configuration,,}-${libraries_configuration,,}.sh
 if [[ ! -f $runscript ]]; then
     echo "Generating runscript."
-    echo "$testhost_root/dotnet exec ./bin/$stress_configuration/net$version/HttpStress.dll \$@" > $runscript
+    echo "$testhost_root/dotnet exec --roll-forward Major ./bin/$stress_configuration/net$version/HttpStress.dll \$@" > $runscript
     chmod +x $runscript
 fi
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/windows.Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/windows.Dockerfile
@@ -27,5 +27,5 @@ ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
 ENV HTTPSTRESS_ARGS=""
 
-CMD & C:/live-runtime-artifacts/testhost/net$env:VERSION-windows-$env:CONFIGURATION-x64/dotnet.exe exec `
+CMD & C:/live-runtime-artifacts/testhost/net$env:VERSION-windows-$env:CONFIGURATION-x64/dotnet.exe exec --roll-forward Major `
     ./bin/$env:CONFIGURATION/net$env:VERSION/HttpStress.dll $env:HTTPSTRESS_ARGS.Split()

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Directory.Build.props
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Directory.Build.props
@@ -7,7 +7,7 @@
         <RepositoryRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)../, global.json))/</RepositoryRoot>
 
         <TargetingPacksTargetsLocation Condition="'$(TargetingPacksTargetsLocation)' == ''">$(RepositoryRoot)eng/targetingpacks.targets</TargetingPacksTargetsLocation>
-        <ProductVersion>7.0.0</ProductVersion>
+        <ProductVersion>8.0.0</ProductVersion>
         <NetCoreAppCurrent>net7.0</NetCoreAppCurrent>
         <NetCoreAppCurrentVersion>7.0</NetCoreAppCurrentVersion>
         <MicrosoftNetCoreAppFrameworkName>Microsoft.NETCore.App</MicrosoftNetCoreAppFrameworkName>

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Dockerfile
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Dockerfile
@@ -19,5 +19,5 @@ ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
 ENV SSLSTRESS_ARGS=''
 
-CMD /live-runtime-artifacts/testhost/net$VERSION-Linux-$CONFIGURATION-x64/dotnet exec \
+CMD /live-runtime-artifacts/testhost/net$VERSION-Linux-$CONFIGURATION-x64/dotnet exec --roll-forward Major \
     ./bin/$CONFIGURATION/net$VERSION/SslStress.dll $SSLSTRESS_ARGS

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/build-local.sh
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/build-local.sh
@@ -35,13 +35,26 @@ if [[ ! -d $testhost_root ]]; then
     exit 1
 fi
 
+if [[ ! -d $daily_dotnet_root ]]; then
+    echo "Downloading daily SDK to $daily_dotnet_root"
+    mkdir $daily_dotnet_root
+    wget https://dot.net/v1/dotnet-install.sh -O $daily_dotnet_root/dotnet-install.sh
+    bash $daily_dotnet_root/dotnet-install.sh --no-path --channel $version.1xx --quality daily --install-dir $daily_dotnet_root
+else
+    echo "Daily SDK found in $daily_dotnet_root"
+fi
+
+export DOTNET_ROOT=$daily_dotnet_root
+export PATH=$DOTNET_ROOT:$PATH
+export DOTNET_MULTILEVEL_LOOKUP=0
+
 echo "Building solution."
 dotnet build -c $stress_configuration
 
 runscript=./run-stress-${stress_configuration,,}-${libraries_configuration,,}.sh
 if [[ ! -f $runscript ]]; then
     echo "Generating runscript."
-    echo "$testhost_root/dotnet exec ./bin/$stress_configuration/net$version/SslStress.dll \$@" > $runscript
+    echo "$testhost_root/dotnet exec --roll-forward Major ./bin/$stress_configuration/net$version/SslStress.dll \$@" > $runscript
     chmod +x $runscript
 fi
 

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/windows.Dockerfile
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/windows.Dockerfile
@@ -23,5 +23,5 @@ ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
 ENV SSLSTRESS_ARGS=""
 
-CMD & C:/live-runtime-artifacts/testhost/net$env:VERSION-windows-$env:CONFIGURATION-x64/dotnet.exe exec `
+CMD & C:/live-runtime-artifacts/testhost/net$env:VERSION-windows-$env:CONFIGURATION-x64/dotnet.exe exec --roll-forward Major `
     ./bin/$env:CONFIGURATION/net$env:VERSION/SslStress.dll $env:SSLSTRESS_ARGS.Split()


### PR DESCRIPTION
Fixes #74604

- Set `ProductVersion` to `8.0.0`
- Configure roll-forward as recommended in https://github.com/dotnet/runtime/issues/74604#issuecomment-1235844402
- Build non-containerized SslStress using a private dotnet install, just like HttpStress