### PR TITLE
[wasm-mt] Fix pack/build issues in threaded builds

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -190,9 +190,9 @@
         IsNative="true" />
       <!-- for threaded wasm -->
       <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser' and Exists('$(LibrariesNativeArtifactsPath)dotnet.worker.js')"
-			     Include="
-	$(LibrariesNativeArtifactsPath)dotnet.worker.js"
-	IsNative="true" />
+                             Include="
+        $(LibrariesNativeArtifactsPath)dotnet.worker.js"
+        IsNative="true" />
       <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser'"
                              Include="
         $(LibrariesNativeArtifactsPath)src\*.c;

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -188,6 +188,11 @@
         $(LibrariesNativeArtifactsPath)dotnet.timezones.blat;
         $(LibrariesNativeArtifactsPath)*.dat;"
         IsNative="true" />
+      <!-- for threaded wasm -->
+      <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser' and Exists('$(LibrariesNativeArtifactsPath)dotnet.worker.js')"
+			     Include="
+	$(LibrariesNativeArtifactsPath)dotnet.worker.js"
+	IsNative="true" />
       <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser'"
                              Include="
         $(LibrariesNativeArtifactsPath)src\*.c;

--- a/src/libraries/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/libraries/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true'">
+  <ItemGroup Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread' or '$(MonoWasmBuildVariant)' == 'perftrace'">
     <!-- when wasm threading is enabled the implementation in CoreLib won't have the UnsupportedOSAttribute for browser,
          but this contract still does since we only expose the wasm threading through System.Diagnostics.Tracing.WebAssembly.PerfTracing
          so we need to baseline the ApiCompat errors related to that -->

--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.csproj
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.csproj
@@ -10,8 +10,8 @@
     <NoWarn>$(NoWarn);0809;0618;CS8614;CS3015</NoWarn>
     <StrongNameKeyId>SilverlightPlatform</StrongNameKeyId>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <FeatureWasmPerfTracing Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true'">true</FeatureWasmPerfTracing>
-    <FeatureWasmThreads Condition="'$(WasmEnableThreads)' == 'true'">true</FeatureWasmThreads>
+    <FeatureWasmPerfTracing Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread' or '$(MonoWasmBuildVariant)' == 'perftrace'">true</FeatureWasmPerfTracing>
+    <FeatureWasmThreads Condition="'$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread'">true</FeatureWasmThreads>
     <DefineConstants Condition="'$(FeatureWasmPerfTracing)' == 'true'">$(DefineConstants);FEATURE_WASM_PERFTRACING</DefineConstants>
     <DefineConstants Condition="'$(FeatureWasmThreads)' == 'true'">$(DefineConstants);FEATURE_WASM_THREADS</DefineConstants>
     <DefineConstants>$(DefineConstants);BUILDING_CORELIB_REFERENCE</DefineConstants>

--- a/src/libraries/System.Threading.Thread/src/System.Threading.Thread.csproj
+++ b/src/libraries/System.Threading.Thread/src/System.Threading.Thread.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(WasmEnableThreads)' == 'true'">
+  <ItemGroup Condition="'$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread'">
     <!-- when wasm threading is enabled the implementation in CoreLib won't have the UnsupportedOSAttribute for browser,
          but this contract still does since we only expose the wasm threading through System.Diagnostics.Threading.Thread.WebAssembly.Threading
          so we need to baseline the ApiCompat errors related to that -->

--- a/src/libraries/System.Threading.ThreadPool/src/System.Threading.ThreadPool.csproj
+++ b/src/libraries/System.Threading.ThreadPool/src/System.Threading.ThreadPool.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(WasmEnableThreads)' == 'true'">
+  <ItemGroup Condition="'$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread'">
     <!-- when wasm threading is enabled the implementation in CoreLib won't have the UnsupportedOSAttribute for browser,
          but this contract still does since we only expose the wasm threading through System.Diagnostics.Threading.ThreadPool.WebAssembly.Threading
          so we need to baseline the ApiCompat errors related to that -->

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
@@ -125,8 +125,8 @@
     <DefineConstants>$(DefineConstants);MONO_FEATURE_SRE</DefineConstants>
 
     <FeatureMono>true</FeatureMono>
