### PR TITLE
Fix querying L3 cache size on osx-x64

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -968,10 +968,11 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);
         const bool success = false
-            // macOS-arm64: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency
+            // macOS: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency
             // and performance cores separately. "perflevel0" stands for "performance"
+            || sysctlbyname("hw.perflevel0.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.perflevel0.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
-            // macOS-arm64: these report cache sizes for efficiency cores only:
+            // macOS: these report cache sizes for efficiency cores only:
             || sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -636,10 +636,11 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);
         const bool success = false
-            // macOS-arm64: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency
+            // macOS: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency
             // and performance cores separately. "perflevel0" stands for "performance"
+            || sysctlbyname("hw.perflevel0.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.perflevel0.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
-            // macOS-arm64: these report cache sizes for efficiency cores only:
+            // macOS: these report cache sizes for efficiency cores only:
             || sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;


### PR DESCRIPTION
Originally reported [here](https://github.com/dotnet/runtime/pull/75421#issuecomment-1251447746):

The [code for determining the L3 cache size](https://github.com/dotnet/runtime/blob/0bce5f69ee027fd148a8d878af5642726ad36a19/src/coreclr/gc/unix/gcenv.unix.cpp#L970-L978) returns incorrect value on osx-x64. The machine I use for testing is running macOS 12.2.1 on Intel i5-8500B processor. This processor has 9MB of L3 cache but only 256Kb of L2 cache. The ARM64 fix for checking `hw.perflevel0.l2cachesize` mistakenly returns the L2 cache size on this machine. This in turn results in abysmal GC performance (on debug builds, at least) and frequent garbage collections.

Values on Intel:
```
teamcity@172-4-1-71 runtime % sysctl hw.perflevel0.l2cachesize
hw.perflevel0.l2cachesize: 262144
teamcity@172-4-1-71 runtime % sysctl hw.perflevel0.l3cachesize
hw.perflevel0.l3cachesize: 9437184
teamcity@172-4-1-71 runtime % sysctl hw.l3cachesize           
hw.l3cachesize: 9437184
```

Values on M1:
```
filipnavara@172-4-1-20 runtime % sysctl hw.perflevel0.l2cachesize
hw.perflevel0.l2cachesize: 12582912
filipnavara@172-4-1-20 runtime % sysctl hw.perflevel0.l3cachesize
filipnavara@172-4-1-20 runtime % sysctl hw.l3cachesize
```
