### PR TITLE
Ensure gc collects memory for CriticalFinalizer test

### DIFF
--- a/src/tests/baseservices/finalization/CriticalFinalizer.cs
+++ b/src/tests/baseservices/finalization/CriticalFinalizer.cs
@@ -52,9 +52,14 @@ static class CriticalFinalizerTest
         // Allocate a bunch of Normal and Critical objects, then unroot them
         AllocateObjects(Count);
 
-        // Force a garbage collection and wait until all finalizers are executed
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
+        //Ensure GC collects allocated memory.
+        var currentTotalMemory = GC.GetTotalMemory(false);
+        do
+        {
+            // Force a garbage collection and wait until all finalizers are executed
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        } while (currentTotalMemory <= GC.GetTotalMemory(false));
 
         // Check that all Normal objects were finalized before all Critical objects
         int normalFinalized = Normal.Finalized;


### PR DESCRIPTION
Test assumes `GC.Collect()` successfully collects allocated `Normal` and `Critical` objects.

>  Finalized 0 Normal and 0 Critical objects.
>  The first Critical object was finalized after 0 Normal objects.

https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-76007-merge-ac12cc893b1f4aa0bc/baseservices.finalization/1/console.34afcb43.log?helixlogtype=result

