### PR TITLE
Replace marshalled delegate in X509Certificate verification

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -12,8 +12,6 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        internal delegate int X509StoreVerifyCallback(int ok, IntPtr ctx);
-
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NotBefore")]
         internal static partial IntPtr GetX509NotBefore(SafeX509Handle x509);
 
@@ -82,15 +80,15 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PemReadX509FromBioAux")]
         internal static partial SafeX509Handle PemReadX509FromBioAux(SafeBioHandle bio);
 
-        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509GetSerialNumber")]
-        private static partial SafeSharedAsn1IntegerHandle X509GetSerialNumber_private(SafeX509Handle x);
+        [LibraryImport(Libraries.CryptoNative)]
+        private static partial SafeSharedAsn1IntegerHandle CryptoNative_X509GetSerialNumber(SafeX509Handle x);
 
         internal static SafeSharedAsn1IntegerHandle X509GetSerialNumber(SafeX509Handle x)
         {
             CheckValidOpenSslHandle(x);
 
             return SafeInteriorHandle.OpenInteriorHandle(
-                X509GetSerialNumber_private,
+                CryptoNative_X509GetSerialNumber,
                 x);
         }
 
@@ -166,7 +164,7 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool X509StoreAddCrl(SafeX509StoreHandle ctx, SafeX509CrlHandle x);
 
-        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreSetRevocationFlag")]
+        [LibraryImport(Libraries.CryptoNative)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool CryptoNative_X509StoreSetRevocationFlag(SafeX509StoreHandle ctx, X509RevocationFlag revocationFlag);
 
@@ -238,16 +236,27 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetErrorDepth")]
         internal static partial int X509StoreCtxGetErrorDepth(SafeX509StoreCtxHandle ctx);
 
-        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxSetVerifyCallback")]
-        internal static partial void X509StoreCtxSetVerifyCallback(SafeX509StoreCtxHandle ctx, X509StoreVerifyCallback callback);
+        [LibraryImport(Libraries.CryptoNative)]
+        private static unsafe partial int CryptoNative_X509StoreCtxSetVerifyCallback(SafeX509StoreCtxHandle ctx, delegate* unmanaged<int, IntPtr, int> callback, void* appData);
+
+        internal static unsafe void X509StoreCtxSetVerifyCallback(SafeX509StoreCtxHandle ctx, delegate* unmanaged<int, IntPtr, int> callback, void* appData)
+        {
+            if (CryptoNative_X509StoreCtxSetVerifyCallback(ctx, callback, appData) != 1)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+        }
+
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetAppData")]
+        internal static unsafe partial void* X509StoreCtxGetAppData(SafeX509StoreCtxHandle ctx);
 
         internal static string GetX509VerifyCertErrorString(int n)
         {
-            return Marshal.PtrToStringUTF8(X509VerifyCertErrorString(n))!;
+            return Marshal.PtrToStringUTF8(CryptoNative_X509VerifyCertErrorString(n))!;
         }
 
-        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCertErrorString")]
-        private static partial IntPtr X509VerifyCertErrorString(int n);
+        [LibraryImport(Libraries.CryptoNative)]
+        private static partial IntPtr CryptoNative_X509VerifyCertErrorString(int n);
 
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509CrlDestroy")]
         internal static partial void X509CrlDestroy(IntPtr a);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -685,6 +685,8 @@ namespace System.Security.Cryptography.X509Certificates
                 extraDispose = workingChain;
                 workingChain = new WorkingChain(abortOnSignatureError: false);
 
+                Interop.Crypto.X509StoreCtxSetVerifyCallback(_storeCtx, &VerifyCallback, Unsafe.AsPointer(ref workingChain));
+
                 verify = Interop.Crypto.X509VerifyCert(_storeCtx);
             }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Formats.Asn1;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.Asn1;
 using System.Security.Cryptography.X509Certificates.Asn1;
