### PR TITLE
CI: Fix conditions for running mono, and coreclr jobs

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -41,10 +41,4 @@ variables:
                 ne(variables['isExtraPlatformsBuild'], true),
                 eq(variables['isRollingBuild'], true))) ]
 
-- name: nonWasmRuntimeTestsContainsChange
-  value:
-    and(
-        eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-        ne(dependencies.evaluate_paths.outputs['SetPathVars_wasm.containsChange'], true))
-
 - template: /eng/pipelines/common/perf-variables.yml

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -54,6 +54,7 @@ jobs:
       timeoutInMinutes: 90
       condition:
         or(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -73,6 +74,7 @@ jobs:
       timeoutInMinutes: 90
       condition:
         or(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -92,6 +94,7 @@ jobs:
       timeoutInMinutes: 90
       condition:
         or(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -112,7 +115,7 @@ jobs:
       timeoutInMinutes: 90
       condition:
         or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -132,7 +135,7 @@ jobs:
       timeoutInMinutes: 90
       condition:
         or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #

--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -21,6 +21,7 @@ parameters:
   runtimeVariant: ''
   pool: ''
   pgoType: ''
+  runOnlyIfDependenciesSucceeded: false
 
   # The target names here should match container names in the resources section in our pipelines, like runtime.yml
   packageDistroList:
@@ -52,7 +53,12 @@ jobs:
     enableMicrobuild: true
     stagedBuild: ${{ parameters.stagedBuild }}
     pool: ${{ parameters.pool }}
-    condition: ${{ parameters.condition }}
+
+    ${{ if eq(parameters.runOnlyIfDependenciesSucceeded, true) }}:
+      condition: and(succeeded(), ${{ parameters.condition }})
+    ${{ if ne(parameters.runOnlyIfDependenciesSucceeded, true) }}:
+      condition: ${{ parameters.condition }}
+
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
     disableClrTest: ${{ parameters.disableClrTest }}
     pgoType: ${{ parameters.pgoType }}

--- a/eng/pipelines/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/runtime-extra-platforms-other.yml
@@ -469,7 +469,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -488,7 +488,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -521,7 +521,7 @@ jobs:
       condition: >-
         or(
             eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-            eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
             eq(variables['isRollingBuild'], true))
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
@@ -559,7 +559,7 @@ jobs:
       runtimeVariant: monointerpreter
       condition: >-
         or(
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
       # extra steps, run tests
@@ -597,7 +597,7 @@ jobs:
       timeoutInMinutes: 240
       condition: >-
         or(
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
       # don't run tests on PRs until we can get significantly more devices
@@ -629,7 +629,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -652,5 +652,5 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -95,8 +95,8 @@ jobs:
       condition:
         or(
           eq(variables['isRollingBuild'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_libraries.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_NET_ILLink_Tasks'], true))
       extraStepsTemplate: /eng/pipelines/libraries/execute-trimming-tests-steps.yml
       extraStepsParameters:

--- a/eng/pipelines/runtime-llvm.yml
+++ b/eng/pipelines/runtime-llvm.yml
@@ -159,7 +159,7 @@ jobs:
       runtimeVariant: llvmaot
       condition: >-
         or(
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -186,7 +186,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -211,5 +211,5 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))

--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -87,7 +87,7 @@ jobs:
       timeoutInMinutes: 240
       condition: >-
         or(
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
       ${{ if eq(variables['isRollingBuild'], true) }}:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -314,17 +314,16 @@ jobs:
     buildConfig: release
     platforms:
     - Android_x64
-    - Browser_wasm
+    #- Browser_wasm - unused
     - tvOS_arm64
     - iOS_arm64
     - MacCatalyst_x64
     jobParameters:
       isOfficialBuild: ${{ variables.isOfficialBuild }}
+      # needed by crossaot
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_libraries.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -674,15 +673,13 @@ jobs:
       runtimeVariant: crossaot
       dependsOn:
       - mono_android_offsets
-      - mono_browser_offsets
+      #- mono_browser_offsets - unused
       monoCrossAOTTargetOS:
       - Android
-      - Browser
+      #- Browser - unused
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_libraries.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -697,13 +694,13 @@ jobs:
       runtimeVariant: crossaot
       dependsOn:
       - mono_android_offsets
-      - mono_browser_offsets
+      #- mono_browser_offsets - unused
       - mono_tvos_offsets
       - mono_ios_offsets
       - mono_maccatalyst_offsets
       monoCrossAOTTargetOS:
       - Android
-      - Browser
+      #- Browser - unused
       - tvOS
       - iOS
       - MacCatalyst

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -163,10 +163,12 @@ jobs:
     - FreeBSD_x64
     jobParameters:
       testGroup: innerloop
-      # Don't run these when we have only wasm changes on PRs
+      # Mono/runtimetests also need this, but skip for wasm
       condition:
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -794,7 +796,9 @@ jobs:
     jobParameters:
       condition:
         or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -813,7 +817,9 @@ jobs:
       testScope: innerloop
       condition:
         or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -901,6 +901,7 @@ jobs:
     jobParameters:
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: Release
+      runOnlyIfDependenciesSucceeded: true
       condition:
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
@@ -921,6 +922,7 @@ jobs:
     jobParameters:
       liveRuntimeBuildConfig: release
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      runOnlyIfDependenciesSucceeded: true
       condition:
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -94,7 +94,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -117,7 +117,7 @@ jobs:
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -136,7 +136,7 @@ jobs:
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -210,7 +210,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isFullMatrix'], true))
 
 #
@@ -232,7 +232,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isFullMatrix'], true))
 
 #
@@ -256,7 +256,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isFullMatrix'], true))
 
 #
@@ -750,7 +750,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -770,7 +770,7 @@ jobs:
       runtimeVariant: llvmaot
       condition: >-
         or(
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
@@ -938,7 +938,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -961,7 +961,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -981,7 +981,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 - template: /eng/pipelines/common/platform-matrix.yml
@@ -1015,7 +1015,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -1039,7 +1039,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -1062,7 +1062,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 #
 # Mono CoreCLR runtime Test executions using live libraries and LLVM AOT
@@ -1087,7 +1087,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #
@@ -1112,7 +1112,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(variables['nonWasmRuntimeTestsContainsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
 #


### PR DESCRIPTION
- this will fix the case where `src/mono/` changes didn't trigger some
  mono jobs that depend on corresponding coreclr jobs.

1. `Fix conditions for runtime tests`
```
For all the non-wasm mono runtime tests:
- run if runtime tests themselves have changes
- or run if there are any mono changes
```
2. `run coreclr and library build jobs when mono_except_wasm, coreclr, or installer have changes.`
3. `Disable AOT offsets, and crossaot jobs for wasm as they are not currently used.`
4. `runtime-dev-innerloop: condition jobs for coreclr, or mono accordingly`
5. `runtime-linker-tests: adjust conditions for wasm, and non wasm jobs`
6.  `Run the installer jobs in runtime.yml only if the dependencies succeed`

```
... otherwise they will fail when trying to get the results of
those dependencies. For example, `Installer Build and Test coreclr
OSX_arm64 Release` fails with:

[error]Artifact CoreCLRProduct___OSX_arm64_release not found for build 17835. Please ensure you have published artifacts in any previous phases of the current build.

.. when `CoreCLR Product Build OSX arm64 release` timed out.
```