### PR TITLE
[release/7.0] [QUIC] Fix native crashes and heap corruption via "generated-like" interop

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.NativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.NativeMethods.cs
@@ -1,0 +1,378 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Quic;
+
+namespace System.Net.Quic;
+
+internal sealed unsafe partial class MsQuicApi
+{
+    public void SetContext(MsQuicSafeHandle handle, void* context)
+    {
+        bool success = false;
+        try
+        {
+            handle.DangerousAddRef(ref success);
+            ApiTable->SetContext(handle.QuicHandle, context);
+        }
+        finally
+        {
+            if (success)
+            {
+                handle.DangerousRelease();
+            }
+        }
+    }
+
+    public void* GetContext(MsQuicSafeHandle handle)
+    {
+        bool success = false;
+        try
+        {
+            handle.DangerousAddRef(ref success);
+            return ApiTable->GetContext(handle.QuicHandle);
+        }
+        finally
+        {
+            if (success)
+            {
+                handle.DangerousRelease();
+            }
+        }
+    }
+
+    public void SetCallbackHandler(MsQuicSafeHandle handle, void* callback, void* context)
+    {
+        bool success = false;
+        try
+        {
+            handle.DangerousAddRef(ref success);
+            ApiTable->SetCallbackHandler(handle.QuicHandle, callback, context);
+        }
+        finally
+        {
+            if (success)
+            {
+                handle.DangerousRelease();
+            }
+        }
+    }
+
+    public int SetParam(MsQuicSafeHandle handle, uint param, uint bufferLength, void* buffer)
+    {
+        bool success = false;
+        try
+        {
+            handle.DangerousAddRef(ref success);
+            return ApiTable->SetParam(handle.QuicHandle, param, bufferLength, buffer);
+        }
+        finally
+        {
+            if (success)
+            {
+                handle.DangerousRelease();
+            }
+        }
+    }
+
+    public int GetParam(MsQuicSafeHandle handle, uint param, uint* bufferLength, void* buffer)
+    {
+        bool success = false;
+        try
+        {
+            handle.DangerousAddRef(ref success);
+            return ApiTable->GetParam(handle.QuicHandle, param, bufferLength, buffer);
+        }
+        finally
+        {
+            if (success)
+            {
+                handle.DangerousRelease();
+            }
+        }
+    }
+
+    public void RegistrationShutdown(MsQuicSafeHandle registration, QUIC_CONNECTION_SHUTDOWN_FLAGS flags, ulong code)
+    {
+        bool success = false;
+        try
+        {
+            registration.DangerousAddRef(ref success);
+            ApiTable->RegistrationShutdown(registration.QuicHandle, flags, code);
+        }
+        finally
+        {
+            if (success)
+            {
+                registration.DangerousRelease();
+            }
+        }
+    }
+
+    public int ConfigurationOpen(MsQuicSafeHandle registration, QUIC_BUFFER* alpnBuffers, uint alpnBuffersCount, QUIC_SETTINGS* settings, uint settingsSize, void* context, QUIC_HANDLE** configuration)
+    {
+        bool success = false;
+        try
+        {
+            registration.DangerousAddRef(ref success);
+            return ApiTable->ConfigurationOpen(registration.QuicHandle, alpnBuffers, alpnBuffersCount, settings, settingsSize, context, configuration);
+        }
+        finally
+        {
+            if (success)
+            {
+                registration.DangerousRelease();
+            }
+        }
+    }
+
+    public int ConfigurationLoadCredential(MsQuicSafeHandle configuration, QUIC_CREDENTIAL_CONFIG* config)
+    {
+        bool success = false;
+        try
+        {
+            configuration.DangerousAddRef(ref success);
+            return ApiTable->ConfigurationLoadCredential(configuration.QuicHandle, config);
+        }
+        finally
+        {
+            if (success)
+            {
+                configuration.DangerousRelease();
+            }
+        }
+    }
+
+    public int ListenerOpen(MsQuicSafeHandle registration, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_LISTENER_EVENT*, int> callback, void* context, QUIC_HANDLE** listener)
+    {
+        bool success = false;
+        try
+        {
+            registration.DangerousAddRef(ref success);
+            return ApiTable->ListenerOpen(registration.QuicHandle, callback, context, listener);
+        }
+        finally
+        {
+            if (success)
+            {
+                registration.DangerousRelease();
+            }
+        }
+    }
+
+    public int ListenerStart(MsQuicSafeHandle listener, QUIC_BUFFER* alpnBuffers, uint alpnBuffersCount, QuicAddr* localAddress)
+    {
+        bool success = false;
+        try
+        {
+            listener.DangerousAddRef(ref success);
+            return ApiTable->ListenerStart(listener.QuicHandle, alpnBuffers, alpnBuffersCount, localAddress);
+        }
+        finally
+        {
+            if (success)
+            {
+                listener.DangerousRelease();
+            }
+        }
+    }
+
+    public void ListenerStop(MsQuicSafeHandle listener)
+    {
+        bool success = false;
+        try
+        {
+            listener.DangerousAddRef(ref success);
+            ApiTable->ListenerStop(listener.QuicHandle);
+        }
+        finally
+        {
+            if (success)
+            {
+                listener.DangerousRelease();
+            }
+        }
+    }
+
+    public int ConnectionOpen(MsQuicSafeHandle registration, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_CONNECTION_EVENT*, int> callback, void* context, QUIC_HANDLE** connection)
+    {
+        bool success = false;
+        try
+        {
+            registration.DangerousAddRef(ref success);
+            return ApiTable->ConnectionOpen(registration.QuicHandle, callback, context, connection);
+        }
+        finally
+        {
+            if (success)
+            {
+                registration.DangerousRelease();
+            }
+        }
+    }
+
+    public void ConnectionShutdown(MsQuicSafeHandle connection, QUIC_CONNECTION_SHUTDOWN_FLAGS flags, ulong code)
+    {
+        bool success = false;
+        try
+        {
+            connection.DangerousAddRef(ref success);
+            ApiTable->ConnectionShutdown(connection.QuicHandle, flags, code);
+        }
+        finally
+        {
+            if (success)
+            {
+                connection.DangerousRelease();
+            }
+        }
+    }
+
+    public int ConnectionStart(MsQuicSafeHandle connection, MsQuicSafeHandle configuration, ushort family, sbyte* serverName, ushort serverPort)
+    {
+        bool connectionSuccess = false;
+        bool configurationSuccess = false;
+        try
+        {
+            connection.DangerousAddRef(ref connectionSuccess);
+            configuration.DangerousAddRef(ref configurationSuccess);
+            return ApiTable->ConnectionStart(connection.QuicHandle, configuration.QuicHandle, family, serverName, serverPort);
+        }
+        finally
+        {
+            if (connectionSuccess)
+            {
+                connection.DangerousRelease();
+            }
+            if (configurationSuccess)
+            {
+                configuration.DangerousRelease();
+            }
+        }
+    }
+
+    public int ConnectionSetConfiguration(MsQuicSafeHandle connection, MsQuicSafeHandle configuration)
+    {
+        bool connectionSuccess = false;
+        bool configurationSuccess = false;
+        try
+        {
+            connection.DangerousAddRef(ref connectionSuccess);
+            configuration.DangerousAddRef(ref configurationSuccess);
+            return ApiTable->ConnectionSetConfiguration(connection.QuicHandle, configuration.QuicHandle);
+        }
+        finally
+        {
+            if (connectionSuccess)
+            {
+                connection.DangerousRelease();
+            }
+            if (configurationSuccess)
+            {
+                configuration.DangerousRelease();
+            }
+        }
+    }
+
+    public int StreamOpen(MsQuicSafeHandle connection, QUIC_STREAM_OPEN_FLAGS flags, delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_STREAM_EVENT*, int> callback, void* context, QUIC_HANDLE** stream)
+    {
+        bool success = false;
+        try
+        {
+            connection.DangerousAddRef(ref success);
+            return ApiTable->StreamOpen(connection.QuicHandle, flags, callback, context, stream);
+        }
+        finally
+        {
+            if (success)
+            {
+                connection.DangerousRelease();
+            }
+        }
+    }
+
+    public int StreamStart(MsQuicSafeHandle stream, QUIC_STREAM_START_FLAGS flags)
+    {
+        bool success = false;
+        try
+        {
+            stream.DangerousAddRef(ref success);
+            return ApiTable->StreamStart(stream.QuicHandle, flags);
+        }
+        finally
+        {
+            if (success)
+            {
+                stream.DangerousRelease();
+            }
+        }
+    }
+
+    public int StreamShutdown(MsQuicSafeHandle stream, QUIC_STREAM_SHUTDOWN_FLAGS flags, ulong code)
+    {
+        bool success = false;
+        try
+        {
+            stream.DangerousAddRef(ref success);
+            return ApiTable->StreamShutdown(stream.QuicHandle, flags, code);
+        }
+        finally
+        {
+            if (success)
+            {
+                stream.DangerousRelease();
+            }
+        }
+    }
+
+    public int StreamSend(MsQuicSafeHandle stream, QUIC_BUFFER* buffers, uint buffersCount, QUIC_SEND_FLAGS flags, void* context)
+    {
+        bool success = false;
+        try
+        {
+            stream.DangerousAddRef(ref success);
+            return ApiTable->StreamSend(stream.QuicHandle, buffers, buffersCount, flags, context);
+        }
+        finally
+        {
+            if (success)
+            {
+                stream.DangerousRelease();
+            }
+        }
+    }
+
+    public void StreamReceiveComplete(MsQuicSafeHandle stream, ulong length)
+    {
+        bool success = false;
+        try
+        {
+            stream.DangerousAddRef(ref success);
+            ApiTable->StreamReceiveComplete(stream.QuicHandle, length);
+        }
+        finally
+        {
+            if (success)
+            {
+                stream.DangerousRelease();
+            }
+        }
+    }
+
+    public int StreamReceiveSetEnabled(MsQuicSafeHandle stream, byte enabled)
+    {
+        bool success = false;
+        try
+        {
+            stream.DangerousAddRef(ref success);
+            return ApiTable->StreamReceiveSetEnabled(stream.QuicHandle, enabled);
+        }
+        finally
+        {
+            if (success)
+            {
+                stream.DangerousRelease();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -13,7 +13,7 @@ using Microsoft.Win32;
 
 namespace System.Net.Quic;
 
-internal sealed unsafe class MsQuicApi
+internal sealed unsafe partial class MsQuicApi
 {
     private static readonly Version MinWindowsVersion = new Version(10, 0, 20145, 1000);
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -131,8 +131,8 @@ internal static class MsQuicConfiguration
 
         using MsQuicBuffers msquicBuffers = new MsQuicBuffers();
         msquicBuffers.Initialize(alpnProtocols, alpnProtocol => alpnProtocol.Protocol);
-        ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->ConfigurationOpen(
-            MsQuicApi.Api.Registration.QuicHandle,
+        ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ConfigurationOpen(
+            MsQuicApi.Api.Registration,
             msquicBuffers.Buffers,
             (uint)alpnProtocols.Count,
             &settings,
@@ -140,7 +140,7 @@ internal static class MsQuicConfiguration
             (void*)IntPtr.Zero,
             &handle),
             "ConfigurationOpen failed");
-        MsQuicSafeHandle configurationHandle = new MsQuicSafeHandle(handle, MsQuicApi.Api.ApiTable->ConfigurationClose, SafeHandleType.Configuration);
+        MsQuicSafeHandle configurationHandle = new MsQuicSafeHandle(handle, SafeHandleType.Configuration);
 
         try
         {
@@ -157,13 +157,13 @@ internal static class MsQuicConfiguration
             if (certificate is null)
             {
                 config.Type = QUIC_CREDENTIAL_TYPE.NONE;
-                status = MsQuicApi.Api.ApiTable->ConfigurationLoadCredential(configurationHandle.QuicHandle, &config);
+                status = MsQuicApi.Api.ConfigurationLoadCredential(configurationHandle, &config);
             }
             else if (MsQuicApi.UsesSChannelBackend)
             {
                 config.Type = QUIC_CREDENTIAL_TYPE.CERTIFICATE_CONTEXT;
                 config.CertificateContext = (void*)certificate.Handle;
-                status = MsQuicApi.Api.ApiTable->ConfigurationLoadCredential(configurationHandle.QuicHandle, &config);
+                status = MsQuicApi.Api.ConfigurationLoadCredential(configurationHandle, &config);
             }
             else
             {
@@ -192,7 +192,7 @@ internal static class MsQuicConfiguration
                         PrivateKeyPassword = (sbyte*)IntPtr.Zero
                     };
                     config.CertificatePkcs12 = &pkcs12Certificate;
-                    status = MsQuicApi.Api.ApiTable->ConfigurationLoadCredential(configurationHandle.QuicHandle, &config);
+                    status = MsQuicApi.Api.ConfigurationLoadCredential(configurationHandle, &config);
                 }
             }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -61,8 +61,8 @@ internal static class MsQuicHelpers
         T value;
         uint length = (uint)sizeof(T);
 
-        int status = MsQuicApi.Api.ApiTable->GetParam(
-            handle.QuicHandle,
+        int status = MsQuicApi.Api.GetParam(
+            handle,
             parameter,
             &length,
             (byte*)&value);
@@ -78,8 +78,8 @@ internal static class MsQuicHelpers
     internal static unsafe void SetMsQuicParameter<T>(MsQuicSafeHandle handle, uint parameter, T value)
         where T : unmanaged
     {
-        int status = MsQuicApi.Api.ApiTable->SetParam(
-            handle.QuicHandle,
+        int status = MsQuicApi.Api.SetParam(
+            handle,
             parameter,
             (uint)sizeof(T),
             (byte*)&value);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -106,13 +106,13 @@ public sealed partial class QuicListener : IAsyncDisposable
         try
         {
             QUIC_HANDLE* handle;
-            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->ListenerOpen(
-                MsQuicApi.Api.Registration.QuicHandle,
+            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ListenerOpen(
+                MsQuicApi.Api.Registration,
                 &NativeCallback,
                 (void*)GCHandle.ToIntPtr(context),
                 &handle),
                 "ListenerOpen failed");
-            _handle = new MsQuicContextSafeHandle(handle, context, MsQuicApi.Api.ApiTable->ListenerClose, SafeHandleType.Listener);
+            _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Listener);
         }
         catch
         {
@@ -135,8 +135,8 @@ public sealed partial class QuicListener : IAsyncDisposable
             // Using the Unspecified family makes MsQuic handle connections from all IP addresses.
             address.Family = QUIC_ADDRESS_FAMILY_UNSPEC;
         }
-        ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->ListenerStart(
-            _handle.QuicHandle,
+        ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ListenerStart(
+            _handle,
             alpnBuffers.Buffers,
             (uint)alpnBuffers.Count,
             &address),
@@ -266,7 +266,7 @@ public sealed partial class QuicListener : IAsyncDisposable
         {
             unsafe
             {
-                MsQuicApi.Api.ApiTable->ListenerStop(_handle.QuicHandle);
+                MsQuicApi.Api.ListenerStop(_handle);
             }
         }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -90,6 +90,7 @@ public sealed partial class QuicStream
         }
     };
     private MsQuicBuffers _sendBuffers = new MsQuicBuffers();
+    private object _sendBuffersLock = new object();
 
     private readonly long _defaultErrorCode;
 
@@ -141,14 +142,14 @@ public sealed partial class QuicStream
         try
         {
             QUIC_HANDLE* handle;
-            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->StreamOpen(
-                connectionHandle.QuicHandle,
+            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.StreamOpen(
+                connectionHandle,
                 type == QuicStreamType.Unidirectional ? QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL : QUIC_STREAM_OPEN_FLAGS.NONE,
                 &NativeCallback,
                 (void*)GCHandle.ToIntPtr(context),
                 &handle),
                 "StreamOpen failed");
-            _handle = new MsQuicContextSafeHandle(handle, context, MsQuicApi.Api.ApiTable->StreamClose, SafeHandleType.Stream, connectionHandle);
+            _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle);
         }
         catch
         {
@@ -179,12 +180,12 @@ public sealed partial class QuicStream
         GCHandle context = GCHandle.Alloc(this, GCHandleType.Weak);
         try
         {
+            _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle);
             delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_STREAM_EVENT*, int> nativeCallback = &NativeCallback;
-            MsQuicApi.Api.ApiTable->SetCallbackHandler(
-                handle,
+            MsQuicApi.Api.SetCallbackHandler(
+                _handle,
                 nativeCallback,
                 (void*)GCHandle.ToIntPtr(context));
-            _handle = new MsQuicContextSafeHandle(handle, context, MsQuicApi.Api.ApiTable->StreamClose, SafeHandleType.Stream, connectionHandle);
         }
         catch
         {
@@ -220,8 +221,8 @@ public sealed partial class QuicStream
         {
             unsafe
             {
-                int status = MsQuicApi.Api.ApiTable->StreamStart(
-                    _handle.QuicHandle,
+                int status = MsQuicApi.Api.StreamStart(
+                    _handle,
                     QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT);
                 if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception))
                 {
@@ -297,8 +298,8 @@ public sealed partial class QuicStream
         {
             unsafe
             {
-                ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->StreamReceiveSetEnabled(
-                    _handle.QuicHandle,
+                ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.StreamReceiveSetEnabled(
+                    _handle,
                     1),
                 "StreamReceivedSetEnabled failed");
             }
@@ -360,19 +361,34 @@ public sealed partial class QuicStream
             return valueTask;
         }
 
-        _sendBuffers.Initialize(buffer);
-        unsafe
+        lock (_sendBuffersLock)
         {
-            int status = MsQuicApi.Api.ApiTable->StreamSend(
-                _handle.QuicHandle,
-                _sendBuffers.Buffers,
-                (uint)_sendBuffers.Count,
-                completeWrites ? QUIC_SEND_FLAGS.FIN : QUIC_SEND_FLAGS.NONE,
-                null);
-            if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception))
+            ObjectDisposedException.ThrowIf(_disposed == 1, this); // TODO: valueTask is left unobserved
+            unsafe
             {
-                _sendBuffers.Reset();
-                _sendTcs.TrySetException(exception, final: true);
+                if (_sendBuffers.Count > 0 && _sendBuffers.Buffers[0].Buffer != null)
+                {
+                    // _sendBuffers are not reset, meaning SendComplete for the previous WriteAsync call didn't arrive yet.
+                    // In case of cancellation, the task from _sendTcs is finished before the aborting. It is technically possible for subsequent
+                    // WriteAsync to grab the next task from _sendTcs and start executing before SendComplete event occurs for the previous (canceled) write.
+                    // This is not an "invalid nested call", because the previous task has finished. Best guess is to mimic OperationAborted as it will be from Abort
+                    // that would execute soon enough, if not already. Not final, because Abort should be the one to set final exception.
+                    _sendTcs.TrySetException(ThrowHelper.GetOperationAbortedException(SR.net_quic_writing_aborted), final: false);
+                    return valueTask;
+                }
+
+                _sendBuffers.Initialize(buffer);
+                int status = MsQuicApi.Api.StreamSend(
+                    _handle,
+                    _sendBuffers.Buffers,
+                    (uint)_sendBuffers.Count,
+                    completeWrites ? QUIC_SEND_FLAGS.FIN : QUIC_SEND_FLAGS.NONE,
+                    null);
+                if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception))
+                {
+                    _sendBuffers.Reset();
+                    _sendTcs.TrySetException(exception, final: true);
+                }
             }
         }
 
@@ -419,8 +435,8 @@ public sealed partial class QuicStream
 
         unsafe
         {
-            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->StreamShutdown(
-                _handle.QuicHandle,
+            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.StreamShutdown(
+                _handle,
                 flags,
                 (ulong)errorCode),
                 "StreamShutdown failed");
@@ -442,8 +458,8 @@ public sealed partial class QuicStream
         {
             unsafe
             {
-                ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.ApiTable->StreamShutdown(
-                    _handle.QuicHandle,
+                ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.StreamShutdown(
+                    _handle,
                     QUIC_STREAM_SHUTDOWN_FLAGS.GRACEFUL,
                     default),
                     "StreamShutdown failed");
@@ -490,7 +506,12 @@ public sealed partial class QuicStream
     }
     private unsafe int HandleEventSendComplete(ref SEND_COMPLETE data)
     {
-        _sendBuffers.Reset();
+        // In case of cancellation, the task from _sendTcs is finished before the aborting. It is technically possible for subsequent WriteAsync to grab the next task
+        // from _sendTcs and start executing before SendComplete event occurs for the previous (canceled) write
+        lock (_sendBuffersLock)
+        {
+            _sendBuffers.Reset();
+        }
         if (data.Canceled == 0)
         {
             _sendTcs.TrySetResult();
@@ -653,13 +674,16 @@ public sealed partial class QuicStream
         await valueTask.ConfigureAwait(false);
         _handle.Dispose();
 
-        // TODO: memory leak if not disposed
-        _sendBuffers.Dispose();
+        lock (_sendBuffersLock)
+        {
+            // TODO: memory leak if not disposed
+            _sendBuffers.Dispose();
+        }
 
         unsafe void StreamShutdown(QUIC_STREAM_SHUTDOWN_FLAGS flags, long errorCode)
         {
-            int status = MsQuicApi.Api.ApiTable->StreamShutdown(
-                _handle.QuicHandle,
+            int status = MsQuicApi.Api.StreamShutdown(
+                _handle,
                 flags,
                 (ulong)errorCode);
             if (StatusFailed(status))


### PR DESCRIPTION
Backport of #74669 to release/7.0
Fixes #72696

/cc @CarnaViire 

## Customer Impact

HTTP/3 or QUIC application crashed with either "Aborted" or "Segmentation Fault" due to native heap corruption. The native crash happened in a time frame from several minutes to several hours, depending on how common was the race between Dispose and other QUIC calls (e.g. cancelling/disposing the stream while sending the data) in the user scenario.

The root cause of the native heap corruption was incorrect and unsynchronized usage of native pointers and arrays, which in case of multithreaded access led to use-after-free and other native memory access issues. This eventually led to native heap corruption which manifested as a crash after some time.

There are 2 main parts of the fix:
1) Wrap the use of the native MsQuic pointers into "generated-like" SafeHandle pattern, which will ensure the disposed/closed handles are not used and handles are not disposed/closed while in use (during 7.0, interop changed from marshalling to unmanaged function pointers, at which point we have lost automatic SafeHandle "safety").
2) In QuicStream, wrap SendBuffers native array usages into lock to ensure it will not get freed while being used by native code.

Discovered in HTTP/3 stress runs.

## Testing

Multiple **10+ hours** of **general** HTTP/3 stress test runs, multiple **~3h** runs for **targeted** stress scenario with high race probability (POST Duplex Dispose with cancel rate 100%).
Before the fix, the issue would almost always manifest in **~1h** timeframe for **general** HTTP/3 stress test run, and in **~5min** for **targeted** stress scenario.

## Risk

Low, System.Net.Quic is still in preview.