@@ -634,7 +635,32 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        private WorkingChain BuildWorkingChain()
+        [UnmanagedCallersOnly]
+        private static unsafe int VerifyCallback(int ok, IntPtr ctx)
+        {
+            if (ok != 0)
+            {
+                return ok;
+            }
+
+            try
+            {
+                using (var storeCtx = new SafeX509StoreCtxHandle(ctx, ownsHandle: false))
+                {
+                    void* appData = Interop.Crypto.X509StoreCtxGetAppData(storeCtx);
+
+                    ref WorkingChain workingChain = ref Unsafe.As<byte, WorkingChain>(ref *(byte*)appData);
+
+                    return workingChain.VerifyCallback(storeCtx);
+                }
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        private unsafe WorkingChain BuildWorkingChain()
         {
             if (_workingChain != null)
             {
@@ -645,8 +671,8 @@ namespace System.Security.Cryptography.X509Certificates
             WorkingChain? extraDispose = null;
 
             Interop.Crypto.X509StoreCtxReset(_storeCtx);
-            Interop.Crypto.X509StoreVerifyCallback workingCallback = workingChain.VerifyCallback;
-            Interop.Crypto.X509StoreCtxSetVerifyCallback(_storeCtx, workingCallback);
+
+            Interop.Crypto.X509StoreCtxSetVerifyCallback(_storeCtx, &VerifyCallback, Unsafe.AsPointer(ref workingChain));
 
             bool verify = Interop.Crypto.X509VerifyCert(_storeCtx);
 
@@ -658,14 +684,9 @@ namespace System.Security.Cryptography.X509Certificates
                 // Reset to a WorkingChain that won't fail.
                 extraDispose = workingChain;
                 workingChain = new WorkingChain(abortOnSignatureError: false);
-                workingCallback = workingChain.VerifyCallback;
-                Interop.Crypto.X509StoreCtxSetVerifyCallback(_storeCtx, workingCallback);
 
                 verify = Interop.Crypto.X509VerifyCert(_storeCtx);
             }
-
-            // Keep the bound delegate alive until X509_verify_cert isn't going to call it any longer.
-            GC.KeepAlive(workingCallback);
 
             // Because our callback tells OpenSSL that every problem is ignorable, it should tell us that the
             // chain is just fine (unless it returned a negative code for an exception)
@@ -1337,66 +1358,50 @@ namespace System.Security.Cryptography.X509Certificates
                 }
             }
 
-            internal int VerifyCallback(int ok, IntPtr ctx)
+            internal int VerifyCallback(SafeX509StoreCtxHandle storeCtx)
             {
-                if (ok != 0)
+                Interop.Crypto.X509VerifyStatusCode errorCode = Interop.Crypto.X509StoreCtxGetError(storeCtx);
+                int errorDepth = Interop.Crypto.X509StoreCtxGetErrorDepth(storeCtx);
+
+                if (AbortOnSignatureError &&
+                    errorCode == X509VerifyStatusCodeUniversal.X509_V_ERR_CERT_SIGNATURE_FAILURE)
                 {
-                    return ok;
+                    AbortedForSignatureError = true;
+                    return 0;
                 }
 
-                try
+                // * We don't report "OK" as an error.
+                // * For compatibility with Windows / .NET Framework, do not report X509_V_CRL_NOT_YET_VALID.
+                // * X509_V_ERR_DIFFERENT_CRL_SCOPE will result in X509_V_ERR_UNABLE_TO_GET_CRL
+                //   which will trigger OCSP, so is ignorable.
+                if (errorCode != X509VerifyStatusCodeUniversal.X509_V_OK &&
+                    errorCode != X509VerifyStatusCodeUniversal.X509_V_ERR_CRL_NOT_YET_VALID &&
+                    errorCode != X509VerifyStatusCodeUniversal.X509_V_ERR_DIFFERENT_CRL_SCOPE)
                 {
-                    using (var storeCtx = new SafeX509StoreCtxHandle(ctx, ownsHandle: false))
+                    if (_errors == null)
                     {
-                        Interop.Crypto.X509VerifyStatusCode errorCode = Interop.Crypto.X509StoreCtxGetError(storeCtx);
-                        int errorDepth = Interop.Crypto.X509StoreCtxGetErrorDepth(storeCtx);
+                        int size = Math.Max(DefaultChainCapacity, errorDepth + 1);
+                        // Since ErrorCollection is a non-public type, this is a private pool.
+                        _errors = ArrayPool<ErrorCollection>.Shared.Rent(size);
 
-                        if (AbortOnSignatureError &&
-                            errorCode == X509VerifyStatusCodeUniversal.X509_V_ERR_CERT_SIGNATURE_FAILURE)
-                        {
-                            AbortedForSignatureError = true;
-                            return 0;
-                        }
+                        // We only do spares writes.
+                        _errors.AsSpan().Clear();
+                    }
+                    else if (errorDepth >= _errors.Length)
+                    {
+                        ErrorCollection[] toReturn = _errors;
+                        _errors = ArrayPool<ErrorCollection>.Shared.Rent(errorDepth + 1);
+                        toReturn.AsSpan().CopyTo(_errors);
 
-                        // * We don't report "OK" as an error.
-                        // * For compatibility with Windows / .NET Framework, do not report X509_V_CRL_NOT_YET_VALID.
-                        // * X509_V_ERR_DIFFERENT_CRL_SCOPE will result in X509_V_ERR_UNABLE_TO_GET_CRL
-                        //   which will trigger OCSP, so is ignorable.
-                        if (errorCode != X509VerifyStatusCodeUniversal.X509_V_OK &&
-                            errorCode != X509VerifyStatusCodeUniversal.X509_V_ERR_CRL_NOT_YET_VALID &&
-                            errorCode != X509VerifyStatusCodeUniversal.X509_V_ERR_DIFFERENT_CRL_SCOPE)
-                        {
-                            if (_errors == null)
-                            {
-                                int size = Math.Max(DefaultChainCapacity, errorDepth + 1);
-                                // Since ErrorCollection is a non-public type, this is a private pool.
-                                _errors = ArrayPool<ErrorCollection>.Shared.Rent(size);
-
-                                // We only do spares writes.
-                                _errors.AsSpan().Clear();
-                            }
-                            else if (errorDepth >= _errors.Length)
-                            {
-                                ErrorCollection[] toReturn = _errors;
-                                _errors = ArrayPool<ErrorCollection>.Shared.Rent(errorDepth + 1);
-                                toReturn.AsSpan().CopyTo(_errors);
-
-                                // We only do spares writes, clear the remainder.
-                                _errors.AsSpan(toReturn.Length).Clear();
-                                ArrayPool<ErrorCollection>.Shared.Return(toReturn);
-                            }
-
-                            LastError = Math.Max(errorDepth, LastError);
-                            _errors[errorDepth].Add(errorCode);
-                        }
+                        // We only do spares writes, clear the remainder.
+                        _errors.AsSpan(toReturn.Length).Clear();
+                        ArrayPool<ErrorCollection>.Shared.Return(toReturn);
                     }
 
-                    return 1;
+                    LastError = Math.Max(errorDepth, LastError);
+                    _errors[errorDepth].Add(errorCode);
                 }
-                catch
-                {
-                    return -1;
-                }
+                return 1;
             }
         }
 

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -271,6 +271,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_X509StoreCtxReset)
     DllImportEntry(CryptoNative_X509StoreCtxResetForSignatureError)
     DllImportEntry(CryptoNative_X509StoreCtxSetVerifyCallback)
