### PR TITLE
Add back missing conv opcodes when compiling via System.Linq.Expressions

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -673,11 +673,6 @@ namespace System.Linq.Expressions.Compiler
                     }
                     else
                     {
-                        if (tf == TypeCode.Byte)
-                        {
-                            return;
-                        }
-
                         convCode = OpCodes.Conv_I1;
                     }
 
@@ -689,11 +684,6 @@ namespace System.Linq.Expressions.Compiler
                     }
                     else
                     {
-                        if (tf == TypeCode.SByte)
-                        {
-                            return;
-                        }
-
                         convCode = OpCodes.Conv_U1;
                     }
 
@@ -704,14 +694,6 @@ namespace System.Linq.Expressions.Compiler
                         case TypeCode.SByte:
                         case TypeCode.Byte:
                             return;
-                        case TypeCode.Char:
-                        case TypeCode.UInt16:
-                            if (!isChecked)
-                            {
-                                return;
-                            }
-
-                            break;
                     }
 
                     convCode = isChecked
@@ -726,14 +708,6 @@ namespace System.Linq.Expressions.Compiler
                         case TypeCode.Char:
                         case TypeCode.UInt16:
                             return;
-                        case TypeCode.SByte:
-                        case TypeCode.Int16:
-                            if (!isChecked)
-                            {
-                                return;
-                            }
-
-                            break;
                     }
 
                     convCode = isChecked

--- a/src/libraries/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -183,6 +183,15 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertByteToSByteRetIntTest(bool useInterpreter)
+        {
+            foreach (byte value in new byte[] { 0, 1, byte.MaxValue })
+            {
+                VerifyByteToSByteRetInt(value, useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertByteToNullableSByteTest(bool useInterpreter)
         {
             foreach (byte value in new byte[] { 0, 1, byte.MaxValue })
@@ -4413,6 +4422,15 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertSByteToByteRetIntTest(bool useInterpreter)
+        {
+            foreach (sbyte value in new sbyte[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue })
+            {
+                VerifySByteToByteRetInt(value, useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertSByteToNullableByteTest(bool useInterpreter)
         {
             foreach (sbyte value in new sbyte[] { 0, 1, -1, sbyte.MinValue, sbyte.MaxValue })
@@ -5147,6 +5165,15 @@ namespace System.Linq.Expressions.Tests
             foreach (short value in new short[] { 0, 1, -1, short.MinValue, short.MaxValue })
             {
                 VerifyShortToUShort(value, useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertShortToUShortRetIntTest(bool useInterpreter)
+        {
+            foreach (short value in new short[] { 0, 1, -1, short.MinValue, short.MaxValue })
+            {
+                VerifyShortToUShortRetInt(value, useInterpreter);
             }
         }
 
@@ -6609,6 +6636,15 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        public static void ConvertUShortToShortRetIntTest(bool useInterpreter)
+        {
+            foreach (ushort value in new ushort[] { 0, 1, ushort.MaxValue })
+            {
+                VerifyUShortToShortRetInt(value, useInterpreter);
+            }
+        }
+
+        [Theory, ClassData(typeof(CompilationTypes))]
         public static void ConvertUShortToNullableShortTest(bool useInterpreter)
         {
             foreach (ushort value in new ushort[] { 0, 1, ushort.MaxValue })
@@ -7134,6 +7170,17 @@ namespace System.Linq.Expressions.Tests
             Func<sbyte> f = e.Compile(useInterpreter);
 
             Assert.Equal(unchecked((sbyte)value), f());
+        }
+
+        private static void VerifyByteToSByteRetInt(byte value, bool useInterpreter)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Convert(Expression.Convert(Expression.Constant(value, typeof(byte)), typeof(sbyte)), typeof(int)),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile(useInterpreter);
+
+            Assert.Equal((int)unchecked((sbyte)value), f());
         }
 
         private static void VerifyByteToNullableSByte(byte value, bool useInterpreter)
@@ -13178,6 +13225,17 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(unchecked((byte)value), f());
         }
 
+        private static void VerifySByteToByteRetInt(sbyte value, bool useInterpreter)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Convert(Expression.Convert(Expression.Constant(value, typeof(sbyte)), typeof(byte)), typeof(int)),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile(useInterpreter);
+
+            Assert.Equal((int)unchecked((byte)value), f());
+        }
+
         private static void VerifySByteToNullableByte(sbyte value, bool useInterpreter)
         {
             Expression<Func<byte?>> e =
@@ -14120,6 +14178,17 @@ namespace System.Linq.Expressions.Tests
             Func<ushort> f = e.Compile(useInterpreter);
 
             Assert.Equal(unchecked((ushort)value), f());
+        }
+
+        private static void VerifyShortToUShortRetInt(short value, bool useInterpreter)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Convert(Expression.Convert(Expression.Constant(value, typeof(short)), typeof(ushort)), typeof(int)),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile(useInterpreter);
+
+            Assert.Equal((int)unchecked((ushort)value), f());
         }
 
         private static void VerifyShortToNullableUShort(short value, bool useInterpreter)
@@ -16028,6 +16097,17 @@ namespace System.Linq.Expressions.Tests
             Func<short> f = e.Compile(useInterpreter);
 
             Assert.Equal(unchecked((short)value), f());
+        }
+
+        private static void VerifyUShortToShortRetInt(ushort value, bool useInterpreter)
+        {
+            Expression<Func<int>> e =
+                Expression.Lambda<Func<int>>(
+                    Expression.Convert(Expression.Convert(Expression.Constant(value, typeof(ushort)), typeof(short)), typeof(int)),
+                    Enumerable.Empty<ParameterExpression>());
+            Func<int> f = e.Compile(useInterpreter);
+
+            Assert.Equal((int)unchecked((short)value), f());
         }
 
         private static void VerifyUShortToNullableShort(ushort value, bool useInterpreter)


### PR DESCRIPTION
The conversion opcodes are still necessary when the sign of the value might change, in which case the conversion opcode will do a sign/zero extend to the full i32 storage used by the IL execution stack.

For example, before this change, conversions from ushort to short were ignored. Consider expressions converting the value `ushort.MaxValue` to short (testcase ConvertUShortToShortTest). `ushort.MaxValue` will be pushed to execution stack as a i32 ldc of value 0xffff. The conv.i2 opcode would change the value on the stack to 0xffffffff so it shouldn't be omitted.