### PR TITLE
Refine json comment position for Utf8JsonWriter; Make WriteCommentValue() overloads have same behavior

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
@@ -36,6 +36,7 @@ namespace System.Text.Json
 
                 _currentDepth &= JsonConstants.RemoveFlagsBitMask;
                 _tokenType = JsonTokenType.PropertyName;
+                _commentAfterNoneOrPropertyName = false;
             }
         }
 
@@ -47,6 +48,7 @@ namespace System.Text.Json
 
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _tokenType = JsonTokenType.PropertyName;
+            _commentAfterNoneOrPropertyName = false;
         }
 
         /// <summary>
@@ -105,6 +107,7 @@ namespace System.Text.Json
             }
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _tokenType = JsonTokenType.PropertyName;
+            _commentAfterNoneOrPropertyName = false;
         }
 
         private void WriteStringEscapeProperty(scoped ReadOnlySpan<char> propertyName, int firstEscapeIndexProp)
@@ -253,6 +256,7 @@ namespace System.Text.Json
             }
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _tokenType = JsonTokenType.PropertyName;
+            _commentAfterNoneOrPropertyName = false;
         }
 
         private void WritePropertyNameUnescaped(ReadOnlySpan<byte> utf8PropertyName)
@@ -262,6 +266,7 @@ namespace System.Text.Json
 
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _tokenType = JsonTokenType.PropertyName;
+            _commentAfterNoneOrPropertyName = false;
         }
 
         private void WriteStringEscapeProperty(scoped ReadOnlySpan<byte> utf8PropertyName, int firstEscapeIndexProp)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Comment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Comment.cs
@@ -53,6 +53,10 @@ namespace System.Text.Json
             }
 
             WriteCommentByOptions(value);
+            if (_tokenType is JsonTokenType.PropertyName or JsonTokenType.None)
+            {
+                _commentAfterNoneOrPropertyName = true;
+            }
         }
 
         private void WriteCommentByOptions(ReadOnlySpan<char> value)
@@ -116,13 +120,12 @@ namespace System.Text.Json
 
             Span<byte> output = _memory.Span;
 
-            if (_tokenType != JsonTokenType.None)
+            if (_tokenType != JsonTokenType.None || _commentAfterNoneOrPropertyName)
             {
                 WriteNewLine(output);
+                JsonWriterHelper.WriteIndentation(output.Slice(BytesPending), indent);
+                BytesPending += indent;
             }
-
-            JsonWriterHelper.WriteIndentation(output.Slice(BytesPending), indent);
-            BytesPending += indent;
 
             output[BytesPending++] = JsonConstants.Slash;
             output[BytesPending++] = JsonConstants.Asterisk;
@@ -165,6 +168,10 @@ namespace System.Text.Json
             }
 
             WriteCommentByOptions(utf8Value);
+            if (_tokenType is JsonTokenType.PropertyName or JsonTokenType.None)
+            {
+                _commentAfterNoneOrPropertyName = true;
+            }
         }
 
         private void WriteCommentByOptions(ReadOnlySpan<byte> utf8Value)
@@ -219,12 +226,10 @@ namespace System.Text.Json
 
             Span<byte> output = _memory.Span;
 
-            if (_tokenType != JsonTokenType.PropertyName)
+            if (_tokenType != JsonTokenType.None || _commentAfterNoneOrPropertyName)
             {
-                if (_tokenType != JsonTokenType.None)
-                {
-                    WriteNewLine(output);
-                }
+                WriteNewLine(output);
+
                 JsonWriterHelper.WriteIndentation(output.Slice(BytesPending), indent);
                 BytesPending += indent;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -47,6 +47,7 @@ namespace System.Text.Json
         private Memory<byte> _memory;
 
         private bool _inObject;
+        private bool _commentAfterNoneOrPropertyName;
         private JsonTokenType _tokenType;
         private BitStack _bitStack;
 
@@ -261,6 +262,7 @@ namespace System.Text.Json
 
             _inObject = default;
             _tokenType = default;
+            _commentAfterNoneOrPropertyName = default;
             _currentDepth = default;
 
             _bitStack = default;
@@ -568,12 +570,9 @@ namespace System.Text.Json
                 output[BytesPending++] = JsonConstants.ListSeparator;
             }
 
-            if (_tokenType != JsonTokenType.PropertyName)
+            if (_tokenType is not JsonTokenType.PropertyName and not JsonTokenType.None || _commentAfterNoneOrPropertyName)
             {
-                if (_tokenType != JsonTokenType.None)
-                {
-                    WriteNewLine(output);
-                }
+                WriteNewLine(output);
                 JsonWriterHelper.WriteIndentation(output.Slice(BytesPending), indent);
                 BytesPending += indent;
             }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
