### PR TITLE
ZipArchive.CreateEntry: include file type in default ExternalAttributes.

### DIFF
--- a/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Unix.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Unix.cs
@@ -8,16 +8,22 @@ namespace System.IO.Compression
         /// <summary>
         /// The default external file attributes are used to support zip archives on multiple platforms.
         /// </summary>
-        internal const UnixFileMode DefaultFileEntryPermissions = UnixFileMode.UserRead | UnixFileMode.UserWrite
-                                                            | UnixFileMode.GroupRead
-                                                            | UnixFileMode.OtherRead;
+        internal const uint DefaultFileExternalAttributes =
+            (Interop.Sys.FileTypes.S_IFREG |
+                (uint)(UnixFileMode.UserRead | UnixFileMode.UserWrite
+                    | UnixFileMode.GroupRead
+                    | UnixFileMode.OtherRead)
+            ) << 16;
 
         /// <summary>
         /// The default external directory attributes are used to support zip archives on multiple platforms.
         /// Directories on Unix require the execute permissions to get into them.
         /// </summary>
-        internal const UnixFileMode DefaultDirectoryEntryPermissions = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
-                                                               | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
-                                                               | UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+        internal const uint DefaultDirectoryExternalAttributes =
+            (Interop.Sys.FileTypes.S_IFDIR |
+                (uint)(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute)
+            ) << 16;
     }
 }

--- a/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Unix.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Unix.cs
@@ -8,9 +8,9 @@ namespace System.IO.Compression
         /// <summary>
         /// The default external file attributes are used to support zip archives on multiple platforms.
         /// </summary>
-        internal const uint DefaultFileExternalAttributes =
+        internal const int DefaultFileExternalAttributes =
             (Interop.Sys.FileTypes.S_IFREG |
-                (uint)(UnixFileMode.UserRead | UnixFileMode.UserWrite
+                (int)(UnixFileMode.UserRead | UnixFileMode.UserWrite
                     | UnixFileMode.GroupRead
                     | UnixFileMode.OtherRead)
             ) << 16;
@@ -19,9 +19,9 @@ namespace System.IO.Compression
         /// The default external directory attributes are used to support zip archives on multiple platforms.
         /// Directories on Unix require the execute permissions to get into them.
         /// </summary>
-        internal const uint DefaultDirectoryExternalAttributes =
+        internal const int DefaultDirectoryExternalAttributes =
             (Interop.Sys.FileTypes.S_IFDIR |
-                (uint)(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                (int)(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
                     | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
                     | UnixFileMode.OtherRead | UnixFileMode.OtherExecute)
             ) << 16;

--- a/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Unix.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Unix.cs
@@ -8,9 +8,9 @@ namespace System.IO.Compression
         /// <summary>
         /// The default external file attributes are used to support zip archives on multiple platforms.
         /// </summary>
-        internal const int DefaultFileExternalAttributes =
+        internal const uint DefaultFileExternalAttributes =
             (Interop.Sys.FileTypes.S_IFREG |
-                (int)(UnixFileMode.UserRead | UnixFileMode.UserWrite
+                (uint)(UnixFileMode.UserRead | UnixFileMode.UserWrite
                     | UnixFileMode.GroupRead
                     | UnixFileMode.OtherRead)
             ) << 16;
@@ -19,9 +19,9 @@ namespace System.IO.Compression
         /// The default external directory attributes are used to support zip archives on multiple platforms.
         /// Directories on Unix require the execute permissions to get into them.
         /// </summary>
-        internal const int DefaultDirectoryExternalAttributes =
+        internal const uint DefaultDirectoryExternalAttributes =
             (Interop.Sys.FileTypes.S_IFDIR |
-                (int)(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                (uint)(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
                     | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
                     | UnixFileMode.OtherRead | UnixFileMode.OtherExecute)
             ) << 16;

--- a/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Windows.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Windows.cs
@@ -9,12 +9,12 @@ namespace System.IO.Compression
         /// The default external file attributes are used to support zip archives on multiple platforms.
         /// Since Windows doesn't use file permissions, there's no default value needed.
         /// </summary>
-        internal const UnixFileMode DefaultFileEntryPermissions = UnixFileMode.None;
+        internal const uint DefaultFileExternalAttributes = 0;
 
         /// <summary>
         /// The default external directory attributes are used to support zip archives on multiple platforms.
         /// Since Windows doesn't use file permissions, there's no default value needed.
         /// </summary>
-        internal const UnixFileMode DefaultDirectoryEntryPermissions = UnixFileMode.None;
+        internal const uint DefaultDirectoryExternalAttributes = 0;
     }
 }

--- a/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Windows.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Windows.cs
@@ -9,12 +9,12 @@ namespace System.IO.Compression
         /// The default external file attributes are used to support zip archives on multiple platforms.
         /// Since Windows doesn't use file permissions, there's no default value needed.
         /// </summary>
-        internal const uint DefaultFileExternalAttributes = 0;
+        internal const int DefaultFileExternalAttributes = 0;
 
         /// <summary>
         /// The default external directory attributes are used to support zip archives on multiple platforms.
         /// Since Windows doesn't use file permissions, there's no default value needed.
         /// </summary>
-        internal const uint DefaultDirectoryExternalAttributes = 0;
+        internal const int DefaultDirectoryExternalAttributes = 0;
     }
 }

