### PR TITLE
Fix visibility modifier inconsistency in TextFieldParser

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -1366,7 +1366,7 @@ namespace Microsoft.VisualBasic.FileIO
         public string? ReadToEnd() { throw null; }
         public void SetDelimiters(params string[]? delimiters) { }
         public void SetFieldWidths(params int[]? fieldWidths) { }
-        public void System.IDisposable.Dispose() { }
+        public void Dispose() { }
     }
     public enum UICancelOption
     {

--- a/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -1366,7 +1366,7 @@ namespace Microsoft.VisualBasic.FileIO
         public string? ReadToEnd() { throw null; }
         public void SetDelimiters(params string[]? delimiters) { }
         public void SetFieldWidths(params int[]? fieldWidths) { }
-        void System.IDisposable.Dispose() { }
+        public void System.IDisposable.Dispose() { }
     }
     public enum UICancelOption
     {


### PR DESCRIPTION
The original change brought this API over from .NET Framework without an explicit visibility modifier: https://github.com/dotnet/corefx/pull/32668/files#diff-b244839a8ccb916e708d4ea6158d8bb573e3768d6bb7a3e327a51f2ab1e37c28R641.

That member is publicly exposed on .NET Framework: https://referencesource.microsoft.com/#Microsoft.VisualBasic/Microsoft/VisualBasic/FileIO/TextFieldParser.cs,42.

Noticed during the bootstrap of the new APICompat tooling: https://github.com/dotnet/runtime/pull/73263.

CI protection for this will be added when the above PR is merged.