### PR TITLE
Change LibrariesConfiguration defaults in tests

### DIFF
--- a/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+++ b/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
@@ -17,7 +17,7 @@ steps:
 
   # Build coreclr native test output
   - ${{ if eq(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build.cmd nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} -p:BuildNativeAotFrameworkObjects=true -p:LibrariesConfiguration=${{ parameters.libsConfig }}
+    - script: $(Build.SourcesDirectory)/src/tests/build.cmd nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} /p:BuildNativeAotFrameworkObjects=true /p:LibrariesConfiguration=${{ parameters.libsConfig }}
       displayName: Build tests
   - ${{ if ne(parameters.osGroup, 'windows') }}:
     - script: $(Build.SourcesDirectory)/src/tests/build.sh nativeaot $(buildConfigUpper) ${{ parameters.archType }} '${{ parameters.testFilter }}' -p:LibrariesConfiguration=${{ parameters.libsConfig }}
@@ -25,7 +25,7 @@ steps:
 
   - ${{ if eq(parameters.runSingleFileTests, true) }}:
     - ${{ if eq(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/tests/run.cmd runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} -p:LibrariesConfiguration=${{ parameters.libsConfig }}
+      - script: $(Build.SourcesDirectory)/src/tests/run.cmd runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} /p:LibrariesConfiguration=${{ parameters.libsConfig }}
         displayName: Run tests in single file mode
     - ${{ if ne(parameters.osGroup, 'windows') }}:
       - script: $(Build.SourcesDirectory)/src/tests/run.sh --runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} -p:LibrariesConfiguration=${{ parameters.libsConfig }}

--- a/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+++ b/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
@@ -5,6 +5,7 @@ parameters:
   osSubgroup: ''
   platform: ''
   pgoType: ''
+  libsConfig: ''
   runtimeVariant: ''
   uploadTests: false
   testFilter: tree nativeaot
@@ -16,16 +17,16 @@ steps:
 
   # Build coreclr native test output
   - ${{ if eq(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build.cmd nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} /p:BuildNativeAotFrameworkObjects=true
+    - script: $(Build.SourcesDirectory)/src/tests/build.cmd nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} -p:BuildNativeAotFrameworkObjects=true -p:LibrariesConfiguration=${{ parameters.libsConfig }}
       displayName: Build tests
   - ${{ if ne(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build.sh nativeaot $(buildConfigUpper) ${{ parameters.archType }} '${{ parameters.testFilter }}'
+    - script: $(Build.SourcesDirectory)/src/tests/build.sh nativeaot $(buildConfigUpper) ${{ parameters.archType }} '${{ parameters.testFilter }}' -p:LibrariesConfiguration=${{ parameters.libsConfig }}
       displayName: Build tests
 
   - ${{ if eq(parameters.runSingleFileTests, true) }}:
     - ${{ if eq(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/tests/run.cmd runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}
+      - script: $(Build.SourcesDirectory)/src/tests/run.cmd runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} -p:LibrariesConfiguration=${{ parameters.libsConfig }}
         displayName: Run tests in single file mode
     - ${{ if ne(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/tests/run.sh --runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}
+      - script: $(Build.SourcesDirectory)/src/tests/run.sh --runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} -p:LibrariesConfiguration=${{ parameters.libsConfig }}
         displayName: Run tests in single file mode

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -199,6 +199,8 @@ jobs:
       nameSuffix: NativeAOT
       buildArgs: -s clr.aot+libs -rc $(_BuildConfig) -lc Release
       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      extraStepsParameters:
+        libsConfig: Release
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -221,6 +223,8 @@ jobs:
       nameSuffix: NativeAOT
       buildArgs: -s clr.aot+libs -rc $(_BuildConfig) -lc Release
       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      extraStepsParameters:
+        libsConfig: Release
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -245,6 +249,8 @@ jobs:
       nameSuffix: NativeAOT
       buildArgs: -s clr.aot+libs -rc $(_BuildConfig) -lc Release
       extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+      extraStepsParameters:
+        libsConfig: Release
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <LibrariesConfiguration>Release</LibrariesConfiguration>
+    <LibrariesConfiguration Condition="'$(LibrariesConfiguration)' == ''">$(Configuration)</LibrariesConfiguration>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\Common\dir.sdkbuild.props" Condition="'$(UsingMicrosoftNETSdk)' == 'true'"  />


### PR DESCRIPTION
We can pass `-p:LibrariesConfiguration=` to set library configuration of our choice, but setting default to `$(Configuration)` is better; same as: https://github.com/dotnet/runtime/blob/01251a8eed36a144d33e19c8bd96ac39b67204f2/Directory.Build.props#L131

e.g.
```
$ ./build.sh
$ src/tests/build.sh -nativeaot -tree:nativeaot
````
fails without explicitly specifying `-p:LibrariesConfiguration=Debug`.