### PR TITLE
Fix servicing failures when building coreclr nuget packages

### DIFF
--- a/src/coreclr/.nuget/Directory.Build.props
+++ b/src/coreclr/.nuget/Directory.Build.props
@@ -17,6 +17,11 @@
     <!-- coreclr doesn't currently use the index so don't force it to be in sync -->
     <SkipIndexCheck>true</SkipIndexCheck>
   </PropertyGroup>
+  
+  <!-- CoreCLR nuget packages shouldn't be published during servicing. -->
+  <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageIndex Condition="'$(MSBuildProjectExtension)' == '.pkgproj'" Include="$(PackageIndexFile)" />


### PR DESCRIPTION
This change was part of https://github.com/dotnet/runtime/commit/a23a20b74e6a6d4992bb5d3578997da939fa5314#diff-8ff7afaf3544b3026538912211057b70e70c5957b1581d3623ad34d4eba2fc59R26-R28 (during .NET 6) but never got forward ported into main.

Fixes the failures in the 7.0.1 test servicing build:

```
/__w/1/s/.packages/microsoft.dotnet.build.tasks.packaging/7.0.0-beta.22416.1/build/Packaging.targets(800,5): error : No VersionSuffix was set. Ensure it is set before targets in packaging are ran. [/__w/1/s/src/coreclr/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.pkgproj]
##[error].packages/microsoft.dotnet.build.tasks.packaging/7.0.0-beta.22416.1/build/Packaging.targets(800,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) No VersionSuffix was set. Ensure it is set before targets in packaging are ran.
/__w/1/s/.packages/microsoft.dotnet.build.tasks.packaging/7.0.0-beta.22416.1/build/Packaging.targets(800,5): error : No VersionSuffix was set. Ensure it is set before targets in packaging are ran. [/__w/1/s/src/coreclr/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.pkgproj]
##[error].packages/microsoft.dotnet.build.tasks.packaging/7.0.0-beta.22416.1/build/Packaging.targets(800,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) No VersionSuffix was set. Ensure it is set before targets in packaging are ran.
```