### PR TITLE
WIP: Initial provisions for semantic Crossgen2 PDB validation

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -80,7 +80,6 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       OneFileCrossgen2() {
         date +%H:%M:%S
         __OutputFile=$1
-        __PdbFile=$
 
         __ResponseFile="$__OutputFile.rsp"
         rm $__ResponseFile 2>/dev/null

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -80,6 +80,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       OneFileCrossgen2() {
         date +%H:%M:%S
         __OutputFile=$1
+        __PdbFile=$
 
         __ResponseFile="$__OutputFile.rsp"
         rm $__ResponseFile 2>/dev/null
@@ -168,8 +169,12 @@ if /i "$(AlwaysUseCrossGen2)" == "true" (
 REM CrossGen2 Script
 if defined RunCrossGen2 (
     set ExtraCrossGen2Args=!ExtraCrossGen2Args! $(CrossGen2TestExtraArguments)
+    set CrossGen2TestCheckPdb=$(CrossGen2TestCheckPdb)
+    set __CreatePdb=$(__CreatePdb)
 
     if defined LargeVersionBubble ( set ExtraCrossGen2Args=!ExtraCrossGen2Args! --inputbubble)
+    if defined CrossGen2TestCheckPdb ( set __CreatePdb=1)
+
     set CrossGen2Status=0
     set compilationDoneFlagFile=!ScriptPath!IL-CG2\done
     if exist "IL-CG2" (
@@ -192,6 +197,7 @@ if defined RunCrossGen2 (
     if defined CompositeBuildMode (
         set ExtraCrossGen2Args=!ExtraCrossGen2Args! --composite
         set __OutputFile=!scriptPath!\composite-r2r.dll
+        set __PdbFile=!scriptPath!\composite-r2r.ni.pdb
         rem In composite mode, treat all dll's in the test folder as rooting inputs
         set __InputFile=!scriptPath!IL-CG2\*.dll
         call :CompileOneFileCrossgen2
@@ -200,6 +206,7 @@ if defined RunCrossGen2 (
         set ExtraCrossGen2Args=!ExtraCrossGen2Args! -r:!scriptPath!IL-CG2\*.dll
         for %%I in (!scriptPath!IL-CG2\*.dll) do (
             set __OutputFile=!scriptPath!%%~nI.dll
+            set __PdbFile=!scriptPath!%%~nI.ni.pdb
             set __InputFile=%%I
             call :CompileOneFileCrossgen2
             IF NOT !CrossGen2Status!==0 (
@@ -216,13 +223,14 @@ if defined RunCrossGen2 (
     set __ResponseFile=!__OutputFile!.rsp
     del /Q !__ResponseFile! 2>nul
 
-    set __Command=!_DebuggerFullPath!
     REM Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
     if defined __TestDotNetCmd (
-        set __Command=!__Command! "!__TestDotNetCmd!"
+        set __DotNet="!__TestDotNetCmd!"
     ) else (
-        set __Command=!__Command! "dotnet"
+        set __DotNet="dotnet"
     )
+    set __Command=!_DebuggerFullPath!
+    set __Command=!__Command! !__DotNet!
     set __Command=!__Command! "!CORE_ROOT!\crossgen2\crossgen2.dll"
     set __Command=!__Command! @"!__ResponseFile!"
     set __Command=!__Command! !ExtraCrossGen2Args!
@@ -237,7 +245,7 @@ if defined RunCrossGen2 (
     echo -r:!CORE_ROOT!\netstandard.dll>>!__ResponseFile!
     echo -O>>!__ResponseFile!
 
-    if not "$(__CreatePdb)" == "" (
+    if defined __CreatePdb (
         echo --pdb>>!__ResponseFile!
     )
 
@@ -259,6 +267,21 @@ if defined RunCrossGen2 (
     endlocal
     set CrossGen2Status=!ERRORLEVEL!
     echo %time%
+
+    if !CrossGen2Status!==0 (
+        if defined CrossGen2TestCheckPdb (
+            set __CheckPdbCommand=!__DotNet!
+            set __CheckPdbCommand=!__CheckPdbCommand! "!CORE_ROOT!\PdbChecker\PdbChecker.dll"
+            set __CheckPdbCommand=!__CheckPdbCommand! !__PdbFile! @(CheckPdbSymbol->'%22%(Identity)%22', ' ')
+            echo "!__CheckPdbCommand!"
+            call !__CheckPdbCommand!
+            if not !ERRORLEVEL!==0 (
+                echo PDB check failed for file !__PdbFile! >2
+                set CrossGen2Status=42
+            )
+        )
+    )
+
     Exit /b 0
 
 :DoneCrossgen2Operations

--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -44,6 +44,7 @@
       <RunTimeDependencyCopyLocal Include="@(RunTimeDependencyCopyLocalFile -> '%(File)')"  />
       <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/*" />
       <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/xunit.*" TargetDir="xunit/" />
+      <RunTimeDependencyCopyLocal Include="$(XUnitTestBinBase)/Common/PdbChecker/PdbChecker/*.*" TargetDir="PdbChecker/" />
     </ItemGroup>
 
     <ItemGroup>
@@ -174,7 +175,7 @@
       <RuntimeDependencyCopyLocal Condition="'$(TargetOS)' != 'windows'" Include="$(MonoArtifactsPath)/libcoreclr$(LibSuffix)" TargetDir=""  />
       <RuntimeDependencyCopyLocal Condition="'$(TargetOS)' == 'windows'" Include="$(MonoArtifactsPath)coreclr$(LibSuffix)" TargetDir=""  />
       <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/libmono-component-*" TargetDir=""  />
-       <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/*.dll" TargetDir="/"  />
+      <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/*.dll" TargetDir="/"  />
     </ItemGroup>
 
     <Copy

--- a/src/tests/Common/PdbChecker/MSDiaSymbolReader.cs
+++ b/src/tests/Common/PdbChecker/MSDiaSymbolReader.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Dia2Lib;
+
+class MSDiaSymbolReader
+{
+    private readonly IDiaDataSource _diaDataSource;
+    private readonly IDiaSession _diaSession;
+
+    private readonly List<string> _pdbSymbols;
+
+    public MSDiaSymbolReader(string pdbFile)
+    {
+        try
+        {
+            _diaDataSource = new DiaSourceClass();
+            _diaDataSource.loadDataFromPdb(pdbFile);
+            _diaDataSource.openSession(out _diaSession);
+
+            _pdbSymbols = new List<string>();
+
+            _diaSession.getSymbolsByAddr(out IDiaEnumSymbolsByAddr symbolEnum);
+            int symbolsTotal = 0;
+            for (IDiaSymbol symbol = symbolEnum.symbolByRVA(0); symbol != null; symbolEnum.Next(1, out symbol, out uint fetched))
+            {
+                symbolsTotal++;
+                if (symbol.symTag == (uint)SymTagEnum.SymTagFunction || symbol.symTag == (uint)SymTagEnum.SymTagPublicSymbol)
+                {
+                    _pdbSymbols.Add(symbol.name);
+                }
+            }
+
+            Console.WriteLine("PDB file:       {0}", pdbFile);
+            Console.WriteLine("Total symbols:  {0}", symbolsTotal);
+            Console.WriteLine("Public symbols: {0}", _pdbSymbols.Count);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Error opening PDB file {pdbFile}", ex);
+        }
+    }
+
+    public void DumpSymbols()
+    {
+        Console.WriteLine("PDB public symbol list:");
+        foreach (string symbol in _pdbSymbols.OrderBy(s => s))
+        {
+            Console.WriteLine(symbol);
+        }
+        Console.WriteLine("End of PDB public symbol list");
+    }
+
+    public bool ContainsSymbol(string symbolName) => _pdbSymbols.Any(s => s.Contains(symbolName));
+}

--- a/src/tests/Common/PdbChecker/PdbChecker.csproj
+++ b/src/tests/Common/PdbChecker/PdbChecker.csproj
@@ -12,28 +12,11 @@
     <Compile Include="*.cs" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetOS)' == 'windows'">
-    <DiaSymReaderTargetArch>$(TargetArchitectureForSharedLibraries)</DiaSymReaderTargetArch>
-    <DiaSymReaderTargetArch Condition="'$(DiaSymReaderTargetArch)' == 'x64'">amd64</DiaSymReaderTargetArch>
-    <DiaSymReaderTargetArchFileName>Microsoft.DiaSymReader.Native.$(DiaSymReaderTargetArch).dll</DiaSymReaderTargetArchFileName>
-    <DiaSymReaderTargetArchPath Condition="'$(PkgMicrosoft_DiaSymReader_Native)' != ''">$(PkgMicrosoft_DiaSymReader_Native)\runtimes\win\native\$(DiaSymReaderTargetArchFileName)</DiaSymReaderTargetArchPath>
-    <!-- When publishing we won't have the NuGet packages, so use the copy from the build artifacts directory. -->
-    <DiaSymReaderTargetArchPath Condition="'$(PkgMicrosoft_DiaSymReader_Native)' == ''">$(CoreCLRArtifactsPath)crossgen2/$(DiaSymReaderTargetArchFileName)</DiaSymReaderTargetArchPath>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(TargetOS)' == 'windows'">
-    <PackageReference Include="Microsoft.DiaSymReader.Native"
-      Version="$(MicrosoftDiaSymReaderNativeVersion)"
-      IsImplicitlyDefined="true"
-      ExcludeAssets="all"
-      GeneratePathProperty="true"
-      />
-
-    <Content Include="$(DiaSymReaderTargetArchPath)"
-      CopyToOutputDirectory="PreserveNewest"
-      CopyToPublishDirectory="PreserveNewest"
-      Link="%(FileName)%(Extension)"
-      />
+    <PackageReference
+      Include="Microsoft.Diagnostics.Tracing.TraceEvent"
+      Version="$(TraceEventVersion)"
+    />
   </ItemGroup>
 
 </Project>

--- a/src/tests/Common/PdbChecker/PdbChecker.csproj
+++ b/src/tests/Common/PdbChecker/PdbChecker.csproj
@@ -10,8 +10,30 @@
 
   <ItemGroup>
     <Compile Include="*.cs" />
+  </ItemGroup>
 
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
+  <PropertyGroup Condition="'$(TargetOS)' == 'windows'">
+    <DiaSymReaderTargetArch>$(TargetArchitectureForSharedLibraries)</DiaSymReaderTargetArch>
+    <DiaSymReaderTargetArch Condition="'$(DiaSymReaderTargetArch)' == 'x64'">amd64</DiaSymReaderTargetArch>
+    <DiaSymReaderTargetArchFileName>Microsoft.DiaSymReader.Native.$(DiaSymReaderTargetArch).dll</DiaSymReaderTargetArchFileName>
+    <DiaSymReaderTargetArchPath Condition="'$(PkgMicrosoft_DiaSymReader_Native)' != ''">$(PkgMicrosoft_DiaSymReader_Native)\runtimes\win\native\$(DiaSymReaderTargetArchFileName)</DiaSymReaderTargetArchPath>
+    <!-- When publishing we won't have the NuGet packages, so use the copy from the build artifacts directory. -->
+    <DiaSymReaderTargetArchPath Condition="'$(PkgMicrosoft_DiaSymReader_Native)' == ''">$(CoreCLRArtifactsPath)crossgen2/$(DiaSymReaderTargetArchFileName)</DiaSymReaderTargetArchPath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
+    <PackageReference Include="Microsoft.DiaSymReader.Native"
+      Version="$(MicrosoftDiaSymReaderNativeVersion)"
+      IsImplicitlyDefined="true"
+      ExcludeAssets="all"
+      GeneratePathProperty="true"
+      />
+
+    <Content Include="$(DiaSymReaderTargetArchPath)"
+      CopyToOutputDirectory="PreserveNewest"
+      CopyToPublishDirectory="PreserveNewest"
+      Link="%(FileName)%(Extension)"
+      />
   </ItemGroup>
 
 </Project>

--- a/src/tests/Common/PdbChecker/PdbChecker.csproj
+++ b/src/tests/Common/PdbChecker/PdbChecker.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="*.cs" />
+
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/Common/PdbChecker/PdbChecker.csproj
+++ b/src/tests/Common/PdbChecker/PdbChecker.csproj
@@ -10,13 +10,7 @@
 
   <ItemGroup>
     <Compile Include="*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetOS)' == 'windows'">
-    <PackageReference
-      Include="Microsoft.Diagnostics.Tracing.TraceEvent"
-      Version="$(TraceEventVersion)"
-    />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/tests/Common/PdbChecker/PdbChecker.sln
+++ b/src/tests/Common/PdbChecker/PdbChecker.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32708.82
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdbChecker", "PdbChecker.csproj", "{6247A503-5387-4BE1-ACA3-027CADA30CA9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6247A503-5387-4BE1-ACA3-027CADA30CA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6247A503-5387-4BE1-ACA3-027CADA30CA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6247A503-5387-4BE1-ACA3-027CADA30CA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6247A503-5387-4BE1-ACA3-027CADA30CA9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4033231C-763B-4C57-BA35-7C1AC007AD0E}
+	EndGlobalSection
+EndGlobal

--- a/src/tests/Common/PdbChecker/Program.cs
+++ b/src/tests/Common/PdbChecker/Program.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Dia2Lib;
+class Program
+{
+    public static int Main(string[] args)
+    {
+        try
+        {
+            TryMain(args);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("Fatal error: {0}", ex);
+            return 1;
+        }
+    }
+
+    private static void TryMain(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            DisplayUsage();
+            return;
+        }
+        MSDiaSymbolReader reader = new MSDiaSymbolReader(args[0]);
+        int matchedSymbols = 0;
+        int missingSymbols = 0;
+        for (int symbolArgIndex = 1; symbolArgIndex < args.Length; symbolArgIndex++)
+        {
+            string symbolName = args[symbolArgIndex];
+            if (reader.ContainsSymbol(symbolName))
+            {
+                matchedSymbols++;
+            }
+            else
+            {
+                missingSymbols++;
+                Console.Error.WriteLine("Missing symbol: {0}", symbolName);
+            }
+        }
+        if (missingSymbols > 0)
+        {
+            reader.DumpSymbols();
+            throw new Exception($"{missingSymbols} missing symbols ({matchedSymbols} symbols matched)");
+        }
+        if (matchedSymbols > 0)
+        {
+            Console.WriteLine("Matched all {0} symbols", matchedSymbols);
+        }
+    }
+
+    private static void DisplayUsage()
+    {
+        Console.WriteLine("Usage: PdbChecker <pdb file to check> { <symbol to check for existence in the PDB file> }");
+    }
+}

--- a/src/tests/Common/test_dependencies/test_dependencies.csproj
+++ b/src/tests/Common/test_dependencies/test_dependencies.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tools.RuntimeClient" Version="$(MicrosoftDiagnosticsToolsRuntimeClientVersion)" />
-    <ProjectReference Include="$(RepoRoot)\src\tests\Common\PdbChecker\PdbChecker.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\tests\Common\PdbChecker\PdbChecker.csproj" Condition="'$(TargetOS)' == 'windows'" />
   </ItemGroup>
 
   <Target Name="Build" DependsOnTargets="$(TraversalBuildDependsOn)" />

--- a/src/tests/Common/test_dependencies/test_dependencies.csproj
+++ b/src/tests/Common/test_dependencies/test_dependencies.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tools.RuntimeClient" Version="$(MicrosoftDiagnosticsToolsRuntimeClientVersion)" />
+    <ProjectReference Include="$(RepoRoot)\src\tests\Common\PdbChecker\PdbChecker.csproj" />
   </ItemGroup>
 
   <Target Name="Build" DependsOnTargets="$(TraversalBuildDependsOn)" />

--- a/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
@@ -5,6 +5,13 @@
 
     <!-- This is an explicit crossgen test -->
     <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
+    <CrossGen2TestCheckPdb>true</CrossGen2TestCheckPdb>
   </PropertyGroup>
+
+  <ItemGroup>
+    <CheckPdbSymbol Include="System.Int32 Program+SomeClass::GetHashCode()" />
+    <CheckPdbSymbol Include="System.String Program::ObjectToStringOnGenericParamTestWorker(System.__Canon&amp;)" />
+  </ItemGroup>
+
   <Import Project="smoketest.targets" />
 </Project>

--- a/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <CheckPdbSymbol Include="System.Int32 Program+SomeClass::GetHashCode()" />
     <CheckPdbSymbol Include="System.String Program::ObjectToStringOnGenericParamTestWorker(System.__Canon&amp;)" />
+    <CheckPdbSymbol Include="missing symbol" />
   </ItemGroup>
 
   <Import Project="smoketest.targets" />


### PR DESCRIPTION
This Quality Week work item is motivated by my findings from a few months back that Crossgen2 PDB generator had been producing bogus symbol files for almost half a year due to a trivial bug and no testing in place was able to catch that. This change adds initial provisions for semantic PDB validation.

In this initial commit I'm adding a new managed app PdbChecker that uses the DIA library to read a given PDB and optionally check it for the presence of given symbols. In parallel I'm making test infra changes that enable selective PDB validation support in individual tests including checks for the presence of expected symbols.

This change by itself introduces rudimentary PR / CI validation of PDB files produced by Crossgen2. As next step I plan to introduce additional provisions for running this logic for all tests to be added to one of the Crossgen2-specific pipelines, and validation of PDBs produced during compilation of the framework assemblies.

Thanks

Tomas