--- a/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Windows.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZipArchiveEntryConstants.Windows.cs
@@ -9,12 +9,12 @@ namespace System.IO.Compression
         /// The default external file attributes are used to support zip archives on multiple platforms.
         /// Since Windows doesn't use file permissions, there's no default value needed.
         /// </summary>
-        internal const int DefaultFileExternalAttributes = 0;
+        internal const uint DefaultFileExternalAttributes = 0;
 
         /// <summary>
         /// The default external directory attributes are used to support zip archives on multiple platforms.
         /// Since Windows doesn't use file permissions, there's no default value needed.
         /// </summary>
-        internal const int DefaultDirectoryExternalAttributes = 0;
+        internal const uint DefaultDirectoryExternalAttributes = 0;
     }
 }

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.Unix.cs
@@ -16,7 +16,7 @@ namespace System.IO.Compression
             // SetExternalAttributes is only used to overwrite the default values when reading on the unix systems
             // This assert ensures that nothing else sets values different to the default before
             // overwriting it with the data read from the files
-            Debug.Assert(entry.ExternalAttributes == ((uint)DefaultFileEntryPermissions << 16));
+            Debug.Assert(entry.ExternalAttributes == DefaultFileExternalAttributes);
 
             Interop.Sys.FileStatus status;
             Interop.CheckIo(Interop.Sys.FStat(fs.SafeFileHandle, out status), fs.Name);

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.Unix.cs
@@ -16,7 +16,7 @@ namespace System.IO.Compression
             // SetExternalAttributes is only used to overwrite the default values when reading on the unix systems
             // This assert ensures that nothing else sets values different to the default before
             // overwriting it with the data read from the files
-            Debug.Assert(entry.ExternalAttributes == DefaultFileExternalAttributes);
+            Debug.Assert((uint)entry.ExternalAttributes == DefaultFileExternalAttributes);
 
             Interop.Sys.FileStatus status;
             Interop.CheckIo(Interop.Sys.FStat(fs.SafeFileHandle, out status), fs.Name);

--- a/src/libraries/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/libraries/System.IO.Compression/src/System.IO.Compression.csproj
@@ -57,6 +57,8 @@
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.PathConf.cs"
              Link="Common\Interop\Unix\System.Native\Interop.PathConf.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.cs"
+             Link="Common\Interop\Unix\System.Native\Interop.Stat.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -117,10 +117,9 @@ namespace System.IO.Compression
 
             _compressedSize = 0; // we don't know these yet
             _uncompressedSize = 0;
-            UnixFileMode defaultEntryPermissions = entryName.EndsWith(Path.DirectorySeparatorChar) || entryName.EndsWith(Path.AltDirectorySeparatorChar)
-                                        ? DefaultDirectoryEntryPermissions
-                                        : DefaultFileEntryPermissions;
-            _externalFileAttr = (uint)(defaultEntryPermissions) << 16;
+            _externalFileAttr = entryName.EndsWith(Path.DirectorySeparatorChar) || entryName.EndsWith(Path.AltDirectorySeparatorChar)
+                                        ? DefaultDirectoryExternalAttributes
+                                        : DefaultFileExternalAttributes;
 
             _offsetOfLocalHeader = 0;
             _storedOffsetOfCompressedData = null;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -37,7 +37,7 @@ namespace System.IO.Compression
         private bool _currentlyOpenForWrite;
         private bool _everOpenedForWrite;
         private Stream? _outstandingWriteStream;
