### PR TITLE
SPMI: Add and utilize number of contexts with diffs 

### DIFF
--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -116,6 +116,12 @@ PhaseStatus Compiler::fgForwardSub()
     }
 #endif
 
+    CLRRandom rng;
+    rng.Init(info.compILCodeSize ^ info.compILlocalsCount ^ 0x12345678);
+    if (rng.Next(10) == 0)
+    {
+        return PhaseStatus::MODIFIED_NOTHING;
+    }
     bool changed = false;
 
     for (BasicBlock* const block : Blocks())

--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -116,12 +116,6 @@ PhaseStatus Compiler::fgForwardSub()
     }
 #endif
 
-    CLRRandom rng;
-    rng.Init(info.compILCodeSize ^ info.compILlocalsCount ^ 0x12345678);
-    if (rng.Next(10) == 0)
-    {
-        return PhaseStatus::MODIFIED_NOTHING;
-    }
     bool changed = false;
 
     for (BasicBlock* const block : Blocks())

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1900,29 +1900,29 @@ class SuperPMIReplayAsmDiffs:
                 if any(has_diffs(diff_metrics["Overall"]) for (_, _, diff_metrics, _, _) in asm_diffs):
                     def write_pivot_section(row):
                         # Exclude this particular Overall/MinOpts/FullOpts table?
-                        if any(has_diffs(diff_metrics[row]) for (_, _, diff_metrics, _, _) in asm_diffs):
-                            write_fh.write("\n<details>\n")
-                            sum_base = sum(int(base_metrics[row]["Diffed code bytes"]) for (_, base_metrics, _, _, _) in asm_diffs)
-                            sum_diff = sum(int(diff_metrics[row]["Diffed code bytes"]) for (_, _, diff_metrics, _, _) in asm_diffs)
+                        if not any(has_diffs(diff_metrics[row]) for (_, _, diff_metrics, _, _) in asm_diffs):
+                            return
 
-                            write_fh.write("<summary>{} ({} bytes)</summary>\n\n".format(row, format_delta(sum_base, sum_diff)))
-                            write_fh.write("|Collection|Base size (bytes)|Diff size (bytes)|\n")
-                            write_fh.write("|---|--:|--:|\n")
-                            for (mch_file, base_metrics, diff_metrics, _, _) in asm_diffs:
-                                # Exclude this particular row?
-                                if not has_diffs(diff_metrics[row]):
-                                    continue
+                        write_fh.write("\n<details>\n")
+                        sum_base = sum(int(base_metrics[row]["Diffed code bytes"]) for (_, base_metrics, _, _, _) in asm_diffs)
+                        sum_diff = sum(int(diff_metrics[row]["Diffed code bytes"]) for (_, _, diff_metrics, _, _) in asm_diffs)
 
-                                write_fh.write("|{}|{:,d}|{}|\n".format(
-                                    mch_file,
+                        write_fh.write("<summary>{} ({} bytes)</summary>\n\n".format(row, format_delta(sum_base, sum_diff)))
+                        write_fh.write("|Collection|Base size (bytes)|Diff size (bytes)|\n")
+                        write_fh.write("|---|--:|--:|\n")
+                        for (mch_file, base_metrics, diff_metrics, _, _) in asm_diffs:
+                            # Exclude this particular row?
+                            if not has_diffs(diff_metrics[row]):
+                                continue
+
+                            write_fh.write("|{}|{:,d}|{}|\n".format(
+                                mch_file,
+                                int(base_metrics[row]["Diffed code bytes"]),
+                                format_delta(
                                     int(base_metrics[row]["Diffed code bytes"]),
-                                    format_delta(
-                                        int(base_metrics[row]["Diffed code bytes"]),
-                                        int(diff_metrics[row]["Diffed code bytes"]))))
+                                    int(diff_metrics[row]["Diffed code bytes"]))))
 
-                            write_fh.write("\n\n</details>\n")
-                        else:
-                            write_fh.write("\nNo {} diffs found.\n".format(row))
+                        write_fh.write("\n\n</details>\n")
 
                     write_pivot_section("Overall")
                     write_pivot_section("MinOpts")
