### PR TITLE
[release/7.0-rc2] [wasm] fix missing managed stack trace on managed exceptions marshaled to JS

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -124,7 +124,7 @@ namespace System.Runtime.InteropServices.JavaScript
         public static void CreateTaskCallback(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
-            ref JSMarshalerArgument arg_return = ref arguments_buffer[1]; // used as return vaule
+            ref JSMarshalerArgument arg_return = ref arguments_buffer[1]; // used as return value
             try
             {
                 JSHostImplementation.TaskCallback holder = new JSHostImplementation.TaskCallback();
@@ -187,6 +187,32 @@ namespace System.Runtime.InteropServices.JavaScript
                 else
                 {
                     throw new InvalidOperationException("TaskCallback is null");
+                }
+            }
+            catch (Exception ex)
+            {
+                arg_exc.ToJS(ex);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)] // https://github.com/dotnet/runtime/issues/71425
+        // the marshaled signature is:
+        // string GetManagedStackTrace(GCHandle exception)
+        public static void GetManagedStackTrace(JSMarshalerArgument* arguments_buffer)
+        {
+            ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
+            ref JSMarshalerArgument arg_return = ref arguments_buffer[1]; // used as return value
+            ref JSMarshalerArgument arg_1 = ref arguments_buffer[2];// initialized and set by caller
+            try
+            {
+                GCHandle exception_gc_handle = (GCHandle)arg_1.slot.GCHandle;
+                if (exception_gc_handle.Target is Exception exception)
+                {
+                    arg_return.ToJS(exception.StackTrace);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Exception is null");
                 }
             }
             catch (Exception ex)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportExportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportExportTest.cs
@@ -1358,9 +1358,26 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public void JsExportThrows()
         {
-            var ex = Assert.Throws<ArgumentException>(() => JavaScriptTestHelper.invoke1_String("-t-e-s-t-", nameof(JavaScriptTestHelper.Throw)));
+            var ex = Assert.Throws<ArgumentException>(() => JavaScriptTestHelper.invoke1_String("-t-e-s-t-", nameof(JavaScriptTestHelper.ThrowFromJSExport)));
             Assert.DoesNotContain("Unexpected error", ex.Message);
             Assert.Contains("-t-e-s-t-", ex.Message);
+        }
+
+        [Fact]
+        public void JsExportCatchToString()
+        {
+            var toString = JavaScriptTestHelper.catch1toString("-t-e-s-t-", nameof(JavaScriptTestHelper.ThrowFromJSExport));
+            Assert.DoesNotContain("Unexpected error", toString);
+            Assert.Contains("-t-e-s-t-", toString);
+            Assert.DoesNotContain(nameof(JavaScriptTestHelper.ThrowFromJSExport), toString);
+        }
+
+        [Fact]
+        public void JsExportCatchStack()
+        {
+            var stack = JavaScriptTestHelper.catch1stack("-t-e-s-t-", nameof(JavaScriptTestHelper.ThrowFromJSExport));
+            Assert.Contains(nameof(JavaScriptTestHelper.ThrowFromJSExport), stack);
+            Assert.Contains("catch1stack", stack);
         }
 
         #endregion Exception
@@ -1906,12 +1923,12 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             var exThrow0 = Assert.Throws<JSException>(() => JavaScriptTestHelper.throw0());
             Assert.Contains("throw-0-msg", exThrow0.Message);
             Assert.DoesNotContain(" at ", exThrow0.Message);
-            Assert.Contains(" at Module.throw0", exThrow0.StackTrace);
+            Assert.Contains("throw0fn", exThrow0.StackTrace);
 
             var exThrow1 = Assert.Throws<JSException>(() => throw1(value));
             Assert.Contains("throw1-msg", exThrow1.Message);
             Assert.DoesNotContain(" at ", exThrow1.Message);
-            Assert.Contains(" at Module.throw1", exThrow1.StackTrace);
+            Assert.Contains("throw1fn", exThrow1.StackTrace);
 
             // anything is a system.object, sometimes it would be JSObject wrapper
             if (typeof(T).IsPrimitive)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -32,8 +32,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Console.WriteLine(message);
         }
 
