### PR TITLE
Use UTF8 encoding on Tar string fields

### DIFF
--- a/src/libraries/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Unix.cs
@@ -17,6 +17,7 @@ namespace System.IO
         internal const string DirectorySeparatorCharAsString = "/";
         internal const string ParentDirectoryPrefix = @"../";
         internal const string DirectorySeparators = DirectorySeparatorCharAsString;
+        internal static ReadOnlySpan<byte> Utf8DirectorySeparators => "/"u8;
 
         internal static int GetRootLength(ReadOnlySpan<char> path)
         {

--- a/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
@@ -55,6 +55,7 @@ namespace System.IO
         internal const string DevicePathPrefix = @"\\.\";
         internal const string ParentDirectoryPrefix = @"..\";
         internal const string DirectorySeparators = @"\/";
+        internal static ReadOnlySpan<byte> Utf8DirectorySeparators => @"\/"u8;
 
         internal const int MaxShortPath = 260;
         internal const int MaxShortDirectoryPath = 248;

--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -260,5 +260,8 @@
   </data>
   <data name="TarInvalidNumber" xml:space="preserve">
     <value>Unable to parse number.</value>
+  </data>
+  <data name="TarEntryNameExceedsMaxLength" xml:space="preserve">
+    <value>The name exceeds the maximum allowed length for this format.</value>
   </data>
 </root>

--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -261,7 +261,7 @@
   <data name="TarInvalidNumber" xml:space="preserve">
     <value>Unable to parse number.</value>
   </data>
-  <data name="TarEntryNameExceedsMaxLength" xml:space="preserve">
-    <value>The name exceeds the maximum allowed length for this format.</value>
+  <data name="TarEntryFieldExceedsMaxLength" xml:space="preserve">
+    <value>The field '{0}' exceeds the maximum allowed length for this format.</value>
   </data>
 </root>

--- a/src/libraries/System.Formats.Tar/src/System.Formats.Tar.csproj
+++ b/src/libraries/System.Formats.Tar/src/System.Formats.Tar.csproj
@@ -65,6 +65,7 @@
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MkFifo.cs" Link="Common\Interop\Unix\System.Native\Interop.MkFifo.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.cs" Link="Common\Interop\Unix\Interop.Stat.cs" />
     <Compile Include="$(CommonPath)System\IO\Archiving.Utils.Unix.cs" Link="Common\System\IO\Archiving.Utils.Unix.cs" />
+    <Compile Include="$(CommonPath)System\IO\PathInternal.Unix.cs" Link="Common\System\IO\PathInternal.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -517,8 +517,8 @@ namespace System.Formats.Tar
         private void ReadPosixAndGnuSharedAttributes(Span<byte> buffer)
         {
             // Convert the byte arrays
-            _uName = TarHelpers.GetTrimmedAsciiString(buffer.Slice(FieldLocations.UName, FieldLengths.UName));
-            _gName = TarHelpers.GetTrimmedAsciiString(buffer.Slice(FieldLocations.GName, FieldLengths.GName));
+            _uName = TarHelpers.GetTrimmedUtf8String(buffer.Slice(FieldLocations.UName, FieldLengths.UName));
+            _gName = TarHelpers.GetTrimmedUtf8String(buffer.Slice(FieldLocations.GName, FieldLengths.GName));
 
             // DevMajor and DevMinor only have values with character devices and block devices.
             // For all other typeflags, the values in these fields are irrelevant.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -836,6 +836,12 @@ namespace System.Formats.Tar
         // Returns the text's utf16 length truncated at the specified max length.
         private static int GetUtf16TruncatedTextLength(ReadOnlySpan<char> text, int maxLength)
         {
+            // fast path, most entries will be smaller than maxLength.
+            if (Encoding.UTF8.GetByteCount(text) <= maxLength)
+            {
+                return text.Length;
+            }
+
             int utf8Length = 0;
             int utf16TruncatedLength = 0;
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -366,9 +366,9 @@ namespace System.Formats.Tar
 
             ReadOnlySpan<char> truncatedName = name.Slice(0, utf16NameTruncatedLength);
             Span<byte> destination = buffer.Slice(FieldLocations.Name, FieldLengths.Name);
-            Encoding.UTF8.GetBytes(truncatedName, destination);
+            int encoded = Encoding.UTF8.GetBytes(truncatedName, destination);
 
-            return Checksum(destination);
+            return Checksum(destination.Slice(0, encoded));
         }
 
         // Ustar and PAX save in the name byte array only the UTF8 bytes that fit, and the rest of that string is saved in the prefix field.
@@ -379,9 +379,9 @@ namespace System.Formats.Tar
 
             ReadOnlySpan<char> truncatedName = name.Slice(0, utf16NameTruncatedLength);
             Span<byte> destination = buffer.Slice(FieldLocations.Name, FieldLengths.Name);
-            Encoding.UTF8.GetBytes(truncatedName, destination);
+            int encoded = Encoding.UTF8.GetBytes(truncatedName, destination);
 
-            int checksum = Checksum(destination);
+            int checksum = Checksum(destination.Slice(0, encoded));
 
             if (utf16NameTruncatedLength < name.Length)
             {
@@ -390,9 +390,9 @@ namespace System.Formats.Tar
 
                 destination = buffer.Slice(FieldLocations.Prefix, FieldLengths.Prefix);
                 ReadOnlySpan<char> truncatedPrefix = prefix.Slice(0, utf16PrefixTruncatedLength);
-                Encoding.UTF8.GetBytes(truncatedPrefix, destination);
+                encoded = Encoding.UTF8.GetBytes(truncatedPrefix, destination);
 
-                checksum += Checksum(destination);
+                checksum += Checksum(destination.Slice(0, encoded));
             }
 
             return checksum;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -559,6 +559,7 @@ namespace System.Formats.Tar
             if (!string.IsNullOrEmpty(_gName))
             {
                 ReadOnlySpan<char> gName = _gName;
+
                 if (GetUtf8TextLength(gName) > FieldLengths.GName)
                 {
                     if (_format is not TarEntryFormat.Pax)
@@ -566,7 +567,7 @@ namespace System.Formats.Tar
                         throw new ArgumentException(SR.Format(SR.TarEntryFieldExceedsMaxLength, nameof(PaxTarEntry.GroupName)), ArgNameEntry);
                     }
 
-                    int truncatedLength = GetUtf16TruncatedTextLength(gName, FieldLengths.UName);
+                    int truncatedLength = GetUtf16TruncatedTextLength(gName, FieldLengths.GName);
                     gName = gName.Slice(0, truncatedLength);
                 }
 
@@ -924,6 +925,8 @@ namespace System.Formats.Tar
         // Returns the text's utf16 length truncated at the specified utf8 max length.
         private static int GetUtf16TruncatedTextLength(ReadOnlySpan<char> text, int utf8MaxLength)
         {
+            Debug.Assert(GetUtf8TextLength(text) > utf8MaxLength);
+
             int utf8Length = 0;
             int utf16TruncatedLength = 0;
 

--- a/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
+++ b/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="TarTestsBase.Posix.cs" />
     <Compile Include="TarTestsBase.Ustar.cs" />
     <Compile Include="TarTestsBase.V7.cs" />
+    <Compile Include="TarWriter\TarWriter.WriteEntry.Entry.Roundtrip.Tests.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.File.Tests.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntry.Base.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.Tests.cs" />

--- a/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
+++ b/src/libraries/System.Formats.Tar/tests/System.Formats.Tar.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.File.Tests.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntry.Base.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.Tests.cs" />
+    <Compile Include="TarWriter\TarWriter.WriteEntryAsync.Entry.Roundtrip.Tests.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.Entry.Ustar.Tests.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.Entry.V7.Tests.cs" />
     <Compile Include="TarWriter\TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs" />

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -90,8 +90,8 @@ namespace System.Formats.Tar.Tests
         protected const string PaxEaDevMajor = "devmajor";
         protected const string PaxEaDevMinor = "devminor";
         internal const char OneByteCharacter = 'a';
-        internal const char TwoBytesCharacter = 'ö';
-        internal const string FourBytesCharacter = "😒";
+        internal const char TwoBytesCharacter = '\u00F6';
+        internal const string FourBytesCharacter = "\uD83D\uDE12";
         internal const char Separator = '/';
         internal const int MaxPathComponent = 255;
 

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -630,7 +630,7 @@ namespace System.Formats.Tar.Tests
 
         private static List<string> GetPrefixes()
         {
-            List<string> prefixes = new() { "", "/", "./", "../" };
+            List<string> prefixes = new() { "", "/a/", "./", "../" };
 
             if (OperatingSystem.IsWindows())
                 prefixes.Add("C:/");
@@ -643,13 +643,17 @@ namespace System.Formats.Tar.Tests
             Assert.True(Enum.IsDefined(max));
             List<string> prefixes = GetPrefixes();
 
-            // prefix + name of length 100
             foreach (string prefix in prefixes)
             {
+                // prefix + name of length 100
                 int nameLength = 100 - prefix.Length;
                 yield return prefix + Repeat(OneByteCharacter, nameLength);
-                yield return prefix + Repeat(OneByteCharacter, nameLength - 2) + Repeat(TwoBytesCharacter, 1);
-                yield return prefix + Repeat(OneByteCharacter, nameLength - 4) + Repeat(FourBytesCharacter, 1);
+                yield return prefix + Repeat(OneByteCharacter, nameLength - 2) + TwoBytesCharacter;
+                yield return prefix + Repeat(OneByteCharacter, nameLength - 4) + FourBytesCharacter;
+
+                // prefix alone
+                if (prefix != string.Empty)
+                    yield return prefix;
             }
 
             if (max == NameCapabilities.Name)
@@ -659,8 +663,8 @@ namespace System.Formats.Tar.Tests
             foreach (string prefix in prefixes)
             {
                 yield return prefix + Repeat(OneByteCharacter, 100);
-                yield return prefix + Repeat(OneByteCharacter, 100 - 2) + Repeat(TwoBytesCharacter, 1);
-                yield return prefix + Repeat(OneByteCharacter, 100 - 4) + Repeat(FourBytesCharacter, 1);
+                yield return prefix + Repeat(OneByteCharacter, 100 - 2) + TwoBytesCharacter;
+                yield return prefix + Repeat(OneByteCharacter, 100 - 4) + FourBytesCharacter;
             }
 
             // maxed out prefix and name.
@@ -668,8 +672,8 @@ namespace System.Formats.Tar.Tests
             {
                 int directoryLength = 155 - prefix.Length;
                 yield return prefix + Repeat(OneByteCharacter, directoryLength) + Separator + Repeat(OneByteCharacter, 100);
-                yield return prefix + Repeat(OneByteCharacter, directoryLength - 2) + Repeat(TwoBytesCharacter, 1) + Separator + Repeat(OneByteCharacter, 100);
-                yield return prefix + Repeat(OneByteCharacter, directoryLength - 4) + Repeat(FourBytesCharacter, 1) + Separator + Repeat(OneByteCharacter, 100);
+                yield return prefix + Repeat(OneByteCharacter, directoryLength - 2) + TwoBytesCharacter + Separator + Repeat(OneByteCharacter, 100);
+                yield return prefix + Repeat(OneByteCharacter, directoryLength - 4) + FourBytesCharacter + Separator + Repeat(OneByteCharacter, 100);
             }
 
             if (max == NameCapabilities.NameAndPrefix)
@@ -679,8 +683,8 @@ namespace System.Formats.Tar.Tests
             {
                 int directoryLength = MaxPathComponent - prefix.Length;
                 yield return prefix + Repeat(OneByteCharacter, directoryLength) + Separator + Repeat(OneByteCharacter, MaxPathComponent);
-                yield return prefix + Repeat(OneByteCharacter, directoryLength - 2) + Repeat(TwoBytesCharacter, 1) + Separator + Repeat(OneByteCharacter, MaxPathComponent);
-                yield return prefix + Repeat(OneByteCharacter, directoryLength - 4) + Repeat(FourBytesCharacter, 1) + Separator + Repeat(OneByteCharacter, MaxPathComponent);
+                yield return prefix + Repeat(OneByteCharacter, directoryLength - 2) + TwoBytesCharacter + Separator + Repeat(OneByteCharacter, MaxPathComponent);
+                yield return prefix + Repeat(OneByteCharacter, directoryLength - 4) + FourBytesCharacter + Separator + Repeat(OneByteCharacter, MaxPathComponent);
             }
         }
 
@@ -730,6 +734,10 @@ namespace System.Formats.Tar.Tests
         internal static IEnumerable<string> GetTooLongNamesTestData(NameCapabilities max)
         {
             Assert.True(max is NameCapabilities.Name or NameCapabilities.NameAndPrefix);
+
+            // root directory can't be saved as prefix
+            yield return "/" + Repeat(OneByteCharacter, 100);
+
             List<string> prefixes = GetPrefixes();
 
             // 1. non-ascii last character doesn't fit in name.
@@ -754,8 +762,8 @@ namespace System.Formats.Tar.Tests
             yield return Repeat(OneByteCharacter, 155 - 4) + Repeat(FourBytesCharacter, 2) + Separator + maxedOutName;
 
             // 2.2 last char doesn't fit by one byte.
-            yield return Repeat(OneByteCharacter, 155 - 2 + 1) + Repeat(TwoBytesCharacter, 1) + Separator + maxedOutName;
-            yield return Repeat(OneByteCharacter, 155 - 4 + 1) + Repeat(FourBytesCharacter, 1) + Separator + maxedOutName;
+            yield return Repeat(OneByteCharacter, 155 - 2 + 1) + TwoBytesCharacter + Separator + maxedOutName;
+            yield return Repeat(OneByteCharacter, 155 - 4 + 1) + FourBytesCharacter + Separator + maxedOutName;
 
             if (max is NameCapabilities.NameAndPrefix)
                 yield break;

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.Tests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
@@ -195,17 +194,18 @@ namespace System.Formats.Tar.Tests
             }
             else
             {
-                entryName = new string('a', 150);
-                // 100 * 97 = 9700 (first 100 bytes go into 'name' field)
-                expectedChecksum += 9700;
+                entryName = new string('a', 100);
+                expectedChecksum += 9700; // 100 * 97 = 9700 (first 100 bytes go into 'name' field)
 
-                // - V7 does not support name fields larger than 100, writes what it can
-                // - Gnu writes first 100 bytes in 'name' field, then the full name is written in a LonPath entry
-                // that precedes this one.
-                if (format is TarEntryFormat.Ustar or TarEntryFormat.Pax)
+                // V7 does not support name fields larger than 100
+                if (format is not TarEntryFormat.V7)
+                    entryName += "/" + new string('a', 50);
+
+                // Gnu and Pax writes first 100 bytes in 'name' field, then the full name is written in a metadata entry that precedes this one.
+                if (format is TarEntryFormat.Ustar)
                 {
-                    // 50 * 97 = 4850 (rest of bytes go into 'prefix' field)
-                    expectedChecksum += 4850;
+                    // Ustar can write the directory into prefix.
+                    expectedChecksum += 4850; // 50 * 97 = 4850
                 }
             }
             return expectedChecksum;

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Roundtrip.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Roundtrip.Tests.cs
@@ -1,0 +1,140 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace System.Formats.Tar.Tests
+{
+    public class TarWriter_WriteEntry_Roundtrip_Tests : TarTestsBase
+    {
+        public static IEnumerable<object[]> NameRoundtripsTheoryData()
+        {
+            foreach (TarEntryType entryType in new[] { TarEntryType.RegularFile, TarEntryType.Directory })
+            {
+                TarEntryType v7EntryType = entryType is TarEntryType.RegularFile ? TarEntryType.V7RegularFile : entryType;
+                foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.Name).Concat(GetNamesPrefixedTestData(NameCapabilities.Name)))
+                {
+                    yield return new object[] { TarEntryFormat.V7, v7EntryType, name };
+                }
+
+                // TODO: Use NameCapabilities.NameAndPrefix once https://github.com/dotnet/runtime/issues/75360 is fixed.
+                foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.Name).Concat(GetNamesPrefixedTestData(NameCapabilities.Name)))
+                {
+                    yield return new object[] { TarEntryFormat.Ustar, entryType, name };
+                }
+
+                foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.Unlimited).Concat(GetNamesPrefixedTestData(NameCapabilities.Unlimited)))
+                {
+                    yield return new object[] { TarEntryFormat.Pax, entryType, name };
+                    yield return new object[] { TarEntryFormat.Gnu, entryType, name };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NameRoundtripsTheoryData))]
+        public void NameRoundtrips(TarEntryFormat entryFormat, TarEntryType entryType, string name)
+        {
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, name);
+            entry.Name = name;
+
+            MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                writer.WriteEntry(entry);
+            }
+
+            ms.Position = 0;
+            using TarReader reader = new(ms);
+
+            entry = reader.GetNextEntry();
+            Assert.Null(reader.GetNextEntry());
+            Assert.Equal(name, entry.Name);
+        }
+
+        public static IEnumerable<object[]> LinkNameRoundtripsTheoryData()
+        {
+            foreach (TarEntryType entryType in new[] { TarEntryType.SymbolicLink, TarEntryType.HardLink })
+            {
+                foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.Name).Concat(GetNamesPrefixedTestData(NameCapabilities.Name)))
+                {
+                    yield return new object[] { TarEntryFormat.V7, entryType, name };
+                    // TODO: Use NameCapabilities.NameAndPrefix once https://github.com/dotnet/runtime/issues/75360 is fixed.
+                    yield return new object[] { TarEntryFormat.Ustar, entryType, name };
+                }
+
+                foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.Unlimited).Concat(GetNamesPrefixedTestData(NameCapabilities.Unlimited)))
+                {
+                    yield return new object[] { TarEntryFormat.Pax, entryType, name };
+                    yield return new object[] { TarEntryFormat.Gnu, entryType, name };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LinkNameRoundtripsTheoryData))]
+        public void LinkNameRoundtrips(TarEntryFormat entryFormat, TarEntryType entryType, string linkName)
+        {
+            string name = "foo";
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, name);
+            entry.LinkName = linkName;
+
+            MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                writer.WriteEntry(entry);
+            }
+
+            ms.Position = 0;
+            using TarReader reader = new(ms);
+
+            entry = reader.GetNextEntry();
+            Assert.Null(reader.GetNextEntry());
+            Assert.Equal(name, entry.Name);
+            Assert.Equal(linkName, entry.LinkName);
+        }
+
+
+        public static IEnumerable<object[]> UserNameGroupNameRoundtripsTheoryData()
+        {
+            foreach (TarEntryFormat entryFormat in new[] { TarEntryFormat.Ustar, TarEntryFormat.Pax, TarEntryFormat.Gnu })
+            {
+                yield return new object[] { entryFormat, Repeat(OneByteCharacter, 32) };
+                yield return new object[] { entryFormat, Repeat(TwoBytesCharacter, 32 / 2) };
+                yield return new object[] { entryFormat, Repeat(FourBytesCharacter, 32 / 4) };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(UserNameGroupNameRoundtripsTheoryData))]
+        public void UserNameGroupNameRoundtrips(TarEntryFormat entryFormat, string userGroupName)
+        {
+            string name = "foo";
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, name);
+            PosixTarEntry posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
+            posixEntry.UserName = userGroupName;
+            posixEntry.GroupName = userGroupName;
+
+            MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                writer.WriteEntry(posixEntry);
+            }
+
+            ms.Position = 0;
+            using TarReader reader = new(ms);
+
+            entry = reader.GetNextEntry();
+            posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
+            Assert.Null(reader.GetNextEntry());
+
+            Assert.Equal(name, posixEntry.Name);
+            Assert.Equal(userGroupName, posixEntry.UserName);
+            Assert.Equal(userGroupName, posixEntry.GroupName);
+        }
+    }
+}

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Roundtrip.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Roundtrip.Tests.cs
@@ -15,14 +15,13 @@ namespace System.Formats.Tar.Tests
         {
             foreach (TarEntryType entryType in new[] { TarEntryType.RegularFile, TarEntryType.Directory })
             {
-                TarEntryType v7EntryType = entryType is TarEntryType.RegularFile ? TarEntryType.V7RegularFile : entryType;
                 foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.Name).Concat(GetNamesPrefixedTestData(NameCapabilities.Name)))
                 {
+                    TarEntryType v7EntryType = entryType is TarEntryType.RegularFile ? TarEntryType.V7RegularFile : entryType;
                     yield return new object[] { TarEntryFormat.V7, v7EntryType, name };
                 }
 
