### PR TITLE
Manually backporting #74599 to 7.0 for RC2.

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
@@ -1350,14 +1350,14 @@ namespace System.Xml
 
         public override int ReadArray(string localName, string namespaceUri, float[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
         public override int ReadArray(XmlDictionaryString localName, XmlDictionaryString namespaceUri, float[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
@@ -1373,14 +1373,14 @@ namespace System.Xml
 
         public override int ReadArray(string localName, string namespaceUri, double[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
         public override int ReadArray(XmlDictionaryString localName, XmlDictionaryString namespaceUri, double[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
@@ -1396,14 +1396,14 @@ namespace System.Xml
 
         public override int ReadArray(string localName, string namespaceUri, decimal[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }
 
         public override int ReadArray(XmlDictionaryString localName, XmlDictionaryString namespaceUri, decimal[] array, int offset, int count)
         {
-            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement))
+            if (IsStartArray(localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement) && BitConverter.IsLittleEndian)
                 return ReadArray(array, offset, count);
             return base.ReadArray(localName, namespaceUri, array, offset, count);
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -758,7 +758,7 @@ namespace System.Xml
             {
                 int offset;
                 byte[] buffer = GetTextNodeBuffer(1 + sizeof(float), out offset);
-                buffer[offset + 0] = (byte)XmlBinaryNodeType.FloatText;
+                buffer[offset] = (byte)XmlBinaryNodeType.FloatText;
                 BinaryPrimitives.WriteSingleLittleEndian(buffer.AsSpan(offset + 1, sizeof(float)), f);
                 Advance(1 + sizeof(float));
             }
@@ -775,7 +775,7 @@ namespace System.Xml
             {
                 int offset;
                 byte[] buffer = GetTextNodeBuffer(1 + sizeof(double), out offset);
-                buffer[offset + 0] = (byte)XmlBinaryNodeType.DoubleText;
+                buffer[offset] = (byte)XmlBinaryNodeType.DoubleText;
                 BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan(offset + 1, sizeof(double)), d);
                 Advance(1 + sizeof(double));
             }
@@ -1015,6 +1015,7 @@ namespace System.Xml
                 }
             }
         }
+
         public void WriteDateTimeArray(DateTime[] array, int offset, int count)
         {
             WriteArrayInfo(XmlBinaryNodeType.DateTimeTextWithEndElement, count);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Runtime.Serialization;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Buffers.Binary;
 
 namespace System.Xml
 {
@@ -757,12 +758,8 @@ namespace System.Xml
             {
                 int offset;
                 byte[] buffer = GetTextNodeBuffer(1 + sizeof(float), out offset);
-                byte* bytes = (byte*)&f;
                 buffer[offset + 0] = (byte)XmlBinaryNodeType.FloatText;
-                buffer[offset + 1] = bytes[0];
-                buffer[offset + 2] = bytes[1];
-                buffer[offset + 3] = bytes[2];
-                buffer[offset + 4] = bytes[3];
+                BinaryPrimitives.WriteSingleLittleEndian(buffer.AsSpan(offset + 1, sizeof(float)), f);
                 Advance(1 + sizeof(float));
             }
         }
@@ -778,16 +775,8 @@ namespace System.Xml
             {
                 int offset;
                 byte[] buffer = GetTextNodeBuffer(1 + sizeof(double), out offset);
-                byte* bytes = (byte*)&d;
                 buffer[offset + 0] = (byte)XmlBinaryNodeType.DoubleText;
-                buffer[offset + 1] = bytes[0];
-                buffer[offset + 2] = bytes[1];
-                buffer[offset + 3] = bytes[2];
-                buffer[offset + 4] = bytes[3];
-                buffer[offset + 5] = bytes[4];
-                buffer[offset + 6] = bytes[5];
-                buffer[offset + 7] = bytes[6];
-                buffer[offset + 8] = bytes[7];
+                BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan(offset + 1, sizeof(double)), d);
                 Advance(1 + sizeof(double));
             }
         }
@@ -798,9 +787,24 @@ namespace System.Xml
             byte[] buffer = GetTextNodeBuffer(1 + sizeof(decimal), out offset);
             byte* bytes = (byte*)&d;
             buffer[offset++] = (byte)XmlBinaryNodeType.DecimalText;
-            for (int i = 0; i < sizeof(decimal); i++)
+            if (BitConverter.IsLittleEndian)
             {
-                buffer[offset++] = bytes[i];
+                for (int i = 0; i < sizeof(decimal); i++)
+                {
+                    buffer[offset++] = bytes[i];
+                }
+            }
+            else
+            {
+                Span<int> bits = stackalloc int[4];
+                decimal.TryGetBits(d, bits, out int intsWritten);
+                Debug.Assert(intsWritten == 4);
+
+                Span<byte> span = buffer.AsSpan(offset, sizeof(decimal));
+                BinaryPrimitives.WriteInt32LittleEndian(span, bits[3]);
+                BinaryPrimitives.WriteInt32LittleEndian(span.Slice(4), bits[2]);
+                BinaryPrimitives.WriteInt32LittleEndian(span.Slice(8), bits[0]);
+                BinaryPrimitives.WriteInt32LittleEndian(span.Slice(12), bits[1]);
             }
             Advance(1 + sizeof(decimal));
         }
@@ -870,17 +874,147 @@ namespace System.Xml
             WriteMultiByteInt32(count);
         }
 
-        public unsafe void UnsafeWriteArray(XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
+        public unsafe void UnsafeWriteBoolArray(bool[] array, int offset, int count)
         {
-            WriteArrayInfo(nodeType, count);
-            UnsafeWriteArray(array, (int)(arrayMax - array));
+            WriteArrayInfo(XmlBinaryNodeType.BoolTextWithEndElement, count);
+            fixed (bool* items = &array[offset])
+            {
+                base.UnsafeWriteBytes((byte*)items, count);
+            }
         }
 
-        private unsafe void UnsafeWriteArray(byte* array, int byteCount)
+        public unsafe void UnsafeWriteInt16Array(short[] array, int offset, int count)
         {
-            base.UnsafeWriteBytes(array, byteCount);
+            WriteArrayInfo(XmlBinaryNodeType.Int16TextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (short* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, sizeof(short) * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(sizeof(short), out int bufferOffset).AsSpan(bufferOffset, sizeof(short));
+                    BinaryPrimitives.WriteInt16LittleEndian(span, array[offset + i]);
+                    Advance(sizeof(short));
+                }
+            }
         }
 
+        public unsafe void UnsafeWriteInt32Array(int[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.Int32TextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (int* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, sizeof(int) * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(sizeof(int), out int bufferOffset).AsSpan(bufferOffset, sizeof(int));
+                    BinaryPrimitives.WriteInt32LittleEndian(span, array[offset + i]);
+                    Advance(sizeof(int));
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteInt64Array(long[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.Int64TextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (long* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, sizeof(long) * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(sizeof(long), out int bufferOffset).AsSpan(bufferOffset, sizeof(long));
+                    BinaryPrimitives.WriteInt64LittleEndian(span, array[offset + i]);
+                    Advance(sizeof(long));
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteFloatArray(float[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.FloatTextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (float* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, sizeof(float) * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(sizeof(float), out int bufferOffset).AsSpan(bufferOffset, sizeof(float));
+                    BinaryPrimitives.WriteSingleLittleEndian(span, array[offset + i]);
+                    Advance(sizeof(float));
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteDoubleArray(double[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.DoubleTextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (double* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, sizeof(double) * count);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    Span<byte> span = GetBuffer(sizeof(double), out int bufferOffset).AsSpan(bufferOffset, sizeof(double));
+                    BinaryPrimitives.WriteDoubleLittleEndian(span, array[offset + i]);
+                    Advance(sizeof(double));
+                }
+            }
+        }
+
+        public unsafe void UnsafeWriteDecimalArray(decimal[] array, int offset, int count)
+        {
+            WriteArrayInfo(XmlBinaryNodeType.DecimalTextWithEndElement, count);
+            if (BitConverter.IsLittleEndian)
+            {
+                fixed (decimal* items = &array[offset])
+                {
+                    base.UnsafeWriteBytes((byte*)items, sizeof(decimal) * count);
+                }
+            }
+            else
+            {
+                Span<int> bits = stackalloc int[4];
+                for (int i = 0; i < count; i++)
+                {
+                    decimal.TryGetBits(array[offset + i], bits, out int intsWritten);
+                    Debug.Assert(intsWritten == 4);
+
+                    Span<byte> span = GetBuffer(16, out int bufferOffset).AsSpan(bufferOffset, 16);
+                    BinaryPrimitives.WriteInt32LittleEndian(span, bits[3]);
+                    BinaryPrimitives.WriteInt32LittleEndian(span.Slice(4), bits[2]);
+                    BinaryPrimitives.WriteInt32LittleEndian(span.Slice(8), bits[0]);
+                    BinaryPrimitives.WriteInt32LittleEndian(span.Slice(12), bits[1]);
+                    Advance(16);
+                }
+            }
+        }
         public void WriteDateTimeArray(DateTime[] array, int offset, int count)
         {
             WriteArrayInfo(XmlBinaryNodeType.DateTimeTextWithEndElement, count);
@@ -1160,20 +1294,6 @@ namespace System.Xml
             WriteEndElement();
         }
 
-        private unsafe void UnsafeWriteArray(string? prefix, string localName, string? namespaceUri,
-                               XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
-        {
-            WriteStartArray(prefix, localName, namespaceUri, count);
-            _writer.UnsafeWriteArray(nodeType, count, array, arrayMax);
-        }
-
-        private unsafe void UnsafeWriteArray(string? prefix, XmlDictionaryString localName, XmlDictionaryString? namespaceUri,
-                               XmlBinaryNodeType nodeType, int count, byte* array, byte* arrayMax)
-        {
-            WriteStartArray(prefix, localName, namespaceUri, count);
-            _writer.UnsafeWriteArray(nodeType, count, array, arrayMax);
-        }
-
         private static void CheckArray(Array array, int offset, int count)
         {
             ArgumentNullException.ThrowIfNull(array);
@@ -1199,10 +1319,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (bool* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.BoolTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteBoolArray(array, offset, count);
                 }
             }
         }
@@ -1218,10 +1336,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (bool* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.BoolTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteBoolArray(array, offset, count);
                 }
             }
         }
@@ -1237,10 +1353,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (short* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int16TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt16Array(array, offset, count);
                 }
             }
         }
@@ -1256,10 +1370,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (short* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int16TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt16Array(array, offset, count);
                 }
             }
         }
@@ -1275,10 +1387,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (int* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int32TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt32Array(array, offset, count);
                 }
             }
         }
@@ -1294,10 +1404,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (int* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int32TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt32Array(array, offset, count);
                 }
             }
         }