@@ -2182,26 +2182,26 @@ class SuperPMIReplayThroughputDiff:
 
                 if any(is_significant(row, base, diff) for row in ["Overall", "MinOpts", "FullOpts"] for (_, base, diff) in tp_diffs):
                     def write_pivot_section(row):
-                        if any(is_significant(row, base, diff) for (_, base, diff) in tp_diffs):
-                            write_fh.write("\n<details>\n")
-                            sum_base = sum(int(base_metrics[row]["Diff executed instructions"]) for (_, base_metrics, _) in tp_diffs)
-                            sum_diff = sum(int(diff_metrics[row]["Diff executed instructions"]) for (_, _, diff_metrics) in tp_diffs)
+                        if not any(is_significant(row, base, diff) for (_, base, diff) in tp_diffs):
+                            return
 
-                            write_fh.write("<summary>{} ({})</summary>\n\n".format(row, format_pct(sum_base, sum_diff)))
-                            write_fh.write("|Collection|PDIFF|\n")
-                            write_fh.write("|---|--:|\n")
-                            for mch_file, base, diff in tp_diffs:
-                                base_instructions = int(base[row]["Diff executed instructions"])
-                                diff_instructions = int(diff[row]["Diff executed instructions"])
+                        write_fh.write("\n<details>\n")
+                        sum_base = sum(int(base_metrics[row]["Diff executed instructions"]) for (_, base_metrics, _) in tp_diffs)
+                        sum_diff = sum(int(diff_metrics[row]["Diff executed instructions"]) for (_, _, diff_metrics) in tp_diffs)
 
-                                if is_significant(row, base, diff):
-                                    write_fh.write("|{}|{}|\n".format(
-                                        mch_file,
-                                        format_pct(base_instructions, diff_instructions)))
+                        write_fh.write("<summary>{} ({})</summary>\n\n".format(row, format_pct(sum_base, sum_diff)))
+                        write_fh.write("|Collection|PDIFF|\n")
+                        write_fh.write("|---|--:|\n")
+                        for mch_file, base, diff in tp_diffs:
+                            base_instructions = int(base[row]["Diff executed instructions"])
+                            diff_instructions = int(diff[row]["Diff executed instructions"])
 
-                            write_fh.write("\n\n</details>\n")
-                        else:
-                            write_fh.write("\nNo significant {} throughput differences found\n".format(row))
+                            if is_significant(row, base, diff):
+                                write_fh.write("|{}|{}|\n".format(
+                                    mch_file,
+                                    format_pct(base_instructions, diff_instructions)))
+
+                        write_fh.write("\n\n</details>\n")
 
                     write_pivot_section("Overall")
                     write_pivot_section("MinOpts")

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1900,29 +1900,29 @@ class SuperPMIReplayAsmDiffs:
                 if any(has_diffs(diff_metrics["Overall"]) for (_, _, diff_metrics, _, _) in asm_diffs):
                     def write_pivot_section(row):
                         # Exclude this particular Overall/MinOpts/FullOpts table?
-                        if not any(has_diffs(diff_metrics[row]) for (_, _, diff_metrics, _, _) in asm_diffs):
-                            return
+                        if any(has_diffs(diff_metrics[row]) for (_, _, diff_metrics, _, _) in asm_diffs):
+                            write_fh.write("\n<details>\n")
+                            sum_base = sum(int(base_metrics[row]["Diffed code bytes"]) for (_, base_metrics, _, _, _) in asm_diffs)
+                            sum_diff = sum(int(diff_metrics[row]["Diffed code bytes"]) for (_, _, diff_metrics, _, _) in asm_diffs)
 
