### PR TITLE
No need to try hijack/suspend GC threads

### DIFF
--- a/src/coreclr/gc/sample/gcenv.h
+++ b/src/coreclr/gc/sample/gcenv.h
@@ -122,7 +122,7 @@ public:
         return (alloc_context *)&m_alloc_context;
     }
 
-    void SetGCSpecial(bool fGCSpecial)
+    void SetGCSpecial()
     {
     }
 };

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -992,9 +992,6 @@ HRESULT ETW::GCLog::ForceGCForDiagnostics()
         ThreadStore::AttachCurrentThread();
         Thread* pThread = ThreadStore::GetCurrentThread();
 
-        // Doing this prevents the GC from trying to walk this thread's stack for roots.
-        pThread->SetGCSpecial(true);
-
         // While doing the GC, much code assumes & asserts the thread doing the GC is in
         // cooperative mode.
         pThread->DisablePreemptiveMode();

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -1239,7 +1239,7 @@ bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool i
             ThreadStore::AttachCurrentThread(false);
         }
 
-        ThreadStore::RawGetCurrentThread()->SetGCSpecial(true);
+        ThreadStore::RawGetCurrentThread()->SetGCSpecial();
 
         auto realStartRoutine = pStartContext->m_pRealStartRoutine;
         void* realContext = pStartContext->m_pRealContext;

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -309,10 +309,15 @@ void Thread::SetGCSpecial(bool isGCSpecial)
 {
     if (!IsInitialized())
         Construct();
+
     if (isGCSpecial)
+    {
         SetState(TSF_IsGcSpecialThread);
+    }
     else
-        ClearState(TSF_IsGcSpecialThread);
+    {
+        UNREACHABLE_MSG("GC thread should never switch back to become an ordinary thread.");
+    }
 }
 
 bool Thread::IsGCSpecial()
@@ -600,6 +605,12 @@ void Thread::Hijack()
     if (m_hPalThread == INVALID_HANDLE_VALUE)
     {
         // cannot proceed
+        return;
+    }
+
+    if (IsGCSpecial())
+    {
+        // GC threads can not be forced to run preemptively, so we will not try.
         return;
     }
 

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -305,19 +305,12 @@ bool Thread::IsInitialized()
 // -----------------------------------------------------------------------------------------------------------
 // GC support APIs - do not use except from GC itself
 //
-void Thread::SetGCSpecial(bool isGCSpecial)
+void Thread::SetGCSpecial()
 {
     if (!IsInitialized())
         Construct();
 
-    if (isGCSpecial)
-    {
-        SetState(TSF_IsGcSpecialThread);
-    }
-    else
-    {
-        UNREACHABLE_MSG("GC thread should never switch back to become an ordinary thread.");
-    }
+    SetState(TSF_IsGcSpecialThread);
 }
 
 bool Thread::IsGCSpecial()

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -263,7 +263,7 @@ public:
     //
     // GC support APIs - do not use except from GC itself
     //
-    void SetGCSpecial(bool isGCSpecial);
+    void SetGCSpecial();
     bool IsGCSpecial();
     bool CatchAtSafePoint();
 

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1397,7 +1397,7 @@ namespace
             assert(args != nullptr);
 
             ClrFlsSetThreadType(ThreadType_GC);
-            args->Thread->SetGCSpecial(true);
+            args->Thread->SetGCSpecial();
             STRESS_LOG_RESERVE_MEM(GC_STRESSLOG_MULTIPLY);
             args->HasStarted = !!args->Thread->HasStarted();
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -4260,7 +4260,7 @@ public:
 
     // GC calls this when creating special threads that also happen to have an EE Thread
     // object associated with them (e.g., the bgc thread).
-    void SetGCSpecial(bool fGCSpecial);
+    void SetGCSpecial();
 
 private:
 

--- a/src/coreclr/vm/threads.inl
+++ b/src/coreclr/vm/threads.inl
@@ -165,10 +165,10 @@ inline bool Thread::IsGCSpecial()
     return m_fGCSpecial;
 }
 
-inline void Thread::SetGCSpecial(bool fGCSpecial)
+inline void Thread::SetGCSpecial()
 {
     LIMITED_METHOD_CONTRACT;
-    m_fGCSpecial = fGCSpecial;
+    m_fGCSpecial = true;
 }
 
 #if !defined(DACCESS_COMPILE)

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -3394,6 +3394,12 @@ void ThreadSuspend::SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason)
                 continue;
             }
 
+            if (thread->IsGCSpecial())
+            {
+                // GC threads can not be forced to run preemptively, so we will not try.
+                continue;
+            }
+
             // this is an interesting thread in cooperative mode, let's guide it to preemptive
 
             if (!Thread::UseContextBasedThreadRedirection())


### PR DESCRIPTION

Re: https://github.com/dotnet/runtime/pull/75421#issuecomment-1250348875

>> background GC thread received a SIGUSR1 signal

>Yes, this is normal. Every complete GC cycle has at least one blocking stage that needs exclusive access to the stacks and heap. Background GC threads need to be stopped together with user code. 
When background GC is active, its threads run in coop mode. They are not managed code, but they regularly poll if they should suspend themselves.

There is no point in trying to suspend GC threads asynchronously though. That will never succeed, so it is counterproductive.
It has not come up before, but not trying to suspend GC threads could be a trivial and useful optimization, especially on a manycore machines that could run a lot of BG threads. 

 @filipnavara I'll put up a PR. Thanks for bringing this up!
