### PR TITLE
Avoid recommitting the mark array

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2019,7 +2019,7 @@ protected:
     PER_HEAP_ISOLATED
     void init_heap_segment (heap_segment* seg, gc_heap* hp
 #ifdef USE_REGIONS
-                            , uint8_t* start, size_t size, int gen_num
+                            , uint8_t* start, size_t size, int gen_num, bool existing_region_p=false
 #endif //USE_REGIONS
                            );
     PER_HEAP
@@ -2525,7 +2525,7 @@ protected:
                                uint8_t** range_beg,
                                uint8_t** range_end);
     PER_HEAP
-    void bgc_verify_mark_array_cleared (heap_segment* seg);
+    void bgc_verify_mark_array_cleared (heap_segment* seg, bool always_verify_p = false);
     PER_HEAP
     void verify_mark_array_cleared();
     PER_HEAP


### PR DESCRIPTION
This change fixes #75207.

When we `init_heap_segment`, we preserve the `heap_segment_flags_ma_committed`, and before we `commit_mark_array_new_seg`, we check the flag first and avoid recommitting.

For reviewers, I assumed (i.e. please check):
- The place I changed in the only call site where we commit for the mark array for regions. The other ones are either not defined under `USE_REGIONS`, or it is for frozen segments where by design it can never overlap with the region reserved range, and
- Since frozen segments can never overlap with the reserved range, we should never have a region (or a frozen segment) with the flag `heap_segment_flags_ma_pcommitted` turned on under `USE_REGIONS`.
