### PR TITLE
Flow internal transport packages during servicing

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -19,9 +19,8 @@
                                        '$(IsRIDSpecificProject)' == 'true') and
                                        '$(PreReleaseVersionLabel)' != 'servicing' and
                                        '$(GitHubRepositoryName)' != 'runtimelab'">true</GeneratePackageOnBuild>
-    <GeneratePackageOnBuild Condition="'$(GeneratePackageOnBuild)' != 'true'">false</GeneratePackageOnBuild>
     <!-- When in source-build we need to generate all packages when building for all configurations even in servicing. -->
-    <GeneratePackageOnBuild Condition="!$(GeneratePackageOnBuild) and
+    <GeneratePackageOnBuild Condition="'$(GeneratePackageOnBuild)' != 'true' and
                                        '$(BuildAllConfigurations)' == 'true' and
                                        '$(DotNetBuildFromSource)' == 'true'">true</GeneratePackageOnBuild>
     <!-- Search for the documentation file in the intellisense package and otherwise pick up the generated one. -->

--- a/src/libraries/Microsoft.Internal.Runtime.AspNetCore.Transport/src/Microsoft.Internal.Runtime.AspNetCore.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.AspNetCore.Transport/src/Microsoft.Internal.Runtime.AspNetCore.Transport.proj
@@ -13,6 +13,12 @@
     <NoWarn>$(NoWarn);NU5131</NoWarn>
   </PropertyGroup>
 
+  <!-- Always generate this package during servicing to flow the dependency to AspNetCore. -->
+  <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>$(PatchVersion)</ServicingVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items. -->
     <ProjectReference Include="@(AspNetCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj')"

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -13,6 +13,12 @@
     <NoWarn>$(NoWarn);NU5131</NoWarn>
   </PropertyGroup>
 
+  <!-- Always generate this package during servicing to flow the dependency to WindowsDesktop. -->
+  <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>$(PatchVersion)</ServicingVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items.
          ReferringTargetFramework is set to $(NetCoreAppCurrent)-windows so that we pack the Windows specific implementation assemblies -->


### PR DESCRIPTION
This makes sure that partner repositories have their internal transport packages available. This needs to be set explicitly as during servicing, libraries only publish on demand.

This also fixes broken 7.0 servicing builds which require at least one package to be published.

Manual, partial backport of c5a20f916b465707919aa5b6a78f7c4c7675c423.

This change will be backported into release/7.0 after it is merged.