### PR TITLE
R2R fixes for [Equality]Comparer.Default in jit

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4631,6 +4631,8 @@ public:
 
     GenTreeCall* fgGetStaticsCCtorHelper(CORINFO_CLASS_HANDLE cls, CorInfoHelpFunc helper);
 
+    bool fgIsCurrentCallDceCandidate();
+
     GenTreeCall* fgGetSharedCCtor(CORINFO_CLASS_HANDLE cls);
 
     bool backendRequiresLocalVarLifetimes()

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1630,44 +1630,20 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
 
                         // For case (1)
                         //
-                        // Look for the following tree shapes
-                        // prejit: (IND (ADD (CONST, CALL(special dce helper...))))
-                        // jit   : (COMMA (CALL(special dce helper...), (FIELD ...)))
-                        if (argNode->gtOper == GT_COMMA)
+                        if (argNode->OperIs(GT_COMMA))
                         {
                             // Look for (COMMA (CALL(special dce helper...), (FIELD ...)))
-                            GenTree* op1 = argNode->AsOp()->gtOp1;
-                            GenTree* op2 = argNode->AsOp()->gtOp2;
+                            GenTree* op1 = argNode->gtGetOp1();
+                            GenTree* op2 = argNode->gtGetOp2();
                             if (op1->IsCall() &&
                                 ((op1->AsCall()->gtCallMoreFlags & GTF_CALL_M_HELPER_SPECIAL_DCE) != 0) &&
-                                (op2->gtOper == GT_FIELD) && ((op2->gtFlags & GTF_EXCEPT) == 0))
+                                (op2->OperIs(GT_FIELD)) && ((op2->gtFlags & GTF_EXCEPT) == 0))
                             {
                                 JITDUMP("\nPerforming special dce on unused arg [%06u]:"
                                         " actual arg [%06u] helper call [%06u]\n",
                                         argNode->gtTreeID, argNode->gtTreeID, op1->gtTreeID);
                                 // Drop the whole tree
                                 append = false;
-                            }
-                        }
-                        else if (argNode->gtOper == GT_IND)
-                        {
-                            // Look for (IND (ADD (CONST, CALL(special dce helper...))))
-                            GenTree* addr = argNode->AsOp()->gtOp1;
-
-                            if (addr->gtOper == GT_ADD)
-                            {
-                                GenTree* op1 = addr->AsOp()->gtOp1;
-                                GenTree* op2 = addr->AsOp()->gtOp2;
-                                if (op1->IsCall() &&
-                                    ((op1->AsCall()->gtCallMoreFlags & GTF_CALL_M_HELPER_SPECIAL_DCE) != 0) &&
-                                    op2->IsCnsIntOrI())
-                                {
-                                    // Drop the whole tree
-                                    JITDUMP("\nPerforming special dce on unused arg [%06u]:"
-                                            " actual arg [%06u] helper call [%06u]\n",
-                                            argNode->gtTreeID, argNode->gtTreeID, op1->gtTreeID);
-                                    append = false;
-                                }
                             }
                         }
                     }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -793,6 +793,31 @@ GenTreeLclVar* Compiler::fgIsIndirOfAddrOfLocal(GenTree* tree)
     return res;
 }
 
+//------------------------------------------------------------------------
+// fgIsCurrentCallDceCandidate: Determine whether the currently compiled method
+//   is a DCE candidate
+//
+// Returns:
+//    True if the currently compiled method can be removed if it's not used
+//    despite potential side-effects
+//
+bool Compiler::fgIsCurrentCallDceCandidate()
+{
+    // If we're importing the special EqualityComparer<T>.Default or Comparer<T>.Default
+    // intrinsics, flag the helper call. Later during inlining, we can
+    // remove the helper call if the associated field lookup is unused.
+    if ((info.compFlags & CORINFO_FLG_INTRINSIC) != 0)
+    {
+        NamedIntrinsic ni = lookupNamedIntrinsic(info.compMethodHnd);
+        if ((ni == NI_System_Collections_Generic_EqualityComparer_get_Default) ||
+            (ni == NI_System_Collections_Generic_Comparer_get_Default))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 GenTreeCall* Compiler::fgGetStaticsCCtorHelper(CORINFO_CLASS_HANDLE cls, CorInfoHelpFunc helper)
 {
     bool         bNeedClassID = true;
@@ -891,18 +916,10 @@ GenTreeCall* Compiler::fgGetStaticsCCtorHelper(CORINFO_CLASS_HANDLE cls, CorInfo
 
     result->gtFlags |= callFlags;
 
-    // If we're importing the special EqualityComparer<T>.Default or Comparer<T>.Default
-    // intrinsics, flag the helper call. Later during inlining, we can
-    // remove the helper call if the associated field lookup is unused.
-    if ((info.compFlags & CORINFO_FLG_INTRINSIC) != 0)
+    if (fgIsCurrentCallDceCandidate())
     {
-        NamedIntrinsic ni = lookupNamedIntrinsic(info.compMethodHnd);
-        if ((ni == NI_System_Collections_Generic_EqualityComparer_get_Default) ||
-            (ni == NI_System_Collections_Generic_Comparer_get_Default))
-        {
-            JITDUMP("\nmarking helper call [%06u] as special dce...\n", result->gtTreeID);
-            result->gtCallMoreFlags |= GTF_CALL_M_HELPER_SPECIAL_DCE;
-        }
+        JITDUMP("\nmarking helper call [%06u] as special dce...\n", result->gtTreeID);
+        result->gtCallMoreFlags |= GTF_CALL_M_HELPER_SPECIAL_DCE;
     }
 
     return result;


### PR DESCRIPTION
```csharp
bool Foo(int a, int b) => EqualityComparer<int>.Default.Equals(a, b);
```
Current R2R codegen:
```asm
; Method Foo(int,int):bool:this
G_M42273_IG01:              ;; offset=0000H
       57                   push     rdi
       56                   push     rsi
       4883EC28             sub      rsp, 40
       8BF2                 mov      esi, edx
       418BF8               mov      edi, r8d
G_M42273_IG02:              ;; offset=000BH
       FF1500000000         call     [CORINFO_HELP_READYTORUN_STATIC_BASE]
       488B00               mov      rax, gword ptr [rax]
       3800                 cmp      byte  ptr [rax], al
       33C0                 xor      eax, eax
       3BF7                 cmp      esi, edi
       0F94C0               sete     al
G_M42273_IG03:              ;; offset=001DH
       4883C428             add      rsp, 40
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      
; Total bytes of code: 36
```
New R2R codegen:
```asm
; Method Foo(int,int):bool:this
G_M42273_IG01:              ;; offset=0000H
G_M42273_IG02:              ;; offset=0000H
       33C0                 xor      eax, eax
       413BD0               cmp      edx, r8d
       0F94C0               sete     al
G_M42273_IG03:              ;; offset=0008H
       C3                   ret    
; Total bytes of code: 9
```