### PR TITLE
move ref DirectoryEntryConverter to System.DirectoryServices.Design namespace

### DIFF
--- a/src/libraries/System.DirectoryServices/ref/System.DirectoryServices.manual.cs
+++ b/src/libraries/System.DirectoryServices/ref/System.DirectoryServices.manual.cs
@@ -4,10 +4,10 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+using System.DirectoryServices.Design;
+
 namespace System.DirectoryServices
 {
-    using System.DirectoryServices.Design;
-    
     [System.ComponentModel.TypeConverter(typeof(DirectoryEntryConverter))]
     public partial class DirectoryEntry { }
 }

--- a/src/libraries/System.DirectoryServices/ref/System.DirectoryServices.manual.cs
+++ b/src/libraries/System.DirectoryServices/ref/System.DirectoryServices.manual.cs
@@ -4,9 +4,15 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-namespace System.DirectoryServices.Design
+namespace System.DirectoryServices
 {
+    using System.DirectoryServices.Design;
+    
     [System.ComponentModel.TypeConverter(typeof(DirectoryEntryConverter))]
     public partial class DirectoryEntry { }
+}
+
+namespace System.DirectoryServices.Design
+{
     internal sealed class DirectoryEntryConverter { }
 }

--- a/src/libraries/System.DirectoryServices/ref/System.DirectoryServices.manual.cs
+++ b/src/libraries/System.DirectoryServices/ref/System.DirectoryServices.manual.cs
@@ -4,7 +4,7 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
-namespace System.DirectoryServices
+namespace System.DirectoryServices.Design
 {
     [System.ComponentModel.TypeConverter(typeof(DirectoryEntryConverter))]
     public partial class DirectoryEntry { }


### PR DESCRIPTION
The DirectoryEntryConverter's implementation is in the System.DirectoryServices.Design namespace. However, the reference was mistakenly put in the System.DirectoryServices namespace. This was flagged by the new ApiCompat tool, where the type argument to the TypeConverter attribute was different (since they're in different namespaces).