### PR TITLE
[wasm] Rename `$(WasmSIMD)`, and `$(WasmExceptionHandling)` to `$(WasmEnable*)`

### DIFF
--- a/eng/testing/scenarios/BuildWasmAppsJobsList.txt
+++ b/eng/testing/scenarios/BuildWasmAppsJobsList.txt
@@ -17,6 +17,7 @@ Wasm.Build.Tests.RebuildTests
 Wasm.Build.Tests.SatelliteAssembliesTests
 Wasm.Build.Tests.WasmBuildAppTest
 Wasm.Build.Tests.WasmNativeDefaultsTests
-Wasm.Build.Tests.WorkloadTests
 Wasm.Build.Tests.WasmRunOutOfAppBundleTests
+Wasm.Build.Tests.WasmSIMDTests
 Wasm.Build.Tests.WasmTemplateTests
+Wasm.Build.Tests.WorkloadTests

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
@@ -9,7 +9,7 @@
 
     <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' AND '$(UsingBrowserRuntimeWorkload)' == ''">
         <!-- $(WasmBuildNative)==true is needed to enable workloads, when using native references, without AOT -->
-        <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or '$(WasmBuildNative)' == 'true' or '$(WasmGenerateAppBundle)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true'" >true</UsingBrowserRuntimeWorkload>
+        <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or '$(WasmEnableSIMD)' == 'true' or '$(WasmBuildNative)' == 'true' or '$(WasmGenerateAppBundle)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true'" >true</UsingBrowserRuntimeWorkload>
         <UsingBrowserRuntimeWorkload Condition="'$(UsingBrowserRuntimeWorkload)' == ''" >$(WasmNativeWorkload)</UsingBrowserRuntimeWorkload>
     </PropertyGroup>
 

--- a/src/mono/wasm/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
@@ -21,7 +21,7 @@ namespace Wasm.Build.Tests
             _enablePerTestCleanup = true;
         }
 
-        [Theory]
+        [Theory, TestCategory("no-workload")]
         [InlineData("Debug")]
         [InlineData("Release")]
         public void DefaultTemplate_WithoutWorkload(string config)

--- a/src/mono/wasm/Wasm.Build.Tests/EnvironmentVariables.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/EnvironmentVariables.cs
@@ -16,5 +16,6 @@ namespace Wasm.Build.Tests
         internal static readonly string? TestLogPath               = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
         internal static readonly string? SkipProjectCleanup        = Environment.GetEnvironmentVariable("SKIP_PROJECT_CLEANUP");
         internal static readonly string? XHarnessCliPath           = Environment.GetEnvironmentVariable("XHARNESS_CLI_PATH");
+        internal static readonly string? BrowserPathForTests       = Environment.GetEnvironmentVariable("BROWSER_PATH_FOR_TESTS");
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -56,7 +56,7 @@
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="chmod +x $HELIX_WORKITEM_ROOT/.playwright/node/linux/node" />
     </ItemGroup>
 
-    <PropertyGroup Condition="'$(Scenario)' == 'BuildWasmApps'">
+    <PropertyGroup>
       <_XUnitTraitArg Condition="'$(TestUsingWorkloads)' == 'true'">-notrait category=no-workload</_XUnitTraitArg>
       <_XUnitTraitArg Condition="'$(TestUsingWorkloads)' != 'true'">-trait category=no-workload</_XUnitTraitArg>
     </PropertyGroup>

--- a/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,25 +17,112 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
+        [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ false, RunHost.All })]
+        public void BuildWithSIMD_NoAOT_ShouldRelink(BuildArgs buildArgs, RunHost host, string id)
+        {
+            string projectName = $"sim_with_workload_no_aot";
+            buildArgs = buildArgs with { ProjectName = projectName };
+            buildArgs = ExpandBuildArgs(buildArgs, "<WasmEnableSIMD>true</WasmEnableSIMD>");
+
+            (_, string output) = BuildProject(buildArgs,
+                                    id: id,
+                                    new BuildProjectOptions(
+                                        InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_simdProgramText),
+                                        Publish: false,
+                                        DotnetWasmFromRuntimePack: false));
+
+            if (!_buildContext.TryGetBuildFor(buildArgs, out _))
+            {
+                // Check if this is not a cached build
+                Assert.Contains("Compiling native assets with excc", output);
+            }
+
+            RunAndTestWasmApp(buildArgs,
+                                extraXHarnessArgs: host == RunHost.NodeJS ? "--engine-arg=--experimental-wasm-simd" : "",
+                                expectedExitCode: 42,
+                                test: output =>
+                                {
+                                    Assert.Contains("<-2094756296, -2094756296, -2094756296, -2094756296>", output);
+                                    Assert.Contains("Hello, World!", output);
+                                }, host: host, id: id);
+        }
+
+        [Theory]
         [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ true, RunHost.All })]
