### PR TITLE
Improve total L2 size calculation logic on osx-arm64

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -985,7 +985,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
             if (sysctlbyname("hw.perflevel0.physicalcpu_max", &cpusMax, &szCpusMax, nullptr, 0) == 0 &&
                 sysctlbyname("hw.perflevel0.cpusperl2", &cpusPerL2, &szCpusPerL2, nullptr, 0) == 0)
             {
-                cacheSizeFromSysctl = cacheSizeFromSysctl * (cpusMax / cpusPerL2);
+                cacheSizeFromSysctl *= (cpusMax / cpusPerL2);
             }
             success = true;
         }

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -965,17 +965,38 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 #if HAVE_SYSCTLBYNAME
     if (cacheSize == 0)
     {
+        bool success = false;
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);
-        const bool success = false
-            // macOS: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency
-            // and performance cores separately. "perflevel0" stands for "performance"
-            || sysctlbyname("hw.perflevel0.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
-            || sysctlbyname("hw.perflevel0.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
+        // macOS: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency
+        // and performance cores separately. "perflevel0" stands for "performance"
+        if (sysctlbyname("hw.perflevel0.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0)
+        {
+            success = true;
+        }
+        else if (sysctlbyname("hw.perflevel0.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0)
+        {
+            int64_t cpusMax;
+            int64_t cpusPerL2;
+            size_t szCpusMax = sizeof(cpusMax);
+            size_t szCpusPerL2 = sizeof(cpusPerL2);
+            // macOS: The reported L2 cache size is actually not total but rather per CPU "cluster".
+            // Therefore, we need to account for CPU count per "cluster" to calculate total size
+            if (sysctlbyname("hw.perflevel0.physicalcpu_max", &cpusMax, &szCpusMax, nullptr, 0) == 0 &&
+                sysctlbyname("hw.perflevel0.cpusperl2", &cpusPerL2, &szCpusPerL2, nullptr, 0) == 0)
+            {
+                cacheSizeFromSysctl = cacheSizeFromSysctl * (cpusMax / cpusPerL2);
+            }
+            success = true;
+        }
+        else
+        {
             // macOS: these report cache sizes for efficiency cores only:
-            || sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
-            || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
-            || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;
+            success = sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
+                || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
+                || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;
+        }
+
         if (success)
         {
             assert(cacheSizeFromSysctl > 0);

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -633,9 +633,9 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
 #if HAVE_SYSCTLBYNAME
     if (cacheSize == 0)
     {
+        bool success = false;
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);
-        bool success = false;
         // macOS: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency
         // and performance cores separately. "perflevel0" stands for "performance"
         if (sysctlbyname("hw.perflevel0.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0)
@@ -653,7 +653,7 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
             if (sysctlbyname("hw.perflevel0.physicalcpu_max", &cpusMax, &szCpusMax, nullptr, 0) == 0 &&
                 sysctlbyname("hw.perflevel0.cpusperl2", &cpusPerL2, &szCpusPerL2, nullptr, 0) == 0)
             {
-                cacheSizeFromSysctl = cacheSizeFromSysctl * (cpusMax / cpusPerL2);
+                cacheSizeFromSysctl *= (cpusMax / cpusPerL2);
             }
             success = true;
         }


### PR DESCRIPTION
While looking at https://github.com/dotnet/runtime/pull/75854 and double-checking `sysctl` behavior, I've noticed that on `M1 Pro` the actual value reported for `hw.perflevel0.l2cachesize` is `12582912` instead of roughly 24MB which is its actual L2 cache size.

However, `sysctl` has another key `hw.perflevel0.cpusperl2` which allows us to calculate the total size of L2 of all performance cores.

```
macOS 13.0 22A5342f arm64 | M1 Pro 2E+6P

hw.perflevel0.physicalcpu: 6
hw.perflevel0.physicalcpu_max: 6
hw.perflevel0.logicalcpu: 6
hw.perflevel0.logicalcpu_max: 6
hw.perflevel0.l1icachesize: 196608
hw.perflevel0.l1dcachesize: 131072
hw.perflevel0.l2cachesize: 12582912
hw.perflevel0.cpusperl2: 3
hw.perflevel0.name: Performance
```