### PR TITLE
Fix GCEvent::Wait with timeout on OSX

### DIFF
--- a/src/coreclr/gc/unix/events.cpp
+++ b/src/coreclr/gc/unix/events.cpp
@@ -131,6 +131,7 @@ public:
         if (milliseconds != INFINITE)
         {
             uint64_t nanoseconds = (uint64_t)milliseconds * tccMilliSecondsToNanoSeconds;
+            NanosecondsToTimeSpec(nanoseconds, &endTime);
             endMachTime = clock_gettime_nsec_np(CLOCK_UPTIME_RAW) + nanoseconds;
         }
 #elif HAVE_PTHREAD_CONDATTR_SETCLOCK


### PR DESCRIPTION
Fixes:https://github.com/dotnet/runtime/issues/75005

We are using uninitialized `endTime` when Wait with a timeout waits on a conditional variable on OSX. 
This can result in unpredictable behavior. On NativeAOT it results in BGC starting without a signal and asserting/crashing.