### PR TITLE
Allow Hardware Intrinsics to work with the AltJit

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3656,15 +3656,23 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 {
     assert((methodFlags & CORINFO_FLG_INTRINSIC) != 0);
 
-    bool           mustExpand = false;
-    bool           isSpecial  = false;
-    NamedIntrinsic ni         = NI_Illegal;
+    bool           mustExpand  = false;
+    bool           isSpecial   = false;
+    bool           isIntrinsic = false;
+    NamedIntrinsic ni          = NI_Illegal;
 
     if ((methodFlags & CORINFO_FLG_INTRINSIC) != 0)
     {
+        isIntrinsic = true;
+
         // The recursive non-virtual calls to Jit intrinsics are must-expand by convention.
         mustExpand = gtIsRecursiveCall(method) && !(methodFlags & CORINFO_FLG_VIRTUAL);
+    }
 
+    // For mismatched VM (AltJit) we want to check all methods as intrinsic to ensure
+    // we get more accurate codegen. This particularly applies to HWIntrinsic usage
+    if (isIntrinsic || !info.compMatchedVM)
+    {
         ni = lookupNamedIntrinsic(method);
 
         // We specially support the following on all platforms to allow for dead

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Crc32.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Crc32.PlatformNotSupported.cs
@@ -8,7 +8,6 @@ namespace System.Runtime.Intrinsics.Arm
     /// <summary>
     /// This class provides access to the ARM Crc32 hardware instructions via intrinsics
     /// </summary>
-    [Intrinsic]
     [CLSCompliant(false)]
     public abstract class Crc32 : ArmBase
     {
@@ -16,7 +15,6 @@ namespace System.Runtime.Intrinsics.Arm
 
         public static new bool IsSupported { [Intrinsic] get { return false; } }
 
-        [Intrinsic]
         public new abstract class Arm64 : ArmBase.Arm64
         {
             internal Arm64() { }


### PR DESCRIPTION
There were two issues blocking this:
1. The `*.PlatformNotSupported.cs` files weren't marking all methods as `[Intrinsic]` (outside `IsSupported`)
2. The VM was restricting the type handling from recursively marking methods in `[Intrinsic]` types for mismatched platforms