### PR TITLE
Cache dynamically generated RSA keys in tests

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -58,9 +58,8 @@ namespace System.Security.Cryptography.Rsa.Tests
             RSAParameters diminishedDPParameters = TestData.DiminishedDPParameters;
             RSAParameters exported;
 
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(diminishedDPParameters))
             {
-                rsa.ImportParameters(diminishedDPParameters);
                 exported = rsa.ExportParameters(true);
             }
 
@@ -111,9 +110,8 @@ namespace System.Security.Cryptography.Rsa.Tests
             RSAParameters unusualExponentParameters = TestData.UnusualExponentParameters;
             RSAParameters exported;
 
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(unusualExponentParameters))
             {
-                rsa.ImportParameters(unusualExponentParameters);
                 exported = rsa.ExportParameters(true);
             }
 
@@ -129,9 +127,8 @@ namespace System.Security.Cryptography.Rsa.Tests
             RSAParameters exported;
             RSAParameters exportedPublic;
 
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(imported))
             {
-                rsa.ImportParameters(imported);
                 exported = rsa.ExportParameters(true);
                 exportedPublic = rsa.ExportParameters(false);
             }
@@ -178,10 +175,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             RSAParameters imported = TestData.RSA1024Params;
 
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(imported))
             {
-                rsa.ImportParameters(imported);
-
                 RSAParameters exportedPublic = rsa.ExportParameters(false);
 
                 Assert.Equal(imported.Modulus, exportedPublic.Modulus);
@@ -196,10 +191,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             RSAParameters imported = TestData.RSA1024Params;
 
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(imported))
             {
-                rsa.ImportParameters(imported);
-
                 RSAParameters exportedPrivate = rsa.ExportParameters(true);
                 RSAParameters exportedPrivate2 = rsa.ExportParameters(true);
                 RSAParameters exportedPublic = rsa.ExportParameters(false);
@@ -231,9 +224,8 @@ namespace System.Security.Cryptography.Rsa.Tests
                 Exponent = TestData.RSA1024Params.Exponent,
             };
 
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(imported))
             {
-                rsa.ImportParameters(imported);
                 Assert.ThrowsAny<CryptographicException>(() => rsa.ExportParameters(true));
             }
         }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Tests;
+
 namespace System.Security.Cryptography.Rsa.Tests
 {
     public interface IRSAProvider
@@ -32,6 +34,37 @@ namespace System.Security.Cryptography.Rsa.Tests
             rsa.ImportParameters(rsaParameters);
             return rsa;
         }
