### PR TITLE
[release/7.0] Make System.Transactions.Local trimmable on Windows (#75176)

### DIFF
--- a/src/libraries/System.Transactions.Local/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
+++ b/src/libraries/System.Transactions.Local/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="System.Transactions.Local">
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Transactions.DtcProxyShim.DtcProxyShimFactory.ConnectToProxyCore(System.String,System.Guid,System.Object,System.Boolean@,System.Byte[]@,System.Transactions.DtcProxyShim.ResourceManagerShim@)</property>
+      <property name="Justification">This warning is left in the product so developers get an ILLink warning when trimming an app using this transaction support</property>
+    </attribute>
+  </assembly>
+</linker>

--- a/src/libraries/System.Transactions.Local/src/System.Transactions.Local.csproj
+++ b/src/libraries/System.Transactions.Local/src/System.Transactions.Local.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)</TargetFrameworks>
     <NoWarn>CA1805;IDE0059;CS1591</NoWarn>
     <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
-    <IsTrimmable Condition="'$(TargetPlatformIdentifier)' == 'windows'">false</IsTrimmable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Transactions\CommittableTransaction.cs" />

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
@@ -47,7 +47,10 @@ internal sealed class DtcProxyShimFactory
         object? pvConfigPararms,
         [MarshalAs(UnmanagedType.Interface)] out ITransactionDispenser ppvObject);
 
-    [UnconditionalSuppressMessage("Trimming", "IL2050", Justification = "Leave me alone")]
+    [RequiresUnreferencedCode("Distributed transactions support may not be compatible with trimming. If your program creates a distributed transaction via System.Transactions, the correctness of the application cannot be guaranteed after trimming.")]
+    private static void DtcGetTransactionManager(string? nodeName, out ITransactionDispenser localDispenser) =>
+        DtcGetTransactionManagerExW(nodeName, null, Guids.IID_ITransactionDispenser_Guid, 0, null, out localDispenser);
+
     public void ConnectToProxy(
         string? nodeName,
         Guid resourceManagerIdentifier,
@@ -61,9 +64,22 @@ internal sealed class DtcProxyShimFactory
             throw new PlatformNotSupportedException(SR.DistributedNotSupportOn32Bits);
         }
 
+        ConnectToProxyCore(nodeName, resourceManagerIdentifier, managedIdentifier, out nodeNameMatches, out whereabouts, out resourceManagerShim);
+    }
+
+    private void ConnectToProxyCore(
+        string? nodeName,
+        Guid resourceManagerIdentifier,
+        object managedIdentifier,
+        out bool nodeNameMatches,
+        out byte[] whereabouts,
+        out ResourceManagerShim resourceManagerShim)
+    {
         lock (_proxyInitLock)
         {
-            DtcGetTransactionManagerExW(nodeName, null, Guids.IID_ITransactionDispenser_Guid, 0, null, out ITransactionDispenser? localDispenser);
+#pragma warning disable IL2026 // This warning is left in the product so developers get an ILLink warning when trimming an app using this transaction support
+            DtcGetTransactionManager(nodeName, out ITransactionDispenser? localDispenser);
+#pragma warning restore IL2026
 
             // Check to make sure the node name matches.
             if (nodeName is not null)

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
@@ -573,7 +573,7 @@ namespace System.Transactions
         }
 
         [Event(ENLISTMENT_CREATED_LTM_EVENTID, Keywords = Keywords.TraceLtm, Level = EventLevel.Informational, Task = Tasks.Enlistment, Opcode = Opcodes.Create, Message = "Enlistment Created (LTM). ID is {0}, type is {1}, options is {2}")]
-        [UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2026", Justification = "Only string/int are passed")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Only string/int are passed")]
         private void EnlistmentCreatedLtm(int enlistmentIdentifier, string enlistmentType, string enlistmentOptions)
         {
             SetActivityId(string.Empty);
@@ -581,7 +581,7 @@ namespace System.Transactions
         }
 
         [Event(ENLISTMENT_CREATED_OLETX_EVENTID, Keywords = Keywords.TraceOleTx, Level = EventLevel.Informational, Task = Tasks.Enlistment, Opcode = Opcodes.Create, Message = "Enlistment Created (OLETX). ID is {0}, type is {1}, options is {2}")]
-        [UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2026", Justification = "Only string/int are passed")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Only string/int are passed")]
         private void EnlistmentCreatedOleTx(int enlistmentIdentifier, string enlistmentType, string enlistmentOptions)
         {
             SetActivityId(string.Empty);


### PR DESCRIPTION
Backport of #75176 to release/7.0

## Customer Impact
This is fixing the trimmability of the new distributed transaction support in .NET 7.

1. When an app using distributed transactions is trimmed, no warning is emitted to the developer, but their app doesn't work. This breaks our goal of "no warnings means your app works after trimming".
2. When a Windows app is trimmed, the `System.Transactions.Local` assembly is not being trimmed, even if the app doesn't use Transactions.

## Testing
Manually tested that System.Transactions.Local gets trimmed away when trimming an app on Windows that doesn't use System.Transactions.

No real logic has changed. All automated tests pass.

## Risk
Low. This is a feature ported from .NET Framework to .NET 7. This code was never supported on .NET Core previously, so it won't break anyone.

_____

Remove `IsTrimmable=false` from the project, so this assembly is still trimmed with `partial` trimming on Windows.

Add a "LibraryBuild" ILLink warning, so when the distributed transaction code is not trimmed, the app developer gets a warning that it is not guaranteed to work.

Fix #75031

* Fix x86 build. Move the ILLink suppression to a method that is completely trimmed on x86.