### PR TITLE
Ensure that all paths of double.Hypot use the absolute value where required

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -1562,7 +1562,7 @@ namespace System
                     else
                     {
                         // x or y is insignificant compared to the other
-                        result = x + y;
+                        result = ax + ay;
                     }
                 }
             }

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -1615,5 +1615,16 @@ namespace System.Tests
             AssertExtensions.Equal(-expectedResult, double.TanPi(-value), allowedVariance);
             AssertExtensions.Equal(+expectedResult, double.TanPi(+value), allowedVariance);
         }
+
+        [Theory]
+        [InlineData(+1e+20, 1e+20, 0.0)]
+        [InlineData(-1e+10, 1e+10, 0.0)]
+        [InlineData(-1e+20, 1e+20, 0.0)]
+        public static void Regression75651(double value, double expectedResult, double allowedVariance)
+        {
+            AssertExtensions.Equal(expectedResult, double.Hypot(1, value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, double.Hypot(1, value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, double.Hypot(1, value), allowedVariance);
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -171,6 +171,8 @@ namespace System.Tests
         [InlineData(0.0,                     3.0,                     3.0,                     0.0)]
         [InlineData(0.0,                     10.0,                    10.0,                    0.0)]
         [InlineData(1.0,                     1.0,                     1.4142135623730950,      CrossPlatformMachineEpsilon * 10)]
+        [InlineData(1.0,                     1e+10,                   1e+10,                   0.0)] // dotnet/runtime#75651
+        [InlineData(1.0,                     1e+20,                   1e+20,                   0.0)] // dotnet/runtime#75651
         [InlineData(2.7182818284590452,      0.31830988618379067,     2.7368553638387594,      CrossPlatformMachineEpsilon * 10)]   // x: (e)   y: (1 / pi)
         [InlineData(2.7182818284590452,      0.43429448190325183,     2.7527563996732919,      CrossPlatformMachineEpsilon * 10)]   // x: (e)   y: (log10(e))
         [InlineData(2.7182818284590452,      0.63661977236758134,     2.7918346715914253,      CrossPlatformMachineEpsilon * 10)]   // x: (e)   y: (2 / pi)
@@ -191,7 +193,7 @@ namespace System.Tests
         [InlineData(10.0,                    0.69314718055994531,     10.023993865417028,      CrossPlatformMachineEpsilon * 100)]  //          y: (ln(2))
         [InlineData(10.0,                    0.70710678118654752,     10.024968827881711,      CrossPlatformMachineEpsilon * 100)]  //          y: (1 / sqrt(2))
         [InlineData(10.0,                    0.78539816339744831,     10.030795096853892,      CrossPlatformMachineEpsilon * 100)]  //          y: (pi / 4)
-        [InlineData(10.0,                    1.0,                     10.049875621120890,      CrossPlatformMachineEpsilon * 100)]  //       
+        [InlineData(10.0,                    1.0,                     10.049875621120890,      CrossPlatformMachineEpsilon * 100)]  //
         [InlineData(10.0,                    1.1283791670955126,      10.063460614755501,      CrossPlatformMachineEpsilon * 100)]  //          y: (2 / sqrt(pi))
         [InlineData(10.0,                    1.4142135623730950,      10.099504938362078,      CrossPlatformMachineEpsilon * 100)]  //          y: (sqrt(2))
         [InlineData(10.0,                    1.4426950408889634,      10.103532500121213,      CrossPlatformMachineEpsilon * 100)]  //          y: (log2(e))
@@ -664,7 +666,7 @@ namespace System.Tests
         [InlineData(-0.0,                      2,  0.0,                     0.0)]
         [InlineData(-0.0,                      3, -0.0,                     0.0)]
         [InlineData(-0.0,                      4,  0.0,                     0.0)]
-        [InlineData(-0.0,                      5, -0.0,                     0.0)]                                  
+        [InlineData(-0.0,                      5, -0.0,                     0.0)]
         [InlineData( double.NaN,              -5,  double.NaN,              0.0)]
         [InlineData( double.NaN,              -4,  double.NaN,              0.0)]
         [InlineData( double.NaN,              -3,  double.NaN,              0.0)]
@@ -1470,7 +1472,7 @@ namespace System.Tests
             AssertExtensions.Equal(+expectedResult, double.AsinPi(+value), allowedVariance);
         }
 
-        [Theory]                                                      
+        [Theory]
         [InlineData( double.NaN,               double.NaN,              double.NaN,           0.0)]
         [InlineData( 0.0,                     -1.0,                      1.0,                 CrossPlatformMachineEpsilon)] // y: sinpi(0)              x:  cospi(1)            ; This should be exact, but has an issue on WASM/Unix
         [InlineData( 0.0,                     -0.0,                      1.0,                 CrossPlatformMachineEpsilon)] // y: sinpi(0)              x: -cospi(0.5)          ; This should be exact, but has an issue on WASM/Unix
@@ -1512,8 +1514,8 @@ namespace System.Tests
         [InlineData(-2.1850398632615190,      -0.36338022763241866, CrossPlatformMachineEpsilon)]
         [InlineData(-1.4406084404920341,      -0.30685281944005469, CrossPlatformMachineEpsilon)]
         [InlineData(-1.3136757077477542,      -0.29289321881345248, CrossPlatformMachineEpsilon)]
-        [InlineData(-0.79909939792801821,     -0.21460183660255169, CrossPlatformMachineEpsilon)]     
-        [InlineData( 0.42670634433261806,      0.12837916709551257, CrossPlatformMachineEpsilon)]    
+        [InlineData(-0.79909939792801821,     -0.21460183660255169, CrossPlatformMachineEpsilon)]
+        [InlineData( 0.42670634433261806,      0.12837916709551257, CrossPlatformMachineEpsilon)]
         [InlineData( 3.6202185671074506,       0.41421356237309505, CrossPlatformMachineEpsilon)]
         [InlineData( 5.4945259425167300,       0.44269504088896341, CrossPlatformMachineEpsilon)]
         [InlineData(-4.4217522209161288,      -0.42920367320510338, CrossPlatformMachineEpsilon)]
@@ -1614,17 +1616,6 @@ namespace System.Tests
         {
             AssertExtensions.Equal(-expectedResult, double.TanPi(-value), allowedVariance);
             AssertExtensions.Equal(+expectedResult, double.TanPi(+value), allowedVariance);
-        }
-
-        [Theory]
-        [InlineData(+1e+20, 1e+20, 0.0)]
-        [InlineData(-1e+10, 1e+10, 0.0)]
-        [InlineData(-1e+20, 1e+20, 0.0)]
-        public static void Regression75651(double value, double expectedResult, double allowedVariance)
-        {
-            AssertExtensions.Equal(expectedResult, double.Hypot(1, value), allowedVariance);
-            AssertExtensions.Equal(expectedResult, double.Hypot(1, value), allowedVariance);
-            AssertExtensions.Equal(expectedResult, double.Hypot(1, value), allowedVariance);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/SingleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.cs
@@ -168,6 +168,8 @@ namespace System.Tests
         [InlineData(0.0f,                   3.0f,                   3.0f,                   0.0f)]
         [InlineData(0.0f,                   10.0f,                  10.0f,                  0.0f)]
         [InlineData(1.0f,                   1.0f,                   1.41421356f,            CrossPlatformMachineEpsilon * 10)]
+        [InlineData(1.0f,                   1e+10f,                 1e+10f,                 0.0)] // dotnet/runtime#75651
+        [InlineData(1.0f,                   1e+20f,                 1e+20f,                 0.0)] // dotnet/runtime#75651
         [InlineData(2.71828183f,            0.318309886f,           2.73685536f,            CrossPlatformMachineEpsilon * 10)]   // x: (e)   y: (1 / pi)
         [InlineData(2.71828183f,            0.434294482f,           2.75275640f,            CrossPlatformMachineEpsilon * 10)]   // x: (e)   y: (log10(e))
         [InlineData(2.71828183f,            0.636619772f,           2.79183467f,            CrossPlatformMachineEpsilon * 10)]   // x: (e)   y: (2 / pi)
@@ -188,7 +190,7 @@ namespace System.Tests
         [InlineData(10.0f,                  0.693147181f,           10.0239939f,            CrossPlatformMachineEpsilon * 100)]  //          y: (ln(2))
         [InlineData(10.0f,                  0.707106781f,           10.0249688f,            CrossPlatformMachineEpsilon * 100)]  //          y: (1 / sqrt(2))
         [InlineData(10.0f,                  0.785398163f,           10.0307951f,            CrossPlatformMachineEpsilon * 100)]  //          y: (pi / 4)
-        [InlineData(10.0f,                  1.0f,                   10.0498756f,            CrossPlatformMachineEpsilon * 100)]  //       
+        [InlineData(10.0f,                  1.0f,                   10.0498756f,            CrossPlatformMachineEpsilon * 100)]  //
         [InlineData(10.0f,                  1.12837917f,            10.0634606f,            CrossPlatformMachineEpsilon * 100)]  //          y: (2 / sqrt(pi))
         [InlineData(10.0f,                  1.41421356f,            10.0995049f,            CrossPlatformMachineEpsilon * 100)]  //          y: (sqrt(2))
         [InlineData(10.0f,                  1.44269504f,            10.1035325f,            CrossPlatformMachineEpsilon * 100)]  //          y: (log2(e))
@@ -603,7 +605,7 @@ namespace System.Tests
         [InlineData(-0.0f,                    2,  0.0f,                   0.0f)]
         [InlineData(-0.0f,                    3, -0.0f,                   0.0f)]
         [InlineData(-0.0f,                    4,  0.0f,                   0.0f)]
-        [InlineData(-0.0f,                    5, -0.0f,                   0.0f)]                                  
+        [InlineData(-0.0f,                    5, -0.0f,                   0.0f)]
         [InlineData( float.NaN,              -5,  float.NaN,              0.0f)]
         [InlineData( float.NaN,              -4,  float.NaN,              0.0f)]
         [InlineData( float.NaN,              -3,  float.NaN,              0.0f)]
@@ -1383,7 +1385,7 @@ namespace System.Tests
             AssertExtensions.Equal(+expectedResult, float.AsinPi(+value), allowedVariance);
         }
 
-        [Theory]                                                      
+        [Theory]
         [InlineData( float.NaN,               float.NaN,               float.NaN,    0.0f)]
         [InlineData( 0.0f,                   -1.0f,                    1.0f,         CrossPlatformMachineEpsilon)]  // y: sinpi(0)              x:  cospi(1)            ; This should be exact, but has an issue on WASM/Unix
         [InlineData( 0.0f,                   -0.0f,                    1.0f,         CrossPlatformMachineEpsilon)]  // y: sinpi(0)              x: -cospi(0.5)          ; This should be exact, but has an issue on WASM/Unix
@@ -1425,8 +1427,8 @@ namespace System.Tests
         [InlineData(-2.18503986f,            -0.363380228f, CrossPlatformMachineEpsilon)]
         [InlineData(-1.44060844f,            -0.306852819f, CrossPlatformMachineEpsilon)]
         [InlineData(-1.31367571f,            -0.292893219f, CrossPlatformMachineEpsilon)]
-        [InlineData(-0.79909940f,            -0.214601837f, CrossPlatformMachineEpsilon)]     
-        [InlineData( 0.42670634f,             0.128379167f, CrossPlatformMachineEpsilon)]    
+        [InlineData(-0.79909940f,            -0.214601837f, CrossPlatformMachineEpsilon)]
+        [InlineData( 0.42670634f,             0.128379167f, CrossPlatformMachineEpsilon)]
         [InlineData( 3.62021857f,             0.414213562f, CrossPlatformMachineEpsilon)]
         [InlineData( 5.49452594f,             0.442695041f, CrossPlatformMachineEpsilon)]
         [InlineData(-4.42175222f,            -0.429203673f, CrossPlatformMachineEpsilon)]
@@ -1527,17 +1529,6 @@ namespace System.Tests
         {
             AssertExtensions.Equal(-expectedResult, float.TanPi(-value), allowedVariance);
             AssertExtensions.Equal(+expectedResult, float.TanPi(+value), allowedVariance);
-        }
-
-        [Theory]
-        [InlineData(+1e+20f, 1e+20f, 0.0)]
-        [InlineData(-1e+10f, 1e+10f, 0.0)]
-        [InlineData(-1e+20f, 1e+20f, 0.0)]
-        public static void Regression75651(float value, float expectedResult, float allowedVariance)
-        {
-            AssertExtensions.Equal(expectedResult, float.Hypot(1, value), allowedVariance);
-            AssertExtensions.Equal(expectedResult, float.Hypot(1, value), allowedVariance);
-            AssertExtensions.Equal(expectedResult, float.Hypot(1, value), allowedVariance);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/SingleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.cs
@@ -1528,5 +1528,16 @@ namespace System.Tests
             AssertExtensions.Equal(-expectedResult, float.TanPi(-value), allowedVariance);
             AssertExtensions.Equal(+expectedResult, float.TanPi(+value), allowedVariance);
         }
+
+        [Theory]
+        [InlineData(+1e+20f, 1e+20f, 0.0)]
+        [InlineData(-1e+10f, 1e+10f, 0.0)]
+        [InlineData(-1e+20f, 1e+20f, 0.0)]
+        public static void Regression75651(float value, float expectedResult, float allowedVariance)
+        {
+            AssertExtensions.Equal(expectedResult, float.Hypot(1, value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, float.Hypot(1, value), allowedVariance);
+            AssertExtensions.Equal(expectedResult, float.Hypot(1, value), allowedVariance);
+        }
     }
 }


### PR DESCRIPTION
This resolves #75651 