### PR TITLE
[wasm] Fix errors being logged multiple times

### DIFF
--- a/src/mono/wasm/runtime/run.ts
+++ b/src/mono/wasm/runtime/run.ts
@@ -118,7 +118,7 @@ function set_exit_code_and_quit_now(exit_code: number, reason?: any): void {
     }
     logErrorOnExit(exit_code, reason);
     appendElementOnExit(exit_code);
-    if (exit_code !== 0 || !ENVIRONMENT_IS_WEB) {
+    if (exit_code !== 0 && !ENVIRONMENT_IS_WEB) {
         if (runtimeHelpers.quit) {
             runtimeHelpers.quit(exit_code, reason);
         } else {

--- a/src/mono/wasm/runtime/run.ts
+++ b/src/mono/wasm/runtime/run.ts
@@ -109,12 +109,7 @@ function set_exit_code_and_quit_now(exit_code: number, reason?: any): void {
     if (runtimeHelpers.ExitStatus) {
         if (reason && !(reason instanceof runtimeHelpers.ExitStatus)) {
             if (!runtimeHelpers.config.logExitCode) {
-                if (reason instanceof Error)
-                    Module.printErr(mono_wasm_stringify_as_error_with_stack(reason));
-                else if (typeof reason == "string")
-                    Module.printErr(reason);
-                else
-                    Module.printErr(JSON.stringify(reason));
+                Module.printErr(mono_wasm_stringify_as_error_with_stack(reason));
             }
         }
         else {
@@ -146,12 +141,7 @@ function appendElementOnExit(exit_code: number) {
 function logErrorOnExit(exit_code: number, reason?: any) {
     if (runtimeHelpers.config.logExitCode) {
         if (exit_code != 0 && reason) {
-            if (reason instanceof Error)
-                console.error(mono_wasm_stringify_as_error_with_stack(reason));
-            else if (typeof reason == "string")
-                console.error(reason);
-            else
-                console.error(JSON.stringify(reason));
+            console.error(mono_wasm_stringify_as_error_with_stack(reason));
         }
         if (consoleWebSocket) {
             const stop_when_ws_buffer_empty = () => {


### PR DESCRIPTION
Before the patch:
```
  info: Starting:    System.Private.Xml.Tests.dll
  fail: 205871424
  fail: 205871424
  fail: 205871424
  fail: 205872584
  info: WASM EXIT 1
  info: Waiting to flush log messages with a timeout of 120 secs ..
  fail: Application has finished with exit code TESTS_FAILED but 0 was expected
```

Note the the 3 errors are the same.

```
  info: Starting:    System.Private.Xml.Tests.dll
  fail: Error: 159389216
            at mono_wasm_stringify_as_error_with_stack (http://127.0.0.1:42001/dotnet.js:799:22)
            at logErrorOnExit (http://127.0.0.1:42001/dotnet.js:1067:31)
            at set_exit_code_and_quit_now (http://127.0.0.1:42001/dotnet.js:1042:9)
            at mono_exit (http://127.0.0.1:42001/dotnet.js:1008:13)
            at run (http://127.0.0.1:42001/test-main.js:335:21)
  fail: Error: 159813440
            at mono_wasm_stringify_as_error_with_stack (http://127.0.0.1:42001/dotnet.js:799:22)
            at logErrorOnExit (http://127.0.0.1:42001/dotnet.js:1067:31)
            at set_exit_code_and_quit_now (http://127.0.0.1:42001/dotnet.js:1042:9)
            at mono_exit (http://127.0.0.1:42001/dotnet.js:1008:13)
            at fatal_handler (http://127.0.0.1:42001/dotnet.js:9598:21)
            at http://127.0.0.1:42001/dotnet.js:9608:65
  info: WASM EXIT 1
  info: Waiting to flush log messages with a timeout of 120 secs ..
  fail: Application has finished with exit code TESTS_FAILED but 0 was expected
```

- this avoids errors being thrown, and logged repeatedly for the same error
- `runtimeHelpers.quit` also throws, which is not needed in the browser case