### PR TITLE
Minor fixes to write barriers

### DIFF
--- a/src/coreclr/vm/amd64/JitHelpers_Fast.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Fast.asm
@@ -279,7 +279,7 @@ ifdef WRITE_BARRIER_CHECK
         ; Check that our adjusted destination is somewhere in the shadow gc
         add     r10, [g_GCShadow]
         cmp     r10, [g_GCShadowEnd]
-        ja      NoShadow
+        jnb     NoShadow
 
         ; Write ref into real GC
         mov     [rdi], rcx

--- a/src/coreclr/vm/amd64/JitHelpers_Slow.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Slow.asm
@@ -81,7 +81,7 @@ ifdef WRITE_BARRIER_CHECK
         ; Check that our adjusted destination is somewhere in the shadow gc
         add     r10, [g_GCShadow]
         cmp     r10, [g_GCShadowEnd]
-        ja      NoShadow
+        jnb     NoShadow
 
         ; Write ref into real GC; see comment below about possibility of AV
         mov     [rcx], rdx

--- a/src/coreclr/vm/amd64/jithelpers_fast.S
+++ b/src/coreclr/vm/amd64/jithelpers_fast.S
@@ -300,7 +300,7 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         add     r10, [rax]
         PREPARE_EXTERNAL_VAR g_GCShadowEnd, rax
         cmp     r10, [rax]
-        ja      NoShadow_ByRefWriteBarrier
+        jnb     NoShadow_ByRefWriteBarrier
 
         // Write ref into real GC
         mov     [rdi], rcx

--- a/src/coreclr/vm/amd64/jithelpers_slow.S
+++ b/src/coreclr/vm/amd64/jithelpers_slow.S
@@ -28,7 +28,7 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         add     r10, [rax]
         PREPARE_EXTERNAL_VAR g_GCShadowEnd, r11
         cmp     r10, [r11]
-        ja      NoShadow
+        jnb     NoShadow
 
         // Write ref into real GC// see comment below about possibility of AV
         mov     [rdi], rsi

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -420,7 +420,7 @@ LOCAL_LABEL(CheckCardTable):
     // branch to exit is taken.
     ccmp x15, x12, #0x2, hs
 
-    bhi  LOCAL_LABEL(Exit)
+    bhs  LOCAL_LABEL(Exit)
 
 LOCAL_LABEL(SkipEphemeralCheck):
     // Check if we need to update the card table

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -473,15 +473,14 @@ ShadowUpdateDisabled
 CheckCardTable
         ; Branch to Exit if the reference is not in the Gen0 heap
         ;
-        adr      x12,  wbs_ephemeral_low
-        ldp      x12,  x16, [x12]
+        ldr      x12,  wbs_ephemeral_low
         cbz      x12,  SkipEphemeralCheck
-
         cmp      x15,  x12
         blo      Exit
 
-        cmp      x15,  x16
-        bhi      Exit
+        ldr      x12,  wbs_ephemeral_high
+        cmp      x15,  x12
+        bhs      Exit
 
 SkipEphemeralCheck
         ; Check if we need to update the card table

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -476,10 +476,15 @@ CheckCardTable
         ldr      x12,  wbs_ephemeral_low
         cbz      x12,  SkipEphemeralCheck
         cmp      x15,  x12
-        blo      Exit
 
         ldr      x12,  wbs_ephemeral_high
-        cmp      x15,  x12
+
+        ; Compare against the upper bound if the previous comparison indicated
+        ; that the destination address is greater than or equal to the lower
+        ; bound. Otherwise, set the C flag (specified by the 0x2) so that the
+        ; branch to exit is taken.
+        ccmp     x15,  x12, #0x2, hs
+
         bhs      Exit
 
 SkipEphemeralCheck

--- a/src/coreclr/vm/i386/jithelp.S
+++ b/src/coreclr/vm/i386/jithelp.S
@@ -109,7 +109,7 @@ PATCH_LABEL JIT_DebugWriteBarrier\rg
     mov     [edx], edx
     cmp     ecx, [edx]
     pop     edx
-    ja      LOCAL_LABEL(WriteBarrier_NoShadow_\rg)
+    jae     LOCAL_LABEL(WriteBarrier_NoShadow_\rg)
 
     // TODO: In Orcas timeframe if we move to P4+ only on X86 we should enable
     // mfence barriers on either side of these two writes to make sure that
@@ -281,7 +281,7 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
     mov     eax, [eax]
     cmp     edx, [eax]
     pop     eax
-    ja      LOCAL_LABEL(ByRefWriteBarrier_NoShadow)
+    jae     LOCAL_LABEL(ByRefWriteBarrier_NoShadow)
 
     // TODO: In Orcas timeframe if we move to P4+ only on X86 we should enable
     // mfence barriers on either side of these two writes to make sure that

--- a/src/coreclr/vm/i386/jithelp.asm
+++ b/src/coreclr/vm/i386/jithelp.asm
@@ -193,7 +193,7 @@ ifdef WRITE_BARRIER_CHECK
         jb      WriteBarrier_NoShadow_&rg
         add     ecx, [g_GCShadow]
         cmp     ecx, [g_GCShadowEnd]
-        ja      WriteBarrier_NoShadow_&rg
+        jae     WriteBarrier_NoShadow_&rg
 
         ; TODO: In Orcas timeframe if we move to P4+ only on X86 we should enable
         ; mfence barriers on either side of these two writes to make sure that
@@ -330,7 +330,7 @@ ifdef WRITE_BARRIER_CHECK
         jb      ByRefWriteBarrier_NoShadow
         add     edx, [g_GCShadow]
         cmp     edx, [g_GCShadowEnd]
-        ja      ByRefWriteBarrier_NoShadow
+        jae     ByRefWriteBarrier_NoShadow
 
         ; TODO: In Orcas timeframe if we move to P4+ only on X86 we should enable
         ; mfence barriers on either side of these two writes to make sure that


### PR DESCRIPTION
Similar to #74325, uniformly exclude the `g_GCShadowEnd`, `g_ephemeral_high`, and `g_highest_address` upper bounds in the corresponding range checks.

Note that `JNB`, `JAE`, and `JNC` mnemonics correspond to the same processor instruction (jump if CF = 0).  I used `JNB` for amd64 and `JAE` for i386 for "local consistency" with other range checks in the corresponding files.

The Windows ARM64 version would trash the `x16` register in the `CheckCardTable` block. That was not reflected in the comments — neither in this file nor in `src\coreclr\jit\targetarm64.h`. I am not convinced that `ldp` improves performance here as it requires an additional `adr` instruction and increases the average number of retired instructions.  The Linux ARM64 version uses two `ldr` instructions instead and I decided to use the same for Windows.