### PR TITLE
Add option for truncated stream detection

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -469,7 +469,6 @@ namespace System.IO.Compression
             Assert.True(optimalLength >= smallestLength);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/47563")]
         [Theory]
         [InlineData(TestScenario.ReadAsync)]
         [InlineData(TestScenario.Read)]
@@ -479,6 +478,8 @@ namespace System.IO.Compression
         [InlineData(TestScenario.ReadByteAsync)]
         public async Task StreamTruncation_IsDetected(TestScenario scenario)
         {
+            AppContext.SetSwitch("System.IO.Compression.UseStrictValidation", true);
+
             var buffer = new byte[16];
             byte[] source = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
             byte[] compressedData;

--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.IO.Compression.Tests;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Sdk;
 
 namespace System.IO.Compression
 {
@@ -467,87 +464,6 @@ namespace System.IO.Compression
             Assert.True(noCompressionLength >= fastestLength);
             Assert.True(fastestLength >= optimalLength);
             Assert.True(optimalLength >= smallestLength);
-        }
-
-        [Theory]
-        [InlineData(TestScenario.ReadAsync)]
-        [InlineData(TestScenario.Read)]
-        [InlineData(TestScenario.Copy)]
-        [InlineData(TestScenario.CopyAsync)]
-        [InlineData(TestScenario.ReadByte)]
-        [InlineData(TestScenario.ReadByteAsync)]
-        public async Task StreamTruncation_IsDetected(TestScenario scenario)
-        {
-            AppContext.SetSwitch("System.IO.Compression.UseStrictValidation", true);
-
-            var buffer = new byte[16];
-            byte[] source = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
-            byte[] compressedData;
-            using (var compressed = new MemoryStream())
-            using (Stream compressor = CreateStream(compressed, CompressionMode.Compress))
-            {
-                foreach (byte b in source)
-                {
-                    compressor.WriteByte(b);
-                }
-
-                compressor.Dispose();
-                compressedData = compressed.ToArray();
-            }
-
-            for (var i = 1; i <= compressedData.Length; i += 1)
-            {
-                bool expectException = i < compressedData.Length;
-                using (var compressedStream = new MemoryStream(compressedData.Take(i).ToArray()))
-                {
-                    using (Stream decompressor = CreateStream(compressedStream, CompressionMode.Decompress))
-                    {
-                        var decompressedStream = new MemoryStream();
-
-                        try
-                        {
-                            switch (scenario)
-                            {
-                                case TestScenario.Copy:
-                                    decompressor.CopyTo(decompressedStream);
-                                    break;
-
-                                case TestScenario.CopyAsync:
-                                    await decompressor.CopyToAsync(decompressedStream);
-                                    break;
-
-                                case TestScenario.Read:
-                                    while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { };
-                                    break;
-
-                                case TestScenario.ReadAsync:
-                                    while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { };
-                                    break;
-
-                                case TestScenario.ReadByte:
-                                    while (decompressor.ReadByte() != -1) { }
-                                    break;
-
-                                case TestScenario.ReadByteAsync:
-                                    while (await decompressor.ReadByteAsync() != -1) { }
-                                    break;
-                            }
-                        }
-                        catch (InvalidDataException e)
-                        {
-                            if (expectException)
-                                continue;
-
-                            throw new XunitException($"An unexpected error occurred while decompressing data:{e}");
-                        }
-
-                        if (expectException)
-                        {
-                            throw new XunitException($"Truncated stream was decompressed successfully but exception was expected: length={i}/{compressedData.Length}");
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -181,7 +181,7 @@ namespace System.IO.Compression.Tests
                     bd = NormalizeLineEndings(bd);
                 }
 
-                AssertExtensions.SequenceEqual(ad, bd);
+                AssertExtensions.SequenceEqual(ad.AsSpan(0, ac), bd.AsSpan(0, bc));
 
                 blocksRead++;
             } while (ac == bufSize);

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -173,8 +173,8 @@ namespace System.IO.Compression.Tests
                 if (blocksToRead != -1 && blocksRead >= blocksToRead)
                     break;
 
-                ac = await ast.ReadAtLeastAsync(ad, 4096);
-                bc = await bst.ReadAtLeastAsync(bd, 4096);
+                ac = await ast.ReadAtLeastAsync(ad, 4096, throwOnEndOfStream: false);
+                bc = await bst.ReadAtLeastAsync(bd, 4096, throwOnEndOfStream: false);
 
                 if (ac != bc)
                 {

--- a/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/ZipTestHelper.cs
@@ -173,15 +173,15 @@ namespace System.IO.Compression.Tests
                 if (blocksToRead != -1 && blocksRead >= blocksToRead)
                     break;
 
-                ac = await ReadAllBytesAsync(ast, ad, 0, 4096);
-                bc = await ReadAllBytesAsync(bst, bd, 0, 4096);
+                ac = await ast.ReadAtLeastAsync(ad, 4096);
+                bc = await bst.ReadAtLeastAsync(bd, 4096);
 
                 if (ac != bc)
                 {
                     bd = NormalizeLineEndings(bd);
                 }
 
-                Assert.True(ArraysEqual<byte>(ad, bd, ac), "Stream contents not equal: " + ast.ToString() + ", " + bst.ToString());
+                AssertExtensions.SequenceEqual(ad, bd);
 
                 blocksRead++;
             } while (ac == bufSize);

--- a/src/libraries/System.IO.Compression.Brotli/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression.Brotli/src/Resources/Strings.resx
@@ -175,6 +175,9 @@
   <data name="BrotliStream_Decompress_InvalidStream" xml:space="preserve">
     <value>BrotliStream.BaseStream returned more bytes than requested in Read.</value>
   </data>
+  <data name="BrotliStream_Decompress_TruncatedData" xml:space="preserve">
+    <value>Decoder ran into truncated data.</value>
+  </data>
   <data name="IOCompressionBrotli_PlatformNotSupported" xml:space="preserve">
     <value>System.IO.Compression.Brotli is not supported on this platform.</value>
   </data>

--- a/src/libraries/System.IO.Compression.Brotli/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression.Brotli/src/Resources/Strings.resx
@@ -176,7 +176,7 @@
     <value>BrotliStream.BaseStream returned more bytes than requested in Read.</value>
   </data>
   <data name="BrotliStream_Decompress_TruncatedData" xml:space="preserve">
-    <value>Decoder ran into truncated data.</value>
+    <value>Found truncated data while decoding.</value>
   </data>
   <data name="IOCompressionBrotli_PlatformNotSupported" xml:space="preserve">
     <value>System.IO.Compression.Brotli is not supported on this platform.</value>

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
@@ -66,7 +66,7 @@ namespace System.IO.Compression
                 int bytesRead = _stream.Read(_buffer, _bufferCount, _buffer.Length - _bufferCount);
                 if (bytesRead <= 0)
                 {
-                    if (UseStrictValidation && _nonEmptyInput && !buffer.IsEmpty)
+                    if (s_useStrictValidation && _nonEmptyInput && !buffer.IsEmpty)
                         ThrowTruncatedInvalidData();
                     break;
                 }
@@ -154,7 +154,7 @@ namespace System.IO.Compression
                         int bytesRead = await _stream.ReadAsync(_buffer.AsMemory(_bufferCount), cancellationToken).ConfigureAwait(false);
                         if (bytesRead <= 0)
                         {
-                            if (UseStrictValidation && _nonEmptyInput && !buffer.IsEmpty)
+                            if (s_useStrictValidation && _nonEmptyInput && !buffer.IsEmpty)
                                 ThrowTruncatedInvalidData();
                             break;
                         }
@@ -234,7 +234,7 @@ namespace System.IO.Compression
             return false;
         }
 
-        private static readonly bool UseStrictValidation =
+        private static readonly bool s_useStrictValidation =
             AppContext.TryGetSwitch("System.IO.Compression.UseStrictValidation", out bool strictValidation) ? strictValidation : false;
 
         private static void ThrowInvalidStream() =>

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
@@ -66,7 +66,7 @@ namespace System.IO.Compression
                 int bytesRead = _stream.Read(_buffer, _bufferCount, _buffer.Length - _bufferCount);
                 if (bytesRead <= 0)
                 {
-                    if (GetStrictValidationSetting() && _nonEmptyInput && !buffer.IsEmpty)
+                    if (UseStrictValidation && _nonEmptyInput && !buffer.IsEmpty)
                         ThrowTruncatedInvalidData();
                     break;
                 }
@@ -154,7 +154,7 @@ namespace System.IO.Compression
                         int bytesRead = await _stream.ReadAsync(_buffer.AsMemory(_bufferCount), cancellationToken).ConfigureAwait(false);
                         if (bytesRead <= 0)
                         {
-                            if (GetStrictValidationSetting() && _nonEmptyInput && !buffer.IsEmpty)
+                            if (UseStrictValidation && _nonEmptyInput && !buffer.IsEmpty)
                                 ThrowTruncatedInvalidData();
                             break;
                         }
@@ -234,16 +234,8 @@ namespace System.IO.Compression
             return false;
         }
 
-        private static bool GetStrictValidationSetting()
-        {
-            if (AppContext.TryGetSwitch("System.IO.Compression.UseStrictValidation", out bool strictValidation))
-            {
-                return strictValidation;
-            }
-
-            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_COMPRESSION_STRICT_VALIDATION");
-            return envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
-        }
+        private static readonly bool UseStrictValidation =
+            AppContext.TryGetSwitch("System.IO.Compression.UseStrictValidation", out bool strictValidation) ? strictValidation : false;
 
         private static void ThrowInvalidStream() =>
             // The stream is either malicious or poorly implemented and returned a number of

--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -278,6 +278,9 @@
   <data name="SplitSpanned" xml:space="preserve">
     <value>Split or spanned archives are not supported.</value>
   </data>
+  <data name="TruncatedData" xml:space="preserve">
+    <value>Found truncated data while decoding.</value>
+  </data>
   <data name="UnexpectedEndOfStream" xml:space="preserve">
     <value>Zip file corrupt: unexpected end of stream reached.</value>
   </data>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -284,7 +284,7 @@ namespace System.IO.Compression
                         // - Inflation is not finished yet.
                         // - Provided input wasn't completely empty
                         // In such case, we are dealing with a truncated input stream.
-                        if (UseStrictValidation && !buffer.IsEmpty && !_inflater.Finished() && _inflater.NonEmptyInput())
+                        if (s_useStrictValidation && !buffer.IsEmpty && !_inflater.Finished() && _inflater.NonEmptyInput())
                         {
                             ThrowTruncatedInvalidData();
                         }
@@ -433,7 +433,7 @@ namespace System.IO.Compression
                                 // - Inflation is not finished yet.
                                 // - Provided input wasn't completely empty
                                 // In such case, we are dealing with a truncated input stream.
-                                if (UseStrictValidation && !_inflater.Finished() && _inflater.NonEmptyInput() && !buffer.IsEmpty)
+                                if (s_useStrictValidation && !_inflater.Finished() && _inflater.NonEmptyInput() && !buffer.IsEmpty)
                                 {
                                     ThrowTruncatedInvalidData();
                                 }
@@ -914,7 +914,7 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
-                    if (!_deflateStream._inflater.Finished() && UseStrictValidation)
+                    if (!_deflateStream._inflater.Finished() && s_useStrictValidation)
                     {
                         ThrowTruncatedInvalidData();
                     }
@@ -950,7 +950,7 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     _deflateStream._stream.CopyTo(this, _arrayPoolBuffer.Length);
-                    if (!_deflateStream._inflater.Finished() && UseStrictValidation)
+                    if (!_deflateStream._inflater.Finished() && s_useStrictValidation)
                     {
                         ThrowTruncatedInvalidData();
                     }
@@ -1079,7 +1079,7 @@ namespace System.IO.Compression
         private static void ThrowInvalidBeginCall() =>
             throw new InvalidOperationException(SR.InvalidBeginCall);
 
-        private static readonly bool UseStrictValidation =
+        private static readonly bool s_useStrictValidation =
             AppContext.TryGetSwitch("System.IO.Compression.UseStrictValidation", out bool strictValidation) ? strictValidation : false;
     }
 }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -279,6 +279,15 @@ namespace System.IO.Compression
                     int n = _stream.Read(_buffer, 0, _buffer.Length);
                     if (n <= 0)
                     {
+                        // - Inflater didn't return any data although a non-empty output buffer was passed by the caller.
+                        // - More input is needed but there is no more input available.
+                        // - Inflation is not finished yet.
+                        // - Provided input wasn't completely empty
+                        // In such case, we are dealing with a truncated input stream.
+                        if (GetStrictValidationSetting() && !buffer.IsEmpty && !_inflater.Finished() && _inflater.NonEmptyInput())
+                        {
+                            ThrowTruncatedInvalidData();
+                        }
                         break;
                     }
                     else if (n > _buffer.Length)
