### PR TITLE
Set names to runtime internal threads

### DIFF
--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -1365,13 +1365,17 @@ HRESULT DebuggerRCThread::Start(void)
         if (m_thread == NULL)
         {
             LOG((LF_CORDB, LL_EVERYTHING, "DebuggerRCThread failed, err=%d\n", GetLastError()));
-            hr = HRESULT_FROM_GetLastError();
+            return HRESULT_FROM_GetLastError();
+        }
 
-        }
-        else
+        hr = SetThreadDescription(m_thread, W(".NET DebuggerRCThread"));
+        if (FAILED(hr))
         {
-            LOG((LF_CORDB, LL_EVERYTHING, "DebuggerRCThread start was successful, id=%d\n", helperThreadId));
+            LOG((LF_CORDB, LL_INFO10000, "DebuggerRCThread name set failed\n"));
+            return hr;
         }
+
+        LOG((LF_CORDB, LL_EVERYTHING, "DebuggerRCThread start was successful, id=%d\n", helperThreadId));
 
         // This gets published immediately.
         DebuggerIPCControlBlock* dcb = GetDCB();
@@ -1383,11 +1387,7 @@ HRESULT DebuggerRCThread::Start(void)
         m_DbgHelperThreadOSTid = helperThreadId ;
 #endif
 
-        if (m_thread != NULL)
-        {
-            ResumeThread(m_thread);
-        }
-
+        ResumeThread(m_thread);
     }
 
     // unlock debugger lock is implied.

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -1311,10 +1311,12 @@ LExit:
 
     DebuggerRCThread* t = (DebuggerRCThread*)g_pRCThread;
 
+#if defined(__linux__) || defined(__FreeBSD__)
     if (FAILED(SetThreadDescription(t->m_thread, W(".NET Debugger"))))
     {
         LOG((LF_CORDB, LL_INFO10000, "DebuggerRCThread name set failed\n"));
     }
+#endif
 
     t->ThreadProc(); // this thread is local, go and become the helper
 

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -1311,12 +1311,10 @@ LExit:
 
     DebuggerRCThread* t = (DebuggerRCThread*)g_pRCThread;
 
-#if defined(__linux__) || defined(__FreeBSD__)
-    if (FAILED(SetThreadDescription(t->m_thread, W(".NET Debugger"))))
+    if (FAILED(SetThreadName(t->m_thread, W(".NET Debugger"))))
     {
         LOG((LF_CORDB, LL_INFO10000, "DebuggerRCThread name set failed\n"));
     }
-#endif
 
     t->ThreadProc(); // this thread is local, go and become the helper
 

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -1311,7 +1311,7 @@ LExit:
 
     DebuggerRCThread* t = (DebuggerRCThread*)g_pRCThread;
 
-    if (FAILED(SetThreadDescription(t->m_thread, W(".NET RC Thread"))))
+    if (FAILED(SetThreadDescription(t->m_thread, W(".NET Debugger"))))
     {
         LOG((LF_CORDB, LL_INFO10000, "DebuggerRCThread name set failed\n"));
     }

--- a/src/coreclr/debug/shared/dbgtransportsession.cpp
+++ b/src/coreclr/debug/shared/dbgtransportsession.cpp
@@ -157,7 +157,7 @@ HRESULT DbgTransportSession::Init(DebuggerIPCControlBlock *pDCB, AppDomainEnumer
         return E_OUTOFMEMORY;
     }
 
-    return S_OK;
+    return SetThreadDescription(m_hTransportThread, W(".NET Debug Transport Thread"));
 }
 
 // Drive the session to the SS_Closed state, which will deallocate all remaining transport resources

