### PR TITLE
[release/7.0][wasm] Add CI job for AOT+SIMD to `runtime-wasm` for PRs

### DIFF
--- a/eng/pipelines/runtime-wasm-features.yml
+++ b/eng/pipelines/runtime-wasm-features.yml
@@ -1,0 +1,27 @@
+# This pipeline is meant to be run manually. It contains
+# jobs that exercise extra/optional features for wasm, eg. SIMD
+
+trigger: none
+
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
+jobs:
+
+# Evaluate paths
+- template: /eng/pipelines/common/evaluate-default-paths.yml
+
+# Run AOT tests with SIMD enabled
+- template: /eng/pipelines/common/templates/wasm-library-tests.yml
+  parameters:
+    platforms:
+      - Browser_wasm
+    nameSuffix: _SIMD_AOT
+    isExtraPlatformsBuild: false
+    isWasmOnlyBuild: true
+    extraBuildArgs: /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=true /p:RunAOTCompilation=true
+    extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true /p:WasmEnableSIMD=true
+    runSmokeOnlyArg: ''
+    alwaysRun: true
+    scenarios:
+      - WasmTestOnNodeJS

--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -32,5 +32,9 @@ jobs:
     extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true /p:WasmEnableSIMD=true
     runSmokeOnlyArg: ''
     alwaysRun: true
+    # failures due to
+    #   https://github.com/dotnet/runtime/issues/75044
+    #   and https://github.com/dotnet/runtime/issues/75098
+    shouldContinueOnError: true
     scenarios:
       - WasmTestOnNodeJS

--- a/eng/pipelines/runtime-wasm.yml
+++ b/eng/pipelines/runtime-wasm.yml
@@ -19,3 +19,18 @@ jobs:
   parameters:
     isWasmOnlyBuild: ${{ variables.isWasmOnlyBuild }}
     isRollingBuild: ${{ variables.isRollingBuild }}
+
+# Run AOT tests with SIMD enabled
+- template: /eng/pipelines/common/templates/wasm-library-tests.yml
+  parameters:
+    platforms:
+      - Browser_wasm
+    nameSuffix: _SIMD_AOT
+    isExtraPlatformsBuild: false
+    isWasmOnlyBuild: true
+    extraBuildArgs: /p:EnableAggressiveTrimming=true /p:BuildAOTTestsOnHelix=true /p:RunAOTCompilation=true
+    extraHelixArgs: /p:NeedsToBuildWasmAppsOnHelix=true /p:WasmEnableSIMD=true
+    runSmokeOnlyArg: ''
+    alwaysRun: true
+    scenarios:
+      - WasmTestOnNodeJS

--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -105,6 +105,8 @@
     <_AOTBuildCommand Condition="'$(ContinuousIntegrationBuild)' != 'true'">$(_AOTBuildCommand) /p:RuntimeSrcDir=$(RepoRoot) /p:RuntimeConfig=$(Configuration)</_AOTBuildCommand>
 
     <_AOTBuildCommand>$(_AOTBuildCommand) /p:RunAOTCompilation=$(RunAOTCompilation)</_AOTBuildCommand>
+    <_AOTBuildCommand Condition="'$(BrowserHost)' == 'windows'">$(_AOTBuildCommand) %AOT_BUILD_ARGS%</_AOTBuildCommand>
+    <_AOTBuildCommand Condition="'$(BrowserHost)' != 'windows'">$(_AOTBuildCommand) %24AOT_BUILD_ARGS</_AOTBuildCommand>
     <_AOTBuildCommand>$(_AOTBuildCommand) $(_ShellCommandSeparator) cd wasm_build/AppBundle</_AOTBuildCommand>
 
     <RunScriptCommand Condition="'$(RunScriptCommand)' == ''">$(_AOTBuildCommand)</RunScriptCommand>

