### PR TITLE
Delete duplicative code in WebClient

### DIFF
--- a/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -28,6 +28,7 @@
     <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.ComponentModel.EventBasedAsync" />
     <Reference Include="System.ComponentModel.Primitives" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Net.Requests" />
     <Reference Include="System.Net.WebHeaderCollection" />


### PR DESCRIPTION
It had its own implementation of URL encoding; we can just use WebUtility.UrlEncode.  And it had its own helper for checking whether a byte array had a prefix; we can just use StartsWith.