### PR TITLE
Fix wasm template README

### DIFF
--- a/src/mono/wasm/templates/templates/browser/README.md
+++ b/src/mono/wasm/templates/templates/browser/README.md
@@ -2,7 +2,7 @@
 
 ## Build
 
-You can build the applcation from Visual Studio or by dotnet cli
+You can build the application from Visual Studio or by dotnet cli
 
 ```
 dotnet build -c Debug/Release -r browser-wasm
@@ -12,7 +12,7 @@ After building the application, the result is in the `bin/$(Configuration)/net7.
 
 ## Run
 
-You can build the applcation from Visual Studio or by dotnet cli
+You can build the application from Visual Studio or by dotnet cli
 
 ```
 dotnet run -c Debug/Release -r browser-wasm

--- a/src/mono/wasm/templates/templates/browser/README.md
+++ b/src/mono/wasm/templates/templates/browser/README.md
@@ -5,7 +5,7 @@
 You can build the application from Visual Studio or by dotnet cli
 
 ```
-dotnet build -c Debug/Release -r browser-wasm
+dotnet build -c Debug/Release
 ```
 
 After building the application, the result is in the `bin/$(Configuration)/net7.0/browser-wasm/AppBundle` directory.
@@ -15,7 +15,7 @@ After building the application, the result is in the `bin/$(Configuration)/net7.
 You can build the application from Visual Studio or by dotnet cli
 
 ```
-dotnet run -c Debug/Release -r browser-wasm
+dotnet run -c Debug/Release
 ```
 
 Or you can start any static file server from the AppBundle directory

--- a/src/mono/wasm/templates/templates/console/README.md
+++ b/src/mono/wasm/templates/templates/console/README.md
@@ -5,7 +5,7 @@
 You can build the application from Visual Studio or by dotnet cli
 
 ```
-dotnet build -c Debug/Release -r browser-wasm
+dotnet build -c Debug/Release
 ```
 
 After building the application, the result is in the `bin/$(Configuration)/net7.0/browser-wasm/AppBundle` directory.
@@ -15,7 +15,7 @@ After building the application, the result is in the `bin/$(Configuration)/net7.
 You can build the application from Visual Studio or by dotnet cli
 
 ```
-dotnet run -c Debug/Release -r browser-wasm --h=node
+dotnet run -c Debug/Release
 ```
 
 Or you can start any static file server from the AppBundle directory

--- a/src/mono/wasm/templates/templates/console/README.md
+++ b/src/mono/wasm/templates/templates/console/README.md
@@ -15,7 +15,7 @@ After building the application, the result is in the `bin/$(Configuration)/net7.
 You can build the application from Visual Studio or by dotnet cli
 
 ```
-dotnet run -c Debug/Release -r browser-wasm -h=nodejs
+dotnet run -c Debug/Release -r browser-wasm -- -h=node
 ```
 
 Or you can start any static file server from the AppBundle directory

--- a/src/mono/wasm/templates/templates/console/README.md
+++ b/src/mono/wasm/templates/templates/console/README.md
@@ -15,7 +15,7 @@ After building the application, the result is in the `bin/$(Configuration)/net7.
 You can build the application from Visual Studio or by dotnet cli
 
 ```
-dotnet run -c Debug/Release -r browser-wasm -- -h=node
+dotnet run -c Debug/Release -r browser-wasm --h=node
 ```
 
 Or you can start any static file server from the AppBundle directory

--- a/src/mono/wasm/templates/templates/console/README.md
+++ b/src/mono/wasm/templates/templates/console/README.md
@@ -2,7 +2,7 @@
 
 ## Build
 
-You can build the applcation from Visual Studio or by dotnet cli
+You can build the application from Visual Studio or by dotnet cli
 
 ```
 dotnet build -c Debug/Release -r browser-wasm
@@ -12,7 +12,7 @@ After building the application, the result is in the `bin/$(Configuration)/net7.
 
 ## Run
 
-You can build the applcation from Visual Studio or by dotnet cli
+You can build the application from Visual Studio or by dotnet cli
 
 ```
 dotnet run -c Debug/Release -r browser-wasm -h=nodejs


### PR DESCRIPTION
README has some typos and invalid arguments that is passed to dotnet cli.

before

```
# ~/Projects/github.com/yamachu/try-net7-dotnet-webassembly/wasmconsole-rc1 $ [master]
LANG=en_US.UTF-8;  dotnet run -c Debug -r browser-wasm -h=nodejs

Description:
  .NET Run Command

Usage:
  dotnet run [<applicationArguments>...] [options]

Arguments:
  <applicationArguments>  Arguments passed to the application that is being run. []

Options:
  -c, --configuration <CONFIGURATION>     The configuration to run for. The default for most projects is 'Debug'.
  -f, --framework <FRAMEWORK>             The target framework to run for. The target framework must also be specified in the project file.
  -r, --runtime <RUNTIME_IDENTIFIER>      The target runtime to run for.
  --project <project>                     The path to the project file to run (defaults to the current directory if there is only one project).
  -p, --property <property>               Properties to be passed to MSBuild.
  -lp, --launch-profile <launch-profile>  The name of the launch profile (if any) to use when launching the application.
  --no-launch-profile                     Do not attempt to use launchSettings.json to configure the application.
  --no-build                              Do not build the project before running. Implies --no-restore.
  --interactive                           Allows the command to stop and wait for user input or action (for example to complete authentication).
  --no-restore                            Do not restore the project before building.
  --sc, --self-contained                  Publish the .NET runtime with your application so the runtime doesn't need to be installed on the target machine.
                                          The default is 'true' if a runtime identifier is specified.
  --no-self-contained                     Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application.
  -v, --verbosity <LEVEL>                 Set the MSBuild verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
  -a, --arch <arch>                       The target architecture.
  --os <os>                               The target operating system.
  -?, -h, --help                          Show command line help.
```

after
```
# ~/Projects/github.com/yamachu/try-net7-dotnet-webassembly/wasmconsole-rc1 $ [master]
LANG=en_US.UTF-8; dotnet run -c Debug -r browser-wasm --h=node

/usr/local/share/dotnet/sdk/7.0.100-rc.1.22431.12/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(1136,5): warning NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used. [/Users/yk-yamada/Projects/github.com/yamachu/try-net7-dotnet-webassembly/wasmconsole-rc1/wasmconsole-rc1.csproj]
WasmAppHost --runtime-config /Users/yk-yamada/Projects/github.com/yamachu/try-net7-dotnet-webassembly/wasmconsole-rc1/bin/Debug/net7.0/browser-wasm/AppBundle//wasmconsole-rc1.runtimeconfig.json --h=node
Running: node main.mjs
Using working directory: /Users/yk-yamada/Projects/github.com/yamachu/try-net7-dotnet-webassembly/wasmconsole-rc1/bin/Debug/net7.0/browser-wasm/AppBundle
mono_wasm_runtime_ready fe00e07a-5519-4dfe-b35a-f867dbaf2e28
Hello, World! Greetings from node version: v16.15.1
Hello, Console!
```