@@ -23,6 +23,46 @@ namespace System.Text.Json.Tests
         private const int MaxEscapedTokenSize = 1_000_000_000;   // Max size for already escaped value.
         private const int MaxUnescapedTokenSize = MaxEscapedTokenSize / MaxExpansionFactorWhileEscaping;  // 166_666_666 bytes
 
+        private const string ExpectedIndentedCommentJsonOfArray = """
+/*Comment at start of doc*/
+/*Multiple comment line*/
+[
+  /*Comment as first array item*/
+  /*Multiple comment line*/
+  []
+  /*Comment in the middle of array*/,
+  {}
+  /*Comment as the last array item*/
+]
+/*Comment at end of doc*/
+""";
+
+        private const string ExpectedNonIndentedCommentJsonOfArray = "/*Comment at start of doc*//*Multiple comment line*/[/*Comment as first array item*//*Multiple comment line*/[]/*Comment in the middle of array*/,{}/*Comment as the last array item*/]/*Comment at end of doc*/";
+
+        private const string ExpectedIndentedCommentJsonOfObject = """
+/*Comment at start of doc*/
+/*Multiple comment line*/
+{
+  /*Comment before first object property*/
+  /*Multiple comment line*/
+  "property1": 
+  /*Comment of string property value*/"stringValue",
+  "property2": 
+  /*Comment of object property value*/
+  {}
+  /*Comment in the middle of object*/,
+  "property3": 
+  /*Comment of array property value*/
+  []
+  /*Comment after the last property*/
+}
+/*Comment at end of doc*/
+""";
+
+        private const string ExpectedNonIndentedCommentJsonOfObject = """
+/*Comment at start of doc*//*Multiple comment line*/{/*Comment before first object property*//*Multiple comment line*/"property1":/*Comment of string property value*/"stringValue","property2":/*Comment of object property value*/{}/*Comment in the middle of object*/,"property3":/*Comment of array property value*/[]/*Comment after the last property*/}/*Comment at end of doc*/
+""";
+
         [Theory]
         [InlineData(true, true)]
         [InlineData(true, false)]
