### PR TITLE
Fix grammatical error in #75831.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -866,8 +866,8 @@ namespace System.Collections.Generic
             return Array.LastIndexOf(_items, item, index, count);
         }
 
-        // Removes the first occurrence given element, if found. The size of the list is
-        // decreased by one.
+        // Removes the first occurrence of the given element, if found.
+        // The size of the list is decreased by one if successful.
         public bool Remove(T item)
         {
             int index = IndexOf(item);


### PR DESCRIPTION
In response to feedback from https://github.com/dotnet/runtime/pull/75831#pullrequestreview-1112287106