+        [JSImport("catch1toString", "JavaScriptTestHelper")]
+        public static partial string catch1toString(string message, string functionName);
+
+        [JSImport("catch1stack", "JavaScriptTestHelper")]
+        public static partial string catch1stack(string message, string functionName);
+
         [JSExport]
-        public static void Throw(string message)
+        public static void ThrowFromJSExport(string message)
         {
             throw new ArgumentException(message);
         }
@@ -57,7 +63,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [return: JSMarshalAs<JSType.String>]
         internal static partial string getClass1();
 
-        [JSImport("throw0", "JavaScriptTestHelper")]
+        [JSImport("throw0fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Discard>]
         internal static partial void throw0();
 
@@ -215,7 +221,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Int32([JSMarshalAs<JSType.Number>] int value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial int throw1_Int32([JSMarshalAs<JSType.Number>] int value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -241,7 +247,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_String([JSMarshalAs<JSType.String>] string value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.String>]
         internal static partial string throw1_String([JSMarshalAs<JSType.String>] string value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -273,7 +279,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Object([JSMarshalAs<JSType.Any>] object value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Any>]
         internal static partial object throw1_Object([JSMarshalAs<JSType.Any>] object value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -299,7 +305,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Exception([JSMarshalAs<JSType.Error>] Exception value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Error>]
         internal static partial Exception throw1_Exception([JSMarshalAs<JSType.Error>] Exception value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -431,7 +437,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Boolean([JSMarshalAs<JSType.Boolean>] bool value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool throw1_Boolean([JSMarshalAs<JSType.Boolean>] bool value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -458,7 +464,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Char([JSMarshalAs<JSType.String>] char value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.String>]
         internal static partial char throw1_Char([JSMarshalAs<JSType.String>] char value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -484,7 +490,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Byte([JSMarshalAs<JSType.Number>] byte value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial byte throw1_Byte([JSMarshalAs<JSType.Number>] byte value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -510,7 +516,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Int16([JSMarshalAs<JSType.Number>] short value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial short throw1_Int16([JSMarshalAs<JSType.Number>] short value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -536,7 +542,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Int52([JSMarshalAs<JSType.Number>] long value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial long throw1_Int52([JSMarshalAs<JSType.Number>] long value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -562,7 +568,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_BigInt64([JSMarshalAs<JSType.BigInt>] long value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.BigInt>]
         internal static partial long throw1_BigInt64([JSMarshalAs<JSType.BigInt>] long value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -588,7 +594,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Double([JSMarshalAs<JSType.Number>] double value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial double throw1_Double([JSMarshalAs<JSType.Number>] double value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -614,7 +620,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_Single([JSMarshalAs<JSType.Number>] float value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial float throw1_Single([JSMarshalAs<JSType.Number>] float value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -640,7 +646,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_IntPtr([JSMarshalAs<JSType.Number>] IntPtr value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial IntPtr throw1_IntPtr([JSMarshalAs<JSType.Number>] IntPtr value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -667,7 +673,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal unsafe static partial bool identity1_VoidPtr([JSMarshalAs<JSType.Number>] void* value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal unsafe static partial void* throw1_VoidPtr([JSMarshalAs<JSType.Number>] void* value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -693,7 +699,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_DateTime([JSMarshalAs<JSType.Date>] DateTime value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Date>]
         internal static partial DateTime throw1_DateTime([JSMarshalAs<JSType.Date>] DateTime value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -719,7 +725,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_DateTimeOffset([JSMarshalAs<JSType.Date>] DateTimeOffset value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Date>]
         internal static partial DateTimeOffset throw1_DateTimeOffset([JSMarshalAs<JSType.Date>] DateTimeOffset value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -746,7 +752,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_NullableBoolean([JSMarshalAs<JSType.Boolean>] bool? value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool? throw1_NullableBoolean([JSMarshalAs<JSType.Boolean>] bool? value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -773,7 +779,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_NullableInt32([JSMarshalAs<JSType.Number>] int? value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial int? throw1_NullableInt32([JSMarshalAs<JSType.Number>] int? value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -800,7 +806,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_NullableBigInt64([JSMarshalAs<JSType.BigInt>] long? value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.BigInt>]
         internal static partial long? throw1_NullableBigInt64([JSMarshalAs<JSType.BigInt>] long? value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -827,7 +833,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_NullableIntPtr([JSMarshalAs<JSType.Number>] IntPtr? value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial IntPtr? throw1_NullableIntPtr([JSMarshalAs<JSType.Number>] IntPtr? value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -854,7 +860,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_NullableDouble([JSMarshalAs<JSType.Number>] double? value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial double? throw1_NullableDouble([JSMarshalAs<JSType.Number>] double? value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -881,7 +887,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_NullableDateTime([JSMarshalAs<JSType.Date>] DateTime? value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Date>]
         internal static partial DateTime? throw1_NullableDateTime([JSMarshalAs<JSType.Date>] DateTime? value);
         [JSImport("invoke1", "JavaScriptTestHelper")]
@@ -907,7 +913,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("identity1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Boolean>]
         internal static partial bool identity1_JSObject([JSMarshalAs<JSType.Object>] JSObject value);
-        [JSImport("throw1", "JavaScriptTestHelper")]
+        [JSImport("throw1fn", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Object>]
         internal static partial JSObject throw1_JSObject([JSMarshalAs<JSType.Object>] JSObject value);
         [JSImport("invoke1", "JavaScriptTestHelper")]

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
@@ -105,12 +105,34 @@ export function retrieve1() {
     return val;
 }
 
-export function throw0() {
+export function throw0fn() {
     //console.log(`throw0()`)
     throw new Error('throw-0-msg');
 }
 
-export function throw1(arg1) {
+export function catch1toString(message, functionName) {
+    const JavaScriptTestHelper = dllExports.System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper;
+    const fn = JavaScriptTestHelper[functionName];
+    try {
+        fn(message);
+        return "bad";
+    } catch (err) {
+        return err.toString();
+    }
+}
+
+export function catch1stack(message, functionName) {
+    const JavaScriptTestHelper = dllExports.System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper;
+    const fn = JavaScriptTestHelper[functionName];
+    try {
+        fn(message);
+        return "bad";
+    } catch (err) {
+        return err.stack;
+    }
+}
+
+export function throw1fn(arg1) {
     //console.log(`throw1(arg1:${arg1 !== null ? arg1 : '<null>'})`)
     throw new Error('throw1-msg ' + arg1);
 }

--- a/src/mono/wasm/runtime/logging.ts
+++ b/src/mono/wasm/runtime/logging.ts
@@ -62,8 +62,9 @@ export function mono_wasm_symbolicate_string(message: string): string {
 
 export function mono_wasm_stringify_as_error_with_stack(err: Error | string): string {
     let errObj: any = err;
-    if (!(err instanceof Error))
-        errObj = new Error(err);
+    if (!(errObj instanceof Error)) {
+        errObj = new Error(errObj);
+    }
 
     // Error
     return mono_wasm_symbolicate_string(errObj.stack);

--- a/src/mono/wasm/runtime/marshal-to-js.ts
+++ b/src/mono/wasm/runtime/marshal-to-js.ts
@@ -32,7 +32,7 @@ export function initialize_marshalers_to_js(): void {
         cs_to_js_marshalers.set(MarshalerType.Single, _marshal_float_to_js);
         cs_to_js_marshalers.set(MarshalerType.IntPtr, _marshal_intptr_to_js);
         cs_to_js_marshalers.set(MarshalerType.Double, _marshal_double_to_js);
-        cs_to_js_marshalers.set(MarshalerType.String, _marshal_string_to_js);
+        cs_to_js_marshalers.set(MarshalerType.String, marshal_string_to_js);
         cs_to_js_marshalers.set(MarshalerType.Exception, marshal_exception_to_js);
         cs_to_js_marshalers.set(MarshalerType.JSException, marshal_exception_to_js);
         cs_to_js_marshalers.set(MarshalerType.JSObject, _marshal_js_object_to_js);
@@ -353,7 +353,7 @@ export function mono_wasm_marshal_promise(args: JSMarshalerArguments): void {
     set_arg_type(exc, MarshalerType.None);
 }
 
-function _marshal_string_to_js(arg: JSMarshalerArgument): string | null {
+export function marshal_string_to_js(arg: JSMarshalerArgument): string | null {
     const type = get_arg_type(arg);
     if (type == MarshalerType.None) {
         return null;
@@ -383,7 +383,7 @@ export function marshal_exception_to_js(arg: JSMarshalerArgument): Error | null 
     let result = _lookup_js_owned_object(gc_handle);
     if (result === null || result === undefined) {
         // this will create new ManagedError
-        const message = _marshal_string_to_js(arg);
+        const message = marshal_string_to_js(arg);
         result = new ManagedError(message!);
 
         setup_managed_proxy(result, gc_handle);
@@ -462,7 +462,7 @@ function _marshal_array_to_js_impl(arg: JSMarshalerArgument, element_type: Marsh
         result = new Array(length);
         for (let index = 0; index < length; index++) {
             const element_arg = get_arg(<any>buffer_ptr, index);
-            result[index] = _marshal_string_to_js(element_arg);
+            result[index] = marshal_string_to_js(element_arg);
         }
         cwraps.mono_wasm_deregister_root(<any>buffer_ptr);
     }

--- a/src/mono/wasm/runtime/marshal.ts
+++ b/src/mono/wasm/runtime/marshal.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { js_owned_gc_handle_symbol, teardown_managed_proxy } from "./gc-handles";
-import { Module } from "./imports";
+import { Module, runtimeHelpers } from "./imports";
 import { getF32, getF64, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8 } from "./memory";
 import { mono_wasm_new_external_root } from "./roots";
 import { mono_assert, GCHandle, JSHandle, MonoObject, MonoString, GCHandleNull, JSMarshalerArguments, JSFunctionSignature, JSMarshalerType, JSMarshalerArgument, MarshalerToJs, MarshalerToCs, WasmRoot } from "./types";
@@ -316,13 +316,31 @@ export class ManagedObject implements IDisposable {
 }
 
 export class ManagedError extends Error implements IDisposable {
+    private superStack: any;
     constructor(message: string) {
         super(message);
+        this.superStack = Object.getOwnPropertyDescriptor(this, "stack"); // this works on Chrome
+        Object.defineProperty(this, "stack", {
+            get: this.getManageStack,
+        });
     }
 
-    get stack(): string | undefined {
-        //todo implement lazy managed stack strace from  this[js_owned_gc_handle_symbol]!
-        return super.stack;
+    getSuperStack() {
+        if (this.superStack) {
+            return this.superStack.value;
+        }
+        return super.stack; // this works on FF
+    }
+
+    getManageStack() {
+        const gc_handle = (<any>this)[js_owned_gc_handle_symbol];
+        if (gc_handle) {
+            const managed_stack = runtimeHelpers.javaScriptExports.get_managed_stack_trace(gc_handle);
+            if (managed_stack) {
+                return managed_stack + "\n" + this.getSuperStack();
+            }
+        }
+        return this.getSuperStack();
     }
 
     dispose(): void {
@@ -331,10 +349,6 @@ export class ManagedError extends Error implements IDisposable {
 
     get isDisposed(): boolean {
         return (<any>this)[js_owned_gc_handle_symbol] === GCHandleNull;
-    }
-
-    toString(): string {
-        return `ManagedError(gc_handle: ${(<any>this)[js_owned_gc_handle_symbol]})`;
     }
 }
 

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -411,6 +411,9 @@ export interface JavaScriptExports {
 
     // the marshaled signature is: void InstallSynchronizationContext()
     install_synchronization_context(): void;
+
+    // the marshaled signature is: string GetManagedStackTrace(GCHandle exception)
+    get_managed_stack_trace(exception_gc_handle: GCHandle): string | null
 }
 
 export type MarshalerToJs = (arg: JSMarshalerArgument, sig?: JSMarshalerType, res_converter?: MarshalerToJs, arg1_converter?: MarshalerToCs, arg2_converter?: MarshalerToCs) => any;


### PR DESCRIPTION
Backport of #75678 to release/7.0-rc2

/cc @pavelsavara @kg

## Customer Impact

Fixes stack trace on managed stack trace, which was marshaled as JavaScript Error. The main impact is that unhanded exceptions from `[JSExport]` will be easier to diagnose than without the managed stack.

## Testing

I done:
- New unit tests
- run unit tests on Chrome, FireFox and NodeJS
- run full CI test suite for wasm on main branch
- manual test

## Risk

Low
There is probably no production code which would rely on this yet, as the `[JSExport]` interop is new in .Net 7.
The stack traces are targeted at human developer and relying on exact text of the stack trace is considered bad practice.