### PR TITLE
JIT: propagate some block assertions after expansion

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -19,7 +19,8 @@ protected:
     virtual void TrySpecialCases();
     virtual void MorphStructCases();
 
-    void PropagateAssertions();
+    void PropagateBlockAssertions();
+    void PropagateExpansionAssertions();
 
     virtual const char* GetHelperName() const
     {
@@ -127,7 +128,7 @@ GenTree* MorphInitBlockHelper::Morph()
 
     PrepareDst();
     PrepareSrc();
-    PropagateAssertions();
+    PropagateBlockAssertions();
     TrySpecialCases();
 
     if (m_transformationDecision == BlockTransformation::Undefined)
@@ -149,6 +150,8 @@ GenTree* MorphInitBlockHelper::Morph()
             MorphStructCases();
         }
     }
+
+    PropagateExpansionAssertions();
 
     assert(m_transformationDecision != BlockTransformation::Undefined);
     assert(m_result != nullptr);
@@ -278,7 +281,7 @@ void MorphInitBlockHelper::PrepareDst()
 }
 
 //------------------------------------------------------------------------
-// PropagateAssertions: propagate assertions based on the original tree
+// PropagateBlockAssertions: propagate assertions based on the original tree
 //
 // Notes:
 //    Once the init or copy tree is morphed, assertion gen can no
@@ -286,9 +289,27 @@ void MorphInitBlockHelper::PrepareDst()
 //
 //    So we generate assertions based on the original tree.
 //
-void MorphInitBlockHelper::PropagateAssertions()
+void MorphInitBlockHelper::PropagateBlockAssertions()
 {
     if (m_comp->optLocalAssertionProp)
+    {
+        m_comp->optAssertionGen(m_asg);
+    }
+}
+
+//------------------------------------------------------------------------
+// PropagateExpansionAssertions: propagate assertions based on the
+//   expanded tree
+//
+// Notes:
+//    After the copy/init is expanded, we may see additional expansions
+//    to generate.
+//
+void MorphInitBlockHelper::PropagateExpansionAssertions()
+{
+    // Consider doing this for FieldByField as well
+    //
+    if (m_comp->optLocalAssertionProp && (m_transformationDecision == BlockTransformation::OneAsgBlock))
     {
         m_comp->optAssertionGen(m_asg);
     }


### PR DESCRIPTION
In #74384 I modified morph to generate assertions before a block op was morphed, but after the source and dest were morphed. This misses generating some assertions that arise once the expanded form is known.

We now re-run assertion gen on the expanded tree, when we do an `OneAsgBlock` expansion. Other cases my also prove profitable.

Closes #75229.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=9798&view=ms.vss-build-web.run-extensions-tab)