### PR TITLE
[mono] Fix assertion while adding a new method using Hot Reload.

### DIFF
--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2118,6 +2118,13 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 			if (func_code == ENC_FUNC_ADD_PARAM)
 				break;
 
+			if (!base_info->method_table_update)
+				base_info->method_table_update = g_hash_table_new (g_direct_hash, g_direct_equal);
+			if (!delta_info->method_table_update)
+				delta_info->method_table_update = g_hash_table_new (g_direct_hash, g_direct_equal);
+			if (!delta_info->method_ppdb_table_update)
+				delta_info->method_ppdb_table_update = g_hash_table_new (g_direct_hash, g_direct_equal);
+
 			if (is_addition) {
 				g_assertf (add_member_typedef, "EnC: new method added but I don't know the class, should be caught by pass1");
 				if (pass2_context_is_skeleton (ctx, add_member_typedef)) {
@@ -2138,14 +2145,6 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 				}
 				add_member_typedef = 0;
 			}
-
-			if (!base_info->method_table_update)
-				base_info->method_table_update = g_hash_table_new (g_direct_hash, g_direct_equal);
-			if (!delta_info->method_table_update)
-				delta_info->method_table_update = g_hash_table_new (g_direct_hash, g_direct_equal);
-			if (!delta_info->method_ppdb_table_update)
-
-				delta_info->method_ppdb_table_update = g_hash_table_new (g_direct_hash, g_direct_equal);
 
 			int mapped_token = hot_reload_relative_delta_index (image_dmeta, delta_info, mono_metadata_make_token (token_table, token_index));
 			guint32 rva = mono_metadata_decode_row_col (&image_dmeta->tables [MONO_TABLE_METHOD], mapped_token - 1, MONO_METHOD_RVA);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -996,7 +996,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                             {
                                 var document = pdbMetadataReaderParm.GetDocument(methodDebugInformation.Document);
                                 var documentName = pdbMetadataReaderParm.GetString(document.Name);
-                                source = GetOrAddSourceFile(methodDebugInformation.Document, asmMetadataReaderParm.GetRowNumber(methodDebugInformation.Document), documentName);
+                                source = GetOrAddSourceFile(methodDebugInformation.Document, documentName);
                             }
                             var methodInfo = new MethodInfo(this, MetadataTokens.MethodDefinitionHandle(methodIdxAsm), entryRow, source, typeInfo, asmMetadataReaderParm, pdbMetadataReaderParm);
                             methods[entryRow] = methodInfo;
@@ -1018,13 +1018,13 @@ namespace Microsoft.WebAssembly.Diagnostics
                 }
             }
         }
-        private SourceFile GetOrAddSourceFile(DocumentHandle doc, int rowid, string documentName)
+        private SourceFile GetOrAddSourceFile(DocumentHandle doc, string documentName)
         {
-            if (_documentIdToSourceFileTable.TryGetValue(rowid, out SourceFile source))
+            if (_documentIdToSourceFileTable.TryGetValue(documentName.GetHashCode(), out SourceFile source))
                 return source;
 
             var src = new SourceFile(this, _documentIdToSourceFileTable.Count, doc, GetSourceLinkUrl(documentName), documentName);
-            _documentIdToSourceFileTable[rowid] = src;
+            _documentIdToSourceFileTable[documentName.GetHashCode()] = src;
             return src;
         }
 
@@ -1054,7 +1054,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         {
                             var document = pdbMetadataReader.GetDocument(methodDebugInformation.Document);
                             var documentName = pdbMetadataReader.GetString(document.Name);
-                            source = GetOrAddSourceFile(methodDebugInformation.Document, asmMetadataReader.GetRowNumber(methodDebugInformation.Document), documentName);
+                            source = GetOrAddSourceFile(methodDebugInformation.Document, documentName);
                         }
                     }
                     var methodInfo = new MethodInfo(this, method, asmMetadataReader.GetRowNumber(method), source, typeInfo, asmMetadataReader, pdbMetadataReader);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -868,7 +868,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             var methodId = retDebuggerCmdReader.ReadInt32();
             var method = await context.SdbAgent.GetMethodInfo(methodId, token);