@@ -1313,10 +1421,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (long* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int64TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt64Array(array, offset, count);
                 }
             }
         }
@@ -1332,10 +1438,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (long* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.Int64TextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteInt64Array(array, offset, count);
                 }
             }
         }
@@ -1351,10 +1455,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (float* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteFloatArray(array, offset, count);
                 }
             }
         }
@@ -1370,10 +1472,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (float* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.FloatTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteFloatArray(array, offset, count);
                 }
             }
         }
@@ -1389,10 +1489,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (double* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteDoubleArray(array, offset, count);
                 }
             }
         }
@@ -1408,10 +1506,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (double* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.DoubleTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteDoubleArray(array, offset, count);
                 }
             }
         }
@@ -1427,10 +1523,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (decimal* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteDecimalArray(array, offset, count);
                 }
             }
         }
@@ -1446,10 +1540,8 @@ namespace System.Xml
                 CheckArray(array, offset, count);
                 if (count > 0)
                 {
-                    fixed (decimal* items = &array[offset])
-                    {
-                        UnsafeWriteArray(prefix, localName, namespaceUri, XmlBinaryNodeType.DecimalTextWithEndElement, count, (byte*)items, (byte*)&items[count]);
-                    }
+                    WriteStartArray(prefix, localName, namespaceUri, count);
+                    _writer.UnsafeWriteDecimalArray(array, offset, count);
                 }
             }
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -376,7 +376,7 @@ namespace System.Xml
             => BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(sizeof(float), out int offset).AsSpan(offset, sizeof(float)));
 
         public double ReadDouble()
