### PR TITLE
[DOC][MONO] Update example wasm test run command

### DIFF
--- a/docs/workflow/testing/mono/testing.md
+++ b/docs/workflow/testing/mono/testing.md
@@ -55,11 +55,9 @@ The last few lines of the build log should contain something like this:
 --------------------------------------------------
  Example run.sh command
 
- src/tests/run.sh --coreOverlayDir=<repo_root>artifacts/tests/coreclr/Browser.wasm.Release/Tests/Core_Root --testNativeBinDir=<repo_root>/artifacts/obj/coreclr/Browser.wasm.Release/tests --testRootDir=<repo_root>/artifacts/tests/coreclr/Browser.wasm.Release --copyNativeTestBin Release
+ src/tests/run.sh wasm <Debug|Release>
 --------------------------------------------------
 ```
-
-To run all tests, execute that command, adding `wasm` to the end.
 
 ### Android:
 Build the runtime tests for Android x64/ARM64


### PR DESCRIPTION
This documentation fix updates the example command for running the runtime test with wasm, by removing parameters that no longer are needed, or even exist in some cases.