### PR TITLE
[wasm] fix prefetch in samples

### DIFF
--- a/src/mono/sample/mbr/browser/index.html
+++ b/src/mono/sample/mbr/browser/index.html
@@ -7,8 +7,6 @@
   <title>Hot Reload Sample</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
 </head>
 
 <body>

--- a/src/mono/sample/mbr/browser/index.html
+++ b/src/mono/sample/mbr/browser/index.html
@@ -7,6 +7,7 @@
   <title>Hot Reload Sample</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type='module' src="./main.js"></script>
 </head>
 
 <body>
@@ -15,7 +16,6 @@
     Click here (upto 2 times): <button id="update">Update</button>
   </div>
   Answer to the Ultimate Question of Life, the Universe, and Everything is : <span id="out"></span>
-  <script type='module' src="./main.js"></script>
 </body>
 
 </html>

--- a/src/mono/sample/wasm/browser-advanced/index.html
+++ b/src/mono/sample/wasm/browser-advanced/index.html
@@ -7,18 +7,17 @@
   <title>Wasm Browser Advanced Sample</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
+  <script type='module' src="./main.js"></script>
+  <script type='module' src="./dotnet.js"></script>
   <link rel="preload" href="./mono-config.json" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./icudt.dat" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./managed/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./icudt.dat" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./managed/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
 </head>
 
 <body>
   <h3 id="header">Wasm Browser Advanced Sample</h3>
   Answer to the Ultimate Question of Life, the Universe, and Everything is : <span id="out"></span>
-  <script type='module' src="./main.js"></script>
 </body>
 
 </html>

--- a/src/mono/sample/wasm/browser-bench/appstart-frame.html
+++ b/src/mono/sample/wasm/browser-bench/appstart-frame.html
@@ -7,18 +7,17 @@
   <title>App task</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./frame-main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
+  <script type="module" src="frame-main.js"></script>
+  <script type='module' src="./dotnet.js"></script>
   <link rel="preload" href="./mono-config.json" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./icudt.dat" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./managed/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./icudt.dat" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./managed/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
 </head>
 
 <body>
   <h3 id="header">Wasm Browser Sample - App task frame</h3>
   <span id="out"></span>
-  <script type="module" src="frame-main.js"></script>
 </body>
 
 </html>

--- a/src/mono/sample/wasm/browser-bench/appstart-frame.html
+++ b/src/mono/sample/wasm/browser-bench/appstart-frame.html
@@ -7,7 +7,7 @@
   <title>App task</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script type="module" src="frame-main.js"></script>
+  <script type="module" src="./frame-main.js"></script>
   <script type='module' src="./dotnet.js"></script>
   <link rel="preload" href="./mono-config.json" as="fetch" crossorigin="anonymous">
   <link rel="prefetch" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">

--- a/src/mono/sample/wasm/browser-bench/index.html
+++ b/src/mono/sample/wasm/browser-bench/index.html
@@ -8,12 +8,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
+  <script type="module" src="./main.js"></script>
 </head>
 
 <body>
   <h3 id="header">Wasm Browser Sample - Simple Benchmark</h3>
   Output:<br><br> <span id="out"></span>
-  <script type="module" src="main.js"></script>
 </body>
 
 </html>

--- a/src/mono/sample/wasm/browser-bench/index.html
+++ b/src/mono/sample/wasm/browser-bench/index.html
@@ -8,12 +8,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
-  <link rel="preload" href="./mono-config.json" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./icudt.dat" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./managed/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
 </head>
 
 <body>

--- a/src/mono/sample/wasm/browser-eventpipe/index.html
+++ b/src/mono/sample/wasm/browser-eventpipe/index.html
@@ -7,8 +7,6 @@
   <title>Sample EventPipe profile session</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
 </head>
 
 <body>

--- a/src/mono/sample/wasm/browser-eventpipe/index.html
+++ b/src/mono/sample/wasm/browser-eventpipe/index.html
@@ -7,6 +7,7 @@
   <title>Sample EventPipe profile session</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type="module" src="./main.js"></script>
 </head>
 
 <body>
@@ -16,7 +17,6 @@
     <label for="inputN">N:</label> <input type="number" id="inputN" value="10"/>
   </div>
   <div>Computing Fib(N) repeatedly: <span id="out"></span>
-  <script type="module" src="./main.js"></script>
 </body>
 
 </html>

--- a/src/mono/sample/wasm/browser-profile/index.html
+++ b/src/mono/sample/wasm/browser-profile/index.html
@@ -7,8 +7,6 @@
   <title>Profiler Sample</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
 </head>
 
 <body>

--- a/src/mono/sample/wasm/browser-profile/index.html
+++ b/src/mono/sample/wasm/browser-profile/index.html
@@ -7,12 +7,12 @@
   <title>Profiler Sample</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type='module' src="./main.js"></script>
 </head>
 
 <body>
   <h3 id="header">Wasm Profiler Sample</h3>
   Result from Sample.Test.TestMeaning: <span id="out"></span>
-  <script type='module' src="./main.js"></script>
 </body>
 
 </html>

