### PR TITLE
Do no test StartTime in GetProcessesByName test

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1248,7 +1248,6 @@ namespace System.Diagnostics.Tests
 
                 Assert.All(processes, process => Assert.Equal(currentProcess.ProcessName, process.ProcessName));
                 Assert.All(processes, process => Assert.Equal(".", process.MachineName));
-                Assert.All(processes, process => Assert.Equal(currentProcess.StartTime, process.StartTime));
             }
 
             // Outputs a list of active processes in case of failure: https://github.com/dotnet/runtime/issues/28874


### PR DESCRIPTION
When there are multiple `dotnet` processes running, this assertion fails. Fix is to delete it.

Fix #75329