### PR TITLE
[wasm][debugger] Fix behavior of JMC

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -60,7 +60,8 @@ namespace Microsoft.WebAssembly.Diagnostics
         ForDebuggerProxyAttribute = 8,
         ForDebuggerDisplayAttribute = 16,
         WithProperties = 32,
-        JustMyCode = 64
+        JustMyCode = 64,
+        AutoExpandable = 128
     }
 
     internal enum CommandSet {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
@@ -290,7 +290,7 @@ namespace BrowserDebugProxy
                     typeId,
                     className,
                     Buffer,
-                    autoExpand,
+                    autoExpand ? GetObjectCommandOptions.AutoExpandable : GetObjectCommandOptions.None,
                     Id,
                     isValueType: true,
                     isOwn: i == 0,

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1067,7 +1067,11 @@ namespace DebuggerTests
                         {
                             myField = TNumber(0),
                             myField2 = TNumber(0),
-                        }, "this_props", num_fields: 2);
+                            propB = TGetter("propB"),
+                            propC = TGetter("propC"),
+                            e = TNumber(50),
+                            f = TNumber(60),
+                        }, "this_props", num_fields: 6);
                     }
                     else
                     {

--- a/src/mono/wasm/debugger/tests/debugger-test-with-non-user-code-class/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-non-user-code-class/test.cs
@@ -16,11 +16,11 @@ namespace DebuggerTests
         private int d;
         public int e;
         protected int f;
-        public int G
+        private int G
         {
             get {return f + 1;}
         }
-        public int H => f;
+        private int H => f;
 
         public ClassNonUserCodeToInheritThatInheritsFromNormalClass()
         {

--- a/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-without-debug-symbols-to-load/test.cs
@@ -10,11 +10,11 @@ namespace DebuggerTests
         private int d;
         public int e;
         protected int f;
-        public int G
+        private int G
         {
             get {return f + 1;}
         }
-        public int H => f;
+        private int H => f;
 
         public ClassWithoutDebugSymbolsToInherit()
         {

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1300,11 +1300,11 @@ public class ClassNonUserCodeToInherit
     private int d;
     public int e;
     protected int f;
-    public int G
+    private int G
     {
         get {return f + 1;}
     }
-    public int H => f;
+    private int H => f;
 
     public ClassNonUserCodeToInherit()
     {


### PR DESCRIPTION
We only should hide private members from types that are not UserCode when JMC is enabled.
I understood it wrongly when I implemented, fixing it now.

Fixes #75763 