### PR TITLE
Replace assert with BADCODE

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -15254,7 +15254,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             }
                             if (objType == nullptr)
                             {
-                                BADCODE3("top of stack must be a value type");
+                                BADCODE("top of stack must be a value type");
                             }
                             obj = impGetStructAddr(obj, objType, CHECK_SPILL_ALL, true);
                         }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -15248,8 +15248,14 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         // for the field to operate on the address of the struct.
                         if (varTypeIsStruct(obj))
                         {
-                            assert(opcode == CEE_LDFLD && objType != nullptr);
-
+                            if (opcode != CEE_LDFLD)
+                            {
+                                BADCODE3("Unexpected opcode (has to be LDFLD)", ": %02X", (int)opcode);
+                            }
+                            if (objType == nullptr)
+                            {
+                                BADCODE3("top of stack must be a value type");
+                            }
                             obj = impGetStructAddr(obj, objType, CHECK_SPILL_ALL, true);
                         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/74593

The test does:
```
.method public hidebysig instance int32& LocalStructFieldByRef_Invalid_ReturnPtrToStack(valuetype Struct s) cil managed
{
    ldarg.1
    ldflda      int32 Struct::instanceField
    ret
}
```