### PR TITLE
Bump 7.0 intellisense to RC1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -174,7 +174,7 @@
     <!--<SdkVersionForWorkloadTesting>7.0.100-rc.1.22402.35</SdkVersionForWorkloadTesting>-->
     <CompilerPlatformTestingVersion>1.1.2-beta1.22403.2</CompilerPlatformTestingVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220822.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220914.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>7.0.100-1.22423.4</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>


### PR DESCRIPTION
The intellisense package version for RC1 has been generated:
https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=318925&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=11e7ea89-affe-5194-cdc6-0171c3394706

The dotnet-api-docs RC1 source branch is located here: https://github.com/dotnet/dotnet-api-docs/pull/8380/

This is the package that should get shipped with RC2.
