### PR TITLE
Join the special sweep decision

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3852,8 +3852,10 @@ public:
     PER_HEAP_ISOLATED
     VOLATILE(bool) full_gc_approach_event_set;
 
+#ifdef USE_REGIONS
     PER_HEAP
     bool special_sweep_p;
+#endif
 
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED


### PR DESCRIPTION
There are a few issues I introduced in https://github.com/dotnet/runtime/pull/74625, and this PR is meant to fix them.

Without fixing these issues, the most common symptom is that because we are reading the `special_sweep_p` flag in an arbitrary heap that reaches the join to decide whether or not we will compact, we might be compacting while some other heaps demand the special sweep, leading to missing regions when we `thread_final_regions`, having the same consequence as in https://github.com/dotnet/runtime/issues/74401. There could be other bugs as well (e.g. `special_sweep_p` was not reset before `make_phase` begins, ...)

Here are all the changes:
- Make sure I initialize `special_sweep_p` to `false` for each heap before `mark_phase` starts.
- Make sure we perform the special sweep whenever *any* request for it.
- Make sure `special_sweep_p` for all heaps agree after joining for compaction decision.
- Make `special_sweep_p` a `USE_REGIONS` specific field.