### PR TITLE
[release/6.0] Fix build for musl 1.2.3 (backports #67772)

### DIFF
--- a/src/coreclr/pal/src/include/pal/palinternal.h
+++ b/src/coreclr/pal/src/include/pal/palinternal.h
@@ -695,30 +695,30 @@ T* InterlockedCompareExchangePointerT(
 template <typename T>
 inline T* InterlockedExchangePointerT(
     T* volatile * target,
-    int           value) // When NULL is provided as argument.
+    std::nullptr_t           value) // When NULL is provided as argument.
 {
     //STATIC_ASSERT(value == 0);
-    return InterlockedExchangePointerT(target, reinterpret_cast<T*>(value));
+    return InterlockedExchangePointerT(target, (T*)(void*)value);
 }
 
 template <typename T>
 inline T* InterlockedCompareExchangePointerT(
     T* volatile * destination,
-    int           exchange,  // When NULL is provided as argument.
+    std::nullptr_t           exchange,  // When NULL is provided as argument.
     T*            comparand)
 {
     //STATIC_ASSERT(exchange == 0);
-    return InterlockedCompareExchangePointerT(destination, reinterpret_cast<T*>(exchange), comparand);
+    return InterlockedCompareExchangePointerT(destination, (T*)(void*)exchange, comparand);
 }
 
 template <typename T>
 inline T* InterlockedCompareExchangePointerT(
     T* volatile * destination,
     T*            exchange,
-    int           comparand) // When NULL is provided as argument.
+    std::nullptr_t           comparand) // When NULL is provided as argument.
 {
     //STATIC_ASSERT(comparand == 0);
-    return InterlockedCompareExchangePointerT(destination, exchange, reinterpret_cast<T*>(comparand));
+    return InterlockedCompareExchangePointerT(destination, exchange, (T*)(void*)comparand);
 }
 
 #undef InterlockedExchangePointer