-            if (method == null)
+            if (method == null || method.Info.Source is null)
             {
                 return true;
             }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1322,7 +1322,7 @@ namespace DebuggerTests
             return await WaitFor(Inspector.PAUSE);
         }
 
-        internal async Task<JObject> LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(string asm_file, string pdb_file, string class_name, string method_name, bool expectBpResolvedEvent)
+        internal async Task<JObject> LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(string asm_file, string pdb_file, string class_name, string method_name, bool expectBpResolvedEvent, params string[] sourcesToWait)
         {
             byte[] bytes = File.ReadAllBytes(asm_file);
             string asm_base64 = Convert.ToBase64String(bytes);
@@ -1338,7 +1338,7 @@ namespace DebuggerTests
 
             Task eventTask = expectBpResolvedEvent
                                 ? WaitForBreakpointResolvedEvent()
-                                : WaitForScriptParsedEventsAsync("MethodBody0.cs", "MethodBody1.cs");
+                                : WaitForScriptParsedEventsAsync(sourcesToWait);
             (await cli.SendCommand("Runtime.evaluate", load_assemblies, token)).AssertOk();
             await eventTask;
 
@@ -1397,7 +1397,7 @@ namespace DebuggerTests
             return await WaitFor(Inspector.PAUSE);
         }
 
-        internal async Task<JObject> LoadAssemblyAndTestHotReload(string asm_file, string pdb_file, string asm_file_hot_reload, string class_name, string method_name, bool expectBpResolvedEvent)
+        internal async Task<JObject> LoadAssemblyAndTestHotReload(string asm_file, string pdb_file, string asm_file_hot_reload, string class_name, string method_name, bool expectBpResolvedEvent, string[] sourcesToWait, string methodName2 = "", string methodName3 = "")
         {
             byte[] bytes = File.ReadAllBytes(asm_file);
             string asm_base64 = Convert.ToBase64String(bytes);
@@ -1434,13 +1434,18 @@ namespace DebuggerTests
 
             Task eventTask = expectBpResolvedEvent
                                 ? WaitForBreakpointResolvedEvent()
-                                : WaitForScriptParsedEventsAsync("MethodBody0.cs", "MethodBody1.cs");
+                                : WaitForScriptParsedEventsAsync(sourcesToWait);
             (await cli.SendCommand("Runtime.evaluate", load_assemblies, token)).AssertOk();
             await eventTask;
 
+            if (methodName2 == "")
+                methodName2 = method_name;
+            if (methodName3 == "")
+                methodName3 = method_name;
+
             var run_method = JObject.FromObject(new
             {
-                expression = "window.setTimeout(function() { invoke_static_method('[debugger-test] TestHotReload:RunMethod', '" + class_name + "', '" + method_name + "'); }, 1);"
+                expression = "window.setTimeout(function() { invoke_static_method('[debugger-test] TestHotReload:RunMethod', '" + class_name + "', '" + method_name + "', '" + methodName2 + "', '" + methodName3 + "'); }, 1);"
             });
 
             await cli.SendCommand("Runtime.evaluate", run_method, token);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BrowserDebugHost\BrowserDebugHost.csproj" />
     <ProjectReference Include="..\BrowserDebugProxy\BrowserDebugProxy.csproj" />
-    <ProjectReference Include="..\tests\debugger-test\debugger-test.csproj" AdditionalProperties="RuntimeConfiguration=Debug" ReferenceOutputAssembly="false" Private="false" />
+    <ProjectReference Include="..\tests\debugger-test\debugger-test.csproj" AdditionalProperties="RuntimeConfiguration=$(RuntimeConfiguration)" ReferenceOutputAssembly="false" Private="false" />
 
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <!-- needed for ConditionalFact etc -->

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BrowserDebugHost\BrowserDebugHost.csproj" />
     <ProjectReference Include="..\BrowserDebugProxy\BrowserDebugProxy.csproj" />
-    <ProjectReference Include="..\tests\debugger-test\debugger-test.csproj" AdditionalProperties="RuntimeConfiguration=$(RuntimeConfiguration)" ReferenceOutputAssembly="false" Private="false" />
+    <ProjectReference Include="..\tests\debugger-test\debugger-test.csproj" AdditionalProperties="RuntimeConfiguration=Debug" ReferenceOutputAssembly="false" Private="false" />
 
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <!-- needed for ConditionalFact etc -->

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -22,7 +22,7 @@ namespace DebuggerTests
                     Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll"),
                     Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.pdb"),
                     Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll"),
-                    "MethodBody1", "StaticMethod1", expectBpResolvedEvent: false);
+                    "MethodBody1", "StaticMethod1", expectBpResolvedEvent: false, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckNumber(locals, "a", 10);
             pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 12, 16, "ApplyUpdateReferencedAssembly.MethodBody1.StaticMethod1");
