### PR TITLE
Fix XML canonicalization to replace &#13; sequences with &#xD; according to spec

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -422,6 +422,7 @@ namespace System.Security.Cryptography.Xml
         {
             StringBuilder sb = new StringBuilder();
             sb.Append(data);
+            sb.Replace("&#13;", "&#xD");
             Utils.SBReplaceCharWithString(sb, (char)13, "&#xD;");
             return sb.ToString();
         }
@@ -433,6 +434,7 @@ namespace System.Security.Cryptography.Xml
             sb.Replace("&", "&amp;");
             sb.Replace("<", "&lt;");
             sb.Replace(">", "&gt;");
+            sb.Replace("&#13;", "&#xD");
             SBReplaceCharWithString(sb, (char)13, "&#xD;");
             return sb.ToString();
         }
@@ -449,6 +451,9 @@ namespace System.Security.Cryptography.Xml
             sb.Replace("&", "&amp;");
             sb.Replace("<", "&lt;");
             sb.Replace("\"", "&quot;");
+            sb.Replace("&#9;", "&#x9;");
+            sb.Replace("&#10;", "&#xA;");
+            sb.Replace("&#13;", "&#xD");
             SBReplaceCharWithString(sb, (char)9, "&#x9;");
             SBReplaceCharWithString(sb, (char)10, "&#xA;");
             SBReplaceCharWithString(sb, (char)13, "&#xD;");

--- a/src/libraries/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/XmlDsigC14NTransformTest.cs
@@ -185,6 +185,13 @@ namespace System.Security.Cryptography.Xml.Tests
             Assert.Equal(C14NSpecExample6Output, result);
         }
 
+        [Fact]
+        public void C14NSpecExample7()
+        {
+            string result = TestHelpers.ExecuteTransform(C14NSpecExample7Input, new XmlDsigC14NTransform());
+            Assert.Equal(C14NSpecExample7Output, result);
+        }
+
         //
         // Example 1 from C14N spec - PIs, Comments, and Outside of Document Element:
         // http://www.w3.org/TR/xml-c14n#Example-OutsideDoc
@@ -343,6 +350,15 @@ namespace System.Security.Cryptography.Xml.Tests
                     "<doc>&#169;</doc>\n";
         static string C14NSpecExample6Output =
                 "<doc>\xC2\xA9</doc>";
+
+        //
+        // Example 7 from C14N spec - Character Modifications and Character References
+        // https://www.w3.org/TR/xml-c14n/#Example-Chars
+        //
+        static string C14NSpecExample7Input =
+                    "<doc>&#13;</doc>";
+        static string C14NSpecExample7Output =
+                    "<doc>&#xD;</doc>";
 
         [Fact]
         public void SimpleNamespacePrefixes()


### PR DESCRIPTION
This fixes an incompatibility bug in XML canonicalization where a signing party
uses &#13; character sequence when breaking lines in attributes.

Specifically, the Java xmldigsig library inserts this when breaking the lines within
the digest and the signature elements when signing XML documents.

The c18n spec defining the correct behaviour can be seen here:
https://www.w3.org/TR/xml-c14n/#Example-Chars

Refer to the added unit test for a minimal example of the bug currently in the SDK