### PR TITLE
Ensure regions will always have enough memory for the bookkeeping

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -4092,6 +4092,12 @@ public:
     size_t heap_hard_limit_oh[total_oh_count];
 
     PER_HEAP_ISOLATED
+    size_t heap_hard_limit_for_heap;
+
+    PER_HEAP_ISOLATED
+    size_t heap_hard_limit_for_bookkeeping;
+
+    PER_HEAP_ISOLATED
     CLRCriticalSection check_commit_cs;
 
     PER_HEAP_ISOLATED


### PR DESCRIPTION
This PR fixes #74401 in the case that the `virtual_commit` for the mark array in `init_table_for_region` failed because of `heap_hard_limit` (or the implicit `heap_hard_limit` because we are running under a small container).

> This does not fix the case where the commit for the mark array is failing because we are running out of physical memory, and there is no equivalent trick that we could use for that case.