### PR TITLE
Use generated runtime.json when building shared framework packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -274,7 +274,8 @@
     <PackageProjectUrl>https://dot.net</PackageProjectUrl>
     <Owners>microsoft,dotnetframework</Owners>
     <IncludeSymbols>true</IncludeSymbols>
-    <RuntimeIdGraphDefinitionFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</RuntimeIdGraphDefinitionFile>
+    <SourceRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</SourceRuntimeIdentifierGraphFile>
+    <GeneratedRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.NETCore.Platforms', '$(Configuration)', 'runtime.json'))</GeneratedRuntimeIdentifierGraphFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -274,8 +274,7 @@
     <PackageProjectUrl>https://dot.net</PackageProjectUrl>
     <Owners>microsoft,dotnetframework</Owners>
     <IncludeSymbols>true</IncludeSymbols>
-    <SourceRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</SourceRuntimeIdentifierGraphFile>
-    <GeneratedRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.NETCore.Platforms', '$(Configuration)', 'runtime.json'))</GeneratedRuntimeIdentifierGraphFile>
+    <GeneratedRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.NETCore.Platforms', 'runtime.json'))</GeneratedRuntimeIdentifierGraphFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -274,7 +274,6 @@
     <PackageProjectUrl>https://dot.net</PackageProjectUrl>
     <Owners>microsoft,dotnetframework</Owners>
     <IncludeSymbols>true</IncludeSymbols>
-    <GeneratedRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.NETCore.Platforms', 'runtime.json'))</GeneratedRuntimeIdentifierGraphFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -223,6 +223,7 @@
             ResolveLibrariesRuntimeFilesFromLocalBuild" />
 
   <PropertyGroup>
-    <BundledRuntimeIdentifierGraphFile>$(SourceRuntimeIdentifierGraphFile)</BundledRuntimeIdentifierGraphFile>
+    <BundledRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</BundledRuntimeIdentifierGraphFile>
+    <BundledRuntimeIdentifierGraphFile Condition="Exists('$(GeneratedRuntimeIdentifierGraphFile)')">$(GeneratedRuntimeIdentifierGraphFile)</BundledRuntimeIdentifierGraphFile>
   </PropertyGroup>
 </Project>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -223,6 +223,6 @@
             ResolveLibrariesRuntimeFilesFromLocalBuild" />
 
   <PropertyGroup>
-    <BundledRuntimeIdentifierGraphFile>$(RuntimeIdGraphDefinitionFile)</BundledRuntimeIdentifierGraphFile>
+    <BundledRuntimeIdentifierGraphFile>$(SourceRuntimeIdentifierGraphFile)</BundledRuntimeIdentifierGraphFile>
   </PropertyGroup>
 </Project>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -223,7 +223,8 @@
             ResolveLibrariesRuntimeFilesFromLocalBuild" />
 
   <PropertyGroup>
-    <BundledRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</BundledRuntimeIdentifierGraphFile>
-    <BundledRuntimeIdentifierGraphFile Condition="Exists('$(GeneratedRuntimeIdentifierGraphFile)')">$(GeneratedRuntimeIdentifierGraphFile)</BundledRuntimeIdentifierGraphFile>
+    <!-- Keep in sync with outputs defined in Microsoft.NETCore.Platforms.csproj. -->
+    <BundledRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.NETCore.Platforms', 'runtime.json'))</BundledRuntimeIdentifierGraphFile>
+    <BundledRuntimeIdentifierGraphFile Condition="!Exists('$(BundledRuntimeIdentifierGraphFile)')">$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</BundledRuntimeIdentifierGraphFile>
   </PropertyGroup>
 </Project>

--- a/src/installer/pkg/sfx/Directory.Build.targets
+++ b/src/installer/pkg/sfx/Directory.Build.targets
@@ -1,7 +1,3 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <BundledRuntimeIdentifierGraphFile>$(GeneratedRuntimeIdentifierGraphFile)</BundledRuntimeIdentifierGraphFile>
-  </PropertyGroup>
 </Project>

--- a/src/installer/pkg/sfx/Directory.Build.targets
+++ b/src/installer/pkg/sfx/Directory.Build.targets
@@ -1,3 +1,7 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <BundledRuntimeIdentifierGraphFile>$(GeneratedRuntimeIdentifierGraphFile)</BundledRuntimeIdentifierGraphFile>
+  </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -8,10 +8,10 @@
     <AssemblyName>Microsoft.NETCore.Platforms.BuildTasks</AssemblyName>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
