### PR TITLE
[release/6.0] Fix `DataContractJsonSerializer`'s handling of -0.0

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
@@ -640,7 +640,7 @@ namespace System.Xml
             if (count == 10)
                 return false;
             if (negative)
-                result = -value;
+                result = -(float)value;
             else
                 result = value;
             return true;
@@ -692,7 +692,7 @@ namespace System.Xml
             if (count == 10)
                 return false;
             if (negative)
-                result = -value;
+                result = -(double)value;
             else
                 result = value;
             return true;

--- a/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -139,26 +139,30 @@ public static partial class DataContractJsonSerializerTests
     [Fact]
     public static void DCJS_DoubleAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<double>(-1.2, "-1.2"), -1.2);
-        Assert.StrictEqual(0, SerializeAndDeserialize<double>(0, "0"));
+        Assert.StrictEqual(-1.2, SerializeAndDeserialize<double>(-1.2, "-1.2"));
+        Assert.StrictEqual(0.0, SerializeAndDeserialize<double>(0.0, "0"));
+        Assert.StrictEqual(0.0, SerializeAndDeserialize<double>(-0.0, "-0"));
+        Assert.Equal("-0", SerializeAndDeserialize<double>(-0.0, "-0").ToString());
         Assert.StrictEqual(2.3, SerializeAndDeserialize<double>(2.3, "2.3"));
-        Assert.StrictEqual(SerializeAndDeserialize<double>(double.MinValue, "-1.7976931348623157E+308"), double.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<double>(double.MaxValue, "1.7976931348623157E+308"), double.MaxValue);
+        Assert.StrictEqual(double.MinValue, SerializeAndDeserialize<double>(double.MinValue, "-1.7976931348623157E+308"));
+        Assert.StrictEqual(double.MaxValue, SerializeAndDeserialize<double>(double.MaxValue, "1.7976931348623157E+308"));
     }
 
     [Fact]
     public static void DCJS_FloatAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2, "-1.2"), (float)-1.2);
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)0, "0"), (float)0);
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3, "2.3"), (float)2.3);
+        Assert.StrictEqual((float)-1.2, SerializeAndDeserialize<float>((float)-1.2, "-1.2"));
+        Assert.StrictEqual((float)0.0, SerializeAndDeserialize<float>((float)0.0, "0"));
+        Assert.StrictEqual((float)0.0, SerializeAndDeserialize<float>((float)-0.0, "-0"));
+        Assert.Equal("-0", SerializeAndDeserialize<float>((float)-0.0, "-0").ToString());
+        Assert.StrictEqual((float)2.3, SerializeAndDeserialize<float>((float)2.3, "2.3"));
     }
 
     [Fact]
     public static void DCJS_FloatAsRoot_NotNetFramework()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<float>(float.MinValue, "-3.4028235E+38"), float.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<float>(float.MaxValue, "3.4028235E+38"), float.MaxValue);
+        Assert.StrictEqual(float.MinValue, SerializeAndDeserialize<float>(float.MinValue, "-3.4028235E+38"));
+        Assert.StrictEqual(float.MaxValue, SerializeAndDeserialize<float>(float.MaxValue, "3.4028235E+38"));
     }
 
     [Fact]


### PR DESCRIPTION
Backport of #69020 to release/6.0.

## Customer Impact
When serializing a "negative zero", DCS should preserve the sign so that a round-tripped negative zero is still "negative." Going back to the days of NetFx, DCS has been serializing negative zero float/double values as "-0" which does preserve the sign. However, it reads those back in without accounting for the sign. (If the serialized value is expressed as "-0.0" DCS handles deserialization correctly... but as stated, DCS itself serializes out with the problematic "-0" format.) This results in a loss of information when round-tripping data in this scenario.

## Testing

A test has been added to verify the serialized format ("-0") and successful round-tripping of negative zero for float and double types.

## Regression

No. This has been a problem going back to NetFx. But it is information loss, which is not good.

## Risk

Low. Negative zero is not a common case, and the changed behavior is simply adding a cast to preserve a sign that otherwise gets lost.