@@ -40,7 +40,7 @@ namespace DebuggerTests
                     Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll"),
                     Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.pdb"),
                     Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll"),
-                    "MethodBody2", "StaticMethod1", expectBpResolvedEvent: false);
+                    "MethodBody2", "StaticMethod1", expectBpResolvedEvent: false, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckNumber(locals, "a", 10);
             pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 21, 12, "ApplyUpdateReferencedAssembly.MethodBody2.StaticMethod1");
@@ -62,7 +62,7 @@ namespace DebuggerTests
                     Path.Combine(DebuggerTestAppPath, $"{assembly_name}.dll"),
                     Path.Combine(DebuggerTestAppPath, $"{assembly_name}.pdb"),
                     Path.Combine(DebuggerTestAppPath, $"../wasm/{assembly_name}.dll"),
-                    "MethodBody3", "StaticMethod3", expectBpResolvedEvent: true);
+                    "MethodBody3", "StaticMethod3", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckNumber(locals, "a", 10);
@@ -110,7 +110,7 @@ namespace DebuggerTests
                     Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll"),
                     Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.pdb"),
                     Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll"),
-                    "MethodBody4", "StaticMethod4", expectBpResolvedEvent: true);
+                    "MethodBody4", "StaticMethod4", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 38, 12, "ApplyUpdateReferencedAssembly.MethodBody4.StaticMethod4");
@@ -166,7 +166,7 @@ namespace DebuggerTests
             string asm_file_hot_reload = Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll");
 
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody1", "StaticMethod1", expectBpResolvedEvent: false);
+                    asm_file, pdb_file, "MethodBody1", "StaticMethod1", expectBpResolvedEvent: false, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckNumber(locals, "a", 10);
@@ -198,7 +198,7 @@ namespace DebuggerTests
             string asm_file_hot_reload = Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll");
 
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody2", "StaticMethod1", expectBpResolvedEvent: false);
+                    asm_file, pdb_file, "MethodBody2", "StaticMethod1", expectBpResolvedEvent: false, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckNumber(locals, "a", 10);
@@ -231,7 +231,7 @@ namespace DebuggerTests
             int line = 30;
             await SetBreakpoint(".*/MethodBody1.cs$", line, 12, use_regex: true);
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody3", "StaticMethod3", expectBpResolvedEvent: true);
+                    asm_file, pdb_file, "MethodBody3", "StaticMethod3", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckNumber(locals, "a", 10);
@@ -294,7 +294,7 @@ namespace DebuggerTests
             int line = 38;
             await SetBreakpoint(".*/MethodBody1.cs$", line, 0, use_regex: true);
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody4", "StaticMethod4", expectBpResolvedEvent: true);
+                    asm_file, pdb_file, "MethodBody4", "StaticMethod4", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             //apply first update
             pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
@@ -351,7 +351,7 @@ namespace DebuggerTests
 
             var bp = await SetBreakpoint(".*/MethodBody1.cs$", 48, 12, use_regex: true);
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody5", "StaticMethod1", expectBpResolvedEvent: true);
+                    asm_file, pdb_file, "MethodBody5", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             //apply first update
             pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
@@ -376,7 +376,7 @@ namespace DebuggerTests
 
             var bp = await SetBreakpoint(".*/MethodBody1.cs$", 49, 12, use_regex: true);
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody5", "StaticMethod1", expectBpResolvedEvent: true);
+                    asm_file, pdb_file, "MethodBody5", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             //apply first update
             pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
@@ -403,7 +403,7 @@ namespace DebuggerTests
             var bp_notchanged = await SetBreakpoint(".*/MethodBody1.cs$", 48, 12, use_regex: true);
 
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody5", "StaticMethod1", expectBpResolvedEvent: true);
+                    asm_file, pdb_file, "MethodBody5", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 48, 12, scripts, pause_location["callFrames"]?[0]["location"]);
             //apply first update
