### PR TITLE
[wasm] hide interop delegates from intellisense

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/ref/System.Runtime.InteropServices.JavaScript.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/ref/System.Runtime.InteropServices.JavaScript.cs
@@ -201,7 +201,9 @@ public sealed class JSMarshalerType
 [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
 public struct JSMarshalerArgument
 {
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public delegate void ArgumentToManagedCallback<T>(ref JSMarshalerArgument arg, out T value);
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public delegate void ArgumentToJSCallback<T>(ref JSMarshalerArgument arg, T value);
     public void Initialize() { throw null; }
     public void ToManaged(out bool value) { throw null; }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -13,12 +13,14 @@ namespace System.Runtime.InteropServices.JavaScript
         /// Helps with marshaling of the Task result or Function arguments.
         /// It's used by JSImport code generator and should not be used by developers in source code.
         /// </summary>
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public delegate void ArgumentToManagedCallback<T>(ref JSMarshalerArgument arg, out T value);
 
         /// <summary>
         /// Helps with marshaling of the Task result or Function arguments.
         /// It's used by JSImport code generator and should not be used by developers in source code.
         /// </summary>
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public delegate void ArgumentToJSCallback<T>(ref JSMarshalerArgument arg, T value);
 
         /// <summary>


### PR DESCRIPTION
There are delegate types `ArgumentToManagedCallback<>` and `ArgumentToJSCallback<>` which are used by Roslyn code generator of the JavaScript interop. 

They are not intended to be used directly by the developer and we could hide them from intellisense.

Related discussion https://github.com/dotnet/dotnet-api-docs/pull/8392#issuecomment-1249770289