### PR TITLE
Ensure that the VNFunc for HWIntrinsics are properly marked as commutative where possible

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7028,6 +7028,12 @@ void ValueNumStore::InitValueNumStoreStatics()
 
             ValueNumFuncSetArity(func, newArity);
         }
+
+        if (HWIntrinsicInfo::IsCommutative(id))
+        {
+            VNFunc func = VNFunc(VNF_HWI_FIRST + (id - NI_HW_INTRINSIC_START - 1));
+            vnfOpAttribs[func] |= VNFOA_Commutative;
+        }
     }
 
 #endif // FEATURE_HW_INTRINSICS


### PR DESCRIPTION
This ensures that VN recognizes commutative HWIntrinsics as commutative. It not being set is likely why https://github.com/dotnet/runtime/pull/75818 had no diffs.

Notably there are some intrinsics which are "maybe commutative". These either require special handling (due to taking more than 2 operands) or require checking that one of the inputs is constant and within the bounds of a particular optimization. Such intrinsics aren't being handled as part of this change.