-    <FeatureWasmThreads Condition="'$(TargetsBrowser)' == 'true' and '$(WasmEnableThreads)' == 'true'">true</FeatureWasmThreads>
-    <FeatureWasmPerfTracing Condition="'$(TargetsBrowser)' == 'true' and ('$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true')">true</FeatureWasmPerfTracing>
+    <FeatureWasmThreads Condition="'$(TargetsBrowser)' == 'true' and ('$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread')">true</FeatureWasmThreads>
+    <FeatureWasmPerfTracing Condition="'$(TargetsBrowser)' == 'true' and ('$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread' or '$(MonoWasmBuildVariant)' == 'perftrace')">true</FeatureWasmPerfTracing>
     <FeatureManagedEtwChannels>true</FeatureManagedEtwChannels>
     <FeatureManagedEtw>true</FeatureManagedEtw>
     <FeaturePortableTimer Condition="'$(TargetsBrowser)' != 'true'">true</FeaturePortableTimer>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
@@ -89,8 +89,8 @@
       <KnownRuntimePack Update="@(KnownRuntimePack)">
         <LatestRuntimeFrameworkVersion Condition="'%(KnownRuntimePack.TargetFramework)' == '${NetCoreAppCurrent}' and '%(KnownRuntimePack.RuntimePackLabels)' == 'Mono'">**FromWorkload**</LatestRuntimeFrameworkVersion>
         <!-- Overrides for wasm threading support -->
-        <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnableThreading)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.multithread.**RID**</RuntimePackNamePatterns>
-        <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnablePerfTrace)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.perftrace.**RID**</RuntimePackNamePatterns>
+        <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnableThreads)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.multithread.**RID**</RuntimePackNamePatterns>
+        <RuntimePackNamePatterns Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(WasmEnablePerfTracing)' == 'true'">Microsoft.NETCore.App.Runtime.Mono.perftrace.**RID**</RuntimePackNamePatterns>
       </KnownRuntimePack>
     </ItemGroup>
 
@@ -113,8 +113,8 @@
     </Target>
 
     <Target Name="_ErrorDualWasmThreadProps"
-            Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(BrowserWorkloadDisabled)' != 'true' and '$(WasmEnableThreading)' == 'true' and '$(WasmEnablePerfTrace)' == 'true'"
+            Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(BrowserWorkloadDisabled)' != 'true' and '$(WasmEnableThreads)' == 'true' and '$(WasmEnablePerfTracing)' == 'true'"
             BeforeTargets="Build">
-        <Error Text="WebAssembly workloads can only support one active threading mode at a time. Either set WasmEnableThreading or WasmEnablePerfTrace to true, but not both." />
+        <Error Text="WebAssembly workloads can only support one active threading mode at a time. Either set WasmEnableThreads or WasmEnablePerfTracing to true, but not both." />
     </Target>
 </Project>

--- a/src/mono/wasm/templates/templates/browser/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/browser/.template.config/template.json
@@ -6,7 +6,7 @@
   "name": "WebAssembly Browser App",
   "shortName": "wasmbrowser",
   "sourceName": "browser.0",
-  "preferNameDirectory": true,  
+  "preferNameDirectory": true,
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/mono/wasm/templates/templates/browser/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/browser/.template.config/template.json
@@ -6,6 +6,7 @@
   "name": "WebAssembly Browser App",
   "shortName": "wasmbrowser",
   "sourceName": "browser.0",
+  "preferNameDirectory": true,  
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/mono/wasm/templates/templates/console/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/console/.template.config/template.json
@@ -6,6 +6,7 @@
   "name": "WebAssembly Console App",
   "shortName": "wasmconsole",
   "sourceName": "console.0",
+  "preferNameDirectory": true,
   "tags": {
     "language": "C#",
     "type": "project"


### PR DESCRIPTION
Addresses the following from https://github.com/dotnet/runtime/issues/74654:

- `dotnet.worker.js` missing from the runtime pack
- [WorkloadManifest.targets.in](https://github.com/dotnet/runtime/blob/536f34d9ab88e153aa11329e789afe6975fbe9a9/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in#L92) uses `WasmEnableThreading` instead of `WasmEnableThreads`
- The CoreLibs in the multithread and perftrace build variants don't define the correct feature flags.
- `dotnet new wasmbrowser` creates `browser.csproj`, not `<dirname>.csproj`