### PR TITLE
Implement List<T>.Slice

### DIFF
--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -657,6 +657,7 @@ namespace System.Collections.Generic
         public void RemoveRange(int index, int count) { }
         public void Reverse() { }
         public void Reverse(int index, int count) { }
+        public System.Collections.Generic.List<T> Slice(int index, int count) { throw null; }
         public void Sort() { }
         public void Sort(System.Collections.Generic.IComparer<T>? comparer) { }
         public void Sort(System.Comparison<T> comparison) { }

--- a/src/libraries/System.Collections/ref/System.Collections.cs
+++ b/src/libraries/System.Collections/ref/System.Collections.cs
@@ -657,7 +657,7 @@ namespace System.Collections.Generic
         public void RemoveRange(int index, int count) { }
         public void Reverse() { }
         public void Reverse(int index, int count) { }
-        public System.Collections.Generic.List<T> Slice(int index, int count) { throw null; }
+        public System.Collections.Generic.List<T> Slice(int start, int length) { throw null; }
         public void Sort() { }
         public void Sort(System.Collections.Generic.IComparer<T>? comparer) { }
         public void Sort(System.Comparison<T> comparison) { }

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
@@ -206,7 +206,25 @@ namespace System.Collections.Tests
             public void BasicGetRange(T[] items, int index, int count, bool useSlice)
             {
                 List<T> list = new List<T>(items);
-                List<T> range = useSlice ? list[index..(index + count)] : list.GetRange(index, count);
+                List<T> range = useSlice ? list.Slice(index, count) : list.GetRange(index, count);
+
+                //ensure range is good
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(range[i], items[i + index]); //String.Format("Err_170178aqhbpa Expected item: {0} at: {1} actual: {2}", items[i + index], i, range[i])
+                }
+
+                //ensure no side effects
+                for (int i = 0; i < items.Length; i++)
+                {
+                    Assert.Equal(list[i], items[i]); //String.Format("Err_00125698ahpap Expected item: {0} at: {1} actual: {2}", items[i], i, list[i])
+                }
+            }
+
+            public void BasicSliceSyntax(T[] items, int index, int count)
+            {
+                List<T> list = new List<T>(items);
+                List<T> range = list[index..(index + count)];
 
                 //ensure range is good
                 for (int i = 0; i < count; i++)
@@ -279,9 +297,9 @@ namespace System.Collections.Tests
                 {
                     AssertExtensions.Throws<ArgumentException>(null, () =>
                     {
-                        var index = bad[i];
-                        var count = bad[++i];
-                        return useSlice ? list[index..(index + count)] : list.GetRange(index, count);
+                        int index = bad[i];
+                        int count = bad[++i];
+                        return useSlice ? list.Slice(index, count) : list.GetRange(index, count);
                     }); //"ArgumentException expected."
                 }
 
@@ -306,9 +324,9 @@ namespace System.Collections.Tests
                 {
                     Assert.Throws<ArgumentOutOfRangeException>(() =>
                     {
-                        var index = bad[i];
-                        var count = bad[++i];
-                        return useSlice ? list[index..(index + count)] : list.GetRange(index, count);
+                        int index = bad[i];
+                        int count = bad[++i];
+                        return useSlice ? list.Slice(index, count) : list.GetRange(index, count);
                     }); //"ArgumentOutOfRangeException expected."
                 }
             }
@@ -880,6 +898,25 @@ namespace System.Collections.Tests
             StringDriver.BasicGetRange(stringArr1, 99, 1, useSlice);
             StringDriver.EnsureRangeIsReference(stringArr1, "SometestString101", 0, 10, useSlice);
             StringDriver.EnsureThrowsAfterModification(stringArr1, "str", 10, 10, useSlice);
+        }
+
+        [Fact]
+        public static void SlicingWorks()
+        {
+            Driver<int> IntDriver = new Driver<int>();
+            int[] intArr1 = new int[100];
+            for (int i = 0; i < 100; i++)
+                intArr1[i] = i;
+
+            IntDriver.BasicSliceSyntax(intArr1, 50, 50);
+            IntDriver.BasicSliceSyntax(intArr1, 0, 50);
+            IntDriver.BasicSliceSyntax(intArr1, 50, 25);
+            IntDriver.BasicSliceSyntax(intArr1, 0, 25);
+            IntDriver.BasicSliceSyntax(intArr1, 75, 25);
+            IntDriver.BasicSliceSyntax(intArr1, 0, 100);
+            IntDriver.BasicSliceSyntax(intArr1, 0, 99);
+            IntDriver.BasicSliceSyntax(intArr1, 1, 1);
+            IntDriver.BasicSliceSyntax(intArr1, 99, 1);
         }
 
         [Theory]

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
@@ -203,10 +203,10 @@ namespace System.Collections.Tests
 
             #region GetRange
 
-            public void BasicGetRange(T[] items, int index, int count)
+            public void BasicGetRange(T[] items, int index, int count, bool useSlice)
             {
                 List<T> list = new List<T>(items);
-                List<T> range = list.GetRange(index, count);
+                List<T> range = useSlice ? list[index..(index + count)] : list.GetRange(index, count);
 
                 //ensure range is good
                 for (int i = 0; i < count; i++)
@@ -221,26 +221,26 @@ namespace System.Collections.Tests
                 }
             }
 
