### PR TITLE
Revert "[release/7.0] Pass resource items for VS generated authoring"

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -115,7 +115,7 @@
     <CreateVisualStudioWorkload BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
                                 AllowMissingPacks="True"
                                 BaseOutputPath="$(WorkloadOutputPath)"
-                                ComponentResources="@(ComponentResources)"
+                                ComponentResources="$(ComponentResources)"
                                 PackageSource="$(PackageSource)"
                                 ShortNames="@(ShortNames)"
                                 WorkloadManifestPackageFiles="@(ManifestPackages)"


### PR DESCRIPTION
Reverts dotnet/runtime#75461 which is breaking the official build, we can pick the change back up with other workload work that can't land until rc1 is public

cc @joeloff 