### PR TITLE
JIT: optimize "o is byte[]" casts

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12429,7 +12429,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
             // If the class is exact, the jit can expand the IsInst check inline.
             canExpandInline = isClassExact;
         }
-        else if (CORINFO_HELP_ISINSTANCEOFARRAY)
+        else if (helper == CORINFO_HELP_ISINSTANCEOFARRAY)
         {
             CORINFO_CLASS_HANDLE elementCls = NO_CLASS_HANDLE;
             if (!isClassExact && impIsPrimitive(info.compCompHnd->getChildType(pResolvedToken->hClass, &elementCls)))

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12431,7 +12431,6 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
         }
         else if (CORINFO_HELP_ISINSTANCEOFARRAY)
         {
-            canExpandInline                 = isClassExact;
             CORINFO_CLASS_HANDLE elementCls = NO_CLASS_HANDLE;
             if (!isClassExact && impIsPrimitive(info.compCompHnd->getChildType(pResolvedToken->hClass, &elementCls)))
             {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12431,14 +12431,17 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
         }
         else if (CORINFO_HELP_ISINSTANCEOFARRAY)
         {
-            canExpandInline = isClassExact;
-
+            canExpandInline                 = isClassExact;
             CORINFO_CLASS_HANDLE elementCls = NO_CLASS_HANDLE;
-            if (impIsPrimitive(info.compCompHnd->getChildType(pResolvedToken->hClass, &elementCls)))
+            if (!isClassExact && impIsPrimitive(info.compCompHnd->getChildType(pResolvedToken->hClass, &elementCls)))
             {
                 canExpandInline = true;
                 partialExpand   = true;
                 likelyCls       = pResolvedToken->hClass;
+            }
+            else
+            {
+                canExpandInline = isClassExact;
             }
         }
 


### PR DESCRIPTION
Follow up to https://github.com/dotnet/runtime/pull/75816 that optimized such checks for exact classes.

Array of integers, bytes, etc are special and can be casted to their signed/unsigned equivalents, so let's expand `isinst` for them to handle at least one of the cases as a fast path. Presumably, it's a rare case when e.g. `obj is int[]` and `obj` is `uint[]`. In theory we can check for both without the fallback but that will require a new JIT-EE API with extra complexity while I think the declaration type is the most likely target.

```csharp
bool IsByteArray(IEnumerable o) => o is byte[];
```
Current codegen:
```asm
; Method Tests:IsByteArray(System.Collections.IEnumerable):bool:this
G_M51298_IG01:             
       4883EC28             sub      rsp, 40
G_M51298_IG02:              
       48B920FD447CFE7F0000 mov      rcx, 0x7FFE7C44FD20      ; ubyte[]
       FF155472FBFF         call     [CORINFO_HELP_ISINSTANCEOFARRAY]
       4885C0               test     rax, rax
       0F95C0               setne    al
       0FB6C0               movzx    rax, al
G_M51298_IG03:            
       4883C428             add      rsp, 40
       C3                   ret      
; Total bytes of code: 34
```
New codegen:
```asm
; Method Tests:IsByteArray(System.Collections.IEnumerable):bool:this
G_M51298_IG01:              
       4883EC28             sub      rsp, 40
G_M51298_IG02:             
       488BC2               mov      rax, rdx
       4885C0               test     rax, rax
       741F                 je       SHORT G_M51298_IG05
G_M51298_IG03:         
       48B920FDB976FE7F0000 mov      rcx, 0x7FFE76B9FD20      ; ubyte[]
       483908               cmp      qword ptr [rax], rcx
       7410                 je       SHORT G_M51298_IG05
G_M51298_IG04:             
       48B920FDB976FE7F0000 mov      rcx, 0x7FFE76B9FD20      ; ubyte[]
       FF153D72FBFF         call     [CORINFO_HELP_ISINSTANCEOFARRAY]
G_M51298_IG05:             
       4885C0               test     rax, rax
       0F95C0               setne    al
       0FB6C0               movzx    rax, al
G_M51298_IG06:             
       4883C428             add      rsp, 40
       C3                   ret      
; Total bytes of code: 57
```