### PR TITLE
Fix not to create unnecessary `thread_params`

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2038,14 +2038,17 @@ ep_rt_thread_create (
 
 				if (thread_params->thread_params.thread->CreateNewThread (0, ep_rt_thread_coreclr_start_func, thread_params))
 				{
-					thread_params->thread_params.thread->SetBackground (TRUE);
-					thread_params->thread_params.thread->StartThread ();
-
 					if (id)
 					{
 						*reinterpret_cast<DWORD *>(id) = thread_params->thread_params.thread->GetThreadId ();
 					}
+					thread_params->thread_params.thread->SetBackground (TRUE);
+					thread_params->thread_params.thread->StartThread ();
 					result = true;
+				}
+				else
+				{
+					delete thread_params;
 				}
 			}
 		}

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2012,27 +2012,39 @@ ep_rt_thread_create (
 
 	EX_TRY
 	{
-		rt_coreclr_thread_params_internal_t *thread_params = new (nothrow) rt_coreclr_thread_params_internal_t ();
-		if (thread_params) {
-			thread_params->thread_params.thread_type = thread_type;
-			if (thread_type == EP_THREAD_TYPE_SESSION || thread_type == EP_THREAD_TYPE_SAMPLING) {
+		if (thread_type == EP_THREAD_TYPE_SERVER)
+		{
+			DWORD thread_id = 0;
+			HANDLE server_thread = ::CreateThread (nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_func), nullptr, 0, &thread_id);
+			if (server_thread != NULL)
+			{
+				if (id)
+				{
+					*reinterpret_cast<DWORD *>(id) = thread_id;
+				}
+				::CloseHandle (server_thread);
+				result = true;
+			}
+		}
+		else if (thread_type == EP_THREAD_TYPE_SESSION || thread_type == EP_THREAD_TYPE_SAMPLING)
+		{
+			rt_coreclr_thread_params_internal_t *thread_params = new (nothrow) rt_coreclr_thread_params_internal_t ();
+			if (thread_params)
+			{
+				thread_params->thread_params.thread_type = thread_type;
 				thread_params->thread_params.thread = SetupUnstartedThread ();
 				thread_params->thread_params.thread_func = reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_func);
 				thread_params->thread_params.thread_params = params;
-				if (thread_params->thread_params.thread->CreateNewThread (0, ep_rt_thread_coreclr_start_func, thread_params)) {
+
+				if (thread_params->thread_params.thread->CreateNewThread (0, ep_rt_thread_coreclr_start_func, thread_params))
+				{
 					thread_params->thread_params.thread->SetBackground (TRUE);
 					thread_params->thread_params.thread->StartThread ();
+
 					if (id)
+					{
 						*reinterpret_cast<DWORD *>(id) = thread_params->thread_params.thread->GetThreadId ();
-					result = true;
-				}
-			} else if (thread_type == EP_THREAD_TYPE_SERVER) {
-				DWORD thread_id = 0;
-				HANDLE server_thread = ::CreateThread (nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_func), nullptr, 0, &thread_id);
-				if (server_thread != NULL) {
-					::CloseHandle (server_thread);
-					if (id)
-						*reinterpret_cast<DWORD *>(id) = thread_id;
+					}
 					result = true;
 				}
 			}


### PR DESCRIPTION
In case of `EP_THREAD_TYPE_SERVER`, thread_param is a leak in the original code.