### PR TITLE
JIT: Fix unrecognized unaligned field indirections on ARM32

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11301,13 +11301,14 @@ DONE_MORPHING_CHILDREN:
                         temp = nullptr;
                     }
                 }
-                else if (op1->OperGet() == GT_ADD)
+                else
                 {
 #ifdef TARGET_ARM
+                    GenTree* effOp1 = op1->gtEffectiveVal(true);
                     // Check for a misalignment floating point indirection.
-                    if (varTypeIsFloating(typ))
+                    if (effOp1->OperIs(GT_ADD) && varTypeIsFloating(typ))
                     {
-                        GenTree* addOp2 = op1->AsOp()->gtGetOp2();
+                        GenTree* addOp2 = effOp1->gtGetOp2();
                         if (addOp2->IsCnsIntOrI())
                         {
                             ssize_t offset = addOp2->AsIntCon()->gtIconVal;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170.cs
@@ -21,7 +21,7 @@ internal struct FloatNonAlignedFieldWithSmallOffset
 [StructLayout(LayoutKind.Explicit)]
 internal struct FloatNonAlignedFieldWithLargeOffset
 {
-    [FieldOffset(1021)]
+    [FieldOffset(0x10001)]
     public float field;
 
     public FloatNonAlignedFieldWithLargeOffset(float a)
@@ -45,7 +45,7 @@ internal struct DoubleNonAlignedFieldWithSmallOffset
 [StructLayout(LayoutKind.Explicit)]
 internal struct DoubleNonAlignedFieldWithLargeOffset
 {
-    [FieldOffset(1021)]
+    [FieldOffset(0x10001)]
     public double field;
 
     public DoubleNonAlignedFieldWithLargeOffset(float a)


### PR DESCRIPTION
For large field offsets we need to insert explicit null checks. This was
breaking recognition of unaligned accesses that needs special treatment
for floating point instructions.

Fix #74260