### PR TITLE
JIT: Evaluate GDV call args early

### DIFF
--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -545,28 +545,28 @@ private:
             // have to spill all arguments with side effects.
             for (CallArg& arg : origCall->gtArgs.Args())
             {
-                bool     spill = false;
-                GenTree* node  = arg.GetNode();
+                bool     spill   = false;
+                GenTree* argNode = arg.GetNode();
 
                 if (arg.GetWellKnownArg() == WellKnownArg::ThisPointer)
                 {
                     // Guard is going to access this arg, spill it if it is
                     // complex, regardless of side effects.
-                    spill = !node->IsLocal();
+                    spill = !argNode->IsLocal();
                 }
                 else
                 {
-                    spill = (arg.GetNode()->gtFlags & GTF_SIDE_EFFECT) != 0;
+                    spill = (argNode->gtFlags & GTF_SIDE_EFFECT) != 0;
                 }
 
                 if (spill)
                 {
                     unsigned   tmpNum  = compiler->lvaGrabTemp(true DEBUGARG("guarded devirt arg temp"));
-                    GenTree*   asgTree = compiler->gtNewTempAssign(tmpNum, arg.GetNode());
+                    GenTree*   asgTree = compiler->gtNewTempAssign(tmpNum, argNode);
                     Statement* asgStmt = compiler->fgNewStmtFromTree(asgTree, stmt->GetDebugInfo());
                     compiler->fgInsertStmtAtEnd(checkBlock, asgStmt);
 
-                    arg.SetEarlyNode(compiler->gtNewLclvNode(tmpNum, genActualType(arg.GetNode())));
+                    arg.SetEarlyNode(compiler->gtNewLclvNode(tmpNum, genActualType(argNode)));
                 }
             }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_75607/Runtime_75607.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_75607/Runtime_75607.cs
@@ -52,7 +52,7 @@ public class Program
 
 public interface Base
 {
-    public abstract void Test(long arg);
+    void Test(long arg);
 }
 
 public class C : Base

--- a/src/tests/JIT/Regression/JitBlue/Runtime_75607/Runtime_75607.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_75607/Runtime_75607.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public class Program
+{
+    private static int s_result;
+    public static int Main()
+    {
+        C c = new();
+        for (int i = 0; i < 100; i++)
+        {
+            Foo(c);
+            Thread.Sleep(15);
+        }
+
+        s_result = -1;
+        try
+        {
+            Foo(null);
+            Console.WriteLine("FAIL: No exception thrown");
+            return -2;
+        }
+        catch (NullReferenceException)
+        {
+            if (s_result == 100)
+            {
+                Console.WriteLine("PASS");
+            }
+            else
+            {
+                Console.WriteLine("FAIL: Result is {0}", s_result);
+            }
+
+            return s_result;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Foo(Base b)
+    {
+        b.Test(SideEffect(10));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long SideEffect(long i)
+    {
+        s_result = 100;
+        return i;
+    }
+}
+
+public interface Base
+{
+    public abstract void Test(long arg);
+}
+
+public class C : Base
+{
+    public void Test(long arg)
+    {
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_75607/Runtime_75607.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_75607/Runtime_75607.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TieredPGO=1
+set COMPlus_TC_QuickJitForLoops=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TieredPGO=1
+export COMPlus_TC_QuickJitForLoops=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The normal evaluation order for a callvirt is the following:
1. The 'this' arg is evaluated
2. The arguments are evaluated
3. 'this' is null-checked
4. The call is performed

Step 1 and 2 happen as part of the IL instructions that load the
arguments, while step 3 and 4 happen as part of the callvirt IL
instruction.

For GDV the guards need to dereference 'this'. We were doing this too
early, causing step 3 to happen before step 2. The fix is to spill
arguments for GDVs more aggressively when side effects are encountered.

Fix #75607