### PR TITLE
JitDisasm cosmetic improvements

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1757,15 +1757,15 @@ void CodeGen::genGenerateMachineCode()
 
         if (compiler->compCodeOpt() == Compiler::SMALL_CODE)
         {
-            printf("SMALL_CODE");
+            printf("small");
         }
         else if (compiler->compCodeOpt() == Compiler::FAST_CODE)
         {
-            printf("FAST_CODE");
+            printf("fast");
         }
         else
         {
-            printf("BLENDED_CODE");
+            printf("blended");
         }
 
         printf(" for ");
@@ -1829,6 +1829,10 @@ void CodeGen::genGenerateMachineCode()
         {
             printf("; Tier-1 compilation\n");
         }
+        else if (compiler->IsTargetAbi(CORINFO_NATIVEAOT_ABI))
+        {
+            printf("; NativeAOT compilation\n");
+        }
         else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_READYTORUN))
         {
             printf("; ReadyToRun compilation\n");
@@ -1869,12 +1873,14 @@ void CodeGen::genGenerateMachineCode()
             printf("; optimized using profile data\n");
         }
 
+#if DEBUG
 #if DOUBLE_ALIGN
         if (compiler->genDoubleAlign())
             printf("; double-aligned frame\n");
         else
 #endif
             printf("; %s based frame\n", isFramePointerUsed() ? STR_FPBASE : STR_SPBASE);
+#endif
 
         if (GetInterruptible())
         {

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1873,14 +1873,12 @@ void CodeGen::genGenerateMachineCode()
             printf("; optimized using profile data\n");
         }
 
-#if DEBUG
 #if DOUBLE_ALIGN
         if (compiler->genDoubleAlign())
             printf("; double-aligned frame\n");
         else
 #endif
             printf("; %s based frame\n", isFramePointerUsed() ? STR_FPBASE : STR_SPBASE);
-#endif
 
         if (GetInterruptible())
         {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2799,6 +2799,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.disAsm      = false;
     opts.disDiffable = false;
     opts.dspDiffable = false;
+    opts.disRawInstr = false;
 #ifdef DEBUG
     opts.dspInstrs       = false;
     opts.dspLines        = false;
@@ -3011,6 +3012,11 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         opts.disAsm = true;
     }
 #endif // !DEBUG
+
+    if (JitConfig.JitDisasmShowRawInstructions() != 0)
+    {
+        opts.disRawInstr = true;
+    }
 
 //-------------------------------------------------------------------------
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9225,6 +9225,7 @@ public:
         bool disAsm;      // Display native code as it is generated
         bool dspDiffable; // Makes the Jit Dump 'diff-able' (currently uses same COMPlus_* flag as disDiffable)
         bool disDiffable; // Makes the Disassembly code 'diff-able'
+        bool disRawInstr; // Display raw bytes for instructions
 #ifdef DEBUG
         bool compProcedureSplittingEH; // Separate cold code from hot code for functions with EH
         bool dspCode;                  // Display native code generated

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6700,7 +6700,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
         if (emitComp->opts.disAsm)
         {
             printf("\n%s:", emitLabelString(ig));
-            if (!emitComp->opts.disDiffable)
+            if (!emitComp->opts.disDiffable && emitComp->opts.disRawInstr)
             {
                 printf("                ;; offset=%04XH", emitCurCodeOffs(cp));
             }

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -7080,7 +7080,7 @@ void emitter::emitDispGC(emitAttr attr)
 void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 {
     // We do not display the instruction hex if we want diff-able disassembly
-    if (!emitComp->opts.disDiffable)
+    if (!emitComp->opts.disDiffable && emitComp->opts.disRawInstr)
     {
         if (sz == 2)
         {

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12368,7 +12368,7 @@ void emitter::emitDispAddrRRExt(regNumber reg1, regNumber reg2, insOpts opt, boo
 void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 {
     // We do not display the instruction hex if we want diff-able disassembly
-    if (!emitComp->opts.disDiffable)
+    if (!emitComp->opts.disDiffable && emitComp->opts.disRawInstr)
     {
         if (sz == 4)
         {

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8848,7 +8848,7 @@ void emitter::emitDispShift(instruction ins, int cnt)
 void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 {
     // We do not display the instruction hex if we want diff-able disassembly
-    if (!emitComp->opts.disDiffable)
+    if (!emitComp->opts.disDiffable && emitComp->opts.disRawInstr)
     {
 #ifdef TARGET_AMD64
         // how many bytes per instruction we format for

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -256,6 +256,11 @@ CONFIG_INTEGER(EnableIncompleteISAClass, W("EnableIncompleteISAClass"), 0) // En
 CONFIG_METHODSET(JitDisasm, W("JitDisasm"))
 #endif // !defined(DEBUG)
 
+// Print raw bytes for instructions, e.g.
+//
+//   488B09               mov      rcx, gword ptr [rcx]
+CONFIG_INTEGER(JitDisasmShowRawInstructions, W("JitDisasmShowRawInstructions"), 0)
+
 CONFIG_INTEGER(JitDisasmSummary, W("JitDisasmSummary"), 0) // Prints all jitted methods to the console
 CONFIG_STRING(JitStdOutFile, W("JitStdOutFile"))           // If set, sends JIT's stdout output to this file.
 


### PR DESCRIPTION
Minor improvements for JitDisasm:
1) Display `; NativeAOT compilation` instead of `; ReadyToRun compilation` for NAOT
2) Don't display raw bytes for instructions by default - they take a lot of space and rarely needed - hide them under `DOTNET_JitDisasmShowRawInstructions`
I know we have JitDiffableDasm for that, but that hides too much including all constants

New default JitDisasm:
```asm
; Assembly listing for method ConsoleApp29.Program:Main(<unnamed>)
; Emitting blended for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 1 single block inlinees; 0 inlinees without PGO data

G_M000_IG01:
       sub      rsp, 56

G_M000_IG02:
       mov      rcx, 0x2120D004F68
       mov      rcx, gword ptr [rcx]
       call     [System.Console:WriteLine(System.String)]
       lea      rcx, bword ptr [rsp+28H]
       xor      edx, edx
       call     [System.ConsolePal:ReadKey(bool):System.ConsoleKeyInfo]
       nop

G_M000_IG03:
       add      rsp, 56
       ret

; Total bytes of code 42
```