-            public void EnsureRangeIsReference(T[] items, T item, int index, int count)
+            public void EnsureRangeIsReference(T[] items, T item, int index, int count, bool useSlice)
             {
                 List<T> list = new List<T>(items);
-                List<T> range = list.GetRange(index, count);
+                List<T> range = useSlice ? list[index..(index + count)] : list.GetRange(index, count);
                 T tempItem = list[index];
                 range[0] = item;
                 Assert.Equal(list[index], tempItem); //String.Format("Err_707811hapba Expected item: {0} at: {1} actual: {2}", tempItem, index, list[index])
             }
 
-            public void EnsureThrowsAfterModification(T[] items, T item, int index, int count)
+            public void EnsureThrowsAfterModification(T[] items, T item, int index, int count, bool useSlice)
             {
                 List<T> list = new List<T>(items);
-                List<T> range = list.GetRange(index, count);
+                List<T> range = useSlice ? list[index..(index + count)] : list.GetRange(index, count);
                 T tempItem = list[index];
                 list[index] = item;
 
                 Assert.Equal(range[0], tempItem); //String.Format("Err_1221589ajpa Expected item: {0} at: {1} actual: {2}", tempItem, 0, range[0])
             }
 
-            public void GetRangeValidations(T[] items)
+            public void GetRangeValidations(T[] items, bool useSlice)
             {
                 //
                 //Always send items.Length is even
@@ -277,7 +277,12 @@ namespace System.Collections.Tests
 
                 for (int i = 0; i < bad.Length; i++)
                 {
-                    AssertExtensions.Throws<ArgumentException>(null, () => list.GetRange(bad[i], bad[++i])); //"ArgumentException expected."
+                    AssertExtensions.Throws<ArgumentException>(null, () =>
+                    {
+                        var index = bad[i];
+                        var count = bad[++i];
+                        return useSlice ? list[index..(index + count)] : list.GetRange(index, count);
+                    }); //"ArgumentException expected."
                 }
 
                 bad = new int[] {
@@ -299,7 +304,12 @@ namespace System.Collections.Tests
 
                 for (int i = 0; i < bad.Length; i++)
                 {
-                    Assert.Throws<ArgumentOutOfRangeException>(() => list.GetRange(bad[i], bad[++i])); //"ArgumentOutOfRangeException expected."
+                    Assert.Throws<ArgumentOutOfRangeException>(() =>
+                    {
+                        var index = bad[i];
+                        var count = bad[++i];
+                        return useSlice ? list[index..(index + count)] : list.GetRange(index, count);
+                    }); //"ArgumentOutOfRangeException expected."
                 }
             }
 
@@ -832,46 +842,50 @@ namespace System.Collections.Tests
             StringDriver.InsertRangeValidations(stringArr1, StringDriver.ConstructTestEnumerable);
         }
 
-        [Fact]
-        public static void GetRangeTests()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void GetRangeTests(bool useSlice)
         {
             Driver<int> IntDriver = new Driver<int>();
             int[] intArr1 = new int[100];
             for (int i = 0; i < 100; i++)
                 intArr1[i] = i;
 
-            IntDriver.BasicGetRange(intArr1, 50, 50);
-            IntDriver.BasicGetRange(intArr1, 0, 50);
-            IntDriver.BasicGetRange(intArr1, 50, 25);
-            IntDriver.BasicGetRange(intArr1, 0, 25);
-            IntDriver.BasicGetRange(intArr1, 75, 25);
-            IntDriver.BasicGetRange(intArr1, 0, 100);
-            IntDriver.BasicGetRange(intArr1, 0, 99);
-            IntDriver.BasicGetRange(intArr1, 1, 1);
-            IntDriver.BasicGetRange(intArr1, 99, 1);
-            IntDriver.EnsureRangeIsReference(intArr1, 101, 0, 10);
-            IntDriver.EnsureThrowsAfterModification(intArr1, 10, 10, 10);
+            IntDriver.BasicGetRange(intArr1, 50, 50, useSlice);
+            IntDriver.BasicGetRange(intArr1, 0, 50, useSlice);
+            IntDriver.BasicGetRange(intArr1, 50, 25, useSlice);
+            IntDriver.BasicGetRange(intArr1, 0, 25, useSlice);
+            IntDriver.BasicGetRange(intArr1, 75, 25, useSlice);
+            IntDriver.BasicGetRange(intArr1, 0, 100, useSlice);
+            IntDriver.BasicGetRange(intArr1, 0, 99, useSlice);
+            IntDriver.BasicGetRange(intArr1, 1, 1, useSlice);
+            IntDriver.BasicGetRange(intArr1, 99, 1, useSlice);
+            IntDriver.EnsureRangeIsReference(intArr1, 101, 0, 10, useSlice);
+            IntDriver.EnsureThrowsAfterModification(intArr1, 10, 10, 10, useSlice);
 
             Driver<string> StringDriver = new Driver<string>();
             string[] stringArr1 = new string[100];
             for (int i = 0; i < 100; i++)
                 stringArr1[i] = "SomeTestString" + i.ToString();
 
-            StringDriver.BasicGetRange(stringArr1, 50, 50);
-            StringDriver.BasicGetRange(stringArr1, 0, 50);
-            StringDriver.BasicGetRange(stringArr1, 50, 25);
-            StringDriver.BasicGetRange(stringArr1, 0, 25);
-            StringDriver.BasicGetRange(stringArr1, 75, 25);
-            StringDriver.BasicGetRange(stringArr1, 0, 100);
-            StringDriver.BasicGetRange(stringArr1, 0, 99);
-            StringDriver.BasicGetRange(stringArr1, 1, 1);
-            StringDriver.BasicGetRange(stringArr1, 99, 1);
-            StringDriver.EnsureRangeIsReference(stringArr1, "SometestString101", 0, 10);
-            StringDriver.EnsureThrowsAfterModification(stringArr1, "str", 10, 10);
+            StringDriver.BasicGetRange(stringArr1, 50, 50, useSlice);
+            StringDriver.BasicGetRange(stringArr1, 0, 50, useSlice);
+            StringDriver.BasicGetRange(stringArr1, 50, 25, useSlice);
+            StringDriver.BasicGetRange(stringArr1, 0, 25, useSlice);
+            StringDriver.BasicGetRange(stringArr1, 75, 25, useSlice);
+            StringDriver.BasicGetRange(stringArr1, 0, 100, useSlice);
+            StringDriver.BasicGetRange(stringArr1, 0, 99, useSlice);
+            StringDriver.BasicGetRange(stringArr1, 1, 1, useSlice);
+            StringDriver.BasicGetRange(stringArr1, 99, 1, useSlice);
+            StringDriver.EnsureRangeIsReference(stringArr1, "SometestString101", 0, 10, useSlice);
+            StringDriver.EnsureThrowsAfterModification(stringArr1, "str", 10, 10, useSlice);
         }
 
