### PR TITLE
[release/6.0] Pass resource items for VS generated authoring

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -101,7 +101,7 @@
 
     <CreateVisualStudioWorkload BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
                                 BaseOutputPath="$(WorkloadOutputPath)"
-                                ComponentResources="$(ComponentResources)"
+                                ComponentResources="@(ComponentResources)"
                                 PackageSource="$(PackageSource)"
                                 ShortNames="@(ShortNames)"
                                 WorkloadManifestPackageFiles="@(ManifestPackages)"


### PR DESCRIPTION
## Description
A non-existing property instead of an item is being passed to the workload generation task. It won't cause build breaks because the task has fallback logic that will extract information from the workload manifest when it generates the SWIX authoring for VS.

It is ignoring all the specific resource values and versions we're providing for workloads. The version numbers are the more critical concern for the component and component group authoring as it will require manually updating authoring in VS when we insert.

## Testing
Manually verify the intermediate JSON manifests generated for Visual Studio using an official build. Otherwise, wait for a staging build to verify the files being pushed to VSDROP for an insertion (likely too late to take corrective actions)