### PR TITLE
[release/7.0] Fix tests to use valid PBE iterations

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/AsymmetricAlgorithmTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/AsymmetricAlgorithmTests.cs
@@ -370,7 +370,7 @@ namespace System.Security.Cryptography.Tests
             PbeParameters expectedPbeParameters = new PbeParameters(
                 PbeEncryptionAlgorithm.Aes256Cbc,
                 HashAlgorithmName.SHA384,
-                RandomNumberGenerator.GetInt32(0, 100_000));
+                RandomNumberGenerator.GetInt32(1, 100_000));
 
             byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters)
             {
@@ -407,7 +407,7 @@ namespace System.Security.Cryptography.Tests
             PbeParameters expectedPbeParameters = new PbeParameters(
                 PbeEncryptionAlgorithm.Aes256Cbc,
                 HashAlgorithmName.SHA384,
-                RandomNumberGenerator.GetInt32(0, 100_000));
+                RandomNumberGenerator.GetInt32(1, 100_000));
 
             bool TryExportEncryptedPkcs8PrivateKey(
                 ReadOnlySpan<char> password,


### PR DESCRIPTION
This is a manual port of https://github.com/dotnet/runtime/pull/75238 for the release/7.0 branch (backport bot would get a conflict)

Currently, these two tests will fail 1/100,000 times.