### PR TITLE
Initialization failures logging

### DIFF
--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -1159,13 +1159,11 @@ HRESULT AssemblyBinderCommon::BindUsingHostAssemblyResolver(/* in */ INT_PTR pMa
                                                             /* in */ AssemblyBinder *pBinder,
                                                             /* out */ Assembly **ppAssembly)
 {
-    HRESULT hr = E_FAIL;
-
     _ASSERTE(pManagedAssemblyLoadContextToBindWithin != NULL);
 
     // RuntimeInvokeHostAssemblyResolver will perform steps 2-4 of CustomAssemblyBinder::BindAssemblyByName.
     BINDER_SPACE::Assembly *pLoadedAssembly = NULL;
-    hr = RuntimeInvokeHostAssemblyResolver(pManagedAssemblyLoadContextToBindWithin,
+    HRESULT hr = RuntimeInvokeHostAssemblyResolver(pManagedAssemblyLoadContextToBindWithin,
                                            pAssemblyName, pDefaultBinder, pBinder, &pLoadedAssembly);
     if (SUCCEEDED(hr))
     {
@@ -1183,7 +1181,7 @@ HRESULT AssemblyBinderCommon::BindUsingPEImage(/* in */  AssemblyBinder* pBinder
                                                /* in */  bool               excludeAppPaths,
                                                /* [retval] [out] */  Assembly **ppAssembly)
 {
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     LONG kContextVersion = 0;
     BindResult bindResult;

--- a/src/coreclr/binder/customassemblybinder.cpp
+++ b/src/coreclr/binder/customassemblybinder.cpp
@@ -161,7 +161,7 @@ HRESULT CustomAssemblyBinder::SetupContext(DefaultAssemblyBinder *pDefaultBinder
                                            UINT_PTR ptrAssemblyLoadContext,
                                            CustomAssemblyBinder **ppBindContext)
 {
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
     EX_TRY
     {
         if(ppBindContext != NULL)
@@ -197,6 +197,10 @@ HRESULT CustomAssemblyBinder::SetupContext(DefaultAssemblyBinder *pDefaultBinder
                 // Return reference to the allocated Binder instance
                 *ppBindContext = pBinder.Extract();
             }
+        }
+        else
+        {
+            hr = LogHR(E_FAIL);
         }
     }
     EX_CATCH_HRESULT(hr);

--- a/src/coreclr/binder/inc/bindertypes.hpp
+++ b/src/coreclr/binder/inc/bindertypes.hpp
@@ -99,7 +99,7 @@ struct AssemblyNameData
 
 #define IF_FALSE_GO(expr)                       \
    if (!(expr)) {                               \
-       hr = E_FAIL;                             \
+       hr = LogHR(E_FAIL);                      \
        goto Exit;                               \
    }
 

--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -184,7 +184,7 @@ int coreclr_get_error_info(error_info_callback callBack, void* arg)
     for (int i = 0; i < count; i++)
     {
         FailedHRLogEntry* pEntry = GetFailedHRLogEntry(i);
-        int length = sprintf_s(line, hresultFormatString, pEntry->hr);
+        int length = sprintf_s(line, sizeof(line), hresultFormatString, pEntry->hr);
         VMToOSInterface::GetSymbolFromAddress(pEntry->address, line + length, sizeof(line) - length);
         callBack(line, arg);
     }

--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -21,7 +21,7 @@ EXPORTS
         ; Unix hosting API
         coreclr_create_delegate
         coreclr_execute_assembly
-        coreclr_get_error_info
+        coreclr_set_error_writer
         coreclr_initialize
         coreclr_shutdown
         coreclr_shutdown_2

--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -21,6 +21,7 @@ EXPORTS
         ; Unix hosting API
         coreclr_create_delegate
         coreclr_execute_assembly
+        coreclr_get_error_info
         coreclr_initialize
         coreclr_shutdown
         coreclr_shutdown_2

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -1,6 +1,7 @@
 ; Unix hosting API
 coreclr_create_delegate
 coreclr_execute_assembly
+coreclr_get_error_info
 coreclr_initialize
 coreclr_shutdown
 coreclr_shutdown_2

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -1,7 +1,7 @@
 ; Unix hosting API
 coreclr_create_delegate
 coreclr_execute_assembly
-coreclr_get_error_info
+coreclr_set_error_writer
 coreclr_initialize
 coreclr_shutdown
 coreclr_shutdown_2

--- a/src/coreclr/dlls/mscorpe/ceefilegenwriter.cpp
+++ b/src/coreclr/dlls/mscorpe/ceefilegenwriter.cpp
@@ -1321,7 +1321,7 @@ HRESULT CeeFileGenWriter::computeOffset(_In_ char *ptr,
         s++;
     }
 
-    return E_FAIL;
+    return LogHR(E_FAIL);
 } // HRESULT CeeFileGenWriter::computeOffset()
 
 HRESULT CeeFileGenWriter::getCorHeader(IMAGE_COR20_HEADER **ppHeader)

--- a/src/coreclr/gc/env/gcenv.ee.h
+++ b/src/coreclr/gc/env/gcenv.ee.h
@@ -94,6 +94,9 @@ public:
     static uint32_t GetCurrentProcessCpuCount();
 
     static void DiagAddNewRegion(int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved);
+
+    static uint32_t LogHR(uint32_t hr, void* address);
+    static uint32_t LogHR(uint32_t hr);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -13333,7 +13333,7 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
         gc_log = CreateLogFile(GCConfig::GetLogFile(), false);
 
         if (gc_log == NULL)
-            return E_FAIL;
+            return GCToEEInterface::LogHR(E_FAIL);
 
         // GCLogFileSize in MBs.
         gc_log_file_size = static_cast<size_t>(GCConfig::GetLogFileSize());
@@ -13341,7 +13341,7 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
         if (gc_log_file_size <= 0 || gc_log_file_size > 500)
         {
             fclose (gc_log);
-            return E_FAIL;
+            return GCToEEInterface::LogHR(E_FAIL);
         }
 
         gc_log_lock.Initialize();
@@ -13349,7 +13349,7 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
         if (!gc_log_buffer)
         {
             fclose(gc_log);
-            return E_FAIL;
+            return GCToEEInterface::LogHR(E_FAIL);
         }
 
         memset (gc_log_buffer, '*', gc_log_buffer_size);
@@ -13364,13 +13364,13 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
         gc_config_log = CreateLogFile(GCConfig::GetConfigLogFile(), true);
 
         if (gc_config_log == NULL)
-            return E_FAIL;
+            return GCToEEInterface::LogHR(E_FAIL);
 
         gc_config_log_buffer = new (nothrow) uint8_t [gc_config_log_buffer_size];
         if (!gc_config_log_buffer)
         {
             fclose(gc_config_log);
-            return E_FAIL;
+            return GCToEEInterface::LogHR(E_FAIL);
         }
 
         compact_ratio = static_cast<int>(GCConfig::GetCompactRatio());
@@ -13477,7 +13477,7 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
     else
     {
         assert (!"cannot use regions without specifying the range!!!");
-        return E_FAIL;
+        return GCToEEInterface::LogHR(E_FAIL);
     }
 #else //USE_REGIONS
     bool separated_poh_p = use_large_pages_p &&
@@ -13590,7 +13590,7 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
 
     if (!init_semi_shared())
     {
-        hres = E_FAIL;
+        hres = GCToEEInterface::LogHR(E_FAIL);
     }
 
     return hres;
@@ -45008,7 +45008,7 @@ HRESULT GCHeap::Initialize()
 
     if (!WaitForGCEvent->CreateManualEventNoThrow(TRUE))
     {
-        return E_FAIL;
+        return GCToEEInterface::LogHR(E_FAIL);
     }
 
 #ifndef FEATURE_NATIVEAOT // Redhawk forces relocation a different way
@@ -45089,9 +45089,9 @@ HRESULT GCHeap::Initialize()
         int hb_info_size_per_node = hb_info_size_per_proc * procs_per_numa_node;
         uint8_t* numa_mem = (uint8_t*)GCToOSInterface::VirtualReserve (hb_info_size_per_node, 0, 0, numa_node_index);
         if (!numa_mem)
-            return E_FAIL;
+            return GCToEEInterface::LogHR(E_FAIL);
         if (!GCToOSInterface::VirtualCommit (numa_mem, hb_info_size_per_node, numa_node_index))
-            return E_FAIL;
+            return GCToEEInterface::LogHR(E_FAIL);
 
         heap_balance_info_proc* hb_info_procs = (heap_balance_info_proc*)numa_mem;
         hb_info_numa_nodes[numa_node_index].hb_info_procs = hb_info_procs;
@@ -47462,7 +47462,7 @@ size_t GCHeap::ApproxFreeBytes()
 HRESULT GCHeap::GetGcCounters(int gen, gc_counters* counters)
 {
     if ((gen < 0) || (gen > max_generation))
-        return E_FAIL;
+        return GCToEEInterface::LogHR(E_FAIL);
 #ifdef MULTIPLE_HEAPS
     counters->current_size = 0;
     counters->promoted_size = 0;
@@ -48591,7 +48591,7 @@ HRESULT GCHeap::WaitUntilConcurrentGCCompleteAsync(int millisecondsTimeout)
         else if (dwRet == WAIT_TIMEOUT)
             return HRESULT_FROM_WIN32(ERROR_TIMEOUT);
         else
-            return E_FAIL;      // It is not clear if what the last error would be if the wait failed,
+            return GCToEEInterface::LogHR(E_FAIL);      // It is not clear if what the last error would be if the wait failed,
                                 // as there are too many layers in between. The best we can do is to return E_FAIL;
     }
 #endif

--- a/src/coreclr/gc/gcenv.ee.standalone.inl
+++ b/src/coreclr/gc/gcenv.ee.standalone.inl
@@ -311,4 +311,16 @@ inline void GCToEEInterface::DiagAddNewRegion(int generation, uint8_t* rangeStar
     g_theGCToCLR->DiagAddNewRegion(generation, rangeStart, rangeEnd, rangeEndReserved);
 }
 
+inline uint32_t GCToEEInterface::LogHR(uint32_t hr, void* address)
+{
+    return g_theGCToCLR->LogHR(hr, address);
+}
+
+// This function is marked as NOINLINE so that it can get the caller's address
+NOINLINE
+inline uint32_t GCToEEInterface::LogHR(uint32_t hr)
+{
+    return LogHR(hr, nullptr);
+}
+
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/coreclr/gc/gcinterface.ee.h
+++ b/src/coreclr/gc/gcinterface.ee.h
@@ -446,6 +446,9 @@ public:
 
     virtual
     void DiagAddNewRegion(int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved) = 0;
+
+    virtual
+    uint32_t LogHR(uint32_t hr, void* address) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/coreclr/gc/gcload.cpp
+++ b/src/coreclr/gc/gcload.cpp
@@ -31,6 +31,7 @@
 namespace WKS
 {
     extern void PopulateDacVars(GcDacVars* dacVars);
+    uint32_t LogHR(uint32_t hr);
 }
 
 namespace SVR
@@ -81,7 +82,7 @@ GC_Initialize(
 #ifndef FEATURE_NATIVEAOT // GCToOSInterface is initialized directly
     if (!GCToOSInterface::Initialize())
     {
-        return E_FAIL;
+        return GCToEEInterface::LogHR(E_FAIL);
     }
 #endif
 

--- a/src/coreclr/gc/sample/gcenv.ee.cpp
+++ b/src/coreclr/gc/sample/gcenv.ee.cpp
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include "windows.h"
+#include <intrin.h>
 
 #include "gcenv.h"
 #include "gc.h"
@@ -358,3 +359,18 @@ uint32_t GCToEEInterface::GetCurrentProcessCpuCount()
 void GCToEEInterface::DiagAddNewRegion(int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
 {
 }
+
+uint32_t GCToEEInterface::LogHR(uint32_t hr, void* address)
+{
+    return hr;
+}
+
+#pragma intrinsic(_ReturnAddress)
+
+// This function is marked as NOINLINE so that it can get the caller's address
+NOINLINE
+uint32_t GCToEEInterface::LogHR(uint32_t hr)
+{
+    return LogHR(hr, _ReturnAddress());
+}
+

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -147,11 +147,11 @@ static string_t build_tpa(const string_t& core_root, const string_t& core_librar
     return tpa_list.str();
 }
 
-static bool try_get_export(pal::mod_t mod, const char* symbol, void** fptr)
+static bool try_get_export(pal::mod_t mod, const char* symbol, void** fptr, bool isOptional = false)
 {
     assert(mod != nullptr && symbol != nullptr && fptr != nullptr);
     *fptr = pal::get_module_symbol(mod, symbol);
-    if (*fptr != nullptr)
+    if ((*fptr != nullptr) || isOptional)
         return true;
 
     pal::fprintf(stderr, W("Export '%s' not found.\n"), symbol);
@@ -205,7 +205,7 @@ public:
 static void* CurrentClrInstance;
 static unsigned int CurrentAppDomainId;
 
-static void log_error_info(const char* line, void* arg)
+static void log_error_info(const char* line)
 {
     std::fprintf(stderr, "%s\n", line);
 }
@@ -286,7 +286,7 @@ static int run(const configuration& config)
 
     // Get CoreCLR exports
     coreclr_initialize_ptr coreclr_init_func = nullptr;
-    coreclr_get_error_info_ptr coreclr_get_error_info_func = nullptr;
+    coreclr_set_error_writer_ptr coreclr_set_error_writer_func = nullptr;
     coreclr_execute_assembly_ptr coreclr_execute_func = nullptr;
     coreclr_shutdown_2_ptr coreclr_shutdown2_func = nullptr;
     if (!try_get_export(coreclr_mod, "coreclr_initialize", (void**)&coreclr_init_func)
@@ -296,8 +296,8 @@ static int run(const configuration& config)
         return -1;
     }
 
-    // The coreclr_get_error_info is optional
-    try_get_export(coreclr_mod, "coreclr_get_error_info", (void**)&coreclr_get_error_info_func);
+    // The coreclr_set_error_writer is optional
+    try_get_export(coreclr_mod, "coreclr_set_error_writer", (void**)&coreclr_set_error_writer_func, true /* isOptional */);
 
     // Construct CoreCLR properties.
     pal::string_utf8_t tpa_list_utf8 = pal::convert_to_utf8(tpa_list.c_str());
@@ -353,6 +353,11 @@ static int run(const configuration& config)
         propertyCount, propertyKeys.data(), propertyValues.data(),
         entry_assembly_utf8.c_str(), config.entry_assembly_argc, argv_utf8.get() };
 
+    if (coreclr_set_error_writer_func != nullptr)
+    {
+        coreclr_set_error_writer_func(log_error_info);
+    }
+
     int result;
     result = coreclr_init_func(
         exe_path_utf8.c_str(),
@@ -365,13 +370,14 @@ static int run(const configuration& config)
     if (FAILED(result))
     {
         pal::fprintf(stderr, W("BEGIN: coreclr_initialize failed - Error: 0x%08x\n"), result);
-        if (coreclr_get_error_info_func != nullptr)
-        {
-            coreclr_get_error_info_func(log_error_info, nullptr);
-        }
         logger.dump_details();
         pal::fprintf(stderr, W("END: coreclr_initialize failed - Error: 0x%08x\n"), result);
         return -1;
+    }
+
+    if (coreclr_set_error_writer_func != nullptr)
+    {
+        coreclr_set_error_writer_func(nullptr);
     }
 
     int exit_code;

--- a/src/coreclr/hosts/inc/coreclrhost.h
+++ b/src/coreclr/hosts/inc/coreclrhost.h
@@ -48,23 +48,22 @@ CORECLR_HOSTING_API(coreclr_initialize,
             unsigned int* domainId);
 
 //
-// Type of the callback function called by the coreclr_get_error_info
+// Type of the callback function that can be set by the coreclr_set_error_writer
 //
-typedef void (*error_info_callback)(const char* line, void* arg);
+typedef void (*coreclr_error_writer_callback_fn) (const char *message);
 
 //
-// Initialize the CoreCLR. Creates and starts CoreCLR host and creates an app domain
+// Set callback for writing error logging
 //
 // Parameters:
-//  callBack                - callback that will be called for each line of the error info
-//  arg                     - argument to pass to the callback
+//  errorWriter             - callback that will be called for each line of the error info
+//                          - passing in NULL removes a callback that was previously set
 //
 // Returns:
-//  HRESULT indicating status of the operation. S_OK if the error info was successfully retrieved
+//  S_OK
 //
-CORECLR_HOSTING_API(coreclr_get_error_info,
-            error_info_callback callBack,
-            void* arg);
+CORECLR_HOSTING_API(coreclr_set_error_writer, 
+            coreclr_error_writer_callback_fn errorWriter);
 
 //
 // Shutdown CoreCLR. It unloads the app domain and stops the CoreCLR host.

--- a/src/coreclr/hosts/inc/coreclrhost.h
+++ b/src/coreclr/hosts/inc/coreclrhost.h
@@ -48,6 +48,25 @@ CORECLR_HOSTING_API(coreclr_initialize,
             unsigned int* domainId);
 
 //
+// Type of the callback function called by the coreclr_get_error_info
+//
+typedef void (*error_info_callback)(const char* line, void* arg);
+
+//
+// Initialize the CoreCLR. Creates and starts CoreCLR host and creates an app domain
+//
+// Parameters:
+//  callBack                - callback that will be called for each line of the error info
+//  arg                     - argument to pass to the callback
+//
+// Returns:
+//  HRESULT indicating status of the operation. S_OK if the error info was successfully retrieved
+//
+CORECLR_HOSTING_API(coreclr_get_error_info,
+            error_info_callback callBack,
+            void* arg);
+
+//
 // Shutdown CoreCLR. It unloads the app domain and stops the CoreCLR host.
 //
 // Parameters:

--- a/src/coreclr/inc/ceegentokenmapper.h
+++ b/src/coreclr/inc/ceegentokenmapper.h
@@ -122,7 +122,7 @@ public:
         else
         {
             _ASSERTE(!"Token mapper already set!");
-            return E_FAIL;
+            return LogHR(E_FAIL);
         }
     }
 

--- a/src/coreclr/inc/corhlprpriv.cpp
+++ b/src/coreclr/inc/corhlprpriv.cpp
@@ -79,7 +79,7 @@ HRESULT CQuickMemoryBase<SIZE, INCREMENT>::ReSizeNoThrow(SIZE_T iItems)
 * get number of bytes consumed by one argument/return type
 *
 *************************************************************************************/
-#define CHECK_REMAINDER  if(cbTotal >= cbTotalMax){hr=E_FAIL; goto ErrExit;}
+#define CHECK_REMAINDER  if(cbTotal >= cbTotalMax){hr=LogHR(E_FAIL); goto ErrExit;}
 HRESULT _CountBytesOfOneArg(
     PCCOR_SIGNATURE pbSig,
     ULONG       *pcbTotal)  // Initially, *pcbTotal contains the remaining size of the sig blob
@@ -97,7 +97,7 @@ HRESULT _CountBytesOfOneArg(
     ULONG       cArgsIndex;
     HRESULT     hr = NOERROR;
 
-    if(pcbTotal==NULL) return E_FAIL;
+    if(pcbTotal==NULL) return LogHR(E_FAIL);
     cbTotalMax = *pcbTotal;
 
     CHECK_REMAINDER;

--- a/src/coreclr/inc/stacktrace.h
+++ b/src/coreclr/inc/stacktrace.h
@@ -18,30 +18,34 @@ HINSTANCE LoadDbgHelp();
 
 #define cchMaxAssertModuleLen 60
 #define cchMaxAssertSymbolLen 257
+#define cchMaxAssertSourceLen MAX_PATH
 #define cfrMaxAssertStackLevels 20
 #define cchMaxAssertExprLen 257
+#define cchMaxAssertLineNumberLen 6
 
 #ifdef HOST_64BIT
 
 #define cchMaxAssertStackLevelStringLen \
-    ((3 * 8) + cchMaxAssertModuleLen + cchMaxAssertSymbolLen + 13)
-    // 3 addresses of at most 8 char, module, symbol, and the extra chars:
-    // 0x<address>: <module>! <symbol> + 0x<offset>\n
+    ((3 * 8) + cchMaxAssertModuleLen + cchMaxAssertSymbolLen + cchMaxAssertSourceLen + cchMaxAssertLineNumberLen + 15)
+    // 3 addresses of at most 8 char, module, symbol, source file, line number, and the extra chars:
+    // 0x<address>: <module>! <symbol> + 0x<offset> source:line\n
     //FMT_ADDR_BARE   is defined as   "%08x`%08x" on Win64, and as
     //"%08x" on 32 bit platforms. Hence the difference in the definitions.
 
 #else
 
 #define cchMaxAssertStackLevelStringLen \
-    ((2 * 8) + cchMaxAssertModuleLen + cchMaxAssertSymbolLen + 12)
-    // 2 addresses of at most 8 char, module, symbol, and the extra chars:
-    // 0x<address>: <module>! <symbol> + 0x<offset>\n
+    ((2 * 8) + cchMaxAssertModuleLen + cchMaxAssertSymbolLen + cchMaxAssertSourceLen + cchMaxAssertLineNumberLen + 14)
+    // 2 addresses of at most 8 char, module, symbol, source file, line number, and the extra chars:
+    // 0x<address>: <module>! <symbol> + 0x<offset> source:line\n
 
 #endif
 
 //
 //--- Prototypes --------------------------------------------------------------
 //
+
+void MagicInit();
 
 /****************************************************************************
 * MagicDeinit *
@@ -71,7 +75,7 @@ void GetStringFromStackLevels(UINT ifrStart, UINT cfrTotal, _Out_writes_(cchMaxA
 *
 *           0x<address>: <module>! <symbol> + 0x<offset>
 ******************************************************************** robch */
-void GetStringFromAddr(DWORD_PTR dwAddr, _Out_writes_(cchMaxAssertStackLevelStringLen) LPSTR szString);
+void GetStringFromAddr(DWORD_PTR dwAddr, _Out_writes_(stringBufferSize) LPSTR szString, size_t stringBufferSize);
 
 #if defined(HOST_X86) && !defined(TARGET_UNIX)
 /****************************************************************************

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -62,6 +62,18 @@
 
 class StringArrayList;
 
+struct FailedHRLogEntry
+{
+    DWORD hr;
+    void *address;
+};
+
+DWORD LogHR(DWORD hr);
+DWORD LogHR(DWORD hr, void* address);
+
+UINT32 GetFailedHRLogEntryCount();
+FailedHRLogEntry* GetFailedHRLogEntry(UINT32 index);
+
 #if !defined(_DEBUG_IMPL) && defined(_DEBUG) && !defined(DACCESS_COMPILE)
 #define _DEBUG_IMPL 1
 #endif
@@ -840,7 +852,7 @@ inline HRESULT HRESULT_FROM_GetLastError()
     if (dw == ERROR_SUCCESS)
     {
         _ASSERTE(!"We were expecting to get an error code, but a success code is being returned. Check this code path for Everett!");
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
     else
         return HRESULT_FROM_WIN32(dw);
@@ -852,7 +864,7 @@ inline HRESULT HRESULT_FROM_GetLastErrorNA()
     DWORD dw = GetLastError();
     // Make sure we return a failure
     if (dw == ERROR_SUCCESS)
-        return E_FAIL;
+        return LogHR(E_FAIL);
     else
         return HRESULT_FROM_WIN32(dw);
 }

--- a/src/coreclr/md/ceefilegen/cceegen.cpp
+++ b/src/coreclr/md/ceefilegen/cceegen.cpp
@@ -114,19 +114,25 @@ ErrExit:
 
 STDMETHODIMP CCeeGen::GetString(ULONG RVA, __inout LPWSTR *lpString)
 {
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
     BEGIN_ENTRYPOINT_NOTHROW;
 
     if (! lpString)
         IfFailGo(E_POINTER);
     *lpString = (LPWSTR)getStringSection().computePointer(RVA);
-
+    if (*lpString == NULL)
+    {
+        hr = LogHR(E_FAIL);
+    }
+    else
+    {
+        hr = S_OK;
+    }
 
 ErrExit:
 
     END_ENTRYPOINT_NOTHROW;
-    if (*lpString)
-        return S_OK;
+
     return hr;
 }
 
@@ -159,37 +165,47 @@ ErrExit:
 
 STDMETHODIMP CCeeGen::GetMethodBuffer(ULONG RVA, UCHAR **lpBuffer)
 {
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
     BEGIN_ENTRYPOINT_NOTHROW;
 
     if (! lpBuffer)
         IfFailGo(E_POINTER);
     *lpBuffer = (UCHAR*)getIlSection().computePointer(RVA);
-
+    if (*lpBuffer == 0)
+    {
+        hr = LogHR(E_FAIL);
+    }
+    else
+    {
+        hr = S_OK;
+    }
 
 ErrExit:
     END_ENTRYPOINT_NOTHROW;
-
-    if (lpBuffer != NULL && *lpBuffer != 0)
-        return S_OK;
 
     return hr;
 }
 
 STDMETHODIMP CCeeGen::ComputePointer(HCEESECTION section, ULONG RVA, UCHAR **lpBuffer)
 {
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
     BEGIN_ENTRYPOINT_NOTHROW;
 
     if (! lpBuffer)
         IfFailGo(E_POINTER);
     *lpBuffer = (UCHAR*) ((CeeSection *)section)->computePointer(RVA);
+    if (*lpBuffer == 0)
+    {
+        hr = LogHR(E_FAIL);
+    }
+    else
+    {
+        hr = S_OK;
+    }
 
 ErrExit:
     END_ENTRYPOINT_NOTHROW;
 
-    if (lpBuffer != NULL && *lpBuffer != 0)
-        return S_OK;
     return hr;
 }
 

--- a/src/coreclr/md/ceefilegen/ceegentokenmapper.cpp
+++ b/src/coreclr/md/ceefilegen/ceegentokenmapper.cpp
@@ -139,7 +139,7 @@ HRESULT CeeGenTokenMapper::GetMetaData(
     if (m_pIImport)
         return (m_pIImport->QueryInterface(IID_IMetaDataImport, (PVOID *) ppIImport));
     *ppIImport = 0;
-    return E_FAIL;
+    return LogHR(E_FAIL);
 }
 
 

--- a/src/coreclr/md/ceefilegen/pesectionman.cpp
+++ b/src/coreclr/md/ceefilegen/pesectionman.cpp
@@ -298,7 +298,7 @@ unsigned PESection::computeOffset(_In_ char *ptr) const // virtual
 HRESULT PESection::addBaseReloc(unsigned offset, CeeSectionRelocType reloc,
                                 CeeSectionRelocExtra *extra)
 {
-    HRESULT     hr = E_FAIL;
+    HRESULT     hr;
 
     // Use for fixing up pointers pointing outside of the module.
     //
@@ -325,6 +325,7 @@ HRESULT PESection::addBaseReloc(unsigned offset, CeeSectionRelocType reloc,
 
     default:
         _ASSERTE(!"unhandled reloc in PESection::addBaseReloc");
+        hr = LogHR(E_FAIL);
         break;
     }
     return hr;

--- a/src/coreclr/md/compiler/custattr_emit.cpp
+++ b/src/coreclr/md/compiler/custattr_emit.cpp
@@ -539,7 +539,7 @@ HRESULT ParseKnownCaValue(
     default:
         // The arguments of all known custom attributes are Type, String, Enum, or primitive types.
         _ASSERTE(!"Unexpected internal error");
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
         break;
     } // End switch
 

--- a/src/coreclr/md/compiler/importhelper.cpp
+++ b/src/coreclr/md/compiler/importhelper.cpp
@@ -1393,7 +1393,7 @@ HRESULT ImportHelper::FindAssemblyRef(
             else if (IsAfPublicKey(dwTmp))
             {
 #if defined(FEATURE_METADATA_EMIT_IN_DEBUGGER) && !defined(DACCESS_COMPILE)
-                return E_FAIL;
+                return LogHR(E_FAIL);
 #else //!FEATURE_METADATA_EMIT_IN_DEBUGGER || DACCESS_COMPILE
                 // Need to compress target public key to see if it matches.
                 IfFailRet(StrongNameTokenFromPublicKey((BYTE*)pbTmp,
@@ -1413,7 +1413,7 @@ HRESULT ImportHelper::FindAssemblyRef(
                 if (!pbToken)
                 {
 #if defined(FEATURE_METADATA_EMIT_IN_DEBUGGER) && !defined(DACCESS_COMPILE)
-                    return E_FAIL;
+                    return LogHR(E_FAIL);
 #else //!FEATURE_METADATA_EMIT_IN_DEBUGGER || DACCESS_COMPILE
                     IfFailRet(StrongNameTokenFromPublicKey((BYTE*)pbPublicKeyOrToken,
                         cbPublicKeyOrToken,

--- a/src/coreclr/md/compiler/mdutil.cpp
+++ b/src/coreclr/md/compiler/mdutil.cpp
@@ -244,7 +244,7 @@ HRESULT LOADEDMODULES::FindCachedReadOnlyEntry(
         // Figure out the size and timestamp of this file
         WIN32_FILE_ATTRIBUTE_DATA faData;
         if (!WszGetFileAttributesEx(szName, GetFileExInfoStandard, &faData))
-            return E_FAIL;
+            return LogHR(E_FAIL);
         dwLowFileSize = faData.nFileSizeLow;
         dwLowFileTime = faData.ftLastWriteTime.dwLowDateTime;
 
@@ -432,7 +432,7 @@ LOADEDMODULES::ResolveTypeRefWithLoadedModules(
     if (FAILED(hr))
     {
         // cannot find the match!
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
     }
 ErrExit:
     return hr;

--- a/src/coreclr/md/enc/liteweightstgdbrw.cpp
+++ b/src/coreclr/md/enc/liteweightstgdbrw.cpp
@@ -449,7 +449,7 @@ HRESULT CLiteWeightStgdbRW::OpenForRead(
     else
     {
         _ASSERTE(!"Unknown file type.");
-        IfFailGo( E_FAIL );
+        IfFailGo( LogHR(E_FAIL) );
     }
 
     // Save off everything.
@@ -460,7 +460,7 @@ HRESULT CLiteWeightStgdbRW::OpenForRead(
     {
         WIN32_FILE_ATTRIBUTE_DATA faData;
         if (!WszGetFileAttributesEx(szDatabase, GetFileExInfoStandard, &faData))
-            IfFailGo(E_FAIL);
+            IfFailGo(LogHR(E_FAIL));
         m_dwDatabaseLFS = faData.nFileSizeLow;
         m_dwDatabaseLFT = faData.ftLastWriteTime.dwLowDateTime;
     }

--- a/src/coreclr/md/enc/mdinternalrw.cpp
+++ b/src/coreclr/md/enc/mdinternalrw.cpp
@@ -1631,7 +1631,7 @@ HRESULT MDInternalRW::GetNameOfCustomAttribute( // S_OK or error.
     HRESULT hr = S_OK;
     LOCKREADIFFAILRET();
     hr =  m_pStgdb->m_MiniMd.CommonGetNameOfCustomAttribute(RidFromToken(mdAttribute), pszNamespace, pszName);
-    return (hr == S_FALSE) ? E_FAIL : hr;
+    return (hr == S_FALSE) ? LogHR(E_FAIL) : hr;
 } // MDInternalRW::GetNameOfCustomAttribute
 
 //*****************************************************************************
@@ -4051,7 +4051,7 @@ HRESULT MDInternalRW::ApplyEditAndContinue(
     _ASSERTE(pDeltaMD);
     _ASSERTE(ppv);
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
     IMDInternalImportENC *pDeltaMDImport = NULL;
 
     IfFailGo(GetInternalWithRWFormat(pDeltaMD, cbDeltaMD, 0, IID_IMDInternalImportENC, (void**)&pDeltaMDImport));

--- a/src/coreclr/md/enc/metamodelrw.cpp
+++ b/src/coreclr/md/enc/metamodelrw.cpp
@@ -4386,7 +4386,7 @@ CMiniMdRW::PutToken(    // S_OK or E_UNEXPECTED.
         else
         {
             _ASSERTE(!"PutToken called on unexpected coded token type");
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
         }
     }
     else // It is an error.

--- a/src/coreclr/md/enc/pdbheap.cpp
+++ b/src/coreclr/md/enc/pdbheap.cpp
@@ -38,20 +38,20 @@ HRESULT PdbHeap::SetData(PORT_PDB_STREAM* data)
 
     ULONG offset = 0;
     if (memcpy_s(m_data + offset, m_size, &data->id, sizeof(data->id)))
-        return E_FAIL;
+        return LogHR(E_FAIL);
     offset += sizeof(data->id);
 
     if (memcpy_s(m_data + offset, m_size, &data->entryPoint, sizeof(data->entryPoint)))
-        return E_FAIL;
+        return LogHR(E_FAIL);
     offset += sizeof(data->entryPoint);
 
     if (memcpy_s(m_data + offset, m_size, &data->referencedTypeSystemTables, sizeof(data->referencedTypeSystemTables)))
-        return E_FAIL;
+        return LogHR(E_FAIL);
     offset += sizeof(data->referencedTypeSystemTables);
 
 #if !BIGENDIAN
     if (memcpy_s(m_data + offset, m_size, data->typeSystemTableRows, sizeof(ULONG) * data->typeSystemTableRowsSize))
-        return E_FAIL;
+        return LogHR(E_FAIL);
     offset += sizeof(ULONG) * data->typeSystemTableRowsSize;
 #else
     for (int i = 0; i < data->typeSystemTableRowsSize; i++)

--- a/src/coreclr/md/enc/rwutil.cpp
+++ b/src/coreclr/md/enc/rwutil.cpp
@@ -691,7 +691,7 @@ HRESULT MDTOKENMAP::InsertNotFound(
                 else
                 {
                     _ASSERTE(!"inconsistent token has been added to the table!");
-                    IfFailGo( E_FAIL );
+                    IfFailGo( LogHR(E_FAIL) );
                 }
             }
 

--- a/src/coreclr/md/runtime/mdinternalro.cpp
+++ b/src/coreclr/md/runtime/mdinternalro.cpp
@@ -739,7 +739,7 @@ HRESULT MDInternalRO::GetNameOfCustomAttribute( // S_OK or error.
     _ASSERTE(TypeFromToken(mdAttribute) == mdtCustomAttribute);
 
     HRESULT hr = m_LiteWeightStgdb.m_MiniMd.CommonGetNameOfCustomAttribute(RidFromToken(mdAttribute), pszNamespace, pszName);
-    return (hr == S_FALSE) ? E_FAIL : hr;
+    return (hr == S_FALSE) ? LogHR(E_FAIL) : hr;
 } // MDInternalRO::GetNameOfCustomAttribute
 
 //*****************************************************************************
@@ -3322,7 +3322,7 @@ HRESULT MDInternalRO::ApplyEditAndContinue(
     _ASSERTE(pDeltaMD);
     _ASSERTE(ppv);
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     IMDInternalImportENC *pDeltaMDImport = NULL;
 

--- a/src/coreclr/md/runtime/mdinternalro.h
+++ b/src/coreclr/md/runtime/mdinternalro.h
@@ -700,7 +700,7 @@ public:
 
     STDMETHODIMP_(IUnknown *) GetCachedPublicInterface(BOOL fWithLock) { return NULL;}  // return the cached public interface
     __checkReturn
-    STDMETHODIMP SetCachedPublicInterface(IUnknown *pUnk) { return E_FAIL;} ;// return hresult
+    STDMETHODIMP SetCachedPublicInterface(IUnknown *pUnk) { return LogHR(E_FAIL);} ;// return hresult
     STDMETHODIMP_(UTSemReadWrite*) GetReaderWriterLock() {return NULL;}   // return the reader writer lock
     __checkReturn
     STDMETHODIMP SetReaderWriterLock(UTSemReadWrite *pSem) { return NOERROR; }

--- a/src/coreclr/minipal/Unix/CMakeLists.txt
+++ b/src/coreclr/minipal/Unix/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(coreclrminipal
     STATIC
     doublemapping.cpp
+    symbols.cpp
 )

--- a/src/coreclr/minipal/Unix/symbols.cpp
+++ b/src/coreclr/minipal/Unix/symbols.cpp
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+#include "minipal.h"
+#include <cxxabi.h>
+
+// Get a string describing the symbol located at the specified address.
+// Parameters:
+//  address      - address to find the symbol for
+//  buffer       - buffer to store the resulting string
+//  bufferSize   - size of the buffer
+void VMToOSInterface::GetSymbolFromAddress(const void* address, char* buffer, size_t bufferSize)
+{
+    Dl_info dlInfo;
+    int st = dladdr(address, &dlInfo);
+    if (st != 0)
+    {
+        const char* filename = dlInfo.dli_fname;
+        const char* lastSlash = strrchr(dlInfo.dli_fname, '/');
+        if (lastSlash != nullptr)
+        {
+            filename = lastSlash + 1;
+        }
+
+        if (dlInfo.dli_sname != nullptr)
+        {
+            // Symbol was found
+            const char* demangledName = abi::__cxa_demangle(dlInfo.dli_sname, NULL, NULL, &st);
+            snprintf(buffer, bufferSize, "%s + 0x%zx (%s + 0x%zx)", (demangledName != nullptr) ? demangledName : dlInfo.dli_sname, (char*)address - (char*)dlInfo.dli_saddr, filename, (char*)address - (char*)dlInfo.dli_fbase);
+            free((void*)demangledName);
+        }
+        else
+        {
+            // No symbol was found, return name of the shared library and an offset in it
+            snprintf(buffer, bufferSize, "<unknown> (%s + 0x%zx)", filename, (char*)address - (char*)dlInfo.dli_fbase);
+        }
+    }
+    else
+    {
+        // dladdr has failed to locate the address, so just print it
+        snprintf(buffer, bufferSize, "%p", address);
+    }
+}

--- a/src/coreclr/minipal/Unix/symbols.cpp
+++ b/src/coreclr/minipal/Unix/symbols.cpp
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/coreclr/minipal/Windows/CMakeLists.txt
+++ b/src/coreclr/minipal/Windows/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(coreclrminipal
     STATIC
     doublemapping.cpp
+    symbols.cpp
 )

--- a/src/coreclr/minipal/Windows/symbols.cpp
+++ b/src/coreclr/minipal/Windows/symbols.cpp
@@ -1,0 +1,16 @@
+#include <windows.h>
+#include "minipal.h"
+
+void MagicInit();
+void GetStringFromAddr(DWORD_PTR dwAddr, _Out_writes_(stringBufferSize) LPSTR szString, size_t stringBufferSize);
+
+// Get a string describing the symbol located at the specified address.
+// Parameters:
+//  address      - address to find the symbol for
+//  buffer       - buffer to store the resulting string
+//  bufferSize   - size of the buffer
+void VMToOSInterface::GetSymbolFromAddress(const void* address, char* buffer, size_t bufferSize)
+{
+    MagicInit();
+    GetStringFromAddr((DWORD_PTR)address, buffer, bufferSize);
+}

--- a/src/coreclr/minipal/Windows/symbols.cpp
+++ b/src/coreclr/minipal/Windows/symbols.cpp
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 #include <windows.h>
 #include "minipal.h"
 

--- a/src/coreclr/minipal/minipal.h
+++ b/src/coreclr/minipal/minipal.h
@@ -75,4 +75,11 @@ public:
     // Return:
     //  true if it succeeded, false if it failed
     static bool ReleaseRWMapping(void* pStart, size_t size);
+
+    // Get a string describing the symbol located at the specified address.
+    // Parameters:
+    //  address      - address to find the symbol for
+    //  buffer       - buffer to store the resulting string
+    //  bufferSize   - size of the buffer
+    static void GetSymbolFromAddress(const void* address, char* buffer, size_t bufferSize);
 };

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -1376,6 +1376,11 @@ void GCToEEInterface::FreeStringConfigValue(const char* value)
     delete[] value;
 }
 
+uint32_t GCToEEInterface::LogHR(uint32_t hr)
+{
+    return hr;
+}
+
 #endif // !DACCESS_COMPILE
 
 // NOTE: this method is not in thread.cpp because it needs access to the layout of alloc_context for DAC to know the

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.cpp
@@ -270,8 +270,10 @@ void SetSpmiTargetArchitecture(SPMI_TARGET_ARCHITECTURE spmiTargetArchitecture)
 // The following functions are used for arm64/arm32 relocation processing.
 // They are copies of the code in src\coreclr\utilcode\util.cpp.
 // We decided to copy them instead of linking with utilcode library
-// to avoid introducing additional runtime dependencies.
+// to avoid introducing additional runtime dependencies on Windows.
+// On Unix, utilcode is already linked in for other reasons.
 
+#ifndef TARGET_UNIX
 void PutArm64Rel28(UINT32* pCode, INT32 imm28)
 {
     UINT32 branchInstr = *pCode;
@@ -335,3 +337,5 @@ void PutThumb2BlRel24(UINT16* p, INT32 imm24)
     p[0] = Opcode0;
     p[1] = Opcode1;
 }
+#endif
+

--- a/src/coreclr/unwinder/amd64/unwinder.cpp
+++ b/src/coreclr/unwinder/amd64/unwinder.cpp
@@ -230,13 +230,11 @@ BOOL DacUnwindStackFrame(CONTEXT * pContext, KNONVOLATILE_CONTEXT_POINTERS* pCon
 
 BOOL OOPStackUnwinderAMD64::Unwind(CONTEXT * pContext)
 {
-    HRESULT hr = E_FAIL;
-
     ULONG64 uControlPC = (DWORD64)dac_cast<PCODE>(::GetIP(pContext));
 
     // get the module base
     ULONG64 uImageBase;
-    hr = GetModuleBase(uControlPC, &uImageBase);
+    HRESULT hr = GetModuleBase(uControlPC, &uImageBase);
     if (FAILED(hr))
     {
         return FALSE;
@@ -536,7 +534,7 @@ HRESULT.
 
         ChainCount += 1;
         if (ChainCount > UNWIND_CHAIN_LIMIT) {
-            return E_FAIL;
+            return LogHR(E_FAIL);
         }
 
         Index = CountOfCodes;

--- a/src/coreclr/unwinder/arm/unwinder.cpp
+++ b/src/coreclr/unwinder/arm/unwinder.cpp
@@ -1195,7 +1195,7 @@ ExecuteCodes:
 
         else if (CurCode < 0xc0) {
             if (UnwindCodePtr >= UnwindCodesEndPtr) {
-                Status = E_FAIL;
+                Status = LogHR(E_FAIL);
             } else {
                 Param = ((CurCode & 0x20) << 9) |
                         ((CurCode & 0x1f) << 8) |
@@ -1255,7 +1255,7 @@ ExecuteCodes:
 
             case 0xe8:  case 0xe9:  case 0xea:  case 0xeb:
                 if (UnwindCodePtr >= UnwindCodesEndPtr) {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                     break;
                 }
                 ContextRecord->Sp += 4 * 256 * (CurCode & 3);
@@ -1269,7 +1269,7 @@ ExecuteCodes:
 
             case 0xec:  case 0xed:
                 if (UnwindCodePtr >= UnwindCodesEndPtr) {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                     break;
                 }
                 Status = RtlpPopRegisterMask(ContextRecord,
@@ -1285,7 +1285,7 @@ ExecuteCodes:
 
             case 0xee:
                 if (UnwindCodePtr >= UnwindCodesEndPtr) {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                     break;
                 }
                 Param = MEMORY_READ_BYTE(UnwindParams, UnwindCodePtr);
@@ -1295,7 +1295,7 @@ ExecuteCodes:
                                               Param & 0x0f,
                                               UnwindParams);
                 } else {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                 }
                 break;
 
@@ -1305,7 +1305,7 @@ ExecuteCodes:
 
             case 0xef:
                 if (UnwindCodePtr >= UnwindCodesEndPtr) {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                     break;
                 }
                 Param = MEMORY_READ_BYTE(UnwindParams, UnwindCodePtr);
@@ -1316,7 +1316,7 @@ ExecuteCodes:
                                                  UnwindParams);
                     ContextRecord->Sp += ((Param & 15) - 1) * 4;
                 } else {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                 }
                 break;
 
@@ -1326,7 +1326,7 @@ ExecuteCodes:
 
             case 0xf5:
                 if (UnwindCodePtr >= UnwindCodesEndPtr) {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                     break;
                 }
                 Param = MEMORY_READ_BYTE(UnwindParams, UnwindCodePtr);
@@ -1342,7 +1342,7 @@ ExecuteCodes:
 
             case 0xf6:
                 if (UnwindCodePtr >= UnwindCodesEndPtr) {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                     break;
                 }
                 Param = MEMORY_READ_BYTE(UnwindParams, UnwindCodePtr);
@@ -1360,7 +1360,7 @@ ExecuteCodes:
             case 0xf7:
             case 0xf9:
                 if (UnwindCodePtr + 2 > UnwindCodesEndPtr) {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                     break;
                 }
                 ContextRecord->Sp += 4 * 256 * MEMORY_READ_BYTE(UnwindParams, UnwindCodePtr);
@@ -1376,7 +1376,7 @@ ExecuteCodes:
             case 0xf8:
             case 0xfa:
                 if (UnwindCodePtr + 3 > UnwindCodesEndPtr) {
-                    Status = E_FAIL;
+                    Status = LogHR(E_FAIL);
                     break;
                 }
                 ContextRecord->Sp += 4 * 256 * 256 * MEMORY_READ_BYTE(UnwindParams, UnwindCodePtr);
@@ -1406,7 +1406,7 @@ ExecuteCodes:
                 goto finished;
 
             default:
-                Status = E_FAIL;
+                Status = LogHR(E_FAIL);
                 break;
             }
         }

--- a/src/coreclr/unwinder/baseunwinder.cpp
+++ b/src/coreclr/unwinder/baseunwinder.cpp
@@ -28,7 +28,7 @@ HRESULT OOPStackUnwinder::GetModuleBase(      DWORD64  address,
                                           _Out_ PDWORD64 pdwBase)
 {
     GetRuntimeStackWalkInfo(address, reinterpret_cast<UINT_PTR *>(pdwBase), NULL);
-    return ((*pdwBase == NULL) ? E_FAIL : S_OK);
+    return ((*pdwBase == NULL) ? LogHR(E_FAIL) : S_OK);
 }
 
 //---------------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ HRESULT OOPStackUnwinder::GetFunctionEntry(                       DWORD64 addres
     GetRuntimeStackWalkInfo(address, NULL, reinterpret_cast<UINT_PTR *>(&pFuncEntry));
     if (pFuncEntry == NULL)
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     memcpy(pBuffer, pFuncEntry, cbBuffer);

--- a/src/coreclr/utilcode/ccomprc.cpp
+++ b/src/coreclr/utilcode/ccomprc.cpp
@@ -324,6 +324,10 @@ HRESULT CCompRC::GetLibrary(LocaleID langId, HRESOURCEDLL* phInst)
             hInst = m_Primary.GetLibraryHandle();
             hr = S_OK;
         }
+        else
+        {
+            hr = LogHR(E_FAIL);
+        }
     }
     else if(m_Primary.IsMissing())
     {

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -259,7 +259,7 @@ namespace
         }
 
         *result = defValue;
-        return (E_FAIL);
+        return E_FAIL;
     }
 
     LPWSTR GetConfigString(

--- a/src/coreclr/utilcode/dacutil.cpp
+++ b/src/coreclr/utilcode/dacutil.cpp
@@ -123,7 +123,7 @@ LiveProcDataTarget::GetImageBase(
     //
     // Our creator must have told us WHICH clr to work with.
     //
-    return E_FAIL;
+    return LogHR(E_FAIL);
 }
 
 HRESULT STDMETHODCALLTYPE
@@ -156,7 +156,7 @@ LiveProcDataTarget::ReadVirtual(
             if (totalDone == 0)
             {
                 // If we haven't read anything indicate failure.
-                status = E_FAIL;
+                status = LogHR(E_FAIL);
             }
             break;
         }

--- a/src/coreclr/utilcode/ex.cpp
+++ b/src/coreclr/utilcode/ex.cpp
@@ -894,7 +894,7 @@ HRESULT DelegatingException::GetHR()
 
     // If there is a delegate exception, defer to it.  Otherwise,
     //  default to E_FAIL.
-    return pDelegate ? pDelegate->GetHR() : E_FAIL;
+    return pDelegate ? pDelegate->GetHR() : LogHR(E_FAIL);
 
 } // HRESULT DelegatingException::GetHR()
 
@@ -972,7 +972,7 @@ void DECLSPEC_NORETURN ThrowHR(HRESULT hr)
     // Catchers assume only failing hresults
     _ASSERTE(FAILED(hr));
     if (hr == S_OK)
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
 
     EX_THROW(HRException, (hr));
 }
@@ -989,7 +989,7 @@ void DECLSPEC_NORETURN ThrowHR(HRESULT hr, SString const &msg)
     // Catchers assume only failing hresults
     _ASSERTE(FAILED(hr));
     if (hr == S_OK)
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
 
     EX_THROW(HRMsgException, (hr, msg));
 }
@@ -1005,7 +1005,7 @@ void DECLSPEC_NORETURN ThrowHR(HRESULT hr, UINT uText)
     // Catchers assume only failing hresults
     _ASSERTE(FAILED(hr));
     if (hr == S_OK)
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
 
     SString sExceptionText;
 

--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -232,7 +232,7 @@ HRESULT ExecutableAllocator::StaticInitialize(FatalErrorHandler fatalErrorHandle
 
     if (!g_instance->Initialize())
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
 #ifdef LOG_EXECUTABLE_ALLOCATOR_STATISTICS

--- a/src/coreclr/utilcode/longfilepathwrappers.cpp
+++ b/src/coreclr/utilcode/longfilepathwrappers.cpp
@@ -720,7 +720,7 @@ HRESULT LongFile::NormalizePath(SString & path)
 
     if (ret == 0)
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     if (ret > size - prefixLen)
@@ -740,7 +740,7 @@ HRESULT LongFile::NormalizePath(SString & path)
 
         if (ret == 0)
         {
-            return E_FAIL;
+            return LogHR(E_FAIL);
         }
     }
 

--- a/src/coreclr/utilcode/sstring_com.cpp
+++ b/src/coreclr/utilcode/sstring_com.cpp
@@ -35,7 +35,7 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
     }
     CONTRACT_END;
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
 #ifndef FEATURE_UTILCODE_NO_DEPENDENCIES
     if (pResourceDLL == NULL)
@@ -91,11 +91,15 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
         }
         EX_CATCH
         {
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
         }
         EX_END_CATCH(SwallowAllExceptions);
     }
+    else
 #endif //!FEATURE_UTILCODE_NO_DEPENDENCIES
+    {
+        hr = LogHR(E_FAIL);
+    }
 
     RETURN hr;
 } // SString::LoadResourceAndReturnHR

--- a/src/coreclr/utilcode/stgpool.cpp
+++ b/src/coreclr/utilcode/stgpool.cpp
@@ -503,7 +503,7 @@ StgPool::PersistToStream(
     }
     EX_CATCH
     {
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
     }
     EX_END_CATCH(SwallowAllExceptions);
 
@@ -613,7 +613,7 @@ StgPool::CopyPool(
     if (cbDataSize != cbCopiedDataSize)
     {
         Debug_ReportInternalError("It is expected to copy everything from the source pool.");
-        IfFailGo(E_FAIL);
+        IfFailGo(LogHR(E_FAIL));
     }
 
     // Add the newly allocated segment to the pool
@@ -1917,7 +1917,7 @@ CInMemoryStream::Seek(
             plibNewPosition->QuadPart = m_cbCurrent;
     }
 
-    return (m_cbCurrent < m_cbSize) ? (S_OK) : E_FAIL;
+    return (m_cbCurrent < m_cbSize) ? (S_OK) : LogHR(E_FAIL);
 } // CInMemoryStream::Seek
 
 HRESULT

--- a/src/coreclr/utilcode/util_nodependencies.cpp
+++ b/src/coreclr/utilcode/util_nodependencies.cpp
@@ -606,7 +606,7 @@ HRESULT GetHex(
         }
         else
         {
-            return E_FAIL;
+            return LogHR(E_FAIL);
         }
         val = (val << 4) + nibble;
     }

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -4806,7 +4806,7 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
     }
     CONTRACTL_END;
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     // Switch to COOP mode since we are going to work with managed references
     GCX_COOP();

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -1407,7 +1407,7 @@ HRESULT RunMain(MethodDesc *pFD ,
 
     if (!pFD) {
         _ASSERTE(!"Must have a function to call!");
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     CorEntryPointType EntryType = EntryManagedMain;

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3149,7 +3149,7 @@ DomainAssembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
 DomainAssembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
 {
     WRAPPER_NO_CONTRACT;
-    ThrowHR(E_FAIL);
+    ThrowHR(LogHR(E_FAIL));
 }
 #endif // !DACCESS_COMPILE
 
@@ -5582,7 +5582,7 @@ void DECLSPEC_NORETURN ModuleBase::ThrowTypeLoadExceptionImpl(IMDInternalImport 
                                                       UINT resIDWhy)
 {
     WRAPPER_NO_CONTRACT;
-    ThrowHR(E_FAIL);
+    ThrowHR(LogHR(E_FAIL));
 }
 #else
 void DECLSPEC_NORETURN Module::ThrowTypeLoadExceptionImpl(IMDInternalImport *pInternalImport,

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -273,9 +273,9 @@ HRESULT EnsureEEStarted()
     CONTRACTL_END;
 
     if (g_fEEShutDown)
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     // On non x86 platforms, when we load CoreLib during EEStartup, we will
     // re-enter _CorDllMain with a DLL_PROCESS_ATTACH for CoreLib. We are
@@ -763,7 +763,7 @@ void EEStartupHelper()
             if (!Disassembler::IsAvailable())
             {
                 fprintf(stderr, "External disassembler is not available.\n");
-                IfFailGo(E_FAIL);
+                IfFailGo(LogHR(E_FAIL));
             }
         }
 #endif // USE_DISASSEMBLER
@@ -823,7 +823,7 @@ void EEStartupHelper()
 #ifndef TARGET_UNIX
         if (!RegisterOutOfProcessWatsonCallbacks())
         {
-            IfFailGo(E_FAIL);
+            IfFailGo(LogHR(E_FAIL));
         }
 #endif // !TARGET_UNIX
 
@@ -849,7 +849,7 @@ void EEStartupHelper()
         //
         if (!InstallUnhandledExceptionFilter())
         {
-            IfFailGo(E_FAIL);
+            IfFailGo(LogHR(E_FAIL));
         }
 
         // throws on error
@@ -989,6 +989,7 @@ ErrExit: ;
     }
     EX_CATCH
     {
+        hr = GET_EXCEPTION()->GetHR();
     }
     EX_END_CATCH(RethrowTerminalExceptionsWithInitCheck)
 
@@ -997,7 +998,7 @@ ErrExit: ;
             g_fEEInit = false;
 
         if (!FAILED(hr))
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
 
         g_EEStartupStatus = hr;
     }
@@ -1028,7 +1029,7 @@ LONG FilterStartupException(PEXCEPTION_POINTERS p, PVOID pv)
 
     // Make sure we got a failure code in this case
     if (!FAILED(g_EEStartupStatus))
-        g_EEStartupStatus = E_FAIL;
+        g_EEStartupStatus = LogHR(E_FAIL);
 
     // Initializations has failed so reset the g_fEEInit flag.
     g_fEEInit = false;

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -490,7 +490,7 @@ HRESULT EEClass::AddField(MethodTable * pMT, mdFieldDef fieldDef, EnCFieldDesc *
     // We'll just update our private EnC structures instead.
     EnCEEClassData *pEnCClass = ((EditAndContinueModule*)pModule)->GetEnCEEClassData(pMT);
     if (! pEnCClass)
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
     // Add the field element to the list of added fields for this class
     pEnCClass->AddField(pAddedField);
@@ -572,7 +572,7 @@ HRESULT EEClass::AddMethod(MethodTable * pMT, mdMethodDef methodDef, RVA newRVA,
     {
         _ASSERTE(! "**Error** EEClass::AddMethod parent token not found");
         LOG((LF_ENC, LL_INFO100, "**Error** EEClass::AddMethod parent token not found\n"));
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 #endif // _DEBUG
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4370,7 +4370,6 @@ void GetUnmanagedStackWalkInfo(IN  ULONG64   ControlPc,
             if (pExceptionDir != NULL)
             {
                 // Do a binary search on the static function table of mscorwks.dll.
-                HRESULT hr = E_FAIL;
                 TADDR   taFuncEntry;
                 T_RUNTIME_FUNCTION functionEntry;
 
@@ -4382,7 +4381,7 @@ void GetUnmanagedStackWalkInfo(IN  ULONG64   ControlPc,
                 {
                     dwMid = (dwLow + dwHigh) >> 1;
                     taFuncEntry = pExceptionDir + dwMid * sizeof(T_RUNTIME_FUNCTION);
-                    hr = DacReadAll(taFuncEntry, &functionEntry, sizeof(functionEntry), false);
+                    HRESULT hr = DacReadAll(taFuncEntry, &functionEntry, sizeof(functionEntry), false);
                     if (FAILED(hr))
                     {
                         return;

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1909,7 +1909,7 @@ HRESULT CodeVersionManager::PublishNativeCodeVersion(MethodDesc* pMethod, Native
     else
     {
         _ASSERTE(!"This method doesn't support versioning but was requested to be versioned.");
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 }
 

--- a/src/coreclr/vm/commtmemberinfomap.cpp
+++ b/src/coreclr/vm/commtmemberinfomap.cpp
@@ -756,7 +756,7 @@ void ComMTMemberInfoMap::GetMethodPropsForMeth(
         // Get the name.
         pszName = pMeth->GetName();
         if (pszName == NULL)
-            ThrowHR(E_FAIL);
+            ThrowHR(LogHR(E_FAIL));
 
         if (stricmpUTF8(pszName, szInitName) == 0)
         {

--- a/src/coreclr/vm/customattribute.cpp
+++ b/src/coreclr/vm/customattribute.cpp
@@ -302,7 +302,7 @@ HRESULT Attribute::ParseCaValue(
 
     default:
         // The format of the custom attribute record is invalid.
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
         break;
     } // End switch
 

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -4467,14 +4467,14 @@ HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, Met
         if (pTargetMT->HasInstantiation())
         {
             // ManagedToNativeComInteropStubAttribute is not supported with generics
-            return E_FAIL;
+            return LogHR(E_FAIL);
         }
 
         if (pTargetMD->IsFCall())
         {
             // ManagedToNativeComInteropStubAttribute is not supported on FCalls (i.e. methods on legacy
             // interfaces forwarded to CustomMarshalers.dll such as IEnumerable::GetEnumerator)
-            return E_FAIL;
+            return LogHR(E_FAIL);
         }
         _ASSERTE(pTargetMD->IsComPlusCall());
 
@@ -4490,7 +4490,7 @@ HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, Met
             // GetCustomAttribute returns S_FALSE when it cannot find the attribute but nothing fails...
             // Translate that to E_FAIL
             else if (hr == S_FALSE)
-                RETURN E_FAIL;
+                RETURN LogHR(E_FAIL);
         }
         else
         {
@@ -4505,11 +4505,11 @@ HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, Met
                 RETURN hr;
             }
             else
-                RETURN E_FAIL;
+                RETURN LogHR(E_FAIL);
         }
     }
     else
-        RETURN E_FAIL;
+        RETURN LogHR(E_FAIL);
 
     //
     // Parse the attribute

--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -483,7 +483,7 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
             // add FCUnique(<a random unique number here>); to one of the offending fcalls.
 
             _ASSERTE(!"Duplicate pImplementation entries found in reverse fcall table");
-            ThrowHR(E_FAIL);
+            ThrowHR(LogHR(E_FAIL));
         }
     }
     else

--- a/src/coreclr/vm/eetoprofinterfaceimpl.cpp
+++ b/src/coreclr/vm/eetoprofinterfaceimpl.cpp
@@ -541,7 +541,7 @@ HRESULT EEToProfInterfaceImpl::Init(
         // A specialized event log entry for this failure would be confusing and
         // unhelpful.  So just log a generic internal failure event
         ProfilingAPIUtility::LogProfError(IDS_E_PROF_INTERNAL_INIT, szClsid, E_FAIL);
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     // CEEInfo::GetProfilingHandle will be PREEMPTIVE mode when trying to update
@@ -2118,7 +2118,7 @@ HRESULT EEToProfInterfaceImpl::DetermineAndSetEnterLeaveFunctionHooksForJit()
     }
     EX_CATCH
     {
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
     }
     // We need to swallow all exceptions, because we will lock otherwise (in addition to
     // the IA64-only lock while allocating stub space!).  For example, specifying
@@ -2233,7 +2233,7 @@ HRESULT EEToProfInterfaceImpl::SetEventMask(DWORD dwEventMask, DWORD dwEventMask
                 (m_pProfilerInfo->eventMask.GetEventMaskHigh() & COR_PRF_HIGH_MONITOR_IMMUTABLE)))
         {
             // FUTURE: Should we have a dedicated HRESULT for setting immutable flag?
-            return E_FAIL;
+            return LogHR(E_FAIL);
         }
     }
 

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -871,12 +871,12 @@ HRESULT EECodeManager::FixContextForEnC(PCONTEXT         pCtx,
 
     if (!oldInfo.ebpFrame || !newInfo.ebpFrame) {
         LOG((LF_ENC, LL_INFO100, "**Error** EECM::FixContextForEnC Esp frames NYI\n"));
-        return E_FAIL; // Esp frames NYI
+        return LogHR(E_FAIL); // Esp frames NYI
     }
 
     if (pCtx->Esp != pCtx->Ebp - oldInfo.stackSize + sizeof(DWORD)) {
         LOG((LF_ENC, LL_INFO100, "**Error** EECM::FixContextForEnC stack should be empty\n"));
-        return E_FAIL; // stack should be empty - <TODO> @TODO : Barring localloc</TODO>
+        return LogHR(E_FAIL); // stack should be empty - <TODO> @TODO : Barring localloc</TODO>
     }
 
     if (oldInfo.handlers)
@@ -1020,7 +1020,7 @@ HRESULT EECodeManager::FixContextForEnC(PCONTEXT         pCtx,
 
     // x64: SP == FP before localloc
     if (oldStackBase != GetFP(&oldCtx))
-        return E_FAIL;
+        return LogHR(E_FAIL);
 #elif defined(TARGET_ARM64)
     DWORD oldFixedStackSize = oldGcDecoder.GetSizeOfEditAndContinueFixedStackFrame();
     DWORD newFixedStackSize = newGcDecoder.GetSizeOfEditAndContinueFixedStackFrame();
@@ -1029,7 +1029,7 @@ HRESULT EECodeManager::FixContextForEnC(PCONTEXT         pCtx,
 
     // ARM64: FP + 16 == SP + oldFixedStackSize before localloc
     if (GetFP(&oldCtx) + 16 != oldStackBase + oldFixedStackSize)
-        return E_FAIL;
+        return LogHR(E_FAIL);
 #else
     PORTABILITY_ASSERT("Edit-and-continue not enabled on this platform.");
 #endif
@@ -1041,7 +1041,7 @@ HRESULT EECodeManager::FixContextForEnC(PCONTEXT         pCtx,
     if (oldSizeOfPreservedArea != newSizeOfPreservedArea)
     {
         _ASSERTE(!"FixContextForEnC called with method whose frame header size changed from old to new version.");
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     TADDR callerSP = oldStackBase + oldFixedStackSize;
@@ -1110,7 +1110,7 @@ HRESULT EECodeManager::FixContextForEnC(PCONTEXT         pCtx,
         oldMethodVarsSortedBase = new  (nothrow) ICorDebugInfo::NativeVarInfo[oldNumVars];
         if (!oldMethodVarsSortedBase)
         {
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
             goto ErrExit;
         }
         oldMethodVarsSorted = oldMethodVarsSortedBase + (-ICorDebugInfo::UNKNOWN_ILNUM);
@@ -1164,7 +1164,7 @@ HRESULT EECodeManager::FixContextForEnC(PCONTEXT         pCtx,
         newMethodVarsSortedBase = new (nothrow) ICorDebugInfo::NativeVarInfo[newNumVars];
         if (!newMethodVarsSortedBase)
         {
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
             goto ErrExit;
         }
         newMethodVarsSorted = newMethodVarsSortedBase + (-ICorDebugInfo::UNKNOWN_ILNUM);
@@ -1199,14 +1199,14 @@ HRESULT EECodeManager::FixContextForEnC(PCONTEXT         pCtx,
         rgVal1 = new (nothrow) SIZE_T[newNumVars];
         if (rgVal1 == NULL)
         {
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
             goto ErrExit;
         }
 
         rgVal2 = new (nothrow) SIZE_T[newNumVars];
         if (rgVal2 == NULL)
         {
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
             goto ErrExit;
         }
 

--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -363,7 +363,7 @@ HRESULT EditAndContinueModule::AddMethod(mdMethodDef token)
     if (FAILED(hr))
     {
         LOG((LF_ENC, LL_INFO100, "**Error** EnCModule::AM can't find parent token for method token %08x\n", token));
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     // see if the class is loaded yet.
@@ -440,7 +440,7 @@ HRESULT EditAndContinueModule::AddField(mdFieldDef token)
     if (FAILED(hr))
     {
         LOG((LF_ENC, LL_INFO100, "**Error** EnCModule::AF can't find parent token for field token %08x\n", token));
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     // see if the class is loaded yet. If not we don't need to do anything.  When this class is
@@ -622,8 +622,6 @@ HRESULT EditAndContinueModule::ResumeInUpdatedFunction(
     }
 #endif
 
-    HRESULT hr = E_FAIL;
-
     // JIT-compile the updated version of the method
     PCODE jittedCode = JitUpdatedFunction(pMD, pOrigContext);
     if ( jittedCode == NULL )
@@ -706,7 +704,7 @@ HRESULT EditAndContinueModule::ResumeInUpdatedFunction(
     LOG((LF_ENC, LL_ERROR, "**Error** EnCModule::ResumeInUpdatedFunction returned from ResumeAtJit"));
     _ASSERTE(!"Should not return from FixContextAndResume()");
 
-    hr = E_FAIL;
+    HRESULT hr = LogHR(E_FAIL);
 
     // If we fail for any reason we have already potentially trashed with new locals and we have also unwound any
     // Win32 handlers on the stack so cannot ever return from this function.

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -949,7 +949,7 @@ HRESULT ETW::GCLog::ForceGCForDiagnostics()
     // the Thread object here instead.
     if (GetThreadNULLOk() == NULL)
     {
-        HRESULT hr = E_FAIL;
+        HRESULT hr;
         SetupThreadNoThrow(&hr);
         if (FAILED(hr))
             return hr;
@@ -973,7 +973,10 @@ HRESULT ETW::GCLog::ForceGCForDiagnostics()
 
 #ifndef FEATURE_NATIVEAOT
     }
-    EX_CATCH { }
+    EX_CATCH 
+    {
+        hr = LogHR(E_FAIL);
+    }
     EX_END_CATCH(RethrowTerminalExceptions);
 #endif // FEATURE_NATIVEAOT
 
@@ -2798,7 +2801,7 @@ HRESULT ETW::TypeSystemLog::PreRegistrationInit()
         CrstEtwTypeLogHash,
         CRST_UNSAFE_ANYMODE))       // This lock is taken during a GC while walking the heap
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     return S_OK;

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -284,17 +284,22 @@ HRESULT GetExceptionHResult(OBJECTREF throwable)
     }
     CONTRACTL_END;
 
-    HRESULT hr = E_FAIL;
     if (throwable == NULL)
-        return hr;
+        return LogHR(E_FAIL);
 
     // Since any object can be thrown in managed code, not only instances of System.Exception subclasses
     // we need to check to see if we are dealing with an exception before attempting to retrieve
     // the HRESULT field. If we are not dealing with an exception, then we will simply return E_FAIL.
     _ASSERTE(IsException(throwable->GetMethodTable()));        // what is the pathway here?
+
+    HRESULT hr;
     if (IsException(throwable->GetMethodTable()))
     {
         hr = ((EXCEPTIONREF)throwable)->GetHResult();
+    }
+    else
+    {
+        hr = LogHR(E_FAIL);
     }
 
     return hr;
@@ -310,17 +315,21 @@ DWORD GetExceptionXCode(OBJECTREF throwable)
     }
     CONTRACTL_END;
 
-    HRESULT hr = E_FAIL;
     if (throwable == NULL)
-        return hr;
+        return LogHR(E_FAIL);
 
     // Since any object can be thrown in managed code, not only instances of System.Exception subclasses
     // we need to check to see if we are dealing with an exception before attempting to retrieve
     // the HRESULT field. If we are not dealing with an exception, then we will simply return E_FAIL.
     _ASSERTE(IsException(throwable->GetMethodTable()));        // what is the pathway here?
+    HRESULT hr;
     if (IsException(throwable->GetMethodTable()))
     {
         hr = ((EXCEPTIONREF)throwable)->GetXCode();
+    }
+    else
+    {
+        hr = LogHR(E_FAIL);
     }
 
     return hr;
@@ -1736,7 +1745,7 @@ HRESULT IsLegalTransition(Thread *pThread,
                                         pFilterCtx,
                                         gcInfoToken,
                                         offFrom))
-                            return E_FAIL;
+                            return LogHR(E_FAIL);
                     }
                     return S_OK;
 #else  // FEATURE_EH_FUNCLETS
@@ -1792,7 +1801,7 @@ HRESULT IsLegalTransition(Thread *pThread,
                             if (!pEECM->LeaveFinally(gcInfoToken,
                                                      offFrom,
                                                      pFilterCtx))
-                                return E_FAIL;
+                                return LogHR(E_FAIL);
                         }
                         return S_OK;
                     }
@@ -2643,16 +2652,21 @@ HRESULT GetHRFromThrowable(OBJECTREF throwable)
     STATIC_CONTRACT_GC_TRIGGERS;
     STATIC_CONTRACT_MODE_ANY;
 
-    HRESULT    hr  = E_FAIL;
     MethodTable *pMT = throwable->GetMethodTable();
 
     // Only Exception objects have a HResult field
     // So don't fetch the field unless we have an exception
 
     _ASSERTE(IsException(pMT));     // what is the pathway here?
+
+    HRESULT hr;
     if (IsException(pMT))
     {
         hr = ((EXCEPTIONREF)throwable)->GetHResult();
+    }
+    else
+    {
+        hr = LogHR(E_FAIL);
     }
 
     return hr;
@@ -7673,7 +7687,7 @@ void CLRAddVectoredHandlers(void)
     if (g_hVectoredExceptionHandler == NULL)
     {
         LOG((LF_EH, LL_INFO100, "CLRAddVectoredHandlers: AddVectoredExceptionHandler() failed\n"));
-        COMPlusThrowHR(E_FAIL);
+        COMPlusThrowHR(LogHR(E_FAIL));
     }
 
     LOG((LF_EH, LL_INFO100, "CLRAddVectoredHandlers: AddVectoredExceptionHandler() succeeded\n"));

--- a/src/coreclr/vm/fcall.cpp
+++ b/src/coreclr/vm/fcall.cpp
@@ -340,7 +340,7 @@ VOID PermitHelperMethodFrameState::CheckHelperMethodFramePermitted ()
         if (!nAssociatedListEntries)
         {
             char szFunction[cchMaxAssertStackLevelStringLen];
-            GetStringFromAddr((DWORD_PTR)CurrentIP, szFunction);
+            GetStringFromAddr((DWORD_PTR)CurrentIP, szFunction, sizeof(szFunction));
 
             CONSISTENCY_CHECK_MSGF(false, ("Unmanaged caller %s at sp %p/ip %p is missing a "
                                            "PERMIT_HELPER_METHOD_FRAME_BEGIN, or this function "
@@ -358,7 +358,7 @@ VOID PermitHelperMethodFrameState::CheckHelperMethodFramePermitted ()
     if (pList)
     {
         char szFunction[cchMaxAssertStackLevelStringLen];
-        GetStringFromAddr((DWORD_PTR)CurrentIP, szFunction);
+        GetStringFromAddr((DWORD_PTR)CurrentIP, szFunction, sizeof(szFunction));
 
         CONSISTENCY_CHECK_MSGF(false, ("fcall entry point %s at sp %p/ip %p is missing a "
                                        "FCALL_TRANSITION_BEGIN or a FCIMPL\n", szFunction, CurrentSP, CurrentIP));

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "gcrefmap.h"
+#include <intrin.h>
 
 void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
 {
@@ -1736,4 +1737,18 @@ uint32_t GCToEEInterface::GetCurrentProcessCpuCount()
 void GCToEEInterface::DiagAddNewRegion(int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
 {
     ProfilerAddNewRegion(generation, rangeStart, rangeEnd, rangeEndReserved);
+}
+
+uint32_t GCToEEInterface::LogHR(uint32_t hr, void* address)
+{
+    return ::LogHR(hr, address);
+}
+
+#pragma intrinsic(_ReturnAddress)
+
+// This function is marked as NOINLINE so that it can get the caller's address
+NOINLINE
+uint32_t GCToEEInterface::LogHR(uint32_t hr)
+{
+    return LogHR(hr, _ReturnAddress());
 }

--- a/src/coreclr/vm/gcenv.ee.h
+++ b/src/coreclr/vm/gcenv.ee.h
@@ -87,6 +87,10 @@ public:
     uint32_t GetCurrentProcessCpuCount();
 
     void DiagAddNewRegion(int generation, BYTE * rangeStart, BYTE * rangeEnd, BYTE * rangeEndReserved);
+
+    uint32_t LogHR(uint32_t hr, void* address);
+
+    uint32_t LogHR(uint32_t hr);
 };
 
 } // namespace standalone

--- a/src/coreclr/vm/gcheaputilities.cpp
+++ b/src/coreclr/vm/gcheaputilities.cpp
@@ -185,7 +185,7 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
 
 #ifndef FEATURE_STANDALONE_GC
     LOG((LF_GC, LL_FATALERROR, "EE not built with the ability to load standalone GCs"));
-    return E_FAIL;
+    return LogHR(E_FAIL);
 #else
     HMODULE hMod = LoadStandaloneGc(standaloneGcLocation);
     if (!hMod)
@@ -220,7 +220,7 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
     {
         LOG((LF_GC, LL_FATALERROR, "Loaded GC has incompatible major version number (expected %d, got %d)\n",
             GC_INTERFACE_MAJOR_VERSION, g_gc_version_info.MajorVersion));
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     if (g_gc_version_info.MinorVersion < GC_INTERFACE_MINOR_VERSION)

--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -357,7 +357,7 @@ GetMethodNativeMap(MethodDesc* methodDesc,
 
     if (!success)
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     // Need to convert map formats.
@@ -502,22 +502,22 @@ GetDebugInfoFromPDB(MethodDesc* methodDescPtr,
     ULONG32 numMap;
 
     if (!getInfoForMethodDelegate)
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
     if (GetMethodNativeMap(methodDescPtr, &numMap, map, &locals.countVars, &locals.vars) != S_OK)
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
     const Module* mod = methodDescPtr->GetMethodTable()->GetModule();
     SString modName = mod->GetFile()->GetPath();
     if (modName.IsEmpty())
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
     const char* szModName = modName.GetUTF8();
 
     MethodDebugInfo methodDebugInfo(numMap, locals.countVars);
 
     if (getInfoForMethodDelegate(szModName, methodDescPtr->GetMemberDef(), methodDebugInfo) == FALSE)
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
     symInfoLen = numMap;
     symInfo = new SymbolsInfo[numMap];

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -171,7 +171,7 @@ HRESULT SetupErrorInfo(OBJECTREF pThrownObject)
         EX_CATCH
         {
             if (SUCCEEDED(hr))
-                hr = E_FAIL;
+                hr = LogHR(E_FAIL);
         }
         EX_END_CATCH(SwallowAllExceptions);
     }
@@ -1117,7 +1117,7 @@ HRESULT SafeQueryInterface(IUnknown* pUnk, REFIID riid, IUnknown** pResUnk)
     Thread * const pThread = GetThreadNULLOk();
 
     *pResUnk = NULL;
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     GCX_PREEMP_NO_DTOR_HAVE_THREAD(pThread);
 
@@ -1132,6 +1132,7 @@ HRESULT SafeQueryInterface(IUnknown* pUnk, REFIID riid, IUnknown** pResUnk)
     }
     PAL_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
+        hr = LogHR(E_FAIL);
 #if defined(STACK_GUARDS_DEBUG)
         // Catching and just swallowing an exception means we need to tell
         // the SO code that it should go back to normal operation, as it
@@ -1175,7 +1176,7 @@ HRESULT SafeQueryInterfacePreemp(IUnknown* pUnk, REFIID riid, IUnknown** pResUnk
     Thread * const pThread = GetThreadNULLOk();
 
     *pResUnk = NULL;
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     BEGIN_CONTRACT_VIOLATION(ThrowsViolation); // message pump could happen, so arbitrary managed code could run
 
@@ -1188,6 +1189,7 @@ HRESULT SafeQueryInterfacePreemp(IUnknown* pUnk, REFIID riid, IUnknown** pResUnk
     }
     PAL_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
+        hr = LogHR(E_FAIL);
 #if defined(STACK_GUARDS_DEBUG)
         // Catching and just swallowing an exception means we need to tell
         // the SO code that it should go back to normal operation, as it

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11224,14 +11224,14 @@ void CEEJitInfo::allocUnwindInfo (
     if (!FitsInU4(currentCodeSizeT))
     {
         _ASSERTE(!"Bad currentCodeSizeT");
-        COMPlusThrowHR(E_FAIL);
+        COMPlusThrowHR(LogHR(E_FAIL));
     }
 
     /* Check if EndAddress offset fits in 32-bit */
     if (!FitsInU4(currentCodeSizeT + endOffset))
     {
         _ASSERTE(!"Bad currentCodeSizeT");
-        COMPlusThrowHR(E_FAIL);
+        COMPlusThrowHR(LogHR(E_FAIL));
     }
 
     unsigned currentCodeOffset = (unsigned) currentCodeSizeT;
@@ -11243,7 +11243,7 @@ void CEEJitInfo::allocUnwindInfo (
     if (!FitsInU4(unwindInfoDeltaT))
     {
         _ASSERTE(!"Bad unwindInfoDeltaT");
-        COMPlusThrowHR(E_FAIL);
+        COMPlusThrowHR(LogHR(E_FAIL));
     }
 
     unsigned unwindInfoDelta = (unsigned) unwindInfoDeltaT;
@@ -11853,6 +11853,11 @@ HRESULT CEEJitInfo::allocPgoInstrumentationBySchema(
 
     EE_TO_JIT_TRANSITION();
 
+    if (hr == E_FAIL)
+    {
+        LogHR(E_FAIL);
+    }
+
     return hr;
 }
 
@@ -11917,6 +11922,11 @@ HRESULT CEEJitInfo::getPgoInstrumentationResults(
 #endif
 
     EE_TO_JIT_TRANSITION();
+
+    if (hr == E_FAIL)
+    {
+        LogHR(E_FAIL);
+    }
 
     return hr;
 }

--- a/src/coreclr/vm/managedmdimport.cpp
+++ b/src/coreclr/vm/managedmdimport.cpp
@@ -48,7 +48,7 @@ FCIMPL11(void, MetaDataImport::GetMarshalAs,
 
         if (!ParseNativeTypeInfo(&info, pvNativeType, cbNativeType))
         {
-            ThrowMetaDataImportException(E_FAIL);
+            ThrowMetaDataImportException(LogHR(E_FAIL));
         }
 
         *unmanagedType = info.m_NativeType;
@@ -364,7 +364,7 @@ MDImpl2(void, MetaDataImport::GetName, mdToken tk, LPCSTR* pszName)
     }
     else
     {
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
     }
 
     if (FAILED(hr))

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3645,7 +3645,6 @@ void MethodTable::DoRunClassInitThrowing()
 
     AppDomain *pDomain = GetAppDomain();
 
-    HRESULT hrResult = E_FAIL;
     const char *description;
     STRESS_LOG2(LF_CLASSLOADER, LL_INFO100000, "DoRunClassInit: Request to init %pT in appdomain %p\n", this, pDomain);
 
@@ -3833,7 +3832,7 @@ void MethodTable::DoRunClassInitThrowing()
                             pEntry->m_hInitException = pEntry->m_pLoaderAllocator->AllocateHandle(CLRException::GetPreallocatedOutOfMemoryException());
                         } EX_END_CATCH(SwallowAllExceptions);
 
-                        pEntry->m_hrResultCode = E_FAIL;
+                        pEntry->m_hrResultCode = LogHR(E_FAIL);
                         SetClassInitError();
 
                         COMPlusThrow(gc.pThrowable);
@@ -3854,7 +3853,7 @@ void MethodTable::DoRunClassInitThrowing()
             {
                 // Use previous result
 
-                hrResult = pEntry->m_hrResultCode;
+                HRESULT hrResult = pEntry->m_hrResultCode;
                 if(FAILED(hrResult))
                 {
                     // An exception may have occurred in the cctor. DoRunClassInit() should return FALSE in that
@@ -6270,7 +6269,7 @@ HRESULT MethodTable::GetGuidNoThrow(GUID *pGuid, BOOL bGenerateIfNotFound, BOOL 
 
     // ensure we return a failure hr when pGuid is not filled in
     if (SUCCEEDED(hr) && (*pGuid == GUID_NULL))
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
 
     return hr;
 }
@@ -8353,12 +8352,12 @@ MethodTable::TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType
         }
         else
         {
-            COMPlusThrow(kTypeLoadException, E_FAIL);
+            COMPlusThrow(kTypeLoadException, LogHR(E_FAIL));
         }
 
         if (pMethodDecl == nullptr)
         {
-            COMPlusThrow(kTypeLoadException, E_FAIL);
+            COMPlusThrow(kTypeLoadException, LogHR(E_FAIL));
         }
         if (!pMethodDecl->HasSameMethodDefAs(pInterfaceMD))
         {
@@ -8368,7 +8367,7 @@ MethodTable::TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType
         // Spec requires that all body token for MethodImpls that refer to static virtual implementation methods must be MethodDef tokens.
         if (TypeFromToken(methodBody) != mdtMethodDef)
         {
-            COMPlusThrow(kTypeLoadException, E_FAIL);
+            COMPlusThrow(kTypeLoadException, LogHR(E_FAIL));
         }
 
         MethodDesc *pMethodImpl = MemberLoader::GetMethodDescFromMethodDef(
@@ -8378,14 +8377,14 @@ MethodTable::TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType
             CLASS_LOAD_EXACTPARENTS);
         if (pMethodImpl == nullptr)
         {
-            COMPlusThrow(kTypeLoadException, E_FAIL);
+            COMPlusThrow(kTypeLoadException, LogHR(E_FAIL));
         }
 
         // Spec requires that all body token for MethodImpls that refer to static virtual implementation methods must to methods
         // defined on the same type that defines the MethodImpl
         if (!HasSameTypeDefAs(pMethodImpl->GetMethodTable()))
         {
-            COMPlusThrow(kTypeLoadException, E_FAIL);
+            COMPlusThrow(kTypeLoadException, LogHR(E_FAIL));
         }
 
         if (!verifyImplemented)
@@ -8409,7 +8408,7 @@ MethodTable::TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType
             if (pPrevMethodImpl != nullptr)
             {
                 // Two MethodImpl records found for the same virtual static interface method
-                COMPlusThrow(kTypeLoadException, E_FAIL);
+                COMPlusThrow(kTypeLoadException, LogHR(E_FAIL));
             }
             pPrevMethodImpl = pMethodImpl;
         }

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -1322,7 +1322,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
     // Retrieve the native type for the current parameter.
     if (!ParseNativeTypeInfo(token, pModule->GetMDImport(), &ParamInfo))
     {
-        IfFailGoto(E_FAIL, lFail);
+        IfFailGoto(LogHR(E_FAIL), lFail);
     }
 
     nativeType = ParamInfo.m_NativeType;
@@ -1340,7 +1340,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             // and emit exception throwing code directly in STUB in COM interop
             m_type = MARSHAL_TYPE_UNKNOWN;
             m_resID = IDS_EE_SIZECONTROLOUTOFRANGE;
-            IfFailGoto(E_FAIL, lFail);
+            IfFailGoto(LogHR(E_FAIL), lFail);
         }
     }
 
@@ -1413,7 +1413,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
         if (IsFieldScenario())
         {
             m_resID = IDS_EE_BADMARSHALFIELD_NOCUSTOMMARSH;
-            IfFailGoto(E_FAIL, lFail);
+            IfFailGoto(LogHR(E_FAIL), lFail);
         }
 
         switch (mtype)
@@ -1432,7 +1432,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
             default:
                 m_resID = IDS_EE_BADMARSHAL_CUSTOMMARSHALER;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
         }
 
         // Set m_type to MARSHAL_TYPE_UNKNOWN in case SetupCustomMarshalerHelper throws.
@@ -1512,7 +1512,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
                 default:
                     m_resID = IDS_EE_BADMARSHAL_BOOLEAN;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
             }
             break;
 
@@ -1535,7 +1535,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
                 default:
                     m_resID = IDS_EE_BADMARSHAL_CHAR;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
 
             }
             break;
@@ -1544,7 +1544,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_I1 || nativeType == NATIVE_TYPE_U1 || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_I1;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_GENERIC_1;
             break;
@@ -1553,7 +1553,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_U1 || nativeType == NATIVE_TYPE_I1 || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_I1;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_GENERIC_U1;
             break;
@@ -1562,7 +1562,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_I2 || nativeType == NATIVE_TYPE_U2 || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_I2;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_GENERIC_2;
             break;
@@ -1571,7 +1571,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_U2 || nativeType == NATIVE_TYPE_I2 || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_I2;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_GENERIC_U2;
             break;
@@ -1592,7 +1592,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
                 default:
                 m_resID = IDS_EE_BADMARSHAL_I4;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_GENERIC_4;
             break;
@@ -1613,7 +1613,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
                 default:
                 m_resID = IDS_EE_BADMARSHAL_I4;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_GENERIC_U4;
             break;
@@ -1622,7 +1622,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_I8 || nativeType == NATIVE_TYPE_U8 || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_I8;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_GENERIC_8;
             break;
@@ -1631,7 +1631,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_U8 || nativeType == NATIVE_TYPE_I8 || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_I8;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_GENERIC_8;
             break;
@@ -1640,7 +1640,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_INT || nativeType == NATIVE_TYPE_UINT || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_I;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
 #ifdef TARGET_64BIT
             m_type = MARSHAL_TYPE_GENERIC_8;
@@ -1653,7 +1653,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_UINT || nativeType == NATIVE_TYPE_INT || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_I;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
 #ifdef TARGET_64BIT
             m_type = MARSHAL_TYPE_GENERIC_8;
@@ -1667,7 +1667,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_R4 || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_R4;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_FLOAT;
             break;
@@ -1676,7 +1676,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_R8 || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_R8;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
             m_type = MARSHAL_TYPE_DOUBLE;
             break;
@@ -1685,7 +1685,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (nativeType != NATIVE_TYPE_DEFAULT)
             {
                 m_resID = IDS_EE_BADMARSHAL_PTR;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
 #ifdef TARGET_64BIT
             m_type = MARSHAL_TYPE_GENERIC_8;
@@ -1698,7 +1698,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (!(nativeType == NATIVE_TYPE_FUNC || nativeType == NATIVE_TYPE_DEFAULT))
             {
                 m_resID = IDS_EE_BADMARSHAL_FNPTR;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
 #ifdef TARGET_64BIT
             m_type = MARSHAL_TYPE_GENERIC_8;
@@ -1733,7 +1733,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (sigTH.HasInstantiation())
             {
                 m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
 
             m_pMT = sigTH.GetMethodTable();
@@ -1747,7 +1747,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                 if (sig.IsStringType(pModule, pTypeContext))
                 {
                     m_resID = IsFieldScenario() ? IDS_EE_BADMARSHALFIELD_STRING : IDS_EE_BADMARSHALPARAM_STRING;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 if (COMDelegate::IsDelegate(m_pMT))
@@ -1757,7 +1757,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     // The user can specify UnmanagedType.IDispatch and use the delegate through the IDispatch interface
                     // if they need an interface pointer.
                     m_resID = IDS_EE_BADMARSHAL_DELEGATE_TLB_INTERFACE;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
                 m_type = MARSHAL_TYPE_INTERFACE;
             }
@@ -1773,7 +1773,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (builder && m_ms == MARSHAL_SCENARIO_FIELD)
                     {
                         m_resID = IDS_EE_BADMARSHALFIELD_NOSTRINGBUILDER;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
 
                     switch ( nativeType )
@@ -1797,7 +1797,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                             {
                                 _ASSERTE(m_ms == MARSHAL_SCENARIO_COMINTEROP);
                                 // We disallow NATIVE_TYPE_LPTSTR for COM.
-                                IfFailGoto(E_FAIL, lFail);
+                                IfFailGoto(LogHR(E_FAIL), lFail);
                             }
 #endif // FEATURE_COMINTEROP
                             // We no longer support Win9x so LPTSTR always maps to a Unicode string.
@@ -1809,7 +1809,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                             if (builder)
                             {
                                 m_resID = IDS_EE_BADMARSHALPARAM_STRINGBUILDER;
-                                IfFailGoto(E_FAIL, lFail);
+                                IfFailGoto(LogHR(E_FAIL), lFail);
                             }
                             m_type = MARSHAL_TYPE_BSTR;
                             break;
@@ -1818,7 +1818,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                             if (builder)
                             {
                                 m_resID = IDS_EE_BADMARSHALPARAM_STRINGBUILDER;
-                                IfFailGoto(E_FAIL, lFail);
+                                IfFailGoto(LogHR(E_FAIL), lFail);
                             }
                             m_type = MARSHAL_TYPE_ANSIBSTR;
                             break;
@@ -1828,7 +1828,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                             if (builder)
                             {
                                 m_resID = IDS_EE_BADMARSHALPARAM_STRINGBUILDER;
-                                IfFailGoto(E_FAIL, lFail);
+                                IfFailGoto(LogHR(E_FAIL), lFail);
                             }
 
                             // We no longer support Win9x so TBSTR always maps to a normal (unicode) BSTR.
@@ -1842,7 +1842,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                             if (builder)
                             {
                                 m_resID = IDS_EE_BADMARSHALPARAM_STRINGBUILDER;
-                                IfFailGoto(E_FAIL, lFail);
+                                IfFailGoto(LogHR(E_FAIL), lFail);
                             }
                             m_type = m_fAnsi ? MARSHAL_TYPE_VBBYVALSTR : MARSHAL_TYPE_VBBYVALSTRW;
                             break;
@@ -1853,10 +1853,10 @@ MarshalInfo::MarshalInfo(Module* pModule,
                             if (builder)
                             {
                                 m_resID = IDS_EE_BADMARSHALPARAM_STRINGBUILDER;
-                                IfFailGoto(E_FAIL, lFail);
+                                IfFailGoto(LogHR(E_FAIL), lFail);
                             }
 
-                            IfFailGoto(E_FAIL, lFail);
+                            IfFailGoto(LogHR(E_FAIL), lFail);
                             break;
                         }
 #endif // FEATURE_COMINTEROP
@@ -1867,7 +1867,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                                 if (ParamInfo.m_Additive == 0)
                                 {
                                     m_resID = IDS_EE_BADMARSHALFIELD_ZEROLENGTHFIXEDSTRING;
-                                    IfFailGoto(E_FAIL, lFail);
+                                    IfFailGoto(LogHR(E_FAIL), lFail);
                                 }
 
                                 m_args.fs.fixedStringLength = ParamInfo.m_Additive;
@@ -1911,7 +1911,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                                 m_resID = IDS_EE_BADMARSHALPARAM_STRING;
                             }
 
-                            IfFailGoto(E_FAIL, lFail);
+                            IfFailGoto(LogHR(E_FAIL), lFail);
                             break;
                     }
                 }
@@ -1954,7 +1954,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (nativeType != NATIVE_TYPE_DEFAULT)
                     {
                         m_resID = IDS_EE_BADMARSHAL_SAFEHANDLE;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
                     m_args.m_pMT = m_pMT;
                     m_type = MARSHAL_TYPE_SAFEHANDLE;
@@ -1964,7 +1964,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (nativeType != NATIVE_TYPE_DEFAULT)
                     {
                         m_resID = IDS_EE_BADMARSHAL_CRITICALHANDLE;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
                     m_args.m_pMT = m_pMT;
                     m_type = MARSHAL_TYPE_CRITICALHANDLE;
@@ -1976,7 +1976,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                           nativeType == NATIVE_TYPE_INTF))
                     {
                         m_resID = IDS_EE_BADMARSHAL_INTERFACE;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
                     m_type = MARSHAL_TYPE_INTERFACE;
                 }
@@ -2000,7 +2000,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                                 // The user can specify UnmanagedType.IDispatch and use the delegate through the IDispatch interface
                                 // if they need an interface pointer.
                                 m_resID = IDS_EE_BADMARSHAL_DELEGATE_TLB_INTERFACE;
-                                IfFailGoto(E_FAIL, lFail);
+                                IfFailGoto(LogHR(E_FAIL), lFail);
                             }
                             else
 #endif // FEATURE_COMINTEROP
@@ -2014,7 +2014,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 #endif
                         default:
                         m_resID = IDS_EE_BADMARSHAL_DELEGATE;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                             break;
                     }
                 }
