### PR TITLE
74642 change isostorage path

### DIFF
--- a/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -23,7 +23,7 @@
     <Compile Include="System\IO\IsolatedStorage\Helper.AnyMobile.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.AnyMobile.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS' and '$(TargetPlatformIdentifier)' != ''">
     <Compile Include="System\IO\IsolatedStorage\Helper.NonMobile.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.NonMobile.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-MacCatalyst;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-Android;$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
@@ -26,7 +26,7 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
     <Compile Include="System\IO\IsolatedStorage\Helper.Win32.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Unix'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows'">
     <Compile Include="System\IO\IsolatedStorage\Helper.Unix.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageException.cs" />
-    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.cs" />    
+    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFileStream.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorage.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageScope.cs" />

--- a/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -9,11 +9,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageException.cs" />
-    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.cs" />
-    <Compile Condition="'$(TargetPlatformIdentifier)' == 'Android' or '$(TargetPlatformIdentifier)' == 'iOS' or '$(TargetPlatformIdentifier)' == 'MacCatalyst' or '$(TargetPlatformIdentifier)' == 'tvOS'"
-             Include="System\IO\IsolatedStorage\IsolatedStorageFile.AnyMobile.cs" />
-    <Compile Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS'"
-             Include="System\IO\IsolatedStorage\IsolatedStorageFile.NonMobile.cs" />
+    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.cs" />    
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFileStream.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorage.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageScope.cs" />
@@ -22,6 +18,14 @@
     <Compile Include="System\IO\IsolatedStorage\INormalizeForIsolatedStorage.cs" />
     <Compile Include="$(CommonPath)System\Security\IdentityHelper.cs"
              Link="Common\System\Security\IdentityHelper.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Android' or '$(TargetPlatformIdentifier)' == 'iOS' or '$(TargetPlatformIdentifier)' == 'MacCatalyst' or '$(TargetPlatformIdentifier)' == 'tvOS'">
+    <Compile Include="System\IO\IsolatedStorage\Helper.AnyMobile.cs" />
+    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.AnyMobile.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS'">
+    <Compile Include="System\IO\IsolatedStorage\Helper.NonMobile.cs" />
+    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.NonMobile.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
     <Compile Include="System\IO\IsolatedStorage\Helper.Win32.cs" />

--- a/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -10,9 +10,13 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageException.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFile.cs" />
+    <Compile Condition="'$(TargetPlatformIdentifier)' == 'Android' or '$(TargetPlatformIdentifier)' == 'iOS' or '$(TargetPlatformIdentifier)' == 'MacCatalyst' or '$(TargetPlatformIdentifier)' == 'tvOS'"
+             Include="System\IO\IsolatedStorage\IsolatedStorageFile.AnyMobile.cs" />
+    <Compile Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS'"
+             Include="System\IO\IsolatedStorage\IsolatedStorageFile.NonMobile.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFileStream.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorage.cs" />
-    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageScope.cs" />
+    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageScope.cs" />    
     <Compile Include="System\IO\IsolatedStorage\Helper.cs" />
     <Compile Include="System\IO\IsolatedStorage\Helper.Win32Unix.cs" />
     <Compile Include="System\IO\IsolatedStorage\INormalizeForIsolatedStorage.cs" />

--- a/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -16,7 +16,7 @@
              Include="System\IO\IsolatedStorage\IsolatedStorageFile.NonMobile.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorageFileStream.cs" />
     <Compile Include="System\IO\IsolatedStorage\IsolatedStorage.cs" />
-    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageScope.cs" />    
+    <Compile Include="System\IO\IsolatedStorage\IsolatedStorageScope.cs" />
     <Compile Include="System\IO\IsolatedStorage\Helper.cs" />
     <Compile Include="System\IO\IsolatedStorage\Helper.Win32Unix.cs" />
     <Compile Include="System\IO\IsolatedStorage\INormalizeForIsolatedStorage.cs" />

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.AnyMobile.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.IsolatedStorage
+{
+    internal static partial class Helper
+    {
+        public const string IsolatedStorageDirectoryName = ".isolated-storage";
+    }
+}

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.NonMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.NonMobile.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.IsolatedStorage
+{
+    internal static partial class Helper
+    {
+        public const string IsolatedStorageDirectoryName = "IsolatedStorage";
+    }
+}

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
@@ -30,7 +30,7 @@ namespace System.IO.IsolatedStorage
 
         [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file",
             Justification = "Code handles single-file deployment by using the information of the .exe file")]