--- a/src/coreclr/pal/src/init/pal.cpp
+++ b/src/coreclr/pal/src/init/pal.cpp
@@ -134,7 +134,7 @@ static bool RunningNatively()
 {
     int ret = 0;
     size_t sz = sizeof(ret);
-    if (sysctlbyname("sysctl.proc_native", &ret, &sz, NULL, 0) != 0)
+    if (sysctlbyname("sysctl.proc_native", &ret, &sz, nullptr, 0) != 0)
     {
         // if the sysctl failed, we'll assume this OS does not support
         // binary translation - so we must be running natively.
@@ -207,7 +207,7 @@ int
 PALAPI
 PAL_InitializeDLL()
 {
-    return Initialize(0, NULL, g_initializeDLLFlags);
+    return Initialize(0, nullptr, g_initializeDLLFlags);
 }
 
 /*++
@@ -269,12 +269,12 @@ void
 InitializeDefaultStackSize()
 {
     char* defaultStackSizeStr = getenv("COMPlus_DefaultStackSize");
-    if (defaultStackSizeStr != NULL)
+    if (defaultStackSizeStr != nullptr)
     {
         errno = 0;
         // Like all numeric values specific by the COMPlus_xxx variables, it is a
         // hexadecimal string without any prefix.
-        long int size = strtol(defaultStackSizeStr, NULL, 16);
+        long int size = strtol(defaultStackSizeStr, nullptr, 16);
 
         if (errno == 0)
         {
@@ -311,10 +311,10 @@ Initialize(
     DWORD flags)
 {
     PAL_ERROR palError = ERROR_GEN_FAILURE;
-    CPalThread *pThread = NULL;
-    CSharedMemoryObjectManager *pshmom = NULL;
-    LPWSTR command_line = NULL;
-    LPWSTR exe_path = NULL;
+    CPalThread *pThread = nullptr;
+    CSharedMemoryObjectManager *pshmom = nullptr;
+    LPWSTR command_line = nullptr;
+    LPWSTR exe_path = nullptr;
     int retval = -1;
     bool fFirstTimeInit = false;
 
@@ -336,18 +336,18 @@ Initialize(
 
     CriticalSectionSubSysInitialize();
 
-    if(NULL == init_critsec)
+    if(nullptr == init_critsec)
     {
         pthread_mutex_lock(&init_critsec_mutex); // prevents race condition of two threads
                                                  // initializing the critical section.
-        if(NULL == init_critsec)
+        if(nullptr == init_critsec)
         {
             static CRITICAL_SECTION temp_critsec;
 
             // Want this critical section to NOT be internal to avoid the use of unsafe region markers.
             InternalInitializeCriticalSectionAndSpinCount(&temp_critsec, 0, false);
 
-            if(NULL != InterlockedCompareExchangePointer(&init_critsec, &temp_critsec, NULL))
+            if(nullptr != InterlockedCompareExchangePointer(&init_critsec, &temp_critsec, nullptr))
             {
                 // Another thread got in before us! shouldn't happen, if the PAL
                 // isn't initialized there shouldn't be any other threads
@@ -358,7 +358,7 @@ Initialize(
         pthread_mutex_unlock(&init_critsec_mutex);
     }
 
-    InternalEnterCriticalSection(pThread, init_critsec); // here pThread is always NULL
+    InternalEnterCriticalSection(pThread, init_critsec); // here pThread is always nullptr
 
     if (init_count == 0)
     {
@@ -407,12 +407,12 @@ Initialize(
 
 #ifdef FEATURE_ENABLE_NO_ADDRESS_SPACE_RANDOMIZATION
         char* useDefaultBaseAddr = getenv("COMPlus_UseDefaultBaseAddr");
-        if (useDefaultBaseAddr != NULL)
+        if (useDefaultBaseAddr != nullptr)
         {
             errno = 0;
             // Like all numeric values specific by the COMPlus_xxx variables, it is a
             // hexadecimal string without any prefix.
-            long int flag = strtol(useDefaultBaseAddr, NULL, 16);
+            long int flag = strtol(useDefaultBaseAddr, nullptr, 16);
 
             if (errno == 0)
             {
@@ -508,7 +508,7 @@ Initialize(
         //
 
         pshmom = InternalNew<CSharedMemoryObjectManager>();
-        if (NULL == pshmom)
+        if (nullptr == pshmom)
         {
             ERROR("Unable to allocate new object manager\n");
             palError = ERROR_OUTOFMEMORY;
@@ -531,7 +531,7 @@ Initialize(
         g_pSynchronizationManager =
             CPalSynchMgrController::CreatePalSynchronizationManager();
 
-        if (NULL == g_pSynchronizationManager)
+        if (nullptr == g_pSynchronizationManager)
         {
             palError = ERROR_NOT_ENOUGH_MEMORY;
             ERROR("Failure creating synchronization manager\n");
@@ -545,11 +545,11 @@ Initialize(
 
     palError = ERROR_GEN_FAILURE;
 
-    if (argc > 0 && argv != NULL)
+    if (argc > 0 && argv != nullptr)
     {
         /* build the command line */
         command_line = INIT_FormatCommandLine(argc, argv);
-        if (NULL == command_line)
+        if (nullptr == command_line)
         {
             ERROR("Error building command line\n");
             palError = ERROR_PALINIT_COMMAND_LINE;
@@ -558,7 +558,7 @@ Initialize(
 
         /* find out the application's full path */
         exe_path = INIT_GetCurrentEXEPath();
-        if (NULL == exe_path)
+        if (nullptr == exe_path)
         {
             ERROR("Unable to find exe path\n");
             palError = ERROR_PALINIT_CONVERT_EXE_PATH;
@@ -576,7 +576,7 @@ Initialize(
         }
 
         // InitializeProcessCommandLine took ownership of this memory.
-        command_line = NULL;
+        command_line = nullptr;
 
 #ifdef PAL_PERF
         // Initialize the Profiling structure
@@ -597,7 +597,7 @@ Initialize(
         }
 
         // LOADSetExeName took ownership of this memory.
-        exe_path = NULL;
+        exe_path = nullptr;
     }
 
     if (init_count == 0)
@@ -742,7 +742,7 @@ done:
 
     if (fFirstTimeInit && 0 == retval)
     {
-        _ASSERTE(NULL != pThread);
+        _ASSERTE(nullptr != pThread);
     }
 
     if (retval != 0 && GetLastError() == ERROR_SUCCESS)
@@ -858,7 +858,7 @@ PAL_IsDebuggerPresent()
     struct kinfo_proc info = {};
     size_t size = sizeof(info);
     int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
-    int ret = sysctl(mib, sizeof(mib)/sizeof(*mib), &info, &size, NULL, 0);
+    int ret = sysctl(mib, sizeof(mib)/sizeof(*mib), &info, &size, nullptr, 0);
 
     if (ret == 0)
         return ((info.kp_proc.p_flag & P_TRACED) != 0);
@@ -871,12 +871,12 @@ PAL_IsDebuggerPresent()
 
     struct kinfo_proc *info;
 
-    kd = kvm_open(NULL, NULL, NULL, KVM_NO_FILES, "kvm_open");
-    if (kd == NULL)
+    kd = kvm_open(nullptr, nullptr, nullptr, KVM_NO_FILES, "kvm_open");
+    if (kd == nullptr)
         return FALSE;
 
     info = kvm_getprocs(kd, KERN_PROC_PID, getpid(), &cnt);
-    if (info == NULL || cnt < 1)
+    if (info == nullptr || cnt < 1)
     {
         kvm_close(kd);
         return FALSE;
@@ -960,7 +960,7 @@ PAL_TerminateEx(
 {
     ENTRY_EXTERNAL("PAL_TerminateEx()\n");
 
-    if (NULL == init_critsec)
+    if (nullptr == init_critsec)
     {
         /* note that these macros probably won't output anything, since the
         debug channels haven't been initialized yet */
@@ -1057,7 +1057,7 @@ BOOL PALInitLock(void)
     }
 
     CPalThread * pThread =
-        (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
+        (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : nullptr);
 
     InternalEnterCriticalSection(pThread, init_critsec);
     return TRUE;
@@ -1079,7 +1079,7 @@ void PALInitUnlock(void)
     }
 
     CPalThread * pThread =
-        (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
+        (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : nullptr);
 
     InternalLeaveCriticalSection(pThread, init_critsec);
 }
@@ -1138,7 +1138,7 @@ Abstract:
 
 Parameters :
     int argc : number of arguments in argv
-    char **argv : argument list in an array of NULL-terminated strings
+    char **argv : argument list in an array of nullptr-terminated strings
 
 Return value :
     pointer to Unicode command line. This is a buffer allocated with malloc;
@@ -1161,7 +1161,7 @@ Note : not all peculiarities of Windows command-line processing are supported;
 static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv)
 {
     LPWSTR retval;
-    LPSTR command_line=NULL, command_ptr;
+    LPSTR command_line=nullptr, command_ptr;
     LPCSTR arg_ptr;
     INT length, i,j;
     BOOL bQuoted = FALSE;
@@ -1186,7 +1186,7 @@ static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv)
     if(!command_line)
     {
         ERROR("couldn't allocate memory for command line!\n");
-        return NULL;
+        return nullptr;
     }
 
     command_ptr=command_line;
@@ -1220,32 +1220,32 @@ static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv)
         }
         *command_ptr++=' ';
     }
-    /* replace the last space with a NULL terminator */
+    /* replace the last space with a nullptr terminator */
     command_ptr--;
     *command_ptr='\0';
 
     /* convert to Unicode */
-    i = MultiByteToWideChar(CP_ACP, 0,command_line, -1, NULL, 0);
+    i = MultiByteToWideChar(CP_ACP, 0,command_line, -1, nullptr, 0);
     if (i == 0)
     {
         ASSERT("MultiByteToWideChar failure\n");
         free(command_line);
-        return NULL;
+        return nullptr;
     }
 
     retval = reinterpret_cast<LPWSTR>(InternalMalloc((sizeof(WCHAR)*i)));
-    if(retval == NULL)
+    if(retval == nullptr)
     {
         ERROR("can't allocate memory for Unicode command line!\n");
         free(command_line);
-        return NULL;
+        return nullptr;
     }
 
     if(!MultiByteToWideChar(CP_ACP, 0,command_line, i, retval, i))
     {
         ASSERT("MultiByteToWideChar failure\n");
         free(retval);
-        retval = NULL;
+        retval = nullptr;
     }
     else
         TRACE("Command line is %s\n", command_line);
@@ -1275,25 +1275,25 @@ static LPWSTR INIT_GetCurrentEXEPath()
     if (!path)
     {
         ERROR( "Cannot get current exe path\n" );
-        return NULL;
+        return nullptr;
     }
 
     PathCharString real_path;
     real_path.Set(path, strlen(path));
     free(path);
 
-    return_size = MultiByteToWideChar(CP_ACP, 0, real_path, -1, NULL, 0);
+    return_size = MultiByteToWideChar(CP_ACP, 0, real_path, -1, nullptr, 0);
     if (0 == return_size)
     {
         ASSERT("MultiByteToWideChar failure\n");
-        return NULL;
+        return nullptr;
     }
 
     return_value = reinterpret_cast<LPWSTR>(InternalMalloc((return_size*sizeof(WCHAR))));
-    if (NULL == return_value)
+    if (nullptr == return_value)
     {
         ERROR("Not enough memory to create full path\n");
-        return NULL;
+        return nullptr;
     }
     else
     {
@@ -1302,7 +1302,7 @@ static LPWSTR INIT_GetCurrentEXEPath()
         {
             ASSERT("MultiByteToWideChar failure\n");
             free(return_value);
-            return_value = NULL;
+            return_value = nullptr;
         }
         else
         {


### PR DESCRIPTION
Backports #67772

Not a functional change. 
This is to fix the build with musl 1.2.3 , which was released  7 Apr 2022

Most of the change is switching `NULL` -> `nullptr` in some PAL functions to match musl changes.

## Customer Impact

No impact, this is an infra/build level of a fix.

## Risk

Low, it is a build-related change that should be transparent outside of dotnet/runtime.

## Testing

Regular tests.