+
+        internal static RSALease CreateIdempotent()
+        {
+            RSALease? lease = null;
+            CreateIdempotent(ref lease);
+
+            if (lease != null)
+            {
+                return lease.Value;
+            }
+
+            RSA key = Create();
+            return new RSALease(key, key);
+        }
+
+        internal static RSALease CreateIdempotent(int keySize)
+        {
+            RSALease? lease = null;
+            CreateIdempotent(keySize, ref lease);
+
+            if (lease != null)
+            {
+                return lease.Value;
+            }
+
+            RSA key = Create(keySize);
+            return new RSALease(key, key);
+        }
+
+        static partial void CreateIdempotent(ref RSALease? lease);
+        static partial void CreateIdempotent(int keySize, ref RSALease? lease);
 
         public static bool Supports384PrivateKey => s_provider.Supports384PrivateKey;
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
@@ -13,10 +13,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void VerifyDecryptKeyExchangeOaep()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
             {
-                rsa.ImportParameters(TestData.RSA2048Params);
-
                 var formatter = new RSAOAEPKeyExchangeFormatter(rsa);
                 var deformatter = new RSAOAEPKeyExchangeDeformatter(rsa);
                 VerifyDecryptKeyExchange(formatter, deformatter);
@@ -26,10 +24,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void VerifyDecryptKeyExchangePkcs1()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
             {
-                rsa.ImportParameters(TestData.RSA2048Params);
-
                 var formatter = new RSAPKCS1KeyExchangeFormatter(rsa);
                 var deformatter = new RSAPKCS1KeyExchangeDeformatter(rsa);
                 VerifyDecryptKeyExchange(formatter, deformatter);
@@ -39,9 +35,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void TestKnownValueOaep()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(TestData.RSA1024Params))
             {
-                rsa.ImportParameters(TestData.RSA1024Params);
                 byte[] encrypted =
                     ( "19134ffba4025a1c651120ca07258a46e005a327c3927f615465060734dc0339114cabfd13803288883abf9329296a3e3a5cb1587927"
                     + "a6e8a2e736f0a756e342b4adb0f1de5bba9ba5faee30456fb7409678eb71a70185606eda3303d9425fbeb730ab7803bea50e208b563f"
@@ -56,9 +51,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void TestKnownValuePkcs1()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(TestData.RSA1024Params))
             {
-                rsa.ImportParameters(TestData.RSA1024Params);
                 byte[] encrypted =
                     ( "7061adb87a8759f0a0dc6ece42f5b63bf186f845237c6b16bf824b303812486efbb8f5febb681902228a609d4330a6c21abf0fc0d271"
                     + "ba63d1d0d9e486668270c2dbf73ab33055dfc0b797938557b99c0e9a535605c0a4bceefe5a37594732bb566ab026e4e8d5ce47d0967d"

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSASignatureFormatter.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSASignatureFormatter.cs
@@ -13,10 +13,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         [ConditionalFact(typeof(RSAFactory), nameof(RSAFactory.SupportsSha1Signatures))]
         public static void VerifySignature_SHA1()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
             {
-                rsa.ImportParameters(TestData.RSA2048Params);
-
                 var formatter = new RSAPKCS1SignatureFormatter(rsa);
                 var deformatter = new RSAPKCS1SignatureDeformatter(rsa);
 
@@ -31,10 +29,8 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void VerifySignature_SHA256()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
             {
-                rsa.ImportParameters(TestData.RSA2048Params);
-
                 var formatter = new RSAPKCS1SignatureFormatter(rsa);
                 var deformatter = new RSAPKCS1SignatureDeformatter(rsa);
 
@@ -49,10 +45,10 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void InvalidHashAlgorithm()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSALease lease = RSAFactory.CreateIdempotent())
             {
-                var formatter = new RSAPKCS1SignatureFormatter(rsa);
-                var deformatter = new RSAPKCS1SignatureDeformatter(rsa);
+                var formatter = new RSAPKCS1SignatureFormatter(lease.Key);
+                var deformatter = new RSAPKCS1SignatureDeformatter(lease.Key);
 
                 // Exception is deferred until VerifySignature
                 formatter.SetHashAlgorithm("INVALIDVALUE");
@@ -72,9 +68,8 @@ namespace System.Security.Cryptography.Rsa.Tests
             byte[] hash = "012d161304fa0c6321221516415813022320620c".HexToByteArray();
             byte[] sig;
 
-            using (RSA key = RSAFactory.Create())
+            using (RSA key = RSAFactory.Create(TestData.RSA1024Params))
             {
-                key.ImportParameters(TestData.RSA1024Params);
                 RSAPKCS1SignatureFormatter formatter = new RSAPKCS1SignatureFormatter(key);
                 formatter.SetHashAlgorithm("SHA1");
                 sig = formatter.CreateSignature(hash);
@@ -86,9 +81,8 @@ namespace System.Security.Cryptography.Rsa.Tests
                 Assert.Equal(expectedSig, sig);
             }
 
-            using (RSA key = RSAFactory.Create()) // Test against a different instance
+            using (RSA key = RSAFactory.Create(TestData.RSA1024Params)) // Test against a different instance
             {
-                key.ImportParameters(TestData.RSA1024Params);
                 RSAPKCS1SignatureDeformatter deformatter = new RSAPKCS1SignatureDeformatter(key);
                 deformatter.SetHashAlgorithm("SHA1");
                 bool verified = deformatter.VerifySignature(hash, sig);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Security.Cryptography.Tests;
 using System.Xml.Linq;
 using Xunit;
 
@@ -984,13 +985,13 @@ zM=
         [Fact]
         public static void FromToXml()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSALease lease = RSAFactory.CreateIdempotent())
             {
-                RSAParameters pubOnly = rsa.ExportParameters(false);
-                RSAParameters pubPriv = rsa.ExportParameters(true);
+                RSAParameters pubOnly = lease.Key.ExportParameters(false);
+                RSAParameters pubPriv = lease.Key.ExportParameters(true);
 
-                string xmlPub = rsa.ToXmlString(false);
-                string xmlPriv = rsa.ToXmlString(true);
+                string xmlPub = lease.Key.ToXmlString(false);
+                string xmlPriv = lease.Key.ToXmlString(true);
 
                 using (RSA rsaPub = RSAFactory.Create())
                 {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.netcoreapp.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.netcoreapp.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Tests;
 using Xunit;
 
 namespace System.Security.Cryptography.Rsa.Tests
@@ -85,8 +86,9 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void SignDefaultSpanHash()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSALease lease = RSAFactory.CreateIdempotent())
             {
+                RSA rsa = lease.Key;
                 byte[] signature = new byte[2048 / 8];
 
                 Assert.ThrowsAny<CryptographicException>(
@@ -100,8 +102,9 @@ namespace System.Security.Cryptography.Rsa.Tests
         [Fact]
         public static void VerifyDefaultSpanHash()
         {
-            using (RSA rsa = RSAFactory.Create())
+            using (RSALease lease = RSAFactory.CreateIdempotent())
             {
+                RSA rsa = lease.Key;
                 byte[] signature = new byte[2048 / 8];
 
                 Assert.False(

--- a/src/libraries/Common/tests/System/Security/Cryptography/KeyPool.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/KeyPool.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace System.Security.Cryptography.Tests
+{
+    internal class KeyPool<TKey, TDiscriminator> where TKey : AsymmetricAlgorithm
+    {
+        private readonly List<(TDiscriminator Discriminator, ConcurrentStack<TKey> Pool)> _pools = new();
+        private readonly IEqualityComparer<TDiscriminator> _comparer;
+
+        internal KeyPool(IEqualityComparer<TDiscriminator>? comparer = null)
+        {
+            _comparer = comparer ?? EqualityComparer<TDiscriminator>.Default;
+        }
+
+        private ConcurrentStack<TKey> GetPool(TDiscriminator discriminator)
+        {
+            static ConcurrentStack<TKey>? FindPool(
+                KeyPool<TKey, TDiscriminator> pool,
+                TDiscriminator discriminator)
+            {
+                foreach ((TDiscriminator id, ConcurrentStack<TKey> value) in pool._pools)
+                {
+                    if (pool._comparer.Equals(discriminator, id))
+                    {
+                        return value;
+                    }
+                }
+
+                return null;
+            }
+
+            ConcurrentStack<TKey>? pool = FindPool(this, discriminator);
+
+            if (pool is null)
+            {
+                lock (_pools)
+                {
+                    pool = FindPool(this, discriminator);
+
+                    if (pool is null)
+                    {
+                        pool = new ConcurrentStack<TKey>();
+
+                        _pools.Add((discriminator, pool));
+                    }
+                }
+            }
+
+            return pool;
+        }
+
+        internal KeyPoolLease Rent(
+            TDiscriminator discriminator,
+            Func<TDiscriminator, TKey> creator)
+        {
+            ConcurrentStack<TKey> pool = GetPool(discriminator);
+
+            if (!pool.TryPop(out TKey rented))
+            {
+                rented = creator(discriminator);
+            }
+
+            return new KeyPoolLease(rented, discriminator, this);
+        }
+
+        private void Return(TKey key, TDiscriminator discriminator)
+        {
+            GetPool(discriminator).Push(key);
+        }
+
+        internal class KeyPoolLease : IDisposable
+        {
+            private readonly KeyPool<TKey, TDiscriminator> _pool;
+            private readonly TDiscriminator _discriminator;
+
+            internal TKey Key { get; private set; }
+
+            internal KeyPoolLease(
+                TKey key,
+                TDiscriminator discriminator,
+                KeyPool<TKey, TDiscriminator> pool)
+            {
+                Key = key;
+                _discriminator = discriminator;
+                _pool = pool;
+            }
+
+            public void Dispose()
+            {
+                _pool.Return(Key, _discriminator);
+                Key = null!;
+            }
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/RSAKeyPool.KnownKeys.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/RSAKeyPool.KnownKeys.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography.Rsa.Tests;
+
+namespace System.Security.Cryptography.Tests
+{
+    internal static partial class RSAKeyPool
+    {
+        // Known keys can use the same pool as the generated keys,
+        // but have to avoid legal key sizes.
+        //
+        // Thankfully, the smallest size any provider has is 384,
+        // so 0-383 are automatically available.
+        internal static RSALease RentBigExponentKey()
+        {
+            return ShapeLease(
+                s_pool.Rent(0, ks => new IdempotentRSA(TestData.RsaBigExponentParams)));
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Security/Cryptography/RSAKeyPool.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/RSAKeyPool.cs
@@ -1,0 +1,288 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+
+namespace System.Security.Cryptography.Tests
+{
+    internal struct RSALease : IDisposable
+    {
+        private readonly IDisposable _lease;
+        public RSA Key { get; private set; }
+
+        internal RSALease(RSA key, IDisposable lease)
+        {
+            _lease = lease;
+            Key = key;
+        }
+
+        public void Dispose()
+        {
+            Key = null!;
+            _lease.Dispose();
+        }
+    }
+
+    internal static partial class RSAKeyPool
+    {
+        private static readonly KeyPool<RSA, int> s_pool = new KeyPool<RSA, int>();
+        
+        public static RSALease Rent(int keySize = 2048)
+        {
+            // If a test is behaving oddly, pooling can be disabled (forcing every
+            // potentially-new-key to be an actually-new-key) by defining NO_RENTING.
+#if NO_RENTING
+            RSA rsa = RSA.Create(keySize);
+            return new RSALease(rsa, rsa);
+#else
+            return ShapeLease(s_pool.Rent(keySize, ks => new IdempotentRSA(ks)));
+#endif
+        }
+
+        private static RSALease ShapeLease<T>(KeyPool<RSA, T>.KeyPoolLease lease)
+        {
+            return new RSALease(lease.Key, lease);
+        }
+
+        // An RSA wrapper type that does not support having the key replaced or disposed.
+        private sealed class IdempotentRSA : RSA
+        {
+            private readonly RSA _impl;
+
+            internal IdempotentRSA(int keySize)
+            {
+                _impl = Create(keySize);
+                _impl.TryExportRSAPublicKey(Span<byte>.Empty, out _);
+            }
+
+            public IdempotentRSA(RSAParameters rsaParameters)
+            {
+                _impl = Create(rsaParameters);
+            }
+
+            public override void FromXmlString(string xmlString) => throw new NotSupportedException();
+            public override void ImportParameters(RSAParameters parameters) => throw new NotSupportedException();
+            protected override void Dispose(bool disposing) => throw new NotSupportedException();
+
+            public override string? KeyExchangeAlgorithm => _impl.KeyExchangeAlgorithm;
+
+            public override string SignatureAlgorithm => _impl.SignatureAlgorithm;
+
+            public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding) => _impl.Decrypt(data, padding);
+
+            public override byte[] DecryptValue(byte[] rgb) => _impl.DecryptValue(rgb);
+
+            public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) => _impl.Encrypt(data, padding);
+
+            public override byte[] EncryptValue(byte[] rgb) => _impl.EncryptValue(rgb);
+
+            public override RSAParameters ExportParameters(bool includePrivateParameters) =>
+                _impl.ExportParameters(includePrivateParameters);
+
+            public override byte[] ExportRSAPrivateKey() => _impl.ExportRSAPrivateKey();
+
+            public override byte[] ExportRSAPublicKey() => _impl.ExportRSAPublicKey();
+
+            protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+            {
+                switch (hashAlgorithm.Name)
+                {
+                    case nameof(HashAlgorithmName.SHA256):
+                        return SHA256.HashData(data.AsSpan(offset, count));
+                }
+
+                throw new NotSupportedException(hashAlgorithm.Name);
+            }
+
+            protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
+            {
+                switch (hashAlgorithm.Name)
+                {
+                    case nameof(HashAlgorithmName.SHA256):
+                        return SHA256.HashData(data);
+                }
+
+                throw new NotSupportedException(hashAlgorithm.Name);
+            }
+
+            protected override bool TryHashData(
+                ReadOnlySpan<byte> data,
+                Span<byte> destination,
+                HashAlgorithmName hashAlgorithm,
+                out int bytesWritten)
+            {
+                switch (hashAlgorithm.Name)
+                {
+                    case nameof(HashAlgorithmName.SHA256):
+                        return SHA256.TryHashData(data, destination, out bytesWritten);
+                }
+
+                throw new NotSupportedException(hashAlgorithm.Name);
+            }
+
+            public override byte[] SignData(
+                byte[] data,
+                int offset,
+                int count,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding) =>
+                _impl.SignData(
+                    data,
+                    offset,
+                    count,
+                    hashAlgorithm,
+                    padding);
+
+            public override byte[] SignData(
+                Stream data,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding) =>
+                _impl.SignData(
+                    data,
+                    hashAlgorithm,
+                    padding);
+
+            public override byte[] SignHash(
+                byte[] hash,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding) =>
+                _impl.SignHash(
+                    hash,
+                    hashAlgorithm,
+                    padding);
+
+            public override string ToXmlString(bool includePrivateParameters) =>
+                _impl.ToXmlString(includePrivateParameters);
+
+            public override bool TryDecrypt(
+                ReadOnlySpan<byte> data,
+                Span<byte> destination,
+                RSAEncryptionPadding padding,
+                out int bytesWritten) =>
+                _impl.TryDecrypt(
+                    data,
+                    destination,
+                    padding,
+                    out bytesWritten);
+
+            public override bool TryEncrypt(
+                ReadOnlySpan<byte> data,
+                Span<byte> destination,
+                RSAEncryptionPadding padding,
+                out int bytesWritten) =>
+                _impl.TryEncrypt(
+                    data,
+                    destination,
+                    padding,
+                    out bytesWritten);
+
+            public override bool TryExportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                PbeParameters pbeParameters,
+                Span<byte> destination,
+                out int bytesWritten) =>
+                _impl.TryExportEncryptedPkcs8PrivateKey(passwordBytes, pbeParameters, destination, out bytesWritten);
+
+            public override bool TryExportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                PbeParameters pbeParameters,
+                Span<byte> destination,
+                out int bytesWritten) =>
+                _impl.TryExportEncryptedPkcs8PrivateKey(password, pbeParameters, destination, out bytesWritten);
+
+            public override bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) =>
+                _impl.TryExportPkcs8PrivateKey(destination, out bytesWritten);
+
+            public override bool TryExportRSAPrivateKey(Span<byte> destination, out int bytesWritten) =>
+                _impl.TryExportRSAPrivateKey(destination, out bytesWritten);
+
+            public override bool TryExportRSAPublicKey(Span<byte> destination, out int bytesWritten) =>
+                _impl.TryExportRSAPublicKey(destination, out bytesWritten);
+
+            public override bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) =>
+                _impl.TryExportSubjectPublicKeyInfo(destination, out bytesWritten);
+
+            public override bool TrySignData(
+                ReadOnlySpan<byte> data,
+                Span<byte> destination,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding,
+                out int bytesWritten) =>
+                _impl.TrySignData(data, destination, hashAlgorithm, padding, out bytesWritten);
+
+            public override bool TrySignHash(
+                ReadOnlySpan<byte> hash,
+                Span<byte> destination,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding,
+                out int bytesWritten) =>
+                _impl.TrySignHash(hash, destination, hashAlgorithm, padding, out bytesWritten);
+
+            public override bool VerifyData(
+                byte[] data,
+                int offset,
+                int count,
+                byte[] signature,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding) =>
+                _impl.VerifyData(data, offset, count, signature, hashAlgorithm, padding);
+
+            public override bool VerifyData(
+                ReadOnlySpan<byte> data,
+                ReadOnlySpan<byte> signature,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding) =>
+                _impl.VerifyData(data, signature, hashAlgorithm, padding);
+
+            public override bool VerifyHash(
+                byte[] hash,
+                byte[] signature,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding) =>
+                _impl.VerifyHash(
+                    hash,
+                    signature,
+                    hashAlgorithm,
+                    padding);
+
+            public override bool VerifyHash(
+                ReadOnlySpan<byte> hash,
+                ReadOnlySpan<byte> signature,
+                HashAlgorithmName hashAlgorithm,
+                RSASignaturePadding padding) =>
+                _impl.VerifyHash(hash, signature, hashAlgorithm, padding);
+
+            public override int KeySize
+            {
+                get => _impl.KeySize;
+                set => throw new NotSupportedException();
+            }
+
+            public override KeySizes[] LegalKeySizes => _impl.LegalKeySizes;
+
+            public override byte[] ExportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                PbeParameters pbeParameters) =>
+                _impl.ExportEncryptedPkcs8PrivateKey(
+                    passwordBytes,
+                    pbeParameters);
+
+            public override byte[] ExportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                PbeParameters pbeParameters) =>
+                _impl.ExportEncryptedPkcs8PrivateKey(
+                    password,
+                    pbeParameters);
+
+            public override byte[] ExportPkcs8PrivateKey() => _impl.ExportPkcs8PrivateKey();
+
+            public override byte[] ExportSubjectPublicKeyInfo() => _impl.ExportSubjectPublicKeyInfo();
+
+            public override bool Equals(object? obj) => _impl.Equals(obj);
+
+            public override int GetHashCode() => _impl.GetHashCode();
+
+            public override string ToString() => _impl.ToString();
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -74,8 +74,12 @@
              Link="Common\System\IO\DelegatingStream.cs" />
     <Compile Include="$(CommonTestPath)System\Net\RemoteServerQuery.cs"
              Link="Common\System\Net\RemoteServerQuery.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\KeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\KeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"
              Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\RSAKeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\RSAKeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs"
              Link="Common\System\Net\Configuration.Certificates.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.Dynamic.cs"

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -23,7 +23,9 @@
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.Dynamic.cs" Link="TestCommon\System\Net\Configuration.Certificates.Dynamic.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs" Link="Common\System\Net\Configuration.Http.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs" Link="Common\System\Net\Configuration.Security.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\KeyPool.cs" Link="TestCommon\System\Security\Cryptography\KeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs" Link="TestCommon\System\Security\Cryptography\PlatformSupport.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\RSAKeyPool.cs" Link="TestCommon\System\Security\Cryptography\RSAKeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\CertificateAuthority.cs" Link="CommonTest\System\Security\Cryptography\X509Certificates\CertificateAuthority.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\RevocationResponder.cs" Link="CommonTest\System\Security\Cryptography\X509Certificates\RevocationResponder.cs" />
     <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs" Link="TestCommon\System\Threading\Tasks\TaskTimeoutExtensions.cs" />

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -81,8 +81,12 @@
              Link="Common\System\Net\VerboseTestLogging.cs" />
     <Compile Include="$(CommonTestPath)System\Net\EventSourceTestLogging.cs"
              Link="Common\System\Net\EventSourceTestLogging.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\KeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\KeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"
              Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\RSAKeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\RSAKeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\CertificateAuthority.cs"
              Link="CommonTest\System\Security\Cryptography\X509Certificates\CertificateAuthority.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\RevocationResponder.cs"

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -44,8 +44,12 @@
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs"
              Link="CommonTest\System\Security\Cryptography\CryptoUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\KeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\KeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"
              Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\RSAKeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\RSAKeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\EC\CurveDef.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\EC\EccTestBase.cs"

--- a/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -20,8 +20,12 @@
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs"
              Link="CommonTest\System\Security\Cryptography\CryptoUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\KeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\KeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"
              Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\RSAKeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\RSAKeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs"
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RSA\ImportExport.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -13,8 +13,12 @@
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs"
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\KeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\KeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"
              Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\RSAKeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\RSAKeyPool.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\SignatureSupport.cs"
              Link="CommonTest\System\Security\Cryptography\SignatureSupport.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\RC2\RC2Factory.cs"

--- a/src/libraries/System.Security.Cryptography/tests/DefaultRSAProvider.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultRSAProvider.cs
@@ -52,5 +52,15 @@ namespace System.Security.Cryptography.Rsa.Tests
     public partial class RSAFactory
     {
         private static readonly IRSAProvider s_provider = new DefaultRSAProvider();
+
+        static partial void CreateIdempotent(ref RSALease? lease)
+        {
+            lease = RSAKeyPool.Rent(2048);
+        }
+
+        static partial void CreateIdempotent(int keySize, ref RSALease? lease)
+        {
+            lease = RSAKeyPool.Rent(keySize);
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/RSAKeyExchangeFormatterTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/RSAKeyExchangeFormatterTests.cs
@@ -35,9 +35,9 @@ namespace System.Security.Cryptography.Tests
         [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void RSAOAEPFormatterRng()
         {
-            using (RSA key = RSA.Create())
+            using (RSALease lease = RSAKeyPool.Rent())
             {
-                RSAOAEPKeyExchangeFormatter keyex = new RSAOAEPKeyExchangeFormatter(key);
+                RSAOAEPKeyExchangeFormatter keyex = new RSAOAEPKeyExchangeFormatter(lease.Key);
                 Assert.Null(keyex.Rng);
                 keyex.Rng = RandomNumberGenerator.Create();
                 Assert.NotNull(keyex.Rng);
@@ -48,9 +48,9 @@ namespace System.Security.Cryptography.Tests
         [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void RSAPKCS1FormatterRng()
         {
-            using (RSA key = RSA.Create())
+            using (RSALease lease = RSAKeyPool.Rent())
             {
-                RSAPKCS1KeyExchangeFormatter keyex = new RSAPKCS1KeyExchangeFormatter(key);
+                RSAPKCS1KeyExchangeFormatter keyex = new RSAPKCS1KeyExchangeFormatter(lease.Key);
                 Assert.Null(keyex.Rng);
                 keyex.Rng = RandomNumberGenerator.Create();
                 Assert.NotNull(keyex.Rng);
@@ -61,9 +61,9 @@ namespace System.Security.Cryptography.Tests
         [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
         public static void RSAPKCS1DeformatterRng()
         {
-            using (RSA key = RSA.Create())
+            using (RSALease lease = RSAKeyPool.Rent())
             {
-                RSAPKCS1KeyExchangeDeformatter keyex = new RSAPKCS1KeyExchangeDeformatter(key);
+                RSAPKCS1KeyExchangeDeformatter keyex = new RSAPKCS1KeyExchangeDeformatter(lease.Key);
                 Assert.Null(keyex.RNG);
                 keyex.RNG = RandomNumberGenerator.Create();
                 Assert.NotNull(keyex.RNG);

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -203,6 +203,12 @@
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs"
              Link="CommonTest\System\Security\Cryptography\CryptoUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\KeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\KeyPool.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\RSAKeyPool.cs"
+             Link="CommonTest\System\Security\Cryptography\RSAKeyPool.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\RSAKeyPool.KnownKeys.cs"
+             Link="CommonTest\System\Security\Cryptography\RSAKeyPool.KnownKeys.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"
              Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestApiTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestApiTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Tests;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreation
@@ -38,11 +39,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Fact]
         public static void SelfSign_ArgumentValidation()
         {
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                rsa.ImportParameters(TestData.RsaBigExponentParams);
-
-                var request = new CertificateRequest("CN=Test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                var request = new CertificateRequest("CN=Test", lease.Key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 
                 AssertExtensions.Throws<ArgumentException>(
                     null,
@@ -150,30 +149,27 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         public static void CtorValidation_RSA_string()
         {
             string subjectName = null;
-            RSA key = null;
             RSASignaturePadding padding = null;
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
-                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
+                () => new CertificateRequest(subjectName, null, default(HashAlgorithmName), padding));
 
             subjectName = "";
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "key",
-                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
+                () => new CertificateRequest(subjectName, null, default(HashAlgorithmName), padding));
 
-            key = RSA.Create(TestData.RsaBigExponentParams);
-
-            using (key)
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
                 AssertExtensions.Throws<ArgumentNullException>(
                     "hashAlgorithm",
-                    () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
+                    () => new CertificateRequest(subjectName, lease.Key, default(HashAlgorithmName), padding));
 
                 AssertExtensions.Throws<ArgumentNullException>(
                     "padding",
-                    () => new CertificateRequest(subjectName, key, HashAlgorithmName.SHA256, padding));
+                    () => new CertificateRequest(subjectName, lease.Key, HashAlgorithmName.SHA256, padding));
             }
         }
 
@@ -181,34 +177,32 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         public static void CtorValidation_RSA_X500DN()
         {
             X500DistinguishedName subjectName = null;
-            RSA key = null;
+            const RSA NullKey = null;
             RSASignaturePadding padding = null;
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
-                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
+                () => new CertificateRequest(subjectName, NullKey, default(HashAlgorithmName), padding));
 
             subjectName = new X500DistinguishedName("");
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "key",
-                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
+                () => new CertificateRequest(subjectName, NullKey, default(HashAlgorithmName), padding));
 
-            key = RSA.Create(TestData.RsaBigExponentParams);
-
-            using (key)
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
                 AssertExtensions.Throws<ArgumentNullException>(
                     "hashAlgorithm",
-                    () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
+                    () => new CertificateRequest(subjectName, lease.Key, default(HashAlgorithmName), padding));
 
                 AssertExtensions.Throws<ArgumentException>(
                     "hashAlgorithm",
-                    () => new CertificateRequest(subjectName, key, new HashAlgorithmName(""), padding));
+                    () => new CertificateRequest(subjectName, lease.Key, new HashAlgorithmName(""), padding));
 
                 AssertExtensions.Throws<ArgumentNullException>(
                     "padding",
-                    () => new CertificateRequest(subjectName, key, HashAlgorithmName.SHA256, padding));
+                    () => new CertificateRequest(subjectName, lease.Key, HashAlgorithmName.SHA256, padding));
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestLoadTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestLoadTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Security.Cryptography.Tests;
 using Test.Cryptography;
 using Xunit;
 
@@ -329,11 +330,11 @@ Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAMCB4A=
         {
             HashAlgorithmName hashAlgorithmName = new HashAlgorithmName(hashAlgorithm);
 
-            using (RSA key = RSA.Create())
+            using (RSALease lease = RSAKeyPool.Rent())
             {
                 CertificateRequest first = new CertificateRequest(
                     "CN=Test",
-                    key,
+                    lease.Key,
                     hashAlgorithmName,
                     RSASignaturePadding.Pkcs1);
 
@@ -341,7 +342,7 @@ Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAMCB4A=
 
                 if (hashAlgorithm == "SHA1")
                 {
-                    pkcs10 = first.CreateSigningRequest(new RSASha1Pkcs1SignatureGenerator(key));
+                    pkcs10 = first.CreateSigningRequest(new RSASha1Pkcs1SignatureGenerator(lease.Key));
                 }
                 else
                 {
@@ -374,11 +375,11 @@ Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAMCB4A=
         {
             HashAlgorithmName hashAlgorithmName = new HashAlgorithmName(hashAlgorithm);
 
-            using (RSA key = RSA.Create())
+            using (RSALease lease = RSAKeyPool.Rent())
             {
                 CertificateRequest first = new CertificateRequest(
                     "CN=Test",
-                    key,
+                    lease.Key,
                     hashAlgorithmName,
                     RSASignaturePadding.Pss);
 
@@ -386,7 +387,7 @@ Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAMCB4A=
 
                 if (hashAlgorithm == "SHA1")
                 {
-                    pkcs10 = first.CreateSigningRequest(new RSASha1PssSignatureGenerator(key));
+                    pkcs10 = first.CreateSigningRequest(new RSASha1PssSignatureGenerator(lease.Key));
                 }
                 else
                 {
@@ -449,11 +450,11 @@ Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAMCB4A=
             DateTimeOffset notBefore = now.AddMonths(-1);
             DateTimeOffset notAfter = now.AddMonths(1);
 
-            using (RSA rootKey = RSA.Create(TestData.RsaBigExponentParams))
+            using (RSALease rootKey = RSAKeyPool.RentBigExponentKey())
             {
                 CertificateRequest rootReq = new CertificateRequest(
                     "CN=Root",
-                    rootKey,
+                    rootKey.Key,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 
@@ -475,7 +476,7 @@ Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAMCB4A=
                     Assert.Contains(nameof(X509SignatureGenerator), ex.Message);
 
                     X509SignatureGenerator gen =
-                        X509SignatureGenerator.CreateForRSA(rootKey, RSASignaturePadding.Pkcs1);
+                        X509SignatureGenerator.CreateForRSA(rootKey.Key, RSASignaturePadding.Pkcs1);
 
                     X509Certificate2 issued = req.Create(
                         rootCert.SubjectName,
@@ -500,11 +501,11 @@ Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAMCB4A=
             DateTimeOffset notBefore = now.AddMonths(-1);
             DateTimeOffset notAfter = now.AddMonths(1);
 
-            using (RSA rootKey = RSA.Create(TestData.RsaBigExponentParams))
+            using (RSALease rootKey = RSAKeyPool.RentBigExponentKey())
             {
                 CertificateRequest rootReq = new CertificateRequest(
                     "CN=Root",
-                    rootKey,
+                    rootKey.Key,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 
@@ -534,7 +535,7 @@ Y2FsaG9zdDANBgkqhkiG9w0BAQsFAAMCB4A=
                     // Using a generator overrides the decision
 
                     X509SignatureGenerator gen =
-                        X509SignatureGenerator.CreateForRSA(rootKey, RSASignaturePadding.Pss);
+                        X509SignatureGenerator.CreateForRSA(rootKey.Key, RSASignaturePadding.Pss);
 
                     issued = req.Create(
                         rootCert.SubjectName,

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/RSAPkcs1X509SignatureGeneratorTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/RSAPkcs1X509SignatureGeneratorTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Tests;
 using Test.Cryptography;
 using Xunit;
 
@@ -20,11 +21,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Fact]
         public static void PublicKeyEncoding()
         {
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                rsa.ImportParameters(TestData.RsaBigExponentParams);
-
-                X509SignatureGenerator signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+                X509SignatureGenerator signatureGenerator =
+                    X509SignatureGenerator.CreateForRSA(lease.Key, RSASignaturePadding.Pkcs1);
                 PublicKey publicKey = signatureGenerator.PublicKey;
 
                 // Irrespective of what the current key thinks, the PublicKey value we encode for RSA will always write
@@ -62,12 +62,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("SHA512")]
         public static void SignatureAlgorithm_StableNotSame(string hashAlgorithmName)
         {
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                RSAParameters parameters = TestData.RsaBigExponentParams;
-                rsa.ImportParameters(parameters);
-
-                var signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+                X509SignatureGenerator signatureGenerator =
+                    X509SignatureGenerator.CreateForRSA(lease.Key, RSASignaturePadding.Pkcs1);
 
                 HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
 
@@ -85,12 +83,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("Potato")]
         public static void SignatureAlgorithm_NotSupported(string hashAlgorithmName)
         {
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                RSAParameters parameters = TestData.RsaBigExponentParams;
-                rsa.ImportParameters(parameters);
-
-                var signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+                X509SignatureGenerator signatureGenerator =
+                    X509SignatureGenerator.CreateForRSA(lease.Key, RSASignaturePadding.Pkcs1);
 
                 HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
 
@@ -131,13 +127,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
 
             string expectedHex = $"30{(expectedOid.Length / 2 + 2):X2}{expectedOid}0500";
 
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                RSAParameters parameters = TestData.RsaBigExponentParams;
-                rsa.ImportParameters(parameters);
-
                 HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
-                X509SignatureGenerator signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1);
+                X509SignatureGenerator signatureGenerator =
+                    X509SignatureGenerator.CreateForRSA(lease.Key, RSASignaturePadding.Pkcs1);
                 byte[] sigAlg = signatureGenerator.GetSignatureAlgorithmIdentifier(hashAlgorithm);
 
                 Assert.Equal(expectedHex, sigAlg.ByteArrayToHex());

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/RSAPssX509SignatureGeneratorTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/RSAPssX509SignatureGeneratorTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Cryptography.Tests;
 using Test.Cryptography;
 using Xunit;
 
@@ -20,11 +21,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Fact]
         public static void PublicKeyEncoding()
         {
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                rsa.ImportParameters(TestData.RsaBigExponentParams);
-
-                X509SignatureGenerator signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pss);
+                X509SignatureGenerator signatureGenerator =
+                    X509SignatureGenerator.CreateForRSA(lease.Key, RSASignaturePadding.Pss);
                 PublicKey publicKey = signatureGenerator.PublicKey;
 
                 // Irrespective of what the current key thinks, the PublicKey value we encode for RSA will always write
@@ -62,12 +62,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("SHA512")]
         public static void SignatureAlgorithm_StableNotSame(string hashAlgorithmName)
         {
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                RSAParameters parameters = TestData.RsaBigExponentParams;
-                rsa.ImportParameters(parameters);
-
-                var signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pss);
+                X509SignatureGenerator signatureGenerator =
+                    X509SignatureGenerator.CreateForRSA(lease.Key, RSASignaturePadding.Pss);
 
                 HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
 
@@ -85,12 +83,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("Potato")]
         public static void SignatureAlgorithm_NotSupported(string hashAlgorithmName)
         {
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                RSAParameters parameters = TestData.RsaBigExponentParams;
-                rsa.ImportParameters(parameters);
-
-                var signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pss);
+                X509SignatureGenerator signatureGenerator =
+                    X509SignatureGenerator.CreateForRSA(lease.Key, RSASignaturePadding.Pss);
 
                 HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
 
@@ -161,13 +157,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                             // INTEGER (saltLength == size of hash)
                             "0201" + saltLenByte.ToString("X2");
 
-            using (RSA rsa = RSA.Create())
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
-                RSAParameters parameters = TestData.RsaBigExponentParams;
-                rsa.ImportParameters(parameters);
-
                 HashAlgorithmName hashAlgorithm = new HashAlgorithmName(hashAlgorithmName);
-                var signatureGenerator = X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pss);
+                X509SignatureGenerator signatureGenerator =
+                    X509SignatureGenerator.CreateForRSA(lease.Key, RSASignaturePadding.Pss);
                 byte[] sigAlg = signatureGenerator.GetSignatureAlgorithmIdentifier(hashAlgorithm);
 
                 Assert.Equal(expectedHex, sigAlg.ByteArrayToHex());

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/DynamicChainTests.cs
@@ -6,7 +6,7 @@ using System.Formats.Asn1;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Security.Cryptography.Tests;
 using Test.Cryptography;
 using Xunit;
 
@@ -326,11 +326,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void TestLeafCertificateWithUnknownCriticalExtension()
         {
-            using (RSA key = RSA.Create())
+            using (RSALease lease = RSAKeyPool.Rent())
             {
                 CertificateRequest certReq = new CertificateRequest(
                     new X500DistinguishedName("CN=Cert"),
-                    key,
+                    lease.Key,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 
@@ -373,11 +373,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [SkipOnPlatform(TestPlatforms.Android, "Android does not support AIA fetching")]
         public static void TestInvalidAia()
         {
-            using (RSA key = RSA.Create())
+            using (RSALease lease = RSAKeyPool.Rent())
             {
                 CertificateRequest rootReq = new CertificateRequest(
                     "CN=Root",
-                    key,
+                    lease.Key,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 
@@ -385,7 +385,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 CertificateRequest certReq = new CertificateRequest(
                     "CN=test",
-                    key,
+                    lease.Key,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 
@@ -422,11 +422,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X500DistinguishedName dn = new X500DistinguishedName(
                 "30283117301506052901020203120C313233203635342037383930310D300B0603550403130454657374".HexToByteArray());
 
-            using (RSA key = RSA.Create())
+            using (RSALease lease = RSAKeyPool.Rent())
             {
                 CertificateRequest req = new CertificateRequest(
                     dn,
-                    key,
+                    lease.Key,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/HostnameMatchTests.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/HostnameMatchTests.Unix.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Security.Cryptography.Tests;
 using System.Text;
 using Test.Cryptography;
 using Xunit;
@@ -81,11 +82,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             bool flattenCase,
             bool expectedResult)
         {
-            using (RSA rsa = RSA.Create(TestData.RsaBigExponentParams))
+            using (RSALease lease = RSAKeyPool.RentBigExponentKey())
             {
                 CertificateRequest request = new CertificateRequest(
                     $"CN={FixCase(subjectCN, flattenCase)}, O=.NET Framework (CoreFX)",
-                    rsa,
+                    lease.Key,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/TestDataGenerator.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/TestDataGenerator.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography.Tests;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
 {
@@ -17,15 +18,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             IEnumerable<X509Extension> rootExtensions = null,
             [CallerMemberName] string testName = null)
         {
-            using (RSA rootKey = RSA.Create())
-            using (RSA intermediateKey = RSA.Create())
-            using (RSA endEntityKey = RSA.Create())
+            using (RSALease rootKey = RSAKeyPool.Rent())
+            using (RSALease intermediateKey = RSAKeyPool.Rent())
+            using (RSALease endEntityKey = RSAKeyPool.Rent())
             {
                 ReadOnlySpan<RSA> keys = new[]
                 {
-                    rootKey,
-                    intermediateKey,
-                    endEntityKey,
+                    rootKey.Key,
+                    intermediateKey.Key,
+                    endEntityKey.Key,
                 };
 
                 Span<X509Certificate2> certs = new X509Certificate2[keys.Length];
@@ -54,16 +55,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             IEnumerable<X509Extension> rootExtensions = null,
             [CallerMemberName] string testName = null)
         {
-            using (RSA rootKey = RSA.Create())
-            using (RSA intermediateKey = RSA.Create())
-            using (RSA endEntityKey = RSA.Create())
+            using (RSALease rootKey = RSAKeyPool.Rent())
+            using (RSALease intermediateKey = RSAKeyPool.Rent())
+            using (RSALease endEntityKey = RSAKeyPool.Rent())
             {
                 ReadOnlySpan<RSA> keys = new[]
                 {
-                    rootKey,
-                    intermediateKey,
-                    intermediateKey,
-                    endEntityKey,
+                    rootKey.Key,
+                    intermediateKey.Key,
+                    intermediateKey.Key,
+                    endEntityKey.Key,
                 };
 
                 Span<X509Certificate2> certs = new X509Certificate2[keys.Length];
@@ -126,7 +127,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             TimeSpan notAfterInterval = TimeSpan.FromDays(90);
             DateTimeOffset eeStart = DateTimeOffset.UtcNow.AddDays(-7);
             DateTimeOffset eeEnd = eeStart.AddDays(45);
-            byte[] serialBuf = new byte[16];
 
             int rootIndex = keys.Length - 1;
 


### PR DESCRIPTION
Many of our tests want to use generated keys to avoid any notion that the test pass/fail is tied to using a specific key, but they very rarely care that they're using a completely fresh key.

With this change, the tests that don't involve mutating key objects (via Import*, Dispose, or calling set_KeySize), and otherwise were generating a new key every time, will now share keys across tests.

OuterLoop for S.S.Cryptography.Tests drops from generating 2,039 RSA keys across the various sizes to generating only about 43 (the specific number will depend on concurrency). (For an inner-loop test run it's 189 dropping to the same 43 or so.)

The change also lays infrastructure to pool ECDSA/etc keys, and for commonly-imported key values into pooled objects.

In addition to doing a bit less of a stress-test on the key generator routines, this should speed up the tests a bit.  On Windows, it shaves a couple of seconds off of the outer loop run (~160s -> ~155s).

At this time the specific-type tests (S.S.C.Cng.Tests, etc) are not using pooling.

Hopefully contributes to #25979.