### PR TITLE
[AArch64] amend the disassembly comment for the instruction.

### DIFF
--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -2026,7 +2026,7 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
                 *(DWORD*)p = 0xd280000a | ((UINT32)slotOffset << 5); p += 4;
                 dataOffset -= 4;
 
-                // cmp x9,x10
+                // cmp x11,x10
                 *(DWORD*)p = 0xeb0a017f; p += 4;
                 dataOffset -= 4;
 


### PR DESCRIPTION
The comment for this line is not right.  Because the `X9` is a pointer.
https://github.com/dotnet/runtime/blob/31bdc77701b2f4b2f3391e990938ed8e17eb410f/src/coreclr/vm/arm64/stubs.cpp#L2030

here only the comment is wrong while the instruction's encoding is right.