### PR TITLE
[wasm-mt] Fix failing System.Xml tests on Browser with multi-threading enabled

### DIFF
--- a/src/libraries/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -93,6 +93,7 @@ namespace System.Xml.Tests
         [InlineData("http://notfound.invalid.corp.microsoft.com")]
         [InlineData("ftp://host.invalid")]
         [InlineData("notsupported://host.invalid")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75129", TestPlatforms.Browser)]
         public static void TestResolveInvalidPath(string invalidUri)
         {
             Assert.ThrowsAny<Exception>(() => XmlReader.Create(invalidUri));

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
@@ -64,6 +64,7 @@ namespace System.Xml.Tests
 
         //-----------------------------------------------------------------------------------
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75123", TestPlatforms.Browser)]
         //[Variation(Desc = "v4 - ns = valid, URL = invalid")]
         public void v4()
         {

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
@@ -8,9 +8,6 @@ using System.Xml.Schema;
 
 namespace System.Xml.Tests
 {
-#if TARGET_BROWSER
-    [Collection(nameof(DisableParallelization))]
-#endif
     //[TestCase(Name = "TC_SchemaSet_XmlResolver", Desc = "")]
     public class TC_SchemaSet_XmlResolver : TC_SchemaSetBase
     {
@@ -92,6 +89,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v4 - schema(Local)->schema(Local)", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75183", TestPlatforms.Browser)]
         public void v4()
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -107,6 +105,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v5 - schema(Local)->schema(Local)->schema(Local)", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75183", TestPlatforms.Browser)]
         public void v5()
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_XmlResolver.cs
@@ -8,6 +8,9 @@ using System.Xml.Schema;
 
 namespace System.Xml.Tests
 {
+#if TARGET_BROWSER
+    [Collection(nameof(DisableParallelization))]
+#endif
     //[TestCase(Name = "TC_SchemaSet_XmlResolver", Desc = "")]
     public class TC_SchemaSet_XmlResolver : TC_SchemaSetBase
     {

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -420,7 +420,7 @@ namespace System.Xml.Tests
         [InlineData("SCHEMA", "schB1_a.xsd", 1, 3, 3)]
         [InlineData("SCHEMA", "schM2_a.xsd", 1, 3, 3)]
         [InlineData("SCHEMA", "schH2_a.xsd", 1, 3, 3)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/75132", TestPlatform.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75132", TestPlatforms.Browser)]
         public void AddValid_Import_Include_Redefine(string testDir, string testFile, int expCount, int expCountGT, int expCountGE)
         {
             string xsd = Path.Combine(path, testDir, testFile);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -420,6 +420,7 @@ namespace System.Xml.Tests
         [InlineData("SCHEMA", "schB1_a.xsd", 1, 3, 3)]
         [InlineData("SCHEMA", "schM2_a.xsd", 1, 3, 3)]
         [InlineData("SCHEMA", "schH2_a.xsd", 1, 3, 3)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75132", TestPlatform.Browser)]
         public void AddValid_Import_Include_Redefine(string testDir, string testFile, int expCount, int expCountGT, int expCountGE)
         {
             string xsd = Path.Combine(path, testDir, testFile);


### PR DESCRIPTION
- The `TC_SchemaSet_XmlResolver.v4` and `TC_SchemaSet_XmlResolver.v5` tests get stuck if they run in parallel.
- The `TC_SchemaSet_Add_URL.v4` test tries to make a GET HTTP request to `http://bla/` which blocks the test execution and causes a timeout. The same problem seems to be the causing the `AddValid_Import_Include_Redefine` and `TestResolveInvalidPath` tests to get stuck.

Failing tests disabled with: #75123, #75129, #75132, #75183

Closes #74406
Closes #74407
Closes #74408