### PR TITLE
Fix return code in critical_finalization test

### DIFF
--- a/src/tests/baseservices/critical_finalization/critical_finalization.cs
+++ b/src/tests/baseservices/critical_finalization/critical_finalization.cs
@@ -48,6 +48,6 @@ class T : P {
 			return 1;
 		if (Q.first_p_count < P.count)
 			return 1;
-		return 0;
+		return 100;
 	}
 }

--- a/src/tests/baseservices/critical_finalization/critical_finalization.csproj
+++ b/src/tests/baseservices/critical_finalization/critical_finalization.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="critical_finalization.cs" />

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3267,6 +3267,9 @@
 
 
     <ItemGroup Condition=" '$(TargetArchitecture)' == 'wasm' " >
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/critical_finalization/critical_finalization/critical_finalization/**">
+            <Issue>https://github.com/dotnet/runtime/issues/75756</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Intrinsics/TypeIntrinsics_r/**">
             <Issue>https://github.com/dotnet/runtime/issues/54867</Issue>
         </ExcludeList>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3267,7 +3267,7 @@
 
 
     <ItemGroup Condition=" '$(TargetArchitecture)' == 'wasm' " >
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/critical_finalization/critical_finalization/critical_finalization/**">
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/critical_finalization/critical_finalization/**">
             <Issue>https://github.com/dotnet/runtime/issues/75756</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Intrinsics/TypeIntrinsics_r/**">


### PR DESCRIPTION
Failed in outerloop pipelines, e.g.

https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-heads-main-c06e19b10e3f48f6b2/baseservices.critical_finalization/1/console.28d81afa.log?helixlogtype=result


From my understanding, that test was copied from mono in https://github.com/dotnet/runtime/pull/75662 recently