### PR TITLE
[release/7.0] Workaround for building with clang-14

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -788,6 +788,13 @@ if (CLR_CMAKE_HOST_WIN32)
     endif()
 
 elseif (NOT CLR_CMAKE_HOST_BROWSER)
+    # This is a workaround for upstream issue: https://gitlab.kitware.com/cmake/cmake/-/issues/22995.
+    #
+    # In Clang.cmake, the decision to use single or double hyphen for target and gcc-toolchain
+    # is made based on CMAKE_${LANG}_COMPILER_VERSION, but CMAKE_ASM_COMPILER_VERSION is empty
+    # so it picks up single hyphen options, which new clang versions don't recognize.
+    set (CMAKE_ASM_COMPILER_VERSION "${CMAKE_C_COMPILER_VERSION}")
+
     enable_language(ASM)
 
 endif(CLR_CMAKE_HOST_WIN32)


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/74696/commits/ee779550f927f791324ba8a3df75bf9a7769af43 to fix building with clang-14 that is used by the most recent Linux distros

Fixes #75505