-                // TODO: Use NameCapabilities.NameAndPrefix once https://github.com/dotnet/runtime/issues/75360 is fixed.
-                foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.Name).Concat(GetNamesPrefixedTestData(NameCapabilities.Name)))
+                foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.NameAndPrefix).Concat(GetNamesPrefixedTestData(NameCapabilities.NameAndPrefix)))
                 {
                     yield return new object[] { TarEntryFormat.Ustar, entryType, name };
                 }
@@ -63,7 +62,6 @@ namespace System.Formats.Tar.Tests
                 foreach (string name in GetNamesNonAsciiTestData(NameCapabilities.Name).Concat(GetNamesPrefixedTestData(NameCapabilities.Name)))
                 {
                     yield return new object[] { TarEntryFormat.V7, entryType, name };
-                    // TODO: Use NameCapabilities.NameAndPrefix once https://github.com/dotnet/runtime/issues/75360 is fixed.
                     yield return new object[] { TarEntryFormat.Ustar, entryType, name };
                 }
 
@@ -97,7 +95,6 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(name, entry.Name);
             Assert.Equal(linkName, entry.LinkName);
         }
-
 
         public static IEnumerable<object[]> UserNameGroupNameRoundtripsTheoryData()
         {

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Roundtrip.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Roundtrip.Tests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Xunit;

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
@@ -380,5 +380,75 @@ namespace System.Formats.Tar.Tests
             TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, name);
             Assert.Throws<ArgumentException>("entry", () => writer.WriteEntry(entry));
         }
