### PR TITLE
Update provider_compute_event_enable_mask so EventSouces with no keywords show up by default

### DIFF
--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -145,11 +145,13 @@ provider_compute_event_enable_mask (
 			if (session_provider) {
 				int64_t session_keyword = ep_session_provider_get_keywords (session_provider);
 				EventPipeEventLevel session_level = ep_session_provider_get_logging_level (session_provider);
+				// EventSources always set 0xF00000000000 to signify no keywords 
+				int64_t session_mask = ~0xF00000000000;
 				// The event is enabled if:
 				//  - The provider is enabled.
 				//  - The event keywords are unspecified in the manifest (== 0) or when masked with the enabled config are != 0.
 				//  - The event level is LogAlways or the provider's verbosity level is set to greater than the event's verbosity level in the manifest.
-				bool keyword_enabled = (keywords == 0) || ((session_keyword & keywords) != 0);
+				bool keyword_enabled = ((keywords & session_mask) == 0) || ((session_keyword & keywords) != 0);
 				bool level_enabled = ((event_level == EP_EVENT_LEVEL_LOGALWAYS) || (session_level >= event_level));
 				if (provider_enabled && keyword_enabled && level_enabled)
 					result = result | ep_session_get_mask (session);

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -248,8 +248,12 @@ ep_provider_add_event (
 	// Keyword bits 44-47 are reserved for use by EventSources, and every EventSource sets them all.
 	// We filter out those bits here so later comparisons don't have to take them in to account. Without
 	// filtering, EventSources wouldn't show up with Keywords=0.
-	int64_t session_mask = ~0xF00000000000;
-	keywords &= session_mask;
+	uint64_t session_mask = ~0xF00000000000;
+	// -1 is special, it means all keywords. Don't change it.
+	uint64_t all_keywords = (uint64_t)(-1);
+	if (keywords != all_keywords) {
+		keywords &= session_mask;
+	}
 
 	EventPipeEvent *instance = ep_event_alloc (
 		provider,


### PR DESCRIPTION
Fixes https://github.com/dotnet/diagnostics/issues/3298

EventSource uses bits 44-47 of the keywords to store data about sessions:
https://github.com/dotnet/runtime/blob/01d1c8c2768ae0898468506fab7a0d7e79ab11d8/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L5071-L5073
And we set them all to 1 by default in the manifest:
https://github.com/dotnet/runtime/blob/01d1c8c2768ae0898468506fab7a0d7e79ab11d8/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L3428-L3439

This means that when we compute whether an event should be enabled we won't turn on EventSource events by default, since the event keywords are non-zero `0xF00000000000`: https://github.com/dotnet/runtime/blob/01d1c8c2768ae0898468506fab7a0d7e79ab11d8/src/native/eventpipe/ep-provider.c#L152

We have a workaround in the DiagnosticClient introduced here: https://github.com/dotnet/diagnostics/pull/1091, but any other way of enabling EventPipe (env vars, other clients, etc) will still have this issue.

This fix lets the default EventSource keyword act as if it were 0 for all sessions.

This does have two compat issues
- If someone has a provider that was using any of the masked bits it would now start to show up in traces that didn't have the keyword set
- We cannot use those keywords for runtime events, our current high bit is 42 `0x20000000000` so we are very close to that number. I don't think we have a choice regardless of this change though, due to EventSource treating those bits as reserved.