### PR TITLE
Enable doc generation for source-build

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -10,7 +10,7 @@
   <Import Project="$(RepositoryEngineeringDir)SubsetValidation.targets" />
 
   <!-- Upfront restore hooks -->
-  <Import Project="$(RepositoryEngineeringDir)restore\docs.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)restore\docs.targets" />
   <Import Project="$(RepositoryEngineeringDir)restore\optimizationData.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />
 
   <Target Name="BuildLocalTasks"


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2877

This is a forward port of this 6.0 change: https://github.com/dotnet/runtime/pull/59937

Will backport to 7.0.

Kudos to @MichaelSimons for helping me find the missing change.