### PR TITLE
Enable logging managed stack trace for AV to event log

### DIFF
--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -445,10 +445,12 @@ void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage
                 failureType = EventReporter::ERT_ManagedFailFast;
             else if (exitCode == (UINT)COR_E_CODECONTRACTFAILED)
                 failureType = EventReporter::ERT_CodeContractFailed;
+            else if (exitCode == EXCEPTION_ACCESS_VIOLATION)
+                failureType = EventReporter::ERT_UnhandledException;
             EventReporter reporter(failureType);
             StackSString s(argExceptionString);
 
-            if ((exitCode == (UINT)COR_E_FAILFAST) || (exitCode == (UINT)COR_E_CODECONTRACTFAILED) || (exitCode == (UINT)CLR_E_GC_OOM))
+            if ((exitCode == (UINT)COR_E_FAILFAST) || (exitCode == (UINT)COR_E_CODECONTRACTFAILED) || (exitCode == (UINT)CLR_E_GC_OOM) || (exitCode == EXCEPTION_ACCESS_VIOLATION))
             {
                 if (pszMessage)
                 {


### PR DESCRIPTION
.NET Framework was logging managed stack trace of access violations that happened in external native code in the event log. .NET core only logs the address and error code of the exception, which makes it difficult for developers to figure out which part of their managed code has called the failing native code.
The reason why .NET core doesn't print the stack trace is that the access violation is now handled as fail fast instead of regular unhandled exception. And while we report managed stack traces in the EEPolicy::FatalError for fail fasts called from our runtime and managed code in both runtime and user code, we don't report it when we come to that method due to the access violation.

This change enables printing the stack trace for that case too.