### PR TITLE
Fix impIntrinsic to not raise asserts for the AltJit scenario

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3672,12 +3672,6 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
         // For mismatched VM (AltJit) we want to check all methods as intrinsic to ensure
         // we get more accurate codegen. This particularly applies to HWIntrinsic usage
         assert(!info.compMatchedVM);
-
-        if (ni == NI_Illegal)
-        {
-            // Early exit for the common AltJit scenario
-            return nullptr;
-        }
     }
 
     // We specially support the following on all platforms to allow for dead
@@ -3731,10 +3725,10 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
     if (!isIntrinsic)
     {
-        // TODO-Cleanup: Outside the cases above, there are many intrinsics which
-        // apply to only 1 overload and where simply matching by name may cause
-        // downstream asserts or other failures. Math.Min is one example, where it
-        // only applies to the floating-point overloads.
+        // Outside the cases above, there are many intrinsics which apply to only a
+        // subset of overload and where simply matching by name may cause downstream
+        // asserts or other failures. Math.Min is one example, where it only applies
+        // to the floating-point overloads.
         return nullptr;
     }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3654,8 +3654,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                                 NamedIntrinsic*         pIntrinsicName,
                                 bool*                   isSpecialIntrinsic)
 {
-    bool mustExpand  = false;
-    bool isSpecial   = false;
+    bool       mustExpand  = false;
+    bool       isSpecial   = false;
     const bool isIntrinsic = (methodFlags & CORINFO_FLG_INTRINSIC) != 0;
 
     NamedIntrinsic ni = lookupNamedIntrinsic(method);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3703,6 +3703,22 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 #ifdef FEATURE_HW_INTRINSICS
     if ((ni > NI_HW_INTRINSIC_START) && (ni < NI_HW_INTRINSIC_END))
     {
+        if (!isIntrinsic)
+        {
+#if defined(TARGET_XARCH)
+            if (ni < NI_Vector256_Xor)
+#elif defined(TARGET_ARM64)
+            if (ni < NI_Vector128_Xor)
+#else
+#error Unsupported platform
+#endif
+            {
+                // Several of the NI_Vector64/128/256 APIs do not have
+                // all overloads as intrinsic today so they will assert
+                return nullptr;
+            }
+        }
+
         GenTree* hwintrinsic = impHWIntrinsic(ni, clsHnd, method, sig, mustExpand);
 
         if (mustExpand && (hwintrinsic == nullptr))

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3656,7 +3656,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 {
     bool mustExpand  = false;
     bool isSpecial   = false;
-    bool isIntrinsic = false;
+    const bool isIntrinsic = (methodFlags & CORINFO_FLG_INTRINSIC) != 0;
 
     NamedIntrinsic ni = lookupNamedIntrinsic(method);
 
@@ -9657,7 +9657,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         }
 #endif // DEBUG
 
-        bool isIntrinsic = (mflags & CORINFO_FLG_INTRINSIC) != 0;
+        const bool isIntrinsic = (mflags & CORINFO_FLG_INTRINSIC) != 0;
 
         // <NICE> Factor this into getCallInfo </NICE>
         bool isSpecialIntrinsic = false;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3709,8 +3709,16 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
         if (!isIntrinsic)
         {
 #if defined(TARGET_XARCH)
+            // We can't guarantee that all overloads for the xplat intrinsics can be
+            // handled by the AltJit, so limit only the platform specific intrinsics
+            assert((NI_Vector256_Xor + 1) == NI_X86Base_BitScanForward);
+
             if (ni < NI_Vector256_Xor)
 #elif defined(TARGET_ARM64)
+            // We can't guarantee that all overloads for the xplat intrinsics can be
+            // handled by the AltJit, so limit only the platform specific intrinsics
+            assert((NI_Vector128_Xor + 1) == NI_AdvSimd_Abs);
+
             if (ni < NI_Vector128_Xor)
 #else
 #error Unsupported platform

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3660,10 +3660,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
     NamedIntrinsic ni = lookupNamedIntrinsic(method);
 
-    if ((methodFlags & CORINFO_FLG_INTRINSIC) != 0)
+    if (isIntrinsic)
     {
-        isIntrinsic = true;
-
         // The recursive non-virtual calls to Jit intrinsics are must-expand by convention.
         mustExpand = gtIsRecursiveCall(method) && !(methodFlags & CORINFO_FLG_VIRTUAL);
     }


### PR DESCRIPTION
This is a follow up to https://github.com/dotnet/runtime/pull/75912 and changes the logic slightly so that the AltJit path is slightly more efficient and so it doesn't cause asserts from matching incorrect overloads of APIs like `Math.Min`.