### PR TITLE
JIT: Use gtCloneExpr in fgMorphModToSubMulDiv for potentially complex trees

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13598,8 +13598,8 @@ GenTree* Compiler::fgMorphModToSubMulDiv(GenTreeOp* tree)
     GenTree* dividend = div->IsReverseOp() ? opB : opA;
     GenTree* divisor  = div->IsReverseOp() ? opA : opB;
 
-    div->gtOp1 = gtClone(dividend);
-    div->gtOp2 = gtClone(divisor);
+    div->gtOp1 = gtCloneExpr(dividend);
+    div->gtOp2 = gtCloneExpr(divisor);
 
     var_types      type = div->gtType;
     GenTree* const mul  = gtNewOperNode(GT_MUL, type, div, divisor);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_76051/Runtime_76051.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_76051/Runtime_76051.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_76051
+{
+    public static int Main(string[] args)
+    {
+        GetIndex(1);
+        return 100;
+    }
+
+    // This tests an assertion failure (debug)/segfault (release) in
+    // fgMorphModToSubMulDiv due to the use of gtClone that fails for the
+    // complex tree seen for the address-of expression.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe int GetIndex(uint cellCount) => (int)((ulong)&cellCount % cellCount);
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_76051/Runtime_76051.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_76051/Runtime_76051.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_76051/Runtime_76051.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_76051/Runtime_76051.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
We may get here for any invariant dividend/divisor but these can be
'complex' address-of trees that gtClone does not handle.

Fix #76051