### PR TITLE
[wasm] Use sdk version `8.0.100-alpha.1.22463.23`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -176,7 +176,7 @@
     <GrpcDotnetClientVersion>2.45.0</GrpcDotnetClientVersion>
     <GrpcToolsVersion>2.45.0</GrpcToolsVersion>
     <!-- Uncomment to set a fixed version, else the latest is used -->
-    <!--<SdkVersionForWorkloadTesting>7.0.100-rc.1.22402.35</SdkVersionForWorkloadTesting>-->
+    <SdkVersionForWorkloadTesting>8.0.100-alpha.1.22463.23</SdkVersionForWorkloadTesting>
     <CompilerPlatformTestingVersion>1.1.2-beta1.22403.2</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220822.1</MicrosoftPrivateIntellisenseVersion>


### PR DESCRIPTION
.. because the latest one has net8.0 related changes, which breaks the Wasm.Build.Tests currently.

Issue: https://github.com/dotnet/runtime/issues/75684