### PR TITLE
Clean-up InteropServices.JavaScript project file

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -2,16 +2,9 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-Browser;$(NetCoreAppCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Nullable>enable</Nullable>
+    <FeatureWasmThreads Condition="'$(TargetOS)' == 'browser' and ('$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread')">true</FeatureWasmThreads>
+    <DefineConstants Condition="'$(FeatureWasmThreads)' == 'true'" >$(DefineConstants);FEATURE_WASM_THREADS</DefineConstants>
   </PropertyGroup>
-
-   <PropertyGroup>
-     <FeatureWasmThreads Condition="'$(TargetOS)' == 'browser' and ('$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread')">true</FeatureWasmThreads>
-   </PropertyGroup>
-
-   <PropertyGroup>
-       <DefineConstants Condition="'$(FeatureWasmThreads)' == 'true'" >$(DefineConstants);FEATURE_WASM_THREADS</DefineConstants>
-   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
@@ -22,6 +15,7 @@
   <ItemGroup>
     <Compile Include="System.Runtime.InteropServices.JavaScript.SupportedOSPlatform.cs" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Browser'">
     <Compile Include="$(CommonPath)Interop\Browser\Interop.Runtime.cs" Link="System\Runtime\InteropServices\JavaScript\Interop\Interop.Runtime.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Interop\JavaScriptImports.Generated.cs" />
@@ -72,6 +66,7 @@
 
     <Compile Include="System\Runtime\InteropServices\JavaScript\JSSynchronizationContext.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="System.Collections" />
     <Reference Include="System.Memory" />
@@ -81,8 +76,5 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Threading.Channels" />
-  </ItemGroup>
-  <ItemGroup>
-    <AnalyzerReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -78,7 +78,9 @@
     <Reference Include="System.Threading.Channels" />
   </ItemGroup>
   
-  <ProjectReference Include="..\gen\JSImportGenerator\JSImportGenerator.csproj"
-                    ReferenceOutputAssembly="false"
-                    OutputItemType="Analyzer" />
+  <ItemGroup>
+    <ProjectReference Include="..\gen\JSImportGenerator\JSImportGenerator.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -77,4 +77,8 @@
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Threading.Channels" />
   </ItemGroup>
+  
+  <ProjectReference Include="..\gen\JSImportGenerator\JSImportGenerator.csproj"
+                    ReferenceOutputAssembly="false"
+                    OutputItemType="Analyzer" />
 </Project>


### PR DESCRIPTION
Nullable=enable is the default for source libraries.
The AnalyzerReference shouldn't be required as the library doesn't produce a package.