### PR TITLE
Allow substituting SIMD calls into HWIs

### DIFF
--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -656,17 +656,6 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
         }
     }
 
-#ifdef FEATURE_SIMD
-    // Don't forward sub a SIMD call under a HW intrinsic node.
-    // LowerCallStruct is not prepared for this.
-    //
-    if (fwdSubNode->IsCall() && varTypeIsSIMD(fwdSubNode->TypeGet()) && fsv.GetParentNode()->OperIs(GT_HWINTRINSIC))
-    {
-        JITDUMP(" simd returning call; hw intrinsic\n");
-        return false;
-    }
-#endif // FEATURE_SIMD
-
     // There are implicit assumptions downstream on where/how multi-reg ops
     // can appear.
     //

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3834,6 +3834,18 @@ void Lowering::LowerCallStruct(GenTreeCall* call)
                 assert(returnType == user->TypeGet());
                 break;
 
+#ifdef FEATURE_HW_INTRINSICS
+            case GT_HWINTRINSIC:
+                if (varTypeUsesFloatReg(returnType) != varTypeUsesFloatReg(origType))
+                {
+                    GenTree* bitCast = comp->gtNewBitCastNode(origType, call);
+                    BlockRange().InsertAfter(call, bitCast);
+                    callUse.ReplaceWith(bitCast);
+                    ContainCheckBitCast(bitCast);
+                }
+                break;
+#endif // FEATURE_HW_INTRINSICS
+
             default:
                 unreached();
         }


### PR DESCRIPTION
Quirk removal.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=12865&view=ms.vss-build-web.run-extensions-tab).