-    <!-- Generate a package only during the allconfigurations leg to avoid package clashes during publish. -->
-    <GeneratePackageOnBuild Condition="'$(BuildAllConfigurations)' != 'true'">false</GeneratePackageOnBuild>
 
     <IsPackable>true</IsPackable>
+    <!-- Generate a package only during the allconfigurations leg to avoid package clashes during publish. -->
+    <GeneratePackageOnBuild Condition="'$(BuildAllConfigurations)' != 'true'">false</GeneratePackageOnBuild>
     <PackageId>$(MSBuildProjectName)</PackageId>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages.</PackageDescription>
@@ -44,7 +44,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="$(GeneratedRuntimeIdentifierGraphFile)" PackagePath="/" />
+    <Content Condition="'$(AdditionalRuntimeIdentifiers)' == ''" Include="runtime.json" PackagePath="/" />
+    <Content Condition="'$(AdditionalRuntimeIdentifiers)' != ''" Include="$(GeneratedRuntimeIdentifierGraphFile)" PackagePath="/" />
     <Content Include="$(PlaceholderFile)" PackagePath="lib/netstandard1.0" />
   </ItemGroup>
 
@@ -58,17 +59,13 @@
   
   <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(_generateRuntimeGraphTask)"/>
 
-  <Target Name="GenerateRuntimeJson" AfterTargets="Build">
+  <Target Name="GenerateRuntimeJson" AfterTargets="Build" Condition="'$(AdditionalRuntimeIdentifiers)' != ''">
     <MakeDir Directories="$(IntermediateOutputPath)" />
-    <GenerateRuntimeGraph Condition="'$(AdditionalRuntimeIdentifiers)' != ''"
-                          RuntimeGroups="@(RuntimeGroupWithQualifiers)"
+    <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
                           AdditionalRuntimeIdentifiers="$(AdditionalRuntimeIdentifiers)"
                           AdditionalRuntimeIdentifierParent="$(AdditionalRuntimeIdentifierParent)"
                           RuntimeJson="$(GeneratedRuntimeIdentifierGraphFile)"
                           UpdateRuntimeFiles="True" />
-    <Copy Condition="'$(AdditionalRuntimeIdentifiers)' == ''"
-          SourceFiles="runtime.json"
-          DestinationFiles="$(GeneratedRuntimeIdentifierGraphFile)" />
   </Target>
 
   <Target Name="UpdateRuntimeJson">

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -56,7 +56,7 @@
   
   <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(_generateRuntimeGraphTask)"/>
 
-  <Target Name="GenerateRuntimeJson" BeforeTargets="UpdateRuntimeJson">
+  <Target Name="GenerateRuntimeJson" BeforeTargets="Build">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <GenerateRuntimeGraph Condition="'$(AdditionalRuntimeIdentifiers)' != ''"
                           RuntimeGroups="@(RuntimeGroupWithQualifiers)"
@@ -69,7 +69,7 @@
           DestinationFiles="$(GeneratedRuntimeIdentifierGraphFile)" />
   </Target>
 
-  <Target Name="UpdateRuntimeJson" BeforeTargets="Build">
+  <Target Name="UpdateRuntimeJson">
     <!-- Generates a Runtime graph using RuntimeGroups and diffs it with the graph described by runtime.json and runtime.compatibility.json
          Specifying UpdateRuntimeFiles=true skips the diff and updates those files.
          The graph can be visualized using the generated dmgl -->

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -8,6 +8,8 @@
     <AssemblyName>Microsoft.NETCore.Platforms.BuildTasks</AssemblyName>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
+    <!-- Generate a package only during the allconfigurations leg to avoid package clashes during publish. -->
+    <GeneratePackageOnBuild Condition="'$(BuildAllConfigurations)' != 'true'">false</GeneratePackageOnBuild>
 
     <IsPackable>true</IsPackable>
     <PackageId>$(MSBuildProjectName)</PackageId>
@@ -56,7 +58,7 @@
   
   <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(_generateRuntimeGraphTask)"/>
 
