### PR TITLE
[wasm-mt] Additional build fixes

### DIFF
--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -183,7 +183,7 @@
       <!-- add for non-threaded runtime also -->
       <_NuGetsToBuild Include="$(LibrariesShippingPackagesDir)Microsoft.NETCore.App.Runtime.Mono.browser-wasm.$(_PackageVersion).nupkg"
                       Project="$(InstallerProjectRoot)pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj"
-                      Properties="@(_DefaultPropsForNuGetBuild, ';')"
+                      Properties="@(_DefaultPropsForNuGetBuild, ';');MonoWasmBuildVariant="
                       Dependencies="$(_DefaultRuntimePackNuGetPath)"
                       Descriptor="single threaded runtime pack"
                       Condition="'$(_DefaultBuildVariant)' != '.'" />

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
    <PropertyGroup>
-     <FeatureWasmThreads Condition="'$(TargetOS)' == 'browser' and '$(WasmEnableThreads)' == 'true'">true</FeatureWasmThreads>
+     <FeatureWasmThreads Condition="'$(TargetOS)' == 'browser' and ('$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread')">true</FeatureWasmThreads>
    </PropertyGroup>
 
    <PropertyGroup>


### PR DESCRIPTION
Foward port changes from `release/7.0` https://github.com/dotnet/runtime/pull/75171 that were not included in `main` https://github.com/dotnet/runtime/pull/75162

- when building the InteropServices.JavaScript library, enable threading if MonoWasmBuildVariant is set appropriately.  One consequence is that the runtime will (correctly) install the browser synchronization context on the main thread.

- for workload build testing, unset MonoWasmBuildVariant when creating the non-threaded runtime