### PR TITLE
Revert "[main] Pass resource items for VS generated authoring"

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -142,7 +142,7 @@
     <CreateVisualStudioWorkload BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
                                 AllowMissingPacks="True"
                                 BaseOutputPath="$(WorkloadOutputPath)"
-                                ComponentResources="@(ComponentResources)"
+                                ComponentResources="$(ComponentResources)"
                                 PackageSource="$(PackageSource)"
                                 ShortNames="@(ShortNames)"
                                 WorkloadManifestPackageFiles="@(ManifestPackages)"


### PR DESCRIPTION
Reverts dotnet/runtime#75462 to unbreak official build, will backport [[release/7.0] Port workload fixes from 6.0 by joeloff · Pull Request #75486 · dotnet/runtime (github.com)](https://github.com/dotnet/runtime/pull/75486) instead