### PR TITLE
[mono] Add Vector128 ConvertToSingle intrinsics for Amd64

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -8219,6 +8219,10 @@ MONO_RESTORE_WARNING
 			values [ins->dreg] = LLVMBuildSIToFP (builder, i4, sse_r4_t, dname);
 			break;
 		}
+		case OP_VCVTUDQ2PS: {
+			values [ins->dreg] = LLVMBuildUIToFP (builder, lhs, sse_r4_t, dname);
+			break;
+		}
 		case OP_CVTDQ2PD: {
 			LLVMValueRef indexes [16];
 

--- a/src/mono/mono/mini/mini-ops.h
+++ b/src/mono/mono/mini/mini-ops.h
@@ -1024,6 +1024,7 @@ MINI_OP(OP_CVTPS2DQ, "cvtps2dq", XREG, XREG, NONE)
 MINI_OP(OP_CVTPS2PD, "cvtps2pd", XREG, XREG, NONE)
 MINI_OP(OP_CVTTPD2DQ, "cvttpd2dq", XREG, XREG, NONE)
 MINI_OP(OP_CVTTPS2DQ, "cvttps2dq", XREG, XREG, NONE)
+MINI_OP(OP_VCVTUDQ2PS, "vcvtudq2ps", XREG, XREG, NONE)
 
 /* sse 1 */
 /* inst_c1 is target type */

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1142,7 +1142,7 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 #ifdef TARGET_ARM64
 		int op = arg0_type == MONO_TYPE_I4 ? OP_ARM64_SCVTF : OP_ARM64_UCVTF;
 		return emit_simd_ins_for_sig (cfg, klass, op, -1, arg0_type, fsig, args);
-#elif TARGET_AMD64
+#elif defined(TARGET_AMD64)
 		MonoClass* arg_class = mono_class_from_mono_type_internal (fsig->params [0]);
 		int size = mono_class_value_size (arg_class, NULL);
 		if (size != 16) 		// Works only with Vector128

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1145,7 +1145,7 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 #elif TARGET_AMD64
 		MonoClass* arg_class = mono_class_from_mono_type_internal (fsig->params [0]);
 		int size = mono_class_value_size (arg_class, NULL);
-		if ( size != 16 ) 		// Works only with Vector128
+		if (size != 16) 		// Works only with Vector128
 			return NULL;
 
 		int op = arg0_type == MONO_TYPE_I4 ? OP_CVTDQ2PS : OP_VCVTUDQ2PS;


### PR DESCRIPTION
Add support for the following Vector128 API's:

- ConvertToSingle

Works for both `uint` and `int` sources but the `VCVTUDQ2PS` intrinsic isn't supported yet because it is part of the `AVX512`. Nonetheless, it will emit vector instructions and overall emitted LLVM IR is smaller and without calls to other functions if compared with software fallback. In the future when `AVX512` will get supported, the code should generate the `VCVTUDQ2PS` intrinsic correctly.