+    DllImportEntry(CryptoNative_X509StoreCtxGetAppData)
     DllImportEntry(CryptoNative_X509StoreDestroy)
     DllImportEntry(CryptoNative_X509StoreSetRevocationFlag)
     DllImportEntry(CryptoNative_X509StoreSetVerifyTime)

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -603,6 +603,8 @@ const EVP_CIPHER* EVP_chacha20_poly1305(void);
     REQUIRED_FUNCTION(X509_STORE_CTX_new) \
     REQUIRED_FUNCTION(X509_STORE_CTX_set_flags) \
     REQUIRED_FUNCTION(X509_STORE_CTX_set_verify_cb) \
+    REQUIRED_FUNCTION(X509_STORE_CTX_set_ex_data) \
+    REQUIRED_FUNCTION(X509_STORE_CTX_get_ex_data) \
     REQUIRED_FUNCTION(X509_STORE_free) \
     FALLBACK_FUNCTION(X509_STORE_get0_param) \
     REQUIRED_FUNCTION(X509_STORE_new) \
@@ -1084,6 +1086,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_STORE_CTX_new X509_STORE_CTX_new_ptr
 #define X509_STORE_CTX_set_flags X509_STORE_CTX_set_flags_ptr
 #define X509_STORE_CTX_set_verify_cb X509_STORE_CTX_set_verify_cb_ptr