+
+        public static IEnumerable<object[]> WriteEntry_TooLongLinkName_Throws_TheoryData()
+        {
+            foreach (TarEntryType entryType in new[] { TarEntryType.SymbolicLink, TarEntryType.HardLink })
+            {
+                foreach (string name in GetTooLongNamesTestData(NameCapabilities.Name))
+                {
+                    yield return new object[] { TarEntryFormat.V7, entryType, name };
+                }
+
+                foreach (string name in GetTooLongNamesTestData(NameCapabilities.NameAndPrefix))
+                {
+                    yield return new object[] { TarEntryFormat.Ustar, entryType, name };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(WriteEntry_TooLongLinkName_Throws_TheoryData))] // change usar, v7
+        public void WriteEntry_TooLongLinkName_Throws(TarEntryFormat entryFormat, TarEntryType entryType, string linkName)
+        {
+            using TarWriter writer = new(new MemoryStream());
+
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, "foo");
+            entry.LinkName = linkName;
+
+            Assert.Throws<ArgumentException>("entry", () => writer.WriteEntry(entry));
+        }
+
+        public static IEnumerable<object[]> WriteEntry_TooLongUserGroupName_Throws_TheoryData()
+        {
+            // Not testing Pax as it supports unlimited size uname/gname.
+            foreach (TarEntryFormat entryFormat in new[] { TarEntryFormat.Ustar, TarEntryFormat.Gnu })
+            {
+                // Last character doesn't fit fully.
+                yield return new object[] { entryFormat, Repeat(OneByteCharacter, 32 + 1) };
+                yield return new object[] { entryFormat, Repeat(TwoBytesCharacter, 32 / 2 + 1) };
+                yield return new object[] { entryFormat, Repeat(FourBytesCharacter, 32 / 4 + 1) };
+
+                // Last character doesn't fit by one byte.
+                yield return new object[] { entryFormat, Repeat(TwoBytesCharacter, 32 - 2 + 1) + TwoBytesCharacter };
+                yield return new object[] { entryFormat, Repeat(FourBytesCharacter, 32 - 4 + 1) + FourBytesCharacter };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(WriteEntry_TooLongUserGroupName_Throws_TheoryData))]
+        public void WriteEntry_TooLongUserName_Throws(TarEntryFormat entryFormat, string userName)
+        {
+            using TarWriter writer = new(new MemoryStream());
+
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, "foo");
+            PosixTarEntry posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
+            posixEntry.UserName = userName;
+
+            Assert.Throws<ArgumentException>("entry", () => writer.WriteEntry(entry));
+        }
+
+        [Theory]
+        [MemberData(nameof(WriteEntry_TooLongUserGroupName_Throws_TheoryData))]
+        public void WriteEntry_TooLongGroupName_Throws(TarEntryFormat entryFormat, string groupName)
+        {
+            using TarWriter writer = new(new MemoryStream());
+
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, "foo");
+            PosixTarEntry posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
+            posixEntry.GroupName = groupName;
+
+            Assert.Throws<ArgumentException>("entry", () => writer.WriteEntry(entry));
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Tests.cs
@@ -398,7 +398,7 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [MemberData(nameof(WriteEntry_TooLongLinkName_Throws_TheoryData))] // change usar, v7
+        [MemberData(nameof(WriteEntry_TooLongLinkName_Throws_TheoryData))]
         public void WriteEntry_TooLongLinkName_Throws(TarEntryFormat entryFormat, TarEntryType entryType, string linkName)
         {
             using TarWriter writer = new(new MemoryStream());

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Roundtrip.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Roundtrip.Tests.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Formats.Tar.Tests
+{
+    public class TarWriter_WriteEntryAsync_Roundtrip_Tests : TarTestsBase
+    {
+        public static IEnumerable<object[]> NameRoundtripsAsyncTheoryData()
+            => TarWriter_WriteEntry_Roundtrip_Tests.NameRoundtripsTheoryData();
+
+        [Theory]
+        [MemberData(nameof(NameRoundtripsAsyncTheoryData))]
+        public async Task NameRoundtripsAsync(TarEntryFormat entryFormat, TarEntryType entryType, string name)
+        {
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, name);
+            entry.Name = name;
+
+            MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                await writer.WriteEntryAsync(entry);
+            }
+
+            ms.Position = 0;
+            using TarReader reader = new(ms);
+
+            entry = await reader.GetNextEntryAsync();
+            Assert.Null(await reader.GetNextEntryAsync());
+            Assert.Equal(name, entry.Name);
+        }
+
+        public static IEnumerable<object[]> LinkNameRoundtripsAsyncTheoryData()
+            => TarWriter_WriteEntry_Roundtrip_Tests.LinkNameRoundtripsTheoryData();
+
+        [Theory]
+        [MemberData(nameof(LinkNameRoundtripsAsyncTheoryData))]
+        public async Task LinkNameRoundtrips(TarEntryFormat entryFormat, TarEntryType entryType, string linkName)
+        {
+            string name = "foo";
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, name);
+            entry.LinkName = linkName;
+
+            MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                await writer.WriteEntryAsync(entry);
+            }
+
+            ms.Position = 0;
+            using TarReader reader = new(ms);
+
+            entry = await reader.GetNextEntryAsync();
+            Assert.Null(await reader.GetNextEntryAsync());
+            Assert.Equal(name, entry.Name);
+            Assert.Equal(linkName, entry.LinkName);
+        }
+
+        public static IEnumerable<object[]> UserNameGroupNameRoundtripsAsyncTheoryData()
+            => TarWriter_WriteEntry_Roundtrip_Tests.UserNameGroupNameRoundtripsTheoryData();
+
+        [Theory]
+        [MemberData(nameof(UserNameGroupNameRoundtripsAsyncTheoryData))]
+        public async Task UserNameGroupNameRoundtrips(TarEntryFormat entryFormat, string userGroupName)
+        {
+            string name = "foo";
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, name);
+            PosixTarEntry posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
+            posixEntry.UserName = userGroupName;
+            posixEntry.GroupName = userGroupName;
+
+            MemoryStream ms = new();
+            using (TarWriter writer = new(ms, leaveOpen: true))
+            {
+                await writer.WriteEntryAsync(posixEntry);
+            }
+
+            ms.Position = 0;
+            using TarReader reader = new(ms);
+
+            entry = await reader.GetNextEntryAsync();
+            posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
+            Assert.Null(await reader.GetNextEntryAsync());
+
+            Assert.Equal(name, posixEntry.Name);
+            Assert.Equal(userGroupName, posixEntry.UserName);
+            Assert.Equal(userGroupName, posixEntry.GroupName);
+        }
+    }
+}

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Roundtrip.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Roundtrip.Tests.cs
@@ -23,13 +23,13 @@ namespace System.Formats.Tar.Tests
             MemoryStream ms = new();
             Stream s = unseekableStream ? new WrappedStream(ms, ms.CanRead, ms.CanWrite, canSeek: false) : ms;
 
