### PR TITLE
Fixing SpanHelpers.LastIndexOfAnyValueType to no longer create out of bounds GC refs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -2169,7 +2169,8 @@ namespace System
                     return ComputeLastIndex(offset, equals);
                 }
 
-                // If any elements remain, process the first vector in the search space.
+                // Process the first vector in the search space.
+
                 equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref searchSpace)));
 
                 if (equals != Vector256<TValue>.Zero)
@@ -2197,7 +2198,7 @@ namespace System
                 }
 
 
-                // If any elements remain, process the first vector in the search space.
+                // Process the first vector in the search space.
 
                 equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref searchSpace)));
 
@@ -2306,7 +2307,7 @@ namespace System
                     return ComputeLastIndex(offset, equals);
                 }
 
-                // If any elements remain, process the first vector in the search space.
+                // Process the first vector in the search space.
 
                 current = Vector256.LoadUnsafe(ref searchSpace);
                 equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1));
@@ -2335,7 +2336,7 @@ namespace System
                     return ComputeLastIndex(offset, equals);
                 }
 
-                // If any elements remain, process the first vector in the search space.
+                // Process the first vector in the search space.
 
                 current = Vector128.LoadUnsafe(ref searchSpace);
                 equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1));
@@ -2445,7 +2446,7 @@ namespace System
                     return ComputeLastIndex(offset, equals);
                 }
 
-                // If any elements remain, process the first vector in the search space.
+                // Process the first vector in the search space.
 
                 current = Vector256.LoadUnsafe(ref searchSpace);
                 equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1) | Vector256.Equals(current, values2));
@@ -2475,7 +2476,7 @@ namespace System
                     return ComputeLastIndex(offset, equals);
                 }
 
-                // If any elements remain, process the first vector in the search space.
+                // Process the first vector in the search space.
 
                 current = Vector128.LoadUnsafe(ref searchSpace);
                 equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2));
@@ -2557,7 +2558,7 @@ namespace System
                     return ComputeLastIndex(offset, equals);
                 }
 
-                // If any elements remain, process the first vector in the search space.
+                // Process the first vector in the search space.
 
                 current = Vector256.LoadUnsafe(ref searchSpace);
                 equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1) | Vector256.Equals(current, values2) | Vector256.Equals(current, values3));
@@ -2587,7 +2588,7 @@ namespace System
                     return ComputeLastIndex(offset, equals);
                 }
 
-                // If any elements remain, process the first vector in the search space.
+                // Process the first vector in the search space.
 
                 current = Vector128.LoadUnsafe(ref searchSpace);
                 equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2) | Vector128.Equals(current, values3));

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -2153,59 +2153,57 @@ namespace System
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
                 Vector256<TValue> equals, values = Vector256.Create(value);
-                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+                nint offset = length - Vector256<TValue>.Count;
 
-                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
+                // Loop until either we've finished all elements -or- there's one or less than a vector's-worth remaining.
+                while (offset > 0)
                 {
-                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref currentSearchSpace)));
+                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref searchSpace, (nuint)(offset))));
+
                     if (equals == Vector256<TValue>.Zero)
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<TValue>.Count);
+                        offset -= Vector256<TValue>.Count;
                         continue;
                     }
 
-                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                    return ComputeLastIndex(offset, equals);
                 }
-                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
 
                 // If any elements remain, process the first vector in the search space.
-                if ((uint)length % Vector256<TValue>.Count != 0)
+                equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref searchSpace)));
+
+                if (equals != Vector256<TValue>.Zero)
                 {
-                    equals = TNegator.NegateIfNeeded(Vector256.Equals(values, Vector256.LoadUnsafe(ref searchSpace)));
-                    if (equals != Vector256<TValue>.Zero)
-                    {
-                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
-                    }
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
             else
             {
                 Vector128<TValue> equals, values = Vector128.Create(value);
-                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+                nint offset = length - Vector128<TValue>.Count;
 
-                // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
+                // Loop until either we've finished all elements -or- there's one or less than a vector's-worth remaining.
+                while (offset > 0)
                 {
-                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref currentSearchSpace)));
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref searchSpace, (nuint)(offset))));
+
                     if (equals == Vector128<TValue>.Zero)
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<TValue>.Count);
+                        offset -= Vector128<TValue>.Count;
                         continue;
                     }
 
-                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                    return ComputeLastIndex(offset, equals);
                 }
-                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
+
 
                 // If any elements remain, process the first vector in the search space.
-                if ((uint)length % Vector128<TValue>.Count != 0)
+
+                equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref searchSpace)));
+
+                if (equals != Vector128<TValue>.Zero)
                 {
-                    equals = TNegator.NegateIfNeeded(Vector128.Equals(values, Vector128.LoadUnsafe(ref searchSpace)));
-                    if (equals != Vector128<TValue>.Zero)
-                    {
-                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
-                    }
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
 
@@ -2291,63 +2289,60 @@ namespace System
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
                 Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1);
