### PR TITLE
Fix prefix writing on TarHeaderWrite

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -374,12 +374,10 @@ namespace System.Formats.Tar
 
             if (_name.Length > FieldLengths.Name)
             {
-                int prefixBytesLength = Math.Min(_name.Length - FieldLengths.Name, FieldLengths.Name);
-                Span<byte> remaining = prefixBytesLength <= 256 ?
-                    stackalloc byte[prefixBytesLength] :
-                    new byte[prefixBytesLength];
-
-                int encoded = Encoding.ASCII.GetBytes(_name.AsSpan(FieldLengths.Name), remaining);
+                int prefixBytesLength = Math.Min(_name.Length - FieldLengths.Name, FieldLengths.Prefix);
+                Debug.Assert(prefixBytesLength <= 256);
+                Span<byte> remaining = stackalloc byte[prefixBytesLength];
+                int encoded = Encoding.ASCII.GetBytes(_name.AsSpan(FieldLengths.Name, prefixBytesLength), remaining);
                 Debug.Assert(encoded == remaining.Length);
 
                 checksum += WriteLeftAlignedBytesAndGetChecksum(remaining, buffer.Slice(FieldLocations.Prefix, FieldLengths.Prefix));

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -375,7 +375,6 @@ namespace System.Formats.Tar
             if (_name.Length > FieldLengths.Name)
             {
                 int prefixBytesLength = Math.Min(_name.Length - FieldLengths.Name, FieldLengths.Prefix);
-                Debug.Assert(prefixBytesLength <= 256);
                 Span<byte> remaining = stackalloc byte[prefixBytesLength];
                 int encoded = Encoding.ASCII.GetBytes(_name.AsSpan(FieldLengths.Name, prefixBytesLength), remaining);
                 Debug.Assert(encoded == remaining.Length);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
@@ -323,27 +323,28 @@ namespace System.Formats.Tar.Tests
         {
             Assert.Equal(255, maxPathComponent.Length);
 
-            var ms = new MemoryStream();
-            using (var writer = new TarWriter(ms, true))
+            TarEntry entry;
+            MemoryStream ms = new();
+            using (TarWriter writer = new(ms, true))
             {
                 TarEntryType entryType = format == TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile;
-                var entry1 = InvokeTarEntryCreationConstructor(format, entryType, maxPathComponent);
-                writer.WriteEntry(entry1);
+                entry = InvokeTarEntryCreationConstructor(format, entryType, maxPathComponent);
+                writer.WriteEntry(entry);
 
-                var entry2 = InvokeTarEntryCreationConstructor(format, entryType, Path.Join(maxPathComponent, maxPathComponent));
-                writer.WriteEntry(entry2);
+                entry = InvokeTarEntryCreationConstructor(format, entryType, Path.Join(maxPathComponent, maxPathComponent));
+                writer.WriteEntry(entry);
             }
 
             ms.Position = 0;
-            using var reader = new TarReader(ms);
+            using TarReader reader = new(ms);
 
-            TarEntry readEntry = reader.GetNextEntry();
+            entry = reader.GetNextEntry();
             string expectedName = GetExpectedNameForFormat(format, maxPathComponent);
-            Assert.Equal(expectedName, readEntry.Name);
+            Assert.Equal(expectedName, entry.Name);
 
-            readEntry = reader.GetNextEntry();
+            entry = reader.GetNextEntry();
             expectedName = GetExpectedNameForFormat(format, Path.Join(maxPathComponent, maxPathComponent));
-            Assert.Equal(expectedName, readEntry.Name);
+            Assert.Equal(expectedName, entry.Name);
 
             Assert.Null(reader.GetNextEntry());
 

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
@@ -302,9 +302,7 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [InlineData(TarEntryFormat.V7)]
-        // On reading, ustar just combines prefix(155) + '/' + name(100), which may be wrong but that's how it currently is.
-        // On writing, it writes the first 100 chars of entryName on name and the next 155 on prefix, so it is flipping the name+prefix on reading.
-        //[InlineData(TarEntryFormat.Ustar)]
+        // [InlineData(TarEntryFormat.Ustar)] https://github.com/dotnet/runtime/issues/75360
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
         public void WriteLongName(TarEntryFormat format)


### PR DESCRIPTION
This PR takes the fix from https://github.com/dotnet/runtime/pull/75023 but add tests that don't use the tar tool which is currently hard to get right on all CI configurations.