-        internal static void GetDefaultIdentityAndHash(out object identity, out string hash, char separator)
+        internal static void GetDefaultIdentityAndHash(out object identity, char separator)
         {
             // In .NET Framework IsolatedStorage uses identity from System.Security.Policy.Evidence to build
             // the folder structure on disk. It would use the "best" available evidence in this order:
@@ -56,10 +56,9 @@ namespace System.IO.IsolatedStorage
             {
                 AssemblyName assemblyName = assembly.GetName();
 
-                hash = IdentityHelper.GetNormalizedStrongNameHash(assemblyName)!;
+                string hash = IdentityHelper.GetNormalizedStrongNameHash(assemblyName)!;
                 if (hash != null)
                 {
-                    hash = "StrongName" + separator + hash;
                     identity = assemblyName;
                     return;
                 }
@@ -74,9 +73,7 @@ namespace System.IO.IsolatedStorage
                 location = Environment.ProcessPath;
             if (string.IsNullOrEmpty(location))
                 throw new IsolatedStorageException(SR.IsolatedStorage_Init);
-            Uri locationUri = new Uri(location);
-            hash = "Url" + separator + IdentityHelper.GetNormalizedUriHash(locationUri);
-            identity = locationUri;
+            identity = new Uri(location);
         }
 
         internal static string GetRandomDirectory(string rootDirectory, IsolatedStorageScope scope)

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
@@ -12,7 +12,7 @@ namespace System.IO.IsolatedStorage
     {
         internal static string GetDataDirectory(IsolatedStorageScope scope)
         {
-            // This is the relevant special folder for the given scope plus ".isolated-storage".
+            // This is the relevant special folder for the given scope plus IsolatedStorageDirectoryName.
             // It is meant to replicate the behavior of the VM ComIsolatedStorage::GetRootDir().
 
             // (note that Silverlight used "CoreIsolatedStorage" for a directory name and did not support machine scope)

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
@@ -12,7 +12,7 @@ namespace System.IO.IsolatedStorage
     {
         internal static string GetDataDirectory(IsolatedStorageScope scope)
         {
-            // This is the relevant special folder for the given scope plus "IsolatedStorage".
+            // This is the relevant special folder for the given scope plus ".isolated-storage".
             // It is meant to replicate the behavior of the VM ComIsolatedStorage::GetRootDir().
 
             // (note that Silverlight used "CoreIsolatedStorage" for a directory name and did not support machine scope)

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.Win32Unix.cs
@@ -30,7 +30,7 @@ namespace System.IO.IsolatedStorage
 
         [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file",
             Justification = "Code handles single-file deployment by using the information of the .exe file")]
-        internal static void GetDefaultIdentityAndHash(out object identity, char separator)
+        internal static void GetDefaultIdentityAndHash(out object identity, out string hash, char separator)
         {
             // In .NET Framework IsolatedStorage uses identity from System.Security.Policy.Evidence to build
             // the folder structure on disk. It would use the "best" available evidence in this order:
@@ -56,9 +56,10 @@ namespace System.IO.IsolatedStorage
             {
                 AssemblyName assemblyName = assembly.GetName();
 
-                string hash = IdentityHelper.GetNormalizedStrongNameHash(assemblyName)!;
+                hash = IdentityHelper.GetNormalizedStrongNameHash(assemblyName)!;
                 if (hash != null)
                 {
+                    hash = "StrongName" + separator + hash;
                     identity = assemblyName;
                     return;
                 }
@@ -73,7 +74,9 @@ namespace System.IO.IsolatedStorage
                 location = Environment.ProcessPath;
             if (string.IsNullOrEmpty(location))
                 throw new IsolatedStorageException(SR.IsolatedStorage_Init);
-            identity = new Uri(location);
+            Uri locationUri = new Uri(location);
+            hash = "Url" + separator + IdentityHelper.GetNormalizedUriHash(locationUri);
+            identity = locationUri;
         }
 
         internal static string GetRandomDirectory(string rootDirectory, IsolatedStorageScope scope)

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
@@ -5,22 +5,24 @@ namespace System.IO.IsolatedStorage
 {
     internal static partial class Helper
     {
-        private const string IsolatedStorageDirectoryName = ".isolated-storage";
+        public static string IsolatedStorageDirectoryName { get; set;} = "IsolatedStorage";
 
         private static string? s_machineRootDirectory;
         private static string? s_roamingUserRootDirectory;
         private static string? s_userRootDirectory;
 
         /// <summary>
-        /// The full root directory is the relevant special folder from Environment.GetFolderPath() plus ".isolated-storage"
+        /// The full root directory is the relevant special folder from Environment.GetFolderPath() plus IsolatedStorageDirectoryName
         /// and a set of random directory names if not roaming. (The random directories aren't created for WinRT as
         /// the FolderPath locations for WinRT are app isolated already.)
         ///
         /// Examples:
         ///
         ///     User: @"C:\Users\jerem\AppData\Local\IsolatedStorage\10v31ho4.bo2\eeolfu22.f2w\"
-        ///     User|Roaming: @"C:\Users\jerem\AppData\Roaming\.isolated-storage\"
-        ///     Machine: @"C:\ProgramData\.isolated-storage\nin03cyc.wr0\o3j0urs3.0sn\"
+        ///     User|Roaming: @"C:\Users\jerem\AppData\Roaming\IsolatedStorage\"
+        ///     Machine: @"C:\ProgramData\IsolatedStorage\nin03cyc.wr0\o3j0urs3.0sn\"
+        ///     Android path: "/data/user/0/net.dot.System.IO.IsolatedStorage.Tests/files/.config/.isolated-storage/"
+        ///     iOS path: "/var/mobile/Containers/Data/Application/A323CBB9-A2B3-4432-9449-48CC20C07A7D/Documents/.config/.isolated-storage/"
         ///
         /// Identity for the current store gets tacked on after this.
         /// </summary>

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
@@ -5,14 +5,14 @@ namespace System.IO.IsolatedStorage
 {
     internal static partial class Helper
     {
-        private const string IsolatedStorageDirectoryName = "IsolatedStorage";
+        private const string IsolatedStorageDirectoryName = ".isolated-storage";
 
         private static string? s_machineRootDirectory;
         private static string? s_roamingUserRootDirectory;
         private static string? s_userRootDirectory;
 
         /// <summary>
-        /// The full root directory is the relevant special folder from Environment.GetFolderPath() plus "IsolatedStorage"
+        /// The full root directory is the relevant special folder from Environment.GetFolderPath() plus ".isolated-storage"
         /// and a set of random directory names if not roaming. (The random directories aren't created for WinRT as
         /// the FolderPath locations for WinRT are app isolated already.)
         ///

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
@@ -5,8 +5,6 @@ namespace System.IO.IsolatedStorage
 {
     internal static partial class Helper
     {
-        public static string IsolatedStorageDirectoryName { get; set;} = "IsolatedStorage";
-
         private static string? s_machineRootDirectory;
         private static string? s_roamingUserRootDirectory;
         private static string? s_userRootDirectory;

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/Helper.cs
@@ -19,8 +19,8 @@ namespace System.IO.IsolatedStorage
         /// Examples:
         ///
         ///     User: @"C:\Users\jerem\AppData\Local\IsolatedStorage\10v31ho4.bo2\eeolfu22.f2w\"
-        ///     User|Roaming: @"C:\Users\jerem\AppData\Roaming\IsolatedStorage\"
-        ///     Machine: @"C:\ProgramData\IsolatedStorage\nin03cyc.wr0\o3j0urs3.0sn\"
+        ///     User|Roaming: @"C:\Users\jerem\AppData\Roaming\.isolated-storage\"
+        ///     Machine: @"C:\ProgramData\.isolated-storage\nin03cyc.wr0\o3j0urs3.0sn\"
         ///
         /// Identity for the current store gets tacked on after this.
         /// </summary>

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorage.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorage.cs
@@ -127,6 +127,11 @@ namespace System.IO.IsolatedStorage
 
         public abstract void Remove();
 
+        internal string? IdentityHash
+        {
+            get; private set;
+        }
+
         protected void InitStore(IsolatedStorageScope scope, Type appEvidenceType)
         {
             InitStore(scope, null, appEvidenceType);
@@ -137,7 +142,7 @@ namespace System.IO.IsolatedStorage
             VerifyScope(scope);
             Scope = scope;
 
-            Helper.GetDefaultIdentityAndHash(out object identity, SeparatorInternal);
+            Helper.GetDefaultIdentityAndHash(out object identity, out string hash, SeparatorInternal);
 
             if (Helper.IsApplication(scope))
             {
@@ -148,10 +153,13 @@ namespace System.IO.IsolatedStorage
                 if (Helper.IsDomain(scope))
                 {
                     _domainIdentity = identity;
+                    hash = string.Create(null, stackalloc char[128], $"{hash}{SeparatorExternal}{hash}");
                 }
 
                 _assemblyIdentity = identity;
             }
+
+            IdentityHash = hash;
         }
 
         private static void VerifyScope(IsolatedStorageScope scope)

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorage.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorage.cs
@@ -127,11 +127,6 @@ namespace System.IO.IsolatedStorage
 
         public abstract void Remove();
 
-        internal string? IdentityHash
-        {
-            get; private set;
-        }
-
         protected void InitStore(IsolatedStorageScope scope, Type appEvidenceType)
         {
             InitStore(scope, null, appEvidenceType);
@@ -142,7 +137,7 @@ namespace System.IO.IsolatedStorage
             VerifyScope(scope);
             Scope = scope;
 
-            Helper.GetDefaultIdentityAndHash(out object identity, out string hash, SeparatorInternal);
+            Helper.GetDefaultIdentityAndHash(out object identity, SeparatorInternal);
 
             if (Helper.IsApplication(scope))
             {
@@ -153,13 +148,10 @@ namespace System.IO.IsolatedStorage
                 if (Helper.IsDomain(scope))
                 {
                     _domainIdentity = identity;
-                    hash = string.Create(null, stackalloc char[128], $"{hash}{SeparatorExternal}{hash}");
                 }
 
                 _assemblyIdentity = identity;
             }
-
-            IdentityHash = hash;
         }
 
         private static void VerifyScope(IsolatedStorageScope scope)

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.AnyMobile.cs
@@ -5,7 +5,7 @@ namespace System.IO.IsolatedStorage
 {
     public sealed partial class IsolatedStorageFile : IsolatedStorage, IDisposable
     {
-        private string GetIsolatesStorageRoot()
+        private string GetIsolatedStorageRoot()
         {
             return Helper.GetRootDirectory(Scope);
         }

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.AnyMobile.cs
@@ -5,6 +5,12 @@ namespace System.IO.IsolatedStorage
 {
     public sealed partial class IsolatedStorageFile : IsolatedStorage, IDisposable
     {
+
+        private static void InitializeIsoStorageDirectoryName()
+        {
+            Helper.IsolatedStorageDirectoryName = ".isolated-storage";
+        }
+
         private string GetIsolatedStorageRoot()
         {
             return Helper.GetRootDirectory(Scope);

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.AnyMobile.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.IsolatedStorage
+{
+    public sealed partial class IsolatedStorageFile : IsolatedStorage, IDisposable
+    {
+        private string GetIsolatesStorageRoot()
+        {
+            return Helper.GetRootDirectory(Scope);
+        }
+    }
+}

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.AnyMobile.cs
@@ -5,12 +5,6 @@ namespace System.IO.IsolatedStorage
 {
     public sealed partial class IsolatedStorageFile : IsolatedStorage, IDisposable
     {
-
-        private static void InitializeIsoStorageDirectoryName()
-        {
-            Helper.IsolatedStorageDirectoryName = ".isolated-storage";
-        }
-
         private string GetIsolatedStorageRoot()
         {
             return Helper.GetRootDirectory(Scope);

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.NonMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.NonMobile.cs
@@ -7,11 +7,6 @@ namespace System.IO.IsolatedStorage
 {
     public sealed partial class IsolatedStorageFile : IsolatedStorage, IDisposable
     {
-        private static void InitializeIsoStorageDirectoryName()
-        {
-            Helper.IsolatedStorageDirectoryName = "IsolatedStorage";
-        }
-
         private string GetIsolatedStorageRoot()
         {
             StringBuilder root = new StringBuilder(Helper.GetRootDirectory(Scope));

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.NonMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.NonMobile.cs
@@ -7,6 +7,11 @@ namespace System.IO.IsolatedStorage
 {
     public sealed partial class IsolatedStorageFile : IsolatedStorage, IDisposable
     {
+        private static void InitializeIsoStorageDirectoryName()
+        {
+            Helper.IsolatedStorageDirectoryName = "IsolatedStorage";
+        }
+
         private string GetIsolatedStorageRoot()
         {
             StringBuilder root = new StringBuilder(Helper.GetRootDirectory(Scope));

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.NonMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.NonMobile.cs
@@ -7,7 +7,7 @@ namespace System.IO.IsolatedStorage
 {
     public sealed partial class IsolatedStorageFile : IsolatedStorage, IDisposable
     {
-        private string GetIsolatesStorageRoot()
+        private string GetIsolatedStorageRoot()
         {
             StringBuilder root = new StringBuilder(Helper.GetRootDirectory(Scope));
             root.Append(SeparatorExternal);

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.NonMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.NonMobile.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace System.IO.IsolatedStorage
+{
+    public sealed partial class IsolatedStorageFile : IsolatedStorage, IDisposable
+    {
+        private string GetIsolatesStorageRoot()
+        {
+            StringBuilder root = new StringBuilder(Helper.GetRootDirectory(Scope));
+            root.Append(SeparatorExternal);
+            root.Append(IdentityHash);
+
+            return root.ToString();
+        }
+    }
+}

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -40,12 +40,9 @@ namespace System.IO.IsolatedStorage
             // Evidence isn't currently available: https://github.com/dotnet/runtime/issues/18208
             // public static IsolatedStorageFile GetStore(IsolatedStorageScope scope, Evidence domainEvidence, Type domainEvidenceType, Evidence assemblyEvidence, Type assemblyEvidenceType) { return default(IsolatedStorageFile); }
 
-            // InitStore will set up the IdentityHash
             InitStore(scope, null, null);
 
             StringBuilder sb = new StringBuilder(Helper.GetRootDirectory(scope));
-            sb.Append(SeparatorExternal);
-            sb.Append(IdentityHash);
             sb.Append(SeparatorExternal);
 
             if (Helper.IsApplication(scope))

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -43,7 +43,7 @@ namespace System.IO.IsolatedStorage
             // InitStore will set up the IdentityHash
             InitStore(scope, null, null);
 
-            StringBuilder sb = new StringBuilder(GetIsolatesStorageRoot());
+            StringBuilder sb = new StringBuilder(GetIsolatedStorageRoot());
             sb.Append(SeparatorExternal);
 
             if (Helper.IsApplication(scope))

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -40,9 +40,10 @@ namespace System.IO.IsolatedStorage
             // Evidence isn't currently available: https://github.com/dotnet/runtime/issues/18208
             // public static IsolatedStorageFile GetStore(IsolatedStorageScope scope, Evidence domainEvidence, Type domainEvidenceType, Evidence assemblyEvidence, Type assemblyEvidenceType) { return default(IsolatedStorageFile); }
 
+            // InitStore will set up the IdentityHash
             InitStore(scope, null, null);
 
-            StringBuilder sb = new StringBuilder(Helper.GetRootDirectory(scope));
+            StringBuilder sb = new StringBuilder(GetIsolatesStorageRoot());
             sb.Append(SeparatorExternal);
 
             if (Helper.IsApplication(scope))

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -40,7 +40,10 @@ namespace System.IO.IsolatedStorage
             // Evidence isn't currently available: https://github.com/dotnet/runtime/issues/18208
             // public static IsolatedStorageFile GetStore(IsolatedStorageScope scope, Evidence domainEvidence, Type domainEvidenceType, Evidence assemblyEvidence, Type assemblyEvidenceType) { return default(IsolatedStorageFile); }
 
-            // InitStore will set up the IdentityHash
+            // for non mobile platforms IsolatedStorageDirectoryName is "IsolatedStorage", for mobile platforms ".isolated-storage"
+            InitializeIsoStorageDirectoryName();
+
+           // InitStore will set up the IdentityHash
             InitStore(scope, null, null);
 
             StringBuilder sb = new StringBuilder(GetIsolatedStorageRoot());

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -43,7 +43,7 @@ namespace System.IO.IsolatedStorage
             // for non mobile platforms IsolatedStorageDirectoryName is "IsolatedStorage", for mobile platforms ".isolated-storage"
             InitializeIsoStorageDirectoryName();
 
-           // InitStore will set up the IdentityHash
+            // InitStore will set up the IdentityHash
             InitStore(scope, null, null);
 
             StringBuilder sb = new StringBuilder(GetIsolatedStorageRoot());

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -40,9 +40,6 @@ namespace System.IO.IsolatedStorage
             // Evidence isn't currently available: https://github.com/dotnet/runtime/issues/18208
             // public static IsolatedStorageFile GetStore(IsolatedStorageScope scope, Evidence domainEvidence, Type domainEvidenceType, Evidence assemblyEvidence, Type assemblyEvidenceType) { return default(IsolatedStorageFile); }
 
-            // for non mobile platforms IsolatedStorageDirectoryName is "IsolatedStorage", for mobile platforms ".isolated-storage"
-            InitializeIsoStorageDirectoryName();
-
             // InitStore will set up the IdentityHash
             InitStore(scope, null, null);
 

--- a/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -50,7 +50,7 @@
     <Compile Include="System\IO\IsolatedStorage\MoveDirectoryTests.cs" />
     <Compile Include="System\IO\IsolatedStorage\MoveFileTests.cs" />
     <Compile Include="System\IO\IsolatedStorage\OpenFileTests.cs" />
-    <Compile Include="System\IO\IsolatedStorage\TestHelper.cs" />   
+    <Compile Include="System\IO\IsolatedStorage\TestHelper.cs" />
     <Compile Include="System\IO\IsolatedStorage\RemoveTests.cs" />
   </ItemGroup>
    <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Android' or '$(TargetPlatformIdentifier)' == 'iOS' or '$(TargetPlatformIdentifier)' == 'MacCatalyst' or '$(TargetPlatformIdentifier)' == 'tvOS'">

--- a/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -57,7 +57,7 @@
     <Compile Include="..\src\System\IO\IsolatedStorage\Helper.AnyMobile.cs" />
     <Compile Include="System\IO\IsolatedStorage\TestHelper.AnyMobile.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS' and '$(TargetPlatformIdentifier)' != ''">
     <Compile Include="..\src\System\IO\IsolatedStorage\Helper.NonMobile.cs" />
     <Compile Include="System\IO\IsolatedStorage\TestHelper.NonMobile.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser;$(NetCoreAppCurrent)-MacCatalyst;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-Android</TargetFrameworks>
     <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
@@ -17,7 +17,7 @@
     <Compile Include="..\src\System\IO\IsolatedStorage\Helper.Win32.cs"
              Link="Internals\Helper.Win32.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Unix' or '$(TargetPlatformIdentifier)' == 'Browser'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows'">
     <Compile Include="..\src\System\IO\IsolatedStorage\Helper.Unix.cs"
              Link="Internals\Helper.Unix.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -51,6 +51,10 @@
     <Compile Include="System\IO\IsolatedStorage\MoveFileTests.cs" />
     <Compile Include="System\IO\IsolatedStorage\OpenFileTests.cs" />
     <Compile Include="System\IO\IsolatedStorage\TestHelper.cs" />
+    <Compile Condition="'$(TargetPlatformIdentifier)' == 'Android' or '$(TargetPlatformIdentifier)' == 'iOS' or '$(TargetPlatformIdentifier)' == 'MacCatalyst' or '$(TargetPlatformIdentifier)' == 'tvOS'"
+             Include="System\IO\IsolatedStorage\TestHelper.AnyMobile.cs" />
+    <Compile Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS'"
+             Include="System\IO\IsolatedStorage\TestHelper.NonMobile.cs" />
     <Compile Include="System\IO\IsolatedStorage\RemoveTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -50,12 +50,16 @@
     <Compile Include="System\IO\IsolatedStorage\MoveDirectoryTests.cs" />
     <Compile Include="System\IO\IsolatedStorage\MoveFileTests.cs" />
     <Compile Include="System\IO\IsolatedStorage\OpenFileTests.cs" />
-    <Compile Include="System\IO\IsolatedStorage\TestHelper.cs" />
-    <Compile Condition="'$(TargetPlatformIdentifier)' == 'Android' or '$(TargetPlatformIdentifier)' == 'iOS' or '$(TargetPlatformIdentifier)' == 'MacCatalyst' or '$(TargetPlatformIdentifier)' == 'tvOS'"
-             Include="System\IO\IsolatedStorage\TestHelper.AnyMobile.cs" />
-    <Compile Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS'"
-             Include="System\IO\IsolatedStorage\TestHelper.NonMobile.cs" />
+    <Compile Include="System\IO\IsolatedStorage\TestHelper.cs" />   
     <Compile Include="System\IO\IsolatedStorage\RemoveTests.cs" />
+  </ItemGroup>
+   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Android' or '$(TargetPlatformIdentifier)' == 'iOS' or '$(TargetPlatformIdentifier)' == 'MacCatalyst' or '$(TargetPlatformIdentifier)' == 'tvOS'">
+    <Compile Include="..\src\System\IO\IsolatedStorage\Helper.AnyMobile.cs" />
+    <Compile Include="System\IO\IsolatedStorage\TestHelper.AnyMobile.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Android' and '$(TargetPlatformIdentifier)' != 'iOS' and '$(TargetPlatformIdentifier)' != 'MacCatalyst' and '$(TargetPlatformIdentifier)' != 'tvOS'">
+    <Compile Include="..\src\System\IO\IsolatedStorage\Helper.NonMobile.cs" />
+    <Compile Include="System\IO\IsolatedStorage\TestHelper.NonMobile.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.DirectoryServices\src\System.DirectoryServices.csproj" />

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -25,7 +25,7 @@ namespace System.IO.IsolatedStorage.Tests
             {
                 Assert.StartsWith(@"Url.", hash);
             }
-            else if (identity.GetType() != typeof(Uri))
+            else
             {
                 Assert.IsType<AssemblyName>(identity);
                 Assert.StartsWith(@"StrongName.", hash);

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -13,7 +13,6 @@ namespace System.IO.IsolatedStorage.Tests
         {
             object identity;
             string hash;
-            //TestHelper.InitHelper(out identity,out hash);
             Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
 
             Assert.NotNull(identity);

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -12,16 +12,23 @@ namespace System.IO.IsolatedStorage.Tests
         public void GetDefaultIdentityAndHash()
         {
             object identity;
-            Helper.GetDefaultIdentityAndHash(out identity, '.');
+            string hash;
+            Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
 
             Assert.NotNull(identity);
+            Assert.NotNull(hash);
 
             // We lie about the identity type when creating the folder structure as we're emulating the Evidence types
             // we don't have available in .NET Standard. We don't serialize the actual identity object, so the desktop
             // implementation will work with locations built off the hash.
-            if (identity.GetType() != typeof(Uri))
+            if (identity.GetType() == typeof(Uri))
+            {
+                Assert.StartsWith(@"Url.", hash);
+            }
+            else if (identity.GetType() != typeof(Uri))
             {
                 Assert.IsType<AssemblyName>(identity);
+                Assert.StartsWith(@"StrongName.", hash);
             }
         }
 

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -45,7 +45,7 @@ namespace System.IO.IsolatedStorage.Tests
                 return;
 
             string path = Helper.GetDataDirectory(scope);
-            Assert.Equal("IsolatedStorage", Path.GetFileName(path));
+            Assert.Equal(".isolated-storage", Path.GetFileName(path));
         }
     }
 }

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -12,23 +12,16 @@ namespace System.IO.IsolatedStorage.Tests
         public void GetDefaultIdentityAndHash()
         {
             object identity;
-            string hash;
-            Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
+            Helper.GetDefaultIdentityAndHash(out identity, '.');
 
             Assert.NotNull(identity);
-            Assert.NotNull(hash);
 
             // We lie about the identity type when creating the folder structure as we're emulating the Evidence types
             // we don't have available in .NET Standard. We don't serialize the actual identity object, so the desktop
             // implementation will work with locations built off the hash.
-            if (identity.GetType() == typeof(Uri))
-            {
-                Assert.StartsWith(@"Url.", hash);
-            }
-            else
+            if (identity.GetType() != typeof(Uri))
             {
                 Assert.IsType<AssemblyName>(identity);
-                Assert.StartsWith(@"StrongName.", hash);
             }
         }
 

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -13,6 +13,7 @@ namespace System.IO.IsolatedStorage.Tests
         {
             object identity;
             string hash;
+            //TestHelper.InitHelper(out identity,out hash);
             Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
 
             Assert.NotNull(identity);
@@ -45,7 +46,7 @@ namespace System.IO.IsolatedStorage.Tests
                 return;
 
             string path = Helper.GetDataDirectory(scope);
-            Assert.Equal(".isolated-storage", Path.GetFileName(path));
+            Assert.Equal(Helper.IsolatedStorageDirectoryName, Path.GetFileName(path));
         }
     }
 }

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.AnyMobile.cs
@@ -11,12 +11,14 @@ namespace System.IO.IsolatedStorage
         private static List<string> GetRoots()
         {
             List<string> roots = new List<string>();
+            Helper.IsolatedStorageDirectoryName = ".isolated-storage";
             string userRoot = Helper.GetDataDirectory(IsolatedStorageScope.User);
             string randomUserRoot = Helper.GetRandomDirectory(userRoot, IsolatedStorageScope.User);
             roots.Add(randomUserRoot);
 
             // Application scope doesn't go under a random dir
             roots.Add(userRoot);
+            return roots;
         }
     }
 }

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.AnyMobile.cs
@@ -8,33 +8,15 @@ namespace System.IO.IsolatedStorage
 {
     public static partial class TestHelper
     {
-        static TestHelper()
+        private static List<string> GetRoots()
         {
-            s_rootDirectoryProperty = typeof(IsolatedStorageFile).GetProperty("RootDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            s_roots = new List<string>();
-
-            string hash;
-            object identity;
-            Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
-
+            List<string> roots = new List<string>();
             string userRoot = Helper.GetDataDirectory(IsolatedStorageScope.User);
             string randomUserRoot = Helper.GetRandomDirectory(userRoot, IsolatedStorageScope.User);
-            s_roots.Add(randomUserRoot);
+            roots.Add(randomUserRoot);
 
             // Application scope doesn't go under a random dir
-            s_roots.Add(userRoot);
-
-            // https://github.com/dotnet/runtime/issues/2092
-            // https://github.com/dotnet/runtime/issues/21742
-            if (OperatingSystem.IsWindows()
-                && !PlatformDetection.IsInAppContainer)
-            {
-                s_roots.Add(Helper.GetDataDirectory(IsolatedStorageScope.Machine));
-            }
-
-            // We don't expose Roaming yet
-            // Helper.GetDataDirectory(IsolatedStorageScope.Roaming);
+            roots.Add(userRoot);
         }
     }
 }

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.AnyMobile.cs
@@ -11,7 +11,6 @@ namespace System.IO.IsolatedStorage
         private static List<string> GetRoots()
         {
             List<string> roots = new List<string>();
-            Helper.IsolatedStorageDirectoryName = ".isolated-storage";
             string userRoot = Helper.GetDataDirectory(IsolatedStorageScope.User);
             string randomUserRoot = Helper.GetRandomDirectory(userRoot, IsolatedStorageScope.User);
             roots.Add(randomUserRoot);

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.AnyMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.AnyMobile.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace System.IO.IsolatedStorage
+{
+    public static partial class TestHelper
+    {
+        static TestHelper()
+        {
+            s_rootDirectoryProperty = typeof(IsolatedStorageFile).GetProperty("RootDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            s_roots = new List<string>();
+
+            string hash;
+            object identity;
+            Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
+
+            string userRoot = Helper.GetDataDirectory(IsolatedStorageScope.User);
+            string randomUserRoot = Helper.GetRandomDirectory(userRoot, IsolatedStorageScope.User);
+            s_roots.Add(randomUserRoot);
+
+            // Application scope doesn't go under a random dir
+            s_roots.Add(userRoot);
+
+            // https://github.com/dotnet/runtime/issues/2092
+            // https://github.com/dotnet/runtime/issues/21742
+            if (OperatingSystem.IsWindows()
+                && !PlatformDetection.IsInAppContainer)
+            {
+                s_roots.Add(Helper.GetDataDirectory(IsolatedStorageScope.Machine));
+            }
+
+            // We don't expose Roaming yet
+            // Helper.GetDataDirectory(IsolatedStorageScope.Roaming);
+        }
+    }
+}

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.NonMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.NonMobile.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace System.IO.IsolatedStorage
+{
+    public static partial class TestHelper
+    {
+        static TestHelper()
+        {
+            s_rootDirectoryProperty = typeof(IsolatedStorageFile).GetProperty("RootDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            s_roots = new List<string>();
+
+            string hash;
+            object identity;
+            Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
+
+            string userRoot = Helper.GetDataDirectory(IsolatedStorageScope.User);
+            string randomUserRoot = Helper.GetRandomDirectory(userRoot, IsolatedStorageScope.User);
+            s_roots.Add(Path.Combine(randomUserRoot, hash));
+            s_roots.Add(randomUserRoot);
+
+            // Application scope doesn't go under a random dir
+            s_roots.Add(Path.Combine(userRoot, hash));
+            s_roots.Add(userRoot);
+
+            // https://github.com/dotnet/runtime/issues/2092
+            // https://github.com/dotnet/runtime/issues/21742
+            if (OperatingSystem.IsWindows()
+                && !PlatformDetection.IsInAppContainer)
+            {
+                s_roots.Add(Helper.GetDataDirectory(IsolatedStorageScope.Machine));
+            }
+
+            // We don't expose Roaming yet
+            // Helper.GetDataDirectory(IsolatedStorageScope.Roaming);
+        }
+    }
+}
+    

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.NonMobile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.NonMobile.cs
@@ -8,35 +8,28 @@ namespace System.IO.IsolatedStorage
 {
     public static partial class TestHelper
     {
-        static TestHelper()
+        private static List<string> GetRoots()
         {
-            s_rootDirectoryProperty = typeof(IsolatedStorageFile).GetProperty("RootDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            s_roots = new List<string>();
-
             string hash;
             object identity;
             Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
-
+            List<string> roots = new List<string>();
             string userRoot = Helper.GetDataDirectory(IsolatedStorageScope.User);
             string randomUserRoot = Helper.GetRandomDirectory(userRoot, IsolatedStorageScope.User);
-            s_roots.Add(Path.Combine(randomUserRoot, hash));
-            s_roots.Add(randomUserRoot);
-
+            
+            roots.Add(Path.Combine(randomUserRoot, hash));
             // Application scope doesn't go under a random dir
-            s_roots.Add(Path.Combine(userRoot, hash));
-            s_roots.Add(userRoot);
+            roots.Add(Path.Combine(userRoot, hash));
 
             // https://github.com/dotnet/runtime/issues/2092
             // https://github.com/dotnet/runtime/issues/21742
             if (OperatingSystem.IsWindows()
                 && !PlatformDetection.IsInAppContainer)
             {
-                s_roots.Add(Helper.GetDataDirectory(IsolatedStorageScope.Machine));
+                roots.Add(Helper.GetDataDirectory(IsolatedStorageScope.Machine));
             }
 
-            // We don't expose Roaming yet
-            // Helper.GetDataDirectory(IsolatedStorageScope.Roaming);
+            return roots;
         }
     }
 }

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.cs
@@ -8,38 +8,10 @@ using System.Text;
 
 namespace System.IO.IsolatedStorage
 {
-    public static class TestHelper
+    public static partial class TestHelper
     {
         private static PropertyInfo s_rootDirectoryProperty;
         private static List<string> s_roots;
-
-        static TestHelper()
-        {
-            s_rootDirectoryProperty = typeof(IsolatedStorageFile).GetProperty("RootDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            s_roots = new List<string>();
-
-            object identity;
-            Helper.GetDefaultIdentityAndHash(out identity, '.');
-
-            string userRoot = Helper.GetDataDirectory(IsolatedStorageScope.User);
-            string randomUserRoot = Helper.GetRandomDirectory(userRoot, IsolatedStorageScope.User);
-            s_roots.Add(randomUserRoot);
-
-            // Application scope doesn't go under a random dir
-            s_roots.Add(userRoot);
-
-            // https://github.com/dotnet/runtime/issues/2092
-            // https://github.com/dotnet/runtime/issues/21742
-            if (OperatingSystem.IsWindows()
-                && !PlatformDetection.IsInAppContainer)
-            {
-                s_roots.Add(Helper.GetDataDirectory(IsolatedStorageScope.Machine));
-            }
-
-            // We don't expose Roaming yet
-            // Helper.GetDataDirectory(IsolatedStorageScope.Roaming);
-        }
 
         /// <summary>
         /// Where the user's files go

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.cs
@@ -19,16 +19,15 @@ namespace System.IO.IsolatedStorage
 
             s_roots = new List<string>();
 
-            string hash;
             object identity;
-            Helper.GetDefaultIdentityAndHash(out identity, out hash, '.');
+            Helper.GetDefaultIdentityAndHash(out identity, '.');
 
             string userRoot = Helper.GetDataDirectory(IsolatedStorageScope.User);
             string randomUserRoot = Helper.GetRandomDirectory(userRoot, IsolatedStorageScope.User);
-            s_roots.Add(Path.Combine(randomUserRoot, hash));
+            s_roots.Add(randomUserRoot);
 
             // Application scope doesn't go under a random dir
-            s_roots.Add(Path.Combine(userRoot, hash));
+            s_roots.Add(userRoot);
 
             // https://github.com/dotnet/runtime/issues/2092
             // https://github.com/dotnet/runtime/issues/21742

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/TestHelper.cs
@@ -13,6 +13,16 @@ namespace System.IO.IsolatedStorage
         private static PropertyInfo s_rootDirectoryProperty;
         private static List<string> s_roots;
 
+        static TestHelper()
+        {
+            s_rootDirectoryProperty = typeof(IsolatedStorageFile).GetProperty("RootDirectory", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            s_roots = GetRoots();
+            
+            // We don't expose Roaming yet
+            // Helper.GetDataDirectory(IsolatedStorageScope.Roaming);
+        }
+
         /// <summary>
         /// Where the user's files go
         /// </summary>


### PR DESCRIPTION
The path of a file created by IsolatedStorageFile.GetUserStoreForApplication() changes between Xamarin.iOS and .NET 6, and also changes between different builds of the application under .NET 6.

 Switched back to the .isolatedstorage approach we had in legacy mono https://github.com/mono/mono/blob/main/mcs/class/corlib/System.IO.IsolatedStorage/IsolatedStorageFile.cs#L304-L327


Fix #74642