### PR TITLE
[release/7.0][wasm] Use the correct runtime pack version when the workload is not installed

### DIFF
--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -3,7 +3,9 @@
   <PropertyGroup Condition="'$(TestUsingWorkloads)' == 'true'">
     <!-- for non-ci builds, we install the sdk when tests are run -->
     <InstallWorkloadForTesting Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(ArchiveTests)' == 'true'">true</InstallWorkloadForTesting>
+  </PropertyGroup>
 
+  <PropertyGroup Condition="'$(InstallWorkloadForTesting)' == 'true'">
     <_SdkForWorkloadTestingBasePath>$(ArtifactsBinDir)</_SdkForWorkloadTestingBasePath>
     <_SdkWithNoWorkloadPath>$([MSBuild]::NormalizeDirectory($(_SdkForWorkloadTestingBasePath), 'dotnet-none'))</_SdkWithNoWorkloadPath>
     <_SdkWithNoWorkloadStampPath>$([MSBuild]::NormalizePath($(_SdkWithNoWorkloadPath), '.version-$(SdkVersionForWorkloadTesting).stamp'))</_SdkWithNoWorkloadStampPath>
@@ -190,7 +192,7 @@
 
   <Target Name="_InstallWorkloads"
           Inputs="@(AvailableNuGetsInArtifacts)"
-          Outputs="@(_SdkWithWorkloadToInstall->'%(StampPath)')">
+          Outputs="@(_SdkWithWorkloadToInstall->'%(StampPath)');$(_SdkWithNoWorkloadStampPath)">
     <ItemGroup>
       <_BuiltNuGets Include="$(LibrariesShippingPackagesDir)\*.nupkg" />
     </ItemGroup>
@@ -205,5 +207,7 @@
                      TemplateNuGetConfigPath="$(RepoRoot)NuGet.config"
                      SdkWithNoWorkloadInstalledPath="$(_SdkWithNoWorkloadPath)"
       />
+
+    <WriteLinesToFile Lines="" File="$(_SdkWithNoWorkloadStampPath)" />
   </Target>
 </Project>

--- a/src/libraries/sendtohelix-wasm.targets
+++ b/src/libraries/sendtohelix-wasm.targets
@@ -26,6 +26,7 @@
     <WasmBuildTargetsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'mono', 'wasm', 'build'))</WasmBuildTargetsDir>
     <TestEchoMiddleware>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin', 'NetCoreServer', '$(Configuration)', '$(AspNetCoreAppCurrent)'))</TestEchoMiddleware>
     <RemoteLoopMiddleware>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin', 'RemoteLoopServer', '$(Configuration)', '$(AspNetCoreAppCurrent)'))</RemoteLoopMiddleware>
+    <_ShippingPackagesPath>$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'packages', $(Configuration), 'Shipping'))</_ShippingPackagesPath>
     <WorkItemPrefix Condition="'$(IsWasmDebuggerTests)' == 'true'">$(DebuggerHost)-</WorkItemPrefix>
     <WorkItemPrefix Condition="'$(WorkItemPrefix)' == '' and '$(Scenario)' != ''">$(Scenario)-</WorkItemPrefix>
 
@@ -193,7 +194,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(NeedsBuiltNugets)' == 'true'">
-      <HelixCorrelationPayload Include="$(LibrariesShippingPackagesDirectory)"          Destination="built-nugets" />
+      <HelixCorrelationPayload Include="$(_ShippingPackagesPath)"                Destination="built-nugets" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/sendtohelix-wasm.targets
+++ b/src/libraries/sendtohelix-wasm.targets
@@ -56,6 +56,7 @@
     <NeedsEMSDKNode Condition="'$(Scenario)' == 'WasmTestOnNodeJs' or '$(Scenario)' == 'BuildWasmApps'">true</NeedsEMSDKNode>
     <NeedsToRunOnBrowser Condition="'$(Scenario)' == 'WasmTestOnBrowser' or '$(Scenario)' == 'BuildWasmApps'">true</NeedsToRunOnBrowser>
     <NeedsToRunOnBrowser Condition="'$(NeedsToRunOnBrowser)' == '' and '$(IsWasmDebuggerTests)' == 'true'">true</NeedsToRunOnBrowser>
