### PR TITLE
[release/7.0] Close MsQuic after checking for QUIC support to free resources (#75163, #75441)

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -39,13 +39,9 @@ jobs:
     # Linux arm64
     - ${{ if eq(parameters.platform, 'Linux_arm64') }}:
       - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.2204.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8-20220906173536-06f234f
+        - (Ubuntu.2204.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8-20220504035342-1b9461f
       - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220906173506-06f234f
-      - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Debian.10.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-arm64v8-20220906200500-06f234f
-      - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20220906200540-06f234f
+        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220427172132-97d8652
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'Linux_musl_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -39,9 +39,13 @@ jobs:
     # Linux arm64
     - ${{ if eq(parameters.platform, 'Linux_arm64') }}:
       - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.2204.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8-20220504035342-1b9461f
+        - (Ubuntu.2204.Arm64.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-arm64v8-20220906173536-06f234f
       - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220427172132-97d8652
+        - (Ubuntu.1804.ArmArch.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20220906173506-06f234f
+      - ${{ if or(eq(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
+        - (Debian.10.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-arm64v8-20220906200500-06f234f
+      - ${{ if or(ne(parameters.jobParameters.isExtraPlatforms, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
+        - (Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20220906200540-06f234f
 
     # Linux musl x64
     - ${{ if eq(parameters.platform, 'Linux_musl_x64') }}:

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Quic;
@@ -47,7 +48,8 @@ internal sealed unsafe partial class MsQuicApi
         }
     }
 
-    internal static MsQuicApi Api { get; } = null!;
+    private static readonly Lazy<MsQuicApi> _api = new Lazy<MsQuicApi>(AllocateMsQuicApi);
+    internal static MsQuicApi Api => _api.Value;
 
     internal static bool IsQuicSupported { get; }
 
@@ -58,29 +60,21 @@ internal sealed unsafe partial class MsQuicApi
 
     static MsQuicApi()
     {
-        IntPtr msQuicHandle;
-        if (!NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) &&
-            !NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
+        if (!TryLoadMsQuic(out IntPtr msQuicHandle))
         {
             return;
         }
 
         try
         {
-            if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
-            {
-                return;
-            }
-
-            QUIC_API_TABLE* apiTable = null;
-            delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> msQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)msQuicOpenVersionAddress;
-            if (StatusFailed(msQuicOpenVersion((uint)MsQuicVersion.Major, &apiTable)))
+            if (!TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable, out _))
             {
                 return;
             }
 
             try
             {
+                // Check version
                 int arraySize = 4;
                 uint* libVersion = stackalloc uint[arraySize];
                 uint size = (uint)arraySize * sizeof(uint);
@@ -99,7 +93,7 @@ internal sealed unsafe partial class MsQuicApi
                     return;
                 }
 
-                // Assume SChannel is being used on windows and query for the actual provider from the library
+                // Assume SChannel is being used on windows and query for the actual provider from the library if querying is supported
                 QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
                 size = sizeof(QUIC_TLS_PROVIDER);
                 apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
@@ -122,26 +116,84 @@ internal sealed unsafe partial class MsQuicApi
                     Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
                 }
 
-                Api = new MsQuicApi(apiTable);
                 IsQuicSupported = true;
             }
             finally
             {
-                if (!IsQuicSupported && NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
-                {
-                    // Gracefully close the API table
-                    ((delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)msQuicClose)(apiTable);
-                }
+                // Gracefully close the API table to free resources. The API table will be allocated lazily again if needed
+                bool closed = TryCloseMsQuic(msQuicHandle, apiTable);
+                Debug.Assert(closed, "Failed to close MsQuic");
             }
-
         }
         finally
         {
-            if (!IsQuicSupported)
-            {
-                NativeLibrary.Free(msQuicHandle);
-            }
+            // Unload the library, we will load it again when we actually use QUIC
+            NativeLibrary.Free(msQuicHandle);
         }
+    }
+
+    private static MsQuicApi AllocateMsQuicApi()
+    {
+        Debug.Assert(IsQuicSupported);
+
+        int openStatus = MsQuic.QUIC_STATUS_INTERNAL_ERROR;
+
+        if (TryLoadMsQuic(out IntPtr msQuicHandle) &&
+            TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable, out openStatus))
+        {
+            return new MsQuicApi(apiTable);
+        }
+
+        ThrowHelper.ThrowIfMsQuicError(openStatus);
+
+        // this should unreachable as TryOpenMsQuic returns non-success status on failure
+        throw new Exception("Failed to create MsQuicApi instance");
+    }
+
+    private static bool TryLoadMsQuic(out IntPtr msQuicHandle) =>
+        NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) ||
+        NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
+
+    private static bool TryOpenMsQuic(IntPtr msQuicHandle, out QUIC_API_TABLE* apiTable, out int openStatus)
+    {
+        apiTable = null;
+        if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
+        {
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(null, "Failed to get MsQuicOpenVersion export in msquic library.");
+            }
+
+            openStatus = MsQuic.QUIC_STATUS_NOT_FOUND;
+            return false;
+        }
+
+        QUIC_API_TABLE* table = null;
+        delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> msQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)msQuicOpenVersionAddress;
+        openStatus = msQuicOpenVersion((uint)MsQuicVersion.Major, &table);
+        if (StatusFailed(openStatus))
+        {
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(null, $"MsQuicOpenVersion returned {openStatus} status code.");
+            }
+
+            return false;
+        }
+
+        apiTable = table;
+        return true;
+    }
+
+    private static bool TryCloseMsQuic(IntPtr msQuicHandle, QUIC_API_TABLE* apiTable)
+    {
+        if (NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
+        {
+            ((delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)msQuicClose)(apiTable);
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsWindowsVersionSupported() => OperatingSystem.IsWindowsVersionAtLeast(MinWindowsVersion.Major,

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -20,6 +20,9 @@ internal sealed unsafe partial class MsQuicApi
 
     private static readonly Version MsQuicVersion = new Version(2, 1);
 
+    private static readonly delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> MsQuicOpenVersion;
+    private static readonly delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void> MsQuicClose;
+
     public MsQuicSafeHandle Registration { get; }
 
     public QUIC_API_TABLE* ApiTable { get; }
@@ -58,119 +61,97 @@ internal sealed unsafe partial class MsQuicApi
     internal static bool Tls13ServerMayBeDisabled { get; }
     internal static bool Tls13ClientMayBeDisabled { get; }
 
+#pragma warning disable CA1810 // Initialize all static fields in 'MsQuicApi' when those fields are declared and remove the explicit static constructor
     static MsQuicApi()
     {
-        if (!TryLoadMsQuic(out IntPtr msQuicHandle))
+        if (!NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out IntPtr msQuicHandle) &&
+            !NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
         {
+            // MsQuic library not loaded
+            return;
+        }
+
+        MsQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)NativeLibrary.GetExport(msQuicHandle, nameof(MsQuicOpenVersion));
+        MsQuicClose = (delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)NativeLibrary.GetExport(msQuicHandle, nameof(MsQuicClose));
+
+        if (!TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out _))
+        {
+            // Too low version of the library (likely pre-2.0)
             return;
         }
 
         try
         {
-            if (!TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable, out _))
+            // Check version
+            int arraySize = 4;
+            uint* libVersion = stackalloc uint[arraySize];
+            uint size = (uint)arraySize * sizeof(uint);
+            if (StatusFailed(apiTable->GetParam(null, QUIC_PARAM_GLOBAL_LIBRARY_VERSION, &size, libVersion)))
             {
                 return;
             }
 
-            try
+            var version = new Version((int)libVersion[0], (int)libVersion[1], (int)libVersion[2], (int)libVersion[3]);
+            if (version < MsQuicVersion)
             {
-                // Check version
-                int arraySize = 4;
-                uint* libVersion = stackalloc uint[arraySize];
-                uint size = (uint)arraySize * sizeof(uint);
-                if (StatusFailed(apiTable->GetParam(null, QUIC_PARAM_GLOBAL_LIBRARY_VERSION, &size, libVersion)))
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    return;
+                    NetEventSource.Info(null, $"Incompatible MsQuic library version '{version}', expecting '{MsQuicVersion}'");
                 }
+                return;
+            }
 
-                var version = new Version((int)libVersion[0], (int)libVersion[1], (int)libVersion[2], (int)libVersion[3]);
-                if (version < MsQuicVersion)
+            // Assume SChannel is being used on windows and query for the actual provider from the library if querying is supported
+            QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
+            size = sizeof(QUIC_TLS_PROVIDER);
+            apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
+            UsesSChannelBackend = provider == QUIC_TLS_PROVIDER.SCHANNEL;
+
+            if (UsesSChannelBackend)
+            {
+                // Implies windows platform, check TLS1.3 availability
+                if (!IsWindowsVersionSupported())
                 {
                     if (NetEventSource.Log.IsEnabled())
                     {
-                        NetEventSource.Info(null, $"Incompatible MsQuic library version '{version}', expecting '{MsQuicVersion}'");
+                        NetEventSource.Info(null, $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
                     }
+
                     return;
                 }
 
-                // Assume SChannel is being used on windows and query for the actual provider from the library if querying is supported
-                QUIC_TLS_PROVIDER provider = OperatingSystem.IsWindows() ? QUIC_TLS_PROVIDER.SCHANNEL : QUIC_TLS_PROVIDER.OPENSSL;
-                size = sizeof(QUIC_TLS_PROVIDER);
-                apiTable->GetParam(null, QUIC_PARAM_GLOBAL_TLS_PROVIDER, &size, &provider);
-                UsesSChannelBackend = provider == QUIC_TLS_PROVIDER.SCHANNEL;
-
-                if (UsesSChannelBackend)
-                {
-                    // Implies windows platform, check TLS1.3 availability
-                    if (!IsWindowsVersionSupported())
-                    {
-                        if (NetEventSource.Log.IsEnabled())
-                        {
-                            NetEventSource.Info(null, $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
-                        }
-
-                        return;
-                    }
-
-                    Tls13ServerMayBeDisabled = IsTls13Disabled(isServer: true);
-                    Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
-                }
-
-                IsQuicSupported = true;
+                Tls13ServerMayBeDisabled = IsTls13Disabled(isServer: true);
+                Tls13ClientMayBeDisabled = IsTls13Disabled(isServer: false);
             }
-            finally
-            {
-                // Gracefully close the API table to free resources. The API table will be allocated lazily again if needed
-                bool closed = TryCloseMsQuic(msQuicHandle, apiTable);
-                Debug.Assert(closed, "Failed to close MsQuic");
-            }
+
+            IsQuicSupported = true;
         }
         finally
         {
-            // Unload the library, we will load it again when we actually use QUIC
-            NativeLibrary.Free(msQuicHandle);
+            // Gracefully close the API table to free resources. The API table will be allocated lazily again if needed
+            MsQuicClose(apiTable);
         }
     }
+#pragma warning restore CA1810
 
     private static MsQuicApi AllocateMsQuicApi()
     {
         Debug.Assert(IsQuicSupported);
 
-        int openStatus = MsQuic.QUIC_STATUS_INTERNAL_ERROR;
-
-        if (TryLoadMsQuic(out IntPtr msQuicHandle) &&
-            TryOpenMsQuic(msQuicHandle, out QUIC_API_TABLE* apiTable, out openStatus))
+        if (!TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out int openStatus))
         {
-            return new MsQuicApi(apiTable);
+            throw ThrowHelper.GetExceptionForMsQuicStatus(openStatus);
         }
 
-        ThrowHelper.ThrowIfMsQuicError(openStatus);
-
-        // this should unreachable as TryOpenMsQuic returns non-success status on failure
-        throw new Exception("Failed to create MsQuicApi instance");
+        return new MsQuicApi(apiTable);
     }
 
-    private static bool TryLoadMsQuic(out IntPtr msQuicHandle) =>
-        NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion.Major}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle) ||
-        NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle);
-
-    private static bool TryOpenMsQuic(IntPtr msQuicHandle, out QUIC_API_TABLE* apiTable, out int openStatus)
+    private static bool TryOpenMsQuic(out QUIC_API_TABLE* apiTable, out int openStatus)
     {
-        apiTable = null;
-        if (!NativeLibrary.TryGetExport(msQuicHandle, "MsQuicOpenVersion", out IntPtr msQuicOpenVersionAddress))
-        {
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Info(null, "Failed to get MsQuicOpenVersion export in msquic library.");
-            }
-
-            openStatus = MsQuic.QUIC_STATUS_NOT_FOUND;
-            return false;
-        }
+        Debug.Assert(MsQuicOpenVersion != null);
 
         QUIC_API_TABLE* table = null;
-        delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> msQuicOpenVersion = (delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int>)msQuicOpenVersionAddress;
-        openStatus = msQuicOpenVersion((uint)MsQuicVersion.Major, &table);
+        openStatus = MsQuicOpenVersion((uint)MsQuicVersion.Major, &table);
         if (StatusFailed(openStatus))
         {
             if (NetEventSource.Log.IsEnabled())
@@ -178,22 +159,12 @@ internal sealed unsafe partial class MsQuicApi
                 NetEventSource.Info(null, $"MsQuicOpenVersion returned {openStatus} status code.");
             }
 
+            apiTable = null;
             return false;
         }
 
         apiTable = table;
         return true;
-    }
-
-    private static bool TryCloseMsQuic(IntPtr msQuicHandle, QUIC_API_TABLE* apiTable)
-    {
-        if (NativeLibrary.TryGetExport(msQuicHandle, "MsQuicClose", out IntPtr msQuicClose))
-        {
-            ((delegate* unmanaged[Cdecl]<QUIC_API_TABLE*, void>)msQuicClose)(apiTable);
-            return true;
-        }
-
-        return false;
     }
 
     private static bool IsWindowsVersionSupported() => OperatingSystem.IsWindowsVersionAtLeast(MinWindowsVersion.Major,


### PR DESCRIPTION
Manual backport of #75163 and #75441
Fixes #74629
Replaces #75330 

cc: @wfurt 

## Customer Impact

Memory (and number of processes) regression in .NET 7.0 from .NET 6.0 for all applications (on Win11+/Win2022+ and Linux with OpenSsl 1.1):
Even if app is not using HTTP/3 (or QUIC), we initialize early on native MsQuic.dll which always allocates threads (2* number of logical cores). Thus, causes unnecessary resource increase even if the process does not end up using HTTP/3 at all (HTTP/3 is opt-in like HTTP/2).

The fix closes all MsQuic resources after their initialization.
The change builds on fix in msquic 2.1.1 (Helix images were updated by PR #75479).

Affected platforms include Windows 11, Windows Server 2022, many Linux platforms with msquic package installed. 

Note: The same problem exists also in 6.0, but hidden under opt-in switch into HTTP/3 support. We had 1 customer with ~50-core machine who noticed that in a dump and were surprised to see so many extra threads they didn't know about / they didn't need. At minimum it will help avoid developer confusion in dump investigations in such cases.

## Testing

Functional tests suite passes as part of the CI, resource consumption was checked manually.

## Risk

Low, the fix consists of gracefully de-initializing MsQuic library in the process after checking QUIC support. The library is re-initialized only when actually needed.