-            using (TarWriter writer = new(s, leaveOpen: true))
+            await using (TarWriter writer = new(s, leaveOpen: true))
             {
                 await writer.WriteEntryAsync(entry);
             }
 
             ms.Position = 0;
-            using TarReader reader = new(s);
+            await using TarReader reader = new(s);
 
             entry = await reader.GetNextEntryAsync();
             Assert.Null(await reader.GetNextEntryAsync());
@@ -41,7 +41,7 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(LinkNameRoundtripsAsyncTheoryData))]
-        public async Task LinkNameRoundtrips(TarEntryFormat entryFormat, TarEntryType entryType, bool unseekableStream, string linkName)
+        public async Task LinkNameRoundtripsAsync(TarEntryFormat entryFormat, TarEntryType entryType, bool unseekableStream, string linkName)
         {
             string name = "foo";
             TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, name);
@@ -50,13 +50,13 @@ namespace System.Formats.Tar.Tests
             MemoryStream ms = new();
             Stream s = unseekableStream ? new WrappedStream(ms, ms.CanRead, ms.CanWrite, canSeek: false) : ms;
 
-            using (TarWriter writer = new(s, leaveOpen: true))
+            await using (TarWriter writer = new(s, leaveOpen: true))
             {
                 await writer.WriteEntryAsync(entry);
             }
 
             ms.Position = 0;
