### PR TITLE
Make ResourceManager.BaseName work as documented.

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ComponentResourceManagerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ComponentResourceManagerTests.cs
@@ -24,7 +24,7 @@ namespace System.ComponentModel.Tests
         public void Ctor_Type(Type type)
         {
             var resourceManager = new ComponentResourceManager(type);
-            Assert.Equal("Int32", resourceManager.BaseName);
+            Assert.Equal("System.Int32", resourceManager.BaseName);
             Assert.False(resourceManager.IgnoreCase);
             Assert.NotNull(resourceManager.ResourceSetType);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/FileBasedResourceGroveler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/FileBasedResourceGroveler.cs
@@ -47,10 +47,7 @@ namespace System.Resources
                     // If we've hit top of the Culture tree, return.
                     if (culture.HasInvariantCultureName)
                     {
-                        // We really don't think this should happen - we always
-                        // expect the neutral locale's resources to be present.
-                        string? locationInfo = _mediator.LocationInfo == null ? "<null>" : _mediator.LocationInfo.FullName;
-                        throw new MissingManifestResourceException($"{SR.MissingManifestResource_NoNeutralDisk}{Environment.NewLineConst}baseName: {_mediator.BaseNameField}  locationInfo: {locationInfo}  fileName: {_mediator.GetResourceFileName(culture)}");
+                        throw new MissingManifestResourceException($"{SR.MissingManifestResource_NoNeutralDisk}{Environment.NewLineConst}baseName: {_mediator.BaseNameField}  fileName: {_mediator.GetResourceFileName(culture)}");
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -321,12 +321,12 @@ namespace System.Resources
             return rs;
         }
 
-        private Stream? GetManifestResourceStream(Assembly satellite, string fileName)
+        private static Stream? GetManifestResourceStream(Assembly satellite, string fileName)
         {
             Debug.Assert(satellite != null, "satellite shouldn't be null; check caller");
             Debug.Assert(fileName != null, "fileName shouldn't be null; check caller");
 
-            return satellite.GetManifestResourceStream(_mediator.LocationInfo!, fileName) ??
+            return satellite.GetManifestResourceStream(fileName) ??
                 CaseInsensitiveManifestResourceStreamLookup(satellite, fileName);
         }
 
@@ -334,22 +334,15 @@ namespace System.Resources
         // case-insensitive lookup rules.  Yes, this is slow.  The metadata
         // dev lead refuses to make all assembly manifest resource lookups case-insensitive,
         // even optionally case-insensitive.
-        private Stream? CaseInsensitiveManifestResourceStreamLookup(Assembly satellite, string name)
+        private static Stream? CaseInsensitiveManifestResourceStreamLookup(Assembly satellite, string name)
         {
             Debug.Assert(satellite != null, "satellite shouldn't be null; check caller");
             Debug.Assert(name != null, "name shouldn't be null; check caller");
 
-            string? nameSpace = _mediator.LocationInfo?.Namespace;
-
-            char c = Type.Delimiter;
-            string resourceName = nameSpace != null && name != null ?
-                string.Concat(nameSpace, new ReadOnlySpan<char>(in c), name) :
-                string.Concat(nameSpace, name);
-
             string? canonicalName = null;
             foreach (string existingName in satellite.GetManifestResourceNames())
             {
-                if (string.Equals(existingName, resourceName, StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(existingName, name, StringComparison.InvariantCultureIgnoreCase))
                 {
                     if (canonicalName == null)
                     {
@@ -357,7 +350,7 @@ namespace System.Resources
                     }
                     else
                     {
-                        throw new MissingManifestResourceException(SR.Format(SR.MissingManifestResource_MultipleBlobs, resourceName, satellite.ToString()));
+                        throw new MissingManifestResourceException(SR.Format(SR.MissingManifestResource_MultipleBlobs, name, satellite.ToString()));
                     }
                 }
             }
@@ -488,16 +481,10 @@ namespace System.Resources
                 const string MesgFailFast = System.CoreLib.Name + ResourceManager.ResFileExtension + " couldn't be found!  Large parts of the BCL won't work!";
                 System.Environment.FailFast(MesgFailFast);
             }
-            // We really don't think this should happen - we always
-            // expect the neutral locale's resources to be present.
-            string resName = string.Empty;
-            if (_mediator.LocationInfo != null && _mediator.LocationInfo.Namespace != null)
-                resName = _mediator.LocationInfo.Namespace + Type.Delimiter;
-            resName += fileName;
             Debug.Assert(_mediator.MainAssembly != null);
             throw new MissingManifestResourceException(
                             SR.Format(SR.MissingManifestResource_NoNeutralAsm,
-                            resName, _mediator.MainAssembly.GetName().Name, GetManifestResourceNamesList(_mediator.MainAssembly)));
+                            fileName, _mediator.MainAssembly.GetName().Name, GetManifestResourceNamesList(_mediator.MainAssembly)));
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -229,7 +229,12 @@ namespace System.Resources
 
             _locationInfo = resourceSource;
             MainAssembly = _locationInfo.Assembly;
