### PR TITLE
Don't unload MsQuic from the process

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -20,7 +20,7 @@ internal sealed unsafe partial class MsQuicApi
 
     private static readonly Version MsQuicVersion = new Version(2, 1);
 
-    private static readonly IntPtr MsQuicHandle = TryLoadMsQuic();
+    private static readonly IntPtr MsQuicHandle = TryLoadMsQuic(out IntPtr handle) ? handle : IntPtr.Zero;
 
     public MsQuicSafeHandle Registration { get; }
 
@@ -139,11 +139,9 @@ internal sealed unsafe partial class MsQuicApi
         return new MsQuicApi(apiTable);
     }
 
-    private static IntPtr TryLoadMsQuic() =>
-        (NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out IntPtr msQuicHandle) ||
-        NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
-            ? msQuicHandle
-            : IntPtr.Zero;
+    private static bool TryLoadMsQuic(out IntPtr msQuicHandle) =>
+        NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) ||
+        NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
 
     private static bool TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out int openStatus)
     {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -20,6 +20,8 @@ internal sealed unsafe partial class MsQuicApi
 
     private static readonly Version MsQuicVersion = new Version(2, 1);
 
+    private static readonly IntPtr MsQuicHandle = TryLoadMsQuic();
+
     public MsQuicSafeHandle Registration { get; }
 
     public QUIC_API_TABLE* ApiTable { get; }
@@ -60,75 +62,68 @@ internal sealed unsafe partial class MsQuicApi
 
     static MsQuicApi()
     {
-        if (!TryLoadMsQuic(out IntPtr msQuicHandle))
+        if (MsQuicHandle == IntPtr.Zero)
+        {
+            // MsQuic library not loaded
+            return;
+        }
+
+        if (!TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out _))
         {
             return;
         }
 
         try
         {
-            if (!TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable, out _))
+            // Check version
+            int arraySize = 4;
+            uint* libVersion = stackalloc uint[arraySize];
+            uint size = (uint)arraySize * sizeof(uint);
+            if (StatusFailed(apiTable->GetParam(null, QUIC_PARAM_GLOBAL_LIBRARY_VERSION, &size, libVersion)))
             {
                 return;
             }
 
-            try
+            var version = new Version((int)libVersion[0], (int)libVersion[1], (int)libVersion[2], (int)libVersion[3]);
+            if (version < MsQuicVersion)
             {
-                // Check version
-                int arraySize = 4;
-                uint* libVersion = stackalloc uint[arraySize];
-                uint size = (uint)arraySize * sizeof(uint);
-                if (StatusFailed(apiTable->GetParam(null, QUIC_PARAM_GLOBAL_LIBRARY_VERSION, &size, libVersion)))
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    return;
+                    NetEventSource.Info(null, $"Incompatible MsQuic library version '{version}', expecting '{MsQuicVersion}'");
                 }
+                return;
+            }
 
