### PR TITLE
Configuring Console Json Formatting with JsonWriterOptions doesn't work with Trimming

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerExtensions.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
+using ThrowHelper = System.ThrowHelper;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -28,6 +30,7 @@ namespace Microsoft.Extensions.Logging
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "AddConsoleFormatter and RegisterProviderOptions are only dangerous when the Options type cannot be statically analyzed, but that is not the case here. " +
             "The DynamicallyAccessedMembers annotations on them will make sure to preserve the right members from the different options objects.")]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(JsonWriterOptions))]
         public static ILoggingBuilder AddConsole(this ILoggingBuilder builder)
         {
             builder.AddConfiguration();

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicDependencyAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerExtensionsTests.cs
@@ -271,7 +271,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73436", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void AddJsonConsole_ChangeProperties_IsReadFromLoggingConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new[] {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/TrimmingTests/JsonFormattingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/TrimmingTests/JsonFormattingTests.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+class Program
+{
+    /// <summary>
+    /// Tests that using Logging.Console Json formatter options coming from the Configuration works correctly with trimming
+    /// </summary>
+    static async Task<int> Main()
+    {
+        FakeConsoleWriter consoleWriter = new FakeConsoleWriter();
+        Console.SetOut(consoleWriter);
+
+        IServiceCollection services = new ServiceCollection();
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new[]
+                {
+                    new KeyValuePair<string, string>("Logging:Console:FormatterName", "json"),
+                    new KeyValuePair<string, string>("Logging:Console:FormatterOptions:TimestampFormat", "dd/MM/yy"),
+                    new KeyValuePair<string, string>("Logging:Console:FormatterOptions:JsonWriterOptions:Indented", "true"),
+                })
+            .Build();
+
+        services.AddLogging(logging =>
+        {
+            logging.AddConfiguration(config.GetSection("Logging"));
+            logging.AddConsole();
+        });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ILogger logger = provider.GetRequiredService<ILogger<Program>>();
+
+        logger.LogError("Hello");
+
+        await consoleWriter.FinishedWriting;
+
+        string consoleOutput = consoleWriter.GetStringBuilder().ToString();
+        
+        // ensure the output contains whitespace between the property and the value
+        if (!consoleOutput.Contains("""
+            "Message": "Hello",
+            """))
+        {
+            return -1;
+        }
+
+        // ensure the output contains new lines since JsonWriterOptions.Indented is true
+        if (!consoleOutput.Contains('\n'))
+        {
+            return -2;
+        }
+
+        // ensure the output contains the right Timestamp format
+        int timestampIndex = consoleOutput.IndexOf("\"Timestamp\": \"");
+        if (timestampIndex == -1)
+        {
+            return -3;
+        }
+
+        if (!IsTimestampFormat(consoleOutput.AsSpan(timestampIndex + 14, 8)))
+        {
+            return -4;
+        }
+
+        return 100;
+    }
+
+    private static bool IsTimestampFormat(ReadOnlySpan<char> timestamp) =>
+        timestamp.Length == 8
+        && char.IsDigit(timestamp[0])
+        && char.IsDigit(timestamp[1])
+        && timestamp[2] == '/'
+        && char.IsDigit(timestamp[3])
+        && char.IsDigit(timestamp[4])
+        && timestamp[5] == '/'
+        && char.IsDigit(timestamp[6])
+        && char.IsDigit(timestamp[7]);
+
+    private sealed class FakeConsoleWriter : StringWriter
+    {
+        private TaskCompletionSource _onFinishedWriting;
+        public Task FinishedWriting => _onFinishedWriting.Task;
+
+        public FakeConsoleWriter()
+        {
+            _onFinishedWriting = new TaskCompletionSource();
+        }
+
+        public override void Write(string value)
+        {
+            base.Write(value);
+            _onFinishedWriting.SetResult();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/TrimmingTests/Microsoft.Extensions.Logging.Console.TrimmingTests.proj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/TrimmingTests/Microsoft.Extensions.Logging.Console.TrimmingTests.proj
@@ -8,6 +8,7 @@
   
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="AddConsoleFormatterTests.cs" />
+    <TestConsoleAppSourceFiles Include="JsonFormattingTests.cs" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />


### PR DESCRIPTION
Ensure the correct members are preserved when trimming and add a trimming test.

Fix #73822 #73436