### PR TITLE
Small diagnostics improvements to HostWriter

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/AppHostExceptions.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/AppHostExceptions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.NET.HostModel.AppHost
         public readonly MachOFormatError Error;
 
         internal AppHostMachOFormatException(MachOFormatError error)
+            : base($"Failed to process MachO file: {error}")
         {
             Error = error;
         }

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -141,7 +141,7 @@ namespace Microsoft.NET.HostModel.AppHost
 
                     if (chmodReturnCode == -1)
                     {
-                        throw new Win32Exception(Marshal.GetLastWin32Error(), $"Could not set file permission {filePermissionOctal} for {appHostDestinationFilePath}.");
+                        throw new Win32Exception(Marshal.GetLastWin32Error(), $"Could not set file permission {Convert.ToString(filePermissionOctal, 8)} for {appHostDestinationFilePath}.");
                     }
 
                     if (enableMacOSCodeSign && RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && HostModelUtils.IsCodesignAvailable())


### PR DESCRIPTION
- Print out file permissions in octal (as per Linux standard)
- Actually print out error enum value when MachO processing fails

Related to https://github.com/dotnet/sdk/issues/27436