@@ -346,6 +355,9 @@ namespace System.IO.Compression
             // The stream is either malicious or poorly implemented and returned a number of
             // bytes < 0 || > than the buffer supplied to it.
             throw new InvalidDataException(SR.GenericInvalidData);
+
+        private static void ThrowTruncatedInvalidData() =>
+            throw new InvalidDataException(SR.TruncatedData);
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? asyncCallback, object? asyncState) =>
             TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
@@ -416,6 +428,15 @@ namespace System.IO.Compression
                             int n = await _stream.ReadAsync(new Memory<byte>(_buffer, 0, _buffer.Length), cancellationToken).ConfigureAwait(false);
                             if (n <= 0)
                             {
+                                // - Inflater didn't return any data although a non-empty output buffer was passed by the caller.
+                                // - More input is needed but there is no more input available.
+                                // - Inflation is not finished yet.
+                                // - Provided input wasn't completely empty
+                                // In such case, we are dealing with a truncated input stream.
+                                if (GetStrictValidationSetting() && !_inflater.Finished() && _inflater.NonEmptyInput() && !buffer.IsEmpty)
+                                {
+                                    ThrowTruncatedInvalidData();
+                                }
                                 break;
                             }
                             else if (n > _buffer.Length)
@@ -893,6 +914,10 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
+                    if (!_deflateStream._inflater.Finished() && GetStrictValidationSetting())
+                    {
+                        ThrowTruncatedInvalidData();
+                    }
                 }
                 finally
                 {
@@ -925,6 +950,10 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     _deflateStream._stream.CopyTo(this, _arrayPoolBuffer.Length);
+                    if (!_deflateStream._inflater.Finished() && GetStrictValidationSetting())
+                    {
+                        ThrowTruncatedInvalidData();
+                    }
                 }
                 finally
                 {
@@ -1049,5 +1078,16 @@ namespace System.IO.Compression
 
         private static void ThrowInvalidBeginCall() =>
             throw new InvalidOperationException(SR.InvalidBeginCall);
+
+        private static bool GetStrictValidationSetting()
+        {
+            if (AppContext.TryGetSwitch("System.IO.Compression.UseStrictValidation", out bool strictValidation))
+            {
+                return strictValidation;
+            }
+
+            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_COMPRESSION_STRICT_VALIDATION");
+            return envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -284,7 +284,7 @@ namespace System.IO.Compression
                         // - Inflation is not finished yet.
                         // - Provided input wasn't completely empty
                         // In such case, we are dealing with a truncated input stream.
-                        if (GetStrictValidationSetting() && !buffer.IsEmpty && !_inflater.Finished() && _inflater.NonEmptyInput())
+                        if (UseStrictValidation && !buffer.IsEmpty && !_inflater.Finished() && _inflater.NonEmptyInput())
                         {
                             ThrowTruncatedInvalidData();
                         }
@@ -433,7 +433,7 @@ namespace System.IO.Compression
                                 // - Inflation is not finished yet.
                                 // - Provided input wasn't completely empty
                                 // In such case, we are dealing with a truncated input stream.
-                                if (GetStrictValidationSetting() && !_inflater.Finished() && _inflater.NonEmptyInput() && !buffer.IsEmpty)
+                                if (UseStrictValidation && !_inflater.Finished() && _inflater.NonEmptyInput() && !buffer.IsEmpty)
                                 {
                                     ThrowTruncatedInvalidData();
                                 }
@@ -914,7 +914,7 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
-                    if (!_deflateStream._inflater.Finished() && GetStrictValidationSetting())
+                    if (!_deflateStream._inflater.Finished() && UseStrictValidation)
                     {
                         ThrowTruncatedInvalidData();
                     }
@@ -950,7 +950,7 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     _deflateStream._stream.CopyTo(this, _arrayPoolBuffer.Length);
-                    if (!_deflateStream._inflater.Finished() && GetStrictValidationSetting())
+                    if (!_deflateStream._inflater.Finished() && UseStrictValidation)
                     {
                         ThrowTruncatedInvalidData();
                     }
@@ -1079,15 +1079,7 @@ namespace System.IO.Compression
         private static void ThrowInvalidBeginCall() =>
             throw new InvalidOperationException(SR.InvalidBeginCall);
 
-        private static bool GetStrictValidationSetting()
-        {
-            if (AppContext.TryGetSwitch("System.IO.Compression.UseStrictValidation", out bool strictValidation))
-            {
-                return strictValidation;
-            }
-
-            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_COMPRESSION_STRICT_VALIDATION");
-            return envVar is not null && (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase));
-        }
+        private static readonly bool UseStrictValidation =
+            AppContext.TryGetSwitch("System.IO.Compression.UseStrictValidation", out bool strictValidation) ? strictValidation : false;
     }
 }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -914,7 +914,7 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     await _deflateStream._stream.CopyToAsync(this, _arrayPoolBuffer.Length, _cancellationToken).ConfigureAwait(false);
