### PR TITLE
Fix typo in gentree.cpp

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4258,7 +4258,7 @@ bool Compiler::gtMarkAddrMode(GenTree* addr, int* pCostEx, int* pCostSz, var_typ
         {
             int addrCostExDelta = originalAddrCostEx - addrModeCostEx;
             int addrCostSzDelta = originalAddrCostSz - addrModeCostSz;
-            addrComma->SetCosts(addrComma->GetCostEx() - addrCostExDelta, addrComma->GetCostSz() - addrCostExDelta);
+            addrComma->SetCosts(addrComma->GetCostEx() - addrCostExDelta, addrComma->GetCostSz() - addrCostSzDelta);
 
             *pCostEx += addrComma->AsOp()->gtGetOp1()->GetCostEx();
             *pCostSz += addrComma->AsOp()->gtGetOp1()->GetCostSz();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75071, unlikely to be a bug, but curious to see diffs