### PR TITLE
[release/6.0] Multi-targeting logic in Source Generators in NuGet packages doesn't work transitively

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -6,8 +6,8 @@
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">6.0.0</PackageValidationBaselineVersion>
     <!-- PackDependsOn is the right hook in a targets file if the NuGet.Build.Tasks.Pack nuget package is used, otherwise
          BeforePack must be used. Setting both to ensure that we are always running before other targets. -->
-    <PackDependsOn>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(PackDependsOn)</PackDependsOn>
-    <BeforePack>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(BeforePack)</BeforePack>
+    <PackDependsOn>IncludeAnalyzersInPackage;AddNETStandardCompatErrorFileForPackaging;$(PackDependsOn)</PackDependsOn>
+    <BeforePack>IncludeAnalyzersInPackage;AddNETStandardCompatErrorFileForPackaging;$(BeforePack)</BeforePack>
     <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddRuntimeSpecificFilesToPackage;IncludePrivateProjectReferencesWithPackAttributeInPackage</TargetsForTfmSpecificContentInPackage>
     <TargetsForTfmSpecificDebugSymbolsInPackage>$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
@@ -175,9 +175,8 @@
           Condition="'@(AnalyzerReference)' != '' and '$(IncludeMultiTargetRoslynComponentTargets)' == 'true'"
           DependsOnTargets="GenerateMultiTargetRoslynComponentTargetsFile">
     <ItemGroup>
-      <Content Include="$(MultiTargetRoslynComponentTargetsFileIntermediatePath)"
-               PackagePath="build\$(PackageId).targets"
-               Pack="True" />
+      <Content Include="$(MultiTargetRoslynComponentTargetsFileIntermediatePath)" PackagePath="buildTransitive\netstandard2.0\$(PackageId).targets" />
+      <Content Include="$(MultiTargetRoslynComponentTargetsFileIntermediatePath)" PackagePath="buildTransitive\%(NETStandardCompatError.Supported)\$(PackageId).targets" Condition="'@(NETStandardCompatError)' != ''" />
     </ItemGroup>
   </Target>
 
@@ -224,6 +223,7 @@
   </Target>
 </Project>]]>
       </_NETStandardCompatErrorFileContent>
+      <_NETStandardCompatErrorPlaceholderFilePackagePath>buildTransitive$([System.IO.Path]::DirectorySeparatorChar)%(NETStandardCompatError.Supported)</_NETStandardCompatErrorPlaceholderFilePackagePath>
     </PropertyGroup>
 
     <WriteLinesToFile File="$(_NETStandardCompatErrorFilePath)"
@@ -232,12 +232,19 @@
                       WriteOnlyWhenDifferent="true" />
 
     <ItemGroup>
+      <_PackageBuildFile Include="@(None->Metadata('PackagePath'));
+                                  @(Content->Metadata('PackagePath'))" />
+      <_PackageBuildFile PackagePathWithoutFilename="$([System.IO.Path]::GetDirectoryName('%(Identity)'))" />
+
       <None Include="$(_NETStandardCompatErrorFilePath)"
             PackagePath="buildTransitive\%(NETStandardCompatError.Identity)"
             Pack="true" />
+      <!-- Add the placeholder file to the supported target framework buildTransitive folder, if it's empty. -->
       <None Include="$(PlaceholderFile)"
-            PackagePath="buildTransitive\%(NETStandardCompatError.Supported)"
-            Pack="true" />
+            PackagePath="$(_NETStandardCompatErrorPlaceholderFilePackagePath)\"
+            Pack="true"
+            Condition="'@(_PackageBuildFile)' == '' or
+                       !@(_PackageBuildFile->AnyHaveMetadataValue('PackagePathWithoutFilename', '$(_NETStandardCompatErrorPlaceholderFilePackagePath)'))" />
       <FileWrites Include="$(_NETStandardCompatErrorFilePath)" />
     </ItemGroup>
   </Target>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -17,8 +17,8 @@ Microsoft.Extensions.Logging.LogLevel
 Microsoft.Extensions.Logging.Logger&lt;T&gt;
 Microsoft.Extensions.Logging.LoggerMessage
 Microsoft.Extensions.Logging.Abstractions.NullLogger</PackageDescription>
-    <ServicingVersion>2</ServicingVersion>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>3</ServicingVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -9,8 +9,8 @@
     <Nullable>enable</Nullable>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ServicingVersion>6</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>7</ServicingVersion>
     <PackageDescription>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.
 
 Commonly Used Types:


### PR DESCRIPTION
Partial backport of https://github.com/dotnet/runtime/commit/538934c25f6b0977cc1ecef1d5ecbab42c7937a0 to release/6.0.

## Customer Impact

When developers use our NuGet packages that contain source generators (i.e. `System.Text.Json` and `Microsoft.Extensions.Logging.Abstractions`), the MSBuild logic in it isn't transitively included. This makes 3 things harder:

1. Prevents the generator from being deduplicated (we ship multiple versions in the NuGet package)
2. Prevents the generator from being used
3. Prevents the generator from being disabled (when users don't want to use it at all).

Multiple customers have run into this either trying to use or disable the source generators. Their current workaround is to reference the NuGet package directly, but that is a major hassle for projects that contain many .csproj files.

## Testing

I've manually tested using the 2 NuGet packages transitively and ensured the MSBuild logic is executed correctly.

## Risk

The changes are isolated to just the 2 NuGet packages that contain source generators. It is moving the currently logic from the `build` folder, which only gets included when the package is referenced directly, to the `buildTransitive` folder, which is always included when the package is transitively referenced. Since the logic hasn't changed, this should be a low risk.

### Description

When packages that contain source generators (System.Text.Json and Microsoft.Extensions.Logging.Abstractions) are referenced transitively, the MSBuild logic that controls which source generator version gets picked, and allows for disabling the source generator, doesn't get used in the build. This is because the MSBuild logic is in the "build" folder and not the "buildTransitive" folder.

The fix is to move the logic from the "build" to "buildTransitive" folder in the NuGet package. However, we need to also fix up the "NETStandard Compat" build logic to skip adding a placeholder file when the "buildTransitive" folder is not empty.

This is a partial backport of https://github.com/dotnet/runtime/commit/538934c25f6b0977cc1ecef1d5ecbab42c7937a0.

Here is the diff between the `System.Text.Json v6.0.6` package from nuget.org and my local build:

![image](https://user-images.githubusercontent.com/8291187/190929594-e2d38cbc-57de-4ced-ac02-28051e41200b.png)

Fix #60870