### PR TITLE
Fix WebSockets.Client.ConnectTest crash for apple mobile platforms

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -25,7 +25,14 @@ namespace System.Net.WebSockets.Client.Tests
             yield return NoThrow(options => options.UseDefaultCredentials = false);
             yield return Throw(options => options.Credentials = new NetworkCredential());
             yield return Throw(options => options.Proxy = new WebProxy());
-            yield return Throw(options => options.ClientCertificates.Add(Test.Common.Configuration.Certificates.GetClientCertificate()));
+
+            // Will result in an exception on apple mobile platforms
+            // and crash the test.
+            if (PlatformDetection.IsNotAppleMobile)
+            {
+                yield return Throw(options => options.ClientCertificates.Add(Test.Common.Configuration.Certificates.GetClientCertificate()));
+            }
+
             yield return NoThrow(options => options.ClientCertificates = new X509CertificateCollection());
             yield return Throw(options => options.RemoteCertificateValidationCallback = delegate { return true; });
             yield return Throw(options => options.Cookies = new CookieContainer());


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/74473 had a change where we started adding a client certificate that is not supported on apple mobile platforms. This lead to an unhandled exception in the MemberData setup of ConnectAsync_CustomInvokerWithIncompatibleWebSocketOptions_ThrowsArgumentException and resulted in an app crash.

Addresses https://github.com/dotnet/runtime/issues/75307