@@ -426,7 +426,7 @@ namespace DebuggerTests
             var bp_invalid = await SetBreakpoint(".*/MethodBody1.cs$", 59, 12, use_regex: true);
 
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true);
+                    asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 55, 12, scripts, pause_location["callFrames"]?[0]["location"]);
             //apply first update
@@ -456,7 +456,7 @@ namespace DebuggerTests
             var bp_invalid = await SetBreakpoint(".*/MethodBody1.cs$", 59, 12, use_regex: true);
 
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true);
+                    asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 55, 12, scripts, pause_location["callFrames"]?[0]["location"]);
             //apply first update
@@ -492,7 +492,7 @@ namespace DebuggerTests
             var bp_invalid2 = await SetBreakpoint(".*/MethodBody1.cs$", 102, 12, use_regex: true);
 
             var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
-                    asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true);
+                    asm_file, pdb_file, "MethodBody6", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
 
             CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 55, 12, scripts, pause_location["callFrames"]?[0]["location"]);
             //apply first update
@@ -529,6 +529,37 @@ namespace DebuggerTests
 
             await EvaluateOnCallFrameAndCheck(pause_location["callFrames"]?[0]["callFrameId"].Value<string>(),
             ("ApplyUpdateReferencedAssembly.MethodBody8.staticField", TNumber(80)));
