### PR TITLE
Remove locks from COM events delegate management.

### DIFF
--- a/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
@@ -100,7 +100,7 @@ namespace System.Runtime.InteropServices
         /// Since multicast delegate's built-in chaining supports only chaining instances of the same type,
         /// we need to complement this design by using an explicit linked list data structure.
         /// </summary>
-        private DelegateWrapper[] _delegateWrappers = Array.Empty<DelegateWrapper>();
+        private List<DelegateWrapper> _delegateWrappers = new List<DelegateWrapper>();
 
         private readonly int _dispid;
         private ComEventsMethod? _next;
@@ -157,15 +157,15 @@ namespace System.Runtime.InteropServices
         {
             get
             {
-                DelegateWrapper[] wrappers = _delegateWrappers;
-                return wrappers.Length == 0;
+                List<DelegateWrapper> wrappers = _delegateWrappers;
+                return wrappers.Count == 0;
             }
         }
 
         public void AddDelegate(Delegate d, bool wrapArgs = false)
         {
-            DelegateWrapper[] wrappers;
-            DelegateWrapper[] newWrappers;
+            List<DelegateWrapper> wrappers;
+            List<DelegateWrapper> newWrappers;
             do
             {
                 wrappers = _delegateWrappers;
@@ -180,17 +180,18 @@ namespace System.Runtime.InteropServices
                     }
                 }
 
-                newWrappers = new DelegateWrapper[wrappers.Length + 1];
-                wrappers.CopyTo(newWrappers, 0);
+                newWrappers = wrappers.Count == 0
+                    ? new List<DelegateWrapper>()
+                    : wrappers.GetRange(0, wrappers.Count);
 
-                newWrappers[newWrappers.Length - 1] = new DelegateWrapper(d, wrapArgs);
+                newWrappers.Add(new DelegateWrapper(d, wrapArgs));
             } while (!PublishNewWrappers(newWrappers, wrappers));
         }
 
         public void RemoveDelegate(Delegate d, bool wrapArgs = false)
         {
-            DelegateWrapper[] wrappers;
-            DelegateWrapper[] newWrappers;
+            List<DelegateWrapper> wrappers;
+            List<DelegateWrapper> newWrappers;
             do
             {
                 wrappers = _delegateWrappers;
@@ -198,7 +199,7 @@ namespace System.Runtime.InteropServices
                 // Find delegate wrapper index
                 int removeIdx = -1;
                 DelegateWrapper? wrapper = null;
-                for (int i = 0; i < wrappers.Length; i++)
+                for (int i = 0; i < wrappers.Count; i++)
                 {
                     DelegateWrapper wrapperMaybe = wrappers[i];
                     if (wrapperMaybe.Delegate.GetType() == d.GetType() && wrapperMaybe.WrapArgs == wrapArgs)
@@ -223,22 +224,22 @@ namespace System.Runtime.InteropServices
                     return; // No need to update collection
                 }
 
-                newWrappers = new DelegateWrapper[wrappers.Length - 1];
-                wrappers.AsSpan(0, removeIdx).CopyTo(newWrappers);
-                wrappers.AsSpan(removeIdx + 1).CopyTo(newWrappers.AsSpan(removeIdx));
+                newWrappers = wrappers.GetRange(0, wrappers.Count);
+                newWrappers.RemoveAt(removeIdx);
             } while (!PublishNewWrappers(newWrappers, wrappers));
         }
 
         public void RemoveDelegates(Func<Delegate, bool> condition)
         {
-            DelegateWrapper[] wrappers;
-            DelegateWrapper[] newWrappers;
+            List<DelegateWrapper> wrappers;
+            List<DelegateWrapper> newWrappers;
             do
             {
                 wrappers = _delegateWrappers;
 
+                // Find delegate wrapper indexes. Iterate in reverse such that the list to remove is sorted by high to low index.
                 List<int> toRemove = new List<int>();
-                for (int i = 0; i < wrappers.Length; i++)
+                for (int i = wrappers.Count - 1; i >= 0; i--)
                 {
                     DelegateWrapper wrapper = wrappers[i];
                     Delegate[] invocationList = wrapper.Delegate.GetInvocationList();
@@ -265,35 +266,12 @@ namespace System.Runtime.InteropServices
                     return;
                 }
 
-                newWrappers = RemoveAll(wrappers, CollectionsMarshal.AsSpan(toRemove));
+                newWrappers = wrappers.GetRange(0, wrappers.Count);
+                foreach (int idx in toRemove)
+                {
+                    newWrappers.RemoveAt(idx);
+                }
             } while (!PublishNewWrappers(newWrappers, wrappers));
-
-            // The list of indices is assumed to be sorted in ascending order
-            static DelegateWrapper[] RemoveAll(DelegateWrapper[] oldCol, ReadOnlySpan<int> toRemove)
-            {
-                // Allocate new collection
-                var newCol = new DelegateWrapper[oldCol.Length - toRemove.Length];
-                if (newCol.Length == 0)
-                {
-                    return newCol;
-                }
-
-                // Iterate over collection, skipping elements that should be removed.
-                int ri = 0;
-                for (int oi = 0, ni = 0; oi < oldCol.Length; oi++)
-                {
-                    if (ri < toRemove.Length && oi == toRemove[ri])
-                    {
-                        ri++;
-                        continue;
-                    }
-
-                    newCol[ni] = oldCol[oi];
-                    ni++;
-                }
-
-                return newCol;
-            }
         }
 
         public object? Invoke(object[] args)