+    <NeedsBuiltNugets Condition="'$(Scenario)' == 'BuildWasmApps'">true</NeedsBuiltNugets>
 
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
     <EnableXHarnessTelemetry>false</EnableXHarnessTelemetry>
@@ -121,6 +122,9 @@
   <ItemGroup Condition="'$(Scenario)' == 'BuildWasmApps'">
     <HelixPreCommand Condition="'$(WindowsShell)' == 'true'" Include="set &quot;XUnitTraitArg=$(_XUnitTraitArg)&quot;" />
     <HelixPreCommand Condition="'$(WindowsShell)' != 'true'" Include="export &quot;XUnitTraitArg=$(_XUnitTraitArg)&quot;" />
+
+    <HelixPreCommand Condition="'$(WindowsShell)' == 'true'" Include="set &quot;BUILT_NUGETS_PATH=%HELIX_CORRELATION_PAYLOAD%/built-nugets&quot;" />
+    <HelixPreCommand Condition="'$(WindowsShell)' != 'true'" Include="export &quot;BUILT_NUGETS_PATH=$HELIX_CORRELATION_PAYLOAD/built-nugets&quot;" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -186,6 +190,10 @@
     <ItemGroup Condition="'$(Scenario)' == '' or '$(Scenario)' == 'normal' or '$(Scenario)' == 'WasmTestOnBrowser' or '$(Scenario)' == 'WasmTestOnNodeJS'">
       <HelixCorrelationPayload Include="$(TestEchoMiddleware)" Destination="xharness/TestEchoMiddleware" Condition="Exists('$(TestEchoMiddleware)')" />
       <HelixCorrelationPayload Include="$(RemoteLoopMiddleware)" Destination="xharness/RemoteLoopMiddleware" Condition="Exists('$(RemoteLoopMiddleware)')" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(NeedsBuiltNugets)' == 'true'">
+      <HelixCorrelationPayload Include="$(LibrariesShippingPackagesDirectory)"          Destination="built-nugets" />
     </ItemGroup>
   </Target>
 

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/WorkloadManifest.targets.in
@@ -97,7 +97,7 @@
         <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.net6" />
     </ImportGroup>
 
-    <PropertyGroup Condition="'$(TargetsNet6)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'macOS' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'maccatalyst' or '$(TargetPlatformIdentifier)' == 'tvos' or ('$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true'))">
+    <PropertyGroup Condition="'$(TargetsNet6)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'macOS' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'maccatalyst' or '$(TargetPlatformIdentifier)' == 'tvos' or '$(RuntimeIdentifier)' == 'browser-wasm')">
       <_MonoWorkloadTargetsMobile>true</_MonoWorkloadTargetsMobile>
       <_MonoWorkloadRuntimePackPackageVersion>$(_RuntimePackInWorkloadVersion6)</_MonoWorkloadRuntimePackPackageVersion>
     </PropertyGroup>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.targets.in
@@ -94,7 +94,7 @@
         <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk.net7" />
     </ImportGroup>
 
-    <PropertyGroup Condition="'$(TargetsNet7)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'macOS' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'maccatalyst' or '$(TargetPlatformIdentifier)' == 'tvos' or ('$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true'))">
+    <PropertyGroup Condition="'$(TargetsNet7)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'macOS' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'maccatalyst' or '$(TargetPlatformIdentifier)' == 'tvos' or '$(RuntimeIdentifier)' == 'browser-wasm')">
       <_MonoWorkloadTargetsMobile>true</_MonoWorkloadTargetsMobile>
       <_MonoWorkloadRuntimePackPackageVersion>$(_RuntimePackInWorkloadVersion7)</_MonoWorkloadRuntimePackPackageVersion>
     </PropertyGroup>

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -97,6 +97,8 @@ namespace Microsoft.Workload.Build.Tasks
 
                     if (!ExecuteInternal(req) && !req.IgnoreErrors)
                         return false;
+
+                    File.WriteAllText(req.StampPath, string.Empty);
                 }
 
                 return !Log.HasLoggedErrors;
@@ -399,6 +401,7 @@ namespace Microsoft.Workload.Build.Tasks
             public string ManifestName => Workload.GetMetadata("ManifestName");
             public string Version => Workload.GetMetadata("Version");
             public string TargetPath => Target.GetMetadata("InstallPath");