-        [Fact]
-        public static void GetRangeTests_Negative()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void GetRangeTests_Negative(bool useSlice)
         {
             Driver<int> IntDriver = new Driver<int>();
             int[] intArr1 = new int[100];
@@ -883,8 +897,8 @@ namespace System.Collections.Tests
             for (int i = 0; i < 100; i++)
                 stringArr1[i] = "SomeTestString" + i.ToString();
 
-            StringDriver.GetRangeValidations(stringArr1);
-            IntDriver.GetRangeValidations(intArr1);
+            StringDriver.GetRangeValidations(stringArr1, useSlice);
+            IntDriver.GetRangeValidations(intArr1, useSlice);
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -627,8 +627,19 @@ namespace System.Collections.Generic
             return list;
         }
 
-        // C# slice patterns do not recognize GetRange, so we have Slice to forward to it.
-        public List<T> Slice(int index, int count) => GetRange(index, count);
+        /// <summary>
+        /// Creates a shallow copy of a range of elements in the source <see cref="List{T}" />.
+        /// </summary>
+        /// <param name="start">The zero-based <see cref="List{T}" /> index at which the range starts.</param>
+        /// <param name="length">The length of the range.</param>
+        /// <returns>A shallow copy of a range of elements in the source <see cref="List{T}" />.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index" /> is less than 0.
+        /// -or-
+        /// <paramref name="count" /> is less than 0.
+        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not denote a valid range of elements in the <see cref="List{T}" />.</exception>
+        public List<T> Slice(int start, int length) => GetRange(start, length);
 
         // Returns the index of the first occurrence of a given value in a range of
         // this list. The list is searched forwards from beginning to end.

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -634,11 +634,11 @@ namespace System.Collections.Generic
         /// <param name="length">The length of the range.</param>
         /// <returns>A shallow copy of a range of elements in the source <see cref="List{T}" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index" /> is less than 0.
+        /// <paramref name="start" /> is less than 0.
         /// -or-
-        /// <paramref name="count" /> is less than 0.
+        /// <paramref name="length" /> is less than 0.
         /// </exception>
-        /// <exception cref="ArgumentException"><paramref name="index" /> and <paramref name="count" /> do not denote a valid range of elements in the <see cref="List{T}" />.</exception>
+        /// <exception cref="ArgumentException"><paramref name="start" /> and <paramref name="length" /> do not denote a valid range of elements in the <see cref="List{T}" />.</exception>
         public List<T> Slice(int start, int length) => GetRange(start, length);
 
         // Returns the index of the first occurrence of a given value in a range of

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -627,6 +627,9 @@ namespace System.Collections.Generic
             return list;
         }
 
+        // C# slice patterns do not recognize GetRange, so we have Slice to forward to it.
+        public List<T> Slice(int index, int count) => GetRange(index, count);
+
         // Returns the index of the first occurrence of a given value in a range of
         // this list. The list is searched forwards from beginning to end.
         // The elements of the list are compared to the given value using the


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/66773. I took the approach of just redirecting to GetRange, and using a Theory to make all direct GetRange tests run on both GetRange and Slice (and used list pattern syntax for the Slice version to make sure that's working end-to-end).