+        }
+
+        [ConditionalFact(nameof(RunningOnChrome))]
+        public async Task DebugHotReloadMethod_AddingNewMethodWithoutAnyOtherChange()
+        {
+            string asm_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly2.dll");
+            string pdb_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly2.pdb");
+            string asm_file_hot_reload = Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly2.dll");
+
+            var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
+                    asm_file, pdb_file, "AddMethod", "StaticMethod1", expectBpResolvedEvent: false, sourcesToWait: new string [] { "MethodBody2.cs" });
+            CheckLocation("dotnet://ApplyUpdateReferencedAssembly2.dll/MethodBody2.cs", 12, 12, scripts, pause_location["callFrames"]?[0]["location"]);
+            //apply first update
+            pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
+                    asm_file_hot_reload, "AddMethod", "StaticMethod2", 1);
+
+            JToken top_frame = pause_location["callFrames"]?[0];
+            AssertEqual("ApplyUpdateReferencedAssembly.AddMethod.StaticMethod2", top_frame?["functionName"]?.Value<string>(), top_frame?.ToString());
+            CheckLocation("dotnet://ApplyUpdateReferencedAssembly2.dll/MethodBody2.cs", 18, 12, scripts, top_frame["location"]);
+        }
+
+        [ConditionalFact(nameof(RunningOnChrome))]
+        public async Task DebugHotReloadMethod_AddingNewMethodWithoutAnyOtherChange_WithoutSDB()
+        {
+            var pause_location = await LoadAssemblyAndTestHotReload(
+                    Path.Combine(DebuggerTestAppPath, $"ApplyUpdateReferencedAssembly2.dll"),
+                    Path.Combine(DebuggerTestAppPath, $"ApplyUpdateReferencedAssembly2.pdb"),
+                    Path.Combine(DebuggerTestAppPath, $"../wasm/ApplyUpdateReferencedAssembly2.dll"),
+                    "AddMethod", "StaticMethod1", expectBpResolvedEvent: false, sourcesToWait: new string [] { "MethodBody2.cs" }, "StaticMethod2");
+            CheckLocation("dotnet://ApplyUpdateReferencedAssembly2.dll/MethodBody2.cs", 12, 12, scripts, pause_location["callFrames"]?[0]["location"]);
+            await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", $"dotnet://ApplyUpdateReferencedAssembly2.dll/MethodBody2.cs", 18, 12, "ApplyUpdateReferencedAssembly.AddMethod.StaticMethod2");
         }
     }
 }

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/ApplyUpdateReferencedAssembly2.csproj
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/ApplyUpdateReferencedAssembly2.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="EnableAggressiveTrimming;PublishTrimmed">
+  <PropertyGroup>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+    <OutputType>library</OutputType>
+    <IsTestProject>false</IsTestProject>
+    <IsTestSupportProject>true</IsTestSupportProject>
+    <!-- to call AsssemblyExtensions.ApplyUpdate we need Optimize=false, EmitDebugInformation=true in all configurations -->
+    <Optimize>false</Optimize>
+    <EmitDebugInformation>true</EmitDebugInformation>
+    <!-- hot reload is not compatible with trimming -->
+    <EnableAggressiveTrimming>false</EnableAggressiveTrimming>
+    <PublishTrimmed>false</PublishTrimmed>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EmbedAllSources>true</EmbedAllSources>
+
+    <!-- FIXME: issue -->
+    <DisableSourceLink>true</DisableSourceLink>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="MethodBody2.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- This package from https://github.com/dotnet/hotreload-utils provides
+         targets that read the json delta script and generates deltas based on the baseline assembly and the modified sources.
+
+         Projects must define the DeltaScript property that specifies the (relative) path to the json script.
+         Deltas will be emitted next to the output assembly.  Deltas will be copied when the current
+         project is referenced from other other projects.
+    -->
+    <PackageReference Include="Microsoft.DotNet.HotReload.Utils.Generator.BuildTool" Version="$(MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/MethodBody2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/MethodBody2.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class AddMethod {
+        public static string StaticMethod1 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/MethodBody2_v1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/MethodBody2_v1.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class AddMethod {
+        public static string StaticMethod1 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+        public static string StaticMethod2 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/MethodBody2_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/MethodBody2_v2.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class AddMethod {
+        public static string StaticMethod1 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+        public static string StaticMethod2 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+        public static string StaticMethod3 () {
+            Console.WriteLine("original");
+            int a = 10;
+            Debugger.Break();
+            return "OLD STRING";
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/deltascript.json
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly2/deltascript.json
@@ -1,0 +1,7 @@
+{
+    "changes": [
+        {"document": "MethodBody2.cs", "update": "MethodBody2_v1.cs"},
+        {"document": "MethodBody2.cs", "update": "MethodBody2_v2.cs"}
+    ]
+}
+

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -604,7 +604,7 @@ public class LoadDebuggerTestALC {
             Console.WriteLine($"Loaded - {loadedAssembly}");
 
         }
-        public static void RunMethod(string className, string methodName)
+        public static void RunMethod(string className, string methodName, string methodName2, string methodName3)
         {
             var ty = typeof(System.Reflection.Metadata.MetadataUpdater);
             var mi = ty.GetMethod("GetCapabilities", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, Array.Empty<Type>());
@@ -624,13 +624,13 @@ public class LoadDebuggerTestALC {
             ApplyUpdate(loadedAssembly, 1);
 
             myType = loadedAssembly.GetType($"ApplyUpdateReferencedAssembly.{className}");
-            myMethod = myType.GetMethod(methodName);
+            myMethod = myType.GetMethod(methodName2);
             myMethod.Invoke(null, null);
 
             ApplyUpdate(loadedAssembly, 2);
 
             myType = loadedAssembly.GetType($"ApplyUpdateReferencedAssembly.{className}");
-            myMethod = myType.GetMethod(methodName);
+            myMethod = myType.GetMethod(methodName3);
             myMethod.Invoke(null, null);
         }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -20,6 +20,7 @@
 
     <!-- We want to bundle these assemblies, so build them first -->
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
+    <ProjectReference Include="..\ApplyUpdateReferencedAssembly2\ApplyUpdateReferencedAssembly2.csproj" />
     <ProjectReference Include="..\ApplyUpdateReferencedAssemblyChineseCharInPathㄨ\ApplyUpdateReferencedAssemblyChineseCharInPathㄨ.csproj" />
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\debugger-test-chinese-char-in-path-ㄨ\debugger-test-chinese-char-in-path-ㄨ.csproj" ReferenceOutputAssembly="false" />


### PR DESCRIPTION
- Initializing the hash tables before call `add_method_to_baseline` to avoid the assertion.
- Added a test case that reproduces the error, we cannot have any other difference in the source then add the new method.
- Fixing debugging after adding a new method on blazor, the document rowid of the initial assembly is different of the document rowid of the updated assembly, so the rowid cannot be the key of the document table.

Fixes #75324 