-            => BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(sizeof(double), out int offset).AsSpan(offset, sizeof(double)));
+            => BinaryPrimitives.ReadDoubleLittleEndian(GetBuffer(sizeof(double), out int offset).AsSpan(offset, sizeof(double)));
 
         public decimal ReadDecimal()
         {
@@ -967,7 +967,7 @@ namespace System.Xml
             => BinaryPrimitives.ReadSingleLittleEndian(_buffer.AsSpan(offset, sizeof(float)));
 
         public double GetDouble(int offset)
-            => BinaryPrimitives.ReadSingleLittleEndian(_buffer.AsSpan(offset, sizeof(double)));
+            => BinaryPrimitives.ReadDoubleLittleEndian(_buffer.AsSpan(offset, sizeof(double)));
 
         public decimal GetDecimal(int offset)
         {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -373,10 +373,10 @@ namespace System.Xml
             => BitConverter.IsLittleEndian ? ReadRawBytes<long>() : BinaryPrimitives.ReverseEndianness(ReadRawBytes<long>());
 
         public float ReadSingle()
-            => ReadRawBytes<float>();
+            => BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(sizeof(float), out int offset).AsSpan(offset, sizeof(float)));
 
         public double ReadDouble()
-            => ReadRawBytes<double>();
+            => BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(sizeof(double), out int offset).AsSpan(offset, sizeof(double)));
 
         public decimal ReadDecimal()
         {
@@ -964,10 +964,10 @@ namespace System.Xml
             => (ulong)GetInt64(offset);
 
         public float GetSingle(int offset)
-            => ReadRawBytes<float>(offset);
+            => BinaryPrimitives.ReadSingleLittleEndian(_buffer.AsSpan(offset, sizeof(float)));
 
         public double GetDouble(int offset)
-            => ReadRawBytes<double>(offset);
+            => BinaryPrimitives.ReadSingleLittleEndian(_buffer.AsSpan(offset, sizeof(double)));
 
         public decimal GetDecimal(int offset)
         {


### PR DESCRIPTION
Backport of #74599 to release/7.0 for RC2

## Customer Impact
DataContractSerializer has not been properly accounting for big-or-little endian-ness when writing a few types "to the wire." This has not previously been an issue, since to my knowledge there have not been any commonly used big-endian platforms with .Net. DCS writes little-endian on the wire, so not accounting for endian-ness has simply worked because little-endian platforms write little-endian on the wire as expected. IBM helped bring .Net to their big-endian s360 platform in 6.0 however, causing failures when serializing between different platforms.

## Testing

Tests were added to check the correct little-endian output for affected types and arrays of types.

## Regression

No... but kind of yes. Strictly speaking, the code has always missed this -endian handling for these types and was not regressed. But the introduction of big-endian implementations of dotnet in 6.0 has exposed this issue. So in a sense, DCS was fine in 5.0 and now is not correct on some platforms in 6.0 and later.

## Risk

Low. The change is faithful to current execution for little-endian platforms and only does different things on a big-endian platform... which is currently broken without this fix.
