### PR TITLE
[release/6.0] Add reference assembly for System.Private.CoreLib.dll

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -237,8 +237,10 @@
 
   <PropertyGroup>
     <CoreLibSharedDir>$([MSBuild]::NormalizeDirectory('$(LibrariesProjectRoot)', 'System.Private.CoreLib', 'src'))</CoreLibSharedDir>
+    <CoreLibRefDir>$([MSBuild]::NormalizeDirectory('$(LibrariesProjectRoot)', 'System.Private.CoreLib', 'ref'))</CoreLibRefDir>
     <CoreLibProject Condition="'$(RuntimeFlavor)' == 'CoreCLR'">$([MSBuild]::NormalizePath('$(CoreClrProjectRoot)', 'System.Private.CoreLib', 'System.Private.CoreLib.csproj'))</CoreLibProject>
     <CoreLibProject Condition="'$(RuntimeFlavor)' == 'Mono'">$([MSBuild]::NormalizePath('$(MonoProjectRoot)', 'System.Private.CoreLib', 'System.Private.CoreLib.csproj'))</CoreLibProject>
+    <UriProject>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'System.Private.Uri', 'src', 'System.Private.Uri.csproj'))</UriProject>
 
     <!-- this property is used by the SDK to pull in mono-based runtime packs -->
     <UseMonoRuntime Condition="'$(UseMonoRuntime)' == '' and '$(RuntimeFlavor)' == 'Mono'">true</UseMonoRuntime>

--- a/docs/coding-guidelines/updating-ref-source.md
+++ b/docs/coding-guidelines/updating-ref-source.md
@@ -13,7 +13,7 @@ This document provides the steps you need to take to update the reference assemb
 
 These steps can also be applied to some unique assemblies which depend on changes in System.Private.Corelib. (partial facades like System.Memory, for example).
 
-1) Run `dotnet build --no-incremental /t:GenerateReferenceSource` from the System.Runtime/src directory.
+1) Run `dotnet build --no-incremental /t:GenerateReferenceAssemblySource` from the System.Runtime/src directory.
 2) Filter out all unrelated changes and extract the changes you care about (ignore certain attributes being removed). Generally, this step is not required for other reference assemblies.
 
 ## For Full Facade Assemblies implementation assemblies

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -59,4 +59,15 @@
     <Error Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference' AND '%(ReferencePath.IsReferenceAssembly)' != 'true' AND '%(ReferencePath.ReferenceAssembly)' == ''"
            Text="Reference assemblies must only reference other reference assemblies and '%(ReferencePath.ProjectReferenceOriginalItemSpec)' is not a reference assembly project and does not set 'ProduceReferenceAssembly'." />
   </Target>
+
+  <Target Name="ReplaceCoreLibSrcWithRefAssemblyForCompilation"
+          AfterTargets="FindReferenceAssembliesForReferences"
+          Condition="'$(CompileUsingReferenceAssemblies)' != 'true' and '@(_coreLibProjectReference)' != ''">
+    <ItemGroup>
+      <_resolvedCoreLibProjectReference Include="@(_ResolvedProjectReferencePaths->WithMetadataValue('MSBuildSourceProjectFile','$(CoreLibProject)'))" />
+      <ReferencePathWithRefAssemblies Remove="@(_resolvedCoreLibProjectReference)" />
+      <ReferencePathWithRefAssemblies Include="@(_resolvedCoreLibProjectReference->Metadata('ReferenceAssembly'))" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
@@ -355,4 +355,10 @@
       <FileWrites Include="@(EventingSourceFile)" />
     </ItemGroup>
   </Target>
+
+  <!-- Import refererence assembly logic -->
+  <PropertyGroup>
+    <IsSourceProject>true</IsSourceProject>
+  </PropertyGroup>
+  <Import Project="$(RepositoryEngineeringDir)resolveContract.targets" />
 </Project>

