### PR TITLE
Use CommonPrefixLength for SetOf sort validation

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/SetOfValueComparer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/SetOfValueComparer.cs
@@ -18,13 +18,9 @@ namespace System.Formats.Asn1
             int diff;
 
 #if NET7_0_OR_GREATER
-            int diffIndex = x.Slice(0, min).CommonPrefixLength(y.Slice(0, min));
+            int diffIndex = x.CommonPrefixLength(y);
 
-            if (diffIndex == min)
-            {
-                diff = 0;
-            }
-            else
+            if (diffIndex != min)
             {
                 return (int)x[diffIndex] - y[diffIndex];
             }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/SetOfValueComparer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/SetOfValueComparer.cs
@@ -17,6 +17,18 @@ namespace System.Formats.Asn1
             int min = Math.Min(x.Length, y.Length);
             int diff;
 
+#if NET7_0_OR_GREATER
+            int diffIndex = x.Slice(0, min).CommonPrefixLength(y.Slice(0, min));
+
+            if (diffIndex == min)
+            {
+                diff = 0;
+            }
+            else
+            {
+                return (int)x[diffIndex] - y[diffIndex];
+            }
+#else
             for (int i = 0; i < min; i++)
             {
                 int xVal = x[i];
@@ -28,6 +40,7 @@ namespace System.Formats.Asn1
                     return diff;
                 }
             }
+#endif
 
             // The sorting rules (T-REC-X.690-201508 sec 11.6) say that the shorter one
             // counts as if it are padded with as many 0x00s on the right as required for


### PR DESCRIPTION
Since `CommonPrefixLength` is optimized and vectorized, this gives a small perf bump when validating ASN.1 SetOf sorting for "large" (greater than 16 elements). For small inputs the perf change is negligible.

Note in the table below for `SetOf_CorrectSort`, it shows as being 1ns slower, but other runs it ends up coming out faster, but all within a ns of each other.


|                   Method |        Job | Toolchain |         Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------- |----------- |---------- |-------------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|              SetOf_Empty | Job-GLTSSG |    branch |     11.96 ns |  0.016 ns |  0.013 ns |  1.00 |      - |     - |     - |         - |
|              SetOf_Empty | Job-AXNJXB |      main |     11.95 ns |  0.003 ns |  0.002 ns |  1.00 |      - |     - |     - |         - |
|                          |            |           |              |           |           |       |        |       |       |           |
|      SetOf_IncorrectSort | Job-GLTSSG |    branch | 13,903.47 ns |  9.506 ns |  8.427 ns |  1.00 | 0.0458 |     - |     - |     320 B |
|      SetOf_IncorrectSort | Job-AXNJXB |      main | 13,928.41 ns | 10.076 ns |  8.414 ns |  1.00 | 0.0458 |     - |     - |     320 B |
|                          |            |           |              |           |           |       |        |       |       |           |
| SetOf_LargeIncorrectSort | Job-GLTSSG |    branch | 13,762.73 ns | 12.703 ns | 11.261 ns |  0.99 | 0.0458 |     - |     - |     320 B |
| SetOf_LargeIncorrectSort | Job-AXNJXB |      main | 13,892.17 ns | 11.766 ns | 10.430 ns |  1.00 | 0.0458 |     - |     - |     320 B |
|                          |            |           |              |           |           |       |        |       |       |           |
|        SetOf_CorrectSort | Job-GLTSSG |    branch |     35.48 ns |  0.033 ns |  0.027 ns |  1.12 |      - |     - |     - |         - |
|        SetOf_CorrectSort | Job-AXNJXB |      main |     34.48 ns |  0.040 ns |  0.038 ns |  1.00 |      - |     - |     - |         - |
|                          |            |           |              |           |           |       |        |       |       |           |
|   SetOf_LargeCorrectSort | Job-GLTSSG |    branch |     43.50 ns |  0.137 ns |  0.128 ns |  0.82 |      - |     - |     - |         - |
|   SetOf_LargeCorrectSort | Job-AXNJXB |      main |     53.04 ns |  0.046 ns |  0.043 ns |  1.00 |      - |     - |     - |         - |