@@ -301,7 +279,7 @@ namespace System.Runtime.InteropServices
             Debug.Assert(!Empty);
             object? result = null;
 
-            DelegateWrapper[] wrappers = _delegateWrappers;
+            List<DelegateWrapper> wrappers = _delegateWrappers;
             foreach (DelegateWrapper wrapper in wrappers)
             {
                 result = wrapper.Invoke(args);
@@ -311,7 +289,7 @@ namespace System.Runtime.InteropServices
         }
 
         // Attempt to update the member wrapper field
-        private bool PublishNewWrappers(DelegateWrapper[] newWrappers, DelegateWrapper[] currentMaybe)
+        private bool PublishNewWrappers(List<DelegateWrapper> newWrappers, List<DelegateWrapper> currentMaybe)
         {
             return Interlocked.CompareExchange(ref _delegateWrappers, newWrappers, currentMaybe) == currentMaybe;
         }

--- a/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
@@ -157,7 +157,7 @@ namespace System.Runtime.InteropServices
         {
             get
             {
-                var wrappers = _delegateWrappers;
+                List<DelegateWrapper> wrappers = _delegateWrappers;
                 return wrappers.Count == 0;
             }
         }
@@ -279,7 +279,7 @@ namespace System.Runtime.InteropServices
             Debug.Assert(!Empty);
             object? result = null;
 
-            var wrappers = _delegateWrappers;
+            List<DelegateWrapper> wrappers = _delegateWrappers;
             foreach (DelegateWrapper wrapper in wrappers)
             {
                 result = wrapper.Invoke(args);

--- a/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
@@ -173,7 +173,7 @@ namespace System.Runtime.InteropServices
                 newWrappers = new DelegateWrapper[wrappers.Length + 1];
                 wrappers.CopyTo(newWrappers, 0);
 
-                newWrappers[newWrappers.Length - 1] = new DelegateWrapper(d, wrapArgs);
+                newWrappers[^1] = new DelegateWrapper(d, wrapArgs);
             } while (!PublishNewWrappers(newWrappers, wrappers));
         }
 