@@ -2023,7 +2023,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (!(nativeType == NATIVE_TYPE_DEFAULT || nativeType == (IsFieldScenario() ? NATIVE_TYPE_STRUCT : NATIVE_TYPE_LPSTRUCT)))
                     {
                         m_resID = IsFieldScenario() ? IDS_EE_BADMARSHALFIELD_LAYOUTCLASS : IDS_EE_BADMARSHAL_CLASS;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
                     m_type = IsFieldScenario() ? MARSHAL_TYPE_BLITTABLE_LAYOUTCLASS : MARSHAL_TYPE_BLITTABLEPTR;
                     m_args.m_pMT = m_pMT;
@@ -2033,7 +2033,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (!(nativeType == NATIVE_TYPE_DEFAULT || nativeType == (IsFieldScenario() ? NATIVE_TYPE_STRUCT : NATIVE_TYPE_LPSTRUCT)))
                     {
                         m_resID = IsFieldScenario() ? IDS_EE_BADMARSHALFIELD_LAYOUTCLASS : IDS_EE_BADMARSHAL_CLASS;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
                     m_type = IsFieldScenario() ? MARSHAL_TYPE_LAYOUTCLASS : MARSHAL_TYPE_LAYOUTCLASSPTR;
                     m_args.m_pMT = m_pMT;
@@ -2071,14 +2071,14 @@ MarshalInfo::MarshalInfo(Module* pModule,
                         case NATIVE_TYPE_DEFAULT:
                         case NATIVE_TYPE_STRUCT:
                             m_resID = IDS_EE_OBJECT_TO_VARIANT_NOT_SUPPORTED;
-                            IfFailGoto(E_FAIL, lFail);
+                            IfFailGoto(LogHR(E_FAIL), lFail);
                             break;
 
                         case NATIVE_TYPE_INTF:
                         case NATIVE_TYPE_IUNKNOWN:
                         case NATIVE_TYPE_IDISPATCH:
                             m_resID = IDS_EE_OBJECT_TO_ITF_NOT_SUPPORTED;
-                            IfFailGoto(E_FAIL, lFail);
+                            IfFailGoto(LogHR(E_FAIL), lFail);
                             break;
 #endif // FEATURE_COMINTEROP
 
@@ -2088,7 +2088,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
                         default:
                             m_resID = IsFieldScenario() ? IDS_EE_BADMARSHALFIELD_OBJECT : IDS_EE_BADMARSHAL_OBJECT;
-                            IfFailGoto(E_FAIL, lFail);
+                            IfFailGoto(LogHR(E_FAIL), lFail);
                     }
                 }
 
@@ -2128,14 +2128,14 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
                         default:
                             m_resID = IDS_EE_BADMARSHAL_SYSARRAY;
-                            IfFailGoto(E_FAIL, lFail);
+                            IfFailGoto(LogHR(E_FAIL), lFail);
 
                     }
                 }
                 else if (m_pMT->IsArray())
                 {
                     _ASSERTE(!"This invalid signature should never be hit!");
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 #endif // FEATURE_COMINTEROP
                 else
@@ -2143,14 +2143,14 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (!(nativeType == NATIVE_TYPE_INTF || nativeType == NATIVE_TYPE_DEFAULT))
                     {
                         m_resID = IDS_EE_BADMARSHAL_NOLAYOUT;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
 #ifdef FEATURE_COMINTEROP
                     // default marshalling is interface
                     m_type = MARSHAL_TYPE_INTERFACE;
 #else // FEATURE_COMINTEROP
                     m_resID = IDS_EE_OBJECT_TO_ITF_NOT_SUPPORTED;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
 #endif // FEATURE_COMINTEROP
                 }
             }
