### PR TITLE
don't run RedirectedOutput_EnvVarSet_EmitsAnsiCodes when RemoteExecutor is not supported

### DIFF
--- a/src/libraries/System.Console/tests/Color.cs
+++ b/src/libraries/System.Console/tests/Color.cs
@@ -72,9 +72,10 @@ public class Color
         });
     }
 
-    public static bool TermIsSet => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TERM"));
+    public static bool TermIsSetAndRemoteExecutorIsSupported
+        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TERM")) && RemoteExecutor.IsSupported;
 
-    [ConditionalTheory(nameof(TermIsSet))]
+    [ConditionalTheory(nameof(TermIsSetAndRemoteExecutorIsSupported))]
     [PlatformSpecific(TestPlatforms.AnyUnix)]
     [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on Browser, iOS, MacCatalyst, or tvOS.")]
     [InlineData(null)]


### PR DESCRIPTION
Reported by @filipnavara in https://github.com/dotnet/runtime/pull/75421#issuecomment-1247370487