-                    if (!_deflateStream._inflater.Finished() && s_useStrictValidation)
+                    if (s_useStrictValidation && !_deflateStream._inflater.Finished())
                     {
                         ThrowTruncatedInvalidData();
                     }
@@ -950,7 +950,7 @@ namespace System.IO.Compression
 
                     // Now, use the source stream's CopyToAsync to push directly to our inflater via this helper stream
                     _deflateStream._stream.CopyTo(this, _arrayPoolBuffer.Length);
-                    if (!_deflateStream._inflater.Finished() && s_useStrictValidation)
+                    if (s_useStrictValidation && !_deflateStream._inflater.Finished())
                     {
                         ThrowTruncatedInvalidData();
                     }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -17,6 +17,7 @@ namespace System.IO.Compression
         private const int MinWindowBits = -15;              // WindowBits must be between -8..-15 to ignore the header, 8..15 for
         private const int MaxWindowBits = 47;               // zlib headers, 24..31 for GZip headers, or 40..47 for either Zlib or GZip
 
+        private bool _nonEmptyInput;                        // Whether there is any non empty input
         private bool _finished;                             // Whether the end of the stream has been reached
         private bool _isDisposed;                           // Prevents multiple disposals
         private readonly int _windowBits;                   // The WindowBits parameter passed to Inflater construction
