### PR TITLE
JIT: properly update trees in optOptimizeBoolsGcStress

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9629,6 +9629,15 @@ void OptBoolsDsc::optOptimizeBoolsGcStress()
     // morphing it into a TYP_I_IMPL.
     noway_assert(relop->AsOp()->gtOp2->gtOper == GT_CNS_INT);
     relop->AsOp()->gtOp2->gtType = TYP_I_IMPL;
+
+    // Recost/rethread the tree if necessary
+    //
+    if (m_comp->fgStmtListThreaded)
+    {
+        m_comp->gtPrepareCost(test.testTree);
+        m_comp->gtSetStmtInfo(test.testStmt);
+        m_comp->fgSetStmtSeq(test.testStmt);
+    }
 }
 
 #endif

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9247,16 +9247,14 @@ bool OptBoolsDsc::optOptimizeBoolsChkTypeCostCond()
         return false;
 #endif
     // The second condition must not contain side effects
-
+    //
     if (m_c2->gtFlags & GTF_GLOB_EFFECT)
     {
         return false;
     }
 
     // The second condition must not be too expensive
-
-    m_comp->gtPrepareCost(m_c2);
-
+    //
     if (m_c2->GetCostEx() > 12)
     {
         return false;
@@ -9332,7 +9330,6 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
     //
     if (m_comp->fgStmtListThreaded)
     {
-        m_comp->gtPrepareCost(m_testInfo1.testTree);
         m_comp->gtSetStmtInfo(m_testInfo1.testStmt);
         m_comp->fgSetStmtSeq(m_testInfo1.testStmt);
     }
@@ -9634,7 +9631,6 @@ void OptBoolsDsc::optOptimizeBoolsGcStress()
     //
     if (m_comp->fgStmtListThreaded)
     {
-        m_comp->gtPrepareCost(test.testTree);
         m_comp->gtSetStmtInfo(test.testStmt);
         m_comp->fgSetStmtSeq(test.testStmt);
     }


### PR DESCRIPTION
Under jit stress, `optOptimizeBoolsGcStress` will modify trees. Since this now happens in a phase that runs after `fgSetBlockOrder`, it must also recost and rethread the trees.

Fixes #75944.