### PR TITLE
Enable DOTNET_JitStdOutFile in Release

### DIFF
--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -1643,5 +1643,12 @@ const WCHAR* Compiler::eeGetCPString(size_t strHandle)
     return (WCHAR*)(asString->chars);
 #endif // HOST_UNIX
 }
-
-#endif // DEBUG
+#else  // DEBUG
+void jitprintf(const char* fmt, ...)
+{
+    va_list vl;
+    va_start(vl, fmt);
+    vfprintf(jitstdout, fmt, vl);
+    va_end(vl);
+}
+#endif // !DEBUG

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -72,14 +72,12 @@ extern "C" DLLEXPORT void jitStartup(ICorJitHost* jitHost)
     assert(!JitConfig.isInitialized());
     JitConfig.initialize(jitHost);
 
-#ifdef DEBUG
     const WCHAR* jitStdOutFile = JitConfig.JitStdOutFile();
     if (jitStdOutFile != nullptr)
     {
         jitstdout = _wfopen(jitStdOutFile, W("a"));
         assert(jitstdout != nullptr);
     }
-#endif // DEBUG
 
 #if !defined(HOST_UNIX)
     if (jitstdout == nullptr)

--- a/src/coreclr/jit/host.h
+++ b/src/coreclr/jit/host.h
@@ -41,6 +41,11 @@ extern "C" void ANALYZER_NORETURN __cdecl assertAbort(const char* why, const cha
 
 #else // DEBUG
 
+// Re-define printf in Release to use jitstdout (can be overwritten with DOTNET_JitStdOutFile=file)
+#undef printf
+#define printf jitprintf
+void jitprintf(const char* fmt, ...);
+
 #undef assert
 #define assert(p) (void)0
 #endif // DEBUG
@@ -56,8 +61,8 @@ inline FILE* procstdout()
 {
     return stdout;
 }
+
 #undef stdout
-#define stdout jitstdout
 
 /*****************************************************************************/
 #endif

--- a/src/coreclr/jit/host.h
+++ b/src/coreclr/jit/host.h
@@ -57,7 +57,7 @@ inline FILE* procstdout()
     return stdout;
 }
 #undef stdout
-#define stdout use_jitstdout
+#define stdout jitstdout
 
 /*****************************************************************************/
 #endif

--- a/src/coreclr/jit/host.h
+++ b/src/coreclr/jit/host.h
@@ -63,6 +63,7 @@ inline FILE* procstdout()
 }
 
 #undef stdout
+#define stdout use_jitstdout
 
 /*****************************************************************************/
 #endif

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -155,7 +155,6 @@ CONFIG_INTEGER(JitSplitFunctionSize, W("JitSplitFunctionSize"), 0) // On ARM, us
 CONFIG_INTEGER(JitSsaStress, W("JitSsaStress"), 0) // Perturb order of processing of blocks in SSA; 0 = no stress; 1 =
                                                    // use method hash; * = supplied value as random hash
 CONFIG_INTEGER(JitStackChecks, W("JitStackChecks"), 0)
-CONFIG_STRING(JitStdOutFile, W("JitStdOutFile")) // If set, sends JIT's stdout output to this file.
 CONFIG_INTEGER(JitStress, W("JitStress"), 0) // Internal Jit stress mode: 0 = no stress, 2 = all stress, other = vary
                                              // stress based on a hash of the method and this value
 CONFIG_INTEGER(JitStressBBProf, W("JitStressBBProf"), 0)               // Internal Jit stress mode
@@ -258,6 +257,7 @@ CONFIG_METHODSET(JitDisasm, W("JitDisasm"))
 #endif // !defined(DEBUG)
 
 CONFIG_INTEGER(JitDisasmSummary, W("JitDisasmSummary"), 0) // Prints all jitted methods to the console
+CONFIG_STRING(JitStdOutFile, W("JitStdOutFile"))           // If set, sends JIT's stdout output to this file.
 
 CONFIG_INTEGER(RichDebugInfo, W("RichDebugInfo"), 0) // If 1, keep rich debug info and report it back to the EE
 


### PR DESCRIPTION
This is needed to be able to print `DOTNET_JitDisasm=x` to a file. The primary target for this is `dotnet publish` command with `/p:PublishReadyToRun=true` or `/p:PublishAot=true` whose output is always hidden by msbuild

сс @jakobbotsch @MichalStrehovsky 