### PR TITLE
[release/7.0] Unload MsQuic after checking for QUIC support to free resources (#75163)

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -39,9 +39,13 @@ jobs:
     # Linux arm64
     - ${{ if eq(parameters.platform, 'Linux_arm64') }}:
       - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.2204.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8-20220504035342-1b9461f
+        - (Ubuntu.2204.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8-20220906173536-06f234f
       - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220427172132-97d8652
+        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220906173506-06f234f
+      - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
+        - (Debian.10.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-arm64v8-20220906200500-06f234f
+      - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
+        - (Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20220906200540-06f234f
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'Linux_musl_x64') }}:

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Quic;
@@ -47,7 +48,8 @@ internal sealed unsafe partial class MsQuicApi
         }
     }
 
-    internal static MsQuicApi Api { get; } = null!;
+    private static readonly Lazy<MsQuicApi> _api = new Lazy<MsQuicApi>(AllocateMsQuicApi);
+    internal static MsQuicApi Api => _api.Value;
 
     internal static bool IsQuicSupported { get; }
 
@@ -58,29 +60,21 @@ internal sealed unsafe partial class MsQuicApi
 
     static MsQuicApi()
     {
-        IntPtr msQuicHandle;
-        if (!NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) &&
-            !NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
+        if (!TryLoadMsQuic(out IntPtr msQuicHandle))
         {
             return;
         }
 
         try
         {
-            if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
-            {
-                return;
-            }
-
-            QUIC_API_TABLE* apiTable = null;
-            delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> msQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)msQuicOpenVersionAddress;
-            if (StatusFailed(msQuicOpenVersion((uint)MsQuicVersion.Major, &apiTable)))
+            if (!TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable, out _))
             {
                 return;
             }
 
             try
             {
+                // Check version
                 int arraySize = 4;
                 uint* libVersion = stackalloc uint[arraySize];
                 uint size = (uint)arraySize * sizeof(uint);
@@ -99,7 +93,7 @@ internal sealed unsafe partial class MsQuicApi
                     return;
                 }
 
-                // Assume SChannel is being used on windows and query for the actual provider from the library
+                // Assume SChannel is being used on windows and query for the actual provider from the library if querying is supported
                 QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
                 size = sizeof(QUIC_TLS_PROVIDER);
                 apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
@@ -122,26 +116,84 @@ internal sealed unsafe partial class MsQuicApi
                     Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
                 }
 
-                Api = new MsQuicApi(apiTable);
                 IsQuicSupported = true;
             }
             finally
             {
-                if (!IsQuicSupported && NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
-                {
-                    // Gracefully close the API table
-                    ((delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)msQuicClose)(apiTable);
-                }
+                // Gracefully close the API table to free resources. The API table will be allocated lazily again if needed
+                bool closed = TryCloseMsQuic(msQuicHandle, apiTable);
+                Debug.Assert(closed, "Failed to close MsQuic");
             }
-
         }
         finally
         {
-            if (!IsQuicSupported)
-            {
-                NativeLibrary.Free(msQuicHandle);
-            }
+            // Unload the library, we will load it again when we actually use QUIC
+            NativeLibrary.Free(msQuicHandle);
         }
+    }
+
+    private static MsQuicApi AllocateMsQuicApi()
+    {
+        Debug.Assert(IsQuicSupported);
+
+        int openStatus = MsQuic.QUIC_STATUS_INTERNAL_ERROR;
+
+        if (TryLoadMsQuic(out IntPtr msQuicHandle) &&
+            TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable, out openStatus))
+        {
+            return new MsQuicApi(apiTable);
+        }
+
+        ThrowHelper.ThrowIfMsQuicError(openStatus);
+
+        // this should unreachable as TryOpenMsQuic returns non-success status on failure
+        throw new Exception("Failed to create MsQuicApi instance");
+    }
+
+    private static bool TryLoadMsQuic(out IntPtr msQuicHandle) =>
+        NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) ||
+        NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
+
+    private static bool TryOpenMsQuic(IntPtr msQuicHandle, out QUIC_API_TABLE* apiTable, out int openStatus)
+    {
+        apiTable = null;
+        if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
+        {
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(null, "Failed to get MsQuicOpenVersion export in msquic library.");
+            }
+
+            openStatus = MsQuic.QUIC_STATUS_NOT_FOUND;
+            return false;
+        }
+
+        QUIC_API_TABLE* table = null;
+        delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> msQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)msQuicOpenVersionAddress;
+        openStatus = msQuicOpenVersion((uint)MsQuicVersion.Major, &table);
+        if (StatusFailed(openStatus))
+        {
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(null, $"MsQuicOpenVersion returned {openStatus} status code.");
+            }
+
+            return false;
+        }
+
+        apiTable = table;
+        return true;
+    }
+
+    private static bool TryCloseMsQuic(IntPtr msQuicHandle, QUIC_API_TABLE* apiTable)
+    {
+        if (NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
+        {
+            ((delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)msQuicClose)(apiTable);
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsWindowsVersionSupported() => OperatingSystem.IsWindowsVersionAtLeast(MinWindowsVersion.Major,


### PR DESCRIPTION
Manual backport of #75163
Fixes #74629

cc: @wfurt 

## Customer Impact

When using `HttpClient`, we also check whether the running platform supports QUIC (to enable HTTP/3). However, the way we are checking QUIC support causes many threads to be allocated in the native MsQuic library (2* number of logical cores). This causes unnecessary resource increase even if the process does not end up using HTTP/3 at all (HTTP/3 is opt-in). This would therefore cause regression in memory usage when upgrading to .NET 7 in such cases.

The change builds on fix in msquic -- therefore it includes also update of Docker images to version with the right msquic version (2.1.1).

Affected platforms include Windows 11, Windows Server 2022, many Linux platforms with msquic package installed. 

Note: The same problem exists also in 6.0 and we had 1 customer with ~50-core machine who noticed that and were surprised to see so many extra threads they didn't know about / they didn't need. At minimum it will help avoid confusion in such cases.

## Testing

Functional tests suite passes as part of the CI, resource consumption was checked manually.

## Risk

Low, the fix consists of gracefully unloading MsQuic library from the process after checking QUIC support. The library is reloaded only when actually needed.