### PR TITLE
[release/7.0][sgen] Remove two dead fields; fix wasm-mt AOT compilation

### DIFF
--- a/src/mono/mono/metadata/sgen-client-mono.h
+++ b/src/mono/mono/metadata/sgen-client-mono.h
@@ -40,13 +40,6 @@ struct _SgenClientThreadInfo {
 	gboolean skip, suspend_done;
 	volatile int in_critical_region;
 
-#ifdef SGEN_POSIX_STW
-	/* This is -1 until the first suspend. */
-	int signal;
-	/* FIXME: kill this, we only use signals on systems that have rt-posix, which doesn't have issues with duplicates. */
-	unsigned int stop_count; /* to catch duplicate signals. */
-#endif
-
 	gpointer runtime_data;
 
 	void *stack_end;

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -2153,11 +2153,6 @@ sgen_client_thread_attach (SgenThreadInfo* info)
 
 	info->client_info.stack_start = NULL;
 
-#ifdef SGEN_POSIX_STW
-	info->client_info.stop_count = -1;
-	info->client_info.signal = 0;
-#endif
-
 	memset (&info->client_info.ctx, 0, sizeof (MonoContext));
 
 	if (mono_gc_get_gc_callbacks ()->thread_attach_func)

--- a/src/mono/mono/sgen/sgen-gc.h
+++ b/src/mono/mono/sgen/sgen-gc.h
@@ -51,10 +51,6 @@ typedef enum {
 
 NurseryClearPolicy sgen_get_nursery_clear_policy (void);
 
-#if !defined(__MACH__) && !MONO_MACH_ARCH_SUPPORTED && defined(HAVE_PTHREAD_KILL)
-#define SGEN_POSIX_STW 1
-#endif
-
 /*
  * The nursery section uses this struct.
  */


### PR DESCRIPTION
They were only initialized, but never read.

But what they did do is change the SgenClientInfo field offsets between the threaded and non-threaded wasm runtimes (because emscripten only has HAVE_PTHREAD_KILL in the threaded build).  As a result the offsets for tlab_start, tlab_next and tlab_temp_end were different for the AOT compilers targeting threaded vs non-threaded WASM.

This PR removes the two unused fields which will make the two wasm configurations match again, allowing us to ship a single AOT cross compiler for both threaded and non-threaded wasm.

Fixes https://github.com/dotnet/runtime/issues/75474