### PR TITLE
Implement an AppContext compatibility switch re-enabling reflection fallback in STJ source generators.

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -36,6 +36,7 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="..\Common\JsonSourceGenerationMode.cs" Link="Common\System\Text\Json\Serialization\JsonSourceGenerationMode.cs" />
     <Compile Include="..\Common\JsonSourceGenerationOptionsAttribute.cs" Link="Common\System\Text\Json\Serialization\JsonSourceGenerationOptionsAttribute.cs" />
     <Compile Include="..\Common\ReflectionExtensions.cs" Link="Common\System\Text\Json\Serialization\ReflectionExtensions.cs" />
+    <Compile Include="System\Text\Json\AppContextSwitchHelper.cs" />
     <Compile Include="System\Text\Json\BitStack.cs" />
     <Compile Include="System\Text\Json\Document\JsonDocument.cs" />
     <Compile Include="System\Text\Json\Document\JsonDocument.DbRow.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/AppContextSwitchHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/AppContextSwitchHelper.cs
@@ -1,45 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Text.Json
 {
     internal static class AppContextSwitchHelper
     {
-        private const string SourceGenReflectionFallbackEnabled_SwitchName = "System.Text.Json.Serialization.EnableSourceGenReflectionFallback";
-        private static int s_SourceGenReflectionFallbackEnabled_CachedValue;
+        public static bool IsSourceGenReflectionFallbackEnabled => s_isSourceGenReflectionFallbackEnabled;
 
-        public static bool IsSourceGenReflectionFallbackEnabled
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => GetCachedSwitchValue(SourceGenReflectionFallbackEnabled_SwitchName, ref s_SourceGenReflectionFallbackEnabled_CachedValue, defaultValue: false);
-        }
-
-        // Returns value of given switch using provided cache.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool GetCachedSwitchValue(string switchName, ref int cachedSwitchValue, bool defaultValue)
-        {
-            // The cached switch value has 3 states: 0 - unknown, 1 - true, -1 - false
-            if (cachedSwitchValue < 0) return false;
-            if (cachedSwitchValue > 0) return true;
-
-            return GetCachedSwitchValueInternal(switchName, ref cachedSwitchValue, defaultValue);
-        }
-
-        private static bool GetCachedSwitchValueInternal(string switchName, ref int cachedSwitchValue, bool defaultValue)
-        {
-            if (!AppContext.TryGetSwitch(switchName, out bool isSwitchEnabled))
-            {
-                isSwitchEnabled = defaultValue;
-            }
-
-            cachedSwitchValue = isSwitchEnabled ? 1 /*true*/ : -1 /*false*/;
-            return isSwitchEnabled;
-        }
+        private static readonly bool s_isSourceGenReflectionFallbackEnabled =
+            AppContext.TryGetSwitch(
+                switchName: "System.Text.Json.Serialization.EnableSourceGenReflectionFallback",
+                isEnabled: out bool value)
+            ? value : false;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/AppContextSwitchHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/AppContextSwitchHelper.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Text.Json
+{
+    internal static class AppContextSwitchHelper
+    {
+        private const string SourceGenReflectionFallbackEnabled_SwitchName = "System.Text.Json.Serialization.EnableSourceGenReflectionFallback";
+        private static int s_SourceGenReflectionFallbackEnabled_CachedValue;
+
+        public static bool IsSourceGenReflectionFallbackEnabled
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue(SourceGenReflectionFallbackEnabled_SwitchName, ref s_SourceGenReflectionFallbackEnabled_CachedValue, defaultValue: false);
+        }
+
+        // Returns value of given switch using provided cache.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool GetCachedSwitchValue(string switchName, ref int cachedSwitchValue, bool defaultValue)
+        {
+            // The cached switch value has 3 states: 0 - unknown, 1 - true, -1 - false
+            if (cachedSwitchValue < 0) return false;
+            if (cachedSwitchValue > 0) return true;
+
+            return GetCachedSwitchValueInternal(switchName, ref cachedSwitchValue, defaultValue);
+        }
+
+        private static bool GetCachedSwitchValueInternal(string switchName, ref int cachedSwitchValue, bool defaultValue)
+        {
+            if (!AppContext.TryGetSwitch(switchName, out bool isSwitchEnabled))
+            {
+                isSwitchEnabled = defaultValue;
+            }
+
+            cachedSwitchValue = isSwitchEnabled ? 1 /*true*/ : -1 /*false*/;
+            return isSwitchEnabled;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -643,17 +643,31 @@ namespace System.Text.Json
             // Even if a resolver has already been specified, we need to root
             // the default resolver to gain access to the default converters.
             DefaultJsonTypeInfoResolver defaultResolver = DefaultJsonTypeInfoResolver.RootDefaultInstance();
-            _typeInfoResolver ??= defaultResolver;
+
+            switch (_typeInfoResolver)
+            {
+                case null:
+                    // Use the default reflection-based resolver if no resolver has been specified.
+                    _typeInfoResolver = defaultResolver;
+                    break;
+
+                case JsonSerializerContext ctx when AppContextSwitchHelper.IsSourceGenReflectionFallbackEnabled:
+                    // .NET 6 compatibility mode: enable fallback to reflection metadata for JsonSerializerContext
+                    _effectiveJsonTypeInfoResolver = JsonTypeInfoResolver.Combine(ctx, defaultResolver);
+                    break;
+            }
+
             MakeReadOnly();
             _isInitializedForReflectionSerializer = true;
         }
 
         internal bool IsInitializedForReflectionSerializer => _isInitializedForReflectionSerializer;
         private volatile bool _isInitializedForReflectionSerializer;
+        private IJsonTypeInfoResolver? _effectiveJsonTypeInfoResolver;
 
         private JsonTypeInfo? GetTypeInfoNoCaching(Type type)
         {
-            JsonTypeInfo? info = _typeInfoResolver?.GetTypeInfo(type, this);
+            JsonTypeInfo? info = (_effectiveJsonTypeInfoResolver ?? _typeInfoResolver)?.GetTypeInfo(type, this);
 
             if (info != null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -663,6 +663,8 @@ namespace System.Text.Json
 
         internal bool IsInitializedForReflectionSerializer => _isInitializedForReflectionSerializer;
         private volatile bool _isInitializedForReflectionSerializer;
+
+        // Only populated in .NET 6 compatibility mode encoding reflection fallback in source gen
         private IJsonTypeInfoResolver? _effectiveJsonTypeInfoResolver;
 
         private JsonTypeInfo? GetTypeInfoNoCaching(Type type)


### PR DESCRIPTION
.NET 7 introduced an [intentional breaking change](https://github.com/dotnet/docs/issues/30755) which removes silent fallback to reflection-based serialization in System.Text.Json source generators. Based on early feedback we have been receiving from customers and partner teams, it appears that quite a few users have (mostly accidentally) taken a dependency on the fallback behavior (see https://github.com/dotnet/aspnetcore/issues/43894, https://github.com/dotnet/aspnetcore/issues/43236 for a few examples).

Even though a workaround for the breaking change has been documented, it still requires a code change which might not be possible in certain scenaria. This PR introduces an `AppContext` compatibility switch (named `System.Text.Json.Serialization.EnableSourceGenReflectionFallback`) that brings back the reflection fallback logic for source generators.

Should be backported to `release/7.0`. We should also update the documentation added in https://github.com/dotnet/docs/pull/31132 to incorporate this switch.

cc @ericstj @davidfowl @brunolins16 