### PR TITLE
Fixed assembly load check on default config apply

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -234,10 +234,14 @@ namespace Microsoft.Extensions.Hosting
 
             if (env.IsDevelopment() && env.ApplicationName is { Length: > 0 })
             {
-                var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
-                if (appAssembly is not null)
+                try
                 {
+                    var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
                     appConfigBuilder.AddUserSecrets(appAssembly, optional: true, reloadOnChange: reloadOnChange);
+                }
+                catch (FileNotFoundException)
+                {
+                    // The assembly cannot be found, so just skip it.
                 }
             }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -673,7 +673,8 @@ namespace Microsoft.Extensions.Hosting.Tests
                 {
                     config.AddInMemoryCollection(new[]
                     {
-                        new KeyValuePair<string, string>(HostDefaults.ApplicationKey, "MyProjectReference")
+                        new KeyValuePair<string, string>(HostDefaults.ApplicationKey, "MyProjectReference"),
+                        new KeyValuePair<string, string>(HostDefaults.EnvironmentKey, Environments.Development)
                     });
                 })
                 .Build())

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -673,7 +673,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                 {
                     config.AddInMemoryCollection(new[]
                     {
-                        new KeyValuePair<string, string>(HostDefaults.ApplicationName, "MyProjectReference")
+                        new KeyValuePair<string, string>(HostDefaults.ApplicationKey, "MyProjectReference")
                     });
                 })
                 .Build())

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -247,7 +247,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
             var expected = "MY_TEST_ENVIRONMENT";
 
-
             using (var host = new HostBuilder()
                 .ConfigureHostConfiguration(configBuilder => configBuilder.AddConfiguration(config))
                 .UseEnvironment(expected)
@@ -663,6 +662,27 @@ namespace Microsoft.Extensions.Hosting.Tests
 
             var expectedContentRootPath = Directory.GetCurrentDirectory();
             Assert.Equal(expectedContentRootPath, env.ContentRootPath);
+        }
+
+        [Fact]
+        public void HostBuilderConfigureDefaultsDoesntThrowInDevelopment()
+        {
+            using (var host = new HostBuilder()
+                .ConfigureDefaults(args: null)
+                .ConfigureHostConfiguration(config =>
+                {
+                    config.AddInMemoryCollection(new[]
+                    {
+                        new KeyValuePair<string, string>(HostDefaults.ApplicationName, "MyProjectReference")
+                    });
+                })
+                .Build())
+            {
+                var env = host.Services.GetRequiredService<IHostEnvironment>();
+
+                Assert.Equal("MyProjectReference", env.ApplicationName);
+                Assert.Equal(Environments.Development, env.EnvironmentName);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
# Description

`Assembly.Load` doesn't not return if the specified assembly cannot be found or loaded, but the code configuring default hosting expected that it a non-fallible operation. `WebApplicationBuilder` uses `ConfigureDefaults` which calls `ApplyDefaultAppConfiguration`, which causes a runtime error without that change.

# Customer Impact

No crash when an application name is provided using the development mode in case of no secrets assembly there.

# Regression

The issue exists at least in .NET 6.