### PR TITLE
Re-enable multimodule testing

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -16,7 +16,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
   <!-- Set defaults for unspecified properties -->
   <PropertyGroup>
-    <NativeLib Condition="'$(OutputType)' == 'Library' and '$(NativeLib)' == ''">Shared</NativeLib>
+    <NativeLib Condition="'$(OutputType)' == 'Library' and '$(NativeLib)' == '' and '$(IlcMultiModule)' != 'true'">Shared</NativeLib>
     <NativeIntermediateOutputPath Condition="'$(NativeIntermediateOutputPath)' == ''">$(IntermediateOutputPath)native\</NativeIntermediateOutputPath>
     <NativeOutputPath Condition="'$(NativeOutputPath)' == ''">$(OutputPath)native\</NativeOutputPath>
     <NativeCompilationDuringPublish Condition="'$(NativeCompilationDuringPublish)' == ''">true</NativeCompilationDuringPublish>

--- a/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
+++ b/src/tests/nativeaot/SmokeTests/MultiModule/MultiModule.csproj
@@ -8,9 +8,6 @@
     <!-- This test always runs as multimodule. It's not supported if we don't have framework object files. -->
     <CLRTestTargetUnsupported Condition="'$(BuildNativeAotFrameworkObjects)' != 'true'">true</CLRTestTargetUnsupported>
     <IlcMultiModule>true</IlcMultiModule>
-
-    <!-- https://github.com/dotnet/runtime/issues/66191 -->
-    <CLRTestTargetUnsupported>true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MultiModule.cs" />


### PR DESCRIPTION
Resolves #66191.

I no longer see the warning or the link.exe failure. This likely was a link.exe bug like I suspected in the issue based on available evidence.

Of course we also regressed multimodule mode so I'm fixing that too.

Cc @dotnet/ilc-contrib 