### PR TITLE
Improve "vec == Vector128<>.Zero"

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1088,13 +1088,13 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
     GenTree* op1 = node->Op(1);
     GenTree* op2 = node->Op(2);
 
-    // Optimize comparison against Vector64/128<>.Zero via UMAX:
+    // Optimize comparison against Vector64/128<>.Zero via UMAXV:
     //
     //   bool eq = v == Vector128<integer>.Zero
     //
     // to:
     //
-    //   bool eq = AdvSimd.Arm64.MaxAcross(v.AsUInt16()).ToScalar() == 0;
+    //   bool eq = AdvSimd.Arm64.MaxPairwise(v.AsUInt16(), v.AsUInt16()).GetElement(0) == 0;
     //
     GenTree* op     = nullptr;
     GenTree* opZero = nullptr;

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1138,16 +1138,14 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
         BlockRange().InsertAfter(zroCns, val);
         LowerNode(val);
 
-        GenTree* bitMskCns = comp->gtNewIconNode(0, TYP_LONG);
-        BlockRange().InsertAfter(val, bitMskCns);
+        GenTree* cmpZeroCns = comp->gtNewIconNode(0, TYP_LONG);
+        BlockRange().InsertAfter(val, cmpZeroCns);
 
         node->ChangeOper(cmpOp);
         node->gtType        = TYP_INT;
         node->AsOp()->gtOp1 = val;
-        node->AsOp()->gtOp2 = bitMskCns;
-
-        GenCondition cmpCnd = (cmpOp == GT_EQ) ? GenCondition::EQ : GenCondition::NE;
-        LowerNodeCC(node, cmpCnd);
+        node->AsOp()->gtOp2 = cmpZeroCns;
+        LowerNodeCC(node, (cmpOp == GT_EQ) ? GenCondition::EQ : GenCondition::NE);
         node->gtType = TYP_VOID;
         node->ClearUnusedValue();
         LowerNode(node);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1112,17 +1112,18 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
     // Special case: "vec ==/!= zero_vector"
     if (!varTypeIsFloating(simdBaseType) && (op != nullptr) && (simdSize != 12))
     {
-        GenTree* cmp = node;
+        GenTree* cmp = op;
         if (simdSize != 8) // we don't need compression for Vector64
         {
             node->Op(1) = op;
             LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
             ReplaceWithLclVar(tmp1Use);
-            op = node->Op(1);
+            op               = node->Op(1);
             GenTree* opClone = comp->gtClone(op);
             BlockRange().InsertAfter(op, opClone);
 
-            cmp = comp->gtNewSimdHWIntrinsicNode(simdType, op, opClone, NI_AdvSimd_Arm64_MaxPairwise, CORINFO_TYPE_UINT, simdSize);
+            cmp = comp->gtNewSimdHWIntrinsicNode(simdType, op, opClone, NI_AdvSimd_Arm64_MaxPairwise, CORINFO_TYPE_UINT,
+                                                 simdSize);
             BlockRange().InsertBefore(node, cmp);
             LowerNode(cmp);
         }
@@ -1141,7 +1142,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
         BlockRange().InsertAfter(val, bitMskCns);
 
         node->ChangeOper(cmpOp);
-        node->gtType = TYP_INT;
+        node->gtType        = TYP_INT;
         node->AsOp()->gtOp1 = val;
         node->AsOp()->gtOp2 = bitMskCns;
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1109,27 +1109,44 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
         opZero = op2;
     }
 