-                var version = new Version((int)libVersion[0], (int)libVersion[1], (int)libVersion[2], (int)libVersion[3]);
-                if (version < MsQuicVersion)
+            // Assume SChannel is being used on windows and query for the actual provider from the library if querying is supported
+            QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
+            size = sizeof(QUIC_TLS_PROVIDER);
+            apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
+            UsesSChannelBackend = provider == QUIC_TLS_PROVIDER.SCHANNEL;
+
+            if (UsesSChannelBackend)
+            {
+                // Implies windows platform, check TLS1.3 availability
+                if (!IsWindowsVersionSupported())
                 {
                     if (NetEventSource.Log.IsEnabled())
                     {
-                        NetEventSource.Info(null, $"Incompatible MsQuic library version '{version}', expecting '{MsQuicVersion}'");
+                        NetEventSource.Info(null, $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
                     }
+
                     return;
                 }
 
-                // Assume SChannel is being used on windows and query for the actual provider from the library if querying is supported
-                QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
-                size = sizeof(QUIC_TLS_PROVIDER);
-                apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
-                UsesSChannelBackend = provider == QUIC_TLS_PROVIDER.SCHANNEL;
-
-                if (UsesSChannelBackend)
-                {
-                    // Implies windows platform, check TLS1.3 availability
-                    if (!IsWindowsVersionSupported())
-                    {
-                        if (NetEventSource.Log.IsEnabled())
-                        {
-                            NetEventSource.Info(null, $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
-                        }
-
-                        return;
-                    }
-
-                    Tls13ServerMayBeDisabled = IsTls13Disabled(isServer: true);
-                    Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
-                }
-
-                IsQuicSupported = true;
+                Tls13ServerMayBeDisabled = IsTls13Disabled(isServer: true);
+                Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
             }
-            finally
-            {
-                // Gracefully close the API table to free resources. The API table will be allocated lazily again if needed
-                bool closed = TryCloseMsQuic(msQuicHandle, apiTable);
-                Debug.Assert(closed, "Failed to close MsQuic");
-            }
+
+            IsQuicSupported = true;
         }
         finally
         {
-            // Unload the library, we will load it again when we actually use QUIC
-            NativeLibrary.Free(msQuicHandle);
+            // Gracefully close the API table to free resources. The API table will be allocated lazily again if needed
+            bool closed = TryCloseMsQuic(apiTable);
+            Debug.Assert(closed, "Failed to close MsQuic");
         }
     }
 
@@ -136,28 +131,26 @@ internal sealed unsafe partial class MsQuicApi
     {
         Debug.Assert(IsQuicSupported);
 
-        int openStatus = MsQuic.QUIC_STATUS_INTERNAL_ERROR;
-
-        if (TryLoadMsQuic(out IntPtr msQuicHandle) &&
-            TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable, out openStatus))
+        if (!TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out int openStatus))
         {
-            return new MsQuicApi(apiTable);
+            throw ThrowHelper.GetExceptionForMsQuicStatus(openStatus);
         }
 
-        ThrowHelper.ThrowIfMsQuicError(openStatus);
-
-        // this should unreachable as TryOpenMsQuic returns non-success status on failure
-        throw new Exception("Failed to create MsQuicApi instance");
+        return new MsQuicApi(apiTable);
     }
 
-    private static bool TryLoadMsQuic(out IntPtr msQuicHandle) =>
-        NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) ||
-        NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
+    private static IntPtr TryLoadMsQuic() =>
+        (NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out IntPtr msQuicHandle) ||
+        NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
+            ? msQuicHandle
+            : IntPtr.Zero;
 
-    private static bool TryOpenMsQuic(IntPtr msQuicHandle, out QUIC_API_TABLE* apiTable, out int openStatus)
+    private static bool TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out int openStatus)
     {
+        Debug.Assert(MsQuicHandle != IntPtr.Zero);
+
         apiTable = null;
-        if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
+        if (!NativeLibrary.TryGetExport(MsQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
         {
             if (NetEventSource.Log.IsEnabled())
             {
@@ -185,9 +178,11 @@ internal sealed unsafe partial class MsQuicApi
         return true;
     }
 
-    private static bool TryCloseMsQuic(IntPtr msQuicHandle, QUIC_API_TABLE* apiTable)
+    private static bool TryCloseMsQuic(QUIC_API_TABLE* apiTable)
     {
-        if (NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
+        Debug.Assert(MsQuicHandle != IntPtr.Zero);
+
+        if (NativeLibrary.TryGetExport(MsQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
         {
             ((delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)msQuicClose)(apiTable);
             return true;


### PR DESCRIPTION
Since MsQuic library loads libmsquic.lttng.so on Linuxes it is weird to unload just the library and not the dependent libraries as well, and since we cannot touch libmsquic.lttng.so from .NET, it seems better to keep libmsquic loaded in memory to prevent any weird behavior by having the library only partially loaded.

Note that this change does not negate the benefit of https://github.com/dotnet/runtime/pull/74749, the threads are still being stopped and deallocated in the `MsQuicClose` call.

Related:
- https://github.com/dotnet/runtime/issues/74710#issuecomment-1242131798
- https://github.com/dotnet/runtime/pull/75330/files#r967218611

Fixes #74629

cc: @stephentoub, @jkotas