### PR TITLE
Enable EventSource support in crossgen2

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -13,6 +13,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <Configurations>Debug;Release;Checked</Configurations>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <EventSourceSupport>true</EventSourceSupport>
   </PropertyGroup>
 
   <ItemGroup Label="Embedded Resources">


### PR DESCRIPTION
This was disabled by default in #76000. I started filling out the backport template when it hit me that we want to keep it here.

We'll want to backport these in tandem.