### PR TITLE
[release/6.0] Fix binary serialization of DateTime with DCS and add test.

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlWriterDelegator.cs
@@ -452,7 +452,7 @@ namespace System.Runtime.Serialization
 
         internal virtual void WriteDateTime(DateTime value)
         {
-            WriteString(XmlConvert.ToString(value, XmlDateTimeSerializationMode.RoundtripKind));
+            writer.WriteValue(value);
         }
 
         internal void WriteDateTime(DateTime value, XmlDictionaryString name, XmlDictionaryString? ns)

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -111,6 +111,19 @@ public static partial class DataContractSerializerTests
         Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<DateTime>(DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc), @"<dateTime xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">9999-12-31T23:59:59.9999999Z</dateTime>"), DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc));
     }
 
+
+    [Fact]
+    public static void DCS_BinarySerializationOfDateTime()
+    {
+        DateTime dateTime = DateTime.Parse("2021-01-01");
+        MemoryStream ms = new();
+        DataContractSerializer dcs = new(dateTime.GetType());
+        using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(ms, null, null, ownsStream: true))
+            dcs.WriteObject(writer, dateTime);
+        var serializedBytes = ms.ToArray();
+        Assert.Equal(72, serializedBytes.Length);
+    }
+
     [Fact]
     public static void DCS_DecimalAsRoot()
     {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -118,7 +118,7 @@ public static partial class DataContractSerializerTests
         DateTime dateTime = DateTime.Parse("2021-01-01");
         MemoryStream ms = new();
         DataContractSerializer dcs = new(dateTime.GetType());
-        using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(ms, null, null, ownsStream: true))
+        using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(ms, null, null))
             dcs.WriteObject(writer, dateTime);
         var serializedBytes = ms.ToArray();
         Assert.Equal(72, serializedBytes.Length);


### PR DESCRIPTION
Fixes: #61528 in 6.0.
This exact change was already included as part of the big DCS/NetFx alignment done in 7.0. (#71752)

## Customer Impact
The WCF binary XML format written by XmlDictionaryWriter.CreateBinaryWriter allows for a binary representation of DateTime objects that is shorter and faster to deserialize than the standard string presentation. NetFx used this binary format, but .Net Core has used a string representation. That leads to much larger blobs when the serialized objects contain many DateTimes and, more importantly, _significantly_ longer deserialization times for some customers.

## Testing
A test has been added to verify the use of the binary format vs string format for DateTime.

## Regression
Yes? This is a regression from 4.8, though it has always been this way in .Net Core.

## Risk
Low. This PR restores the NetFx way of serializing a DateTime value... which is to let XmlWriter handle it rather than injecting our own formatting. (I believe the custom formatting was only used because XmlWriter.WriteValue() did not have an overload for DateTime in .Net Core 1.0. It has since been available since 1.1.)