### PR TITLE
Enable the fundamentals behind libraries tests compiled via crossgen2

### DIFF
--- a/docs/workflow/testing/libraries/testing.md
+++ b/docs/workflow/testing/libraries/testing.md
@@ -111,11 +111,11 @@ There are several custom compilation modes for tests. These are enabled by setti
 | --- | --- | --- |
 | TestSingleFile | Test compilation using the single file compilation mode | libs+clr |
 | TestNativeAot | Test by compiling the test using NativeAOT | libs+clr.aot |
-| TestCrossgen2 | Test compilation of the test/libraries into R2R binaries | libs+clr |
+| TestReadyToRun | Test compilation of the test/libraries into R2R binaries | libs+clr |
 
 To run a test in specific mode, simply build the tests after building the prerequisite subsets, and specify the test mode on a command line such as:
 ```cmd
-dotnet build /t:Test /p:Configuration=Release /p:TestCrossgen2=true
+dotnet build /t:Test /p:Configuration=Release /p:TestReadyToRun=true
 ```
 
 These tests do not use the standard XUnit test runner, instead they use [SingleFileTestRunner.cs](../../../../src/libraries/Common/tests/SingleFileTestRunner/SingleFileTestRunner.cs). The set of available command line options is limited to `-xml`, `-notrait`, `-class`, `-class-`, `-noclass`, `-method`, `-method-`, `-nomethod`, `-namespace`, `-namespace-`, `-nonamespace`, and `-parallel`.

--- a/docs/workflow/testing/libraries/testing.md
+++ b/docs/workflow/testing/libraries/testing.md
@@ -102,3 +102,20 @@ dotnet build /t:Test /p:Outerloop=true
 ### Running tests on a different target framework
 
 Each test project can potentially have multiple target frameworks. There are some tests that might be OS-specific, or might be testing an API that is available only on some target frameworks, so the `TargetFrameworks` property specifies the valid target frameworks.
+
+### Running tests in custom compilation modes
+
+There are several custom compilation modes for tests. These are enabled by setting a switch during the config.
+
+| Mode | Description | Prerequisites
+| --- | --- | --- |
+| TestSingleFile | Test compilation using the single file compilation mode | libs+clr |
+| TestNativeAot | Test by compiling the test using NativeAOT | libs+clr.aot |
+| TestCrossgen2 | Test compilation of the test/libraries into R2R binaries | libs+clr |
+
+To run a test in specific mode, simply build the tests after building the prerequisite subsets, and specify the test mode on a command line such as:
+```cmd
+dotnet build /t:Test /p:Configuration=Release /p:TestCrossgen2=true
+```
+
+These tests do not use the standard XUnit test runner, instead they use [SingleFileTestRunner.cs](../../../../src/libraries/Common/tests/SingleFileTestRunner/SingleFileTestRunner.cs). The set of available command line options is limited to `-xml`, `-notrait`, `-class`, `-class-`, `-noclass`, `-method`, `-method-`, `-nomethod`, `-namespace`, `-namespace-`, `-nonamespace`, and `-parallel`.

--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -8,6 +8,7 @@
     <VSTestNoLogo>true</VSTestNoLogo>
     <ILLinkDescriptorsPath>$(MSBuildThisFileDirectory)ILLinkDescriptors\</ILLinkDescriptorsPath>
     <TestSingleFile Condition="'$(TestNativeAot)' == 'true'">true</TestSingleFile>
+    <TestSingleFile Condition="'$(TestCrossgen2)' == 'true'">true</TestSingleFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsMobile)' == 'true'">

--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -8,7 +8,7 @@
     <VSTestNoLogo>true</VSTestNoLogo>
     <ILLinkDescriptorsPath>$(MSBuildThisFileDirectory)ILLinkDescriptors\</ILLinkDescriptorsPath>
     <TestSingleFile Condition="'$(TestNativeAot)' == 'true'">true</TestSingleFile>
-    <TestSingleFile Condition="'$(TestCrossgen2)' == 'true'">true</TestSingleFile>
+    <TestSingleFile Condition="'$(TestReadyToRun)' == 'true'">true</TestSingleFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsMobile)' == 'true'">

--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -16,7 +16,7 @@
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TestCrossgen2)' == 'true'">
+  <PropertyGroup Condition="'$(TestReadyToRun)' == 'true'">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishSingleFile>false</PublishSingleFile>
   </PropertyGroup>
@@ -38,7 +38,7 @@
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(PublishSingleFile)'=='true'">
+  <PropertyGroup Condition="'$(PublishSingleFile)'=='true' or '$(TestNativeAot)' == 'true'">
     <DefineConstants>$(DefineConstants);SINGLE_FILE_TEST_RUNNER</DefineConstants>
   </PropertyGroup>
 

--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -90,6 +90,20 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="__ReplaceCrossgen2ExecutableWithFreshlyBuiltOne" BeforeTargets="_PrepareForReadyToRunCompilation">
+    <PropertyGroup>
+      <Crossgen2ArtifactPath>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)','crossgen2'))crossgen2$(ExeSuffix)</Crossgen2ArtifactPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <Crossgen2CurrentTool Include="@(Crossgen2Tool->'$(Crossgen2ArtifactPath)')" />
+      <Crossgen2Tool Remove="@(Crossgen2Tool)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Crossgen2Tool Include="@(Crossgen2CurrentTool)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="PublishTestAsSingleFile"
           Condition="'$(IsCrossTargetingBuild)' != 'true'"
           AfterTargets="Build"

