### PR TITLE
Faster Vector128/64 compare on arm64

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1190,34 +1190,51 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
         cmp = tmp;
     }
 
-    GenTree* msk =
-        comp->gtNewSimdHWIntrinsicNode(simdType, cmp, NI_AdvSimd_Arm64_MinAcross, CORINFO_TYPE_UBYTE, simdSize);
-    BlockRange().InsertAfter(cmp, msk);
-    LowerNode(msk);
+    if (simdSize != 8) // we don't need compression for Vector64
+    {
+        GenTree* msk;
+
+        // Save cmp into a temp as we're going to need to pass it twice to MinPairwise
+        node->Op(1) = cmp;
+        LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
+        ReplaceWithLclVar(tmp1Use);
+        cmp               = node->Op(1);
+        GenTree* cmpClone = comp->gtClone(cmp);
+        BlockRange().InsertAfter(cmp, cmpClone);
+
+        msk = comp->gtNewSimdHWIntrinsicNode(simdType, cmp, cmpClone, NI_AdvSimd_Arm64_MinPairwise, CORINFO_TYPE_UINT,
+                                             simdSize);
+        BlockRange().InsertAfter(cmpClone, msk);
+        LowerNode(msk);
+
+        cmp = msk;
+    }
 
     GenTree* zroCns = comp->gtNewIconNode(0, TYP_INT);
-    BlockRange().InsertAfter(msk, zroCns);
+    BlockRange().InsertAfter(cmp, zroCns);
 
-    GenTree* val =
-        comp->gtNewSimdHWIntrinsicNode(TYP_UBYTE, msk, zroCns, NI_AdvSimd_Extract, CORINFO_TYPE_UBYTE, simdSize);
+    var_types cmpRegType = (simdSize == 8) ? TYP_INT : TYP_LONG;
+
+    GenTree* val = comp->gtNewSimdHWIntrinsicNode(cmpRegType, cmp, zroCns, NI_AdvSimd_Extract,
+                                                  (simdSize == 8) ? CORINFO_TYPE_UINT : CORINFO_TYPE_ULONG, simdSize);
     BlockRange().InsertAfter(zroCns, val);
     LowerNode(val);
 
-    zroCns = comp->gtNewIconNode(0, TYP_INT);
-    BlockRange().InsertAfter(val, zroCns);
+    GenTree* bitMskCns = comp->gtNewIconNode(ssize_t((simdSize == 8) ? 0xffffffff : 0xffffffffffffffff), cmpRegType);
+    BlockRange().InsertAfter(val, bitMskCns);
 
     node->ChangeOper(cmpOp);
 
-    node->gtType        = TYP_INT;
+    node->gtType        = cmpRegType;
     node->AsOp()->gtOp1 = val;
-    node->AsOp()->gtOp2 = zroCns;
+    node->AsOp()->gtOp2 = bitMskCns;
 
     // The CompareEqual will set (condition is true) or clear (condition is false) all bits of the respective element
     // The MinAcross then ensures we get either all bits set (all conditions are true) or clear (any condition is false)
     // So, we need to invert the condition from the operation since we compare against zero
 
-    GenCondition cmpCnd = (cmpOp == GT_EQ) ? GenCondition::NE : GenCondition::EQ;
-    GenTree*     cc     = LowerNodeCC(node, cmpCnd);
+    GenCondition cmpCnd = (cmpOp == GT_EQ) ? GenCondition::EQ : GenCondition::NE;
+    LowerNodeCC(node, cmpCnd);
 
     node->gtType = TYP_VOID;
     node->ClearUnusedValue();

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1213,19 +1213,17 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
     GenTree* zroCns = comp->gtNewIconNode(0, TYP_INT);
     BlockRange().InsertAfter(cmp, zroCns);
 
-    var_types cmpRegType = (simdSize == 8) ? TYP_INT : TYP_LONG;
-
-    GenTree* val = comp->gtNewSimdHWIntrinsicNode(cmpRegType, cmp, zroCns, NI_AdvSimd_Extract,
-                                                  (simdSize == 8) ? CORINFO_TYPE_UINT : CORINFO_TYPE_ULONG, simdSize);
+    GenTree* val =
+        comp->gtNewSimdHWIntrinsicNode(TYP_LONG, cmp, zroCns, NI_AdvSimd_Extract, CORINFO_TYPE_ULONG, simdSize);
     BlockRange().InsertAfter(zroCns, val);
     LowerNode(val);
 
-    GenTree* bitMskCns = comp->gtNewIconNode(ssize_t((simdSize == 8) ? 0xffffffff : 0xffffffffffffffff), cmpRegType);
+    GenTree* bitMskCns = comp->gtNewIconNode(static_cast<ssize_t>(0xffffffffffffffff), TYP_LONG);
     BlockRange().InsertAfter(val, bitMskCns);
 
     node->ChangeOper(cmpOp);
 
-    node->gtType        = cmpRegType;
+    node->gtType        = TYP_LONG;
     node->AsOp()->gtOp1 = val;
     node->AsOp()->gtOp2 = bitMskCns;
 


### PR DESCRIPTION
Apply @TamarChristinaArm's suggestions for faster vector comparison in https://github.com/dotnet/runtime/issues/75849

```csharp
bool Test1(Vector128<int> a, Vector128<int> b) => a == b;
bool Test2(Vector64<float> a, Vector64<float> b) => a != b;
```
Now emits:
```diff
; Method Tests:Test1
G_M48391_IG01:              
        A9BF7BFD          stp     fp, lr, [sp, #-0x10]!
        910003FD          mov     fp, sp
G_M48391_IG02:              
        6EA18C10          cmeq    v16.4s, v0.4s, v1.4s
-       6E31AA10          uminv   b16, v16.16b
-       0E013E00          umov    w0, v16.b[0]
-       7100001F          cmp     w0, #0
-       9A9F07E0          cset    x0, ne
+       6EB0AE10          uminp   v16.4s, v16.4s, v16.4s
+       4E083E00          umov    x0, v16.d[0]
+       B100041F          cmn     x0, #1
+       9A9F17E0          cset    x0, eq
G_M48391_IG03:              
        A8C17BFD          ldp     fp, lr, [sp], #0x10
        D65F03C0          ret     lr
; Total bytes of code: 36


; Method Tests:Test2
G_M64388_IG01:              
        A9BF7BFD          stp     fp, lr, [sp, #-0x10]!
        910003FD          mov     fp, sp
						;; size=8 bbWeight=1    PerfScore 1.50
G_M64388_IG02:              
        0E21E410          fcmeq   v16.2s, v0.2s, v1.2s
-       2E31AA10          uminv   b16, v16.8b
-       0E013E00          umov    w0, v16.b[0]
-       7100001F          cmp     w0, #0
-       9A9F17E0          cset    x0, eq
+       4E083E00          umov    x0, v16.d[0]
+       B100041F          cmn     x0, #1
+       9A9F07E0          cset    x0, ne
G_M64388_IG03:              
        A8C17BFD          ldp     fp, lr, [sp], #0x10
        D65F03C0          ret     lr
-; Total bytes of code: 36
+; Total bytes of code: 32
```