### PR TITLE
Fix public key token of Serialization.Schema contract assembly

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Schema/Directory.Build.props
+++ b/src/libraries/System.Runtime.Serialization.Schema/Directory.Build.props
@@ -1,6 +1,7 @@
-﻿<Project>
+<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
     <!-- This exclusion list matches System.CodeDom. -->
     <UnsupportedOSPlatforms>browser;ios;tvos;maccatalyst</UnsupportedOSPlatforms>

--- a/src/libraries/System.Runtime.Serialization.Schema/src/System.Runtime.Serialization.Schema.csproj
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System.Runtime.Serialization.Schema.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsPackable>true</IsPackable>
     <!-- TODO: Remove this setting when the package shipped with .NET 7. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>


### PR DESCRIPTION
The Microsoft public key token was only applied to the source assembly but not to the contract. Fixing this by moving the StrongNameKey property into the parent Directory.Build.props file, same as we do for other libraries.

I think we should backport this change into release/7.0 to avoid potential customer observable issues.