--- a/src/mono/sample/wasm/browser-threads/index.html
+++ b/src/mono/sample/wasm/browser-threads/index.html
@@ -7,6 +7,7 @@
     <title>Wasm Browser Sample</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type='module' src="./main.js"></script>
 </head>
 
 <body>
@@ -18,7 +19,6 @@
     <div>
         Progress: <span id="progressElement" style="font-size: 500%"> </span>
     </div>
-    <script type='module' src="./main.js"></script>
 </body>
 
 </html>

--- a/src/mono/sample/wasm/browser-threads/index.html
+++ b/src/mono/sample/wasm/browser-threads/index.html
@@ -7,8 +7,6 @@
     <title>Wasm Browser Sample</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="modulepreload" href="./main.js" />
-    <link rel="modulepreload" href="./dotnet.js" />
 </head>
 
 <body>

--- a/src/mono/sample/wasm/browser-webpack/index.html
+++ b/src/mono/sample/wasm/browser-webpack/index.html
@@ -4,12 +4,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Getting Started</title>
+  <script type='module' src="./main.js"></script>
 </head>
 
 <body>
   <h3 id="header">Wasm Browser Webpack Sample</h3>
   Answer to the Ultimate Question of Life, the Universe, and Everything is: <span id="out"></span>
-  <script type='module' src="./main.js"></script>
 </body>
 
 </html>

--- a/src/mono/sample/wasm/browser-webpack/index.html
+++ b/src/mono/sample/wasm/browser-webpack/index.html
@@ -4,8 +4,6 @@
 <head>
   <meta charset="utf-8" />
   <title>Getting Started</title>
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./app.js" />
 </head>
 
 <body>

--- a/src/mono/sample/wasm/browser/index.html
+++ b/src/mono/sample/wasm/browser/index.html
@@ -7,12 +7,6 @@
   <title>Wasm Browser Sample</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
-  <link rel="preload" href="./mono-config.json" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./icudt.dat" as="fetch" crossorigin="anonymous">
-  <link rel="preload" href="./managed/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
 </head>
 
 <body>

--- a/src/mono/sample/wasm/browser/index.html
+++ b/src/mono/sample/wasm/browser/index.html
@@ -7,12 +7,12 @@
   <title>Wasm Browser Sample</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type='module' src="./main.js"></script>
 </head>
 
 <body>
   <h3 id="header">Wasm Browser Sample</h3>
   Answer to the Ultimate Question of Life, the Universe, and Everything is : <span id="out"></span>
-  <script type='module' src="./main.js"></script>
 </body>
 
 </html>

--- a/src/mono/wasm/templates/templates/browser/index.html
+++ b/src/mono/wasm/templates/templates/browser/index.html
@@ -7,13 +7,12 @@
   <title>browser.0</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
 </head>
 
 <body>
   <span id="out"></span>
   <script type='module' src="./main.js"></script>
+  <script type='module' src="./dotnet.js"></script>
 </body>
 
 </html>

--- a/src/mono/wasm/templates/templates/browser/index.html
+++ b/src/mono/wasm/templates/templates/browser/index.html
@@ -7,12 +7,12 @@
   <title>browser.0</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type='module' src="./main.js"></script>
+  <script type='module' src="./dotnet.js"></script>
 </head>
 
 <body>
   <span id="out"></span>
-  <script type='module' src="./main.js"></script>
-  <script type='module' src="./dotnet.js"></script>
 </body>
 
 </html>

--- a/src/mono/wasm/templates/templates/browser/index.html
+++ b/src/mono/wasm/templates/templates/browser/index.html
@@ -8,7 +8,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>
-  <script type='module' src="./dotnet.js"></script>
 </head>
 
 <body>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
@@ -7,12 +7,12 @@
   <title>Wasm HotReload Test</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type='module' src="./main.js"></script>
 </head>
 
 <body>
   <h3 id="header">Wasm HotReload Test</h3>
   Answer to the Ultimate Question of Life, the Universe, and Everything is : <span id="out"></span>
-  <script type='module' src="./main.js"></script>
 </body>
 
 </html>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
@@ -7,8 +7,6 @@
   <title>Wasm HotReload Test</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
 </head>
 
 <body>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
@@ -7,12 +7,12 @@
   <title>Runtime config test</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type='module' src="./main.js"></script>
 </head>
 
 <body>
   <h3 id="header">Runtime config test</h3>
   Answer to the Ultimate Question of Life, the Universe, and Everything is : <span id="out"></span>
-  <script type='module' src="./main.js"></script>
 </body>
 
 </html>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
@@ -7,8 +7,6 @@
   <title>Runtime config test</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="modulepreload" href="./main.js" />
-  <link rel="modulepreload" href="./dotnet.js" />
 </head>
 
 <body>


### PR DESCRIPTION
- only browser-advanced and browser-bench have preload optimizations now
- modulepreload is not yet supported by FireFox, script tag type='module' works better for dependencies
- preload and prefetch works well enough

Setting [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) header on the server responses may further improve perf.