-    if (!varTypeIsFloating(simdBaseType) && (op != nullptr))
+    // Special case: "vec ==/!= zero_vector"
+    if (!varTypeIsFloating(simdBaseType) && (op != nullptr) && (simdSize != 12))
     {
-        // Use USHORT for V64 and UINT for V128 due to better latency/TP on some CPUs
-        CorInfoType maxType = (simdSize == 8) ? CORINFO_TYPE_USHORT : CORINFO_TYPE_UINT;
-        GenTree*    cmp = comp->gtNewSimdHWIntrinsicNode(simdType, op, NI_AdvSimd_Arm64_MaxAcross, maxType, simdSize);
-        BlockRange().InsertBefore(node, cmp);
-        LowerNode(cmp);
+        GenTree* cmp = node;
+        if (simdSize != 8) // we don't need compression for Vector64
+        {
+            node->Op(1) = op;
+            LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
+            ReplaceWithLclVar(tmp1Use);
+            op = node->Op(1);
+            GenTree* opClone = comp->gtClone(op);
+            BlockRange().InsertAfter(op, opClone);
+
+            cmp = comp->gtNewSimdHWIntrinsicNode(simdType, op, opClone, NI_AdvSimd_Arm64_MaxPairwise, CORINFO_TYPE_UINT, simdSize);
+            BlockRange().InsertBefore(node, cmp);
+            LowerNode(cmp);
+        }
+
         BlockRange().Remove(opZero);
 
-        GenTree* val = comp->gtNewSimdHWIntrinsicNode(TYP_INT, cmp, NI_Vector128_ToScalar, CORINFO_TYPE_UINT, simdSize);
-        BlockRange().InsertAfter(cmp, val);
+        GenTree* zroCns = comp->gtNewIconNode(0, TYP_INT);
+        BlockRange().InsertAfter(cmp, zroCns);
+
+        GenTree* val =
+            comp->gtNewSimdHWIntrinsicNode(TYP_LONG, cmp, zroCns, NI_AdvSimd_Extract, CORINFO_TYPE_ULONG, simdSize);
+        BlockRange().InsertAfter(zroCns, val);
         LowerNode(val);
 
-        GenTree* cmpZeroCns = comp->gtNewIconNode(0, TYP_INT);
-        BlockRange().InsertAfter(val, cmpZeroCns);
+        GenTree* bitMskCns = comp->gtNewIconNode(0, TYP_LONG);
+        BlockRange().InsertAfter(val, bitMskCns);
 
         node->ChangeOper(cmpOp);
-        node->gtType        = TYP_INT;
+        node->gtType = TYP_INT;
         node->AsOp()->gtOp1 = val;
-        node->AsOp()->gtOp2 = cmpZeroCns;
-        LowerNodeCC(node, (cmpOp == GT_EQ) ? GenCondition::EQ : GenCondition::NE);
+        node->AsOp()->gtOp2 = bitMskCns;
+
+        GenCondition cmpCnd = (cmpOp == GT_EQ) ? GenCondition::EQ : GenCondition::NE;
+        LowerNodeCC(node, cmpCnd);
         node->gtType = TYP_VOID;
         node->ClearUnusedValue();
         LowerNode(node);


### PR DESCRIPTION
Follow up to https://github.com/dotnet/runtime/pull/75864 to address @TamarChristinaArm's suggestion in https://github.com/dotnet/runtime/issues/75849#issuecomment-1251456498
Btw, previous improvements seem to show nice benefits https://github.com/dotnet/runtime/pull/75864#issuecomment-1254277984

```csharp
static bool IsZero1(Vector128<int> v) => v == Vector128<int>.Zero;
static bool IsZero2(Vector64<int> v) => v == Vector64<int>.Zero;
```
Codegen diff:
```diff
; Method Tests:IsZero1
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp

-           umaxv   s16, v0.4s
-           umov    w0, v16.s[0]
-           cmp     w0, #0
+           umaxp   v16.4s, v0.4s, v0.4s
+           umov    x0, v16.d[0]
+           cmp     x0, #0
            cset    x0, eq

            ldp     fp, lr, [sp], #0x10
            ret     lr

; Method Tests:IsZero2
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp

-           umaxv   h16, v0.4h
-           umov    w0, v16.s[0]
-           cmp     w0, #0
+           umov    x0, v0.d[0]
+           cmp     x0, #0
            cset    x0, eq

            ldp     fp, lr, [sp], #0x10
            ret     lr
```

Should be a nice win for Vector64. For Vector128 I wasn't able to see noticeable improvements on my Apple M1 but we might see improvements on other (hopefully, on Ampere Altra?)

However, even on M1 it seems to be better:
```
UMAXV                                     3          0.25     1        -     -     1     u11-14
UMAXP                                     2          0.25     1        -     -     1     u11-14
```
(1st column is Latency, according to https://dougallj.github.io/applecpu/firestorm-simd.html)