-            using TarReader reader = new(s);
+            await using TarReader reader = new(s);
 
             entry = await reader.GetNextEntryAsync();
             Assert.Null(await reader.GetNextEntryAsync());
@@ -69,7 +69,7 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(UserNameGroupNameRoundtripsAsyncTheoryData))]
-        public async Task UserNameGroupNameRoundtrips(TarEntryFormat entryFormat, bool unseekableStream, string userGroupName)
+        public async Task UserNameGroupNameRoundtripsAsync(TarEntryFormat entryFormat, bool unseekableStream, string userGroupName)
         {
             string name = "foo";
             TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, name);
@@ -80,13 +80,13 @@ namespace System.Formats.Tar.Tests
             MemoryStream ms = new();
             Stream s = unseekableStream ? new WrappedStream(ms, ms.CanRead, ms.CanWrite, canSeek: false) : ms;
 
-            using (TarWriter writer = new(s, leaveOpen: true))
+            await using (TarWriter writer = new(s, leaveOpen: true))
             {
                 await writer.WriteEntryAsync(posixEntry);
             }
 
             ms.Position = 0;
-            using TarReader reader = new(s);
+            await using TarReader reader = new(s);
 
             entry = await reader.GetNextEntryAsync();
             posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Tests.cs
@@ -330,7 +330,7 @@ namespace System.Formats.Tar.Tests
         [MemberData(nameof(WriteEntry_TooLongName_Throws_Async_TheoryData))]
         public async Task WriteEntry_TooLongName_Throws_Async(TarEntryFormat entryFormat, TarEntryType entryType, string name)
         {
-            using TarWriter writer = new(new MemoryStream());
+            await using TarWriter writer = new(new MemoryStream());
 
             TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, name);
             await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(entry));
