### PR TITLE
Remove enumerator allocation when constructing RestrictedAsciiStringEncoding

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnCharacterStringEncodings.cs
@@ -220,15 +220,12 @@ namespace System.Formats.Asn1
 
             bool[] isAllowed = new bool[0x80];
 
-            for (byte charCode = minCharAllowed; charCode <= maxCharAllowed; charCode++)
-            {
-                isAllowed[charCode] = true;
-            }
+            isAllowed.AsSpan(minCharAllowed, maxCharAllowed - minCharAllowed + 1).Fill(true);
 
             _isAllowed = isAllowed;
         }
 
-        protected RestrictedAsciiStringEncoding(IEnumerable<char> allowedChars)
+        protected RestrictedAsciiStringEncoding(string allowedChars)
         {
             bool[] isAllowed = new bool[0x7F];
 


### PR DESCRIPTION
There's only a few of these constructed, so it's not a big deal, but might as well.