@@ -2174,7 +2174,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                         if (IsFieldScenario())
                         {
                             m_resID = IDS_EE_BADMARSHALFIELD_DECIMAL;
-                            IfFailGoto(E_FAIL, lFail);
+                            IfFailGoto(LogHR(E_FAIL), lFail);
                         }
                         m_type = MARSHAL_TYPE_DECIMAL_PTR;
                         break;
@@ -2185,7 +2185,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
                     default:
                         m_resID = IsFieldScenario() ? IDS_EE_BADMARSHALFIELD_DECIMAL : IDS_EE_BADMARSHALPARAM_DECIMAL;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                 }
             }
             else if (sig.IsClassThrowing(pModule, g_GuidClassName, pTypeContext))
@@ -2201,14 +2201,14 @@ MarshalInfo::MarshalInfo(Module* pModule,
                         if (IsFieldScenario())
                         {
                             m_resID = IDS_EE_BADMARSHAL_GUID;
-                            IfFailGoto(E_FAIL, lFail);
+                            IfFailGoto(LogHR(E_FAIL), lFail);
                         }
                         m_type = MARSHAL_TYPE_GUID_PTR;
                         break;
 
                     default:
                         m_resID = IDS_EE_BADMARSHAL_GUID;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                 }
             }
             else if (sig.IsClassThrowing(pModule, g_DateClassName, pTypeContext))