--- a/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
@@ -170,16 +170,6 @@ namespace System.Runtime.InteropServices
             {
                 wrappers = _delegateWrappers;
 
-                // Update an existing delegate wrapper
-                foreach (DelegateWrapper wrapper in wrappers)
-                {
-                    if (wrapper.Delegate.GetType() == d.GetType() && wrapper.WrapArgs == wrapArgs)
-                    {
-                        wrapper.Delegate = Delegate.Combine(wrapper.Delegate, d);
-                        return;
-                    }
-                }
-
                 newWrappers = new DelegateWrapper[wrappers.Length + 1];
                 wrappers.CopyTo(newWrappers, 0);
 
@@ -197,14 +187,12 @@ namespace System.Runtime.InteropServices
 
                 // Find delegate wrapper index
                 int removeIdx = -1;
-                DelegateWrapper? wrapper = null;
                 for (int i = 0; i < wrappers.Length; i++)
                 {
                     DelegateWrapper wrapperMaybe = wrappers[i];
                     if (wrapperMaybe.Delegate.GetType() == d.GetType() && wrapperMaybe.WrapArgs == wrapArgs)
                     {
                         removeIdx = i;
-                        wrapper = wrapperMaybe;
                         break;
                     }
                 }
@@ -213,14 +201,6 @@ namespace System.Runtime.InteropServices
                 {
                     // Not present in collection
                     return;
-                }
-
-                // Update wrapper or remove from collection
-                Delegate? newDelegate = Delegate.Remove(wrapper!.Delegate, d);
-                if (newDelegate != null)
-                {
-                    wrapper.Delegate = newDelegate;
-                    return; // No need to update collection
                 }
 
                 newWrappers = new DelegateWrapper[wrappers.Length - 1];
@@ -237,25 +217,13 @@ namespace System.Runtime.InteropServices
             {
                 wrappers = _delegateWrappers;
 
-                List<int> toRemove = new List<int>();
+                List<int> toRemove = new();
                 for (int i = 0; i < wrappers.Length; i++)
                 {
                     DelegateWrapper wrapper = wrappers[i];
-                    Delegate[] invocationList = wrapper.Delegate.GetInvocationList();
-                    foreach (Delegate delegateMaybe in invocationList)
+                    if (condition(wrapper.Delegate))
                     {
-                        if (condition(delegateMaybe))
-                        {
-                            Delegate? newDelegate = Delegate.Remove(wrapper!.Delegate, delegateMaybe);
-                            if (newDelegate != null)
-                            {
-                                wrapper.Delegate = newDelegate;
-                            }
-                            else
-                            {
-                                toRemove.Add(i);
-                            }
-                        }
+                        toRemove.Add(i);
                     }
                 }
 

--- a/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ComEventsMethod.cs
@@ -155,17 +155,12 @@ namespace System.Runtime.InteropServices
 
         public bool Empty
         {
-            get
-            {
-                DelegateWrapper[] wrappers = _delegateWrappers;
-                return wrappers.Length == 0;
-            }
+            get => _delegateWrappers.Length == 0;
         }
 
         public void AddDelegate(Delegate d, bool wrapArgs = false)
         {
-            DelegateWrapper[] wrappers;
-            DelegateWrapper[] newWrappers;
+            DelegateWrapper[] wrappers, newWrappers;
             do
             {
                 wrappers = _delegateWrappers;
@@ -177,8 +172,7 @@ namespace System.Runtime.InteropServices
 
         public void RemoveDelegate(Delegate d, bool wrapArgs = false)
         {
-            DelegateWrapper[] wrappers;
-            DelegateWrapper[] newWrappers;
+            DelegateWrapper[] wrappers, newWrappers;
             do
             {
                 wrappers = _delegateWrappers;
@@ -209,8 +203,7 @@ namespace System.Runtime.InteropServices
 
         public void RemoveDelegates(Func<Delegate, bool> condition)
         {
-            DelegateWrapper[] wrappers;
-            DelegateWrapper[] newWrappers;
+            DelegateWrapper[] wrappers, newWrappers;
             do
             {
                 wrappers = _delegateWrappers;
@@ -226,8 +219,7 @@ namespace System.Runtime.InteropServices
             Debug.Assert(!Empty);
             object? result = null;
 
-            DelegateWrapper[] wrappers = _delegateWrappers;
-            foreach (DelegateWrapper wrapper in wrappers)
+            foreach (DelegateWrapper wrapper in _delegateWrappers)
             {
                 result = wrapper.Invoke(args);
             }


### PR DESCRIPTION
This removes locks and instead assumes the collection is immutable.

Fixes #73754
