### PR TITLE
[mono][wasm] Make OP_WASM_SIMD_SWIZZLE use the shufflevector LLVM ins…

### DIFF
--- a/src/mono/mono/mini/llvm-intrinsics.h
+++ b/src/mono/mono/mini/llvm-intrinsics.h
@@ -262,7 +262,6 @@ INTRINS_OVR(WASM_BITMASK_V8, wasm_bitmask, Wasm, sse_i1_t)
 INTRINS_OVR(WASM_BITMASK_V4, wasm_bitmask, Wasm, sse_i4_t)
 INTRINS_OVR(WASM_BITMASK_V2, wasm_bitmask, Wasm, sse_i8_t)
 INTRINS(WASM_SHUFFLE, wasm_shuffle, Wasm)
-INTRINS(WASM_SWIZZLE, wasm_swizzle, Wasm)
 #endif
 #if defined(TARGET_ARM64)
 INTRINS_OVR(BITREVERSE_I32, bitreverse, Generic, LLVMInt32Type ())

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -9719,7 +9719,6 @@ MONO_RESTORE_WARNING
 		case OP_WASM_SIMD_SWIZZLE: {
 			LLVMTypeRef etype = LLVMGetElementType (LLVMTypeOf (lhs));
 			int nelems = LLVMGetVectorSize (LLVMTypeOf (lhs));
-			g_assert (LLVMGetElementType (LLVMTypeOf (rhs)) == etype);
 			LLVMValueRef indexes [16];
 			for (int i = 0; i < nelems; ++i)
 				indexes [i] = LLVMBuildExtractElement (builder, rhs, const_int32 (i), "");

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -7713,6 +7713,14 @@ MONO_RESTORE_WARNING
 			default:
 				element_ix = const_int32 (ins->inst_c0);
 			}
+
+#ifdef TARGET_WASM
+			// LLVM seems to return an invalid result when the input is undef (i.e. the result of an invalid shufflevector for example)
+			if (LLVMIsUndef (lhs)) {
+				values [ins->dreg] = LLVMConstNull (LLVMGetElementType (LLVMTypeOf (lhs)));
+				break;
+			}
+#endif
 			LLVMTypeRef lhs_t = LLVMTypeOf (lhs);
 			int vec_width = mono_llvm_get_prim_size_bits (lhs_t);
 			int elem_width = mono_llvm_get_prim_size_bits (elt_t);
@@ -9717,7 +9725,6 @@ MONO_RESTORE_WARNING
 			break;
 		}
 		case OP_WASM_SIMD_SWIZZLE: {
-			LLVMTypeRef etype = LLVMGetElementType (LLVMTypeOf (lhs));
 			int nelems = LLVMGetVectorSize (LLVMTypeOf (lhs));
 			LLVMValueRef indexes [16];
 			for (int i = 0; i < nelems; ++i)

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -87,7 +87,7 @@
   <PropertyGroup>
     <WasmDedup Condition="'$(WasmDedup)' == ''">false</WasmDedup>
     <WasmExceptionHandling Condition="'$(WasmExceptionHandling)' == ''">false</WasmExceptionHandling>
-    <WasmSIMD Condition="'$(WasmSIMD)' == ''">false</WasmSIMD>
+    <WasmSIMD Condition="'$(WasmSIMD)' == ''">true</WasmSIMD>
 
     <!--<WasmStripAOTAssemblies Condition="'$(AOTMode)' == 'LLVMOnlyInterp'">false</WasmStripAOTAssemblies>-->
     <!--<WasmStripAOTAssemblies Condition="'$(WasmStripAOTAssemblies)' == ''">$(RunAOTCompilation)</WasmStripAOTAssemblies>-->

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -87,7 +87,7 @@
   <PropertyGroup>
     <WasmDedup Condition="'$(WasmDedup)' == ''">false</WasmDedup>
     <WasmExceptionHandling Condition="'$(WasmExceptionHandling)' == ''">false</WasmExceptionHandling>
-    <WasmSIMD Condition="'$(WasmSIMD)' == ''">true</WasmSIMD>
+    <WasmSIMD Condition="'$(WasmSIMD)' == ''">false</WasmSIMD>
 
     <!--<WasmStripAOTAssemblies Condition="'$(AOTMode)' == 'LLVMOnlyInterp'">false</WasmStripAOTAssemblies>-->
     <!--<WasmStripAOTAssemblies Condition="'$(WasmStripAOTAssemblies)' == ''">$(RunAOTCompilation)</WasmStripAOTAssemblies>-->


### PR DESCRIPTION
…truction.

The wasm.swizzle instrinsic always uses byte sized SIMD lanes, so it cannot represent
all the variants of Vector128.Shuffle ().