### PR TITLE
Remove SuperPMI collection of PMI of coreclr tests

### DIFF
--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -104,26 +104,6 @@ jobs:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
       collectionType: pmi
-      collectionName: coreclr_tests
-
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
       collectionName: libraries_tests
 
 - template: /eng/pipelines/common/platform-matrix.yml


### PR DESCRIPTION
With https://github.com/dotnet/runtime/pull/74961, we have a collection of a run of CoreCLR tests. That makes the PMI collection of the tests mostly duplicative.
