### PR TITLE
Fix extraneous parens in EnsureSuccessStatusCode message

### DIFF
--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -211,6 +211,9 @@
     <value>A request message must be provided. It cannot be null.</value>
   </data>
   <data name="net_http_message_not_success_statuscode" xml:space="preserve">
+    <value>Response status code does not indicate success: {0}.</value>
+  </data>
+  <data name="net_http_message_not_success_statuscode_reason" xml:space="preserve">
     <value>Response status code does not indicate success: {0} ({1}).</value>
   </data>
   <data name="net_http_content_field_too_long" xml:space="preserve">

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
@@ -169,7 +169,7 @@ namespace System.Net.Http
                 throw new HttpRequestException(
                     SR.Format(
                         System.Globalization.CultureInfo.InvariantCulture,
-                        SR.net_http_message_not_success_statuscode,
+                        string.IsNullOrWhiteSpace(ReasonPhrase) ? SR.net_http_message_not_success_statuscode : SR.net_http_message_not_success_statuscode_reason,
                         (int)_statusCode,
                         ReasonPhrase),
                     inner: null,

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
@@ -103,12 +103,26 @@ namespace System.Net.Http.Functional.Tests
             {
                 var ex = Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
                 Assert.Equal(HttpStatusCode.MultipleChoices, ex.StatusCode);
+                Assert.Contains(((int)HttpStatusCode.MultipleChoices).ToString(), ex.Message);
+                Assert.Contains("(", ex.Message);
             }
 
             using (var m = new HttpResponseMessage(HttpStatusCode.BadGateway))
             {
                 var ex = Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
                 Assert.Equal(HttpStatusCode.BadGateway, ex.StatusCode);
+                Assert.Contains(((int)HttpStatusCode.BadGateway).ToString(), ex.Message);
+                Assert.Contains("(", ex.Message);
+            }
+
+            using (var m = new HttpResponseMessage(HttpStatusCode.BadGateway))
+            {
+                m.ReasonPhrase = " \t ";
+                var ex = Assert.Throws<HttpRequestException>(() => m.EnsureSuccessStatusCode());
+                Assert.Equal(HttpStatusCode.BadGateway, ex.StatusCode);
+                Assert.Contains(((int)HttpStatusCode.BadGateway).ToString(), ex.Message);
+                Assert.DoesNotContain("(", ex.Message);
+                Assert.DoesNotContain(" \t ", ex.Message);
             }
 
             using (var response = new HttpResponseMessage(HttpStatusCode.OK))

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/AuthenticationHeaderValueTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/AuthenticationHeaderValueTest.cs
@@ -107,7 +107,7 @@ namespace System.Net.Http.Tests
         [Fact]
         public void Add_BadValues_Throws()
         {
-            string x = SR.net_http_message_not_success_statuscode;
+            string x = SR.net_http_message_not_success_statuscode_reason;
             string input = "Digest algorithm=MD5-sess,nonce=\"+Upgraded+v109e309640b\",charset=utf-8,realm=\"Digest\", ";
 
             HttpRequestMessage request = new HttpRequestMessage();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75570
cc: @danmoseley 

Was faster to just do it than to debate it :)