--- a/src/coreclr/debug/shared/dbgtransportsession.cpp
+++ b/src/coreclr/debug/shared/dbgtransportsession.cpp
@@ -1227,7 +1227,7 @@ void DbgTransportSession::InitSessionState()
 // instance method version defined below for convenience in the implementation.
 DWORD WINAPI DbgTransportSession::TransportWorkerStatic(LPVOID pvContext)
 {
-    SetThreadName(PAL_GetCurrentThread(), W(".NET DebugPipe"));
+    SetThreadName(GetCurrentThread(), W(".NET DebugPipe"));
 
     ((DbgTransportSession*)pvContext)->TransportWorker();
 

--- a/src/coreclr/debug/shared/dbgtransportsession.cpp
+++ b/src/coreclr/debug/shared/dbgtransportsession.cpp
@@ -156,7 +156,7 @@ HRESULT DbgTransportSession::Init(DebuggerIPCControlBlock *pDCB, AppDomainEnumer
         Release();
         return E_OUTOFMEMORY;
     }
-    SetThreadName(m_hTransportThread, W(".NET Debug Transport"));
+
     return S_OK;
 }
 
@@ -1227,6 +1227,8 @@ void DbgTransportSession::InitSessionState()
 // instance method version defined below for convenience in the implementation.
 DWORD WINAPI DbgTransportSession::TransportWorkerStatic(LPVOID pvContext)
 {
+    SetThreadName(PAL_GetCurrentThread(), W(".NET DebugPipe"));
+
     ((DbgTransportSession*)pvContext)->TransportWorker();
 
     // Nobody looks at this result, the choice of 0 is arbitrary.

--- a/src/coreclr/debug/shared/dbgtransportsession.cpp
+++ b/src/coreclr/debug/shared/dbgtransportsession.cpp
@@ -157,7 +157,8 @@ HRESULT DbgTransportSession::Init(DebuggerIPCControlBlock *pDCB, AppDomainEnumer
         return E_OUTOFMEMORY;
     }
 
-    return SetThreadDescription(m_hTransportThread, W(".NET Debug Transport Thread"));
+    SetThreadDescription(m_hTransportThread, W(".NET Debug Transport"));
+    return S_OK;
 }
 
 // Drive the session to the SS_Closed state, which will deallocate all remaining transport resources

--- a/src/coreclr/debug/shared/dbgtransportsession.cpp
+++ b/src/coreclr/debug/shared/dbgtransportsession.cpp
@@ -156,8 +156,9 @@ HRESULT DbgTransportSession::Init(DebuggerIPCControlBlock *pDCB, AppDomainEnumer
         Release();
         return E_OUTOFMEMORY;
     }
-
+#if defined(__linux__) || defined(__FreeBSD__)
     SetThreadDescription(m_hTransportThread, W(".NET Debug Transport"));
+#endif
     return S_OK;
 }
 

--- a/src/coreclr/debug/shared/dbgtransportsession.cpp
+++ b/src/coreclr/debug/shared/dbgtransportsession.cpp
@@ -156,9 +156,7 @@ HRESULT DbgTransportSession::Init(DebuggerIPCControlBlock *pDCB, AppDomainEnumer
         Release();
         return E_OUTOFMEMORY;
     }
-#if defined(__linux__) || defined(__FreeBSD__)
-    SetThreadDescription(m_hTransportThread, W(".NET Debug Transport"));
-#endif
+    SetThreadName(m_hTransportThread, W(".NET Debug Transport"));
     return S_OK;
 }
 

