### PR TITLE
Revert "[mono][llvm] Disable simd intrinsics when we might be interop…

### DIFF
--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3027,7 +3027,7 @@ static gboolean
 is_simd_supported (MonoCompile *cfg)
 {
 #ifdef DISABLE_SIMD
-	return FALSE;
+    return FALSE;
 #endif
 	// FIXME: Clean this up
 #ifdef TARGET_WASM
@@ -3035,10 +3035,6 @@ is_simd_supported (MonoCompile *cfg)
 		return FALSE;
 #else
 	if (cfg->llvm_only)
-		return FALSE;
-	// FIXME We disable simd intrinsics when mixing between llvmaot and jit since the llvm backend could
-	// see that certain simd operations are supported while with jit we fail to emit correct code.
-	if (cfg->compile_aot && cfg->compile_llvm && !cfg->full_aot)
 		return FALSE;
 #endif
 	return TRUE;

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -719,6 +719,12 @@ emit_hardware_intrinsics (
 			goto support_probe_complete;
 		id = info->id;
 
+#ifdef TARGET_ARM64
+		if (!(cfg->compile_aot && cfg->full_aot && !cfg->interp) && !intrin_group->jit_supported) {
+			goto support_probe_complete;
+		}
+#endif
+
 		// Hardware intrinsics are LLVM-only.
 		if (!COMPILE_LLVM (cfg) && !intrin_group->jit_supported)
 			goto support_probe_complete;


### PR DESCRIPTION
…ing betwen jit and llvmaot (#74797)"

Fixes #75498

This reverts commit c3ccb8a3dcfb7b5fa23fcb00b9a5346a39e049ed.

On backport PR https://github.com/dotnet/runtime/pull/75261 this was noticed to induce various issues that are awkward to fix (at least for a release branch). Not sure why the original PR was green but revert just in case and wait for a proper fix instead for .net 8 for https://github.com/dotnet/runtime/issues/74587.