### PR TITLE
Use fixed version of dotnet for Spmi benchmark

### DIFF
--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -66,65 +66,65 @@ jobs:
     jobParameters:
       testGroup: outerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+#     buildConfig: checked
+#     platforms:
+#     - OSX_arm64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: pmi
+#       collectionName: libraries
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: libraries_tests
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+#     buildConfig: checked
+#     platforms:
+#     - OSX_arm64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: pmi
+#       collectionName: libraries_tests
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      collectionType: crossgen2
-      collectionName: libraries
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+#     buildConfig: checked
+#     platforms:
+#     - OSX_arm64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       collectionType: crossgen2
+#       collectionName: libraries
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -146,24 +146,24 @@ jobs:
       collectionType: run
       collectionName: benchmarks
 
-#
-# Collection of coreclr test run
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - OSX_arm64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: superpmi
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
-      SuperPmiCollect: true
+# #
+# # Collection of coreclr test run
+# #
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+#     buildConfig: checked
+#     platforms:
+#     - OSX_arm64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: superpmi
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
+#       SuperPmiCollect: true

--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -66,65 +66,65 @@ jobs:
     jobParameters:
       testGroup: outerloop
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-#     buildConfig: checked
-#     platforms:
-#     - OSX_arm64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: pmi
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+    buildConfig: checked
+    platforms:
+    - OSX_arm64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: libraries
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-#     buildConfig: checked
-#     platforms:
-#     - OSX_arm64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: pmi
-#       collectionName: libraries_tests
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+    buildConfig: checked
+    platforms:
+    - OSX_arm64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: pmi
+      collectionName: libraries_tests
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-#     buildConfig: checked
-#     platforms:
-#     - OSX_arm64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: ci
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       collectionType: crossgen2
-#       collectionName: libraries
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+    buildConfig: checked
+    platforms:
+    - OSX_arm64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      collectionType: crossgen2
+      collectionName: libraries
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
@@ -146,24 +146,24 @@ jobs:
       collectionType: run
       collectionName: benchmarks
 
-# #
-# # Collection of coreclr test run
-# #
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-#     buildConfig: checked
-#     platforms:
-#     - OSX_arm64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     helixQueueGroup: superpmi
-#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-#     jobParameters:
-#       testGroup: outerloop
-#       liveLibrariesBuildConfig: Release
-#       SuperPmiCollect: true
+#
+# Collection of coreclr test run
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    buildConfig: checked
+    platforms:
+    - OSX_arm64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    helixQueueGroup: superpmi
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+      SuperPmiCollect: true

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -390,7 +390,9 @@ def setup_microbenchmark(workitem_directory, arch):
             print("Missing " + dotnet_install_script)
             return
 
-        # Hardcode the dotnet-version
+        # Sometimes the dotnet version installed by the script is latest and expect certain versions of SDK that
+        # have not published yet. As a result, we hit errors of "dotnet restore". As a workaround, hard code the
+        # working version until we move to ".NET 8" in the script.
         run_command(
             get_python_name() + [dotnet_install_script, "install", "--dotnet-versions", "7.0.100-rc.2.22458.3", "--architecture", arch, "--install-dir",
                                  dotnet_directory, "--verbose"])

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -37,6 +37,7 @@
 
 import argparse
 import os
+import shutil
 import stat
 
 from coreclr_arguments import *
@@ -376,6 +377,11 @@ def setup_microbenchmark(workitem_directory, arch):
     run_command(
         ["git", "clone", "--quiet", "--depth", "1", "https://github.com/dotnet/performance", performance_directory])
 
+    try:
+        shutil.rmtree(os.path.join(performance_directory, ".git"))
+    except Exception as ex:
+        print("Warning: failed to remove directory \"%s\": %s", os.path.join(performance_directory, ".git"), ex)
+
     with ChangeDir(performance_directory):
         dotnet_directory = os.path.join(performance_directory, "tools", "dotnet", arch)
         dotnet_install_script = os.path.join(performance_directory, "scripts", "dotnet.py")
@@ -384,8 +390,9 @@ def setup_microbenchmark(workitem_directory, arch):
             print("Missing " + dotnet_install_script)
             return
 
+        # Hardcode the dotnet-version
         run_command(
-            get_python_name() + [dotnet_install_script, "install", "--architecture", arch, "--install-dir",
+            get_python_name() + [dotnet_install_script, "install", "--dotnet-versions", "7.0.100-rc.2.22458.3", "--architecture", arch, "--install-dir",
                                  dotnet_directory, "--verbose"])
 
 


### PR DESCRIPTION
As part of MicroBenchmarks superpmi collection setup, we install latest `dotnet` and use it to build `MicroBenchmarks.csproj`. But sometimes, the SDKs it brings are not available on nuget and we end up getting `dotnet restore` error. Hardcode the version of `dotnet` we use to build `MicroBenchmarks.csproj`. It doesn't matter which version we use because eventually we just need to run them once for the collection.

Also, added logic to delete `.git` folder of `dotnet/performance` repo before transferring the payload to helix.