### PR TITLE
Use LastIndexOf{Any} in Path.GetFileName

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -240,13 +240,11 @@ namespace System.IO
             // We don't want to cut off "C:\file.txt:stream" (i.e. should be "file.txt:stream")
             // but we *do* want "C:Foo" => "Foo". This necessitates checking for the root.
 
-            for (int i = path.Length; --i >= 0;)
-            {
-                if (i < root || PathInternal.IsDirectorySeparator(path[i]))
-                    return path.Slice(i + 1);
-            }
+            int i = PathInternal.DirectorySeparatorChar == PathInternal.AltDirectorySeparatorChar ?
+                path.LastIndexOf(PathInternal.DirectorySeparatorChar) :
+                path.LastIndexOfAny(PathInternal.DirectorySeparatorChar, PathInternal.AltDirectorySeparatorChar);
 
-            return path;
+            return path.Slice(i < root ? root : i + 1);
         }
 
         [return: NotNullIfNotNull(nameof(path))]


### PR DESCRIPTION
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.IO;

[HideColumns("Error", "StdDev", "Median", "RatioSD")]
public partial class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    [Benchmark]
    [Arguments(@"C:\test.txt")]
    [Arguments(@"C:\Users\stoub\Desktop\Benchmarks\Program.cs")]
    [Arguments(@"D:\repos\runtime\src\libraries\System.Private.CoreLib\src\System\IO\MemoryStream.cs")]
    public ReadOnlySpan<char> GetFileName(string path) => Path.GetFileName(path.AsSpan());
}
```

|      Method |        Job |         Toolchain |                 path |     Mean | Ratio |
|------------ |----------- |------------------ |--------------------- |---------:|------:|
| GetFileName | Job-ZOQARC | \main\corerun.exe | C:\Us(...)am.cs [44] | 16.41 ns |  1.00 |
| GetFileName | Job-UTQVEC |   \pr\corerun.exe | C:\Us(...)am.cs [44] | 12.22 ns |  0.74 |
|             |            |                   |                      |          |       |
| GetFileName | Job-ZOQARC | \main\corerun.exe |          C:\test.txt | 14.39 ns |  1.00 |
| GetFileName | Job-UTQVEC |   \pr\corerun.exe |          C:\test.txt | 12.00 ns |  0.83 |
|             |            |                   |                      |          |       |
| GetFileName | Job-ZOQARC | \main\corerun.exe | D:\re(...)am.cs [83] | 20.40 ns |  1.00 |
| GetFileName | Job-UTQVEC |   \pr\corerun.exe | D:\re(...)am.cs [83] | 12.27 ns |  0.60 |