### PR TITLE
Make initialization more consistent in `gc.cpp`

### DIFF
--- a/src/coreclr/gc/env/volatile.h
+++ b/src/coreclr/gc/env/volatile.h
@@ -304,9 +304,7 @@ public:
     //
     // Default constructor.
     //
-    inline Volatile() : m_val {}
-    {
-    }
+    inline Volatile() = default;
 
     //
     // Allow initialization of Volatile<T> from a T

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -13667,8 +13667,8 @@ gc_heap::init_semi_shared()
 
     memset (full_gc_counts, 0, sizeof (full_gc_counts));
 
-    last_ephemeral_gc_info = {};
-    last_full_blocking_gc_info = {};
+    memset (&last_ephemeral_gc_info, 0, sizeof (last_ephemeral_gc_info));
+    memset (&last_full_blocking_gc_info, 0, sizeof (last_full_blocking_gc_info));
 #ifdef BACKGROUND_GC
     memset (&last_bgc_info, 0, sizeof (last_bgc_info));
 #endif //BACKGROUND_GC
@@ -28765,7 +28765,7 @@ uint8_t* gc_heap::find_next_marked (uint8_t* x, uint8_t* end,
 #ifdef FEATURE_EVENT_TRACE
 void gc_heap::init_bucket_info()
 {
-    *bucket_info = {};
+    memset (bucket_info, 0, sizeof (bucket_info));
 }
 
 void gc_heap::add_plug_in_condemned_info (generation* gen, size_t plug_size)

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -13667,12 +13667,6 @@ gc_heap::init_semi_shared()
 
     memset (full_gc_counts, 0, sizeof (full_gc_counts));
 
-    memset (&last_ephemeral_gc_info, 0, sizeof (last_ephemeral_gc_info));
-    memset (&last_full_blocking_gc_info, 0, sizeof (last_full_blocking_gc_info));
-#ifdef BACKGROUND_GC
-    memset (&last_bgc_info, 0, sizeof (last_bgc_info));
-#endif //BACKGROUND_GC
-
     should_expand_in_full_gc = FALSE;
 
 #ifdef FEATURE_LOH_COMPACTION

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -648,8 +648,6 @@ struct etw_bucket_info
     uint32_t count;
     size_t size;
 
-    etw_bucket_info() = default;
-
     void set (uint16_t _index, uint32_t _count, size_t _size)
     {
         index = _index;

--- a/src/coreclr/inc/volatile.h
+++ b/src/coreclr/inc/volatile.h
@@ -344,10 +344,7 @@ public:
     //
     // Default constructor.
     //
-    inline Volatile() : m_val {}
-    {
-        STATIC_CONTRACT_SUPPORTS_DAC;
-    }
+    inline Volatile() = default;
 
     //
     // Allow initialization of Volatile<T> from a T


### PR DESCRIPTION
Use `= default;` for `class Volatile` ctor since it permits the compiler to optimize when used in a static context. This also makes the previously troublesome UB issue fixed in https://github.com/dotnet/runtime/pull/74363 no longer exist - calling `memset` on a non-trivial type. Reverting some of the changes in `gc.cpp`.

Fixes #75893 

/cc @Maoni0 @dotnet/gc 