### PR TITLE
[wasm] Add common vector min/max implementation

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Vector.cs
+++ b/src/mono/sample/wasm/browser-bench/Vector.cs
@@ -22,6 +22,10 @@ namespace Sample
                 new DotDouble(),
                 new SumUInt(),
                 new SumDouble(),
+                new MinFloat(),
+                new MaxFloat(),
+                new MinDouble(),
+                new MaxDouble(),
             };
         }
 
@@ -183,6 +187,84 @@ namespace Sample
 
             public override void RunStep() {
                 result = Vector128.Sum(vector1);
+            }
+        }
+
+        class MinFloat : VectorMeasurement
+        {
+            Vector128<float> vector1;
+            Vector128<float> vector2;
+            Vector128<float> result;
+
+            public override string Name => "Min float";
+
+            public MinFloat()
+            {
+                vector1 = Vector128.Create(12f, 34, 56, 78);
+                vector2 = Vector128.Create(13f, 32, 57, 77);
+                System.Console.WriteLine($"min float: {Vector128.Min(vector1, vector2)}");
+            }
+
+            public override void RunStep() {
+                result = Vector128.Min(vector1, vector2);
+            }
+        }
+
+        class MaxFloat : VectorMeasurement
+        {
+            Vector128<float> vector1;
+            Vector128<float> vector2;
+            Vector128<float> result;
+
+            public override string Name => "Max float";
+
+            public MaxFloat()
+            {
+                vector1 = Vector128.Create(12f, 34, 56, 78);
+                vector2 = Vector128.Create(13f, 32, 57, 77);
+            }
+
+            public override void RunStep() {
+                result = Vector128.Max(vector1, vector2);
+            }
+        }
+
+        class MinDouble : VectorMeasurement
+        {
+            Vector128<double> vector1;
+            Vector128<double> vector2;
+            Vector128<double> result;
+
+            public override string Name => "Min double";
+
+            public MinDouble()
+            {
+                vector1 = Vector128.Create(12d, 34);
+                vector2 = Vector128.Create(13d, 32);
+                System.Console.WriteLine($"min double: {Vector128.Min(vector1, vector2)}");
+            }
+
+            public override void RunStep() {
+                result = Vector128.Min(vector1, vector2);
+            }
+        }
+
+        class MaxDouble : VectorMeasurement
+        {
+            Vector128<double> vector1;
+            Vector128<double> vector2;
+            Vector128<double> result;
+
+            public override string Name => "Max double";
+
+            public MaxDouble()
+            {
+                vector1 = Vector128.Create(12d, 34);
+                vector2 = Vector128.Create(13d, 32);
+            }
+
+            public override void RunStep() {
+                result = Vector128.Max(vector1, vector2);
             }
         }
     }


### PR DESCRIPTION
Emit fcmp,select for common case of OP_FMIN/FMAX

This avoids reaching an assert in the aot compiler on wasm and produces reasonable code:

    (func Wasm_Browser_Bench_Sample_Sample_VectorTask_MaxFloat_RunStep(param $0 i32, $1 i32))
     local.get $0
     i32.eqz
     if
      call mini_llvmonly_throw_nullref_exception
      unreachable

     local.get $0
     local.get $0
     v128.load offset:16    [SIMD]
     local.get $0
     v128.load offset:32    [SIMD]
     f32x4.pmax    [SIMD]
     v128.store offset:48    [SIMD]

    (func Wasm_Browser_Bench_Sample_Sample_VectorTask_MinFloat_RunStep(param $0 i32, $1 i32))
     local $2 v128
     local $3 v128
     local.get $0
     i32.eqz
     if
      call mini_llvmonly_throw_nullref_exception
      unreachable

     local.get $0
     local.get $0
     v128.load offset:32    [SIMD]
     local.tee $2
     local.get $0
     v128.load offset:16    [SIMD]
     local.tee $3
     local.get $3
     local.get $2
     f32x4.gt    [SIMD]
     v128.bitselect    [SIMD]
     v128.store offset:48    [SIMD]

Also added measurements for these to the browser-bench