### PR TITLE
[wasm][debugger] Removed internalProperties group.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
@@ -98,9 +98,7 @@ namespace BrowserDebugProxy
                 if (isStatic)
                     fieldValue["name"] = field.Name;
                 FieldAttributes attr = field.Attributes & FieldAttributes.FieldAccessMask;
-                fieldValue["__section"] = attr == FieldAttributes.Public
-                    ? "public" :
-                    attr == FieldAttributes.Private ? "private" : "internal";
+                fieldValue["__section"] = attr == FieldAttributes.Private ? "private" : "result";
 
                 if (field.IsBackingField)
                 {
@@ -218,7 +216,6 @@ namespace BrowserDebugProxy
                 result = _combinedResult.Clone();
                 RemovePropertiesFrom(result.Result);
                 RemovePropertiesFrom(result.PrivateMembers);
-                RemovePropertiesFrom(result.OtherMembers);
             }
 
             // 4 - fields + properties

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -988,7 +988,7 @@ namespace DebuggerTests
             return locals;
         }
 
-        internal async Task<(JToken, JToken, JToken)> GetPropertiesSortedByProtectionLevels(string id, JToken fn_args = null, bool? own_properties = null, bool? accessors_only = null, bool expect_ok = true)
+        internal async Task<(JToken, JToken)> GetPropertiesSortedByProtectionLevels(string id, JToken fn_args = null, bool? own_properties = null, bool? accessors_only = null, bool expect_ok = true)
         {
             if (UseCallFunctionOnBeforeGetProperties && !id.StartsWith("dotnet:scope:"))
             {
@@ -1004,7 +1004,7 @@ namespace DebuggerTests
                 var result = await cli.SendCommand("Runtime.callFunctionOn", cfo_args, token);
                 AssertEqual(expect_ok, result.IsOk, $"Runtime.getProperties returned {result.IsOk} instead of {expect_ok}, for {cfo_args.ToString()}, with Result: {result}");
                 if (!result.IsOk)
-                    return (null, null, null);
+                    return (null, null);
                 id = result.Value["result"]?["objectId"]?.Value<string>();
             }
 
@@ -1024,10 +1024,9 @@ namespace DebuggerTests
             var frame_props = await cli.SendCommand("Runtime.getProperties", get_prop_req, token);
             AssertEqual(expect_ok, frame_props.IsOk, $"Runtime.getProperties returned {frame_props.IsOk} instead of {expect_ok}, for {get_prop_req}, with Result: {frame_props}");
             if (!frame_props.IsOk)
-                return (null, null, null);;
+                return (null, null);;
 
             var locals = frame_props.Value["result"];
-            var locals_internal = frame_props.Value["internalProperties"];
             var locals_private = frame_props.Value["privateProperties"];
 
             // FIXME: Should be done when generating the list in dotnet.es6.lib.js, but not sure yet
@@ -1044,7 +1043,7 @@ namespace DebuggerTests
                 }
             }
 
-            return (locals, locals_internal, locals_private);
+            return (locals, locals_private);
         }
 
         internal virtual async Task<(JToken, Result)> EvaluateOnCallFrame(string id, string expression, bool expect_ok = true)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75778.

Motivation: https://github.com/dotnet/runtime/issues/75778#issuecomment-1252541452.

It fixes a bug from net 7, so will need backporting.