### PR TITLE
Skip ASN.1 SetOf sorting if nothing to sort

### DIFF
--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
@@ -607,25 +607,28 @@ namespace System.Formats.Asn1
             // Since it's not mutating, any restrictions imposed by CER or DER will
             // still be maintained.
             var reader = new AsnReader(new ReadOnlyMemory<byte>(buffer, start, len), AsnEncodingRules.BER);
+            int pos = start;
+            ReadOnlyMemory<byte> encoded = reader.ReadEncodedValue();
+
+            if (!reader.HasData)
+            {
+                // If there is no more data, then there was only one value, so we don't need to sort anything.
+                return;
+            }
 
             List<(int, int)> positions = new List<(int, int)>();
+            positions.Add((pos, encoded.Length));
+            pos += encoded.Length;
 
-            int pos = start;
-
-            while (reader.HasData)
+            do
             {
-                ReadOnlyMemory<byte> encoded = reader.ReadEncodedValue();
+                encoded = reader.ReadEncodedValue();
                 positions.Add((pos, encoded.Length));
                 pos += encoded.Length;
             }
+            while (reader.HasData);
 
             Debug.Assert(pos == end);
-
-            // If there is only one thing in the contents, we have no sorting work to do and it's already sorted.
-            if (positions.Count == 1)
-            {
-                return;
-            }
 
             var comparer = new ArrayIndexSetOfValueComparer(buffer);
             positions.Sort(comparer);

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.cs
@@ -621,6 +621,12 @@ namespace System.Formats.Asn1
 
             Debug.Assert(pos == end);
 
+            // If there is only one thing in the contents, we have no sorting work to do and it's already sorted.
+            if (positions.Count == 1)
+            {
+                return;
+            }
+
             var comparer = new ArrayIndexSetOfValueComparer(buffer);
             positions.Sort(comparer);
 


### PR DESCRIPTION
Many ASN.1 SET OFs that get encoded end up containing only one thing, such as RDNs, SignerInfos in CMS, etc.

The current ASN.1 DER implementation sorts SET OF (good) but it does this sorting work even if there is only one thing in the SET OF. This results in unnecessary copying of data. This change skips the sorting work if there nothing to sort.

This is easily visible in a (pretty unrealistic) benchmark of writing a SET OF that contains a single OCTET STRING that is 1 GB.

|        Method |        Job | Toolchain |     Mean |   Error |  StdDev | Ratio | Allocated |
|-------------- |----------- |---------- |---------:|--------:|--------:|------:|----------:|
| WriteSetOfDER | Job-RWHAMN |        pr | 239.3 ms | 1.85 ms | 1.73 ms |  0.63 |      2 GB |
| WriteSetOfDER | Job-YJKRNM |      main @ f2d65eb | 379.0 ms | 3.09 ms | 2.74 ms |  1.00 |      3 GB |

A more typical usage will still see improvements from skipping a rental and two `BlockCopy` invocations.