@@ -4065,9 +4105,9 @@ namespace System.Text.Json.Tests
         [InlineData(true, false, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
         [InlineData(false, true, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
         [InlineData(false, false, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
-        public void WriteComments(bool formatted, bool skipValidation, string comment)
+        public void WriteCommentsInArray(bool formatted, bool skipValidation, string comment)
         {
-            string expectedStr = GetCommentExpectedString(prettyPrint: formatted, comment);
+            string expectedStr = GetCommentInArrayExpectedString(prettyPrint: formatted, comment);
 
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
@@ -4076,6 +4116,7 @@ namespace System.Text.Json.Tests
                 var output = new ArrayBufferWriter<byte>(32);
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
+                WriteCommentValue(jsonUtf8, i, comment);
                 jsonUtf8.WriteStartArray();
 
                 for (int j = 0; j < 10; j++)
@@ -4098,7 +4139,74 @@ namespace System.Text.Json.Tests
 
                 WriteCommentValue(jsonUtf8, i, comment);
 
+                jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteEndArray();
+
+                WriteCommentValue(jsonUtf8, i, comment);
+
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteEndObject();
+
+                WriteCommentValue(jsonUtf8, i, comment);
+
+                jsonUtf8.WriteEndArray();
+
+                WriteCommentValue(jsonUtf8, i, comment);
+
+                jsonUtf8.Flush();
+
+                JsonTestHelper.AssertContents(expectedStr, output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true, "comment")]
+        [InlineData(true, false, "comment")]
+        [InlineData(false, true, "comment")]
+        [InlineData(false, false, "comment")]
+        [InlineData(true, true, "comm><ent")]
+        [InlineData(true, false, "comm><ent")]
+        [InlineData(false, true, "comm><ent")]
+        [InlineData(false, false, "comm><ent")]
+        [InlineData(true, true, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
+        [InlineData(true, false, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
+        [InlineData(false, true, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
+        [InlineData(false, false, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
+        public void WriteCommentsInObject(bool formatted, bool skipValidation, string comment)
+        {
+            string expectedStr = GetCommentInObjectExpectedString(prettyPrint: formatted, comment);
+
+            var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
+
+            for (int i = 0; i < 3; i++)
+            {
+                var output = new ArrayBufferWriter<byte>();
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+
+                WriteCommentValue(jsonUtf8, i, comment);
+
+                jsonUtf8.WriteStartObject();
+
+                WriteCommentValue(jsonUtf8, i, comment);
+
+                jsonUtf8.WritePropertyName("property1");
+                WriteCommentValue(jsonUtf8, i, comment);
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteEndArray();
+
+                WriteCommentValue(jsonUtf8, i, comment);
+
+                jsonUtf8.WritePropertyName("property2");
+                WriteCommentValue(jsonUtf8, i, comment);
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteEndObject();
+
+                WriteCommentValue(jsonUtf8, i, comment);
+
+                jsonUtf8.WriteEndObject();
+
+                WriteCommentValue(jsonUtf8, i, comment);
+
                 jsonUtf8.Flush();
 
                 JsonTestHelper.AssertContents(expectedStr, output);
@@ -4158,6 +4266,8 @@ namespace System.Text.Json.Tests
             var output = new ArrayBufferWriter<byte>(32);
             using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
+            jsonUtf8.WriteStartArray();
+
             string comment = "comment is * / valid";
             jsonUtf8.WriteCommentValue(comment);
             jsonUtf8.WriteCommentValue(comment.AsSpan());
@@ -4188,6 +4298,8 @@ namespace System.Text.Json.Tests
                 StringEscapeHandling = StringEscapeHandling.EscapeHtml,
             };
 
+            json.WriteStartArray();
+
             string comment = "comment is * / valid";
             json.WriteComment(comment);
             json.WriteComment(comment);
@@ -4205,6 +4317,92 @@ namespace System.Text.Json.Tests
             json.Flush();
 
             return Encoding.UTF8.GetString(ms.ToArray());
+        }
+
+        [Theory]
+        [InlineData(true, ExpectedIndentedCommentJsonOfArray)]
+        [InlineData(false, ExpectedNonIndentedCommentJsonOfArray)]
+        public void WriteCommentsInArray_ComparedWithStringLiteral(bool formatted, string expectedJson)
+        {
+            var options = new JsonWriterOptions { Indented = formatted, SkipValidation = false };
+
+            for (int i = 0; i < 3; i++)
+            {
+                var output = new ArrayBufferWriter<byte>(32);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+
+                WriteCommentValue(jsonUtf8, i, "Comment at start of doc");
+                WriteCommentValue(jsonUtf8, i, "Multiple comment line");
+                jsonUtf8.WriteStartArray();
+
+                WriteCommentValue(jsonUtf8, i, "Comment as first array item");
+                WriteCommentValue(jsonUtf8, i, "Multiple comment line");
+
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteEndArray();
+
+                WriteCommentValue(jsonUtf8, i, "Comment in the middle of array");
+
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteEndObject();
+
+                WriteCommentValue(jsonUtf8, i, "Comment as the last array item");
+
+                jsonUtf8.WriteEndArray();
+
+                WriteCommentValue(jsonUtf8, i, "Comment at end of doc");
+
+                jsonUtf8.Flush();
+
+                JsonTestHelper.AssertContents(expectedJson, output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, ExpectedIndentedCommentJsonOfObject)]
+        [InlineData(false, ExpectedNonIndentedCommentJsonOfObject)]
+        public void WriteCommentsInObject_ComparedWithStringLiteral(bool formatted, string expectedJson)
+        {
+            var options = new JsonWriterOptions { Indented = formatted, SkipValidation = false };
+
+            for (int i = 0; i < 3; i++)
+            {
+                var output = new ArrayBufferWriter<byte>(32);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+
+                WriteCommentValue(jsonUtf8, i, "Comment at start of doc");
+                WriteCommentValue(jsonUtf8, i, "Multiple comment line");
+                jsonUtf8.WriteStartObject();
+
+                WriteCommentValue(jsonUtf8, i, "Comment before first object property");
+                WriteCommentValue(jsonUtf8, i, "Multiple comment line");
+
+                jsonUtf8.WritePropertyName("property1");
+                WriteCommentValue(jsonUtf8, i, "Comment of string property value");
+                jsonUtf8.WriteStringValue("stringValue");
+
+                jsonUtf8.WritePropertyName("property2");
+                WriteCommentValue(jsonUtf8, i, "Comment of object property value");
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteEndObject();
+
+                WriteCommentValue(jsonUtf8, i, "Comment in the middle of object");
+
+                jsonUtf8.WritePropertyName("property3");
+                WriteCommentValue(jsonUtf8, i, "Comment of array property value");
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteEndArray();
+
+                WriteCommentValue(jsonUtf8, i, "Comment after the last property");
+
+                jsonUtf8.WriteEndObject();
+
+                WriteCommentValue(jsonUtf8, i, "Comment at end of doc");
+
+                jsonUtf8.Flush();
+
+                JsonTestHelper.AssertContents(expectedJson, output);
+            }
         }
 
         [Theory]
@@ -7243,7 +7441,7 @@ namespace System.Text.Json.Tests
             return Encoding.UTF8.GetString(ms.ToArray());
         }
 
-        private static string GetCommentExpectedString(bool prettyPrint, string comment)
+        private static string GetCommentInArrayExpectedString(bool prettyPrint, string comment)
         {
             var ms = new MemoryStream();
             TextWriter streamWriter = new StreamWriter(ms, new UTF8Encoding(false), 1024, true);
@@ -7254,13 +7452,90 @@ namespace System.Text.Json.Tests
                 StringEscapeHandling = StringEscapeHandling.EscapeHtml,
             };
 
+            json.WriteComment(comment);
+
+            CompensateNewLine(prettyPrint, json, streamWriter);
             json.WriteStartArray();
             for (int j = 0; j < 10; j++)
                 json.WriteComment(comment);
             json.WriteValue(comment);
             json.WriteComment(comment);
+            json.WriteStartArray();
+            json.WriteEndArray();
+            json.WriteComment(comment);
+            json.WriteStartObject();
+            json.WriteEndObject();
+            json.WriteComment(comment);
             json.WriteEnd();
 
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            json.WriteComment(comment);
+            json.Flush();
+
+            return Encoding.UTF8.GetString(ms.ToArray());
+        }
+
+        private static string GetCommentInObjectExpectedString(bool prettyPrint, string comment)
+        {
+            var ms = new MemoryStream();
+            TextWriter streamWriter = new StreamWriter(ms, new UTF8Encoding(false), 1024, true);
+
+            var json = new JsonTextWriter(streamWriter)
+            {
+                Formatting = prettyPrint ? Formatting.Indented : Formatting.None,
+                StringEscapeHandling = StringEscapeHandling.EscapeHtml,
+            };
+
+            json.WriteComment(comment);
+
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            json.WriteStartObject();
+
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            CompensateWhitespaces(prettyPrint, json, streamWriter, 2);
+            json.WriteComment(comment);
+
+            json.WritePropertyName("property1");
+
+            CompensateWhitespaces(prettyPrint, json, streamWriter); 
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            CompensateWhitespaces(prettyPrint, json, streamWriter);
+
+            json.WriteComment(comment);
+
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            CompensateWhitespaces(prettyPrint, json, streamWriter);
+
+            json.WriteStartArray();
+            json.WriteEndArray();
+
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            CompensateWhitespaces(prettyPrint, json, streamWriter, 2);
+
+            json.WriteComment(comment);
+
+            json.WritePropertyName("property2");
+
+            CompensateWhitespaces(prettyPrint, json, streamWriter);
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            CompensateWhitespaces(prettyPrint, json, streamWriter);
+
+            json.WriteComment(comment);
+
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            CompensateWhitespaces(prettyPrint, json, streamWriter);
+
+            json.WriteStartObject();
+            json.WriteEndObject();
+
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            CompensateWhitespaces(prettyPrint, json, streamWriter, 2);
+
+            json.WriteComment(comment);
+            json.WriteEnd();
+
+            CompensateNewLine(prettyPrint, json, streamWriter);
+            json.WriteComment(comment);
             json.Flush();
 
             return Encoding.UTF8.GetString(ms.ToArray());
@@ -7744,6 +8019,24 @@ namespace System.Text.Json.Tests
             json.Flush();
 
             return Encoding.UTF8.GetString(ms.ToArray());
+        }
+
+        private static void CompensateWhitespaces(bool prettyPrint, JsonTextWriter json, TextWriter streamWriter, int whitespaceCount = 1)
+        {
+            if (prettyPrint)
+            {
+                json.Flush();
+                streamWriter.Write(new string(' ', whitespaceCount));
+            }
+        }
+
+        private static void CompensateNewLine(bool prettyPrint, JsonTextWriter json, TextWriter streamWriter)
+        {
+            if (prettyPrint)
+            {
+                json.Flush();
+                streamWriter.WriteLine();
+            }
         }
 
         public static IEnumerable<object[]> JsonEncodedTextStrings


### PR DESCRIPTION
Fix #52408 and #75075 
Will add related tests after deciding correct format, thanks !