-        public void BuildWithSIMD(BuildArgs buildArgs, RunHost host, string id)
-            => TestMain("main_simd_aot",
-                @"
-                using System;
-                using System.Runtime.Intrinsics;
+        [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ false, RunHost.All })]
+        public void PublishWithSIMD_AOT(BuildArgs buildArgs, RunHost host, string id)
+        {
+            string projectName = $"sim_with_workload_aot";
+            buildArgs = buildArgs with { ProjectName = projectName };
+            buildArgs = ExpandBuildArgs(buildArgs, "<WasmEnableSIMD>true</WasmEnableSIMD>");
 
-                public class TestClass {
-                    public static int Main()
-                    {
-                        var v1 = Vector128.Create(0x12345678);
-                        var v2 = Vector128.Create(0x23456789);
-                        var v3 = v1*v2;
-                        Console.WriteLine(v3);
-                        Console.WriteLine(""Hello, World!"");
+            BuildProject(buildArgs,
+                            id: id,
+                            new BuildProjectOptions(
+                                InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_simdProgramText),
+                                DotnetWasmFromRuntimePack: false));
 
-                        return 42;
-                    }
-                }",
-                buildArgs, host, id, extraProperties: "<WasmSIMD>true</WasmSIMD>");
+            RunAndTestWasmApp(buildArgs,
+                                extraXHarnessArgs: host == RunHost.NodeJS ? "--engine-arg=--experimental-wasm-simd" : "",
+                                expectedExitCode: 42,
+                                test: output =>
+                                {
+                                    Assert.Contains("<-2094756296, -2094756296, -2094756296, -2094756296>", output);
+                                    Assert.Contains("Hello, World!", output);
+                                }, host: host, id: id);
+        }
+
+        [Theory, TestCategory("no-workload")]
+        [InlineData("Debug", /*aot*/true, /*publish*/true)]
+        [InlineData("Debug", /*aot*/false, /*publish*/false)]
+        [InlineData("Debug", /*aot*/false, /*publish*/true)]
+        [InlineData("Release", /*aot*/true, /*publish*/true)]
+        [InlineData("Release", /*aot*/false, /*publish*/false)]
+        [InlineData("Release", /*aot*/false, /*publish*/true)]
+        public void BuildWithSIMDNeedsWorkload(string config, bool aot, bool publish)
+        {
+            string id = Path.GetRandomFileName();
+            string projectName = $"simd_no_workload_{config}_aot_{aot}";
+            BuildArgs buildArgs = new
+            (
+                ProjectName: projectName,
+                Config: config,
+                AOT: aot,
+                ProjectFileContents: "placeholder",
+                ExtraBuildArgs: string.Empty
+            );
+
+            string extraProperties = """
+            <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+            <WasmEnableSIMD>true</WasmEnableSIMD>
+            """;
+            buildArgs = ExpandBuildArgs(buildArgs, extraProperties);
+
+            (_, string output) = BuildProject(buildArgs,
+                                    id: id,
+                                    new BuildProjectOptions(
+                                        InitProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_simdProgramText),
+                                        Publish: publish,
+                                        ExpectSuccess: false,
+                                        UseCache: false));
+            Assert.Contains("following workloads must be installed: wasm-tools", output);
+        }
+
+        private static string s_simdProgramText = @"
+            using System;
+            using System.Runtime.Intrinsics;
+
+            public class TestClass {
+                public static int Main()
+                {
+                    var v1 = Vector128.Create(0x12345678);
+                    var v2 = Vector128.Create(0x23456789);
+                    var v3 = v1*v2;
+                    Console.WriteLine(v3);
+                    Console.WriteLine(""Hello, World!"");
+
+                    return 42;
+                }
+            }";
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmSIMDTests.cs
@@ -48,7 +48,9 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ true, RunHost.All })]
+        // https://github.com/dotnet/runtime/issues/75044 - disabled for V8, and NodeJS
+        //[MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ true, RunHost.All })]
+        [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ true, RunHost.Chrome })]
         [MemberData(nameof(MainMethodTestData), parameters: new object[] { /*aot*/ false, RunHost.All })]
         public void PublishWithSIMD_AOT(BuildArgs buildArgs, RunHost host, string id)
         {

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -108,6 +108,8 @@
       <!-- build AOT, only if explicitly requested -->
       <WasmBuildNative Condition="'$(RunAOTCompilation)' == 'true' and '$(RunAOTCompilationAfterBuild)' == 'true'">true</WasmBuildNative>
 
+      <WasmBuildNative Condition="'$(WasmBuildNative)' == '' and '$(WasmEnableSIMD)' == 'true'">true</WasmBuildNative>
+
       <WasmBuildNative Condition="'$(WasmBuildNative)' == '' and @(NativeFileReference->Count()) > 0" >true</WasmBuildNative>
 
       <WasmBuildNative Condition="'$(WasmBuildNative)' == ''">false</WasmBuildNative>
@@ -118,6 +120,7 @@
       <!-- AOT==true overrides WasmBuildNative -->
       <WasmBuildNative Condition="'$(RunAOTCompilation)' == 'true'">true</WasmBuildNative>
       <WasmBuildNative Condition="'$(WasmBuildNative)' == '' and @(NativeFileReference->Count()) > 0" >true</WasmBuildNative>
+      <WasmBuildNative Condition="'$(WasmBuildNative)' == '' and '$(WasmEnableSIMD)' == 'true'">true</WasmBuildNative>
 
       <!-- not aot, not trimmed app, no reason to relink -->
       <WasmBuildNative Condition="'$(WasmBuildNative)' == '' and '$(PublishTrimmed)' != 'true'">false</WasmBuildNative>

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -195,7 +195,7 @@
       <_EmccCommonFlags Include="-v"                                Condition="'$(EmccVerbose)' != 'false'" />
       <_EmccCommonFlags Include="-s DISABLE_EXCEPTION_CATCHING=0"   Condition="'$(WasmExceptionHandling)' == 'false'" />
       <_EmccCommonFlags Include="-fwasm-exceptions"                 Condition="'$(WasmExceptionHandling)' == 'true'" />
-      <_EmccCommonFlags Include="-msimd128"                         Condition="'$(WasmSIMD)' == 'true'" />
+      <_EmccCommonFlags Include="-msimd128"                         Condition="'$(WasmEnableSIMD)' == 'true'" />
 
       <_EmccIncludePaths Include="$(_WasmIntermediateOutputPath.TrimEnd('\/'))" />
       <_EmccIncludePaths Include="$(_WasmRuntimePackIncludeDir)mono-2.0" />
@@ -524,7 +524,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="static" />
       <MonoAOTCompilerDefaultAotArguments Include="direct-icalls" />
       <MonoAOTCompilerDefaultAotArguments Include="deterministic" />
-      <MonoAOTCompilerDefaultAotArguments Include="mattr=simd" Condition="'$(WasmSIMD)' == 'true'" />
+      <MonoAOTCompilerDefaultAotArguments Include="mattr=simd" Condition="'$(WasmEnableSIMD)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="--wasm-exceptions" Condition="'$(WasmExceptionHandling)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="--wasm-gc-safepoints" Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true'" />
       <AotProfilePath Include="$(WasmAotProfilePath)"/>

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -196,8 +196,8 @@
       <_EmccCommonFlags Include="-s EXPORT_ES6=1" />
       <_EmccCommonFlags Include="-g"                                Condition="'$(WasmNativeStrip)' == 'false'" />
       <_EmccCommonFlags Include="-v"                                Condition="'$(EmccVerbose)' != 'false'" />
-      <_EmccCommonFlags Include="-s DISABLE_EXCEPTION_CATCHING=0"   Condition="'$(WasmExceptionHandling)' == 'false'" />
-      <_EmccCommonFlags Include="-fwasm-exceptions"                 Condition="'$(WasmExceptionHandling)' == 'true'" />
+      <_EmccCommonFlags Include="-s DISABLE_EXCEPTION_CATCHING=0"   Condition="'$(WasmEnableExceptionHandling)' == 'false'" />
+      <_EmccCommonFlags Include="-fwasm-exceptions"                 Condition="'$(WasmEnableExceptionHandling)' == 'true'" />
       <_EmccCommonFlags Include="-msimd128"                         Condition="'$(WasmEnableSIMD)' == 'true'" />
 
       <_EmccIncludePaths Include="$(_WasmIntermediateOutputPath.TrimEnd('\/'))" />
@@ -370,10 +370,10 @@
 
   <Target Name="_WasmWriteRspFilesForLinking">
 	<PropertyGroup>
-      <_WasmEHLib Condition="'$(WasmExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>
-      <_WasmEHLib Condition="'$(WasmExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
-      <_WasmEHLibToExclude Condition="'$(WasmExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
-      <_WasmEHLibToExclude Condition="'$(WasmExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
+      <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>
+      <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
+      <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
+      <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
 	</PropertyGroup>
     <ItemGroup>
       <!-- order matters -->
@@ -528,7 +528,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="direct-icalls" />
       <MonoAOTCompilerDefaultAotArguments Include="deterministic" />
       <MonoAOTCompilerDefaultAotArguments Include="mattr=simd" Condition="'$(WasmEnableSIMD)' == 'true'" />
-      <MonoAOTCompilerDefaultProcessArguments Include="--wasm-exceptions" Condition="'$(WasmExceptionHandling)' == 'true'" />
+      <MonoAOTCompilerDefaultProcessArguments Include="--wasm-exceptions" Condition="'$(WasmEnableExceptionHandling)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="--wasm-gc-safepoints" Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true'" />
       <AotProfilePath Include="$(WasmAotProfilePath)"/>
     </ItemGroup>

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -66,7 +66,7 @@
                                               Defaults to false.
       - $(WasmAotProfilePath)               - Path to an AOT profile file.
       - $(WasmExceptionHandling)            - Enable support for the WASM Exception Handling feature.
-      - $(WasmSIMD)                         - Enable support for the WASM SIMD feature.
+      - $(WasmEnableSIMD)                         - Enable support for the WASM SIMD feature.
 
       Public items:
       - @(WasmExtraFilesToDeploy) - Files to copy to $(WasmAppDir).
@@ -87,7 +87,7 @@
   <PropertyGroup>
     <WasmDedup Condition="'$(WasmDedup)' == ''">false</WasmDedup>
     <WasmExceptionHandling Condition="'$(WasmExceptionHandling)' == ''">false</WasmExceptionHandling>
-    <WasmSIMD Condition="'$(WasmSIMD)' == ''">false</WasmSIMD>
+    <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">false</WasmEnableSIMD>
 
     <!--<WasmStripAOTAssemblies Condition="'$(AOTMode)' == 'LLVMOnlyInterp'">false</WasmStripAOTAssemblies>-->
     <!--<WasmStripAOTAssemblies Condition="'$(WasmStripAOTAssemblies)' == ''">$(RunAOTCompilation)</WasmStripAOTAssemblies>-->

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -65,8 +65,8 @@
       - $(RunAOTCompilationAfterBuild)      - Run AOT compilation even after Build. By default, it is run only for publish.
                                               Defaults to false.
       - $(WasmAotProfilePath)               - Path to an AOT profile file.
-      - $(WasmExceptionHandling)            - Enable support for the WASM Exception Handling feature.
-      - $(WasmEnableSIMD)                         - Enable support for the WASM SIMD feature.
+      - $(WasmEnableExceptionHandling)      - Enable support for the WASM Exception Handling feature.
+      - $(WasmEnableSIMD)                   - Enable support for the WASM SIMD feature.
 
       Public items:
       - @(WasmExtraFilesToDeploy) - Files to copy to $(WasmAppDir).
@@ -86,7 +86,7 @@
 
   <PropertyGroup>
     <WasmDedup Condition="'$(WasmDedup)' == ''">false</WasmDedup>
-    <WasmExceptionHandling Condition="'$(WasmExceptionHandling)' == ''">false</WasmExceptionHandling>
+    <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == ''">false</WasmEnableExceptionHandling>
     <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">false</WasmEnableSIMD>
 
     <!--<WasmStripAOTAssemblies Condition="'$(AOTMode)' == 'LLVMOnlyInterp'">false</WasmStripAOTAssemblies>-->


### PR DESCRIPTION
- rename `$(WasmSIMD)` -> `$(WasmEnableSIMD)`
- Require the workload when the property is set
- Add tests for the various cases
- and rename `$(WasmExceptionHandling)` -> `$(WasmEnableExceptionHandling)`