--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <DefineConstants>$(DefineConstants);SINGLE_FILE_TEST_RUNNER</DefineConstants>
-
     <BundleDir>$([MSBuild]::NormalizeDirectory('$(OutDir)', 'publish'))</BundleDir>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(BundleDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
@@ -16,6 +14,11 @@
     <PublishSingleFile>true</PublishSingleFile>
     <UseAppHost>true</UseAppHost>
     <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TestCrossgen2)' == 'true'">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishSingleFile>false</PublishSingleFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestNativeAot)' == 'true'">
@@ -33,6 +36,10 @@
 
     <!-- Forced by ILLink targets; we should fix the SDK -->
     <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishSingleFile)'=='true'">
+    <DefineConstants>$(DefineConstants);SINGLE_FILE_TEST_RUNNER</DefineConstants>
   </PropertyGroup>
 
   <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets" Condition="'$(TestNativeAot)' == 'true'" />

--- a/src/libraries/Common/tests/SingleFileTestRunner/SingleFileTestRunner.cs
+++ b/src/libraries/Common/tests/SingleFileTestRunner/SingleFileTestRunner.cs
@@ -27,6 +27,9 @@ public class SingleFileTestRunner : XunitTestFramework
         var asm = typeof(SingleFileTestRunner).Assembly;
         Console.WriteLine("Running assembly:" + asm.FullName);
 
+        // The current RemoteExecutor implementation is not compatible with the SingleFileTestRunner
+        Environment.SetEnvironmentVariable("DOTNET_REMOTEEXECUTOR_SUPPORTED", "0");
+
         var diagnosticSink = new ConsoleDiagnosticMessageSink();
         var testsFinished = new TaskCompletionSource();
         var testSink = new TestMessageSink();
@@ -74,10 +77,58 @@ public class SingleFileTestRunner : XunitTestFramework
                     noTraits.Add(traitKeyValue[0], values = new List<string>());
                 }
                 values.Add(traitKeyValue[1]);
+                i++;
             }
             if (args[i].Equals("-xml", StringComparison.OrdinalIgnoreCase))
             {
                 xmlResultFileName=args[i + 1].Trim();
+                i++;
+            }
+            if (args[i].Equals("-class", StringComparison.OrdinalIgnoreCase))
+            {
+                filters.IncludedClasses.Add(args[i + 1].Trim());
+                i++;
+            }
+            if (args[i].Equals("-noclass", StringComparison.OrdinalIgnoreCase) || args[i].Equals("-class-", StringComparison.OrdinalIgnoreCase))
+            {
+                filters.ExcludedClasses.Add(args[i + 1].Trim());
+                i++;
+            }
+            if (args[i].Equals("-method", StringComparison.OrdinalIgnoreCase))
+            {
+                filters.IncludedMethods.Add(args[i + 1].Trim());
+                i++;
+            }
+            if (args[i].Equals("-nomethod", StringComparison.OrdinalIgnoreCase) || args[i].Equals("-method-", StringComparison.OrdinalIgnoreCase))
+            {
+                filters.ExcludedMethods.Add(args[i + 1].Trim());
+                i++;
+            }
+            if (args[i].Equals("-namespace", StringComparison.OrdinalIgnoreCase))
+            {
+                filters.IncludedNamespaces.Add(args[i + 1].Trim());
+                i++;
+            }
+            if (args[i].Equals("-nonamespace", StringComparison.OrdinalIgnoreCase) || args[i].Equals("-namespace-", StringComparison.OrdinalIgnoreCase))
+            {
+                filters.ExcludedNamespaces.Add(args[i + 1].Trim());
+                i++;
+            }
+            if (args[i].Equals("-parallel", StringComparison.OrdinalIgnoreCase))
+            {
+                string parallelismArg = args[i + 1].ToLower();
+                var (parallelizeAssemblies, parallelizeTestCollections) = parallelismArg switch
+                {
+                    "all" => (true, true),
+                    "assemblies" => (true, false),
+                    "collections" => (false, true),
+                    "none" => (false, false),
+                    _ => throw new ArgumentException("unknown parallelism option")
+                };
+
+                assemblyConfig.ParallelizeAssembly = parallelizeAssemblies;
+                assemblyConfig.ParallelizeTestCollections = parallelizeTestCollections;
+                i++;
             }
         }
 

--- a/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -50,5 +50,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ProjectReference>
     <ProjectReference Include="..\System.Diagnostics.FileVersionInfo.TestAssembly\System.Diagnostics.FileVersionInfo.TestAssembly.csproj" Condition="'$(TargetOS)' == 'Browser'" />
+    <!-- R2R testing does not tolerate the combination of a regular project reference and a content reference. -->
+    <PublishReadyToRunExclude Include="System.Diagnostics.FileVersionInfo.TestAssembly.dll" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -68,5 +68,7 @@
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ProjectReference>
+    <!-- R2R testing does not tolerate the combination of a regular project reference and a content reference. -->
+    <PublishReadyToRunExclude Include="LongPath.dll" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Document how to use the special modes of libraries compilation
- Add the TestCrossgen2 flag to libraries testing
  - Unlike TestNativeAot and TestSingleFile, use a self-contained strategy instead of actual single-file to improve debuggability of the produced output
- Tweak the SingleFileTestRunner.cs to avoid the fork bomb problem introduced by RemoteTestExecutor in a self-contained, but not singlefile scenario
- Add support for a set of flags to SingleFileTestRunner to respect the command line options I needed when debugging why the tests were not working.