-  <Target Name="GenerateRuntimeJson" BeforeTargets="Build">
+  <Target Name="GenerateRuntimeJson" AfterTargets="Build">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <GenerateRuntimeGraph Condition="'$(AdditionalRuntimeIdentifiers)' != ''"
                           RuntimeGroups="@(RuntimeGroupWithQualifiers)"

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -17,7 +17,6 @@
     <AvoidRestoreCycleOnSelfReference>true</AvoidRestoreCycleOnSelfReference>
     <!-- TODO: Remove with AvoidRestoreCycleOnSelfReference hack. -->
     <PackageValidationBaselineName>$(MSBuildProjectName)</PackageValidationBaselineName>
-    <BeforePack>GenerateRuntimeJson;UpdateRuntimeJson;$(BeforePack)</BeforePack>
     
     <_generateRuntimeGraphTargetFramework Condition="'$(MSBuildRuntimeType)' == 'core'">$(NetCoreAppToolCurrent)</_generateRuntimeGraphTargetFramework>
     <_generateRuntimeGraphTargetFramework Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_generateRuntimeGraphTargetFramework>
@@ -43,8 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Condition="'$(AdditionalRuntimeIdentifiers)' == ''" Include="runtime.json" PackagePath="/" />
-    <Content Condition="'$(AdditionalRuntimeIdentifiers)' != ''" Include="$(IntermediateOutputPath)runtime.json" PackagePath="/" />
+    <Content Include="$(GeneratedRuntimeIdentifierGraphFile)" PackagePath="/" />
     <Content Include="$(PlaceholderFile)" PackagePath="lib/netstandard1.0" />
   </ItemGroup>
 
@@ -58,16 +56,20 @@
   
   <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(_generateRuntimeGraphTask)"/>
 
-  <Target Name="GenerateRuntimeJson" Condition="'$(AdditionalRuntimeIdentifiers)' != ''">
+  <Target Name="GenerateRuntimeJson" BeforeTargets="UpdateRuntimeJson">
     <MakeDir Directories="$(IntermediateOutputPath)" />
-    <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
+    <GenerateRuntimeGraph Condition="'$(AdditionalRuntimeIdentifiers)' != ''"
+                          RuntimeGroups="@(RuntimeGroupWithQualifiers)"
                           AdditionalRuntimeIdentifiers="$(AdditionalRuntimeIdentifiers)"
                           AdditionalRuntimeIdentifierParent="$(AdditionalRuntimeIdentifierParent)"
-                          RuntimeJson="$(IntermediateOutputPath)runtime.json"
+                          RuntimeJson="$(GeneratedRuntimeIdentifierGraphFile)"
                           UpdateRuntimeFiles="True" />
+    <Copy Condition="'$(AdditionalRuntimeIdentifiers)' == ''"
+          SourceFiles="runtime.json"
+          DestinationFiles="$(GeneratedRuntimeIdentifierGraphFile)" />
   </Target>
 
-  <Target Name="UpdateRuntimeJson">
+  <Target Name="UpdateRuntimeJson" BeforeTargets="Build">
     <!-- Generates a Runtime graph using RuntimeGroups and diffs it with the graph described by runtime.json and runtime.compatibility.json
          Specifying UpdateRuntimeFiles=true skips the diff and updates those files.
          The graph can be visualized using the generated dmgl -->

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <Content Condition="'$(AdditionalRuntimeIdentifiers)' == ''" Include="runtime.json" PackagePath="/" />
-    <Content Condition="'$(AdditionalRuntimeIdentifiers)' != ''" Include="$(GeneratedRuntimeIdentifierGraphFile)" PackagePath="/" />
+    <Content Condition="'$(AdditionalRuntimeIdentifiers)' != ''" Include="$(BaseOutputPath)runtime.json" PackagePath="/" />
     <Content Include="$(PlaceholderFile)" PackagePath="lib/netstandard1.0" />
   </ItemGroup>
 
@@ -64,7 +64,7 @@
     <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
                           AdditionalRuntimeIdentifiers="$(AdditionalRuntimeIdentifiers)"
                           AdditionalRuntimeIdentifierParent="$(AdditionalRuntimeIdentifierParent)"
