### PR TITLE
Fix missing flags for IND(str_handle)

### DIFF
--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -1628,7 +1628,19 @@ const WCHAR* Compiler::eeGetCPString(size_t strHandle)
         return (nullptr);
     }
 
-    CORINFO_String* asString = *((CORINFO_String**)strHandle);
+    CORINFO_String* asString = nullptr;
+    if (impGetStringClass() == *((CORINFO_CLASS_HANDLE*)strHandle))
+    {
+        // strHandle is a frozen string
+        // We assume strHandle is never an "interior" pointer in a frozen string
+        // (jit is not expected to perform such foldings)
+        asString = (CORINFO_String*)strHandle;
+    }
+    else
+    {
+        // strHandle is a pinned handle to a string object
+        asString = *((CORINFO_String**)strHandle);
+    }
 
     if (ReadProcessMemory(GetCurrentProcess(), asString, buff, sizeof(buff), nullptr) == 0)
     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11161,6 +11161,11 @@ DONE_MORPHING_CHILDREN:
             //
             if (!tree->AsIndir()->IsVolatile())
             {
+                if (op1->IsIconHandle(GTF_ICON_STR_HDL))
+                {
+                    tree->gtFlags |= (GTF_IND_INVARIANT | GTF_IND_NONFAULTING | GTF_IND_NONNULL);
+                }
+
                 /* Try to Fold *(&X) into X */
                 if (op1->gtOper == GT_ADDR)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75562
Normally, we set `GTF_IND_INVARIANT` for string literals when we create IND nodes representing them, but after https://github.com/dotnet/runtime/pull/49576 `GTF_ICON_STR_HDL` may be created without `GT_IND` first, so if it appears later - update its flags.

Also, fix `eeGetCPString` (used for e.g. DOTNET_JitDisasm) to handle frozen strings

cc @AndyAyersMS 