### PR TITLE
[NO-MERGE][Hackathon] Allow easy filtering which build legs run on a PR

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -24,7 +24,6 @@ parameters:
 
 jobs:
 
-# Linux arm
 - ${{ if or(containsValue(parameters.platforms, 'Linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
     parameters:
@@ -48,7 +47,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/arm'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux armv6
 - ${{ if containsValue(parameters.platforms, 'Linux_armv6') }}:
   - template: xplat-setup.yml
     parameters:
@@ -72,7 +70,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/armv6'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux arm64
 
 - ${{ if or(containsValue(parameters.platforms, 'Linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
@@ -100,7 +97,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl x64
 
 - ${{ if or(containsValue(parameters.platforms, 'Linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
@@ -124,7 +120,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl arm
 
 - ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
@@ -150,7 +145,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/arm'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl arm64
 
 - ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
@@ -176,7 +170,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux Bionic arm64
 
 - ${{ if containsValue(parameters.platforms, 'Linux_bionic_arm64') }}:
   - template: xplat-setup.yml
@@ -203,7 +196,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux Bionic x64
 
 - ${{ if containsValue(parameters.platforms, 'Linux_bionic_x64') }}:
   - template: xplat-setup.yml
@@ -227,7 +219,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x64
 
 - ${{ if or(containsValue(parameters.platforms, 'Linux_x64'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
@@ -253,7 +244,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x86
 
 - ${{ if containsValue(parameters.platforms, 'Linux_x86') }}:
   - template: xplat-setup.yml
@@ -279,7 +269,6 @@ jobs:
         disableClrTest: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x64 Source Build
 
 - ${{ if containsValue(parameters.platforms, 'SourceBuild_Linux_x64') }}:
   - template: xplat-setup.yml
@@ -303,7 +292,6 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
         buildingOnSourceBuildImage: true
 
-# Linux s390x
 
 - ${{ if containsValue(parameters.platforms, 'Linux_s390x') }}:
   - template: xplat-setup.yml
@@ -328,7 +316,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/s390x'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux PPC64le
 
 - ${{ if containsValue(parameters.platforms, 'Linux_ppc64le') }}:
   - template: xplat-setup.yml
@@ -353,7 +340,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/ppc64le'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# WebAssembly
 
 - ${{ if containsValue(parameters.platforms, 'Browser_wasm') }}:
   - template: xplat-setup.yml
@@ -376,7 +362,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# WebAssembly Linux Firefox
 
 - ${{ if containsValue(parameters.platforms, 'Browser_wasm_firefox') }}:
   - template: xplat-setup.yml
@@ -399,7 +384,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# WebAssembly on Windows
 
 - ${{ if containsValue(parameters.platforms, 'Browser_wasm_win') }}:
   - template: xplat-setup.yml
@@ -419,7 +403,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# FreeBSD
 - ${{ if containsValue(parameters.platforms, 'FreeBSD_x64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -442,7 +425,6 @@ jobs:
         crossrootfsDir: '/crossrootfs/x64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android x64
 
 - ${{ if containsValue(parameters.platforms, 'Android_x64') }}:
   - template: xplat-setup.yml
@@ -465,7 +447,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android x86
 
 - ${{ if containsValue(parameters.platforms, 'Android_x86') }}:
   - template: xplat-setup.yml
@@ -488,7 +469,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android arm
 
 - ${{ if containsValue(parameters.platforms, 'Android_arm') }}:
   - template: xplat-setup.yml
@@ -511,7 +491,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Android arm64
 
 - ${{ if containsValue(parameters.platforms, 'Android_arm64') }}:
   - template: xplat-setup.yml
@@ -534,7 +513,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Mac Catalyst x64
 
 - ${{ if containsValue(parameters.platforms, 'MacCatalyst_x64') }}:
   - template: xplat-setup.yml
@@ -554,7 +532,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Mac Catalyst arm64
 
 - ${{ if containsValue(parameters.platforms, 'MacCatalyst_arm64') }}:
   - template: xplat-setup.yml
@@ -574,7 +551,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS arm64
 
 - ${{ if containsValue(parameters.platforms, 'tvOS_arm64') }}:
   - template: xplat-setup.yml
@@ -594,7 +570,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS Simulator x64
 
 - ${{ if containsValue(parameters.platforms, 'tvOSSimulator_x64') }}:
   - template: xplat-setup.yml
@@ -614,7 +589,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# tvOS Simulator arm64
 
 - ${{ if containsValue(parameters.platforms, 'tvOSSimulator_arm64') }}:
   - template: xplat-setup.yml
@@ -634,7 +608,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS arm
 
 - ${{ if containsValue(parameters.platforms, 'iOS_arm') }}:
   - template: xplat-setup.yml
@@ -654,7 +627,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS arm64
 
 - ${{ if containsValue(parameters.platforms, 'iOS_arm64') }}:
   - template: xplat-setup.yml
@@ -674,7 +646,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS Simulator x64
 
 - ${{ if containsValue(parameters.platforms, 'iOSSimulator_x64') }}:
   - template: xplat-setup.yml
@@ -694,7 +665,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS Simulator x86
 
 - ${{ if containsValue(parameters.platforms, 'iOSSimulator_x86') }}:
   - template: xplat-setup.yml
@@ -715,7 +685,6 @@ jobs:
         managedTestBuildOsGroup: OSX
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# iOS Simulator arm64
 
 - ${{ if containsValue(parameters.platforms, 'iOSSimulator_arm64') }}:
   - template: xplat-setup.yml
@@ -735,7 +704,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# macOS arm64
 
 - ${{ if containsValue(parameters.platforms, 'OSX_arm64') }}:
   - template: xplat-setup.yml
@@ -756,7 +724,6 @@ jobs:
         crossBuild: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# macOS x64
 
 - ${{ if or(containsValue(parameters.platforms, 'OSX_x64'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
@@ -776,7 +743,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Tizen armel
 
 - ${{ if containsValue(parameters.platforms, 'Tizen_armel') }}:
   - template: xplat-setup.yml
@@ -802,7 +768,6 @@ jobs:
         disableClrTest: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows x64
 
 - ${{ if or(containsValue(parameters.platforms, 'windows_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
@@ -822,7 +787,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows x86
 
 - ${{ if or(containsValue(parameters.platforms, 'windows_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
@@ -842,7 +806,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows arm
 - ${{ if or(containsValue(parameters.platforms, 'windows_arm'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
     parameters:
@@ -861,7 +824,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows arm64
 
 - ${{ if or(containsValue(parameters.platforms, 'windows_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -23,7 +23,6 @@ parameters:
   variables: []
 
 jobs:
-
 - ${{ if or(containsValue(parameters.platforms, 'Linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
     parameters:
@@ -44,7 +43,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm'
+        crossrootfsDir: /crossrootfs/arm
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 - ${{ if containsValue(parameters.platforms, 'Linux_armv6') }}:
@@ -67,7 +66,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/armv6'
+        crossrootfsDir: /crossrootfs/armv6
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 
@@ -94,7 +93,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm64'
+        crossrootfsDir: /crossrootfs/arm64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 
@@ -142,7 +141,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm'
+        crossrootfsDir: /crossrootfs/arm
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 
@@ -167,7 +166,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm64'
+        crossrootfsDir: /crossrootfs/arm64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 
@@ -188,8 +187,6 @@ jobs:
         registry: mcr
       jobParameters:
         runtimeFlavor: mono
-        # We build on Linux, but the test queue runs Windows, so
-        # we need to override the test script generation
         runScriptWindowsCmd: true
         stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
@@ -265,7 +262,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/x86'
+        crossrootfsDir: /crossrootfs/x86
         disableClrTest: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -313,7 +310,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/s390x'
+        crossrootfsDir: /crossrootfs/s390x
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 
@@ -337,7 +334,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/ppc64le'
+        crossrootfsDir: /crossrootfs/ppc64le
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 
@@ -422,7 +419,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/x64'
+        crossrootfsDir: /crossrootfs/x64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 
@@ -764,7 +761,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/armel'
+        crossrootfsDir: /crossrootfs/armel
         disableClrTest: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -69,7 +69,6 @@ jobs:
         crossrootfsDir: /crossrootfs/armv6
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if or(containsValue(parameters.platforms, 'Linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
     parameters:
@@ -96,7 +95,6 @@ jobs:
         crossrootfsDir: /crossrootfs/arm64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if or(containsValue(parameters.platforms, 'Linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
     parameters:
@@ -118,7 +116,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
@@ -144,7 +141,6 @@ jobs:
         crossrootfsDir: /crossrootfs/arm
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
     parameters:
@@ -169,7 +165,6 @@ jobs:
         crossrootfsDir: /crossrootfs/arm64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'Linux_bionic_arm64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -193,7 +188,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'Linux_bionic_x64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -215,7 +209,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if or(containsValue(parameters.platforms, 'Linux_x64'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
@@ -241,7 +234,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'Linux_x86') }}:
   - template: xplat-setup.yml
     parameters:
@@ -266,7 +258,6 @@ jobs:
         disableClrTest: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'SourceBuild_Linux_x64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -288,7 +279,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
         buildingOnSourceBuildImage: true
-
 
 - ${{ if containsValue(parameters.platforms, 'Linux_s390x') }}:
   - template: xplat-setup.yml
@@ -313,7 +303,6 @@ jobs:
         crossrootfsDir: /crossrootfs/s390x
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'Linux_ppc64le') }}:
   - template: xplat-setup.yml
     parameters:
@@ -337,7 +326,6 @@ jobs:
         crossrootfsDir: /crossrootfs/ppc64le
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'Browser_wasm') }}:
   - template: xplat-setup.yml
     parameters:
@@ -359,7 +347,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'Browser_wasm_firefox') }}:
   - template: xplat-setup.yml
     parameters:
@@ -380,7 +367,6 @@ jobs:
         stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'Browser_wasm_win') }}:
   - template: xplat-setup.yml
@@ -422,7 +408,6 @@ jobs:
         crossrootfsDir: /crossrootfs/x64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'Android_x64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -443,7 +428,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'Android_x86') }}:
   - template: xplat-setup.yml
@@ -466,7 +450,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'Android_arm') }}:
   - template: xplat-setup.yml
     parameters:
@@ -487,7 +470,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'Android_arm64') }}:
   - template: xplat-setup.yml
@@ -510,7 +492,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'MacCatalyst_x64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -528,7 +509,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'MacCatalyst_arm64') }}:
   - template: xplat-setup.yml
@@ -548,7 +528,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'tvOS_arm64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -566,7 +545,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'tvOSSimulator_x64') }}:
   - template: xplat-setup.yml
@@ -586,7 +564,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'tvOSSimulator_arm64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -604,7 +581,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'iOS_arm') }}:
   - template: xplat-setup.yml
@@ -624,7 +600,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'iOS_arm64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -643,7 +618,6 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'iOSSimulator_x64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -661,7 +635,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'iOSSimulator_x86') }}:
   - template: xplat-setup.yml
@@ -682,7 +655,6 @@ jobs:
         managedTestBuildOsGroup: OSX
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if containsValue(parameters.platforms, 'iOSSimulator_arm64') }}:
   - template: xplat-setup.yml
     parameters:
@@ -700,7 +672,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'OSX_arm64') }}:
   - template: xplat-setup.yml
@@ -721,7 +692,6 @@ jobs:
         crossBuild: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if or(containsValue(parameters.platforms, 'OSX_x64'), eq(parameters.platformGroup, 'all')) }}:
   - template: xplat-setup.yml
     parameters:
@@ -739,7 +709,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if containsValue(parameters.platforms, 'Tizen_armel') }}:
   - template: xplat-setup.yml
@@ -765,7 +734,6 @@ jobs:
         disableClrTest: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-
 - ${{ if or(containsValue(parameters.platforms, 'windows_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
     parameters:
@@ -783,7 +751,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if or(containsValue(parameters.platforms, 'windows_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
@@ -820,7 +787,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
 
 - ${{ if or(containsValue(parameters.platforms, 'windows_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -104,11 +104,11 @@ jobs:
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       variables: ${{ parameters.variables }}
       osGroup: Linux
-      osSubgroup: _musl
       archType: x64
       targetRid: linux-musl-x64
       platform: Linux_musl_x64
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      osSubgroup: _musl
       container:
         image: alpine-3.13-WithNode-20210910135845-c401c85
         registry: mcr
@@ -127,11 +127,11 @@ jobs:
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       variables: ${{ parameters.variables }}
       osGroup: Linux
-      osSubgroup: _musl
       archType: arm
       targetRid: linux-musl-arm
       platform: Linux_musl_arm
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      osSubgroup: _musl
       container:
         image: ubuntu-16.04-cross-arm-alpine-20210923140502-78f7860
         registry: mcr
@@ -152,11 +152,11 @@ jobs:
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       variables: ${{ parameters.variables }}
       osGroup: Linux
-      osSubgroup: _musl
       archType: arm64
       targetRid: linux-musl-arm64
       platform: Linux_musl_arm64
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      osSubgroup: _musl
       container:
         image: ubuntu-16.04-cross-arm64-alpine-20210923140502-78f7860
         registry: mcr
@@ -177,11 +177,11 @@ jobs:
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       variables: ${{ parameters.variables }}
       osGroup: Linux
-      osSubgroup: _bionic
       archType: arm64
       targetRid: linux-bionic-arm64
       platform: Linux_bionic_arm64
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      osSubgroup: _bionic
       container:
         image: ubuntu-18.04-android-20220808192756-8fcaabc
         registry: mcr
@@ -201,11 +201,11 @@ jobs:
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       variables: ${{ parameters.variables }}
       osGroup: Linux
-      osSubgroup: _bionic
       archType: x64
       targetRid: linux-bionic-x64
       platform: Linux_bionic_x64
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      osSubgroup: _bionic
       container:
         image: ubuntu-18.04-android-20220808192756-8fcaabc
         registry: mcr

--- a/eng/pipelines/src/CiFiltering.cs
+++ b/eng/pipelines/src/CiFiltering.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Pipelines;
+
+public static class CiFiltering
+{
+    // These fields can be used to restrict which build legs run in your PR.
+    //
+    // Set this to only dis/allow platforms that contain given substrings.
+    // E.g. add "linux" if you only want to filter platforms containing "linux" in their name.
+    // Then "dotnet build" this project and commit the YAML.
+    //
+    // First allowed platforms are filtered, then disallowed filter is applied.
+    //
+    // Example "Run all linux non-arm legs":
+    //   - allowed  = [ "linux" ]
+    //   - disallowed = [ "arm" ]
+    public static readonly List<string> AllowedPlatforms = new() { };
+    public static readonly List<string> DisallowedPlatforms = new() { };
+}

--- a/eng/pipelines/src/Pipelines.csproj
+++ b/eng/pipelines/src/Pipelines.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Sharpliner" Version="1.4.3" />
+  </ItemGroup>
+
+</Project>

--- a/eng/pipelines/src/PlatformMatrix.cs
+++ b/eng/pipelines/src/PlatformMatrix.cs
@@ -42,16 +42,36 @@ public class PlatformMatrix : PlatformMatrixBase
 
     public override string TargetFile => "eng/pipelines/common/platform-matrix.yml";
 
+    // TODO: We can extract container names somewhere in one place
+    private const string AndroidContainer = "ubuntu-18.04-android-20220808192756-8fcaabc";
+
     protected override List<Platform> Platforms => new()
     {
         new("Linux_arm", "Linux", "arm",
-            Container: "ubuntu-16.04-cross-20210719121212-8a8d3be",
+            Container: "ubuntu-18.04-cross-arm-20220907130538-70ed2e8",
             CrossBuild: true,
             CrossRootFsDir: "/crossrootfs/arm",
             RunForPlatforms: new[] { "all", "gcstress" }),
 
+        new("Linux_armv6", "Linux", "armv6",
+            Container: "ubuntu-20.04-cross-armv6-raspbian-10-20211208135931-e6e3ac4",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/armv6"),
+
         new("Linux_arm64", "Linux", "arm64",
-            Container: "ubuntu-16.04-cross-arm64-20210719121212-8a8d3be",
+            Container:
+                new TemplateParameters
+                {
+                    { If.Equal("parameters.container", "''"), new TemplateParameters
+                    {
+                        { "image", "ubuntu-18.04-cross-arm64-20220907130538-70ed2e8" }
+                    }},
+                    { If.NotEqual("parameters.container", "''"), new TemplateParameters
+                    {
+                        { "image", parameters["container"] }
+                    }},
+                    { "registry", "mcr" }
+                },
             CrossBuild: true,
             CrossRootFsDir: "/crossrootfs/arm64",
             RunForPlatforms: new[] { "all", "gcstress" }),
@@ -74,6 +94,17 @@ public class PlatformMatrix : PlatformMatrixBase
             CrossBuild: true,
             CrossRootFsDir: "/crossrootfs/arm64",
             RunForPlatforms: new[] { "all" }),
+
+        new("Linux_bionic_arm64", "Linux", "arm64",
+            OsSubGroup: "_bionic",
+            Container: "ubuntu-18.04-android-20220808192756-8fcaabc",
+            RuntimeFlavor: "mono",
+            AdditionalJobParams: new() { { "runScriptWindowsCmd", true } }),
+
+        new("Linux_bionic_arm64", "Linux", "x64",
+            OsSubGroup: "_bionic",
+            Container: "ubuntu-18.04-android-20220808192756-8fcaabc",
+            RuntimeFlavor: "mono"),
 
         new("Linux_x64", "Linux", "x64", "linux-x64",
             Container:
@@ -112,9 +143,19 @@ public class PlatformMatrix : PlatformMatrixBase
             CrossBuild: true,
             CrossRootFsDir: "/crossrootfs/s390x"),
 
+        new("Linux_ppc64le", "Linux", "ppc64le",
+            Container: "ubuntu-18.04-cross-ppc64le-20220531132048-b9de666",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/ppc64le"),
+
         new("Browser_wasm", "Browser", "wasm",
-            Container: "ubuntu-18.04-webassembly-20210531091624-f5c7a43",
+            Container: "ubuntu-18.04-webassembly-20220531132048-00a561c",
             HostedOs: "Linux"),
+
+        new("Browser_wasm_firefox", "Browser", "wasm",
+            PlatformId: "Browser_wasm_win",
+            HostedOs: "Linux",
+            Container: "ubuntu-18.04-webassembly-20220531132048-00a561c"),
 
         new("Browser_wasm_win", "Browser", "wasm",
             PlatformId: "Browser_wasm_win",
@@ -124,19 +165,19 @@ public class PlatformMatrix : PlatformMatrixBase
             Container: "ubuntu-18.04-cross-freebsd-12-20210917001307-f13d79e"),
 
         new("Android_x64", "Android", "x64",
-            Container: "ubuntu-18.04-android-20200422191843-e2c3f83",
+            Container: AndroidContainer,
             RuntimeFlavor: "mono"),
 
         new("Android_x86", "Android", "x86",
-            Container: "ubuntu-18.04-android-20200422191843-e2c3f83",
+            Container: AndroidContainer,
             RuntimeFlavor: "mono"),
 
         new("Android_arm", "Android", "arm",
-            Container: "ubuntu-18.04-android-20200422191843-e2c3f83",
+            Container: AndroidContainer,
             RuntimeFlavor: "mono"),
 
         new("Android_arm64", "Android", "arm64",
-            Container: "ubuntu-18.04-android-20200422191843-e2c3f83",
+            Container: AndroidContainer,
             RuntimeFlavor: "mono"),
 
         new("MacCatalyst_x64", "MacCatalyst", "x64",

--- a/eng/pipelines/src/PlatformMatrix.cs
+++ b/eng/pipelines/src/PlatformMatrix.cs
@@ -1,0 +1,207 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Sharpliner;
+using Sharpliner.AzureDevOps;
+
+namespace Pipelines;
+
+public record Platform(
+    string Name,
+    string OsGroup,
+    string Architecture,
+    string? TargetRid = null,
+    string? PlatformId = null,
+    string? OsSubGroup = null,
+    string? HostedOs = null,
+    object? Container = null,
+    string? RuntimeFlavor = null,
+    bool CrossBuild = false,
+    string? CrossRootFsDir = null,
+    IEnumerable<string>? RunForPlatforms = null,
+    TemplateParameters? AdditionalJobParams = null);
+
+public class PlatformMatrix : PlatformMatrixBase
+{
+    // These fields can be used to restrict which build legs run in your PR.
+    //
+    // Set this to only dis/allow platforms that contain given substrings.
+    // E.g. add "linux" if you only want to filter platforms containing "linux" in their name.
+    // Then "dotnet build" this project and commit the YAML.
+    //
+    // First allowed platforms are filtered, then disallowed filter is applied.
+    //
+    // Example "Run all linux non-arm legs":
+    //   - allowed  = [ "linux" ]
+    //   - disallowed = [ "arm" ]
+    protected override List<string> AllowedPlatforms { get; } = new() { };
+    protected override List<string> DisallowedPlatforms { get; } = new() { };
+
+    public override TargetPathType TargetPathType => TargetPathType.RelativeToGitRoot;
+
+    public override string TargetFile => "eng/pipelines/common/platform-matrix.yml";
+
+    protected override List<Platform> Platforms => new()
+    {
+        new("Linux_arm", "Linux", "arm",
+            Container: "ubuntu-16.04-cross-20210719121212-8a8d3be",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/arm",
+            RunForPlatforms: new[] { "all", "gcstress" }),
+
+        new("Linux_arm64", "Linux", "arm64",
+            Container: "ubuntu-16.04-cross-arm64-20210719121212-8a8d3be",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/arm64",
+            RunForPlatforms: new[] { "all", "gcstress" }),
+
+        new("Linux_musl_x64", "Linux", "x64",
+            OsSubGroup: "_musl",
+            Container: "alpine-3.13-WithNode-20210910135845-c401c85",
+            RunForPlatforms: new[] { "all" }),
+
+        new("Linux_musl_arm", "Linux", "arm",
+            OsSubGroup: "_musl",
+            Container: "ubuntu-16.04-cross-arm-alpine-20210923140502-78f7860",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/arm",
+            RunForPlatforms: new[] { "all" }),
+
+        new("Linux_musl_arm64", "Linux", "arm64",
+            OsSubGroup: "_musl",
+            Container: "ubuntu-16.04-cross-arm64-alpine-20210923140502-78f7860",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/arm64",
+            RunForPlatforms: new[] { "all" }),
+
+        new("Linux_x64", "Linux", "x64", "linux-x64",
+            Container:
+                new TemplateParameters
+                {
+                    { If.Equal("parameters.container", "''"), new TemplateParameters
+                    {
+                        { "image", "centos-7-20210714125435-9b5bbc2" }
+                    }},
+                    { If.NotEqual("parameters.container", "''"), new TemplateParameters
+                    {
+                        { "image", parameters["container"] }
+                    }},
+                    { "registry", "mcr" }
+                },
+            RunForPlatforms: new[] { "all" }),
+
+        new("Linux_x86", "Linux", "x86",
+            Container: "ubuntu-18.04-cross-x86-linux-20211022152824-f853169",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/x86",
+            AdditionalJobParams: new()
+            {
+                { "disableClrTest", true }
+            }),
+
+        new("SourceBuild_Linux_x64", "Linux", "x64",
+            Container: "centos-7-source-build-20210714125450-5d87b80",
+            AdditionalJobParams: new()
+            {
+                { "buildingOnSourceBuildImage", true }
+            }),
+
+        new("Linux_s390x", "Linux", "s390x",
+            Container: "ubuntu-18.04-cross-s390x-20201102145728-d6e0352",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/s390x"),
+
+        new("Browser_wasm", "Browser", "wasm",
+            Container: "ubuntu-18.04-webassembly-20210531091624-f5c7a43",
+            HostedOs: "Linux"),
+
+        new("Browser_wasm_win", "Browser", "wasm",
+            PlatformId: "Browser_wasm_win",
+            HostedOs: "windows"),
+
+        new("FreeBSD_x64", "FreeBSD", "x64",
+            Container: "ubuntu-18.04-cross-freebsd-12-20210917001307-f13d79e"),
+
+        new("Android_x64", "Android", "x64",
+            Container: "ubuntu-18.04-android-20200422191843-e2c3f83",
+            RuntimeFlavor: "mono"),
+
+        new("Android_x86", "Android", "x86",
+            Container: "ubuntu-18.04-android-20200422191843-e2c3f83",
+            RuntimeFlavor: "mono"),
+
+        new("Android_arm", "Android", "arm",
+            Container: "ubuntu-18.04-android-20200422191843-e2c3f83",
+            RuntimeFlavor: "mono"),
+
+        new("Android_arm64", "Android", "arm64",
+            Container: "ubuntu-18.04-android-20200422191843-e2c3f83",
+            RuntimeFlavor: "mono"),
+
+        new("MacCatalyst_x64", "MacCatalyst", "x64",
+            RuntimeFlavor: "mono"),
+
+        new("MacCatalyst_arm64", "MacCatalyst", "arm64",
+            RuntimeFlavor: "mono"),
+
+        new("tvOS_arm64", "tvOS", "arm64",
+            RuntimeFlavor: "mono"),
+
+        new("tvOSSimulator_x64", "tvOSSimulator", "x64",
+            RuntimeFlavor: "mono"),
+
+        new("tvOSSimulator_arm64", "tvOSSimulator", "arm64",
+            RuntimeFlavor: "mono"),
+
+        new("iOS_arm", "iOS", "arm",
+            RuntimeFlavor: "mono"),
+
+        new("iOS_arm64", "iOS", "arm64",
+            RuntimeFlavor: "mono"),
+
+        new("iOSSimulator_x64", "iOSSimulator", "x64",
+            RuntimeFlavor: "mono"),
+
+        new("iOSSimulator_x86", "iOSSimulator", "x86",
+            RuntimeFlavor: "mono",
+            AdditionalJobParams: new()
+            {
+                { "managedTestBuildOsGroup", "OSX" }
+            }),
+
+        new("iOSSimulator_arm64", "iOSSimulator", "arm64",
+            RuntimeFlavor: "mono"),
+
+        new("OSX_arm64", "OSX", "arm64",
+            CrossBuild: true),
+
+        new("OSX_x64", "OSX", "x64",
+            RunForPlatforms: new[] { "all" }),
+
+        new("Tizen_armel", "Tizen", "armel",
+            Container: "ubuntu-18.04-cross-armel-tizen-20210719212651-8b02f56",
+            CrossBuild: true,
+            CrossRootFsDir: "/crossrootfs/armel",
+            AdditionalJobParams: new()
+            {
+                { "disableClrTest", true }
+            }),
+
+        new("windows_x64", "windows", "x64",
+            TargetRid: "win-x64",
+            RunForPlatforms: new[] { "all", "gcstress" }),
+
+        new("windows_x86", "windows", "x86",
+            TargetRid: "win-x86",
+            RunForPlatforms: new[] { "all", "gcstress" }),
+
+        new("windows_arm", "windows", "arm",
+            TargetRid: "win-arm",
+            RunForPlatforms: new[] { "all" }),
+
+        new("windows_arm64", "windows", "arm64",
+            TargetRid: "win-arm64",
+            RunForPlatforms: new[] { "all", "gcstress" }),
+    };
+}

--- a/eng/pipelines/src/PlatformMatrix.cs
+++ b/eng/pipelines/src/PlatformMatrix.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using Sharpliner;
 using Sharpliner.AzureDevOps;
 
 namespace Pipelines;
@@ -24,22 +23,6 @@ public record Platform(
 
 public class PlatformMatrix : PlatformMatrixBase
 {
-    // These fields can be used to restrict which build legs run in your PR.
-    //
-    // Set this to only dis/allow platforms that contain given substrings.
-    // E.g. add "linux" if you only want to filter platforms containing "linux" in their name.
-    // Then "dotnet build" this project and commit the YAML.
-    //
-    // First allowed platforms are filtered, then disallowed filter is applied.
-    //
-    // Example "Run all linux non-arm legs":
-    //   - allowed  = [ "linux" ]
-    //   - disallowed = [ "arm" ]
-    protected override List<string> AllowedPlatforms { get; } = new() { };
-    protected override List<string> DisallowedPlatforms { get; } = new() { };
-
-    public override TargetPathType TargetPathType => TargetPathType.RelativeToGitRoot;
-
     public override string TargetFile => "eng/pipelines/common/platform-matrix.yml";
 
     // TODO: We can extract container names somewhere in one place

--- a/eng/pipelines/src/PlatformMatrixTemplate.cs
+++ b/eng/pipelines/src/PlatformMatrixTemplate.cs
@@ -1,0 +1,183 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Sharpliner.AzureDevOps;
+using Sharpliner.AzureDevOps.ConditionedExpressions;
+
+namespace Pipelines;
+
+public abstract class PlatformMatrixBase : JobTemplateDefinition
+{
+    // Fill these three in an ancestor to generate a list of classes
+    protected abstract List<string> AllowedPlatforms { get; }
+    protected abstract List<string> DisallowedPlatforms { get; }
+    protected abstract List<Platform> Platforms { get; }
+
+    public override string[]? Header => base.Header!.Concat(new[]
+    {
+        string.Empty,
+        "You can add platform filters to PlatformMatrix.cs and only keep platforms you care about in your PR",
+    }).ToArray();
+
+    public override List<Parameter> Parameters => new()
+    {
+        StringParameter("runtimeFlavor", "coreclr", new[] { "coreclr", "mono" }),
+        JobParameter("jobTemplate"),
+        StringParameter("buildConfig", string.Empty),
+        ObjectParameter("platforms"),
+
+        // platformGroup is a named collection of platforms.
+        StringParameter("platformGroup", string.Empty, new[]
+        {
+            "all",     // all platforms
+            "gcstress" // platforms that support running under GCStress0x3 and GCStress0xC scenarios
+        }),
+
+        StringParameter("helixQueueGroup", "pr", new[]
+        {
+            "pr",
+            "ci",
+            "all"
+        }),
+
+        // helixQueuesTemplate is a yaml template which will be expanded in order to set up the helix queues
+        // for the given platform and helixQueueGroup.
+        StringParameter("helixQueuesTemplate", string.Empty),
+        BooleanParameter("stagedBuild", false),
+
+        // When set to false, suppresses reuse of OSX managed build artifacts (for pipelines without an OSX obj)
+        // When set to true, passes the 'platforms' value as a job parameter also named 'platforms'.
+        // Handled as an opt-in parameter to avoid excessive yaml.
+        BooleanParameter("passPlatforms", false),
+        StringParameter("container"),
+        ObjectParameter("jobParameters"),
+        ObjectParameter("variables"),
+    };
+
+    public override ConditionedList<JobBase> Definition
+    {
+        get
+        {
+            var list = new ConditionedList<JobBase>();
+
+            foreach (Conditioned<JobBase> job in Platforms.Where(IsAllowed).Select(CreateTemplate))
+            {
+                list.Add(job);
+            }
+
+            return list;
+        }
+    }
+
+    private bool IsAllowed(Platform platform)
+    {
+        static bool ListContains(IEnumerable<string> substrings, string? haystack)
+        {
+            if (haystack is null)
+            {
+                return false;
+            }
+
+            haystack = haystack.ToLowerInvariant();
+            return substrings.Any(substring => haystack.Contains(substring.ToLowerInvariant()));
+        }
+
+        bool isAllowed = true;
+
+        if (AllowedPlatforms.Count > 0
+            && !ListContains(AllowedPlatforms, platform.Name)
+            && !ListContains(AllowedPlatforms, platform.TargetRid))
+        {
+            isAllowed = false;
+        }
+
+        if (ListContains(DisallowedPlatforms, platform.Name)
+            || ListContains(DisallowedPlatforms, platform.TargetRid))
+        {
+            isAllowed = false;
+        }
+
+        return isAllowed;
+    }
+
+    private Conditioned<JobBase> CreateTemplate(Platform platform)
+    {
+        var templateParameters = new TemplateParameters
+        {
+            { "jobTemplate", parameters["jobTemplate"] },
+            { "helixQueuesTemplate", parameters["helixQueuesTemplate"] },
+            { "variables", parameters["variables"] },
+            { "osGroup", platform.OsGroup },
+            { "archType", platform.Architecture },
+            { "targetRid", platform.TargetRid ?? platform.OsGroup.ToLowerInvariant() + platform.OsSubGroup?.Replace("_", "-") + "-" + platform.Architecture.ToLowerInvariant() },
+            { "platform", platform.PlatformId ?? platform.OsGroup + platform.OsSubGroup + "_" + platform.Architecture },
+        };
+
+        if (platform.OsSubGroup != null)
+        {
+            templateParameters["osSubgroup"] = platform.OsSubGroup;
+        }
+
+        if (platform.HostedOs != null)
+        {
+            templateParameters["hostedOs"] = platform.HostedOs;
+        }
+
+        if (platform.Container != null)
+        {
+            templateParameters["container"] = platform.Container is string name
+                ? new TemplateParameters
+                {
+                    { "image", name },
+                    { "registry", "mcr" },
+                }
+                : platform.Container;
+        }
+
+        var jobParameters = new TemplateParameters
+        {
+            { "runtimeFlavor", platform.RuntimeFlavor ?? parameters["runtimeFlavor"] },
+            { "stagedBuild", parameters["stagedBuild"] },
+            { "buildConfig", parameters["buildConfig"] },
+            { "helixQueueGroup", parameters["helixQueueGroup"] },
+            { If.Equal(parameters["passPlatforms"], "true"),
+                new TemplateParameters
+                {
+                    { "platforms", parameters["platforms"] },
+                }
+            },
+        };
+
+        if (platform.CrossBuild)
+        {
+            jobParameters["crossBuild"] = true;
+        }
+
+        if (platform.CrossRootFsDir != null)
+        {
+            jobParameters["crossrootfsDir"] = platform.CrossRootFsDir;
+        }
+
+        if (platform.AdditionalJobParams != null)
+        {
+            foreach (KeyValuePair<string, object> pair in platform.AdditionalJobParams)
+            {
+                jobParameters[pair.Key] = pair.Value;
+            }
+        }
+
+        jobParameters["${{ insert }}"] = parameters["jobParameters"];
+
+        templateParameters["jobParameters"] = jobParameters;
+
+        return platform.RunForPlatforms != null
+            ? If.Or(ContainsValue(platform.Name, parameters["platforms"]),
+                    In(parameters["platformGroup"], platform.RunForPlatforms))
+                .JobTemplate("xplat-setup.yml", templateParameters)
+
+            : If.ContainsValue(platform.Name, parameters["platforms"])
+                 .JobTemplate("xplat-setup.yml", templateParameters);
+    }
+}

--- a/eng/pipelines/src/PlatformMatrixTemplate.cs
+++ b/eng/pipelines/src/PlatformMatrixTemplate.cs
@@ -122,11 +122,6 @@ public abstract class PlatformMatrixBase : JobTemplateDefinition
             templateParameters["osSubgroup"] = platform.OsSubGroup;
         }
 
-        if (platform.HostedOs != null)
-        {
-            templateParameters["hostedOs"] = platform.HostedOs;
-        }
-
         if (platform.Container != null)
         {
             templateParameters["container"] = platform.Container is string name
@@ -145,6 +140,11 @@ public abstract class PlatformMatrixBase : JobTemplateDefinition
             { "buildConfig", parameters["buildConfig"] },
             { "helixQueueGroup", parameters["helixQueueGroup"] },
         };
+
+        if (platform.HostedOs != null)
+        {
+            jobParameters["hostedOs"] = platform.HostedOs;
+        }
 
         if (platform.CrossBuild)
         {

--- a/eng/pipelines/src/PlatformMatrixTemplate.cs
+++ b/eng/pipelines/src/PlatformMatrixTemplate.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Sharpliner;
 using Sharpliner.AzureDevOps;
 using Sharpliner.AzureDevOps.ConditionedExpressions;
 
@@ -10,9 +11,11 @@ namespace Pipelines;
 
 public abstract class PlatformMatrixBase : JobTemplateDefinition
 {
+    public override TargetPathType TargetPathType => TargetPathType.RelativeToGitRoot;
+
     // Fill these three in an ancestor to generate a list of classes
-    protected abstract List<string> AllowedPlatforms { get; }
-    protected abstract List<string> DisallowedPlatforms { get; }
+    protected List<string> AllowedPlatforms => CiFiltering.AllowedPlatforms;
+    protected List<string> DisallowedPlatforms => CiFiltering.DisallowedPlatforms;
     protected abstract List<Platform> Platforms { get; }
 
     public override string[]? Header => base.Header!.Concat(new[]


### PR DESCRIPTION
@radical I spoke to @pavelsavara yesterday and he suggested I open a PR with some ideas for using Sharpliner for generating YAML pipelines in `dotnet/runtime`. I will be off next week unfortunately, but I will have some limited connectivity over the week so I would be available from time to time.

This PR is an idea that I had in December but as I don't work with dotnet/runtime these days at all, I don't fully understand the dev workflow and there might be better uses.

What you can find in this PR:
1. All the changes are in `eng/pipelines/src` where you can find a Sharpliner project `Pipelines.csproj`
2. If you build this project, you will see it overwrites `platform-matrix.yaml` based on configuration in `PlatformMatrix.cs`
3. You can then also change `CiFiltering.cs` where if you can specify platforms and then rebuild the project which will trim down the platform matrix to specific lanes.

The idea is that devs who have PRs that they work on for weeks, could have an easy way to specify build legs in some super simple configuration file (such as the `CiFiltering.cs` even though the name is not great).
They would specify for instance "Wasm + Firefox" and the YAML would get trimmed down for the purpose of running that one specific lane in their PR, not re-running 150 other builds each time they test something.
I can see other uses such as "Run outerloop tests too" etc.
The idea is also easier management of things like used docker images and so on..

Now.. I am not sure `platform-matrix` is the right file to target as there are other files that define build legs, it's just a demonstration of a possible approach. Usually, the C# definitions of pipelines are very close to the YAML one (e.g. [this example](https://dev.azure.com/dnceng/internal/_git/dotnet-vmr-tools?path=/eng/VmrToolPipeline.cs)) but this `PlatformMatrixTemplate` got quite complex. I still think it's worth containing the complexity in one file like this rather than in repetitive and error prone long YAMLs?
Honestly, with C# we could tackle the whole system of templates differently and not trying to mimic what's there at the moment but Sharpliner can be adopted file by file and add new `.cs` files for each `.yml` piece by piece and safely onboard onto C#.
So you can pick some area and csharpify it this way.
It's also super easy to ditch C# at any point as you still have the YAMLs.

Further, I suggest this: https://github.com/sharpliner/sharpliner/blob/main/docs/AzureDevOps/GettingStarted.md
possibly all here https://github.com/sharpliner/sharpliner/tree/main/docs/AzureDevOps

Other ideas related to .NET are that the complex Arcade templates that we share with via `eng/common` could get their C# counterparts so that you could use C# in other (smaller) repos and invoke the Arcade templates via C# APIs rather than trying to guess the right variables in input arguments. I have other Hackathon ideas around this (such as https://github.com/sharpliner/sharpliner/issues/150) but maybe I prefer trying to use Sharpliner in a repo like runtime more. 