@@ -343,7 +343,7 @@ namespace System.Formats.Tar.Tests
         [MemberData(nameof(WriteEntry_TooLongLinkName_Throws_Async_TheoryData))]
         public async Task WriteEntry_TooLongLinkName_Throws_Async(TarEntryFormat entryFormat, TarEntryType entryType, string linkName)
         {
-            using TarWriter writer = new(new MemoryStream());
+            await using TarWriter writer = new(new MemoryStream());
 
             TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, "foo");
             entry.LinkName = linkName;
@@ -356,9 +356,9 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(WriteEntry_TooLongUserGroupName_Throws_Async_TheoryData))]
-        public async Task WriteEntry_TooLongUserName_Throws(TarEntryFormat entryFormat, string userName)
+        public async Task WriteEntry_TooLongUserName_Throws_Async(TarEntryFormat entryFormat, string userName)
         {
-            using TarWriter writer = new(new MemoryStream());
+            await using TarWriter writer = new(new MemoryStream());
 
             TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, "foo");
             PosixTarEntry posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
@@ -369,9 +369,9 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(WriteEntry_TooLongUserGroupName_Throws_Async_TheoryData))]
-        public async Task WriteEntry_TooLongGroupName_Throws(TarEntryFormat entryFormat, string groupName)
+        public async Task WriteEntry_TooLongGroupName_Throws_Async(TarEntryFormat entryFormat, string groupName)
         {
-            using TarWriter writer = new(new MemoryStream());
+            await using TarWriter writer = new(new MemoryStream());
 
             TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, "foo");
             PosixTarEntry posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Tests.cs