+            public string StampPath => Target.GetMetadata("StampPath");
             public bool IgnoreErrors => Workload.GetMetadata("IgnoreErrors").ToLowerInvariant() == "true";
             public string WorkloadId => Workload.ItemSpec;
 

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
@@ -21,7 +21,7 @@ namespace Wasm.Build.Tests
             _enablePerTestCleanup = true;
         }
 
-        [Theory]
+        [Theory, TestCategory("no-workload")]
         [InlineData("Debug")]
         [InlineData("Release")]
         public void DefaultTemplate_WithoutWorkload(string config)

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildEnvironment.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildEnvironment.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 #nullable enable
@@ -25,6 +24,7 @@ namespace Wasm.Build.Tests
         public string                           LogRootPath                   { get; init; }
 
         public string                           WorkloadPacksDir              { get; init; }
+        public string                           BuiltNuGetsPath               { get; init; }
 
         public static readonly string           RelativeTestAssetsPath = @"..\testassets\";
         public static readonly string           TestAssetsPath = Path.Combine(AppContext.BaseDirectory, "testassets");
@@ -98,6 +98,11 @@ namespace Wasm.Build.Tests
                 DirectoryBuildPropsContents = s_directoryBuildPropsForLocal;
                 DirectoryBuildTargetsContents = s_directoryBuildTargetsForLocal;
             }
+
+            if (EnvironmentVariables.BuiltNuGetsPath is null || !Directory.Exists(EnvironmentVariables.BuiltNuGetsPath))
+                throw new Exception($"Cannot find 'BUILT_NUGETS_PATH={EnvironmentVariables.BuiltNuGetsPath}'");
+
+            BuiltNuGetsPath = EnvironmentVariables.BuiltNuGetsPath;
 
             // `runtime` repo's build environment sets these, and they
             // mess up the build for the test project, which is using a different

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -41,6 +41,7 @@ namespace Wasm.Build.Tests
         protected static int s_defaultPerTestTimeoutMs = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 30*60*1000 : 15*60*1000;
         protected static BuildEnvironment s_buildEnv;
         private const string s_runtimePackPathPattern = "\\*\\* MicrosoftNetCoreAppRuntimePackDir : ([^ ]*)";
+        private const string s_nugetInsertionTag = "<!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->";
         private static Regex s_runtimePackPathRegex;
         private static int s_testCounter;
         private readonly int _testIdx;
@@ -410,9 +411,22 @@ namespace Wasm.Build.Tests
             Directory.CreateDirectory(_projectDir);
             Directory.CreateDirectory(Path.Combine(_projectDir, ".nuget"));
 
-            File.Copy(Path.Combine(BuildEnvironment.TestDataPath, NuGetConfigFileNameForDefaultFramework), Path.Combine(_projectDir, "nuget.config"));
+            File.WriteAllText(Path.Combine(_projectDir, "nuget.config"),
+                                GetNuGetConfigWithLocalPackagesPath(
+                                            Path.Combine(BuildEnvironment.TestDataPath, NuGetConfigFileNameForDefaultFramework),
+                                            s_buildEnv.BuiltNuGetsPath));
+
             File.Copy(Path.Combine(BuildEnvironment.TestDataPath, "Blazor.Directory.Build.props"), Path.Combine(_projectDir, "Directory.Build.props"));
             File.Copy(Path.Combine(BuildEnvironment.TestDataPath, "Blazor.Directory.Build.targets"), Path.Combine(_projectDir, "Directory.Build.targets"));
+        }
+
+        private static string GetNuGetConfigWithLocalPackagesPath(string templatePath, string localNuGetsPath)
+        {
+            string contents = File.ReadAllText(templatePath);
+            if (contents.IndexOf(s_nugetInsertionTag, StringComparison.InvariantCultureIgnoreCase) < 0)
+                throw new Exception($"Could not find {s_nugetInsertionTag} in {templatePath}");
+
+            return contents.Replace(s_nugetInsertionTag, $@"<add key=""nuget-local"" value=""{localNuGetsPath}"" />");
         }
 
         public string CreateWasmTemplateProject(string id, string template = "wasmbrowser")

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -214,6 +214,16 @@ namespace Wasm.Build.Tests
             args.Append($" --expected-exit-code={expectedAppExitCode}");
             args.Append($" {extraXHarnessArgs ?? string.Empty}");
 