@@ -2216,7 +2216,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                 if (!(nativeType == NATIVE_TYPE_DEFAULT || nativeType == NATIVE_TYPE_STRUCT))
                 {
                     m_resID = IDS_EE_BADMARSHAL_DATETIME;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
                 m_type = MARSHAL_TYPE_DATE;
             }
@@ -2224,11 +2224,11 @@ MarshalInfo::MarshalInfo(Module* pModule,
             {
                 if (m_ms == MARSHAL_SCENARIO_FIELD)
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
                 if (!(nativeType == NATIVE_TYPE_DEFAULT))
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
                 m_type = MARSHAL_TYPE_ARRAYWITHOFFSET;
             }
@@ -2236,11 +2236,11 @@ MarshalInfo::MarshalInfo(Module* pModule,
             {
                 if (m_ms == MARSHAL_SCENARIO_FIELD)
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
                 if (!(nativeType == NATIVE_TYPE_DEFAULT))
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
                 m_type = MARSHAL_TYPE_HANDLEREF;
             }
@@ -2248,11 +2248,11 @@ MarshalInfo::MarshalInfo(Module* pModule,
             {
                 if (m_ms == MARSHAL_SCENARIO_FIELD)
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
                 if (!(nativeType == NATIVE_TYPE_DEFAULT))
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
                 m_type = MARSHAL_TYPE_ARGITERATOR;
             }
@@ -2261,13 +2261,13 @@ MarshalInfo::MarshalInfo(Module* pModule,
             {
                 if (!(nativeType == NATIVE_TYPE_DEFAULT))
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 // This is only supported for COM interop.
                 if (m_ms != MARSHAL_SCENARIO_COMINTEROP)
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 m_type = MARSHAL_TYPE_OLECOLOR;
@@ -2277,7 +2277,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             {
                 if (nativeType != NATIVE_TYPE_DEFAULT || IsFieldScenario())
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 m_type = MARSHAL_TYPE_RUNTIMETYPEHANDLE;
@@ -2286,7 +2286,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             {
                 if (nativeType != NATIVE_TYPE_DEFAULT || IsFieldScenario())
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 m_type = MARSHAL_TYPE_RUNTIMEFIELDHANDLE;
@@ -2295,7 +2295,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             {
                 if (nativeType != NATIVE_TYPE_DEFAULT || IsFieldScenario())
                 {
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 m_type = MARSHAL_TYPE_RUNTIMEMETHODHANDLE;
@@ -2309,7 +2309,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                 if (!IsValidForGenericMarshalling(m_pMT, IsFieldScenario()))
                 {
                     m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 // * Int128: Represents the 128 bit integer ABI primitive type which requires currently unimplemented handling
@@ -2320,14 +2320,14 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (m_pMT->IsInt128OrHasInt128Fields())
                     {
                         m_resID = IDS_EE_BADMARSHAL_INT128_RESTRICTION;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
                 }
 
                 if (!m_pMT->HasLayout())
                 {
                     m_resID = IDS_EE_BADMARSHAL_AUTOLAYOUT;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 UINT managedSize = m_pMT->GetNumInstanceFieldBytes();
@@ -2337,7 +2337,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     managedSize > 0xfff0)
                 {
                     m_resID = IDS_EE_STRUCTTOOCOMPLEX;
-                    IfFailGoto(E_FAIL, lFail);
+                    IfFailGoto(LogHR(E_FAIL), lFail);
                 }
 
                 if (m_pMT->IsBlittable())
@@ -2345,7 +2345,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (!(nativeType == NATIVE_TYPE_DEFAULT || nativeType == NATIVE_TYPE_STRUCT))
                     {
                         m_resID = IDS_EE_BADMARSHAL_VALUETYPE;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
 
                     if (m_byref && !isParam && !IsFieldScenario())
@@ -2380,7 +2380,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     if (!(nativeType == NATIVE_TYPE_DEFAULT || nativeType == NATIVE_TYPE_STRUCT))
                     {
                         m_resID = IDS_EE_BADMARSHAL_VALUETYPE;
-                        IfFailGoto(E_FAIL, lFail);
+                        IfFailGoto(LogHR(E_FAIL), lFail);
                     }
 #ifdef _DEBUG
                     if (ms == MARSHAL_SCENARIO_FIELD && fEmitsIL)
@@ -2407,7 +2407,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
             if (thElement.HasInstantiation() && !thElement.IsBlittable())
             {
                 m_resID = IDS_EE_BADMARSHAL_GENERICS_RESTRICTION;
-                IfFailGoto(E_FAIL, lFail);
+                IfFailGoto(LogHR(E_FAIL), lFail);
             }
 
             m_args.na.m_pArrayMT = arrayTypeHnd.AsMethodTable();
@@ -2622,7 +2622,7 @@ HRESULT MarshalInfo::HandleArrayElemType(NativeTypeParamInfo *pParamInfo, TypeHa
             m_type = MARSHAL_TYPE_SAFEARRAY;
 #else
             m_resID = IDS_EE_BADMARSHALFIELD_ARRAY;
-            return E_FAIL;
+            return LogHR(E_FAIL);
 #endif
         }
         else
@@ -2644,7 +2644,7 @@ HRESULT MarshalInfo::HandleArrayElemType(NativeTypeParamInfo *pParamInfo, TypeHa
     else
     {
         m_resID = IsFieldScenario() ? IDS_EE_BADMARSHALFIELD_ARRAY : IDS_EE_BADMARSHAL_ARRAY;
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
 #ifdef FEATURE_COMINTEROP
@@ -2668,7 +2668,7 @@ HRESULT MarshalInfo::HandleArrayElemType(NativeTypeParamInfo *pParamInfo, TypeHa
     if (!arrayMarshalInfo.IsValid())
     {
         m_resID = arrayMarshalInfo.GetErrorResourceId();
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     // Set the array type handle and VARTYPE to use for marshalling.
@@ -2688,7 +2688,7 @@ HRESULT MarshalInfo::HandleArrayElemType(NativeTypeParamInfo *pParamInfo, TypeHa
             if (m_additive == 0)
             {
                 m_resID = IDS_EE_BADMARSHALFIELD_FIXEDARRAY_ZEROSIZE;
-                return E_FAIL;
+                return LogHR(E_FAIL);
             }
 
             if (isArrayClass == TRUE)

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -142,7 +142,7 @@ HRESULT MulticoreJitRecorder::WriteOutput()
     }
     CONTRACTL_END;
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     if (m_JitInfoArray == nullptr || m_ModuleList == nullptr)
     {
@@ -181,7 +181,7 @@ HRESULT WriteData(IStream * pStream, const void * pData, unsigned len)
 
     if (SUCCEEDED(hr) && (cbWritten != len))
     {
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
     }
 
     return hr;
@@ -250,7 +250,7 @@ bool ModuleVersion::GetModuleVersion(Module * pModule)
 {
     STANDARD_VM_CONTRACT;
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     // GetMVID can throw exception
     EX_TRY
@@ -270,12 +270,16 @@ bool ModuleVersion::GetModuleVersion(Module * pModule)
 
             hr = S_OK;
         }
+        else
+        {
+            hr = LogHR(E_FAIL);
+        }
 
         // If the load context is LOADFROM, store it in the flags.
     }
     EX_CATCH
     {
-        hr = E_FAIL;
+        hr = LogHR(E_FAIL);
     }
     EX_END_CATCH(SwallowAllExceptions);
 

--- a/src/coreclr/vm/olecontexthelpers.cpp
+++ b/src/coreclr/vm/olecontexthelpers.cpp
@@ -113,7 +113,7 @@ HRESULT GetCurrentThreadTypeNT5(THDTYPE* pType)
     }
     CONTRACTL_END;
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
 
     IObjectContext *pObjCurrCtx = (IObjectContext *)GetCurrentCtxCookie();
     if(pObjCurrCtx)
@@ -127,6 +127,10 @@ HRESULT GetCurrentThreadTypeNT5(THDTYPE* pType)
             _ASSERTE(pThreadInfo);
             hr = pThreadInfo->GetCurrentThreadType(pType);
         }
+    }
+    else
+    {
+        hr = LogHR(E_FAIL);
     }
     return hr;
 }
@@ -146,7 +150,7 @@ HRESULT GetCurrentApartmentTypeNT5(IObjectContext *pObjCurrCtx, APTTYPE* pType)
     }
     CONTRACTL_END;
 
-    HRESULT hr = E_FAIL;
+    HRESULT hr;
     if(pObjCurrCtx)
     {
         GCX_PREEMP();
@@ -158,6 +162,10 @@ HRESULT GetCurrentApartmentTypeNT5(IObjectContext *pObjCurrCtx, APTTYPE* pType)
             _ASSERTE(pThreadInfo);
             hr = pThreadInfo->GetCurrentApartmentType(pType);
         }
+    }
+    else
+    {
+        hr = LogHR(E_FAIL);
     }
     return hr;
 }

--- a/src/coreclr/vm/pgo.cpp
+++ b/src/coreclr/vm/pgo.cpp
@@ -911,7 +911,7 @@ HRESULT PgoManager::getPgoInstrumentationResults(MethodDesc* pMD, BYTE** pAlloca
                     }
                     EX_CATCH
                     {
-                        hr = E_FAIL;
+                        hr = LogHR(E_FAIL);
                     }
                     EX_END_CATCH(RethrowTerminalExceptions)
                 }

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -968,7 +968,7 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
 
         if (!(pOtherCode = pConfig->IsJitCancellationRequested()))
         {
-            pEntry->m_hrResultCode = E_FAIL;
+            pEntry->m_hrResultCode = LogHR(E_FAIL);
             EX_RETHROW;
         }
     }

--- a/src/coreclr/vm/profdetach.cpp
+++ b/src/coreclr/vm/profdetach.cpp
@@ -90,7 +90,7 @@ HRESULT ProfilingAPIDetach::Initialize()
             if (SUCCEEDED(hr))
             {
                 // For exceptions that give us useless hr's, just use E_FAIL
-                hr = E_FAIL;
+                hr = LogHR(E_FAIL);
             }
         }
         EX_END_CATCH(RethrowTerminalExceptions)

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -833,7 +833,7 @@ HRESULT GenerationTable::GetGenerationBounds(ULONG cObjectRanges, ULONG* pcObjec
     CrstHolder holder(&mutex);
     if (genDescTable == nullptr)
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
     ULONG copy = min(count, cObjectRanges);
     for (ULONG i = 0; i < copy; i++)
@@ -1947,7 +1947,7 @@ HRESULT GetFunctionInfoInternal(LPCBYTE ip, EECodeInfo * pCodeInfo)
 
     if (!pCodeInfo->IsValid())
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     return S_OK;
@@ -1979,7 +1979,7 @@ HRESULT GetFunctionFromIPInternal(LPCBYTE ip, EECodeInfo * pCodeInfo, BOOL failO
         // never return a method that the user of the profiler API cannot use
         if (pCodeInfo->GetMethodDesc()->IsNoMetadata())
         {
-            return E_FAIL;
+            return LogHR(E_FAIL);
         }
     }
 
@@ -3066,7 +3066,7 @@ HRESULT ProfToEEInterfaceImpl::GetRVAStaticAddress(ClassID classId,
 
     if (GetAppDomain() == NULL)
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     TypeHandle typeHandle = TypeHandle::FromPtr((void *)classId);
@@ -4670,7 +4670,7 @@ HRESULT ProfToEEInterfaceImpl::ForceGC()
     // this thread before forcing the GC.
     HRESULT hr = ETW::GCLog::ForceGCForDiagnostics();
 #else // !FEATURE_EVENT_TRACE
-    HRESULT hr = E_FAIL;
+    HRESULT hr = LogHR(E_FAIL);
 #endif // FEATURE_EVENT_TRACE
 
     // If a Thread object was just created for this thread, remember the fact that it
@@ -7127,7 +7127,7 @@ HRESULT ProfToEEInterfaceImpl::EventPipeStartSession(
         }
         else
         {
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
         }
     }
     EX_CATCH_HRESULT(hr);
@@ -7247,7 +7247,7 @@ HRESULT ProfToEEInterfaceImpl::EventPipeCreateProvider(
         EventPipeProvider *pRealProvider = EventPipeAdapter::CreateProvider(providerName, nullptr);
         if (pRealProvider == NULL)
         {
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
         }
         else
         {
@@ -7490,7 +7490,7 @@ HRESULT ProfToEEInterfaceImpl::CreateHandle(
     AppDomain* appDomain = GetAppDomain();
     if (appDomain == NULL)
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     OBJECTHANDLE handle;
@@ -7518,7 +7518,7 @@ HRESULT ProfToEEInterfaceImpl::CreateHandle(
 
     *pHandle = (ObjectHandleID)handle;
 
-    return (handle == NULL) ? E_FAIL : S_OK;
+    return (handle == NULL) ? LogHR(E_FAIL) : S_OK;
 }
 
 HRESULT ProfToEEInterfaceImpl::DestroyHandle(
@@ -8378,10 +8378,10 @@ HRESULT ProfToEEInterfaceImpl::ProfilerStackWalkFramesWrapper(Thread * pThreadTo
     {
     default:
         _ASSERTE(!"Unexpected StackWalkAction returned from Thread::StackWalkFrames");
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
     case SWA_FAILED:
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
     case SWA_ABORT:
         return CORPROF_E_STACKSNAPSHOT_ABORTED;
@@ -9026,7 +9026,7 @@ HRESULT ProfToEEInterfaceImpl::GetGenerationBounds(ULONG cObjectRanges,
 
     if (s_currentGenerationTable == NULL)
     {
-        return E_FAIL;
+        return LogHR(E_FAIL);
     }
 
     return s_currentGenerationTable->GetGenerationBounds(cObjectRanges, pcObjectRanges, ranges);

--- a/src/coreclr/vm/rtlfunctions.cpp
+++ b/src/coreclr/vm/rtlfunctions.cpp
@@ -33,11 +33,11 @@ HRESULT EnsureRtlFunctions()
     HMODULE hModuleNtDll = CLRLoadLibrary(W("ntdll"));
 
     if (hModuleNtDll == NULL)
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
 #define ENSURE_FUNCTION_RENAME(clrname, ntname)   \
     if (NULL == clrname) { clrname = (ntname##Fn*)GetProcAddress(hModuleNtDll, #ntname); } \
-    if (NULL == clrname) { return E_FAIL; } \
+    if (NULL == clrname) { return LogHR(E_FAIL); } \
     { }
 
     ENSURE_FUNCTION_RENAME(RtlVirtualUnwind_Unsafe, RtlVirtualUnwind       );

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -351,7 +351,7 @@ OBJECTREF ComClassFactory::CreateAggregatedInstance(MethodTable* pMTClass, BOOL 
                 // Call the method...
                 pUnk = (IUnknown *)delegateMethod.Call_RetArgSlot(args);
                 if (!pUnk)
-                    COMPlusThrowHR(E_FAIL);
+                    COMPlusThrowHR(LogHR(E_FAIL));
             }
             GCPROTECT_END();
         }
@@ -2379,7 +2379,7 @@ bool RCW::SupportsMngStdInterface(MethodTable *pItfMT)
                 // Initialize the return variant.
                 SafeVariantInit(&VarResult);
 
-                HRESULT hr = E_FAIL;
+                HRESULT hr;
                 {
                     // We are about to make a call to COM so switch to preemptive GC.
                     GCX_PREEMP();

--- a/src/coreclr/vm/stdinterfaces.cpp
+++ b/src/coreclr/vm/stdinterfaces.cpp
@@ -759,7 +759,7 @@ HRESULT GetITypeInfoForEEClass(MethodTable *pClass, ITypeInfo **ppTI, bool bClas
             default:
             {
                 _ASSERTE(!"Invalid default interface type!");
-                hr = E_FAIL;
+                hr = LogHR(E_FAIL);
                 break;
             }
         }
@@ -769,7 +769,7 @@ ErrExit:
     if (*ppTI == NULL)
     {
         if (!FAILED(hr))
-            hr = E_FAIL;
+            hr = LogHR(E_FAIL);
     }
 
 ReturnHR:
@@ -2449,7 +2449,7 @@ HRESULT __stdcall ObjectSafety_SetInterfaceSafetyOptions(IUnknown* pUnk,
         return hr;
 
     if ((dwEnabledOptions & ~(INTERFACESAFE_FOR_UNTRUSTED_DATA | INTERFACESAFE_FOR_UNTRUSTED_CALLER)) != 0)
-        return E_FAIL;
+        return LogHR(E_FAIL);
 
     return S_OK;
 }

--- a/src/coreclr/vm/stdinterfaces_wrapper.cpp
+++ b/src/coreclr/vm/stdinterfaces_wrapper.cpp
@@ -259,7 +259,7 @@ VOID AppDomainDoCallBack(ComCallWrapper* pWrap, ADCallBackFcnType pTarget, LPVOI
     // a thread to enter EE.
     if ((g_fEEShutDown & ShutDown_Finalize2) || g_fForbidEnterEE)
     {
-        *phr = E_FAIL;
+        *phr = LogHR(E_FAIL);
         return;
     }
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -816,28 +816,26 @@ Thread* SetupThreadNoThrow(HRESULT *pHR)
     HRESULT hr = S_OK;
 
     Thread *pThread = GetThreadNULLOk();
-    if (pThread != NULL)
+    if (pThread == NULL)
     {
-        return pThread;
-    }
-
-    EX_TRY
-    {
-        pThread = SetupThread();
-    }
-    EX_CATCH
-    {
-        // We failed SetupThread.  GET_EXCEPTION() may depend on Thread object.
-        if (__pException == NULL)
+        EX_TRY
         {
-            hr = E_OUTOFMEMORY;
+            pThread = SetupThread();
         }
-        else
+        EX_CATCH
         {
-        hr = GET_EXCEPTION()->GetHR();
+            // We failed SetupThread.  GET_EXCEPTION() may depend on Thread object.
+            if (__pException == NULL)
+            {
+                hr = E_OUTOFMEMORY;
+            }
+            else
+            {
+                hr = GET_EXCEPTION()->GetHR();
+            }
+        }
+        EX_END_CATCH(SwallowAllExceptions);
     }
-    }
-    EX_END_CATCH(SwallowAllExceptions);
 
     if (pHR)
     {

--- a/src/coreclr/vm/typestring.h
+++ b/src/coreclr/vm/typestring.h
@@ -113,7 +113,7 @@ private:
     void EscapeEmbeddedAssemblyName(LPCWSTR szName);
     BOOL CheckParseState(int validState) { WRAPPER_NO_CONTRACT; return ((int)m_parseState & validState) != 0; }
     //BOOL CheckParseState(int validState) { WRAPPER_NO_CONTRACT; ASSERT(((int)m_parseState & validState) != 0); return TRUE; }
-    HRESULT Fail() { WRAPPER_NO_CONTRACT; m_parseState = ParseStateERROR; return E_FAIL; }
+    HRESULT Fail() { WRAPPER_NO_CONTRACT; m_parseState = ParseStateERROR; return LogHR(E_FAIL); }
     void PushOpenGenericArgument();
     void PopOpenGenericArgument();
 

--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -1336,7 +1336,7 @@ BOOL ZapSig::EncodeMethod(
             if (IsDynamicScope(pResolvedToken->tokenScope))
             {
                 _ASSERTE(FALSE); // IL stubs aren't expected to call methods which need this
-                ThrowHR(E_FAIL);
+                ThrowHR(LogHR(E_FAIL));
             }
 
             DWORD moduleIndex = MODULE_INDEX_NONE;

--- a/src/native/corehost/coreclr_resolver.h
+++ b/src/native/corehost/coreclr_resolver.h
@@ -9,6 +9,8 @@
 
 using host_handle_t = void*;
 
+typedef void (*error_info_callback)(const char* line, void* arg);
+
 // Prototype of the coreclr_initialize function from coreclr.dll
 using coreclr_initialize_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
     const char* exePath,
@@ -18,6 +20,10 @@ using coreclr_initialize_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
     const char** propertyValues,
     host_handle_t* hostHandle,
     unsigned int* domainId);
+
+using coreclr_get_error_info_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
+    error_info_callback callBack,
+    void* arg);
 
 // Prototype of the coreclr_shutdown function from coreclr.dll
 using coreclr_shutdown_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
@@ -48,6 +54,7 @@ struct coreclr_resolver_contract_t
     pal::dll_t coreclr;
     coreclr_shutdown_fn coreclr_shutdown;
     coreclr_initialize_fn coreclr_initialize;
+    coreclr_get_error_info_fn coreclr_get_error_info;
     coreclr_execute_assembly_fn coreclr_execute_assembly;
     coreclr_create_delegate_fn coreclr_create_delegate;
 };

--- a/src/native/corehost/coreclr_resolver.h
+++ b/src/native/corehost/coreclr_resolver.h
@@ -9,7 +9,7 @@
 
 using host_handle_t = void*;
 
-typedef void (*error_info_callback)(const char* line, void* arg);
+typedef void (*coreclr_error_writer_callback_fn)(const char* line);
 
 // Prototype of the coreclr_initialize function from coreclr.dll
 using coreclr_initialize_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
@@ -21,9 +21,8 @@ using coreclr_initialize_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
     host_handle_t* hostHandle,
     unsigned int* domainId);
 
-using coreclr_get_error_info_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
-    error_info_callback callBack,
-    void* arg);
+using coreclr_set_error_writer_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
+    coreclr_error_writer_callback_fn callBack);
 
 // Prototype of the coreclr_shutdown function from coreclr.dll
 using coreclr_shutdown_fn = pal::hresult_t(STDMETHODCALLTYPE*)(
@@ -54,7 +53,7 @@ struct coreclr_resolver_contract_t
     pal::dll_t coreclr;
     coreclr_shutdown_fn coreclr_shutdown;
     coreclr_initialize_fn coreclr_initialize;
-    coreclr_get_error_info_fn coreclr_get_error_info;
+    coreclr_set_error_writer_fn coreclr_set_error_writer;
     coreclr_execute_assembly_fn coreclr_execute_assembly;
     coreclr_create_delegate_fn coreclr_create_delegate;
 };

--- a/src/native/corehost/hostpolicy/coreclr.cpp
+++ b/src/native/corehost/hostpolicy/coreclr.cpp
@@ -19,7 +19,7 @@ namespace
         return true;
     }
 
-    void log_error(const char* line, void* arg)
+    void log_error(const char* line)
     {
         pal::string_t lineStr;
         pal::clr_palstring(line, &lineStr);
@@ -61,6 +61,11 @@ pal::hresult_t coreclr_t::create(
     };
     properties.enumerate(callback);
 
+    if (coreclr_contract.coreclr_set_error_writer != nullptr)
+    {
+        coreclr_contract.coreclr_set_error_writer(log_error);
+    }
+
     pal::hresult_t hr;
     hr = coreclr_contract.coreclr_initialize(
         exe_path,
@@ -71,12 +76,13 @@ pal::hresult_t coreclr_t::create(
         &host_handle,
         &domain_id);
 
+    if (coreclr_contract.coreclr_set_error_writer != nullptr)
+    {
+        coreclr_contract.coreclr_set_error_writer(nullptr);
+    }
+
     if (!SUCCEEDED(hr))
     {
-        if (coreclr_contract.coreclr_get_error_info != nullptr)
-        {
-            coreclr_contract.coreclr_get_error_info(log_error, nullptr);
-        }
         return hr;
     }
 

--- a/src/native/corehost/hostpolicy/coreclr.cpp
+++ b/src/native/corehost/hostpolicy/coreclr.cpp
@@ -18,13 +18,13 @@ namespace
         coreclr_resolver_t::resolve_coreclr(libcoreclr_path, coreclr_contract);
         return true;
     }
-}
 
-void coreclr_t::log_error(const char* line, void* arg)
-{
-    pal::string_t lineStr;
-    pal::clr_palstring(line, &lineStr);
-    trace::error(_X("%s"), lineStr.c_str());
+    void log_error(const char* line, void* arg)
+    {
+        pal::string_t lineStr;
+        pal::clr_palstring(line, &lineStr);
+        trace::error(_X("%s"), lineStr.c_str());
+    }
 }
 
 pal::hresult_t coreclr_t::create(
@@ -75,7 +75,7 @@ pal::hresult_t coreclr_t::create(
     {
         if (coreclr_contract.coreclr_get_error_info != nullptr)
         {
-            coreclr_contract.coreclr_get_error_info(coreclr_t::log_error, nullptr);
+            coreclr_contract.coreclr_get_error_info(log_error, nullptr);
         }
         return hr;
     }

--- a/src/native/corehost/hostpolicy/coreclr.cpp
+++ b/src/native/corehost/hostpolicy/coreclr.cpp
@@ -20,6 +20,13 @@ namespace
     }
 }
 
+void coreclr_t::log_error(const char* line, void* arg)
+{
+    pal::string_t lineStr;
+    pal::clr_palstring(line, &lineStr);
+    trace::error(_X("%s"), lineStr.c_str());
+}
+
 pal::hresult_t coreclr_t::create(
     const pal::string_t& libcoreclr_path,
     const char* exe_path,
@@ -65,7 +72,13 @@ pal::hresult_t coreclr_t::create(
         &domain_id);
 
     if (!SUCCEEDED(hr))
+    {
+        if (coreclr_contract.coreclr_get_error_info != nullptr)
+        {
+            coreclr_contract.coreclr_get_error_info(coreclr_t::log_error, nullptr);
+        }
         return hr;
+    }
 
     inst.reset(new coreclr_t(host_handle, domain_id));
     return StatusCode::Success;

--- a/src/native/corehost/hostpolicy/coreclr.cpp
+++ b/src/native/corehost/hostpolicy/coreclr.cpp
@@ -61,6 +61,9 @@ pal::hresult_t coreclr_t::create(
     };
     properties.enumerate(callback);
 
+    // Can't use propagate_error_writer_t here because of the difference in encoding on Windows
+    // coreclr error writer always gets UTF8 string, but error writers in hostfxr/hostpolicy will use UTF16 on Windows
+    // and UTF8 everywhere else.
     if (coreclr_contract.coreclr_set_error_writer != nullptr)
     {
         coreclr_contract.coreclr_set_error_writer(log_error);

--- a/src/native/corehost/hostpolicy/coreclr.h
+++ b/src/native/corehost/hostpolicy/coreclr.h
@@ -46,6 +46,9 @@ public:
     pal::hresult_t shutdown(int* latchedExitCode);
 
 private:
+
+    static void log_error(const char* line, void* arg);
+
     std::mutex _shutdown_lock;
     bool _is_shutdown;
     host_handle_t _host_handle;

--- a/src/native/corehost/hostpolicy/coreclr.h
+++ b/src/native/corehost/hostpolicy/coreclr.h
@@ -47,8 +47,6 @@ public:
 
 private:
 
-    static void log_error(const char* line, void* arg);
-
     std::mutex _shutdown_lock;
     bool _is_shutdown;
     host_handle_t _host_handle;

--- a/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
+++ b/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
@@ -19,10 +19,12 @@ bool coreclr_resolver_t::resolve_coreclr(const pal::string_t& libcoreclr_path, c
     }
 
     coreclr_resolver_contract.coreclr_initialize = reinterpret_cast<coreclr_initialize_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_initialize"));
+    coreclr_resolver_contract.coreclr_get_error_info = reinterpret_cast<coreclr_get_error_info_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_get_error_info"));
     coreclr_resolver_contract.coreclr_shutdown = reinterpret_cast<coreclr_shutdown_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_shutdown_2"));
     coreclr_resolver_contract.coreclr_execute_assembly = reinterpret_cast<coreclr_execute_assembly_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_execute_assembly"));
     coreclr_resolver_contract.coreclr_create_delegate = reinterpret_cast<coreclr_create_delegate_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_create_delegate"));
 
+    // Only the coreclr_get_error_info is optional
     assert(coreclr_resolver_contract.coreclr_initialize != nullptr
         && coreclr_resolver_contract.coreclr_shutdown != nullptr
         && coreclr_resolver_contract.coreclr_execute_assembly != nullptr

--- a/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
+++ b/src/native/corehost/hostpolicy/standalone/coreclr_resolver.cpp
@@ -19,12 +19,12 @@ bool coreclr_resolver_t::resolve_coreclr(const pal::string_t& libcoreclr_path, c
     }
 
     coreclr_resolver_contract.coreclr_initialize = reinterpret_cast<coreclr_initialize_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_initialize"));
-    coreclr_resolver_contract.coreclr_get_error_info = reinterpret_cast<coreclr_get_error_info_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_get_error_info"));
+    coreclr_resolver_contract.coreclr_set_error_writer = reinterpret_cast<coreclr_set_error_writer_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_set_error_writer"));
     coreclr_resolver_contract.coreclr_shutdown = reinterpret_cast<coreclr_shutdown_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_shutdown_2"));
     coreclr_resolver_contract.coreclr_execute_assembly = reinterpret_cast<coreclr_execute_assembly_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_execute_assembly"));
     coreclr_resolver_contract.coreclr_create_delegate = reinterpret_cast<coreclr_create_delegate_fn>(pal::get_symbol(coreclr_resolver_contract.coreclr, "coreclr_create_delegate"));
 
-    // Only the coreclr_get_error_info is optional
+    // Only the coreclr_set_error_writer is optional
     assert(coreclr_resolver_contract.coreclr_initialize != nullptr
         && coreclr_resolver_contract.coreclr_shutdown != nullptr
         && coreclr_resolver_contract.coreclr_execute_assembly != nullptr


### PR DESCRIPTION
This change enables logging of `E_FAIL` error source so that when coreclr
initialization fails with this generic error (which can stem from more
than 300 places), the exact location can be quickly identified.

With this change, besides the following message in corerun and similar
in the dotnet host / apphost
`BEGIN: coreclr_initialize failed - Error: 0x80004005`
we now get something like
`HR=0x80004005 at CORECLR! WKS::gc_heap::initialize_gc + 0x12
(0x00007ffd'277241cb) F:\git\runtime7\src\coreclr\gc\gc.cpp:13361`

On macOS, we can only get the symbol name and offset programatically,
however, we also print module offset. This can be passed to `atos` command
line tool to get the source line:

`atos -o artifacts/bin/coreclr/OSX.arm64.Debug/libcoreclr.dylib.dwarf
0x7ac654 -fullPath`
`EEStartupHelper() (in libcoreclr.dylib.dwarf)
(/Users/janvorli/git/runtime/src/coreclr/vm/ceemain.cpp:1001)`

On Linux, we cannot get even the symbol, but similar to macOS, there is
a command line tool llvm-symbolizer that can extract both the symbol and
source file:

`llvm-symbolizer-14 --obj
/home/janvorli/git/runtime/artifacts/tests/coreclr/Linux.x64.Debug/Tests/Core_Root/libcoreclr.so
0xbac1de --pretty-print`
`EEStartupHelper() at
/home/janvorli/git/runtime/src/coreclr/vm/ceemain.cpp:1001:16`

While the change logs only sources of `E_FAIL` errors, it is not limited to those
and can be used to log any errors. The `E_FAIL` was picked as in 99% of
cases, the coreclr failures that we couldn't diagnose easily in the past
were caused by the `E_FAIL`.

I have made it use a ring buffer to handle possible cases where there
was a chain of `E_FAIL` errors (or possibly other ones if we added logging them).
All the entries from the buffer are dumped when `coreclr_initialize` exits
with error code.

Besides the added logging, the change also enhances assert stack trace by
adding source line information. This is a side effect of the change as
the symbol details extraction is shared with that stack trace. But it is
something I was missing for a long time, since assert trace was
containing only symbol names / offsets which is not quickly mappable to
the source locations, especially when inlining happens.