-        private uint _externalFileAttr;
+        private int _externalFileAttr;
         private string _storedEntryName;
         private byte[] _storedEntryNameBytes;
         // only apply to update mode
@@ -181,12 +181,12 @@ namespace System.IO.Compression
         {
             get
             {
-                return (int)_externalFileAttr;
+                return _externalFileAttr;
             }
             set
             {
                 ThrowIfInvalidArchive();
-                _externalFileAttr = (uint)value;
+                _externalFileAttr = value;
             }
         }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -37,7 +37,7 @@ namespace System.IO.Compression
         private bool _currentlyOpenForWrite;
         private bool _everOpenedForWrite;
         private Stream? _outstandingWriteStream;
-        private int _externalFileAttr;
+        private uint _externalFileAttr;
         private string _storedEntryName;
         private byte[] _storedEntryNameBytes;
         // only apply to update mode
@@ -181,12 +181,12 @@ namespace System.IO.Compression
         {
             get
             {
-                return _externalFileAttr;
+                return (int)_externalFileAttr;
             }
             set
             {
                 ThrowIfInvalidArchive();
-                _externalFileAttr = value;
+                _externalFileAttr = (uint)value;
             }
         }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -457,7 +457,7 @@ namespace System.IO.Compression
         public ushort FileCommentLength;
         public int DiskNumberStart;
         public ushort InternalFileAttributes;
-        public uint ExternalFileAttributes;
+        public int ExternalFileAttributes;
         public long RelativeOffsetOfLocalHeader;
 
         public byte[] Filename;
@@ -486,7 +486,7 @@ namespace System.IO.Compression
             header.FileCommentLength = reader.ReadUInt16();
             ushort diskNumberStartSmall = reader.ReadUInt16();
             header.InternalFileAttributes = reader.ReadUInt16();
-            header.ExternalFileAttributes = reader.ReadUInt32();
+            header.ExternalFileAttributes = reader.ReadInt32();
             uint relativeOffsetOfLocalHeaderSmall = reader.ReadUInt32();
 
             header.Filename = reader.ReadBytes(header.FilenameLength);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -457,7 +457,7 @@ namespace System.IO.Compression
         public ushort FileCommentLength;
         public int DiskNumberStart;
         public ushort InternalFileAttributes;
-        public int ExternalFileAttributes;
+        public uint ExternalFileAttributes;
         public long RelativeOffsetOfLocalHeader;
 
         public byte[] Filename;
@@ -486,7 +486,7 @@ namespace System.IO.Compression
             header.FileCommentLength = reader.ReadUInt16();
             ushort diskNumberStartSmall = reader.ReadUInt16();
             header.InternalFileAttributes = reader.ReadUInt16();
-            header.ExternalFileAttributes = reader.ReadInt32();
+            header.ExternalFileAttributes = reader.ReadUInt32();
             uint relativeOffsetOfLocalHeaderSmall = reader.ReadUInt32();
 
             header.Filename = reader.ReadBytes(header.FilenameLength);

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.Unix.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.Unix.cs
@@ -9,14 +9,15 @@ namespace System.IO.Compression.Tests
     public partial class zip_CreateTests : ZipFileTestBase
     {
         [Theory]
-        [InlineData("folder/", 493 << 16)]
-        [InlineData("folder/file", 420 << 16)]
-        [InlineData("folder\\file", 420 << 16)]
-        public static void Verify_Default_Permissions_Are_Applied_For_Entries(string path, int permissions)
+        [InlineData("folder/", "40755")]
+        [InlineData("folder/file", "100644")]
+        [InlineData("folder\\file", "100644")]
+        public static void Verify_Default_Permissions_Are_Applied_For_Entries(string path, string mode)
         {
             using var archive = new ZipArchive(new MemoryStream(), ZipArchiveMode.Create, false);
             var newEntry = archive.CreateEntry(path);
-            Assert.Equal(newEntry.ExternalAttributes, permissions);
+            Assert.Equal(0, newEntry.ExternalAttributes & 0xffff);
+            Assert.Equal(mode, Convert.ToString((uint)newEntry.ExternalAttributes >> 16, 8));
         }
     }
 }


### PR DESCRIPTION
For Unix-type zip files, ExternalAttributes value matches 'struct stat' st_mode.
Besides permissions it should also include the file type.