### PR TITLE
disable gcmemoryinfo on win-arm64

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -565,6 +565,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetTotalPauseDuration.csproj">
             <Issue>https://github.com/dotnet/runtime/issues/74631</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetGCMemoryInfo.csproj">
+            <Issue>https://github.com/dotnet/runtime/issues/74902</Issue>
+        </ExcludeList>    
     </ItemGroup>
 
     <!-- The following are x64 Unix failures on CoreCLR. -->


### PR DESCRIPTION
Disabling a test to unblock outerloop.

Attempt to disable test tracked in #74902 (needed fix of the disabling in PR #75475)