### PR TITLE
Make RegisterChangeCallback consistent with CancellationChangeToken and ConfigurationReloadToken

### DIFF
--- a/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
+++ b/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Extensions.Internal
         /// <param name="onFailure">The action to execute when an <see cref="ObjectDisposedException"/> is thrown. Should be used to set the IChangeToken's ActiveChangeCallbacks property to false.</param>
         /// <param name="onFailureState">The state to be passed into the <paramref name="onFailure"/> action.</param>
         /// <returns>The <see cref="CancellationToken"/> registration.</returns>
-        internal static IDisposable UnsafeRegisterChangeCallback<T>(Action<object?> callback, object? state, CancellationToken Token, Action<T> onFailure, T onFailureState)
+        internal static IDisposable UnsafeRegisterChangeCallback<T>(Action<object?> callback, object? state, CancellationToken token, Action<T> onFailure, T onFailureState)
         {
 #if NETCOREAPP || NETSTANDARD2_1
             try
             {
-                return Token.UnsafeRegister(callback, state);
+                return token.UnsafeRegister(callback, state);
             }
             catch (ObjectDisposedException)
             {
@@ -46,7 +46,6 @@ namespace Microsoft.Extensions.Internal
             }
             catch (ObjectDisposedException)
             {
-                // Reset the flag so that we can indicate to future callers that this wouldn't work.
                 onFailure(onFailureState);
             }
             finally

--- a/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
+++ b/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using Microsoft.Extensions.FileProviders;
+
+namespace Microsoft.Extensions.Internal
+{
+    internal static partial class ChangeCallbackRegistrar
+    {
+        /// <summary>
+        /// Registers for a callback that will be invoked when the entry has changed. <see cref="Primitives.IChangeToken.HasChanged"/>
+        /// MUST be set before the callback is invoked.
+        /// </summary>
+        /// <param name="callback">The callback to invoke.</param>
+        /// <param name="state">State to be passed into the callback.</param>
+        /// <param name="_cts"></param>
+        /// <param name="onFailure"></param>
+        /// <param name="onFailureState"></param>
+        /// <returns>The <see cref="CancellationToken"/> registration.</returns>
+        internal static IDisposable UnsafeRegisterChangeCallback<T>(Action<object?> callback, object? state, CancellationTokenSource _cts, Action<T> onFailure, T onFailureState)
+        {
+#if NETCOREAPP || NETSTANDARD2_1
+            try
+            {
+                return _cts.Token.UnsafeRegister(callback, state);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Reset the flag so that we can indicate to future callers that this wouldn't work.
+                onFailure(onFailureState);
+            }
+#else
+            // Don't capture the current ExecutionContext and its AsyncLocals onto the token registration causing them to live forever
+            bool restoreFlow = false;
+            if (!ExecutionContext.IsFlowSuppressed())
+            {
+                ExecutionContext.SuppressFlow();
+                restoreFlow = true;
+            }
+
+            try
+            {
+                return _cts.Token.Register(callback, state);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Reset the flag so that we can indicate to future callers that this wouldn't work.
+                onFailure(onFailureState);
+            }
+            finally
+            {
+                // Restore the current ExecutionContext
+                if (restoreFlow)
+                {
+                    ExecutionContext.RestoreFlow();
+                }
+            }
+#endif
+            return EmptyDisposable.Instance;
+        }
+    }
+}

--- a/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
+++ b/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.Extensions.Internal
 {
-    internal static partial class ChangeCallbackRegistrar
+    internal static class ChangeCallbackRegistrar
     {
         /// <summary>
         /// Registers for a callback that will be invoked when the entry has changed. <see cref="Primitives.IChangeToken.HasChanged"/>
@@ -28,7 +28,6 @@ namespace Microsoft.Extensions.Internal
             }
             catch (ObjectDisposedException)
             {
-                // Reset the flag so that we can indicate to future callers that this wouldn't work.
                 onFailure(onFailureState);
             }
 #else

--- a/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
+++ b/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Internal
         /// </summary>
         /// <param name="callback">The callback to invoke.</param>
         /// <param name="state">State to be passed into the callback.</param>
-        /// <param name="Token">The <see cref="CancellationToken"/> to invoke the callback with.</param>
+        /// <param name="token">The <see cref="CancellationToken"/> to invoke the callback with.</param>
         /// <param name="onFailure">The action to execute when an <see cref="ObjectDisposedException"/> is thrown. Should be used to set the IChangeToken's ActiveChangeCallbacks property to false.</param>
         /// <param name="onFailureState">The state to be passed into the <paramref name="onFailure"/> action.</param>
         /// <returns>The <see cref="CancellationToken"/> registration.</returns>
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Internal
 
             try
             {
-                return Token.Register(callback, state);
+                return token.Register(callback, state);
             }
             catch (ObjectDisposedException)
             {

--- a/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
+++ b/src/libraries/Common/src/Extensions/ChangeCallbackRegistrar.cs
@@ -15,16 +15,16 @@ namespace Microsoft.Extensions.Internal
         /// </summary>
         /// <param name="callback">The callback to invoke.</param>
         /// <param name="state">State to be passed into the callback.</param>
-        /// <param name="_cts"></param>
-        /// <param name="onFailure"></param>
-        /// <param name="onFailureState"></param>
+        /// <param name="Token">The <see cref="CancellationToken"/> to invoke the callback with.</param>
+        /// <param name="onFailure">The action to execute when an <see cref="ObjectDisposedException"/> is thrown. Should be used to set the IChangeToken's ActiveChangeCallbacks property to false.</param>
+        /// <param name="onFailureState">The state to be passed into the <paramref name="onFailure"/> action.</param>
         /// <returns>The <see cref="CancellationToken"/> registration.</returns>
-        internal static IDisposable UnsafeRegisterChangeCallback<T>(Action<object?> callback, object? state, CancellationTokenSource _cts, Action<T> onFailure, T onFailureState)
+        internal static IDisposable UnsafeRegisterChangeCallback<T>(Action<object?> callback, object? state, CancellationToken Token, Action<T> onFailure, T onFailureState)
         {
 #if NETCOREAPP || NETSTANDARD2_1
             try
             {
-                return _cts.Token.UnsafeRegister(callback, state);
+                return Token.UnsafeRegister(callback, state);
             }
             catch (ObjectDisposedException)
             {
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Internal
 
             try
             {
-                return _cts.Token.Register(callback, state);
+                return Token.Register(callback, state);
             }
             catch (ObjectDisposedException)
             {

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationReloadToken.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationReloadToken.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.Configuration
                 callback,
                 state,
                 _cts.Token,
-                static s => s.ActiveChangeCallbacks = false,
+                static s => s.ActiveChangeCallbacks = false, // Reset the flag to indicate to future callers that this wouldn't work.
                 this);
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationReloadToken.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationReloadToken.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Configuration
             return ChangeCallbackRegistrar.UnsafeRegisterChangeCallback(
                 callback,
                 state,
-                _cts,
+                _cts.Token,
                 static s => s.ActiveChangeCallbacks = false,
                 this);
         }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/Microsoft.Extensions.Configuration.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/Microsoft.Extensions.Configuration.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
@@ -11,6 +11,10 @@
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration.Abstractions\src\Microsoft.Extensions.Configuration.Abstractions.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj" />
+    <Compile Include="$(CommonPath)Extensions\ChangeCallbackRegistrar.cs"
+             Link="Common\src\Extensions\ChangeCallbackRegistrar.cs" />
+    <Compile Include="$(CommonPath)Extensions\EmptyDisposable.cs"
+             Link="Common\src\Extensions\EmptyDisposable.cs" />
     <Compile Include="$(CommonPath)System\ThrowHelper.cs"
              Link="Common\System\ThrowHelper.cs" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/CancellationChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/CancellationChangeToken.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Primitives
                 callback,
                 state,
                 Token,
-                static s => s.ActiveChangeCallbacks = false,
+                static s => s.ActiveChangeCallbacks = false, // Reset the flag to indicate to future callers that this wouldn't work.
                 this);
         }
     }

--- a/src/libraries/Microsoft.Extensions.Primitives/src/CancellationChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/CancellationChangeToken.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.Primitives
 {
@@ -31,53 +32,12 @@ namespace Microsoft.Extensions.Primitives
         /// <inheritdoc />
         public IDisposable RegisterChangeCallback(Action<object?> callback, object? state)
         {
-#if NETCOREAPP || NETSTANDARD2_1
-            try
-            {
-                return Token.UnsafeRegister(callback, state);
-            }
-            catch (ObjectDisposedException)
-            {
-                // Reset the flag so that we can indicate to future callers that this wouldn't work.
-                ActiveChangeCallbacks = false;
-            }
-#else
-            // Don't capture the current ExecutionContext and its AsyncLocals onto the token registration causing them to live forever
-            bool restoreFlow = false;
-            if (!ExecutionContext.IsFlowSuppressed())
-            {
-                ExecutionContext.SuppressFlow();
-                restoreFlow = true;
-            }
-
-            try
-            {
-                return Token.Register(callback, state);
-            }
-            catch (ObjectDisposedException)
-            {
-                // Reset the flag so that we can indicate to future callers that this wouldn't work.
-                ActiveChangeCallbacks = false;
-            }
-            finally
-            {
-                // Restore the current ExecutionContext
-                if (restoreFlow)
-                {
-                    ExecutionContext.RestoreFlow();
-                }
-            }
-#endif
-            return NullDisposable.Instance;
-        }
-
-        private sealed class NullDisposable : IDisposable
-        {
-            public static readonly NullDisposable Instance = new NullDisposable();
-
-            public void Dispose()
-            {
-            }
+            return ChangeCallbackRegistrar.UnsafeRegisterChangeCallback(
+                callback,
+                state,
+                Token,
+                static s => s.ActiveChangeCallbacks = false,
+                this);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Primitives/src/Microsoft.Extensions.Primitives.csproj
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/Microsoft.Extensions.Primitives.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
@@ -19,6 +19,10 @@ Microsoft.Extensions.Primitives.StringSegment</PackageDescription>
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs"
              Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <Compile Include="$(CommonPath)Extensions\ChangeCallbackRegistrar.cs"
+             Link="Common\src\Extensions\ChangeCallbackRegistrar.cs" />
+    <Compile Include="$(CommonPath)Extensions\EmptyDisposable.cs"
+             Link="Common\src\Extensions\EmptyDisposable.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">


### PR DESCRIPTION
Fix for issue described in #36507 where [ConfigureReloadToken](https://source.dot.net/#Microsoft.Extensions.Configuration/ConfigurationReloadToken.cs) does not suppress the flow of `ExecutionContext` the same way that (for example) [CancellationChangeToken](https://source.dot.net/#Microsoft.Extensions.Primitives/CancellationChangeToken.cs,345ae463084736b6) does when calling `RegisterChangeCallback`. To solve this, I copied over the method from CancellationChangeToken with a slight tweak to fit in its new context. The proposed fix in #36507 had ConfigureReloadToken inherit CancellationChangeToken to take on this behavior but that was intentionally not done here to maintain separation between the two.

Note: I copied over the internal `NullDisposable` class for this fix to work, and I am wondering if it's fine like this or if we should be pulling it out now that the same internal class is defined in multiple Token classes.