### PR TITLE
Add markdown readme for Microsoft.Extensions.Configuration.Json

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Json/src/Microsoft.Extensions.Configuration.Json.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/src/Microsoft.Extensions.Configuration.Json.csproj
@@ -6,7 +6,8 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <IsPackable>true</IsPackable>
     <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
-    <PackageDescription>JSON configuration provider implementation for Microsoft.Extensions.Configuration.</PackageDescription>
+    <PackageDescription>JSON configuration provider implementation for Microsoft.Extensions.Configuration. This package enables you to read your application's settings from a JSON file. You can use JsonConfigurationExtensions.AddJsonFile extension method on IConfigurationBuilder to add the JSON configuration provider to the configuration builder.</PackageDescription>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +18,7 @@
     <ProjectReference Include="$(LibrariesProjectRoot)System.Text.Json\src\System.Text.Json.csproj" />
     <Compile Include="$(CommonPath)System\ThrowHelper.cs"
              Link="Common\System\ThrowHelper.cs" />
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/src/README.md
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/src/README.md
@@ -1,0 +1,66 @@
+## About
+
+JSON configuration provider implementation for [Microsoft.Extensions.Configuration](https://www.nuget.org/packages/Microsoft.Extensions.Configuration/). This package enables you to read your application's settings from a JSON file. You can use [JsonConfigurationExtensions.AddJsonFile](https://docs.microsoft.com/dotnet/api/microsoft.extensions.configuration.jsonconfigurationextensions.addjsonfile) extension method on `IConfigurationBuilder` to add the JSON configuration provider to the configuration builder.
+
+For more information, see the documentation:
+
+- [Configuration in .NET](https://docs.microsoft.com/dotnet/core/extensions/configuration)
+- [Microsoft.Extensions.Configuration.Json namespace](https://docs.microsoft.com/dotnet/api/microsoft.extensions.configuration.json)
+
+## Example
+
+The following example shows how to read application settings from the JSON configuration file.
+
+```cs
+using System;
+using Microsoft.Extensions.Configuration;
+
+class Program
+{
+    static void Main()
+    {
+        // Build a configuration object from JSON file
+        IConfiguration config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        // Get a configuration section
+        IConfigurationSection section = config.GetSection("Settings");
+
+        // Read simple values
+        Console.WriteLine($"Server: {section["Server"]}");
+        Console.WriteLine($"Database: {section["Database"]}");
+
+        // Read a collection
+        Console.WriteLine("Ports: ");
+        IConfigurationSection ports = section.GetSection("Ports");
+
+        foreach (IConfigurationSection child in ports.GetChildren())
+        {
+            Console.WriteLine(child.Value);
+        }
+    }
+}
+```
+
+To run this example, include an `appsettings.json` file with the following content in your project:
+
+```json
+{
+  "Settings": {
+    "Server": "example.com",
+    "Database": "Northwind",
+    "Ports": [ 80, 81 ]
+  }
+}
+```
+
+You can include a configuration file using a code like this in your `.csproj` file:
+
+```xml
+<ItemGroup>
+  <Content Include="appsettings.json">
+    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+  </Content>
+</ItemGroup>
+```


### PR DESCRIPTION
Issue: #59630 

This aims to add a minimal example of working with JSON configuration in console app using only this package (without hosting, binding etc.) The more complex examples are provided in the linked docs article.