--- a/src/libraries/System.Collections.Concurrent/ref/System.Collections.Concurrent.cs
+++ b/src/libraries/System.Collections.Concurrent/ref/System.Collections.Concurrent.cs
@@ -6,6 +6,7 @@
 
 namespace System.Collections.Concurrent
 {
+#if !BUILDING_CORELIB_REFERENCE
     [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
     public partial class BlockingCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.IDisposable
     {
@@ -126,6 +127,7 @@ namespace System.Collections.Concurrent
         public bool TryRemove(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value) { throw null; }
         public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue) { throw null; }
     }
+#endif
     public partial class ConcurrentQueue<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
     {
         public ConcurrentQueue() { }
@@ -146,6 +148,7 @@ namespace System.Collections.Concurrent
         public bool TryDequeue([System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out T result) { throw null; }
         public bool TryPeek([System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out T result) { throw null; }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class ConcurrentStack<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
     {
         public ConcurrentStack() { }
@@ -176,6 +179,7 @@ namespace System.Collections.Concurrent
         None = 0,
         NoBuffering = 1,
     }
+#endif
     public partial interface IProducerConsumerCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
     {
         void CopyTo(T[] array, int index);
@@ -183,6 +187,7 @@ namespace System.Collections.Concurrent
         bool TryAdd(T item);
         bool TryTake([System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out T item);
     }
+#if !BUILDING_CORELIB_REFERENCE
     public abstract partial class OrderablePartitioner<TSource> : System.Collections.Concurrent.Partitioner<TSource>
     {
         protected OrderablePartitioner(bool keysOrderedInEachPartition, bool keysOrderedAcrossPartitions, bool keysNormalized) { }
@@ -212,4 +217,5 @@ namespace System.Collections.Concurrent
         public virtual System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
         public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
     }
+#endif
 }

--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -6,6 +6,7 @@
 
 namespace System.Collections
 {
+#if !BUILDING_CORELIB_REFERENCE
     public sealed partial class BitArray : System.Collections.ICollection, System.Collections.IEnumerable, System.ICloneable
     {
         public BitArray(bool[] values) { }
@@ -38,9 +39,12 @@ namespace System.Collections
         public static System.Collections.IComparer StructuralComparer { get { throw null; } }
         public static System.Collections.IEqualityComparer StructuralEqualityComparer { get { throw null; } }
     }
+#endif
 }
+
 namespace System.Collections.Generic
 {
+#if !BUILDING_CORELIB_REFERENCE
     public static partial class CollectionExtensions
     {
         public static TValue? GetValueOrDefault<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
@@ -48,6 +52,7 @@ namespace System.Collections.Generic
         public static bool Remove<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute(false)] out TValue value) { throw null; }
         public static bool TryAdd<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue value) { throw null; }
     }
+#endif
     public abstract partial class Comparer<T> : System.Collections.Generic.IComparer<T>, System.Collections.IComparer
     {
         protected Comparer() { }
@@ -240,6 +245,7 @@ namespace System.Collections.Generic
             void System.Collections.IEnumerator.Reset() { }
         }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public sealed partial class LinkedListNode<T>
     {
         public LinkedListNode(T value) { }
@@ -298,6 +304,7 @@ namespace System.Collections.Generic
             void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
+#endif
     public partial class List<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
     {
         public List() { }
@@ -379,7 +386,7 @@ namespace System.Collections.Generic
             void System.Collections.IEnumerator.Reset() { }
         }
     }
-
+#if !BUILDING_CORELIB_REFERENCE
     public partial class PriorityQueue<TElement, TPriority>
     {
         public PriorityQueue() { }
@@ -423,7 +430,7 @@ namespace System.Collections.Generic
             }
         }
     }
-
+#endif
     public partial class Queue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
     {
         public Queue() { }
@@ -466,6 +473,7 @@ namespace System.Collections.Generic
         public new bool Equals(object? x, object? y) { throw null; }
         public int GetHashCode(object? obj) { throw null; }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class SortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable where TKey : notnull
     {
         public SortedDictionary() { }
@@ -718,4 +726,5 @@ namespace System.Collections.Generic
             void System.Collections.IEnumerator.Reset() { }
         }
     }
+#endif
 }

--- a/src/libraries/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>System.Diagnostics.Tests</RootNamespace>
-    <IgnoreArchitectureMismatches>true</IgnoreArchitectureMismatches>
-    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
+    <!-- Some tests need types like System.Diagnostics.DebugProvider which are only exposed from System.Private.CoreLib -->
+    <CompileUsingReferenceAssemblies>false</CompileUsingReferenceAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <DefaultReferenceExclusion Include="System.Diagnostics.Debug" />
     <DefaultReferenceExclusion Include="System.Runtime.Extensions" />
     <ProjectReference Include="$(CoreLibProject)" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime\src\System.Runtime.csproj" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Threading\src\System.Threading.csproj" SkipUseReferenceAssembly="true" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Threading\src\System.Threading.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Collections\src\System.Collections.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DebugTests.cs" />

--- a/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
@@ -52,6 +52,7 @@ namespace System.Diagnostics
 }
 namespace System.Diagnostics.SymbolStore
 {
+#if !BUILDING_CORELIB_REFERENCE
     public partial interface ISymbolBinder
     {
         [System.ObsoleteAttribute("ISymbolBinder.GetReader has been deprecated because it is not 64-bit compatible. Use ISymbolBinder1.GetReader instead. ISymbolBinder1.GetReader accepts the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures.")]
@@ -74,11 +75,13 @@ namespace System.Diagnostics.SymbolStore
         byte[] GetCheckSum();
         byte[] GetSourceRange(int startLine, int startColumn, int endLine, int endColumn);
     }
+#endif
     public partial interface ISymbolDocumentWriter
     {
         void SetCheckSum(System.Guid algorithmId, byte[] checkSum);
         void SetSource(byte[] source);
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial interface ISymbolMethod
     {
         System.Diagnostics.SymbolStore.ISymbolScope RootScope { get; }
@@ -205,4 +208,5 @@ namespace System.Diagnostics.SymbolStore
         public static readonly System.Guid Microsoft;
         public SymLanguageVendor() { }
     }
+#endif
 }

--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -165,6 +165,7 @@ namespace System
             public bool AppendFormatted(string? value, int alignment = 0, string? format = null) { throw null; }
         }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public readonly partial struct SequencePosition : System.IEquatable<System.SequencePosition>
     {
         private readonly object _dummy;
@@ -180,9 +181,11 @@ namespace System
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public object? GetObject() { throw null; }
     }
