### PR TITLE
Fix test issues on armv6, s390x and ppc64le on runtime-community

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -61,7 +61,9 @@ namespace System
         public static bool IsNotArm64Process => !IsArm64Process;
         public static bool IsArmOrArm64Process => IsArmProcess || IsArm64Process;
         public static bool IsNotArmNorArm64Process => !IsArmOrArm64Process;
+        public static bool IsS390xProcess => (int)RuntimeInformation.ProcessArchitecture == 5; // Architecture.S390x
         public static bool IsArmv6Process => (int)RuntimeInformation.ProcessArchitecture == 7; // Architecture.Armv6
+        public static bool IsPpc64leProcess => (int)RuntimeInformation.ProcessArchitecture == 8; // Architecture.Ppc64le
         public static bool IsX64Process => RuntimeInformation.ProcessArchitecture == Architecture.X64;
         public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
         public static bool IsNotX86Process => !IsX86Process;

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
@@ -29,7 +29,15 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                     break;
 
                 case Architecture.Arm64:
-                    Assert.Equal(IntPtr.Size == 4 ? Architecture.Arm : Architecture.Arm64, processArch);
+                    if (IntPtr.Size == 8)
+                    {
+                        Assert.Equal(Architecture.Arm64, processArch);
+                    }
+                    else
+                    {
+                        // armv7/armv6 process running on arm64 host
+                        Assert.True(processArch == Architecture.Arm || processArch == Architecture.Armv6, $"Unexpected process architecture: {processArch}");
+                    }
                     break;
 
                 case Architecture.Wasm:

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -25,6 +25,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/11191", ~RuntimeConfiguration.Release)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/35915", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75281", typeof(PlatformDetection), nameof(PlatformDetection.IsPpc64leProcess))]
         [InlineData(2 * 6_584_983 - 2)] // previous limit
         [InlineData(2 * 7_199_369 - 2)] // last pre-computed prime number
         public void SerializeHugeObjectGraphs(int limit)

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/XmlDictionaryReaderTests.cs
@@ -165,6 +165,7 @@ namespace System.Runtime.Serialization.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74494", typeof(PlatformDetection), nameof(PlatformDetection.IsS390xProcess))]
         public static void BinaryXml_ReadPrimitiveTypes()
         {
             float f = 1.23456788f;
@@ -202,6 +203,7 @@ namespace System.Runtime.Serialization.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74494", typeof(PlatformDetection), nameof(PlatformDetection.IsS390xProcess))]
         public static void BinaryXml_Array_RoundTrip()
         {
             int[] ints = new int[] { -1, 0x01020304, 0x11223344, -1 };


### PR DESCRIPTION
The VerifyArchitecture test wasn't handling armv6 process running on arm64, only armv7.
Also disabled tests that are failing on s390x/ppc64le with ActiveIssue.