### PR TITLE
[wasm] Don't use MS.Build.NoTargets SDK for runtime tests

### DIFF
--- a/src/tests/Common/wasm-test-runner/WasmTestRunner.proj
+++ b/src/tests/Common/wasm-test-runner/WasmTestRunner.proj
@@ -1,6 +1,8 @@
-<!-- This project requires an explicit SDK version number because it is used on Helix,
-      and global.json is not available. -->
-<Project Sdk="Microsoft.Build.NoTargets/3.5.0" DefaultTargets="WasmBuildApp">
+<Project DefaultTargets="WasmBuildApp">
+  <PropertyGroup>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(TestBinDir)\obj\</IntermediateOutputPath>
+  </PropertyGroup>
+
   <Import Project="$(CORE_ROOT)\build\WasmApp.InTree.props" />
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>


### PR DESCRIPTION
This will also avoid intermittent failures like https://github.com/dotnet/runtime/issues/75391