### PR TITLE
[wasm] Use swizzle instruction for byte vectors

### DIFF
--- a/src/mono/mono/mini/llvm-intrinsics.h
+++ b/src/mono/mono/mini/llvm-intrinsics.h
@@ -262,6 +262,7 @@ INTRINS_OVR(WASM_BITMASK_V8, wasm_bitmask, Wasm, sse_i1_t)
 INTRINS_OVR(WASM_BITMASK_V4, wasm_bitmask, Wasm, sse_i4_t)
 INTRINS_OVR(WASM_BITMASK_V2, wasm_bitmask, Wasm, sse_i8_t)
 INTRINS(WASM_SHUFFLE, wasm_shuffle, Wasm)
+INTRINS(WASM_SWIZZLE, wasm_swizzle, Wasm)
 #endif
 #if defined(TARGET_ARM64)
 INTRINS_OVR(BITREVERSE_I32, bitreverse, Generic, LLVMInt32Type ())

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -9726,6 +9726,12 @@ MONO_RESTORE_WARNING
 		}
 		case OP_WASM_SIMD_SWIZZLE: {
 			int nelems = LLVMGetVectorSize (LLVMTypeOf (lhs));
+			if (nelems == 16) {
+				LLVMValueRef args [] = { lhs, rhs };
+				values [ins->dreg] = call_intrins (ctx, INTRINS_WASM_SWIZZLE, args, "");
+				break;
+			}
+
 			LLVMValueRef indexes [16];
 			for (int i = 0; i < nelems; ++i)
 				indexes [i] = LLVMBuildExtractElement (builder, rhs, const_int32 (i), "");


### PR DESCRIPTION
This produces faster code for byte vectors. It is visible in `Span, Reverse bytes` measurements.

    0.0028ms vs 0.0032ms in chrome/amd64
    0.0021ms vs 0.0027ms in firefox/amd64