--- a/src/coreclr/pal/src/synchmgr/synchmanager.cpp
+++ b/src/coreclr/pal/src/synchmgr/synchmanager.cpp
@@ -1519,6 +1519,14 @@ namespace CorUnix
         if (NO_ERROR == palErr)
         {
             pSynchManager->m_dwWorkerThreadTid = (DWORD)osThreadId;
+            palErr = InternalSetThreadDescription(pthrCurrent,
+                                                  hWorkerThread,
+                                                  W(".NET SynchManager"));
+            if (NO_ERROR != palErr)
+            {
+                ERROR("Unable to set worker thread name\n");
+            }
+
             palErr = InternalGetThreadDataFromHandle(pthrCurrent,
                                                      hWorkerThread,
                                                      &pSynchManager->m_pthrWorker,

--- a/src/coreclr/pal/src/synchmgr/synchmanager.cpp
+++ b/src/coreclr/pal/src/synchmgr/synchmanager.cpp
@@ -1519,6 +1519,7 @@ namespace CorUnix
         if (NO_ERROR == palErr)
         {
             pSynchManager->m_dwWorkerThreadTid = (DWORD)osThreadId;
+#if defined(__linux__) || defined(__FreeBSD__)
             palErr = InternalSetThreadDescription(pthrCurrent,
                                                   hWorkerThread,
                                                   W(".NET SynchManager"));
@@ -1526,7 +1527,7 @@ namespace CorUnix
             {
                 ERROR("Unable to set worker thread name\n");
             }
-
+#endif
             palErr = InternalGetThreadDataFromHandle(pthrCurrent,
                                                      hWorkerThread,
                                                      &pSynchManager->m_pthrWorker,

--- a/src/coreclr/pal/src/synchmgr/synchmanager.cpp
+++ b/src/coreclr/pal/src/synchmgr/synchmanager.cpp
@@ -1519,13 +1519,6 @@ namespace CorUnix
         if (NO_ERROR == palErr)
         {
             pSynchManager->m_dwWorkerThreadTid = (DWORD)osThreadId;
-            palErr = InternalSetThreadDescription(pthrCurrent,
-                                                  hWorkerThread,
-                                                  W(".NET SynchManager"));
-            if (NO_ERROR != palErr)
-            {
-                ERROR("Unable to set worker thread name\n");
-            }
             palErr = InternalGetThreadDataFromHandle(pthrCurrent,
                                                      hWorkerThread,
                                                      &pSynchManager->m_pthrWorker,
@@ -1713,6 +1706,10 @@ namespace CorUnix
         CPalSynchronizationManager * pSynchManager =
             reinterpret_cast<CPalSynchronizationManager*>(pArg);
         CPalThread * pthrWorker = InternalGetCurrentThread();
+
+        InternalSetThreadDescription(pthrWorker,
+                                     PAL_GetCurrentThread(),
+                                     W(".NET SynchManager"));
 
         while (!fWorkerIsDone)
         {

--- a/src/coreclr/pal/src/synchmgr/synchmanager.cpp
+++ b/src/coreclr/pal/src/synchmgr/synchmanager.cpp
@@ -1519,7 +1519,6 @@ namespace CorUnix
         if (NO_ERROR == palErr)
         {
             pSynchManager->m_dwWorkerThreadTid = (DWORD)osThreadId;
-#if defined(__linux__) || defined(__FreeBSD__)
             palErr = InternalSetThreadDescription(pthrCurrent,
                                                   hWorkerThread,
                                                   W(".NET SynchManager"));
@@ -1527,7 +1526,6 @@ namespace CorUnix
             {
                 ERROR("Unable to set worker thread name\n");
             }
-#endif
             palErr = InternalGetThreadDataFromHandle(pthrCurrent,
                                                      hWorkerThread,
                                                      &pSynchManager->m_pthrWorker,

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2030,7 +2030,6 @@ ep_rt_thread_create (
 				DWORD thread_id = 0;
 				HANDLE server_thread = ::CreateThread (nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_func), nullptr, 0, &thread_id);
 				if (server_thread != NULL) {
-					::SetThreadName(server_thread, W(".NET EventPipe"));
 					::CloseHandle (server_thread);
 					if (id)
 						*reinterpret_cast<DWORD *>(id) = thread_id;
@@ -2046,6 +2045,14 @@ ep_rt_thread_create (
 	EX_END_CATCH(SwallowAllExceptions);
 
 	return result;
+}
+
+static
+inline
+void
+ep_rt_set_server_name()
+{
+	::SetThreadName(PAL_GetCurrentThread(), W(".NET EventPipe"));
 }
 
 static

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2052,7 +2052,7 @@ inline
 void
 ep_rt_set_server_name()
 {
-	::SetThreadName(PAL_GetCurrentThread(), W(".NET EventPipe"));
+	::SetThreadName(GetCurrentThread(), W(".NET EventPipe"));
 }
 
 static

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2030,9 +2030,7 @@ ep_rt_thread_create (
 				DWORD thread_id = 0;
 				HANDLE server_thread = ::CreateThread (nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_func), nullptr, 0, &thread_id);
 				if (server_thread != NULL) {
-#if defined(__linux__) || defined(__FreeBSD__)
-					::SetThreadDescription(server_thread, W(".NET EventPipe"));
-#endif
+					::SetThreadName(server_thread, W(".NET EventPipe"));
 					::CloseHandle (server_thread);
 					if (id)
 						*reinterpret_cast<DWORD *>(id) = thread_id;

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2030,7 +2030,9 @@ ep_rt_thread_create (
 				DWORD thread_id = 0;
 				HANDLE server_thread = ::CreateThread (nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_func), nullptr, 0, &thread_id);
 				if (server_thread != NULL) {
+#if defined(__linux__) || defined(__FreeBSD__)
 					::SetThreadDescription(server_thread, W(".NET EventPipe"));
+#endif
 					::CloseHandle (server_thread);
 					if (id)
 						*reinterpret_cast<DWORD *>(id) = thread_id;

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2030,7 +2030,7 @@ ep_rt_thread_create (
 				DWORD thread_id = 0;
 				HANDLE server_thread = ::CreateThread (nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_func), nullptr, 0, &thread_id);
 				if (server_thread != NULL) {
-					::SetThreadDescription(server_thread, W(".NET Eventpipe Server"));
+					::SetThreadDescription(server_thread, W(".NET EventPipe"));
 					::CloseHandle (server_thread);
 					if (id)
 						*reinterpret_cast<DWORD *>(id) = thread_id;

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2030,6 +2030,7 @@ ep_rt_thread_create (
 				DWORD thread_id = 0;
 				HANDLE server_thread = ::CreateThread (nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_func), nullptr, 0, &thread_id);
 				if (server_thread != NULL) {
+					::SetThreadDescription(server_thread, W(".NET Eventpipe Server"));
 					::CloseHandle (server_thread);
 					if (id)
 						*reinterpret_cast<DWORD *>(id) = thread_id;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
@@ -239,7 +239,7 @@ namespace System.Threading
                     {
                         IsThreadPoolThread = true,
                         IsBackground = true,
-                        Name = ".NET ThreadPool Gate"
+                        Name = ".NET TPool Gate"
                     };
                     gateThread.UnsafeStart();
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
@@ -239,7 +239,7 @@ namespace System.Threading
                     {
                         IsThreadPoolThread = true,
                         IsBackground = true,
-                        Name = ".NET TPool Gate"
+                        Name = ".NET TP Gate"
                     };
                     gateThread.UnsafeStart();
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -187,7 +187,7 @@ namespace System.Threading
                 {
                     IsThreadPoolThread = true,
                     IsBackground = true,
-                    Name = ".NET ThreadPool Wait"
+                    Name = ".NET TPool Wait"
                 };
                 waitThread.UnsafeStart();
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -187,7 +187,7 @@ namespace System.Threading
                 {
                     IsThreadPoolThread = true,
                     IsBackground = true,
-                    Name = ".NET TPool Wait"
+                    Name = ".NET TP Wait"
                 };
                 waitThread.UnsafeStart();
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1355,7 +1355,7 @@ namespace System.Threading
 
     public static partial class ThreadPool
     {
-        internal const string WorkerThreadName = ".NET TPool Worker";
+        internal const string WorkerThreadName = ".NET TP Worker";
 
         internal static readonly ThreadPoolWorkQueue s_workQueue = new ThreadPoolWorkQueue();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1355,7 +1355,7 @@ namespace System.Threading
 
     public static partial class ThreadPool
     {
-        internal const string WorkerThreadName = ".NET ThreadPool Worker";
+        internal const string WorkerThreadName = ".NET TPool Worker";
 
         internal static readonly ThreadPoolWorkQueue s_workQueue = new ThreadPoolWorkQueue();
 

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1362,6 +1362,14 @@ ep_rt_thread_create (
 static
 inline
 void
+ep_rt_set_server_name()
+{
+	mono_native_thread_set_name(mono_native_thread_id_get(), ".NET EventPipe");
+}
+
+static
+inline
+void
 ep_rt_thread_sleep (uint64_t ns)
 {
 	MONO_REQ_GC_UNSAFE_MODE;

--- a/src/native/eventpipe/ds-server.c
+++ b/src/native/eventpipe/ds-server.c
@@ -116,6 +116,8 @@ EP_RT_DEFINE_THREAD_FUNC (server_thread)
 {
 	EP_ASSERT (server_volatile_load_shutting_down_state () || ds_ipc_stream_factory_has_active_ports ());
 
+	ep_rt_set_server_name();
+
 	if (!ds_ipc_stream_factory_has_active_ports ()) {
 #ifndef DS_IPC_DISABLE_LISTEN_PORTS
 		DS_LOG_ERROR_0 ("Diagnostics IPC listener was undefined");
@@ -256,7 +258,7 @@ ds_server_shutdown (void)
 void
 ds_server_pause_for_diagnostics_monitor (void)
 {
-    _is_paused_for_startup = true;
+	_is_paused_for_startup = true;
 
 	if (ds_ipc_stream_factory_any_suspended_ports ()) {
 		EP_ASSERT (ep_rt_wait_event_is_valid (&_server_resume_runtime_startup_event));
@@ -278,7 +280,7 @@ ds_server_resume_runtime_startup (void)
 	ds_ipc_stream_factory_resume_current_port ();
 	if (!ds_ipc_stream_factory_any_suspended_ports () && ep_rt_wait_event_is_valid (&_server_resume_runtime_startup_event)) {
 		ep_rt_wait_event_set (&_server_resume_runtime_startup_event);
-        _is_paused_for_startup = false;
+		_is_paused_for_startup = false;
 	}
 }
 

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -568,6 +568,10 @@ ep_rt_thread_create (
 
 static
 void
+ep_rt_set_server_name (void);
+
+static
+void
 ep_rt_thread_sleep (uint64_t ns);
 
 static

--- a/src/native/libs/System.Native/pal_signal.c
+++ b/src/native/libs/System.Native/pal_signal.c
@@ -313,8 +313,12 @@ static void* SignalHandlerLoop(void* arg)
     free(arg);
     assert(pipeFd >= 0);
 
+    char* threadName = ".NET SigHandler";
 #if defined(__linux__) || defined(__FreeBSD__)
-    pthread_setname_np(pthread_self(), ".NET SigHandler");
+    pthread_setname_np(pthread_self(), threadName);
+#endif
+#if defined(__APPLE__)
+    pthread_setname_np(threadName);
 #endif
 
     // Continually read a signal code from the signal pipe and process it,

--- a/src/native/libs/System.Native/pal_signal.c
+++ b/src/native/libs/System.Native/pal_signal.c
@@ -313,6 +313,15 @@ static void* SignalHandlerLoop(void* arg)
     free(arg);
     assert(pipeFd >= 0);
 
+#if defined(__linux__) || defined(__FreeBSD__)
+    pthread_setname_np(pthread_self(), ".NET SigHandler");
+#endif
+
+#if defined(__APPLE__)
+    // on macOS, pthread_setname_np only works for the calling thread.
+    pthread_setname_np(".NET Signal Handler");
+#endif
+
     // Continually read a signal code from the signal pipe and process it,
     // until the pipe is closed.
     while (true)
@@ -529,7 +538,6 @@ static bool CreateSignalHandlerThread(int* readFdPtr)
         pthread_t handlerThread;
         if (pthread_create(&handlerThread, &attr, SignalHandlerLoop, readFdPtr) == 0)
         {
-            pthread_setname_np(handlerThread, ".NET SigHandler");
             success = true;
         }
     }

--- a/src/native/libs/System.Native/pal_signal.c
+++ b/src/native/libs/System.Native/pal_signal.c
@@ -319,7 +319,7 @@ static void* SignalHandlerLoop(void* arg)
 
 #if defined(__APPLE__)
     // on macOS, pthread_setname_np only works for the calling thread.
-    pthread_setname_np(".NET Signal Handler");
+    pthread_setname_np(".NET SigHandler");
 #endif
 
     // Continually read a signal code from the signal pipe and process it,

--- a/src/native/libs/System.Native/pal_signal.c
+++ b/src/native/libs/System.Native/pal_signal.c
@@ -529,6 +529,7 @@ static bool CreateSignalHandlerThread(int* readFdPtr)
         pthread_t handlerThread;
         if (pthread_create(&handlerThread, &attr, SignalHandlerLoop, readFdPtr) == 0)
         {
+            pthread_setname_np(handlerThread, ".NET SigHandler");
             success = true;
         }
     }

--- a/src/native/libs/System.Native/pal_signal.c
+++ b/src/native/libs/System.Native/pal_signal.c
@@ -317,11 +317,6 @@ static void* SignalHandlerLoop(void* arg)
     pthread_setname_np(pthread_self(), ".NET SigHandler");
 #endif
 
-#if defined(__APPLE__)
-    // on macOS, pthread_setname_np only works for the calling thread.
-    pthread_setname_np(".NET SigHandler");
-#endif
-
     // Continually read a signal code from the signal pipe and process it,
     // until the pipe is closed.
     while (true)


### PR DESCRIPTION
It gives names to internal threads so that they can be distinguished easier when debugging, triaging, and/or profiling.
```
(gdb) info threads
  Id   Target Id                                            Frame
* 1    Thread 0x7ffff7a4a3c0 (LWP 296950) "corerun"         __GI___libc_read (nbytes=1024, buf=0x7fffffffc810, fd=0) at ../sysdeps/unix/sysv/linux/read.c:26
  2    Thread 0x7ffff6afd640 (LWP 296953) "corerun-ust"     syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
  3    Thread 0x7ffff62fc640 (LWP 296954) "corerun-ust"     syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
  4    Thread 0x7ffff5afb640 (LWP 296955) ".NET SynchManag" 0x00007ffff7b63d7f in __GI___poll (fds=0x7ffff5afa9b8, nfds=1, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
  5    Thread 0x7ffff52fa640 (LWP 296956) ".NET Eventpipe " 0x00007ffff7b63d7f in __GI___poll (fds=0x7fff70008f20, nfds=1, timeout=-1) at ../sysdeps/unix/sysv/linux/poll.c:29
  6    Thread 0x7ffff4ad4640 (LWP 296957) ".NET Debug Tran" 0x00007ffff7b5f764 in __libc_open64 (file=0x55555559fa44 "/tmp/clr-debug-pipe-296950-42007406-in", oflag=0) at ../sysdeps/unix/sysv/linux/open64.c:41
  7    Thread 0x7fffe7fff640 (LWP 296958) ".NET DebuggerRC" __futex_abstimed_wait_common64 (private=0, cancel=true, abstime=0x0, op=393, expected=0, futex_word=0x555555644e10) at ./nptl/futex-internal.c:57
  8    Thread 0x7fff77cc5640 (LWP 296959) ".NET Finalizer"  __futex_abstimed_wait_common64 (private=1432319836, cancel=true, abstime=0x7fff77cc40b8, op=137, expected=0, futex_word=0x555555665950) at ./nptl/futex-internal.c:57
  9    Thread 0x7fffe6e02640 (LWP 296960) ".NET SigHandler" __GI___libc_read (nbytes=1, buf=0x7fffe6e01e47, fd=33) at ../sysdeps/unix/sysv/linux/read.c:26
```