@@ -322,5 +322,62 @@ namespace System.Formats.Tar.Tests
                 }
             }
         }
+
+        public static IEnumerable<object[]> WriteEntry_TooLongName_Throws_Async_TheoryData()
+            => TarWriter_WriteEntry_Tests.WriteEntry_TooLongName_Throws_TheoryData();
+
+        [Theory]
+        [MemberData(nameof(WriteEntry_TooLongName_Throws_Async_TheoryData))]
+        public async Task WriteEntry_TooLongName_Throws_Async(TarEntryFormat entryFormat, TarEntryType entryType, string name)
+        {
+            using TarWriter writer = new(new MemoryStream());
+
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, name);
+            await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(entry));
+        }
+
+        public static IEnumerable<object[]> WriteEntry_TooLongLinkName_Throws_Async_TheoryData()
+            => TarWriter_WriteEntry_Tests.WriteEntry_TooLongLinkName_Throws_TheoryData();
+
+        [Theory]
+        [MemberData(nameof(WriteEntry_TooLongLinkName_Throws_Async_TheoryData))]
+        public async Task WriteEntry_TooLongLinkName_Throws_Async(TarEntryFormat entryFormat, TarEntryType entryType, string linkName)
+        {
+            using TarWriter writer = new(new MemoryStream());
+
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, entryType, "foo");
+            entry.LinkName = linkName;
+
+            await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(entry));
+        }
+
+        public static IEnumerable<object[]> WriteEntry_TooLongUserGroupName_Throws_Async_TheoryData()
+            => TarWriter_WriteEntry_Tests.WriteEntry_TooLongUserGroupName_Throws_TheoryData();
+
+        [Theory]
+        [MemberData(nameof(WriteEntry_TooLongUserGroupName_Throws_Async_TheoryData))]
+        public async Task WriteEntry_TooLongUserName_Throws(TarEntryFormat entryFormat, string userName)
+        {
+            using TarWriter writer = new(new MemoryStream());
+
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, "foo");
+            PosixTarEntry posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
+            posixEntry.UserName = userName;
+
+            await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(entry));
+        }
+
+        [Theory]
+        [MemberData(nameof(WriteEntry_TooLongUserGroupName_Throws_Async_TheoryData))]
+        public async Task WriteEntry_TooLongGroupName_Throws(TarEntryFormat entryFormat, string groupName)
+        {
+            using TarWriter writer = new(new MemoryStream());
+
+            TarEntry entry = InvokeTarEntryCreationConstructor(entryFormat, TarEntryType.RegularFile, "foo");
+            PosixTarEntry posixEntry = Assert.IsAssignableFrom<PosixTarEntry>(entry);
+            posixEntry.GroupName = groupName;
+
+            await Assert.ThrowsAsync<ArgumentException>("entry", () => writer.WriteEntryAsync(entry));
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75482
Fixes https://github.com/dotnet/runtime/issues/75360
Fixes https://github.com/dotnet/runtime/issues/75921