-                        write_fh.write("\n<details>\n")
-                        sum_base = sum(int(base_metrics[row]["Diffed code bytes"]) for (_, base_metrics, _, _, _) in asm_diffs)
-                        sum_diff = sum(int(diff_metrics[row]["Diffed code bytes"]) for (_, _, diff_metrics, _, _) in asm_diffs)
+                            write_fh.write("<summary>{} ({} bytes)</summary>\n\n".format(row, format_delta(sum_base, sum_diff)))
+                            write_fh.write("|Collection|Base size (bytes)|Diff size (bytes)|\n")
+                            write_fh.write("|---|--:|--:|\n")
+                            for (mch_file, base_metrics, diff_metrics, _, _) in asm_diffs:
+                                # Exclude this particular row?
+                                if not has_diffs(diff_metrics[row]):
+                                    continue
 
-                        write_fh.write("<summary>{} ({} bytes)</summary>\n\n".format(row, format_delta(sum_base, sum_diff)))
-                        write_fh.write("|Collection|Base size (bytes)|Diff size (bytes)|\n")
-                        write_fh.write("|---|--:|--:|\n")
-                        for (mch_file, base_metrics, diff_metrics, _, _) in asm_diffs:
-                            # Exclude this particular row?
-                            if not has_diffs(diff_metrics[row]):
-                                continue
-
-                            write_fh.write("|{}|{:,d}|{}|\n".format(
-                                mch_file,
-                                int(base_metrics[row]["Diffed code bytes"]),
-                                format_delta(
+                                write_fh.write("|{}|{:,d}|{}|\n".format(
+                                    mch_file,
                                     int(base_metrics[row]["Diffed code bytes"]),
-                                    int(diff_metrics[row]["Diffed code bytes"]))))
+                                    format_delta(
+                                        int(base_metrics[row]["Diffed code bytes"]),
+                                        int(diff_metrics[row]["Diffed code bytes"]))))
 
-                        write_fh.write("\n\n</details>\n")
+                            write_fh.write("\n\n</details>\n")
+                        else:
+                            write_fh.write("\nNo {} diffs found.\n".format(row))
 
                     write_pivot_section("Overall")
                     write_pivot_section("MinOpts")
@@ -2182,26 +2182,26 @@ class SuperPMIReplayThroughputDiff:
 
                 if any(is_significant(row, base, diff) for row in ["Overall", "MinOpts", "FullOpts"] for (_, base, diff) in tp_diffs):
                     def write_pivot_section(row):
-                        if not any(is_significant(row, base, diff) for (_, base, diff) in tp_diffs):
-                            return
+                        if any(is_significant(row, base, diff) for (_, base, diff) in tp_diffs):
+                            write_fh.write("\n<details>\n")
+                            sum_base = sum(int(base_metrics[row]["Diff executed instructions"]) for (_, base_metrics, _) in tp_diffs)
+                            sum_diff = sum(int(diff_metrics[row]["Diff executed instructions"]) for (_, _, diff_metrics) in tp_diffs)
 
-                        write_fh.write("\n<details>\n")
-                        sum_base = sum(int(base_metrics[row]["Diff executed instructions"]) for (_, base_metrics, _) in tp_diffs)
-                        sum_diff = sum(int(diff_metrics[row]["Diff executed instructions"]) for (_, _, diff_metrics) in tp_diffs)
+                            write_fh.write("<summary>{} ({})</summary>\n\n".format(row, format_pct(sum_base, sum_diff)))
+                            write_fh.write("|Collection|PDIFF|\n")
+                            write_fh.write("|---|--:|\n")
+                            for mch_file, base, diff in tp_diffs:
+                                base_instructions = int(base[row]["Diff executed instructions"])
+                                diff_instructions = int(diff[row]["Diff executed instructions"])
 
-                        write_fh.write("<summary>{} ({})</summary>\n\n".format(row, format_pct(sum_base, sum_diff)))
-                        write_fh.write("|Collection|PDIFF|\n")
-                        write_fh.write("|---|--:|\n")
-                        for mch_file, base, diff in tp_diffs:
-                            base_instructions = int(base[row]["Diff executed instructions"])
-                            diff_instructions = int(diff[row]["Diff executed instructions"])
+                                if is_significant(row, base, diff):
+                                    write_fh.write("|{}|{}|\n".format(
+                                        mch_file,
+                                        format_pct(base_instructions, diff_instructions)))
 
