### PR TITLE
Fail-fast on SuspendThread/ResumeThread failures

### DIFF
--- a/src/coreclr/inc/clrhost.h
+++ b/src/coreclr/inc/clrhost.h
@@ -92,6 +92,14 @@ typedef Holder<CRITSEC_COOKIE, ClrEnterCriticalSection, ClrLeaveCriticalSection,
 FORCEINLINE void VoidClrDeleteCriticalSection(CRITSEC_COOKIE cs) { if (cs != NULL) ClrDeleteCriticalSection(cs); }
 typedef Wrapper<CRITSEC_COOKIE, DoNothing<CRITSEC_COOKIE>, VoidClrDeleteCriticalSection, NULL> CRITSEC_AllocationHolder;
 
+#ifndef DACCESS_COMPILE
+// Suspend/resume APIs that fail-fast on errors
+#ifdef TARGET_WINDOWS
+DWORD ClrSuspendThread(HANDLE hThread);
+#endif // TARGET_WINDOWS
+DWORD ClrResumeThread(HANDLE hThread);
+#endif // !DACCESS_COMPILE
+
 DWORD GetClrModulePathName(SString& buffer);
 
 extern thread_local int t_CantAllocCount;

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -575,7 +575,7 @@ DWORD Thread::StartThread()
 #endif
 
     _ASSERTE (GetThreadHandle() != INVALID_HANDLE_VALUE);
-    DWORD dwRetVal = ::ResumeThread(GetThreadHandle());
+    DWORD dwRetVal = ClrResumeThread(GetThreadHandle());
     return dwRetVal;
 }
 

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -250,7 +250,7 @@ Thread::SuspendThreadResult Thread::SuspendThread(BOOL fOneTryOnly, DWORD *pdwSu
             if (InterlockedOr(&m_dwForbidSuspendThread, 0))
             {
 #if defined(_DEBUG)
-                // Enable the diagnostic ::SuspendThread() if the
+                // Enable the diagnostic ClrSuspendThread() if the
                 //     DiagnosticSuspend config setting is set.
                 // This will interfere with the mutual suspend race but it's
                 //     here only for diagnostic purposes anyway
@@ -259,7 +259,7 @@ Thread::SuspendThreadResult Thread::SuspendThread(BOOL fOneTryOnly, DWORD *pdwSu
                     goto retry;
             }
 
-            dwSuspendCount = ::SuspendThread(hThread);
+            dwSuspendCount = ClrSuspendThread(hThread);
 
             //
             // Since SuspendThread is asynchronous, we now must wait for the thread to
@@ -271,7 +271,7 @@ Thread::SuspendThreadResult Thread::SuspendThread(BOOL fOneTryOnly, DWORD *pdwSu
             {
                 if (!EnsureThreadIsSuspended(hThread, this))
                 {
-                    ::ResumeThread(hThread);
+                    ClrResumeThread(hThread);
                     str = STR_Failure;
                     break;
                 }
@@ -308,7 +308,7 @@ Thread::SuspendThreadResult Thread::SuspendThread(BOOL fOneTryOnly, DWORD *pdwSu
                     ++nCnt;
                 }
 #endif // _DEBUG
-                ::ResumeThread(hThread);
+                ClrResumeThread(hThread);
 
 #if defined(_DEBUG)
                 // If the suspend diagnostics are enabled we need to spin here in order to avoid
@@ -388,10 +388,10 @@ retry:
 
         if (i64TimestampCur - i64TimestampStart >= i64TimestampTicksMax)
         {
-            dwSuspendCount = ::SuspendThread(hThread);
+            dwSuspendCount = ClrSuspendThread(hThread);
             _ASSERTE(!"It takes too long to suspend a thread");
             if ((int)dwSuspendCount >= 0)
-                ::ResumeThread(hThread);
+                ClrResumeThread(hThread);
         }
 #endif // _DEBUG
 
@@ -444,8 +444,8 @@ DWORD Thread::ResumeThread()
 
     _ASSERTE (m_ThreadHandleForResume != INVALID_HANDLE_VALUE);
 
-    //DWORD res = ::ResumeThread(GetThreadHandle());
-    DWORD res = ::ResumeThread(m_ThreadHandleForResume);
+    //DWORD res = ClrResumeThread(GetThreadHandle());
+    DWORD res = ClrResumeThread(m_ThreadHandleForResume);
     _ASSERTE (res != 0 && "Thread is not previously suspended");
 #ifdef _DEBUG_IMPL
     _ASSERTE (!m_Creator.IsCurrentThread());
@@ -3996,8 +3996,8 @@ BOOL Thread::HandleJITCaseForAbort()
     return FALSE;
 }
 
-// Threads suspended by the Win32 ::SuspendThread() are resumed in two ways.  If we
-// suspended them in error, they are resumed via the Win32 ::ResumeThread().  But if
+// Threads suspended by ClrSuspendThread() are resumed in two ways.  If we
+// suspended them in error, they are resumed via ClrResumeThread().  But if
 // this is the HandledJIT() case and the thread is in fully interruptible code, we
 // can resume them under special control.  ResumeRuntime and UserResume are cases
 // of this.


### PR DESCRIPTION
- They would fail typically if the handle is invalid (perhaps because it was erroneously closed, or it's not a thread handle).
- In the places where they are called the handle should be a valid thread handle. Failures can lead to less desirable behaviors, like a deadlock. Added and used `ClrSuspendThread` and `ClrResumeThread` instead, which check for errors and fail-fast.

Fixes https://github.com/dotnet/runtime/issues/13327