### PR TITLE
Include hostcommon sources in hostfxr static library

### DIFF
--- a/src/native/corehost/fxr/CMakeLists.txt
+++ b/src/native/corehost/fxr/CMakeLists.txt
@@ -2,3 +2,4 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 
 add_subdirectory(standalone)
+add_subdirectory(staticlib)

--- a/src/native/corehost/fxr/standalone/CMakeLists.txt
+++ b/src/native/corehost/fxr/standalone/CMakeLists.txt
@@ -28,7 +28,6 @@ else(CLR_CMAKE_TARGET_WIN32)
 endif(CLR_CMAKE_TARGET_WIN32)
 
 include(../../lib.cmake)
-include(../../lib_static.cmake)
 
 if(CLR_CMAKE_HOST_UNIX)
     add_custom_target(hostfxr_exports DEPENDS ${EXPORTS_FILE})
@@ -38,22 +37,7 @@ if(CLR_CMAKE_HOST_UNIX)
     set_property(TARGET hostfxr APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
 endif(CLR_CMAKE_HOST_UNIX)
 
-# Copy static lib PDB to the project output directory
-if (WIN32)
-    set_target_properties(libhostfxr PROPERTIES
-        COMPILE_PDB_NAME "libhostfxr"
-        COMPILE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
-    )
-endif(WIN32)
-
 install_with_stripped_symbols(hostfxr TARGETS corehost)
-
-# Only Windows creates a symbols file for static libs.
-if (WIN32)
-    install_with_stripped_symbols(libhostfxr TARGETS corehost)
-else()
-    install(TARGETS libhostfxr DESTINATION corehost)
-endif(WIN32)
 
 target_link_libraries(hostfxr libhostcommon)
 

--- a/src/native/corehost/fxr/staticlib/CMakeLists.txt
+++ b/src/native/corehost/fxr/staticlib/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+
+project(hostfxr)
+
+set(DOTNET_PROJECT_NAME "hostfxr")
+
+# CMake does not recommend using globbing since it messes with the freshness checks
+set(SOURCES
+    ../standalone/hostpolicy_resolver.cpp
+)
+
+set(HEADERS
+    ../hostpolicy_resolver.h
+)
+
+include(../../hostcommon/files.cmake)
+include(../files.cmake)
+
+include(../../hostmisc/hostmisc.cmake)
+include(../../lib_static.cmake)
+
+# Copy static lib PDB to the project output directory
+if (WIN32)
+    set_target_properties(libhostfxr PROPERTIES
+        COMPILE_PDB_NAME "libhostfxr"
+        COMPILE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
+    )
+endif(WIN32)
+
+if (MSVC)
+    # We ship libhostfxr.lib as a static library for external consumption, so
+    # LTCG must be disabled to ensure that non-MSVC toolchains can work with it.
+
+    target_compile_options(libhostfxr PRIVATE /GL-)
+
+    string(REPLACE "/LTCG" "" CMAKE_STATIC_LINKER_FLAGS_RELEASE ${CMAKE_STATIC_LINKER_FLAGS_RELEASE})
+    string(REPLACE "/LTCG" "" CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO ${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO})
+endif()
+
+# Only Windows creates a symbols file for static libs.
+if (WIN32)
+    install_with_stripped_symbols(libhostfxr TARGETS corehost)
+else()
+    install(TARGETS libhostfxr DESTINATION corehost)
+endif(WIN32)


### PR DESCRIPTION
The hostfxr static library can't be used without this.