### PR TITLE
Ensure GenTree::isCommutativeHWIntrinsic works on Arm64

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18665,7 +18665,6 @@ bool GenTree::isCommutativeHWIntrinsic() const
 {
     assert(gtOper == GT_HWINTRINSIC);
 
-#ifdef TARGET_XARCH
     const GenTreeHWIntrinsic* node = AsHWIntrinsic();
     NamedIntrinsic            id   = node->GetHWIntrinsicId();
 
@@ -18678,6 +18677,7 @@ bool GenTree::isCommutativeHWIntrinsic() const
     {
         switch (id)
         {
+#ifdef TARGET_XARCH
             case NI_SSE_Max:
             case NI_SSE_Min:
             {
@@ -18695,6 +18695,7 @@ bool GenTree::isCommutativeHWIntrinsic() const
             {
                 return false;
             }
+#endif // TARGET_XARCH
 
             default:
             {
@@ -18702,7 +18703,6 @@ bool GenTree::isCommutativeHWIntrinsic() const
             }
         }
     }
-#endif // TARGET_XARCH
 
     return false;
 }


### PR DESCRIPTION
This is a continuation of https://github.com/dotnet/runtime/pull/75683 where I noticed that `Arm64` was hardcoded to just return false.

I expect a few diffs due to CSE and maybe lowering (where we have like 1 check), but don't expect it to be nearly as meaningful as x64. This is because because Arm64 is not RMW for most instructions and so commutativity isn't as important.