-                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+                nint offset = length - Vector256<TValue>.Count;
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
+                while (offset > 0)
                 {
-                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    current = Vector256.LoadUnsafe(ref searchSpace, (nuint)(offset));
                     equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1));
+
                     if (equals == Vector256<TValue>.Zero)
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<TValue>.Count);
+                        offset -= Vector256<TValue>.Count;
                         continue;
                     }
 
-                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                    return ComputeLastIndex(offset, equals);
                 }
-                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
 
                 // If any elements remain, process the first vector in the search space.
-                if ((uint)length % Vector256<TValue>.Count != 0)
+
+                current = Vector256.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1));
+
+                if (equals != Vector256<TValue>.Zero)
                 {
-                    current = Vector256.LoadUnsafe(ref searchSpace);
-                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1));
-                    if (equals != Vector256<TValue>.Zero)
-                    {
-                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
-                    }
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
             else
             {
                 Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1);
-                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+                nint offset = length - Vector128<TValue>.Count;
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
+                while (offset > 0)
                 {
-                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    current = Vector128.LoadUnsafe(ref searchSpace, (nuint)(offset));
                     equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1));
                     if (equals == Vector128<TValue>.Zero)
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<TValue>.Count);
+                        offset -= Vector128<TValue>.Count;
                         continue;
                     }
 
-                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                    return ComputeLastIndex(offset, equals);
                 }
-                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
 
                 // If any elements remain, process the first vector in the search space.
-                if ((uint)length % Vector128<TValue>.Count != 0)
+
+                current = Vector128.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1));
+
+                if (equals != Vector128<TValue>.Zero)
                 {
-                    current = Vector128.LoadUnsafe(ref searchSpace);
-                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1));
-                    if (equals != Vector128<TValue>.Zero)
-                    {
-                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
-                    }
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
 
@@ -2433,63 +2428,61 @@ namespace System
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
                 Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1), values2 = Vector256.Create(value2);
-                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+                nint offset = length - Vector256<TValue>.Count;
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
+                while (offset > 0)
                 {
-                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    current = Vector256.LoadUnsafe(ref searchSpace, (nuint)(offset));
                     equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1) | Vector256.Equals(current, values2));
+
                     if (equals == Vector256<TValue>.Zero)
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<TValue>.Count);
+                        offset -= Vector256<TValue>.Count;
                         continue;
                     }
 
-                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                    return ComputeLastIndex(offset, equals);
                 }
-                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
 
                 // If any elements remain, process the first vector in the search space.
-                if ((uint)length % Vector256<TValue>.Count != 0)
+
+                current = Vector256.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1) | Vector256.Equals(current, values2));
+
+                if (equals != Vector256<TValue>.Zero)
                 {
-                    current = Vector256.LoadUnsafe(ref searchSpace);
-                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1) | Vector256.Equals(current, values2));
-                    if (equals != Vector256<TValue>.Zero)
-                    {
-                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
-                    }
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
             else
             {
                 Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1), values2 = Vector128.Create(value2);
-                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+                nint offset = length - Vector128<TValue>.Count;
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
+                while (offset > 0)
                 {
-                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    current = Vector128.LoadUnsafe(ref searchSpace, (nuint)(offset));
                     equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2));
+
                     if (equals == Vector128<TValue>.Zero)
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<TValue>.Count);
+                        offset -= Vector128<TValue>.Count;
                         continue;
                     }
 
-                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                    return ComputeLastIndex(offset, equals);
                 }
-                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
 
                 // If any elements remain, process the first vector in the search space.
-                if ((uint)length % Vector128<TValue>.Count != 0)
+
+                current = Vector128.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2));
+
+                if (equals != Vector128<TValue>.Zero)
                 {
-                    current = Vector128.LoadUnsafe(ref searchSpace);
-                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2));
-                    if (equals != Vector128<TValue>.Zero)
-                    {
-                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
-                    }
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
 
@@ -2547,67 +2540,61 @@ namespace System
             else if (Vector256.IsHardwareAccelerated && length >= Vector256<TValue>.Count)
             {
                 Vector256<TValue> equals, current, values0 = Vector256.Create(value0), values1 = Vector256.Create(value1), values2 = Vector256.Create(value2), values3 = Vector256.Create(value3);
-                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector256<TValue>.Count);
+                nint offset = length - Vector256<TValue>.Count;
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
+                while (offset > 0)
                 {
-                    current = Vector256.LoadUnsafe(ref currentSearchSpace);
+                    current = Vector256.LoadUnsafe(ref searchSpace, (nuint)(offset));
                     equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1)
                                             | Vector256.Equals(current, values2) | Vector256.Equals(current, values3));
                     if (equals == Vector256<TValue>.Zero)
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<TValue>.Count);
+                        offset -= Vector256<TValue>.Count;
                         continue;
                     }
 
-                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                    return ComputeLastIndex(offset, equals);
                 }
-                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
 
                 // If any elements remain, process the first vector in the search space.
