### PR TITLE
[release/7.0][wasm] Fix reference to `Microsoft.Build.NoTargets`

### DIFF
--- a/src/tests/Common/wasm-test-runner/WasmTestRunner.proj
+++ b/src/tests/Common/wasm-test-runner/WasmTestRunner.proj
@@ -1,6 +1,6 @@
 <!-- This project requires an explicit SDK version number because it is used on Helix,
       and global.json is not available. -->
-<Project Sdk="Microsoft.Build.NoTargets/1.0.53" DefaultTargets="WasmBuildApp">
+<Project Sdk="Microsoft.Build.NoTargets/3.5.0" DefaultTargets="WasmBuildApp">
   <Import Project="$(CORE_ROOT)\build\WasmApp.InTree.props" />
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>


### PR DESCRIPTION
Backport of the fix from https://github.com/dotnet/runtime/pull/75397

## Customer impact

None. This is a tests only change.

## Testing

CI `wasm runtimetests` run, since this is a CI/tests only change.

## Risk

None, as long as the tests pass