+#define X509_STORE_CTX_set_ex_data X509_STORE_CTX_set_ex_data_ptr
+#define X509_STORE_CTX_get_ex_data X509_STORE_CTX_get_ex_data_ptr
 #define X509_STORE_free X509_STORE_free_ptr
 #define X509_STORE_get0_param X509_STORE_get0_param_ptr
 #define X509_STORE_new X509_STORE_new_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -352,7 +352,8 @@ int32_t CryptoNative_X509StoreCtxRebuildChain(X509_STORE_CTX* ctx)
 
 int32_t CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback, void* appData)
 {
-    // Just a field mutator, no error queue interactions apply.
+    ERR_clear_error();
+    
     X509_STORE_CTX_set_verify_cb(ctx, callback);
 
     return X509_STORE_CTX_set_app_data(ctx, appData);
@@ -360,6 +361,7 @@ int32_t CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509Stor
 
 void* CryptoNative_X509StoreCtxGetAppData(X509_STORE_CTX* ctx)
 {
+    // Just a field accessor, no error queue interactions apply.
     return X509_STORE_CTX_get_app_data(ctx);
 }
 

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -350,10 +350,17 @@ int32_t CryptoNative_X509StoreCtxRebuildChain(X509_STORE_CTX* ctx)
     return X509_verify_cert(ctx);
 }
 
-void CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback)
+int32_t CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback, void* appData)
 {
     // Just a field mutator, no error queue interactions apply.
     X509_STORE_CTX_set_verify_cb(ctx, callback);
+
+    return X509_STORE_CTX_set_app_data(ctx, appData);
+}
+
+void* CryptoNative_X509StoreCtxGetAppData(X509_STORE_CTX* ctx)
+{
+    return X509_STORE_CTX_get_app_data(ctx);
 }
 
 int32_t CryptoNative_X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.h
@@ -296,7 +296,7 @@ Shims the X509_STORE_CTX_set_verify_cb and X509_STORE_CTX_set_app_data functions
 PALEXPORT int32_t CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback, void* appData);
 
 /*
-Shims the X509_STORE_CTX_get_app_data functions.
+Shims the X509_STORE_CTX_get_app_data function.
 */
 PALEXPORT void* CryptoNative_X509StoreCtxGetAppData(X509_STORE_CTX* ctx);
 

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.h
@@ -291,9 +291,14 @@ Shims the X509_STORE_CTX_get_error_depth method.
 PALEXPORT int32_t CryptoNative_X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx);
 
 /*
-Shims the X509_STORE_CTX_set_verify_cb function.
+Shims the X509_STORE_CTX_set_verify_cb and X509_STORE_CTX_set_app_data functions.
 */
-PALEXPORT void CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback);
+PALEXPORT int32_t CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback, void* appData);
+
+/*
+Shims the X509_STORE_CTX_get_app_data functions.
+*/
+PALEXPORT void* CryptoNative_X509StoreCtxGetAppData(X509_STORE_CTX* ctx);
 
 /*
 Shims the X509_verify_cert_error_string method.


### PR DESCRIPTION
Replace marshalled delegate with function pointer. This instance of delegate marshalling was somehow missed during the earlier passes.