### PR TITLE
Set `AppHostSigningException.ExitCode`

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/AppHostExceptions.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/AppHostExceptions.cs
@@ -75,6 +75,7 @@ namespace Microsoft.NET.HostModel.AppHost
         internal AppHostSigningException(int exitCode, string signingErrorMessage)
             : base(signingErrorMessage)
         {
+            ExitCode = exitCode;
         }
     }
 

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/AppHostExceptions.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/AppHostExceptions.cs
@@ -50,6 +50,7 @@ namespace Microsoft.NET.HostModel.AppHost
     public sealed class AppHostNotCUIException : AppHostUpdateException
     {
         internal AppHostNotCUIException()
+            : base($"Selected apphost is not a CUI Windows application.")
         {
         }
     }
@@ -60,8 +61,12 @@ namespace Microsoft.NET.HostModel.AppHost
     /// </summary>
     public sealed class AppHostNotPEFileException : AppHostUpdateException
     {
-        internal AppHostNotPEFileException()
+        public readonly string Reason;
+
+        internal AppHostNotPEFileException(string reason)
+            : base($"Selected apphost is not a valid PE file. {reason}")
         {
+            Reason = reason;
         }
     }
 
@@ -73,7 +78,7 @@ namespace Microsoft.NET.HostModel.AppHost
         public readonly int ExitCode;
 
         internal AppHostSigningException(int exitCode, string signingErrorMessage)
-            : base(signingErrorMessage)
+            : base($"{signingErrorMessage}; Exit code: {exitCode}")
         {
             ExitCode = exitCode;
         }
@@ -87,6 +92,7 @@ namespace Microsoft.NET.HostModel.AppHost
         public string LongName { get; }
 
         internal AppNameTooLongException(string name)
+            : base($"The name of the app is too long (must be less than 1024). Name: {name}")
         {
             LongName = name;
         }

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/AppHostExceptions.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/AppHostExceptions.cs
@@ -49,8 +49,8 @@ namespace Microsoft.NET.HostModel.AppHost
     /// </summary>
     public sealed class AppHostNotCUIException : AppHostUpdateException
     {
-        internal AppHostNotCUIException()
-            : base($"Selected apphost is not a CUI Windows application.")
+        internal AppHostNotCUIException(ushort subsystem)
+            : base($"Selected apphost is not a CUI Windows application. Subsystem: {subsystem}")
         {
         }
     }
@@ -92,7 +92,7 @@ namespace Microsoft.NET.HostModel.AppHost
         public string LongName { get; }
 
         internal AppNameTooLongException(string name)
-            : base($"The name of the app is too long (must be less than 1024). Name: {name}")
+            : base($"The name of the app is too long (must be less than 1024 bytes). Name: {name}")
         {
             LongName = name;
         }

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.HostModel.AppHost
                 {
                     if (!appHostIsPEImage)
                     {
-                        throw new AppHostNotPEFileException();
+                        throw new AppHostNotPEFileException("Can't find PE file signature.");
                     }
 
                     PEUtils.SetWindowsGraphicalUserInterfaceBit(accessor);

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.NET.HostModel.AppHost
                 {
                     if (!appHostIsPEImage)
                     {
-                        throw new AppHostNotPEFileException("Can't find PE file signature.");
+                        throw new AppHostNotPEFileException("PE file signature not found.");
                     }
 
                     PEUtils.SetWindowsGraphicalUserInterfaceBit(accessor);

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/PEUtils.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/PEUtils.cs
@@ -97,7 +97,7 @@ namespace Microsoft.NET.HostModel.AppHost
 
                 if (accessor.Capacity < peHeaderOffset + SubsystemOffset + sizeof(ushort))
                 {
-                    throw new AppHostNotPEFileException();
+                    throw new AppHostNotPEFileException("Subsystem offset out of file range.");
                 }
 
                 ushort* subsystem = ((ushort*)(bytes + peHeaderOffset + SubsystemOffset));
@@ -150,7 +150,7 @@ namespace Microsoft.NET.HostModel.AppHost
 
                 if (accessor.Capacity < peHeaderOffset + SubsystemOffset + sizeof(ushort))
                 {
-                    throw new AppHostNotPEFileException();
+                    throw new AppHostNotPEFileException("Subsystem offset out of file range.");
                 }
 
                 ushort* subsystem = ((ushort*)(bytes + peHeaderOffset + SubsystemOffset));

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/PEUtils.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/PEUtils.cs
@@ -106,7 +106,7 @@ namespace Microsoft.NET.HostModel.AppHost
                 // The subsystem of the prebuilt apphost should be set to CUI
                 if (subsystem[0] != WindowsCUISubsystem)
                 {
-                    throw new AppHostNotCUIException();
+                    throw new AppHostNotCUIException(subsystem[0]);
                 }
 
                 // Set the subsystem to GUI

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUpdateTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUpdateTests.cs
@@ -313,6 +313,7 @@ namespace Microsoft.NET.HostModel.Tests
                     windowsGraphicalUserInterface: false,
                     enableMacOSCodeSign: true));
                 Assert.Contains($"{destinationFilePath}: is already signed", exception.Message);
+                Assert.True(exception.ExitCode == 1, $"AppHostSigningException.ExitCode - expected: 1, actual: '{exception.ExitCode}'");
             }
         }
 


### PR DESCRIPTION
Set the `ExitCode` on `AppHostSigningException` to the value passed to its constructor. We were never setting it, so it was always 0, resulting in errors strangely saying that we failed with an exit code of 0.

Noticed this from https://github.com/dotnet/sdk/issues/22201. This change doesn't actually get us any more information for that case, but at least makes the error message accurate.