### PR TITLE
fix exclusions.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -562,10 +562,10 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929/test45929/*">
             <Issue>https://github.com/dotnet/runtime/issues/60152</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetTotalPauseDuration.csproj">
+        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetTotalPauseDuration/*">
             <Issue>https://github.com/dotnet/runtime/issues/74631</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetGCMemoryInfo.csproj">
+        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetGCMemoryInfo/*">
             <Issue>https://github.com/dotnet/runtime/issues/74902</Issue>
         </ExcludeList>    
     </ItemGroup>


### PR DESCRIPTION
Fixing the recently added exclusions. The csproj cant be used as the exclusion but the test script is required instead.

Disables test in #74902 (builds on previous PR #75309)