-                          RuntimeJson="$(GeneratedRuntimeIdentifierGraphFile)"
+                          RuntimeJson="$(BaseOutputPath)runtime.json"
                           UpdateRuntimeFiles="True" />
   </Target>
 

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -10,8 +10,6 @@
     <IncludeSymbols>false</IncludeSymbols>
 
     <IsPackable>true</IsPackable>
-    <!-- Generate a package only during the allconfigurations leg to avoid package clashes during publish. -->
-    <GeneratePackageOnBuild Condition="'$(BuildAllConfigurations)' != 'true'">false</GeneratePackageOnBuild>
     <PackageId>$(MSBuildProjectName)</PackageId>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages.</PackageDescription>

--- a/src/libraries/oob-all.proj
+++ b/src/libraries/oob-all.proj
@@ -16,8 +16,7 @@
     <!-- Build these packages in the allconfigurations leg only. -->
     <ProjectReference Remove="Microsoft.Internal.Runtime.AspNetCore.Transport\src\Microsoft.Internal.Runtime.AspNetCore.Transport.proj;
                               Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj;
-                              Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj;
-                              Microsoft.NETCore.Platforms\src\Microsoft.NETCore.Platforms.csproj"
+                              Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj"
                       Condition="'$(BuildAllConfigurations)' != 'true'" />
 
     <!-- Skip these projects during source-build as they rely on external prebuilts. -->

--- a/src/libraries/oob-src.proj
+++ b/src/libraries/oob-src.proj
@@ -21,8 +21,7 @@
                                                                                                             ('$(BuildAllConfigurations)' != 'true' and '$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)')" />
 
     <!-- Don't build task and tools project in the NetCoreAppCurrent vertical. -->
-    <ProjectReference Remove="Microsoft.NETCore.Platforms\src\Microsoft.NETCore.Platforms.csproj;
-                              Microsoft.XmlSerializer.Generator\src\Microsoft.XmlSerializer.Generator.csproj" />
+    <ProjectReference Remove="Microsoft.XmlSerializer.Generator\src\Microsoft.XmlSerializer.Generator.csproj" />
 
     <!-- Don't build meta-projects in the NetCoreAppCurrent vertical. -->
     <ProjectReference Remove="Microsoft.Internal.Runtime.AspNetCore.Transport\src\Microsoft.Internal.Runtime.AspNetCore.Transport.proj;

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -94,7 +94,7 @@
           Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
     <!-- Shared framework deps file generation. Produces a test shared-framework deps file. -->
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NetCoreAppCurrentTestHostSharedFrameworkPath)"
-                                         RuntimeGraphFiles="$(RuntimeIdGraphDefinitionFile)"
+                                         RuntimeGraphFiles="$(SourceRuntimeIdentifierGraphFile)"
                                          TargetRuntimeIdentifier="$(PackageRID)" />
   </Target>
 

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -94,7 +94,7 @@
           Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
     <!-- Shared framework deps file generation. Produces a test shared-framework deps file. -->
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NetCoreAppCurrentTestHostSharedFrameworkPath)"
-                                         RuntimeGraphFiles="$(SourceRuntimeIdentifierGraphFile)"
+                                         RuntimeGraphFiles="$(BundledRuntimeIdentifierGraphFile)"
                                          TargetRuntimeIdentifier="$(PackageRID)" />
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/53550
Based on https://github.com/dotnet/runtime/pull/69455

With this change, when I build:
```
./build.sh /p:DotnetBuildFromSource=true /p:AdditionalRuntimeIdentifiers=fedora.45-x64
```
The new rid shows up in the packages:
```
artifacts/obj/Microsoft.NETCore.App.Bundle/Debug/net7.0/linux-x64/output/shared/Microsoft.NETCore.App/8.0.0-dev/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Composite.Bundle/Debug/net7.0/linux-x64/output/shared/Microsoft.NETCore.App/8.0.0-dev/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Runtime.Composite/Debug/net7.0/linux-x64/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Runtime.Composite/Debug/net7.0/linux-x64/output/shared/Microsoft.NETCore.App/8.0.0-dev/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Runtime/Debug/net7.0/linux-x64/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Runtime/Debug/net7.0/linux-x64/output/shared/Microsoft.NETCore.App/8.0.0-dev/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/bin/Microsoft.NETCore.Platforms/Debug/runtime.json:    "fedora.45-x64": {
```

@ericstj @ViktorHofer ptal.