### PR TITLE
Prevent exception when attempting to write PaxTarEntry obtained from TarReader

### DIFF
--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -234,6 +234,9 @@
   <data name="TarPosixFormatExpected" xml:space="preserve">
     <value>A POSIX format was expected (Ustar or PAX), but could not be reliably determined for entry '{0}'.</value>
   </data>
+  <data name="TarReservedExtendedAttribute" xml:space="preserve">
+    <value>The extended attributes dictionary cannot contain the reserved key '{0}'.</value>
+  </data>
   <data name="TarSizeFieldNegative" xml:space="preserve">
     <value>The size field is negative in a tar entry.</value>
   </data>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
@@ -33,8 +33,8 @@ namespace System.Formats.Tar
         public GnuTarEntry(TarEntryType entryType, string entryName)
             : base(entryType, entryName, TarEntryFormat.Gnu, isGea: false)
         {
-            _header._aTime = _header._mTime; // mtime was set in base constructor
-            _header._cTime = _header._mTime;
+            _header._aTime = _header.MTime; // mtime was set in base constructor
+            _header._cTime = _header.MTime;
         }
 
         /// <summary>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxGlobalExtendedAttributesTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxGlobalExtendedAttributesTarEntry.cs
@@ -29,7 +29,7 @@ namespace System.Formats.Tar
             : base(TarEntryType.GlobalExtendedAttributes, TarHeader.GlobalHeadFormatPrefix, TarEntryFormat.Pax, isGea: true)
         {
             ArgumentNullException.ThrowIfNull(globalExtendedAttributes);
-            _header.InitializeExtendedAttributesWithExisting(globalExtendedAttributes);
+            _header.InitializeExtendedAttributesWithExisting(globalExtendedAttributes, allowReservedKeys: false);
         }
 
         /// <summary>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PaxTarEntry.cs
@@ -54,7 +54,7 @@ namespace System.Formats.Tar
         {
             _header._prefix = string.Empty;
 
-            Debug.Assert(_header._mTime != default);
+            Debug.Assert(_header.MTime != default);
             AddNewAccessAndChangeTimestampsIfNotExist(useMTime: true);
         }
 
@@ -94,9 +94,9 @@ namespace System.Formats.Tar
             ArgumentNullException.ThrowIfNull(extendedAttributes);
 
             _header._prefix = string.Empty;
-            _header.InitializeExtendedAttributesWithExisting(extendedAttributes);
+            _header.InitializeExtendedAttributesWithExisting(extendedAttributes, allowReservedKeys: false);
 
-            Debug.Assert(_header._mTime != default);
+            Debug.Assert(_header.MTime != default);
             AddNewAccessAndChangeTimestampsIfNotExist(useMTime: true);
         }
 
