### PR TITLE
[NativeAOT] Make conservative stack reporting configurable.

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -94,7 +94,6 @@ static char& __unbox_z = __stop___unbox;
 #endif // _MSC_VER
 
 extern "C" bool RhInitialize();
-extern "C" void RhpEnableConservativeStackReporting();
 extern "C" void RhpShutdown();
 extern "C" void RhSetRuntimeInitializationCallback(int (*fPtr)());
 
@@ -151,8 +150,6 @@ static int InitializeRuntime()
 {
     if (!RhInitialize())
         return -1;
-
-    // RhpEnableConservativeStackReporting();
 
     void * osModule = PalGetModuleHandleFromPointer((void*)&NATIVEAOT_ENTRYPOINT);
 

--- a/src/coreclr/nativeaot/Runtime/RhConfigValues.h
+++ b/src/coreclr/nativeaot/Runtime/RhConfigValues.h
@@ -16,6 +16,7 @@ DEBUG_CONFIG_VALUE_WITH_DEFAULT(BreakOnAssert, 1)
 RETAIL_CONFIG_VALUE(StressLogLevel)
 RETAIL_CONFIG_VALUE(TotalStressLogSize)
 RETAIL_CONFIG_VALUE(gcServer)
+RETAIL_CONFIG_VALUE(GcConservativeStacks)    // Enables conservative stack reporting
 DEBUG_CONFIG_VALUE(GcStressThrottleMode)    // gcstm_TriggerAlways / gcstm_TriggerOnFirstHit / gcstm_TriggerRandom
 DEBUG_CONFIG_VALUE(GcStressFreqCallsite)    // Number of times to force GC out of GcStressFreqDenom (for GCSTM_RANDOM)
 DEBUG_CONFIG_VALUE(GcStressFreqLoop)        // Number of times to force GC out of GcStressFreqDenom (for GCSTM_RANDOM)

--- a/src/coreclr/nativeaot/Runtime/RhConfigValues.h
+++ b/src/coreclr/nativeaot/Runtime/RhConfigValues.h
@@ -16,7 +16,7 @@ DEBUG_CONFIG_VALUE_WITH_DEFAULT(BreakOnAssert, 1)
 RETAIL_CONFIG_VALUE(StressLogLevel)
 RETAIL_CONFIG_VALUE(TotalStressLogSize)
 RETAIL_CONFIG_VALUE(gcServer)
-RETAIL_CONFIG_VALUE(GcConservativeStacks)    // Enables conservative stack reporting
+RETAIL_CONFIG_VALUE(GcConservativeStacks)   // Enables conservative stack reporting
 DEBUG_CONFIG_VALUE(GcStressThrottleMode)    // gcstm_TriggerAlways / gcstm_TriggerOnFirstHit / gcstm_TriggerRandom
 DEBUG_CONFIG_VALUE(GcStressFreqCallsite)    // Number of times to force GC out of GcStressFreqDenom (for GCSTM_RANDOM)
 DEBUG_CONFIG_VALUE(GcStressFreqLoop)        // Number of times to force GC out of GcStressFreqDenom (for GCSTM_RANDOM)

--- a/src/coreclr/nativeaot/Runtime/RhConfigValues.h
+++ b/src/coreclr/nativeaot/Runtime/RhConfigValues.h
@@ -16,7 +16,7 @@ DEBUG_CONFIG_VALUE_WITH_DEFAULT(BreakOnAssert, 1)
 RETAIL_CONFIG_VALUE(StressLogLevel)
 RETAIL_CONFIG_VALUE(TotalStressLogSize)
 RETAIL_CONFIG_VALUE(gcServer)
-RETAIL_CONFIG_VALUE(GcConservativeStacks)   // Enables conservative stack reporting
+RETAIL_CONFIG_VALUE(gcConservative)         // Enables conservative stack reporting
 DEBUG_CONFIG_VALUE(GcStressThrottleMode)    // gcstm_TriggerAlways / gcstm_TriggerOnFirstHit / gcstm_TriggerRandom
 DEBUG_CONFIG_VALUE(GcStressFreqCallsite)    // Number of times to force GC out of GcStressFreqDenom (for GCSTM_RANDOM)
 DEBUG_CONFIG_VALUE(GcStressFreqLoop)        // Number of times to force GC out of GcStressFreqDenom (for GCSTM_RANDOM)

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -177,6 +177,11 @@ bool RedhawkGCInterface::InitializeSubsystems()
     g_heap_type = GC_HEAP_WKS;
 #endif
 
+    if (g_pRhConfig->GetGcConservativeStacks())
+    {
+        GetRuntimeInstance()->EnableConservativeStackReporting();
+    }
+
     HRESULT hr = GCHeapUtilities::InitializeDefaultGC();
     if (FAILED(hr))
         return false;

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -177,7 +177,7 @@ bool RedhawkGCInterface::InitializeSubsystems()
     g_heap_type = GC_HEAP_WKS;
 #endif
 
-    if (g_pRhConfig->GetGcConservativeStacks())
+    if (g_pRhConfig->GetgcConservative())
     {
         GetRuntimeInstance()->EnableConservativeStackReporting();
     }

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -466,11 +466,6 @@ extern "C" bool RhInitialize()
     return true;
 }
 
-COOP_PINVOKE_HELPER(void, RhpEnableConservativeStackReporting, ())
-{
-    GetRuntimeInstance()->EnableConservativeStackReporting();
-}
-
 //
 // Currently called only from a managed executable once Main returns, this routine does whatever is needed to
 // cleanup managed state before exiting. There's not a lot here at the moment since we're always about to let


### PR DESCRIPTION

Conservative stack reporting is a convenient option when investigating issues with suspension/unwinding/root reporting.
Having to rebuild the runtime and testcases in order to switch is not convenient though as switching back and forth takes a very long time.

This change allows turning conservative stack reporting off/on via environment variable.