### PR TITLE
CSE CALL_HOISTABLE

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -3581,6 +3581,11 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
             {
                 return true;
             }
+            else if ((call->gtFlags & GTF_CALL_HOISTABLE) != 0)
+            {
+                // If the call is marked as hoistable, then can be a CSE candidate.
+                return true;
+            }
             else
             {
                 // Calls generally cannot be CSE-ed


### PR DESCRIPTION
If a call is marked as `GTF_CALL_HOISTABLE`, we can CSE it?

There are follow-up changes to this PR, but I want to see what making them available in CSE does.