@@ -116,7 +116,7 @@ namespace System.Formats.Tar
 
             if (other is PaxTarEntry paxOther)
             {
-                _header.InitializeExtendedAttributesWithExisting(paxOther.ExtendedAttributes);
+                _header.InitializeExtendedAttributesWithExisting(paxOther.ExtendedAttributes, allowReservedKeys: true);
             }
             else
             {
@@ -158,13 +158,13 @@ namespace System.Formats.Tar
         // or 'DateTimeOffset.UtcNow', depending on the value of 'useMTime'.
         private void AddNewAccessAndChangeTimestampsIfNotExist(bool useMTime)
         {
-            Debug.Assert(!useMTime || (useMTime && _header._mTime != default));
+            Debug.Assert(!useMTime || (useMTime && _header.MTime != default));
             bool containsATime = _header.ExtendedAttributes.ContainsKey(TarHeader.PaxEaATime);
             bool containsCTime = _header.ExtendedAttributes.ContainsKey(TarHeader.PaxEaCTime);
 
             if (!containsATime || !containsCTime)
             {
-                string secondsFromEpochString = TarHelpers.GetTimestampStringFromDateTimeOffset(useMTime ? _header._mTime : DateTimeOffset.UtcNow);
+                string secondsFromEpochString = TarHelpers.GetTimestampStringFromDateTimeOffset(useMTime ? _header.MTime : DateTimeOffset.UtcNow);
 
                 if (!containsATime)
                 {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
@@ -22,8 +22,8 @@ namespace System.Formats.Tar
         internal PosixTarEntry(TarEntryType entryType, string entryName, TarEntryFormat format, bool isGea)
             : base(entryType, entryName, format, isGea)
         {
-            _header._uName = string.Empty;
-            _header._gName = string.Empty;
+            _header.UName = string.Empty;
+            _header.GName = string.Empty;
             _header._devMajor = 0;
             _header._devMinor = 0;
         }
@@ -34,15 +34,15 @@ namespace System.Formats.Tar
         {
             if (other is PosixTarEntry)
             {
-                Debug.Assert(other._header._uName != null);
-                Debug.Assert(other._header._gName != null);
-                _header._uName = other._header._uName;
-                _header._gName = other._header._gName;
+                Debug.Assert(other._header.UName != null);
+                Debug.Assert(other._header.GName != null);
+                _header.UName = other._header.UName;
+                _header.GName = other._header.GName;
                 _header._devMajor = other._header._devMajor;
                 _header._devMinor = other._header._devMinor;
             }
-            _header._uName ??= string.Empty;
-            _header._gName ??= string.Empty;
+            _header.UName ??= string.Empty;
+            _header.GName ??= string.Empty;
         }
 
         /// <summary>
@@ -99,11 +99,11 @@ namespace System.Formats.Tar
         /// <remarks><see cref="GroupName"/> is only used in Unix platforms.</remarks>
         public string GroupName
         {
-            get => _header._gName ?? string.Empty;
+            get => _header.GName ?? string.Empty;
             set
             {
                 ArgumentNullException.ThrowIfNull(value);
-                _header._gName = value;
+                _header.GName = value;
             }
         }
 
@@ -114,11 +114,11 @@ namespace System.Formats.Tar
         /// <exception cref="ArgumentNullException">Cannot set a null user name.</exception>
         public string UserName
         {
-            get => _header._uName ?? string.Empty;
+            get => _header.UName ?? string.Empty;
             set
             {
                 ArgumentNullException.ThrowIfNull(value);
-                _header._uName = value;
+                _header.UName = value;
             }
         }
     }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -18,7 +18,7 @@ namespace System.Formats.Tar
         internal TarHeader _header;
 
         // Used to access the data section of this entry in an unseekable file
-        private TarReader? _readerOfOrigin;
+        internal TarReader? _readerOfOrigin;
 
         // Constructor called when reading a TarEntry from a TarReader.
         internal TarEntry(TarHeader header, TarReader readerOfOrigin, TarEntryFormat format)
@@ -95,14 +95,14 @@ namespace System.Formats.Tar
         /// <exception cref="ArgumentOutOfRangeException">The specified value is larger than <see cref="DateTimeOffset.UnixEpoch"/>.</exception>
         public DateTimeOffset ModificationTime
         {
-            get => _header._mTime;
+            get => _header.MTime;
             set
             {
                 if (value < DateTimeOffset.UnixEpoch)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
-                _header._mTime = value;
+                _header.MTime = value;
             }
         }
 
@@ -110,7 +110,7 @@ namespace System.Formats.Tar
         /// When the <see cref="EntryType"/> indicates an entry that can contain data, this property returns the length in bytes of such data.
         /// </summary>
         /// <remarks>The entry type that commonly contains data is <see cref="TarEntryType.RegularFile"/> (or <see cref="TarEntryType.V7RegularFile"/> in the <see cref="TarEntryFormat.V7"/> format). Other uncommon entry types that can also contain data are: <see cref="TarEntryType.ContiguousFile"/>, <see cref="TarEntryType.DirectoryList"/>, <see cref="TarEntryType.MultiVolume"/> and <see cref="TarEntryType.SparseFile"/>.</remarks>
-        public long Length => _header._dataStream != null ? _header._dataStream.Length : _header._size;
+        public long Length => _header._dataStream != null ? _header._dataStream.Length : _header.Size;
 
         /// <summary>
         /// When the <see cref="EntryType"/> indicates a <see cref="TarEntryType.SymbolicLink"/> or a <see cref="TarEntryType.HardLink"/>, this property returns the link target path of such link.
@@ -120,7 +120,7 @@ namespace System.Formats.Tar
         /// <exception cref="ArgumentException">The specified value is empty.</exception>
         public string LinkName
         {
-            get => _header._linkName ?? string.Empty;
+            get => _header.LinkName ?? string.Empty;
             set
             {
                 if (_header._typeFlag is not TarEntryType.HardLink and not TarEntryType.SymbolicLink)
@@ -128,7 +128,7 @@ namespace System.Formats.Tar
                     throw new InvalidOperationException(SR.TarEntryHardLinkOrSymLinkExpected);
                 }
                 ArgumentException.ThrowIfNullOrEmpty(value);
-                _header._linkName = value;
+                _header.LinkName = value;
             }
         }
 
@@ -154,11 +154,11 @@ namespace System.Formats.Tar
         /// </summary>
         public string Name
         {
-            get => _header._name;
+            get => _header.Name;
             set
             {
                 ArgumentException.ThrowIfNullOrEmpty(value);
-                _header._name = value;
+                _header.Name = value;
             }
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -618,15 +618,12 @@ namespace System.Formats.Tar
         }
 
         // Some fields that have a reserved spot in the header, may not fit in such field anymore, but they can fit in the
-        // extended attributes. They get collected and saved in that dictionary, with no restrictions.
+        // extended attributes. They are always collected or updated in that dictionary, with no restrictions.
         private void CollectExtendedAttributesFromStandardFieldsIfNeeded()
         {
-            ExtendedAttributes.Add(PaxEaName, _name);
+            ExtendedAttributes[PaxEaName] = _name;
 
-            if (!ExtendedAttributes.ContainsKey(PaxEaMTime))
-            {
-                ExtendedAttributes.Add(PaxEaMTime, TarHelpers.GetTimestampStringFromDateTimeOffset(_mTime));
-            }
+            ExtendedAttributes[PaxEaMTime] = TarHelpers.GetTimestampStringFromDateTimeOffset(_mTime);
 
             if (!string.IsNullOrEmpty(_gName))
             {
@@ -640,12 +637,12 @@ namespace System.Formats.Tar
 
             if (!string.IsNullOrEmpty(_linkName))
             {
-                ExtendedAttributes.Add(PaxEaLinkName, _linkName);
+                ExtendedAttributes[PaxEaLinkName] = _linkName;
             }
 
             if (_size > 99_999_999)
             {
-                ExtendedAttributes.Add(PaxEaSize, _size.ToString());
+                ExtendedAttributes[PaxEaSize] = _size.ToString();
             }
 
             // Adds the specified string to the dictionary if it's longer than the specified max byte length.
@@ -653,7 +650,7 @@ namespace System.Formats.Tar
             {
                 if (Encoding.UTF8.GetByteCount(value) > maxLength)
                 {
-                    extendedAttributes.Add(key, value);
+                    extendedAttributes[key] = value;
                 }
             }
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -145,7 +145,7 @@ namespace System.Formats.Tar
             // First, we write the preceding extended attributes header
             TarHeader extendedAttributesHeader = new(TarEntryFormat.Pax);
             // Fill the current header's dict
-            CollectExtendedAttributesFromStandardFieldsIfNeeded();
+            CollectExtendedAttributesFromStandardFields();
             // And pass the attributes to the preceding extended attributes header for writing
             extendedAttributesHeader.WriteAsPaxExtendedAttributes(archiveStream, buffer, ExtendedAttributes, isGea: false, globalExtendedAttributesEntryNumber: -1);
             buffer.Clear(); // Reset it to reuse it
@@ -164,7 +164,7 @@ namespace System.Formats.Tar
             // First, we write the preceding extended attributes header
             TarHeader extendedAttributesHeader = new(TarEntryFormat.Pax);
             // Fill the current header's dict
-            CollectExtendedAttributesFromStandardFieldsIfNeeded();
+            CollectExtendedAttributesFromStandardFields();
             // And pass the attributes to the preceding extended attributes header for writing
             await extendedAttributesHeader.WriteAsPaxExtendedAttributesAsync(archiveStream, buffer, ExtendedAttributes, isGea: false, globalExtendedAttributesEntryNumber: -1, cancellationToken).ConfigureAwait(false);
 
@@ -619,7 +619,7 @@ namespace System.Formats.Tar
 
         // Some fields that have a reserved spot in the header, may not fit in such field anymore, but they can fit in the
         // extended attributes. They are always collected or updated in that dictionary, with no restrictions.
-        private void CollectExtendedAttributesFromStandardFieldsIfNeeded()
+        private void CollectExtendedAttributesFromStandardFields()
         {
             ExtendedAttributes[PaxEaName] = _name;
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -199,7 +199,7 @@ namespace System.Formats.Tar
                 Debug.Assert(_previouslyReadEntry._header._endOfHeaderAndDataAndBlockAlignment > 0);
                 _archiveStream.Position = _previouslyReadEntry._header._endOfHeaderAndDataAndBlockAlignment;
             }
-            else if (_previouslyReadEntry._header._size > 0)
+            else if (_previouslyReadEntry._header.Size > 0)
             {
                 // When working with seekable streams, every time we return an entry, we avoid advancing the pointer beyond the data section
                 // This is so the user can read the data if desired. But if the data was not read by the user, we need to advance the pointer
@@ -215,14 +215,14 @@ namespace System.Formats.Tar
                 {
                     // If the user did not advance the position, we need to make sure the position
                     // pointer is located at the beginning of the next header.
-                    if (dataStream.Position < (_previouslyReadEntry._header._size - 1))
+                    if (dataStream.Position < (_previouslyReadEntry._header.Size - 1))
                     {
-                        long bytesToSkip = _previouslyReadEntry._header._size - dataStream.Position;
+                        long bytesToSkip = _previouslyReadEntry._header.Size - dataStream.Position;
                         TarHelpers.AdvanceStream(_archiveStream, bytesToSkip);
                         dataStream.HasReachedEnd = true; // Now the pointer is beyond the limit, so any read attempts should throw
                     }
                 }
-                TarHelpers.SkipBlockAlignmentPadding(_archiveStream, _previouslyReadEntry._header._size);
+                TarHelpers.SkipBlockAlignmentPadding(_archiveStream, _previouslyReadEntry._header.Size);
             }
         }
 
@@ -241,7 +241,7 @@ namespace System.Formats.Tar
                 Debug.Assert(_previouslyReadEntry._header._endOfHeaderAndDataAndBlockAlignment > 0);
                 _archiveStream.Position = _previouslyReadEntry._header._endOfHeaderAndDataAndBlockAlignment;
             }
-            else if (_previouslyReadEntry._header._size > 0)
+            else if (_previouslyReadEntry._header.Size > 0)
             {
                 // When working with seekable streams, every time we return an entry, we avoid advancing the pointer beyond the data section
                 // This is so the user can read the data if desired. But if the data was not read by the user, we need to advance the pointer
@@ -257,14 +257,14 @@ namespace System.Formats.Tar
                 {
                     // If the user did not advance the position, we need to make sure the position
                     // pointer is located at the beginning of the next header.
-                    if (dataStream.Position < (_previouslyReadEntry._header._size - 1))
+                    if (dataStream.Position < (_previouslyReadEntry._header.Size - 1))
                     {
-                        long bytesToSkip = _previouslyReadEntry._header._size - dataStream.Position;
+                        long bytesToSkip = _previouslyReadEntry._header.Size - dataStream.Position;
                         await TarHelpers.AdvanceStreamAsync(_archiveStream, bytesToSkip, cancellationToken).ConfigureAwait(false);
                         dataStream.HasReachedEnd = true; // Now the pointer is beyond the limit, so any read attempts should throw
                     }
                 }
-                await TarHelpers.SkipBlockAlignmentPaddingAsync(_archiveStream, _previouslyReadEntry._header._size, cancellationToken).ConfigureAwait(false);
+                await TarHelpers.SkipBlockAlignmentPaddingAsync(_archiveStream, _previouslyReadEntry._header.Size, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -491,18 +491,18 @@ namespace System.Formats.Tar
 
                 if (header._typeFlag is TarEntryType.LongLink)
                 {
-                    Debug.Assert(header._linkName != null);
-                    Debug.Assert(secondHeader._name != null);
+                    Debug.Assert(header.LinkName != null);
+                    Debug.Assert(secondHeader.Name != null);
 
-                    thirdHeader._linkName = header._linkName;
-                    thirdHeader._name = secondHeader._name;
+                    thirdHeader.LinkName = header.LinkName;
+                    thirdHeader.Name = secondHeader.Name;
                 }
                 else if (header._typeFlag is TarEntryType.LongPath)
                 {
-                    Debug.Assert(header._name != null);
-                    Debug.Assert(secondHeader._linkName != null);
-                    thirdHeader._name = header._name;
-                    thirdHeader._linkName = secondHeader._linkName;
+                    Debug.Assert(header.Name != null);
+                    Debug.Assert(secondHeader.LinkName != null);
+                    thirdHeader.Name = header.Name;
+                    thirdHeader.LinkName = secondHeader.LinkName;
                 }
 
                 finalHeader = thirdHeader;
@@ -512,13 +512,13 @@ namespace System.Formats.Tar
             {
                 if (header._typeFlag is TarEntryType.LongLink)
                 {
-                    Debug.Assert(header._linkName != null);
-                    secondHeader._linkName = header._linkName;
+                    Debug.Assert(header.LinkName != null);
+                    secondHeader.LinkName = header.LinkName;
                 }
                 else if (header._typeFlag is TarEntryType.LongPath)
                 {
-                    Debug.Assert(header._name != null);
-                    secondHeader._name = header._name;
+                    Debug.Assert(header.Name != null);
+                    secondHeader.Name = header.Name;
                 }
 
                 finalHeader = secondHeader;
@@ -567,18 +567,18 @@ namespace System.Formats.Tar
 
                 if (header._typeFlag is TarEntryType.LongLink)
                 {
-                    Debug.Assert(header._linkName != null);
-                    Debug.Assert(secondHeader._name != null);
+                    Debug.Assert(header.LinkName != null);
+                    Debug.Assert(secondHeader.Name != null);
 
-                    thirdHeader._linkName = header._linkName;
-                    thirdHeader._name = secondHeader._name;
+                    thirdHeader.LinkName = header.LinkName;
+                    thirdHeader.Name = secondHeader.Name;
                 }
                 else if (header._typeFlag is TarEntryType.LongPath)
                 {
-                    Debug.Assert(header._name != null);
-                    Debug.Assert(secondHeader._linkName != null);
-                    thirdHeader._name = header._name;
-                    thirdHeader._linkName = secondHeader._linkName;
+                    Debug.Assert(header.Name != null);
+                    Debug.Assert(secondHeader.LinkName != null);
+                    thirdHeader.Name = header.Name;
+                    thirdHeader.LinkName = secondHeader.LinkName;
                 }
 
                 finalHeader = thirdHeader;
@@ -588,13 +588,13 @@ namespace System.Formats.Tar
             {
                 if (header._typeFlag is TarEntryType.LongLink)
                 {
-                    Debug.Assert(header._linkName != null);
-                    secondHeader._linkName = header._linkName;
+                    Debug.Assert(header.LinkName != null);
+                    secondHeader.LinkName = header.LinkName;
                 }
                 else if (header._typeFlag is TarEntryType.LongPath)
                 {
-                    Debug.Assert(header._name != null);
-                    secondHeader._name = header._name;
+                    Debug.Assert(header.Name != null);
+                    secondHeader.Name = header.Name;
                 }
 
                 finalHeader = secondHeader;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
@@ -62,7 +62,7 @@ namespace System.Formats.Tar
                 entry._header._devMinor = (int)minor;
             }
 
-            entry._header._mTime = TarHelpers.GetDateTimeOffsetFromSecondsSinceEpoch(status.MTime);
+            entry._header.MTime = TarHelpers.GetDateTimeOffsetFromSecondsSinceEpoch(status.MTime);
             entry._header._aTime = TarHelpers.GetDateTimeOffsetFromSecondsSinceEpoch(status.ATime);
             entry._header._cTime = TarHelpers.GetDateTimeOffsetFromSecondsSinceEpoch(status.CTime);
 
@@ -75,7 +75,7 @@ namespace System.Formats.Tar
                 uName = Interop.Sys.GetUserNameFromPasswd(status.Uid);
                 _userIdentifiers.Add(status.Uid, uName);
             }
-            entry._header._uName = uName;
+            entry._header.UName = uName;
 
             // Gid and GName
             entry._header._gid = (int)status.Gid;
@@ -84,7 +84,7 @@ namespace System.Formats.Tar
                 gName = Interop.Sys.GetGroupName(status.Gid);
                 _groupIdentifiers.Add(status.Gid, gName);
             }
-            entry._header._gName = gName;
+            entry._header.GName = gName;
 
             if (entry.EntryType == TarEntryType.SymbolicLink)
             {

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Windows.cs
@@ -50,7 +50,7 @@ namespace System.Formats.Tar
 
             FileSystemInfo info = (attributes & FileAttributes.Directory) != 0 ? new DirectoryInfo(fullPath) : new FileInfo(fullPath);
 
-            entry._header._mTime = info.LastWriteTimeUtc;
+            entry._header.MTime = info.LastWriteTimeUtc;
             entry._header._aTime = info.LastAccessTimeUtc;
             entry._header._cTime = info.LastWriteTimeUtc; // There is no "change time" property
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -325,7 +325,8 @@ namespace System.Formats.Tar
             {
                 TarEntryFormat.V7 => entry._header.WriteAsV7Async(_archiveStream, buffer, cancellationToken),
                 TarEntryFormat.Ustar => entry._header.WriteAsUstarAsync(_archiveStream, buffer, cancellationToken),
-                TarEntryFormat.Pax when entry._header._typeFlag is TarEntryType.GlobalExtendedAttributes => entry._header.WriteAsPaxGlobalExtendedAttributesAsync(_archiveStream, buffer, _nextGlobalExtendedAttributesEntryNumber++, cancellationToken),
+                TarEntryFormat.Pax when entry._header._typeFlag is TarEntryType.GlobalExtendedAttributes =>
+                    entry._header.WriteAsPaxGlobalExtendedAttributesAsync(_archiveStream, buffer, _nextGlobalExtendedAttributesEntryNumber++, cancellationToken),
                 TarEntryFormat.Pax => entry._header.WriteAsPaxAsync(_archiveStream, buffer, cancellationToken),
                 TarEntryFormat.Gnu => entry._header.WriteAsGnuAsync(_archiveStream, buffer, cancellationToken),
                 _ => throw new InvalidDataException(string.Format(SR.TarInvalidFormat, Format)),

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -221,7 +221,7 @@ namespace System.Formats.Tar
         {
             ObjectDisposedException.ThrowIf(_isDisposed, this);
             ArgumentNullException.ThrowIfNull(entry);
-            ValidateEntryLinkName(entry._header._typeFlag, entry._header._linkName);
+            ValidateEntryLinkName(entry._header._typeFlag, entry._header.LinkName);
             WriteEntryInternal(entry);
         }
 
@@ -269,7 +269,7 @@ namespace System.Formats.Tar
 
             ObjectDisposedException.ThrowIf(_isDisposed, this);
             ArgumentNullException.ThrowIfNull(entry);
-            ValidateEntryLinkName(entry._header._typeFlag, entry._header._linkName);
+            ValidateEntryLinkName(entry._header._typeFlag, entry._header.LinkName);
             return WriteEntryAsyncInternal(entry, cancellationToken);
         }
 

--- a/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
+++ b/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="TarTestsBase.Posix.cs" />
     <Compile Include="TarTestsBase.Ustar.cs" />
     <Compile Include="TarTestsBase.V7.cs" />
+    <Compile Include="TarWriter\TarWriter.File.Base.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.File.Tests.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntry.Base.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.Tests.cs" />

--- a/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
+++ b/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="TarWriter\TarWriter.WriteEntry.Entry.V7.Tests.cs" />
     <Compile Include="WrappedStream.cs" Link="WrappedStream.cs" />
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs" Link="Common\DisableRuntimeMarshalling.cs" />
+    <Compile Include="$(CommonPath)System\IO\PathInternal.cs" Link="Common\System\IO\PathInternal.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ReparsePointUtilities.cs" Link="Common\System\IO\ReparsePointUtilities.cs" />
   </ItemGroup>
   <!-- Windows specific files -->

--- a/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarEntry/PaxTarEntry.Tests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -90,6 +91,16 @@ namespace System.Formats.Tar.Tests
             PaxTarEntry fifo = new PaxTarEntry(TarEntryType.Fifo, InitialEntryName);
             SetFifo(fifo);
             VerifyFifo(fifo);
+        }
+
+        [Fact]
+        public void ThrowIf_Dictionary_Contains_ReservedKey()
+        {
+            foreach (string reservedKey in ReservedExtendedAttributeKeyNames)
+            {
+                Dictionary<string, string> dict = new Dictionary<string, string>() { { reservedKey, "not allowed" } };
+                Assert.Throws<ArgumentException>(() => new PaxTarEntry(TarEntryType.RegularFile, "entryName", dict));
+            }
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Pax.cs
@@ -124,5 +124,19 @@ namespace System.Formats.Tar.Tests
             VerifyExtendedAttributeTimestamp(pax, PaxEaATime, MinimumTime);
             VerifyExtendedAttributeTimestamp(pax, PaxEaCTime, MinimumTime);
         }
+
+        protected void VerifyPaxReservedKeys(PaxTarEntry entry)
+        {
+            foreach (string reservedKey in ReservedExtendedAttributeKeyNames)
+            {
+                if ((reservedKey is PaxEaSize && entry.EntryType is not TarEntryType.RegularFile) ||
+                    (reservedKey is PaxEaLinkName && entry.EntryType is not TarEntryType.SymbolicLink))
+                {
+                    continue;
+                }
+
+                Assert.Contains(reservedKey, entry.ExtendedAttributes);
+            }
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -61,8 +61,8 @@ namespace System.Formats.Tar.Tests
 
         protected const string TestGName = "group";
         protected const string TestUName = "user";
-        protected readonly string TestLongGName = new string('ñ', 33);
-        protected readonly string TestLongUName = new string('ü', 100);
+        protected readonly string TestLongGName = new string('\u00f1', 33);
+        protected readonly string TestLongUName = new string('\u00e4', 100);
 
         // The metadata of the entries inside the asset archives are all set to these values
         protected const int AssetGid = 3579;

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Enumeration;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.DotNet.RemoteExecutor;
@@ -58,6 +59,8 @@ namespace System.Formats.Tar.Tests
 
         protected const string TestGName = "group";
         protected const string TestUName = "user";
+        protected readonly string TestLongGName = new string('ñ', 33);
+        protected readonly string TestLongUName = new string('ü', 100);
 
         // The metadata of the entries inside the asset archives are all set to these values
         protected const int AssetGid = 3579;
@@ -178,7 +181,7 @@ namespace System.Formats.Tar.Tests
             "xattrs"
         };
 
-        protected enum CompressionMethod
+        public enum CompressionMethod
         {
             // Archiving only, no compression
             Uncompressed,
@@ -510,6 +513,16 @@ namespace System.Formats.Tar.Tests
             }
         }
 
+        protected static TarEntryFormat GetEntryFormatForTestTarFormat(TestTarFormat testFormat) =>
+            testFormat switch
+            {
+                TestTarFormat.v7 => TarEntryFormat.V7,
+                TestTarFormat.ustar => TarEntryFormat.Ustar,
+                TestTarFormat.pax or TestTarFormat.pax_gea => TarEntryFormat.Pax,
+                TestTarFormat.oldgnu or TestTarFormat.gnu => TarEntryFormat.Gnu,
+                _ => throw new ArgumentOutOfRangeException(nameof(testFormat)),
+            };
+
         protected static void SetUnixFileMode(string path, UnixFileMode mode)
         {
             if (!PlatformDetection.IsWindows)
@@ -621,6 +634,12 @@ namespace System.Formats.Tar.Tests
             {
                 yield return new object[] { name };
             }
+        }
+
+        protected static FileSystemEnumerable<FileSystemInfo> GetFileSystemInfosRecursive(string path)
+        {
+            var enumerationOptions = new EnumerationOptions { RecurseSubdirectories = true };
+            return new FileSystemEnumerable<FileSystemInfo>(path, (ref FileSystemEntry e) => e.ToFileSystemInfo(), enumerationOptions);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Xunit;
 
 namespace System.Formats.Tar.Tests
 {
@@ -15,7 +12,7 @@ namespace System.Formats.Tar.Tests
         {
             foreach (CompressionMethod compressionMethod in Enum.GetValues<CompressionMethod>())
             {
-                foreach (bool copyData in new object[] { false, true })
+                foreach (bool copyData in new bool[] { false, true })
                 {
                     foreach (object[] testCaseName in GetV7TestCaseNames())
                     {
@@ -29,15 +26,15 @@ namespace System.Formats.Tar.Tests
 
                     foreach (object[] testCaseNameObj in GetUstarTestCaseNames())
                     {
-                        string testcaseName = (string)testCaseNameObj[0];
-                        if (testcaseName is "folder_file_utf8" // The legacy name field is stored in ASCII in the Ustar format
+                        string testCaseName = (string)testCaseNameObj[0];
+                        if (testCaseName is "folder_file_utf8" // The legacy name field is stored in ASCII in the Ustar format
                                          or "longpath_splitable_under255" // Folder stored under 'unarchived' runtime-assets due to NuGet not allowing very long paths
                                          or "specialfiles") // Same but for fifos/chardevices/blockdevices
                         {
                             continue;
                         }
 
-                        yield return new object[] { TestTarFormat.ustar, testcaseName, compressionMethod, copyData };
+                        yield return new object[] { TestTarFormat.ustar, testCaseName, compressionMethod, copyData };
                     }
 
                     foreach (object[] testCaseNameObj in GetPaxAndGnuTestCaseNames())

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace System.Formats.Tar.Tests
+{
+    public partial class TarWriter_File_Base : TarTestsBase
+    {
+        // TestTarFormat, string testCaseName, CompressionMethod, bool copyData
+        public static IEnumerable<object[]> WriteEntry_CopyArchive_Data()
+        {
+            foreach (CompressionMethod compressionMethod in Enum.GetValues<CompressionMethod>())
+            {
+                foreach (bool copyData in new object[] { false, true })
+                {
+                    foreach (object[] testCaseName in GetV7TestCaseNames())
+                    {
+                        if ((string)testCaseName[0] == "folder_file_utf8") // The legacy name field is stored in ASCII in the V7 format
+                        {
+                            continue;
+                        }
+
+                        yield return new object[] { TestTarFormat.v7, testCaseName[0], compressionMethod, copyData };
+                    }
+
+                    foreach (object[] testCaseNameObj in GetUstarTestCaseNames())
+                    {
+                        string testcaseName = (string)testCaseNameObj[0];
+                        if (testcaseName is "folder_file_utf8" // The legacy name field is stored in ASCII in the Ustar format
+                                         or "longpath_splitable_under255" // Folder stored under 'unarchived' runtime-assets due to NuGet not allowing very long paths
+                                         or "specialfiles") // Same but for fifos/chardevices/blockdevices
+                        {
+                            continue;
+                        }
+
+                        yield return new object[] { TestTarFormat.ustar, testcaseName, compressionMethod, copyData };
+                    }
+
+                    foreach (object[] testCaseNameObj in GetPaxAndGnuTestCaseNames())
+                    {
+                        string testCaseName = (string)testCaseNameObj[0];
+                        if (testCaseName is "longpath_splitable_under255"
+                                         or "specialfiles"
+                                         or "longpath_over255" // Folder stored under 'unarchived' runtime-assets due to NuGet not allowing very long paths
+                                         or "longfilename_over100_under255" // Same
+                                         or "file_longsymlink") // Same
+                        {
+                            continue;
+                        }
+
+                        if (testCaseName is not "folder_file_utf8") // The legacy name field is stored in ASCII in the GNU format
+                        {
+                            yield return new object[] { TestTarFormat.oldgnu, testCaseName, compressionMethod, copyData };
+                            yield return new object[] { TestTarFormat.gnu, testCaseName, compressionMethod, copyData };
+                        }
+
+                        // folder_file_utf8 case name is ok to use in PAX because it allows storing the name in UTF8 in the extended attributes
+                        yield return new object[] { TestTarFormat.pax_gea, testCaseName, compressionMethod, copyData };
+                        yield return new object[] { TestTarFormat.pax, testCaseName, compressionMethod, copyData };
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using Xunit;
 
 namespace System.Formats.Tar.Tests
@@ -205,6 +207,85 @@ namespace System.Formats.Tar.Tests
 
                 Assert.Null(reader.GetNextEntry());
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(WriteEntry_CopyArchive_Data))]
+        public void WriteEntry_CopyArchive(TestTarFormat testFormat, string testCaseName, CompressionMethod compressionMethod, bool copyData)
+        {
+            TarEntryFormat entryFormat = GetEntryFormatForTestTarFormat(testFormat);
+            string pathWithExpectedFiles = GetTestCaseUnarchivedFolderPath(testCaseName);
+            if (!Path.EndsInDirectorySeparator(pathWithExpectedFiles))
+            {
+                pathWithExpectedFiles = pathWithExpectedFiles + Path.DirectorySeparatorChar;
+            }
+
+            using Stream file = GetTarMemoryStream(compressionMethod, testFormat, testCaseName);
+            using Stream originArchive = compressionMethod == CompressionMethod.GZip ? new GZipStream(file, CompressionMode.Decompress) : file;
+
+            VerifyCopyArchive(pathWithExpectedFiles, originArchive, entryFormat, copyData);
+        }
+
+        protected void VerifyCopyArchive(string pathWithExpectedFiles, Stream originArchive, TarEntryFormat entryFormat, bool copyData)
+        {
+            TarEntry entry;
+
+            using MemoryStream destinationArchive = new MemoryStream();
+            using (TarReader reader = new TarReader(originArchive, leaveOpen: false))
+            {
+                using (TarWriter writer = new TarWriter(destinationArchive, entryFormat, leaveOpen: true))
+                {
+                    while ((entry = reader.GetNextEntry(copyData)) != null)
+                    {
+                        if (entry is PaxTarEntry paxEntry)
+                        {
+                            paxEntry.GroupName = TestLongGName;
+                            paxEntry.UserName = TestLongUName;
+                        }
+                        writer.WriteEntry(entry);
+                    }
+                }
+            }
+
+            destinationArchive.Position = 0;
+
+            Dictionary<string, FileSystemInfo> expectedEntries = GetFileSystemInfosRecursive(pathWithExpectedFiles).ToDictionary(fsi =>
+                fsi.FullName.Substring(pathWithExpectedFiles.Length).Replace(Path.DirectorySeparatorChar, '/'));
+
+            int count = 0;
+            using (TarReader destinationReader = new TarReader(destinationArchive, leaveOpen: false))
+            {
+                while ((entry = destinationReader.GetNextEntry(copyData)) != null)
+                {
+                    if (entry is PaxGlobalExtendedAttributesTarEntry) // Metadata entry
+                    {
+                        continue;
+                    }
+                    string keyPath = Path.TrimEndingDirectorySeparator(entry.Name);
+                    Assert.True(expectedEntries.TryGetValue(keyPath, out FileSystemInfo expectedFSI), $"Entry '{keyPath}' not found in FileSystemInfos dictionary.");
+
+                    // Cannot compare entry.LinkName with expectedFSI.LinkTarget because links in runtime-assets are not stored by nuget as such, but as regular files
+                    if (entry.EntryType is TarEntryType.HardLink or TarEntryType.SymbolicLink)
+                    {
+                        AssertExtensions.GreaterThan(entry.LinkName.Length, 0, $"Entry LinkName length is 0.");
+                        string expectedLinkTargetPath = Path.Join(pathWithExpectedFiles, entry.LinkName);
+                        Assert.True(Path.Exists(expectedLinkTargetPath), $"Link target does not exist: {expectedLinkTargetPath}");
+                    }
+                    else
+                    {
+                        Assert.Equal(string.Empty, entry.LinkName);
+                    }
+
+                    if (entry is PaxTarEntry paxEntry)
+                    {
+                        Assert.Equal(TestLongGName, paxEntry.GroupName);
+                        Assert.Equal(TestLongUName, paxEntry.UserName);
+                    }
+
+                    count++;
+                }
+            }
+            Assert.Equal(expectedEntries.Count, count);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.cs
@@ -215,13 +215,10 @@ namespace System.Formats.Tar.Tests
         {
             TarEntryFormat entryFormat = GetEntryFormatForTestTarFormat(testFormat);
             string pathWithExpectedFiles = GetTestCaseUnarchivedFolderPath(testCaseName);
-            if (!Path.EndsInDirectorySeparator(pathWithExpectedFiles))
-            {
-                pathWithExpectedFiles = pathWithExpectedFiles + Path.DirectorySeparatorChar;
-            }
+            pathWithExpectedFiles = PathInternal.EnsureTrailingSeparator(pathWithExpectedFiles);
 
-            using Stream file = GetTarMemoryStream(compressionMethod, testFormat, testCaseName);
-            using Stream originArchive = compressionMethod == CompressionMethod.GZip ? new GZipStream(file, CompressionMode.Decompress) : file;
+            using Stream fileMemoryStream = GetTarMemoryStream(compressionMethod, testFormat, testCaseName);
+            using Stream originArchive = compressionMethod == CompressionMethod.GZip ? new GZipStream(fileMemoryStream, CompressionMode.Decompress) : fileMemoryStream;
 
             VerifyCopyArchive(pathWithExpectedFiles, originArchive, entryFormat, copyData);
         }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.cs
@@ -232,13 +232,10 @@ namespace System.Formats.Tar.Tests
         {
             TarEntryFormat entryFormat = GetEntryFormatForTestTarFormat(testFormat);
             string pathWithExpectedFiles = GetTestCaseUnarchivedFolderPath(testCaseName);
-            if (!Path.EndsInDirectorySeparator(pathWithExpectedFiles))
-            {
-                pathWithExpectedFiles = pathWithExpectedFiles + Path.DirectorySeparatorChar;
-            }
+            pathWithExpectedFiles = PathInternal.EnsureTrailingSeparator(pathWithExpectedFiles);
 
-            await using Stream file = GetTarMemoryStream(compressionMethod, testFormat, testCaseName);
-            await using Stream originArchive = compressionMethod == CompressionMethod.GZip ? new GZipStream(file, CompressionMode.Decompress) : file;
+            await using Stream fileMemoryStream = GetTarMemoryStream(compressionMethod, testFormat, testCaseName);
+            await using Stream originArchive = compressionMethod == CompressionMethod.GZip ? new GZipStream(fileMemoryStream, CompressionMode.Decompress) : fileMemoryStream;
 
             await VerifyCopyArchiveAsync(pathWithExpectedFiles, originArchive, entryFormat, copyData);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75215

A `PaxTarEntry` obtained from a `TarReader` will have an extended attributes dictionary filled with the fields that get collected by default.

When attempting to write such entry to a `TarWriter` via `WriteEntry(TarEntry)`, we collect the default extended attribute fields and store them in the dictionary. The problem is that we were using `Dictionary.Add`, which throws if the key already exists, and that is not the intended behavior.

The fix is to add the key using the indexer. That way, we _always_ write the most up-to-date value to the dictionary.

We should try to get it into 7.0 as mentioned in the issue.