+#endif
 }
 namespace System.Buffers
 {
+#if !BUILDING_CORELIB_REFERENCE
     public sealed partial class ArrayBufferWriter<T> : System.Buffers.IBufferWriter<T>
     {
         public ArrayBufferWriter() { }
@@ -315,6 +318,7 @@ namespace System.Buffers
         public bool TryReadToAny(out System.Buffers.ReadOnlySequence<T> sequence, System.ReadOnlySpan<T> delimiters, bool advancePastDelimiter = true) { throw null; }
         public bool TryReadToAny(out System.ReadOnlySpan<T> span, System.ReadOnlySpan<T> delimiters, bool advancePastDelimiter = true) { throw null; }
     }
+#endif
     public readonly partial struct StandardFormat : System.IEquatable<System.Buffers.StandardFormat>
     {
         private readonly int _dummyPrimitive;
@@ -541,6 +545,7 @@ namespace System.Runtime.InteropServices
         public static bool TryWrite<T>(System.Span<byte> destination, ref T value) where T : struct { throw null; }
         public static void Write<T>(System.Span<byte> destination, ref T value) where T : struct { }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public static partial class SequenceMarshal
     {
         public static bool TryGetArray<T>(System.Buffers.ReadOnlySequence<T> sequence, out System.ArraySegment<T> segment) { throw null; }
@@ -548,9 +553,11 @@ namespace System.Runtime.InteropServices
         public static bool TryGetReadOnlySequenceSegment<T>(System.Buffers.ReadOnlySequence<T> sequence, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Buffers.ReadOnlySequenceSegment<T>? startSegment, out int startIndex, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Buffers.ReadOnlySequenceSegment<T>? endSegment, out int endIndex) { throw null; }
         public static bool TryRead<T>(ref System.Buffers.SequenceReader<byte> reader, out T value) where T : unmanaged { throw null; }
     }
+#endif
 }
 namespace System.Text
 {
+#if !BUILDING_CORELIB_REFERENCE
     public static partial class EncodingExtensions
     {
         public static void Convert(this System.Text.Decoder decoder, in System.Buffers.ReadOnlySequence<byte> bytes, System.Buffers.IBufferWriter<char> writer, bool flush, out long charsUsed, out bool completed) { throw null; }
@@ -566,6 +573,7 @@ namespace System.Text
         public static long GetChars(this System.Text.Encoding encoding, System.ReadOnlySpan<byte> bytes, System.Buffers.IBufferWriter<char> writer) { throw null; }
         public static string GetString(this System.Text.Encoding encoding, in System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
     }
+#endif
     public ref partial struct SpanLineEnumerator
     {
         private object _dummy;

--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.cs
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// NOTE: Types/members which are not publicly exposed in System.Runtime.dll but still used internally by libraries.
+//       Manually maintained, keep in sync with System.Private.CoreLib.ExtraApis.txt
+
+namespace System.Runtime.Serialization
+{
+    public readonly partial struct DeserializationToken : System.IDisposable
+    {
+#pragma warning disable CS0414
+        private readonly object _dummy = null;
+        private readonly int _dummyPrimitive = 0;
+#pragma warning restore CS0414
+        internal DeserializationToken(object tracker) { }
+        public void Dispose() { }
+    }
+    public sealed partial class SerializationInfo
+    {
+        public static System.Runtime.Serialization.DeserializationToken StartDeserialization() { throw null; }
+    }
+}
+namespace System.Diagnostics
+{
+    public partial class DebugProvider
+    {
+        public DebugProvider() { }
+        [System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute]
+        public virtual void Fail(string? message, string? detailMessage) { throw null; }
+        public static void FailCore(string stackTrace, string? message, string? detailMessage, string errorSource) { }
+        public virtual void OnIndentLevelChanged(int indentLevel) { }
+        public virtual void OnIndentSizeChanged(int indentSize) { }
+        public virtual void Write(string? message) { }
+        public static void WriteCore(string message) { }
+        public virtual void WriteLine(string? message) { }
+    }
+    public static partial class Debug
+    {
+        public static System.Diagnostics.DebugProvider SetProvider(System.Diagnostics.DebugProvider provider) { throw null; }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ManualShimTypeForwards.cs
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ManualShimTypeForwards.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// NOTE: Types/members which are not publicly exposed in System.Runtime.dll but are forwarded from the mscorlib.dll shim.
+//       Manually maintained.
+
+namespace System
+{
+    public sealed partial class CultureAwareComparer : System.StringComparer, System.Runtime.Serialization.ISerializable
+    {
+        internal CultureAwareComparer() { }
+        public override int Compare(string? x, string? y) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override bool Equals(string? x, string? y) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override int GetHashCode(string obj) { throw null; }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public partial class OrdinalComparer : System.StringComparer
+    {
+        internal OrdinalComparer() { }
+        public override int Compare(string? x, string? y) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override bool Equals(string? x, string? y) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override int GetHashCode(string obj) { throw null; }
+    }
+    public sealed partial class UnitySerializationHolder : System.Runtime.Serialization.IObjectReference, System.Runtime.Serialization.ISerializable
+    {
+        public UnitySerializationHolder(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public object GetRealObject(System.Runtime.Serialization.StreamingContext context) { throw null; }
+    }
+}
+namespace System.Collections
+{
+    public partial class ListDictionaryInternal : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+    {
+        public ListDictionaryInternal() { }
+        public int Count { get { throw null; } }
+        public bool IsFixedSize { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public object? this[object key] { get { throw null; } set { } }
+        public System.Collections.ICollection Keys { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public System.Collections.ICollection Values { get { throw null; } }
+        public void Add(object key, object? value) { }
+        public void Clear() { }
+        public bool Contains(object key) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public System.Collections.IDictionaryEnumerator GetEnumerator() { throw null; }
+        public void Remove(object key) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+}
+namespace System.Collections.Generic
+{
+    public sealed partial class ByteEqualityComparer : System.Collections.Generic.EqualityComparer<byte>
+    {
+        public ByteEqualityComparer() { }
+        public override bool Equals(byte x, byte y) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override int GetHashCode(byte b) { throw null; }
+    }
+    public sealed partial class EnumEqualityComparer<T> : System.Collections.Generic.EqualityComparer<T>, System.Runtime.Serialization.ISerializable where T : struct
+    {
+        public EnumEqualityComparer() { }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override bool Equals(T x, T y) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override int GetHashCode(T obj) { throw null; }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public sealed partial class GenericComparer<T> : System.Collections.Generic.Comparer<T> where T : System.IComparable<T>
+    {
+        public GenericComparer() { }
+        public override int Compare(T? x, T? y) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+    }
+    public sealed partial class GenericEqualityComparer<T> : System.Collections.Generic.EqualityComparer<T> where T : System.IEquatable<T>
+    {
+        public GenericEqualityComparer() { }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override bool Equals(T? x, T? y) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override int GetHashCode([System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T obj) { throw null; }
+    }
+    public partial class NonRandomizedStringEqualityComparer : System.Collections.Generic.IEqualityComparer<string?>, System.Runtime.Serialization.ISerializable
+    {
+        protected NonRandomizedStringEqualityComparer(System.Runtime.Serialization.SerializationInfo information, System.Runtime.Serialization.StreamingContext context) { }
+        public virtual bool Equals(string? x, string? y) { throw null; }
+        public virtual int GetHashCode(string? obj) { throw null; }
+        public static System.Collections.Generic.IEqualityComparer<string>? GetStringComparer(object? comparer) { throw null; }
+        public virtual System.Collections.Generic.IEqualityComparer<string?> GetUnderlyingEqualityComparer() { throw null; }
+        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public sealed partial class NullableComparer<T> : System.Collections.Generic.Comparer<T?>, System.Runtime.Serialization.ISerializable where T : struct
+    {
+        public NullableComparer() { }
+        public override int Compare(T? x, T? y) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public sealed partial class NullableEqualityComparer<T> : System.Collections.Generic.EqualityComparer<T?>, System.Runtime.Serialization.ISerializable where T : struct
+    {
+        public NullableEqualityComparer() { }
+        public override bool Equals(T? x, T? y) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override int GetHashCode(T? obj) { throw null; }
+        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public sealed partial class ObjectComparer<T> : System.Collections.Generic.Comparer<T>
+    {
+        public ObjectComparer() { }
+        public override int Compare(T? x, T? y) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+    }
+    public sealed partial class ObjectEqualityComparer<T> : System.Collections.Generic.EqualityComparer<T>
+    {
+        public ObjectEqualityComparer() { }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public override bool Equals(T? x, T? y) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override int GetHashCode([System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T obj) { throw null; }
+    }
+}
+namespace System.Diagnostics.Contracts
+{
+    public sealed partial class ContractException : System.Exception
+    {
+        public ContractException(System.Diagnostics.Contracts.ContractFailureKind kind, string? failure, string? userMessage, string? condition, System.Exception? innerException) { }
+        public string? Condition { get { throw null; } }
+        public string Failure { get { throw null; } }
+        public System.Diagnostics.Contracts.ContractFailureKind Kind { get { throw null; } }
+        public string? UserMessage { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+}
+namespace System.Reflection.Emit
+{
+    public enum PEFileKinds
+    {
+        Dll = 1,
+        ConsoleApplication = 2,
+        WindowApplication = 3,
+    }
+}

--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.csproj
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+    <!-- It is a core assembly because it defines System.Object so we need to pass RuntimeMetadataVersion to the compiler -->
+    <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
+    <!-- disable warnings about obsolete APIs,
+        Remove warning disable when nullable attributes are respected,
+        Type has no accessible constructors which use only CLS-compliant types -->
+    <NoWarn>$(NoWarn);0809;0618;CS8614;CS3015</NoWarn>
+    <StrongNameKeyId>SilverlightPlatform</StrongNameKeyId>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <DefineConstants>$(DefineConstants);BUILDING_CORELIB_REFERENCE</DefineConstants>
+    <!-- Disable binplacing since the System.Private.CoreLib reference assembly is internal to our build and shouldn't be exposed anywhere -->
+    <EnableBinPlacing>false</EnableBinPlacing>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- contracts where all types were moved to CoreLib, these are used both here and in the contract assemblies and are generated -->
+    <Compile Include="..\..\Microsoft.Win32.Primitives\ref\Microsoft.Win32.Primitives.cs" />
+    <Compile Include="..\..\System.Diagnostics.Contracts\ref\System.Diagnostics.Contracts.cs" />
+    <Compile Include="..\..\System.Diagnostics.Tracing\ref\System.Diagnostics.Tracing.cs" />
+    <Compile Include="..\..\System.Diagnostics.Tracing\ref\System.Diagnostics.Tracing.Counters.cs" />
+    <Compile Include="..\..\System.Numerics.Vectors\ref\System.Numerics.Vectors.cs" />
+    <Compile Include="..\..\System.Reflection.Emit.ILGeneration\ref\System.Reflection.Emit.ILGeneration.cs" />
+    <Compile Include="..\..\System.Reflection.Emit.Lightweight\ref\System.Reflection.Emit.Lightweight.cs" />
+    <Compile Include="..\..\System.Reflection.Emit\ref\System.Reflection.Emit.cs" />
+    <Compile Include="..\..\System.Reflection.Primitives\ref\System.Reflection.Primitives.cs" />
+    <Compile Include="..\..\System.Runtime.Intrinsics\ref\System.Runtime.Intrinsics.cs" />
+    <Compile Include="..\..\System.Runtime.Loader\ref\System.Runtime.Loader.cs" />
+    <Compile Include="..\..\System.Runtime\ref\System.Runtime.cs" />
+    <Compile Include="..\..\System.Text.Encoding.Extensions\ref\System.Text.Encoding.Extensions.cs" />
+    <Compile Include="..\..\System.Threading.Overlapped\ref\System.Threading.Overlapped.cs" />
+    <Compile Include="..\..\System.Threading.ThreadPool\ref\System.Threading.ThreadPool.cs" />
+    <Compile Include="..\..\System.Threading.Thread\ref\System.Threading.Thread.cs" />
+  
+    <!-- contracts where types were partially moved to CoreLib, these are used both here and in the contract assemblies and are generated -->
+    <Compile Include="..\..\System.Collections.Concurrent\ref\System.Collections.Concurrent.cs" />
+    <Compile Include="..\..\System.Collections\ref\System.Collections.cs" />
+    <Compile Include="..\..\System.Diagnostics.StackTrace\ref\System.Diagnostics.StackTrace.cs" />
+    <Compile Include="..\..\System.Memory\ref\System.Memory.cs" />
+    <Compile Include="..\..\System.Runtime.InteropServices\ref\System.Runtime.InteropServices.cs" />
+    <Compile Include="..\..\System.Threading\ref\System.Threading.cs" />
+
+    <!-- types only exposed through CoreLib, this is manually maintained -->
+    <Compile Include="System.Private.CoreLib.ExtraApis.cs" />
+
+    <!-- types not exposed in contracts but forwarded from the mscorlib shim, this is manually maintained -->
+    <Compile Include="System.Private.CoreLib.ManualShimTypeForwards.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -76,6 +76,7 @@ namespace System.IO
 }
 namespace System.Runtime.CompilerServices
 {
+#if !BUILDING_CORELIB_REFERENCE
     [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter, Inherited=false)]
     public sealed partial class IDispatchConstantAttribute : System.Runtime.CompilerServices.CustomConstantAttribute
@@ -89,6 +90,7 @@ namespace System.Runtime.CompilerServices
         public IUnknownConstantAttribute() { }
         public override object Value { get { throw null; } }
     }
+#endif
 }
 namespace System.Runtime.InteropServices
 {
@@ -111,12 +113,14 @@ namespace System.Runtime.InteropServices
         public static bool operator ==(System.Runtime.InteropServices.ArrayWithOffset a, System.Runtime.InteropServices.ArrayWithOffset b) { throw null; }
         public static bool operator !=(System.Runtime.InteropServices.ArrayWithOffset a, System.Runtime.InteropServices.ArrayWithOffset b) { throw null; }
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Interface, Inherited=false)]
     public sealed partial class AutomationProxyAttribute : System.Attribute
     {
         public AutomationProxyAttribute(bool val) { }
         public bool Value { get { throw null; } }
     }
+#endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.Struct, Inherited=false)]
     public sealed partial class BestFitMappingAttribute : System.Attribute
     {
@@ -180,6 +184,7 @@ namespace System.Runtime.InteropServices
         public static ref TValue GetValueRefOrNullRef<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key) where TKey : notnull { throw null; }
         public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, out bool exists) where TKey : notnull { throw null; }
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited=false)]
     public sealed partial class ComAliasNameAttribute : System.Attribute
     {
@@ -223,6 +228,7 @@ namespace System.Runtime.InteropServices
     {
         public ComConversionLossAttribute() { }
     }
+#endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited=false)]
     public sealed partial class ComDefaultInterfaceAttribute : System.Attribute
     {
@@ -273,11 +279,13 @@ namespace System.Runtime.InteropServices
         PropGet = 1,
         PropSet = 2,
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false)]
     public sealed partial class ComRegisterFunctionAttribute : System.Attribute
     {
         public ComRegisterFunctionAttribute() { }
     }
+#endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited=true)]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class ComSourceInterfacesAttribute : System.Attribute
@@ -289,11 +297,13 @@ namespace System.Runtime.InteropServices
         public ComSourceInterfacesAttribute(System.Type sourceInterface1, System.Type sourceInterface2, System.Type sourceInterface3, System.Type sourceInterface4) { }
         public string Value { get { throw null; } }
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false)]
     public sealed partial class ComUnregisterFunctionAttribute : System.Attribute
     {
         public ComUnregisterFunctionAttribute() { }
     }
+#endif
     [System.CLSCompliantAttribute(false)]
     public readonly partial struct CULong : System.IEquatable<System.Runtime.InteropServices.CULong>
     {
@@ -403,6 +413,7 @@ namespace System.Runtime.InteropServices
         public GuidAttribute(string guid) { }
         public string Value { get { throw null; } }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public sealed partial class HandleCollector
     {
         public HandleCollector(string? name, int initialThreshold) { }
@@ -414,6 +425,7 @@ namespace System.Runtime.InteropServices
         public void Add() { }
         public void Remove() { }
     }
+#endif
     public readonly partial struct HandleRef
     {
         private readonly object _dummy;
@@ -451,12 +463,14 @@ namespace System.Runtime.InteropServices
         bool IsInterfaceImplemented(System.RuntimeTypeHandle interfaceType, bool throwIfNotImplemented);
         System.RuntimeTypeHandle GetInterfaceImplementation(System.RuntimeTypeHandle interfaceType);
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, Inherited=false)]
     public sealed partial class ImportedFromTypeLibAttribute : System.Attribute
     {
         public ImportedFromTypeLibAttribute(string tlbFile) { }
         public string Value { get { throw null; } }
     }
+#endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Interface, Inherited=false)]
     public sealed partial class InterfaceTypeAttribute : System.Attribute
     {
@@ -484,6 +498,7 @@ namespace System.Runtime.InteropServices
         public LCIDConversionAttribute(int lcid) { }
         public int Value { get { throw null; } }
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false, AllowMultiple=false)]
     public sealed partial class ManagedToNativeComInteropStubAttribute : System.Attribute
     {
@@ -491,6 +506,7 @@ namespace System.Runtime.InteropServices
         public System.Type ClassType { get { throw null; } }
         public string MethodName { get { throw null; } }
     }
+#endif
     public static partial class Marshal
     {
         public static readonly int SystemDefaultCharSize;
@@ -934,6 +950,7 @@ namespace System.Runtime.InteropServices
     {
         public PreserveSigAttribute() { }
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, Inherited=false, AllowMultiple=true)]
     public sealed partial class PrimaryInteropAssemblyAttribute : System.Attribute
     {
@@ -941,12 +958,14 @@ namespace System.Runtime.InteropServices
         public int MajorVersion { get { throw null; } }
         public int MinorVersion { get { throw null; } }
     }
+#endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited=false)]
     public sealed partial class ProgIdAttribute : System.Attribute
     {
         public ProgIdAttribute(string progId) { }
         public string Value { get { throw null; } }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public static partial class RuntimeEnvironment
     {
         [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are not supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
@@ -959,6 +978,7 @@ namespace System.Runtime.InteropServices
         public static object GetRuntimeInterfaceAsObject(System.Guid clsid, System.Guid riid) { throw null; }
         public static string GetSystemVersion() { throw null; }
     }
+#endif
     public partial class SafeArrayRankMismatchException : System.SystemException
     {
         public SafeArrayRankMismatchException() { }
@@ -993,6 +1013,7 @@ namespace System.Runtime.InteropServices
         public string? Identifier { get { throw null; } }
         public string? Scope { get { throw null; } }
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false)]
     public sealed partial class TypeLibFuncAttribute : System.Attribute
     {
@@ -1079,6 +1100,7 @@ namespace System.Runtime.InteropServices
         public int MajorVersion { get { throw null; } }
         public int MinorVersion { get { throw null; } }
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class UnknownWrapper
     {
@@ -1204,6 +1226,7 @@ namespace System.Runtime.InteropServices
         public VariantWrapper(object? obj) { }
         public object? WrappedObject { get { throw null; } }
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.FlagsAttribute]
     public enum CreateComInterfaceFlags
     {
@@ -1262,9 +1285,11 @@ namespace System.Runtime.InteropServices
         public System.Type[]? CallConvs;
         public string? EntryPoint;
     }
+#endif
 }
 namespace System.Runtime.InteropServices.ComTypes
 {
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.FlagsAttribute]
     public enum ADVF
@@ -1277,6 +1302,7 @@ namespace System.Runtime.InteropServices.ComTypes
         ADVFCACHE_ONSAVE = 32,
         ADVF_DATAONSTOP = 64,
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Explicit)]
     public partial struct BINDPTR
@@ -1318,12 +1344,14 @@ namespace System.Runtime.InteropServices.ComTypes
         public int dwCookie;
         public object pUnk;
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public enum DATADIR
     {
         DATADIR_GET = 1,
         DATADIR_SET = 2,
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public enum DESCKIND
     {
@@ -1343,6 +1371,7 @@ namespace System.Runtime.InteropServices.ComTypes
         public System.IntPtr rgdispidNamedArgs;
         public System.IntPtr rgvarg;
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.FlagsAttribute]
     public enum DVASPECT
@@ -1352,6 +1381,7 @@ namespace System.Runtime.InteropServices.ComTypes
         DVASPECT_ICON = 4,
         DVASPECT_DOCPRINT = 8,
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ELEMDESC
@@ -1388,6 +1418,7 @@ namespace System.Runtime.InteropServices.ComTypes
         public int dwHighDateTime;
         public int dwLowDateTime;
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct FORMATETC
@@ -1398,6 +1429,7 @@ namespace System.Runtime.InteropServices.ComTypes
         public System.IntPtr ptd;
         public System.Runtime.InteropServices.ComTypes.TYMED tymed;
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct FUNCDESC
@@ -1442,6 +1474,7 @@ namespace System.Runtime.InteropServices.ComTypes
         FUNC_STATIC = 3,
         FUNC_DISPATCH = 4,
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IAdviseSink
@@ -1452,6 +1485,7 @@ namespace System.Runtime.InteropServices.ComTypes
         void OnSave();
         void OnViewChange(int aspect, int index);
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IBindCtx
@@ -1484,6 +1518,7 @@ namespace System.Runtime.InteropServices.ComTypes
         void EnumConnectionPoints(out System.Runtime.InteropServices.ComTypes.IEnumConnectionPoints ppEnum);
         void FindConnectionPoint(ref System.Guid riid, out System.Runtime.InteropServices.ComTypes.IConnectionPoint? ppCP);
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IDataObject
     {
@@ -1497,6 +1532,7 @@ namespace System.Runtime.InteropServices.ComTypes
         int QueryGetData(ref System.Runtime.InteropServices.ComTypes.FORMATETC format);
         void SetData(ref System.Runtime.InteropServices.ComTypes.FORMATETC formatIn, ref System.Runtime.InteropServices.ComTypes.STGMEDIUM medium, bool release);
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct IDLDESC
@@ -1532,6 +1568,7 @@ namespace System.Runtime.InteropServices.ComTypes
         void Reset();
         int Skip(int celt);
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IEnumFORMATETC
@@ -1541,6 +1578,7 @@ namespace System.Runtime.InteropServices.ComTypes
         int Reset();
         int Skip(int celt);
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IEnumMoniker
@@ -1550,6 +1588,7 @@ namespace System.Runtime.InteropServices.ComTypes
         void Reset();
         int Skip(int celt);
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IEnumSTATDATA
     {
@@ -1558,6 +1597,7 @@ namespace System.Runtime.InteropServices.ComTypes
         int Reset();
         int Skip(int celt);
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.InterfaceTypeAttribute(System.Runtime.InteropServices.ComInterfaceType.InterfaceIsIUnknown)]
     public partial interface IEnumString
@@ -1791,6 +1831,7 @@ namespace System.Runtime.InteropServices.ComTypes
         PARAMFLAG_FHASDEFAULT = (short)32,
         PARAMFLAG_FHASCUSTDATA = (short)64,
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct STATDATA
@@ -1800,6 +1841,7 @@ namespace System.Runtime.InteropServices.ComTypes
         public int connection;
         public System.Runtime.InteropServices.ComTypes.FORMATETC formatetc;
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct STATSTG
@@ -1816,6 +1858,7 @@ namespace System.Runtime.InteropServices.ComTypes
         public int reserved;
         public int type;
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct STGMEDIUM
@@ -1824,6 +1867,7 @@ namespace System.Runtime.InteropServices.ComTypes
         public System.Runtime.InteropServices.ComTypes.TYMED tymed;
         public System.IntPtr unionmember;
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public enum SYSKIND
     {
@@ -1832,6 +1876,7 @@ namespace System.Runtime.InteropServices.ComTypes
         SYS_MAC = 2,
         SYS_WIN64 = 3,
     }
+#if !BUILDING_CORELIB_REFERENCE
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.FlagsAttribute]
     public enum TYMED
@@ -1845,6 +1890,7 @@ namespace System.Runtime.InteropServices.ComTypes
         TYMED_MFPICT = 32,
         TYMED_ENHMF = 64,
     }
+#endif
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct TYPEATTR
@@ -2021,6 +2067,7 @@ namespace System.Security
         public void RemoveAt(int index) { }
         public void SetAt(int index, char c) { }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public static partial class SecureStringMarshal
     {
         public static System.IntPtr SecureStringToCoTaskMemAnsi(System.Security.SecureString s) { throw null; }
@@ -2028,4 +2075,5 @@ namespace System.Security
         public static System.IntPtr SecureStringToGlobalAllocAnsi(System.Security.SecureString s) { throw null; }
         public static System.IntPtr SecureStringToGlobalAllocUnicode(System.Security.SecureString s) { throw null; }
     }
+#endif
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2861,10 +2861,12 @@ namespace System
         public FieldAccessException(string? message) { }
         public FieldAccessException(string? message, System.Exception? inner) { }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class FileStyleUriParser : System.UriParser
     {
         public FileStyleUriParser() { }
     }
+#endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Enum, Inherited=false)]
     public partial class FlagsAttribute : System.Attribute
     {
@@ -2890,10 +2892,12 @@ namespace System
         public override string ToString() { throw null; }
         public abstract string ToString(System.IFormatProvider? formatProvider);
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class FtpStyleUriParser : System.UriParser
     {
         public FtpStyleUriParser() { }
     }
+#endif
     public delegate TResult Func<out TResult>();
     public delegate TResult Func<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, out TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9);
     public delegate TResult Func<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, out TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10);
@@ -2996,6 +3000,7 @@ namespace System
         Timeout = 3,
         NotApplicable = 4,
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class GenericUriParser : System.UriParser
     {
         public GenericUriParser(System.GenericUriParserOptions options) { }
@@ -3020,6 +3025,7 @@ namespace System
     {
         public GopherStyleUriParser() { }
     }
+#endif
     public readonly partial struct Guid : System.IComparable, System.IComparable<System.Guid>, System.IEquatable<System.Guid>, System.ISpanFormattable
 #if FEATURE_GENERIC_MATH
 #pragma warning disable SA1001
@@ -3386,10 +3392,12 @@ namespace System
         public override int GetHashCode() { throw null; }
         public int ToHashCode() { throw null; }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class HttpStyleUriParser : System.UriParser
     {
         public HttpStyleUriParser() { }
     }
+#endif
 #if FEATURE_GENERIC_MATH
     [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IAdditionOperators<TSelf, TOther, TResult>
@@ -4516,10 +4524,12 @@ namespace System
         public Lazy(TMetadata metadata, System.Threading.LazyThreadSafetyMode mode) { }
         public TMetadata Metadata { get { throw null; } }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class LdapStyleUriParser : System.UriParser
     {
         public LdapStyleUriParser() { }
     }
+#endif
     public enum LoaderOptimization
     {
         NotSpecified = 0,
@@ -4878,6 +4888,7 @@ namespace System
         public MulticastNotSupportedException(string? message) { }
         public MulticastNotSupportedException(string? message, System.Exception? inner) { }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class NetPipeStyleUriParser : System.UriParser
     {
         public NetPipeStyleUriParser() { }
@@ -4890,6 +4901,7 @@ namespace System
     {
         public NewsStyleUriParser() { }
     }
+#endif
     [System.AttributeUsageAttribute(System.AttributeTargets.Field, Inherited=false)]
     public sealed partial class NonSerializedAttribute : System.Attribute
     {
@@ -7693,6 +7705,7 @@ namespace System
         public bool IsTerminating { get { throw null; } }
     }
     public delegate void UnhandledExceptionEventHandler(object sender, System.UnhandledExceptionEventArgs e);
+#if !BUILDING_CORELIB_REFERENCE
     public partial class Uri : System.Runtime.Serialization.ISerializable
     {
         public static readonly string SchemeDelimiter;
@@ -7896,6 +7909,7 @@ namespace System
         Path = 2,
         Query = 3,
     }
+#endif
     public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {
         object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }

--- a/src/libraries/System.Runtime/src/System.Runtime.csproj
+++ b/src/libraries/System.Runtime/src/System.Runtime.csproj
@@ -15,6 +15,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CoreLibProject)" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Private.Uri\src\System.Private.Uri.csproj" />
+    <ProjectReference Include="$(UriProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading/ref/System.Threading.cs
+++ b/src/libraries/System.Threading/ref/System.Threading.cs
@@ -50,6 +50,7 @@ namespace System.Threading
     {
         public AutoResetEvent(bool initialState) : base (default(bool), default(System.Threading.EventResetMode)) { }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class Barrier : System.IDisposable
     {
         public Barrier(int participantCount) { }
@@ -86,7 +87,9 @@ namespace System.Threading
         public BarrierPostPhaseException(string? message) { }
         public BarrierPostPhaseException(string? message, System.Exception? innerException) { }
     }
+#endif
     public delegate void ContextCallback(object? state);
+#if !BUILDING_CORELIB_REFERENCE
     public partial class CountdownEvent : System.IDisposable
     {
         public CountdownEvent(int initialCount) { }
@@ -117,6 +120,7 @@ namespace System.Threading
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public bool Wait(System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
+#endif
     public enum EventResetMode
     {
         AutoReset = 0,
@@ -147,6 +151,7 @@ namespace System.Threading
         public static void Run(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object? state) { }
         public static System.Threading.AsyncFlowControl SuppressFlow() { throw null; }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial class HostExecutionContext : System.IDisposable
     {
         public HostExecutionContext() { }
@@ -163,6 +168,7 @@ namespace System.Threading
         public virtual void Revert(object previousState) { }
         public virtual object SetHostExecutionContext(System.Threading.HostExecutionContext hostExecutionContext) { throw null; }
     }
+#endif
     public static partial class Interlocked
     {
         public static int Add(ref int location1, int value) { throw null; }
@@ -235,6 +241,7 @@ namespace System.Threading
         public static T EnsureInitialized<T>([System.Diagnostics.CodeAnalysis.NotNullAttribute] ref T? target, System.Func<T> valueFactory) where T : class { throw null; }
         public static T EnsureInitialized<T>([System.Diagnostics.CodeAnalysis.NotNullAttribute] ref T? target, [System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("syncLock")] ref object? syncLock, System.Func<T> valueFactory) where T : class { throw null; }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public partial struct LockCookie
     {
         private int _dummyPrimitive;
@@ -244,6 +251,7 @@ namespace System.Threading
         public static bool operator ==(System.Threading.LockCookie a, System.Threading.LockCookie b) { throw null; }
         public static bool operator !=(System.Threading.LockCookie a, System.Threading.LockCookie b) { throw null; }
     }
+#endif
     public partial class LockRecursionException : System.Exception
     {
         public LockRecursionException() { }
@@ -321,6 +329,7 @@ namespace System.Threading
         public void ReleaseMutex() { }
         public static bool TryOpenExisting(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Threading.Mutex? result) { throw null; }
     }
+#if !BUILDING_CORELIB_REFERENCE
     public sealed partial class ReaderWriterLock : System.Runtime.ConstrainedExecution.CriticalFinalizerObject
     {
         public ReaderWriterLock() { }
@@ -345,6 +354,7 @@ namespace System.Threading
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public System.Threading.LockCookie UpgradeToWriterLock(System.TimeSpan timeout) { throw null; }
     }
+#endif
     public partial class ReaderWriterLockSlim : System.IDisposable
     {
         public ReaderWriterLockSlim() { }

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -347,4 +347,10 @@
     </ItemGroup>
   </Target>
 
+  <!-- Import refererence assembly logic -->
+  <PropertyGroup>
+    <IsSourceProject>true</IsSourceProject>
+  </PropertyGroup>
+  <Import Project="$(RepositoryEngineeringDir)resolveContract.targets" />
+
 </Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/72143 to release/6.0

We now compile against the reference assembly in all places where we were compiling against the mono/coreclr System.Private.CoreLib.dll implementation assembly before.

The new reference assembly consumes sources from the existing contracts to avoid checking in a generated version of SPC.dll (this would add ~20k lines of .cs which is mostly duplicated with System.Runtime.cs)

Since a few contracts have only partially moved types to SPC we wrap contract types with `#if !BUILDING_CORELIB_REFERENCE` so we can hide them when compiling the SPC reference assembly.

**NOTE:** to simplify the change for the 6.0 backport this does not include the GenAPI et.al. changes for regenerating the reference assembly sources since we won't be adding new APIs in 6.0.

## Customer Impact

Fixes an issue where Xamarin.Android puts duplicate assemblies into the .apk because the MVID-based deduplication logic didn't work anymore due to an ILLinker fix which increased the app size a lot. This is necessary for 6.0 because the 7.0 SDK includes a new ILLinker which is used even when building a 6.0 app.

## Risk

Low, it is a build-related change that should be transparent outside of dotnet/runtime.

## Testing

Manual testing confirmed it fixes the issue.

