### PR TITLE
Assert fat pointers aligned to MinimumFunctionAlignment

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FatFunctionPointerNode.cs
@@ -60,8 +60,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             var builder = new ObjectDataBuilder(factory, relocsOnly);
 
-            // These need to be aligned the same as method pointers because they show up in same contexts
+            // These need to be aligned the same as method bodies because they show up in same contexts
             // (macOS ARM64 has even stricter alignment requirement for the linker, so round up to pointer size)
+            Debug.Assert(factory.Target.MinimumFunctionAlignment <= factory.Target.PointerSize);
             builder.RequireInitialAlignment(factory.Target.PointerSize);
 
             builder.AddSymbol(this);


### PR DESCRIPTION
The alignment changed in #75264, but it's important this is always at least MinimumFunctionAlignment no matter the platform because that's how we distinguish fat pointers from real pointers. This assert is obviously true on every platform we support right now.