### PR TITLE
Remove update to unit test for speech fix

### DIFF
--- a/src/libraries/System.Speech/tests/SynthesizeRecognizeTests.cs
+++ b/src/libraries/System.Speech/tests/SynthesizeRecognizeTests.cs
@@ -38,7 +38,6 @@ namespace SampleSynthesisTests
             {
                 synth.SetOutputToWaveStream(ms);
                 var prompt = new Prompt("synthesizer");
-                synth.SetOutputToDefaultAudioDevice();
                 synth.Speak(prompt);
             }
 


### PR DESCRIPTION
We've validated the fix separately, and this change to the test is causing failures in CI (no clue why it didn't fail in the PR)

cc: @danmoseley @stephentoub this is blocking clean CI