### PR TITLE
Use more shared bits for CSE on arm64

### DIFF
--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -71,7 +71,7 @@ inline bool compUnixX86Abi()
 
 #elif defined(TARGET_ARM64)
 #define REGMASK_BITS 64
-#define CSE_CONST_SHARED_LOW_BITS 12
+#define CSE_CONST_SHARED_LOW_BITS 14
 
 #elif defined(TARGET_LOONGARCH64)
 #define REGMASK_BITS 64


### PR DESCRIPTION
`sub` is able to "contain" 14 bits (0-4096) rather than 12 (0-1024) on arm64.

Codegen diff example:
```csharp
void foo(int x)
{
    a = 10000000;
    b = 10004000;
}

int a, b;
```
codegen diff: https://www.diffchecker.com/qhrKccIR

I'm seeing nice diffs from this locally on arm64