@@ -34,6 +35,7 @@ namespace System.IO.Compression
         {
             Debug.Assert(windowBits >= MinWindowBits && windowBits <= MaxWindowBits);
             _finished = false;
+            _nonEmptyInput = false;
             _isDisposed = false;
             _windowBits = windowBits;
             InflateInit(windowBits);
@@ -176,6 +178,8 @@ namespace System.IO.Compression
 
         public bool NeedsInput() => _zlibStream.AvailIn == 0;
 
+        public bool NonEmptyInput() => _nonEmptyInput;
+
         public void SetInput(byte[] inputBuffer, int startIndex, int count)
         {
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
@@ -200,6 +204,7 @@ namespace System.IO.Compression
                 _zlibStream.NextIn = (IntPtr)_inputBufferHandle.Pointer;
                 _zlibStream.AvailIn = (uint)inputBuffer.Length;
                 _finished = false;
+                _nonEmptyInput = true;
             }
         }
 

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
@@ -3,10 +3,14 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.IO.Compression.Tests;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Compression
 {
@@ -98,6 +102,92 @@ namespace System.IO.Compression
                     Assert.Equal(Input, Encoding.ASCII.GetString(decompressed.ToArray()));
                 }
             }
+        }
+
+        [InlineData(TestScenario.ReadAsync)]
+        [InlineData(TestScenario.Read)]
+        [InlineData(TestScenario.Copy)]
+        [InlineData(TestScenario.CopyAsync)]
+        [InlineData(TestScenario.ReadByte)]
+        [InlineData(TestScenario.ReadByteAsync)]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void StreamTruncation_IsDetected(TestScenario testScenario)
+        {
+            RemoteExecutor.Invoke(async (testScenario) =>
+            {
+                TestScenario scenario = Enum.Parse<TestScenario>(testScenario);
+
+                AppContext.SetSwitch("System.IO.Compression.UseStrictValidation", true);
+
+                var buffer = new byte[16];
+                byte[] source = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
+                byte[] compressedData;
+                using (var compressed = new MemoryStream())
+                using (Stream compressor = CreateStream(compressed, CompressionMode.Compress))
+                {
+                    foreach (byte b in source)
+                    {
+                        compressor.WriteByte(b);
+                    }
+
+                    compressor.Dispose();
+                    compressedData = compressed.ToArray();
+                }
+
+                for (var i = 1; i <= compressedData.Length; i += 1)
+                {
+                    bool expectException = i < compressedData.Length;
+                    using (var compressedStream = new MemoryStream(compressedData.Take(i).ToArray()))
+                    {
+                        using (Stream decompressor = CreateStream(compressedStream, CompressionMode.Decompress))
+                        {
+                            var decompressedStream = new MemoryStream();
+
+                            try
+                            {
+                                switch (scenario)
+                                {
+                                    case TestScenario.Copy:
+                                        decompressor.CopyTo(decompressedStream);
+                                        break;
+
+                                    case TestScenario.CopyAsync:
+                                        await decompressor.CopyToAsync(decompressedStream);
+                                        break;
+
+                                    case TestScenario.Read:
+                                        while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        break;
+
+                                    case TestScenario.ReadAsync:
+                                        while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        break;
+
+                                    case TestScenario.ReadByte:
+                                        while (decompressor.ReadByte() != -1) { }
+                                        break;
+
+                                    case TestScenario.ReadByteAsync:
+                                        while (await decompressor.ReadByteAsync() != -1) { }
+                                        break;
+                                }
+                            }
+                            catch (InvalidDataException e)
+                            {
+                                if (expectException)
+                                    continue;
+
+                                throw new XunitException($"An unexpected error occurred while decompressing data:{e}");
+                            }
+
+                            if (expectException)
+                            {
+                                throw new XunitException($"Truncated stream was decompressed successfully but exception was expected: length={i}/{compressedData.Length}");
+                            }
+                        }
+                    }
+                }
+            }, testScenario.ToString()).Dispose();
         }
 
         private sealed class DerivedDeflateStream : DeflateStream

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -6,7 +6,9 @@ using System.IO.Compression.Tests;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Compression
 {
@@ -319,6 +321,92 @@ namespace System.IO.Compression
                 // restore the data
                 compressedData[byteToCorrupt]--;
             }