--- a/src/libraries/System.Runtime.Intrinsics/tests/System.Runtime.Intrinsics.Tests.csproj
+++ b/src/libraries/System.Runtime.Intrinsics/tests/System.Runtime.Intrinsics.Tests.csproj
@@ -7,6 +7,10 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <!-- Disable nullability public only feature for NullabilityInfoContextTests -->
     <Features>$(Features.Replace('nullablePublicOnly', '')</Features>
+
+    <HelixTargetsFile Condition="'$(TargetOS)' == 'Browser'">wasm.helix.targets</HelixTargetsFile>
+    <WasmXHarnessArgs Condition="'$(WasmEnableSIMD)' == 'true' and '$(Scenario)' == 'WasmTestOnNodeJs' and
+                        '$(ContinuousIntegrationBuild)' != 'true'">$(WasmXHarnessArgs) --engine-arg=--experimental-wasm-simd</WasmXHarnessArgs>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Vectors\Vector128Tests.cs" />

--- a/src/libraries/System.Runtime.Intrinsics/tests/wasm.helix.targets
+++ b/src/libraries/System.Runtime.Intrinsics/tests/wasm.helix.targets
@@ -1,0 +1,47 @@
+<Project>
+  <PropertyGroup Condition="'$(IsRunningLibraryTests)' == 'true'">
+    <HelixExtensionTargets>$(HelixExtensionTargets);_AddHelixRuntimeIntrinsicsItems</HelixExtensionTargets>
+    <_RuntimeIntrinsicsProjectName>System.Runtime.Intrinsics.Tests</_RuntimeIntrinsicsProjectName>
+  </PropertyGroup>
+
+  <!-- Only add simd/non-simd jobs for nodejs -->
+  <Target Name="_AddHelixRuntimeIntrinsicsItems"
+          Condition="'$(NeedsToBuildWasmAppsOnHelix)' == 'true' and ('$(Scenario)' == 'WasmTestOnNodeJs' or '$(Scenario)' == 'WasmTestOnBrowser')">
+
+    <PropertyGroup Condition="'$(Scenario)' == 'WasmTestOnNodeJs'">
+      <_AOTBuildArgsSIMD Condition="'$(OS)' != 'Windows_NT'">export &quot;WasmXHarnessArgs=$WasmXHarnessArgs --engine-arg=--experimental-wasm-simd&quot;</_AOTBuildArgsSIMD>
+      <_AOTBuildArgsSIMD Condition="'$(OS)' == 'Windows_NT'">set &quot;WasmXHarnessArgs=%WasmXHarnessArgs% --engine-arg=--experimental-wasm-simd&quot;</_AOTBuildArgsSIMD>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <_AOTBuildArgsSIMD Condition="'$(OS)' != 'Windows_NT'">$(_AOTBuildArgsSIMD) &quot;AOT_BUILD_ARGS=-p:WasmEnableSIMD=true&quot;</_AOTBuildArgsSIMD>
+      <_AOTBuildArgsSIMD Condition="'$(OS)' == 'Windows_NT'">$(_AOTBuildArgsSIMD) &quot;AOT_BUILD_ARGS=-p:WasmEnableSIMD=true&quot;</_AOTBuildArgsSIMD>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- remove the existing item -->
+      <HelixWorkItem Remove="@(HelixWorkItem)" Condition="'%(HelixWorkItem.Identity)' == '$(Scenario)-$(_RuntimeIntrinsicsProjectName)'" />
+
+      <HelixWorkItem Include="$(WorkItemPrefix)non-simd-$(_RuntimeIntrinsicsProjectName)">
+        <PayloadArchive>$(TestArchiveTestsDir)$(_RuntimeIntrinsicsProjectName).zip</PayloadArchive>
+        <Command>$(HelixCommand)</Command>
+        <Timeout>$(_workItemTimeout)</Timeout>
+      </HelixWorkItem>
+
+      <HelixWorkItem Include="$(WorkItemPrefix)simd-$(_RuntimeIntrinsicsProjectName)">
+        <PayloadArchive>$(TestArchiveTestsDir)$(_RuntimeIntrinsicsProjectName).zip</PayloadArchive>
+        <Command>$(HelixCommand)</Command>
+        <Timeout>$(_workItemTimeout)</Timeout>
+
+        <PreCommands>$(_AOTBuildArgsSIMD)</PreCommands>
+      </HelixWorkItem>
+
+      <_RuntimeIntrinsicsHelixItem
+                Include="@(HelixWorkItem)"
+                Condition="$([System.String]::new('%(HelixWorkItem.Identity)').EndsWith('-$(_RuntimeIntrinsicsProjectName)'))" />
+    </ItemGroup>
+
+    <Error Text="Something went wrong. Expected to have only two work items for $(_RuntimeIntrinsicsProjectName). But got @(_RuntimeIntrinsicsHelixItem)"
+           Condition="@(_RuntimeIntrinsicsHelixItem->Count()) != 2" />
+  </Target>
+</Project>

--- a/src/libraries/System.Runtime.Intrinsics/tests/wasm.helix.targets
+++ b/src/libraries/System.Runtime.Intrinsics/tests/wasm.helix.targets
@@ -9,13 +9,15 @@
           Condition="'$(NeedsToBuildWasmAppsOnHelix)' == 'true' and ('$(Scenario)' == 'WasmTestOnNodeJs' or '$(Scenario)' == 'WasmTestOnBrowser')">
 
     <PropertyGroup Condition="'$(Scenario)' == 'WasmTestOnNodeJs'">
-      <_AOTBuildArgsSIMD Condition="'$(OS)' != 'Windows_NT'">export &quot;WasmXHarnessArgs=$WasmXHarnessArgs --engine-arg=--experimental-wasm-simd&quot;</_AOTBuildArgsSIMD>
-      <_AOTBuildArgsSIMD Condition="'$(OS)' == 'Windows_NT'">set &quot;WasmXHarnessArgs=%WasmXHarnessArgs% --engine-arg=--experimental-wasm-simd&quot;</_AOTBuildArgsSIMD>
+      <_AOTBuildArgsSIMD Condition="'$(OS)' != 'Windows_NT'">&quot;WasmXHarnessArgs=$WasmXHarnessArgs --engine-arg=--experimental-wasm-simd&quot;</_AOTBuildArgsSIMD>
+      <_AOTBuildArgsSIMD Condition="'$(OS)' == 'Windows_NT'">&quot;WasmXHarnessArgs=%WasmXHarnessArgs% --engine-arg=--experimental-wasm-simd&quot;</_AOTBuildArgsSIMD>
     </PropertyGroup>
 
     <PropertyGroup>
       <_AOTBuildArgsSIMD Condition="'$(OS)' != 'Windows_NT'">$(_AOTBuildArgsSIMD) &quot;AOT_BUILD_ARGS=-p:WasmEnableSIMD=true&quot;</_AOTBuildArgsSIMD>
-      <_AOTBuildArgsSIMD Condition="'$(OS)' == 'Windows_NT'">$(_AOTBuildArgsSIMD) &quot;AOT_BUILD_ARGS=-p:WasmEnableSIMD=true&quot;</_AOTBuildArgsSIMD>
+
+      <_AOTBuildArgsSIMD Condition="'$(OS)' != 'Windows_NT'">export $(_AOTBuildArgsSIMD)</_AOTBuildArgsSIMD>
+      <_AOTBuildArgsSIMD Condition="'$(OS)' == 'Windows_NT'">set $(_AOTBuildArgsSIMD)</_AOTBuildArgsSIMD>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/libraries/sendtohelix-wasm.targets
+++ b/src/libraries/sendtohelix-wasm.targets
@@ -305,7 +305,9 @@
       <_EmSdkFiles Include="$(EMSDK_PATH)\**\*" Exclude="$(EMSDK_PATH)\.git\**\*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(_EmSdkFiles)" DestinationFolder="$(EmSdkDirForHelixPayload)\%(RecursiveDir)" />
+    <Copy SourceFiles="@(_EmSdkFiles)"
+          DestinationFiles="@(_EmSdkFiles -> '$(EmSdkDirForHelixPayload)\%(RecursiveDir)%(FileName)%(Extension)')"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="DownloadFirefoxToSendToHelix" Condition="!Exists($(FirefoxForHelixPayload)) and '$(DebuggerHost)' == 'firefox'">

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -19,6 +19,7 @@
     <TestPackages Condition="'$(TestPackages)' == ''">false</TestPackages>
     <TestTrimming Condition="'$(TestTrimming)' == ''">false</TestTrimming>
 
+    <RunWasmSIMDSmokeTests Condition="'$(TargetOS)' == 'browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(ContinuousIntegrationBuild)' == 'true'">true</RunWasmSIMDSmokeTests>
     <RunHighAOTResourceRequiringTestsOnly Condition="'$(RunHighAOTResourceRequiringTestsOnly)' == ''">false</RunHighAOTResourceRequiringTestsOnly>
 
     <!-- Don't build samples, and functional tests on EAT, AOT, WBT, and Debugger lanes -->
@@ -545,7 +546,12 @@
   </ItemGroup>
 
   <ItemGroup>
-     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+    <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
+
+    <!-- Test SIMD too -->
+    <SmokeTestProject
+        Condition="'$(RunWasmSIMDSmokeTests)' == 'true'"
+        Include="$(MSBuildThisFileDirectory)System.Runtime.Intrinsics\tests\System.Runtime.Intrinsics.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestNativeAot)' == 'true'">


### PR DESCRIPTION
- Adds a job to `runtime-wasm` that runs all the AOT tests with SIMD enabled
- Also, add two `System.Runtime.Intrinsics` runs on helix with, and without simd
   - And run this with smoke tests too
- And add a `runtime-wasm-features` pipeline yml with the AOT+SIMD job. This isn't usable right now because we can't add new pipelines.