+            if (File.Exists("/.dockerenv"))
+                args.Append(" --browser-arg=--no-sandbox");
+
+            if (!string.IsNullOrEmpty(EnvironmentVariables.BrowserPathForTests))
+            {
+                if (!File.Exists(EnvironmentVariables.BrowserPathForTests))
+                    throw new Exception($"Cannot find BROWSER_PATH_FOR_TESTS={EnvironmentVariables.BrowserPathForTests}");
+                args.Append($" --browser-path=\"{EnvironmentVariables.BrowserPathForTests}\"");
+            }
+
             args.Append(" -- ");
             if (extraXHarnessMonoArgs != null)
             {
@@ -326,7 +336,8 @@ namespace Wasm.Build.Tests
             {
                 _testOutput.WriteLine ($"Using existing build found at {product.ProjectDir}, with build log at {product.LogFile}");
 
-                Assert.True(product.Result, $"Found existing build at {product.ProjectDir}, but it had failed. Check build log at {product.LogFile}");
+                if (!product.Result)
+                    throw new XunitException($"Found existing build at {product.ProjectDir}, but it had failed. Check build log at {product.LogFile}");
                 _projectDir = product.ProjectDir;
 
                 // use this test's id for the run logs
@@ -359,7 +370,6 @@ namespace Wasm.Build.Tests
             string logFileSuffix = options.Label == null ? string.Empty : options.Label.Replace(' ', '_');
             string logFilePath = Path.Combine(_logPath, $"{buildArgs.ProjectName}{logFileSuffix}.binlog");
             _testOutput.WriteLine($"-------- Building ---------");
-            _testOutput.WriteLine($"Binlog path: {logFilePath}");
             _testOutput.WriteLine($"Binlog path: {logFilePath}");
             sb.Append($" /bl:\"{logFilePath}\" /nologo");
             sb.Append($" /v:{options.Verbosity ?? "minimal"}");
@@ -650,10 +660,10 @@ namespace Wasm.Build.Tests
         protected (int exitCode, string buildOutput) AssertBuild(string args, string label="build", bool expectSuccess=true, IDictionary<string, string>? envVars=null, int? timeoutMs=null)
         {
             var result = RunProcess(s_buildEnv.DotNet, _testOutput, args, workingDir: _projectDir, label: label, envVars: envVars, timeoutMs: timeoutMs ?? s_defaultPerTestTimeoutMs);
-            if (expectSuccess)
-                Assert.True(0 == result.exitCode, $"Build process exited with non-zero exit code: {result.exitCode}");
-            else
-                Assert.True(0 != result.exitCode, $"Build should have failed, but it didn't. Process exited with exitCode : {result.exitCode}");
+            if (expectSuccess && result.exitCode != 0)
+                throw new XunitException($"Build process exited with non-zero exit code: {result.exitCode}");
+            if (!expectSuccess && result.exitCode == 0)
+                throw new XunitException($"Build should have failed, but it didn't. Process exited with exitCode : {result.exitCode}");
 
             return result;
         }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/EnvironmentVariables.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/EnvironmentVariables.cs
@@ -16,5 +16,6 @@ namespace Wasm.Build.Tests
         internal static readonly string? TestLogPath               = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
         internal static readonly string? SkipProjectCleanup        = Environment.GetEnvironmentVariable("SKIP_PROJECT_CLEANUP");
         internal static readonly string? XHarnessCliPath           = Environment.GetEnvironmentVariable("XHARNESS_CLI_PATH");
+        internal static readonly string? BuiltNuGetsPath           = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
     }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/EnvironmentVariables.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/EnvironmentVariables.cs
@@ -17,5 +17,6 @@ namespace Wasm.Build.Tests
         internal static readonly string? SkipProjectCleanup        = Environment.GetEnvironmentVariable("SKIP_PROJECT_CLEANUP");
         internal static readonly string? XHarnessCliPath           = Environment.GetEnvironmentVariable("XHARNESS_CLI_PATH");
         internal static readonly string? BuiltNuGetsPath           = Environment.GetEnvironmentVariable("BUILT_NUGETS_PATH");
+        internal static readonly string? BrowserPathForTests       = Environment.GetEnvironmentVariable("BROWSER_PATH_FOR_TESTS");
     }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -56,7 +56,7 @@
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="chmod +x $HELIX_WORKITEM_ROOT/.playwright/node/linux/node" />
     </ItemGroup>
 