-            BaseNameField = resourceSource.Name;
+
+            string? nameSpace = resourceSource.Namespace;
+            char c = Type.Delimiter;
+            BaseNameField = nameSpace is null
+                ? resourceSource.Name
+                : string.Concat(nameSpace, new ReadOnlySpan<char>(in c), resourceSource.Name);
 
             CommonAssemblyInit();
         }
@@ -407,7 +412,7 @@ namespace System.Resources
             {
                 string fileName = GetResourceFileName(culture);
                 Debug.Assert(MainAssembly != null);
-                Stream? stream = MainAssembly.GetManifestResourceStream(_locationInfo!, fileName);
+                Stream? stream = MainAssembly.GetManifestResourceStream(fileName);
                 if (createIfNotExists && stream != null)
                 {
                     rs = ((ManifestBasedResourceGroveler)_resourceGroveler).CreateResourceSet(stream, MainAssembly);
@@ -746,9 +751,6 @@ namespace System.Resources
 
             // NEEDED ONLY BY FILE-BASED
             internal string? ModuleDir => _rm._moduleDir;
-
-            // NEEDED BOTH BY FILE-BASED  AND ASSEMBLY-BASED
-            internal Type? LocationInfo => _rm._locationInfo;
 
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
             internal Type? UserResourceSet => _rm._userResourceSet;

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -103,7 +103,6 @@ namespace System.Resources
 
         private Dictionary<string, ResourceSet>? _resourceSets;
         private readonly string? _moduleDir;          // For assembly-ignorant directory location
-        private readonly Type? _locationInfo;         // For Assembly or type-based directory layout
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         private readonly Type? _userResourceSet;      // Which ResourceSet instance to create
@@ -227,8 +226,7 @@ namespace System.Resources
             if (resourceSource is not RuntimeType)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType);
 
-            _locationInfo = resourceSource;
-            MainAssembly = _locationInfo.Assembly;
+            MainAssembly = resourceSource.Assembly;
 
             string? nameSpace = resourceSource.Namespace;
             char c = Type.Delimiter;

--- a/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
+++ b/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
@@ -204,7 +204,10 @@ namespace System.Resources.Tests
         [Fact]
         public static void BaseName()
         {
-            var manager = new ResourceManager("System.Resources.Tests.Resources.TestResx", typeof(ResourceManagerTests).GetTypeInfo().Assembly);
+            var manager = new ResourceManager("System.Resources.Tests.Resources.TestResx", typeof(ResourceManagerTests).Assembly);
+            Assert.Equal("System.Resources.Tests.Resources.TestResx", manager.BaseName);
+
+            manager = new(typeof(System.Resources.Tests.Resources.TestResx));
             Assert.Equal("System.Resources.Tests.Resources.TestResx", manager.BaseName);
         }
 

--- a/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
+++ b/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
@@ -207,8 +207,16 @@ namespace System.Resources.Tests
             var manager = new ResourceManager("System.Resources.Tests.Resources.TestResx", typeof(ResourceManagerTests).Assembly);
             Assert.Equal("System.Resources.Tests.Resources.TestResx", manager.BaseName);
 
-            manager = new(typeof(System.Resources.Tests.Resources.TestResx));
+            manager = new ResourceManager(typeof(System.Resources.Tests.Resources.TestResx));
             Assert.Equal("System.Resources.Tests.Resources.TestResx", manager.BaseName);
+
+            Type typeWithoutNamespace = new { }.GetType();
+            Assert.Null(typeWithoutNamespace.Namespace);
+            manager = new ResourceManager(typeWithoutNamespace);
+            Assert.Equal(typeWithoutNamespace.Name, manager.BaseName);
+
+            manager = new ResourceManager(typeof(List<string>));
+            Assert.Equal("System.Collections.Generic.List`1", manager.BaseName);
         }
 
         [Theory]


### PR DESCRIPTION
This property is documented to return the "qualified namespace name and the root resource name of a resource file". However, previously when constructing a ResourceManager with a Type the BaseName property would instead return the name of the type without its namespace.

fix #74918