### PR TITLE
Fix the definition of IResourceManagerFactory2.

### DIFF
--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/IResourceManagerFactory2.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcInterfaces/IResourceManagerFactory2.cs
@@ -9,16 +9,17 @@ namespace System.Transactions.DtcProxyShim.DtcInterfaces;
 [ComImport, Guid("6B369C21-FBD2-11d1-8F47-00C04F8EE57D"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 internal interface IResourceManagerFactory2
 {
+    // From IResourceManagerFactory
     internal void Create(
-        Guid pguidRM,
+        in Guid pguidRM,
         [MarshalAs(UnmanagedType.LPStr)] string pszRMName,
         [MarshalAs(UnmanagedType.Interface)] IResourceManagerSink pIResMgrSink,
         [MarshalAs(UnmanagedType.Interface)] out IResourceManager rm);
 
     internal void CreateEx(
-        Guid pguidRM,
+        in Guid pguidRM,
         [MarshalAs(UnmanagedType.LPStr)] string pszRMName,
         [MarshalAs(UnmanagedType.Interface)] IResourceManagerSink pIResMgrSink,
-        Guid riidRequested,
+        in Guid riidRequested,
         [MarshalAs(UnmanagedType.Interface)] out object rm);
 }


### PR DESCRIPTION
According to [the docs](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms681318(v=vs.85)) and the Windows SDK headers, the Guid parameters here are all passed by-ref.

Update the definition of the interface to pass the `Guid` parameters with `in` to match the native signature.

Based on the comments on a linked PR, this might not fix all of the issues. Flipping to draft.