-                            if is_significant(row, base, diff):
-                                write_fh.write("|{}|{}|\n".format(
-                                    mch_file,
-                                    format_pct(base_instructions, diff_instructions)))
-
-                        write_fh.write("\n\n</details>\n")
+                            write_fh.write("\n\n</details>\n")
+                        else:
+                            write_fh.write("\nNo significant {} throughput differences found\n".format(row))
 
                     write_pivot_section("Overall")
                     write_pivot_section("MinOpts")

--- a/src/coreclr/tools/superpmi/superpmi/metricssummary.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/metricssummary.cpp
@@ -10,6 +10,7 @@ void MetricsSummary::AggregateFrom(const MetricsSummary& other)
     SuccessfulCompiles += other.SuccessfulCompiles;
     FailingCompiles += other.FailingCompiles;
     MissingCompiles += other.MissingCompiles;
+    NumContextsWithDiffs += other.NumContextsWithDiffs;
     NumCodeBytes += other.NumCodeBytes;
     NumDiffedCodeBytes += other.NumDiffedCodeBytes;
     NumExecutedInstructions += other.NumExecutedInstructions;
@@ -67,7 +68,7 @@ bool MetricsSummaries::SaveToFile(const char* path)
 
     if (!FilePrintf(
         file.get(),
-        "Successful compiles,Failing compiles,Missing compiles,"
+        "Successful compiles,Failing compiles,Missing compiles,Contexts with diffs,"
         "Code bytes,Diffed code bytes,Executed instructions,Diff executed instructions,Name\n"))
     {
         return false;
@@ -84,10 +85,11 @@ bool MetricsSummaries::WriteRow(HANDLE hFile, const char* name, const MetricsSum
     return
         FilePrintf(
             hFile,
-            "%d,%d,%d,%lld,%lld,%lld,%lld,%s\n",
+            "%d,%d,%d,%d,%lld,%lld,%lld,%lld,%s\n",
             summary.SuccessfulCompiles,
             summary.FailingCompiles,
             summary.MissingCompiles,
+            summary.NumContextsWithDiffs,
             summary.NumCodeBytes,
             summary.NumDiffedCodeBytes,
             summary.NumExecutedInstructions,
@@ -150,17 +152,18 @@ bool MetricsSummaries::LoadFromFile(const char* path, MetricsSummaries* metrics)
         int scanResult =
             sscanf_s(
                 line.data(),
-                "%d,%d,%d,%lld,%lld,%lld,%lld,%s",
+                "%d,%d,%d,%d,%lld,%lld,%lld,%lld,%s",
                 &summary.SuccessfulCompiles,
                 &summary.FailingCompiles,
                 &summary.MissingCompiles,
+                &summary.NumContextsWithDiffs,
                 &summary.NumCodeBytes,
                 &summary.NumDiffedCodeBytes,
                 &summary.NumExecutedInstructions,
                 &summary.NumDiffExecutedInstructions,
                 name, (unsigned)sizeof(name));
 
-        if (scanResult == 8)
+        if (scanResult == 9)
         {
             MetricsSummary* tarSummary = nullptr;
             if (strcmp(name, "Overall") == 0)

--- a/src/coreclr/tools/superpmi/superpmi/metricssummary.h
+++ b/src/coreclr/tools/superpmi/superpmi/metricssummary.h
@@ -12,6 +12,8 @@ struct MetricsSummary
     int FailingCompiles = 0;
     // Number of methods that failed jitting due to missing SPMI data.
     int MissingCompiles = 0;
+    // Number of contexts that had any diff.
+    int NumContextsWithDiffs = 0;
     // Number of code bytes produced by the JIT for the successful compiles.
     long long NumCodeBytes = 0;
     // Number of code bytes that were diffed with the other compiler in diff mode.


### PR DESCRIPTION
Previously, if there was any diff in a collection, that collection would be shown in all tables (i.e. Overall, FullOpts, MinOpts). The main reason was that we only had "has diffs" information on a per-collection basis, not for each of the categories. This changes SPMI to communicate back for each category how many contexts had diffs in them, and uses this to hide tables/rows without any diffs, and to show this information under details.