### PR TITLE
Fix IPv6 detection in QUIC tests

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -375,7 +375,7 @@ namespace System.Net.Quic.Tests
         {
             try
             {
-                using Socket s = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Tcp);
+                using Socket s = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
                 s.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
                 return true;
             }


### PR DESCRIPTION
# Problem

In #75341, some QUIC tests were changed to only run when IPv6 is supported. IPv6 was detected by binding a socket. However the socket was bound with an invalid combination of `SocketType.Dgram` and `ProtocolType.Tcp`. On macOS, this fails with the exception:

```
System.Net.Sockets.SocketException (41): Protocol wrong type for socket
```

See the docs for listing of which combinations are valid to use together:

https://docs.microsoft.com/dotnet/api/system.net.sockets.sockettype

# Solution

Since QUIC uses UDP, I think the intention was to bind a UDP socket.