### PR TITLE
Updating the initial capacity of the intrinsic TypeConverter dictionary

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -157,10 +157,11 @@ namespace System.ComponentModel
             [RequiresUnreferencedCode("NullableConverter's UnderlyingType cannot be statically discovered.")]
             get
             {
-                return LazyInitializer.EnsureInitialized(ref s_intrinsicTypeConverters, () => new Dictionary<object, IntrinsicTypeConverterData>(27)
+                return LazyInitializer.EnsureInitialized(ref s_intrinsicTypeConverters, () => new Dictionary<object, IntrinsicTypeConverterData>(32)
                 {
                     // Add the intrinsics
                     //
+                    // When modifying this list, be sure to update the initial dictionary capacity above
                     [typeof(bool)] = new IntrinsicTypeConverterData((type) => new BooleanConverter()),
                     [typeof(byte)] = new IntrinsicTypeConverterData((type) => new ByteConverter()),
                     [typeof(sbyte)] = new IntrinsicTypeConverterData((type) => new SByteConverter()),


### PR DESCRIPTION
We added 5 new intrinsic TypeConverters in https://github.com/dotnet/runtime/commit/367fe33ea0a25392980f44f76307e210813228fb but missed updating the dictionary capacity.