### PR TITLE
[mono][debugger] fix exception while decoding value that has a byref field

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5079,7 +5079,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 			//PRINT_MSG ("%s\n", mono_type_full_name (t));
 			buffer_add_byte (buf, VALUE_TYPE_ID_NULL);
 			if (CHECK_PROTOCOL_VERSION (2, 59))
-				buffer_add_info_for_null_value(buf, t, domain);
+				buffer_add_info_for_null_value (buf, t, domain);
 			return;
 		}
 		g_assert (*(void**)addr);
@@ -5234,7 +5234,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 					/* The client can't handle PARENT_VTYPE */
 					buffer_add_byte (buf, VALUE_TYPE_ID_NULL);
 					if (CHECK_PROTOCOL_VERSION (2, 59))
-						buffer_add_info_for_null_value(buf, t, domain);
+						buffer_add_info_for_null_value (buf, t, domain);
 				}
 				break;
 			} else {

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5078,6 +5078,8 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 			/* This can happen with compiler generated locals */
 			//PRINT_MSG ("%s\n", mono_type_full_name (t));
 			buffer_add_byte (buf, VALUE_TYPE_ID_NULL);
+			if (CHECK_PROTOCOL_VERSION (2, 59))
+				buffer_add_info_for_null_value(buf, t, domain);
 			return;
 		}
 		g_assert (*(void**)addr);
@@ -5231,6 +5233,8 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 				} else {
 					/* The client can't handle PARENT_VTYPE */
 					buffer_add_byte (buf, VALUE_TYPE_ID_NULL);
+					if (CHECK_PROTOCOL_VERSION (2, 59))
+						buffer_add_info_for_null_value(buf, t, domain);
 				}
 				break;
 			} else {
@@ -5612,6 +5616,11 @@ decode_value (MonoType *t, MonoDomain *domain, gpointer void_addr, gpointer void
 	ERROR_DECL (error);
 	ErrorCode err;
 	int type = decode_byte (buf, &buf, limit);
+
+	if (m_type_is_byref (t)) {
+		*(guint8**)addr = (guint8 *)g_malloc (sizeof (void*)); //when the object will be deleted it will delete this memory allocated here together?
+		addr = *(guint8**)addr;
+	}
 
 	if (t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t))) {
 		MonoType *targ = t->data.generic_class->context.class_inst->type_argv [0];
@@ -6082,7 +6091,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 			}
 	} else {
 		if (!(m->flags & METHOD_ATTRIBUTE_STATIC) || (m->flags & METHOD_ATTRIBUTE_STATIC && !CHECK_PROTOCOL_VERSION (2, 59))) { //on icordbg I couldn't find an object when invoking a static method maybe I can change this later
-			err = decode_value(m_class_get_byval_arg(m->klass), domain, this_buf, p, &p, end, FALSE);
+			err = decode_value (m_class_get_byval_arg (m->klass), domain, this_buf, p, &p, end, FALSE);
 			if (err != ERR_NONE)
 				return err;
 		}

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -1608,6 +1608,14 @@ namespace Microsoft.WebAssembly.Diagnostics
                 {
                     dispAttrStr = dispAttrStr.Replace(",nq", "");
                 }
+                if (dispAttrStr.Contains(", raw"))
+                {
+                    dispAttrStr = dispAttrStr.Replace(", raw", "");
+                }
+                if (dispAttrStr.Contains(",raw"))
+                {
+                    dispAttrStr = dispAttrStr.Replace(",raw", "");
+                }
                 expr = "$\"" + dispAttrStr + "\"";
                 JObject retValue = await resolver.Resolve(expr, token);
                 retValue ??= await ExpressionEvaluator.CompileAndRunTheExpression(expr, resolver, logger, token);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1100,5 +1100,30 @@ namespace DebuggerTests
                 bp.Value["locations"][0]["columnNumber"].Value<int>(),
                 $"DebuggerTests.CheckChineseCharacterInPath.Evaluate");
         }
+
+        [Fact]
+        public async Task InspectReadOnlySpan()
+        {
+            var expression = $"{{ invoke_static_method('[debugger-test] ReadOnlySpanTest:Run'); }}";
+
+            await EvaluateAndCheck(
+                "window.setTimeout(function() {" + expression + "; }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 1371, 8,
+                "ReadOnlySpanTest.CheckArguments",
+                wait_for_event_fn: async (pause_location) =>
+                {
+                    var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+                    await EvaluateOnCallFrameAndCheck(id,
+                        ("parameters.ToString()", TString("System.ReadOnlySpan<Object>[1]"))
+                    );
+                }
+            );
+            await StepAndCheck(StepKind.Resume, "dotnet://debugger-test.dll/debugger-test.cs", 1363, 8, "ReadOnlySpanTest.Run",
+                locals_fn: async (locals) =>
+                {
+                    await CheckValueType(locals, "var1", "System.ReadOnlySpan<object>", description: "System.ReadOnlySpan<Object>[0]");
+                }
+            );
+        }
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1355,3 +1355,20 @@ public class ClassInheritsFromNonUserCodeClassThatInheritsFromNormalClass : Debu
 
     public int myField;
 }
+public class ReadOnlySpanTest
+{
+    public static void Run()
+    {
+        Invoke(new string[] {"TEST"});
+        ReadOnlySpan<object> var1 = new ReadOnlySpan<object>();
+        System.Diagnostics.Debugger.Break();
+    }
+    public static void Invoke(object[] parameters)
+    {
+        CheckArguments(parameters);
+    }
+    public static void CheckArguments(ReadOnlySpan<object> parameters)
+    {
+        System.Diagnostics.Debugger.Break();
+    }
+}


### PR DESCRIPTION
To reproduce:

```
Run();
static void Run()
{
    Invoke(new string[] { "TEST" });
}
static void Invoke(object[] parameters)
{
    CheckArguments(parameters);
}
static void CheckArguments(ReadOnlySpan<object> parameters)
{
    System.Diagnostics.Debugger.Break();
}
```
Attach debugger and try to inspect `parameters` parameter, mono runtime will crash.


While decoding a object / valuetype that has a byref field, it was dereferencing the pointer twice when it was trying to use it, and then the address was invalid.

@lambdageek do I need to free the new memory that I allocated or it will be freed when the object is freed?

On wasm we don't have the exception because we don't try to access the `synchronisation` field that was the one that become invalid.
But while trying to create a test for wasm I found another issue related and it's fixed here.

Also created a issue to support Format Specifiers in C# while debugging on wasm:
https://github.com/dotnet/runtime/issues/75773