### PR TITLE
Check for null keys in DSA/RSAKeyValue

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSAKeyValue.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSAKeyValue.cs
@@ -25,6 +25,11 @@ namespace System.Security.Cryptography.Xml
 
         public DSAKeyValue(DSA key)
         {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             _key = key;
         }
 
@@ -34,8 +39,16 @@ namespace System.Security.Cryptography.Xml
 
         public DSA Key
         {
-            get { return _key; }
-            set { _key = value; }
+            get => _key;
+            set
+            {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _key = value;
+            }
         }
 
         //

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAKeyValue.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAKeyValue.cs
@@ -20,6 +20,11 @@ namespace System.Security.Cryptography.Xml
 
         public RSAKeyValue(RSA key)
         {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             _key = key;
         }
 
@@ -29,8 +34,16 @@ namespace System.Security.Cryptography.Xml
 
         public RSA Key
         {
-            get { return _key; }
-            set { _key = value; }
+            get => _key;
+            set
+            {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _key = value;
+            }
         }
 
         //

--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -41,14 +41,24 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void Ctor_Dsa_Null()
         {
+#if NET
             Assert.Throws<ArgumentNullException>("key", () => new DSAKeyValue(null));
+#else
+            DSAKeyValue dsaKeyValue = new DSAKeyValue(null);
+            Assert.Null(dsaKeyValue.Key);
+#endif
         }
 
         [Fact]
         public static void KeyProperty_SetNull()
         {
             DSAKeyValue dsaKeyValue = new DSAKeyValue();
+#if NET
             Assert.Throws<ArgumentNullException>("value", () => dsaKeyValue.Key = null);
+#else
+            dsaKeyValue.Key = null;
+            Assert.Null(dsaKeyValue.Key);
+#endif
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -34,20 +34,21 @@ namespace System.Security.Cryptography.Xml.Tests
             using (DSA dsa = DSA.Create())
             {
                 DSAKeyValue dsaKeyValue = new DSAKeyValue(dsa);
-                Assert.Equal(dsa, dsaKeyValue.Key);
+                Assert.Same(dsa, dsaKeyValue.Key);
             }
         }
 
         [Fact]
         public void Ctor_Dsa_Null()
         {
-            DSAKeyValue dsaKeyValue = new DSAKeyValue(null);
+            Assert.Throws<ArgumentNullException>("key", () => new DSAKeyValue(null));
+        }
 
-            //From https://github.com/peterwurzinger:
-            //This assertion is incorrect, since the parameter value is stored unvalidated/unprocessed
-            //Assert.NotNull(dsaKeyValue.Key);
-
-            Assert.Null(dsaKeyValue.Key);
+        [Fact]
+        public static void KeyProperty_SetNull()
+        {
+            DSAKeyValue dsaKeyValue = new DSAKeyValue();
+            Assert.Throws<ArgumentNullException>("value", () => dsaKeyValue.Key = null);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
@@ -37,14 +37,24 @@ namespace System.Security.Cryptography.Xml.Tests
         [Fact]
         public void Ctor_Rsa_Null()
         {
+#if NET
             Assert.Throws<ArgumentNullException>("key", () => new RSAKeyValue(null));
+#else
+            RSAKeyValue rsaKeyValue = new RSAKeyValue(null);
+            Assert.Null(rsaKeyValue.Key);
+#endif
         }
 
         [Fact]
         public static void KeyProperty_SetNull()
         {
             RSAKeyValue rsaKeyValue = new RSAKeyValue();
+#if NET
             Assert.Throws<ArgumentNullException>("value", () => rsaKeyValue.Key = null);
+#else
+            rsaKeyValue.Key = null;
+            Assert.Null(rsaKeyValue.Key);
+#endif
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
@@ -30,17 +30,22 @@ namespace System.Security.Cryptography.Xml.Tests
             using (RSA rsa = RSA.Create())
             {
                 RSAKeyValue rsaKeyValue = new RSAKeyValue(rsa);
-                Assert.Equal(rsa, rsaKeyValue.Key);
+                Assert.Same(rsa, rsaKeyValue.Key);
             }
         }
 
         [Fact]
         public void Ctor_Rsa_Null()
         {
-            RSAKeyValue rsaKeyValue = new RSAKeyValue(null);
-            Assert.Null(rsaKeyValue.Key);
+            Assert.Throws<ArgumentNullException>("key", () => new RSAKeyValue(null));
         }
 
+        [Fact]
+        public static void KeyProperty_SetNull()
+        {
+            RSAKeyValue rsaKeyValue = new RSAKeyValue();
+            Assert.Throws<ArgumentNullException>("value", () => rsaKeyValue.Key = null);
+        }
 
         [Fact]
         public void GetXml()


### PR DESCRIPTION
Closes #75048

This prevents null DSA/RSA objects in DSA/RSAKeyValue.