+        }
+
+        [InlineData(TestScenario.ReadAsync)]
+        [InlineData(TestScenario.Read)]
+        [InlineData(TestScenario.Copy)]
+        [InlineData(TestScenario.CopyAsync)]
+        [InlineData(TestScenario.ReadByte)]
+        [InlineData(TestScenario.ReadByteAsync)]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void StreamTruncation_IsDetected(TestScenario testScenario)
+        {
+            RemoteExecutor.Invoke(async (testScenario) =>
+            {
+                TestScenario scenario = Enum.Parse<TestScenario>(testScenario);
+
+                AppContext.SetSwitch("System.IO.Compression.UseStrictValidation", true);
+
+                var buffer = new byte[16];
+                byte[] source = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
+                byte[] compressedData;
+                using (var compressed = new MemoryStream())
+                using (Stream compressor = CreateStream(compressed, CompressionMode.Compress))
+                {
+                    foreach (byte b in source)
+                    {
+                        compressor.WriteByte(b);
+                    }
+
+                    compressor.Dispose();
+                    compressedData = compressed.ToArray();
+                }
+
+                for (var i = 1; i <= compressedData.Length; i += 1)
+                {
+                    bool expectException = i < compressedData.Length;
+                    using (var compressedStream = new MemoryStream(compressedData.Take(i).ToArray()))
+                    {
+                        using (Stream decompressor = CreateStream(compressedStream, CompressionMode.Decompress))
+                        {
+                            var decompressedStream = new MemoryStream();
+
+                            try
+                            {
+                                switch (scenario)
+                                {
+                                    case TestScenario.Copy:
+                                        decompressor.CopyTo(decompressedStream);
+                                        break;
+
+                                    case TestScenario.CopyAsync:
+                                        await decompressor.CopyToAsync(decompressedStream);
+                                        break;
+
+                                    case TestScenario.Read:
+                                        while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        break;
+
+                                    case TestScenario.ReadAsync:
+                                        while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        break;
+
+                                    case TestScenario.ReadByte:
+                                        while (decompressor.ReadByte() != -1) { }
+                                        break;
+
+                                    case TestScenario.ReadByteAsync:
+                                        while (await decompressor.ReadByteAsync() != -1) { }
+                                        break;
+                                }
+                            }
+                            catch (InvalidDataException e)
+                            {
+                                if (expectException)
+                                    continue;
+
+                                throw new XunitException($"An unexpected error occurred while decompressing data:{e}");
+                            }
+
+                            if (expectException)
+                            {
+                                throw new XunitException($"Truncated stream was decompressed successfully but exception was expected: length={i}/{compressedData.Length}");
+                            }
+                        }
+                    }
+                }
+            }, testScenario.ToString()).Dispose();
         }
 
         private sealed class DerivedGZipStream : GZipStream

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -275,7 +275,6 @@ namespace System.IO.Compression
         }
 
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/47563")]
         [Fact]
         public void StreamCorruption_IsDetected()
         {

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.ZLib.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.ZLib.cs
@@ -19,7 +19,6 @@ namespace System.IO.Compression
         public override Stream BaseStream(Stream stream) => ((ZLibStream)stream).BaseStream;
         protected override string CompressedTestFile(string uncompressedPath) => Path.Combine("ZLibTestData", Path.GetFileName(uncompressedPath) + ".z");
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/47563")]
         [Fact]
         public void StreamCorruption_IsDetected()
         {

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.ZLib.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.ZLib.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics;
 using System.IO.Compression.Tests;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.IO.Compression
 {
@@ -22,40 +24,131 @@ namespace System.IO.Compression
         [Fact]
         public void StreamCorruption_IsDetected()
         {
-            byte[] source = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
-            var buffer = new byte[64];
-            byte[] compressedData;
-            using (var compressed = new MemoryStream())
-            using (Stream compressor = CreateStream(compressed, CompressionMode.Compress))
+            RemoteExecutor.Invoke(() =>
             {
-                foreach (byte b in source)
+                AppContext.SetSwitch("System.IO.Compression.UseStrictValidation", true);
+
+                byte[] source = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
+                var buffer = new byte[64];
+                byte[] compressedData;
+                using (var compressed = new MemoryStream())
+                using (Stream compressor = CreateStream(compressed, CompressionMode.Compress))
                 {
-                    compressor.WriteByte(b);
+                    foreach (byte b in source)
+                    {
+                        compressor.WriteByte(b);
+                    }
+
+                    compressor.Dispose();
+                    compressedData = compressed.ToArray();
                 }
 
-                compressor.Dispose();
-                compressedData = compressed.ToArray();
-            }
-
-            for (int byteToCorrupt = 0; byteToCorrupt < compressedData.Length; byteToCorrupt++)
-            {
-                // corrupt the data
-                compressedData[byteToCorrupt]++;
-
-                using (var decompressedStream = new MemoryStream(compressedData))
+                for (int byteToCorrupt = 0; byteToCorrupt < compressedData.Length; byteToCorrupt++)
                 {
-                    using (Stream decompressor = CreateStream(decompressedStream, CompressionMode.Decompress))
+                    // corrupt the data
+                    compressedData[byteToCorrupt]++;
+
+                    using (var decompressedStream = new MemoryStream(compressedData))
                     {
-                        Assert.Throws<InvalidDataException>(() =>
+                        using (Stream decompressor = CreateStream(decompressedStream, CompressionMode.Decompress))
                         {
-                            while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0);
-                        });
+                            Assert.Throws<InvalidDataException>(() =>
+                            {
+                                while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0);
+                            });
+                        }
+                    }
+
+                    // restore the data
+                    compressedData[byteToCorrupt]--;
+                }
+            }).Dispose();
+        }
+
+        [InlineData(TestScenario.ReadAsync)]
+        [InlineData(TestScenario.Read)]
+        [InlineData(TestScenario.Copy)]
+        [InlineData(TestScenario.CopyAsync)]
+        [InlineData(TestScenario.ReadByte)]
+        [InlineData(TestScenario.ReadByteAsync)]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void StreamTruncation_IsDetected(TestScenario testScenario)
+        {
+            RemoteExecutor.Invoke(async (testScenario) =>
+            {
+                TestScenario scenario = Enum.Parse<TestScenario>(testScenario);
+
+                AppContext.SetSwitch("System.IO.Compression.UseStrictValidation", true);
+
+                var buffer = new byte[16];
+                byte[] source = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
+                byte[] compressedData;
+                using (var compressed = new MemoryStream())
+                using (Stream compressor = CreateStream(compressed, CompressionMode.Compress))
+                {
+                    foreach (byte b in source)
+                    {
+                        compressor.WriteByte(b);
+                    }
+
+                    compressor.Dispose();
+                    compressedData = compressed.ToArray();
+                }
+
+                for (var i = 1; i <= compressedData.Length; i += 1)
+                {
+                    bool expectException = i < compressedData.Length;
+                    using (var compressedStream = new MemoryStream(compressedData.Take(i).ToArray()))
+                    {
+                        using (Stream decompressor = CreateStream(compressedStream, CompressionMode.Decompress))
+                        {
+                            var decompressedStream = new MemoryStream();
+
+                            try
+                            {
+                                switch (scenario)
+                                {
+                                    case TestScenario.Copy:
+                                        decompressor.CopyTo(decompressedStream);
+                                        break;
+
+                                    case TestScenario.CopyAsync:
+                                        await decompressor.CopyToAsync(decompressedStream);
+                                        break;
+
+                                    case TestScenario.Read:
+                                        while (ZipFileTestBase.ReadAllBytes(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        break;
+
+                                    case TestScenario.ReadAsync:
+                                        while (await ZipFileTestBase.ReadAllBytesAsync(decompressor, buffer, 0, buffer.Length) != 0) { };
+                                        break;
+
+                                    case TestScenario.ReadByte:
+                                        while (decompressor.ReadByte() != -1) { }
+                                        break;
+
+                                    case TestScenario.ReadByteAsync:
+                                        while (await decompressor.ReadByteAsync() != -1) { }
+                                        break;
+                                }
+                            }
+                            catch (InvalidDataException e)
+                            {
+                                if (expectException)
+                                    continue;
+
+                                throw new XunitException($"An unexpected error occurred while decompressing data:{e}");
+                            }
+
+                            if (expectException)
+                            {
+                                throw new XunitException($"Truncated stream was decompressed successfully but exception was expected: length={i}/{compressedData.Length}");
+                            }
+                        }
                     }
                 }
-
-                // restore the data
-                compressedData[byteToCorrupt]--;
-            }
+            }, testScenario.ToString()).Dispose();
         }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.ZLib.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.ZLib.cs
@@ -21,7 +21,7 @@ namespace System.IO.Compression
         public override Stream BaseStream(Stream stream) => ((ZLibStream)stream).BaseStream;
         protected override string CompressedTestFile(string uncompressedPath) => Path.Combine("ZLibTestData", Path.GetFileName(uncompressedPath) + ".z");
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void StreamCorruption_IsDetected()
         {
             RemoteExecutor.Invoke(() =>

--- a/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">


### PR DESCRIPTION
Having another go at https://github.com/dotnet/runtime/issues/47563 (previous https://github.com/dotnet/runtime/pull/61768)

This time using an opt-in flag to avoid breakage like this https://github.com/dotnet/runtime/issues/72726.

/cc @Jozkee