-                if ((uint)length % Vector256<TValue>.Count != 0)
+
+                current = Vector256.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1) | Vector256.Equals(current, values2) | Vector256.Equals(current, values3));
+
+                if (equals != Vector256<TValue>.Zero)
                 {
-                    current = Vector256.LoadUnsafe(ref searchSpace);
-                    equals = TNegator.NegateIfNeeded(Vector256.Equals(current, values0) | Vector256.Equals(current, values1)
-                                            | Vector256.Equals(current, values2) | Vector256.Equals(current, values3));
-                    if (equals != Vector256<TValue>.Zero)
-                    {
-                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
-                    }
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
             else
             {
                 Vector128<TValue> equals, current, values0 = Vector128.Create(value0), values1 = Vector128.Create(value1), values2 = Vector128.Create(value2), values3 = Vector128.Create(value3);
-                ref TValue currentSearchSpace = ref Unsafe.Add(ref searchSpace, length - Vector128<TValue>.Count);
+                nint offset = length - Vector128<TValue>.Count;
 
                 // Loop until either we've finished all elements or there's less than a vector's-worth remaining.
-                do
+                while (offset > 0)
                 {
-                    current = Vector128.LoadUnsafe(ref currentSearchSpace);
-                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1)
-                                            | Vector128.Equals(current, values2) | Vector128.Equals(current, values3));
+                    current = Vector128.LoadUnsafe(ref searchSpace, (nuint)(offset));
+                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2) | Vector128.Equals(current, values3));
+
                     if (equals == Vector128<TValue>.Zero)
                     {
-                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<TValue>.Count);
+                        offset -= Vector128<TValue>.Count;
                         continue;
                     }
 
-                    return ComputeLastIndex(ref searchSpace, ref currentSearchSpace, equals);
+                    return ComputeLastIndex(offset, equals);
                 }
-                while (!Unsafe.IsAddressLessThan(ref currentSearchSpace, ref searchSpace));
 
                 // If any elements remain, process the first vector in the search space.
-                if ((uint)length % Vector128<TValue>.Count != 0)
+
+                current = Vector128.LoadUnsafe(ref searchSpace);
+                equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1) | Vector128.Equals(current, values2) | Vector128.Equals(current, values3));
+
+                if (equals != Vector128<TValue>.Zero)
                 {
-                    current = Vector128.LoadUnsafe(ref searchSpace);
-                    equals = TNegator.NegateIfNeeded(Vector128.Equals(current, values0) | Vector128.Equals(current, values1)
-                                            | Vector128.Equals(current, values2) | Vector128.Equals(current, values3));
-                    if (equals != Vector128<TValue>.Zero)
-                    {
-                        return ComputeLastIndex(ref searchSpace, ref searchSpace, equals);
-                    }
+                    return ComputeLastIndex(offset: 0, equals);
                 }
             }
 
@@ -2631,19 +2618,19 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int ComputeLastIndex<T>(ref T searchSpace, ref T current, Vector128<T> equals) where T : struct
+        private static int ComputeLastIndex<T>(nint offset, Vector128<T> equals) where T : struct
         {
             uint notEqualsElements = equals.ExtractMostSignificantBits();
             int index = 31 - BitOperations.LeadingZeroCount(notEqualsElements); // 31 = 32 (bits in Int32) - 1 (indexing from zero)
-            return (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / Unsafe.SizeOf<T>()) + index;
+            return (int)(offset / Unsafe.SizeOf<T>()) + index;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int ComputeLastIndex<T>(ref T searchSpace, ref T current, Vector256<T> equals) where T : struct
+        private static int ComputeLastIndex<T>(nint offset, Vector256<T> equals) where T : struct
         {
             uint notEqualsElements = equals.ExtractMostSignificantBits();
             int index = 31 - BitOperations.LeadingZeroCount(notEqualsElements); // 31 = 32 (bits in Int32) - 1 (indexing from zero)
-            return (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / Unsafe.SizeOf<T>()) + index;
+            return (int)(offset / Unsafe.SizeOf<T>()) + index;
         }
 
         private interface INegator<T> where T : struct

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -2622,7 +2622,7 @@ namespace System
         {
             uint notEqualsElements = equals.ExtractMostSignificantBits();
             int index = 31 - BitOperations.LeadingZeroCount(notEqualsElements); // 31 = 32 (bits in Int32) - 1 (indexing from zero)
-            return (int)(offset / Unsafe.SizeOf<T>()) + index;
+            return (int)offset + index;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2630,7 +2630,7 @@ namespace System
         {
             uint notEqualsElements = equals.ExtractMostSignificantBits();
             int index = 31 - BitOperations.LeadingZeroCount(notEqualsElements); // 31 = 32 (bits in Int32) - 1 (indexing from zero)
-            return (int)(offset / Unsafe.SizeOf<T>()) + index;
+            return (int)offset + index;
         }
 
         private interface INegator<T> where T : struct


### PR DESCRIPTION
This resolves #75792 