-    <PropertyGroup Condition="'$(Scenario)' == 'BuildWasmApps'">
+    <PropertyGroup>
       <_XUnitTraitArg Condition="'$(TestUsingWorkloads)' == 'true'">-notrait category=no-workload</_XUnitTraitArg>
       <_XUnitTraitArg Condition="'$(TestUsingWorkloads)' != 'true'">-trait category=no-workload</_XUnitTraitArg>
     </PropertyGroup>
@@ -69,6 +69,9 @@
 
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export BASE_DIR=$(ArtifactsBinDir)" />
       <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set BASE_DIR=$(ArtifactsBinDir)" />
+
+      <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export BUILT_NUGETS_PATH=$(LibrariesShippingPackagesDir)/" />
+      <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set BUILT_NUGETS_PATH=$(LibrariesShippingPackagesDir)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/data/Blazor.Directory.Build.targets
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/data/Blazor.Directory.Build.targets
@@ -3,7 +3,26 @@
       <EmscriptenEnvVars Include="FROZEN_CACHE=" Condition="'$(OS)' == 'Windows_NT'" />
   </ItemGroup>
 
-  <Target Name="PrintRuntimePackPath" BeforeTargets="Publish">
+  <Target Name="PrintRuntimePackPath" AfterTargets="ResolveFrameworkReferences" Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
+    <Error Text="Expected to find a ResolvedRuntimePack item, but found none."
+           Condition="@(ResolvedRuntimePack -> Count()) == 0" />
+
+    <Error Text="Missing PackageDirectory metadata on ResolvedRuntimePack: @(ResolvedRuntimePack -> '%(Identity), %(NugetPackageId), %(NuGetPackageVersion), %(NuGetPackageDirectory)')"
+           Condition="'%(ResolvedRuntimePack.PackageDirectory)' == ''" />
     <Message Text="** MicrosoftNetCoreAppRuntimePackDir : %(ResolvedRuntimePack.PackageDirectory)" Importance="High" />
+
+    <Error Text="Missing NuGetPackageVersion metadata on ResolvedRuntimePack: @(ResolvedRuntimePack -> '%(Identity), %(NugetPackageId), %(NuGetPackageVersion), %(NuGetPackageDirectory)')"
+           Condition="'%(ResolvedRuntimePack.NuGetPackageVersion)' == ''" />
+    <Message Text="** ResolvedRuntimePack Version : %(ResolvedRuntimePack.NuGetPackageVersion)" Importance="High" />
+
+    <!-- Using internal properties for the version here. This will be fixed when net6-on-7 workload testing
+         changes land -->
+    <Error Condition="$([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '7.0')) and
+                      '%(ResolvedRuntimePack.NuGetPackageVersion)' != $(_RuntimePackInWorkloadVersion7)"
+           Text="Expected Runtime pack version = '$(_RuntimePackInWorkloadVersion7)', but got '%(ResolvedRuntimePack.NuGetPackageVersion)'" />
+
+    <Error Condition="$([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '6.0')) and
+                      '%(ResolvedRuntimePack.NuGetPackageVersion)' != $(_RuntimePackInWorkloadVersion6)"
+           Text="Expected Runtime pack version = '$(_RuntimePackInWorkloadVersion6)', but got '%(ResolvedRuntimePack.NuGetPackageVersion)'" />
   </Target>
 </Project>

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/data/nuget7.config
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/data/nuget7.config
@@ -7,6 +7,7 @@
   </fallbackPackageFolders>
   <packageSources>
     <clear />
+    <!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="nuget.org"  value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>


### PR DESCRIPTION
`WorkloadManifest.targets` had the runtime pack version update conditioned on the workload being installed, which meant that the original version from the sdk was used if no workload was installed, ignoring the version from the manifest.
- And update tests for this.