### PR TITLE
Fix W^X flag for setting `ITypeInfo`

### DIFF
--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -3852,7 +3852,7 @@ void ComMethodTable::SetITypeInfo(ITypeInfo *pNew)
     CONTRACTL_END;
 
     ExecutableWriterHolder<ComMethodTable> comMTWriterHolder(this, sizeof(ComMethodTable));
-    if (InterlockedCompareExchangeT(&m_pITypeInfo, pNew, NULL) == NULL)
+    if (InterlockedCompareExchangeT(&comMTWriterHolder.GetRW()->m_pITypeInfo, pNew, NULL) == NULL)
     {
         SafeAddRef(pNew);
     }

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -3851,6 +3851,7 @@ void ComMethodTable::SetITypeInfo(ITypeInfo *pNew)
     }
     CONTRACTL_END;
 
+    ExecutableWriterHolder<ComMethodTable> comMTWriterHolder(this, sizeof(ComMethodTable));
     if (InterlockedCompareExchangeT(&m_pITypeInfo, pNew, NULL) == NULL)
     {
         SafeAddRef(pNew);


### PR DESCRIPTION
Fixes #75035 

/cc @dotnet/interop-contrib @jkotas @janvorli 