### PR TITLE
[NativeAOT/iOS] Fix System.Private.Xml tests

### DIFF
--- a/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
@@ -621,7 +621,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="(('$(TargetOS)' != 'tvOS' and '$(TargetOS)' != 'iOS') or '$(RunDisablediOSTests)' == 'true') and
+                        ('$(TestNativeAot)' != 'true' or '$(RunDisabledNativeAotTests)' == 'true')" >
     <Compile Include="Xslt\XslCompiledTransformApi\Errata4.cs" />
     <Compile Include="Xslt\XslCompiledTransformApi\OutputSettings.cs" />
     <Compile Include="Xslt\XslCompiledTransformApi\TempFiles.cs" />
@@ -632,6 +633,9 @@
     <Compile Include="Xslt\XslCompiledTransformApi\XslTransformMultith.cs" />
     <Compile Include="Xslt\XslCompiledTransformApi\XsltSettings.cs" />
     <Compile Include="Xslt\XslCompiledTransformApi\XslCompiledTransform.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="Xslt\XslTransformApi\CXslTArgumentList.cs" />
     <Compile Include="Xslt\XslTransformApi\CXsltArgumentListMultith.cs" />
     <Compile Include="Xslt\XslTransformApi\CXslTransform.cs" />

--- a/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
@@ -621,8 +621,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup Condition="(('$(TargetOS)' != 'tvOS' and '$(TargetOS)' != 'iOS') or '$(RunDisablediOSTests)' == 'true') and
-                        ('$(TestNativeAot)' != 'true' or '$(RunDisabledNativeAotTests)' == 'true')" >
+  <ItemGroup>
     <Compile Include="Xslt\XslCompiledTransformApi\Errata4.cs" />
     <Compile Include="Xslt\XslCompiledTransformApi\OutputSettings.cs" />
     <Compile Include="Xslt\XslCompiledTransformApi\TempFiles.cs" />
@@ -633,9 +632,6 @@
     <Compile Include="Xslt\XslCompiledTransformApi\XslTransformMultith.cs" />
     <Compile Include="Xslt\XslCompiledTransformApi\XsltSettings.cs" />
     <Compile Include="Xslt\XslCompiledTransformApi\XslCompiledTransform.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="Xslt\XslTransformApi\CXslTArgumentList.cs" />
     <Compile Include="Xslt\XslTransformApi\CXsltArgumentListMultith.cs" />
     <Compile Include="Xslt\XslTransformApi\CXslTransform.cs" />

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ExceptionVerifier.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ExceptionVerifier.cs
@@ -134,13 +134,18 @@ namespace System.Xml.XmlSchemaValidatorApiTests
                     {
                         _output.WriteLine(e2.ToString());
                     }
+                    catch (PlatformNotSupportedException e3)
+                    {
+                        // NativeAOT doesn't support assembly loading
+                        _output.WriteLine(e3.ToString());
+                    }
                 }
             }
             catch (Exception e)
             {
                 _output.WriteLine("Exception: " + e.Message);
                 _output.WriteLine("Stack: " + e.StackTrace);
-                throw new VerifyException("Error while loading assembly");
+                throw new VerifyException("Error while loading assembly", e);
             }
 
             string[] resArray;
@@ -394,6 +399,10 @@ namespace System.Xml.XmlSchemaValidatorApiTests
     {
         public VerifyException(string msg)
             : base(msg)
+        { }
+
+        public VerifyException(string msg, Exception innerException)
+            : base(msg, innerException)
         { }
     }
 }

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Initialize_EndValidation.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Initialize_EndValidation.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XmlSchemaValidatorApiTests
 {
     // ===================== Initialize =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCInitialize : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;
@@ -498,7 +498,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
     }
 
     // ===================== EndValidation =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCEndValidation : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/PropertiesTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/PropertiesTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XmlSchemaValidatorApiTests
 {
     // ===================== XmlResolver =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCXmlResolver : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XmlSchemaValidatorApiTests
 {
     // ===================== ValidateAttribute =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCValidateAttribute : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;
@@ -198,7 +198,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
     }
 
     // ===================== GetUnspecifiedDefaultAttributes =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCGetUnspecifiedDefaultAttributes : CXmlSchemaValidatorTestCase
     {
         public TCGetUnspecifiedDefaultAttributes(ITestOutputHelper output) : base(output)

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute_String.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute_String.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XmlSchemaValidatorApiTests
 {
     // ===================== ValidateAttribute =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCValidateAttribute_String : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XmlSchemaValidatorApiTests
 {
     // ===================== ValidateElement =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCValidateElement : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateText_EndElement.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateText_EndElement.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XmlSchemaValidatorApiTests
 {
     // ===================== ValidateText =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCValidateText : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;
@@ -170,7 +170,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
     }
 
     // ===================== ValidateWhitespace =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCValidateWhitespace : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;
@@ -295,7 +295,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
     }
 
     // ===================== ValidateEndElement =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCValidateEndElement : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;
@@ -729,7 +729,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
     }
 
     // ===================== SkipToEndElement =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCSkipToEndElement : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateText_String.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateText_String.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XmlSchemaValidatorApiTests
 {
     // ===================== ValidateText =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCValidateText_String : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateWhitespace_String.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateWhitespace_String.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XmlSchemaValidatorApiTests
 {
     // ===================== ValidateWhitespace =====================
-
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TCValidateWhitespace_String : CXmlSchemaValidatorTestCase
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -21,6 +21,7 @@ using System.Xml.Serialization;
 using SerializationTypes;
 using Xunit;
 
+[ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
 public static partial class XmlSerializerTests
 {
 #if ReflectionOnly|| XMLSERIALIZERGENERATORTESTS

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/Errata4.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/Errata4.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XslCompiledTransformApiTests
 {
     //[TestCase(Name = "Xml 4th Errata tests for XslCompiledTransform", Params = new object[] { 300 })]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class Errata4 : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/OutputSettings.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/OutputSettings.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XslCompiledTransformApiTests
 {
     //[TestCase(Name = "OutputSettings", Desc = "This testcase tests the OutputSettings on XslCompiledTransform", Param = "Debug")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class COutputSettings : XsltApiTestCaseBase2
     {
         private XslCompiledTransform _xsl = null;

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/TempFiles.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/TempFiles.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 namespace System.Xml.XslCompiledTransformApiTests
 {
     //[TestCase(Name = "TemporaryFiles", Desc = "This testcase tests the Temporary Files property on XslCompiledTransform")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class TempFiles : XsltApiTestCaseBase2
     {
         private XslCompiledTransform _xsl = null;

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
@@ -81,6 +81,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     }
 
     //[TestCase(Name = "Load(MethodInfo, ByteArray, TypeArray) tests", Desc = "This testcase tests private Load method via Reflection. This method is used by sharepoint")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CLoadMethInfoTest : ReflectionTestCaseBase
     {
         private ITestOutputHelper _output;
@@ -476,6 +477,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     //[TestCase(Name = "XslCompiledTransform.XmlResolver : Navigator, Stream", Desc = "NAVIGATOR,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.XmlResolver : Navigator, Writer", Desc = "NAVIGATOR,WRITER")]
     //[TestCase(Name = "XslCompiledTransform.XmlResolver : Navigator, TextWriter", Desc = "NAVIGATOR,TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CXmlResolverTest : XsltApiTestCaseBase2, IDisposable
     {
         private ITestOutputHelper _output;
@@ -666,6 +668,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     //[TestCase(Name = "XslCompiledTransform.Load() - Integrity : Navigator, Stream", Desc = "NAVIGATOR,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Load() - Integrity : Navigator, Writer", Desc = "NAVIGATOR,WRITER")]
     //[TestCase(Name = "XslCompiledTransform.Load() - Integrity : Navigator, TextWriter", Desc = "NAVIGATOR,TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CLoadTest : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -1004,6 +1007,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     //[TestCase(Name = "XslCompiledTransform.Load(XmlResolver) - Integrity : URI, Stream", Desc = "URI,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Load(XmlResolver) - Integrity : URI, Writer", Desc = "URI,WRITER")]
     //[TestCase(Name = "XslCompiledTransform.Load(XmlResolver) - Integrity : URI, TextWriter", Desc = "URI,TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CLoadXmlResolverTest : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -1435,6 +1439,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     //[TestCase(Name = "XslCompiledTransform.Load(Url, Resolver) : URI, Stream", Desc = "URI,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Load(Url, Resolver) : URI, Writer", Desc = "URI,WRITER")]
     //[TestCase(Name = "XslCompiledTransform.Load(Url, Resolver) : URI, TextWriter", Desc = "URI,TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CLoadUrlResolverTest : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -1534,6 +1539,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     /***********************************************************/
 
     //[TestCase(Name = "XslCompiledTransform.Load(Url) Integrity : URI, Stream", Desc = "URI,STREAM")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CLoadStringTest : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -1652,6 +1658,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     /***********************************************************/
 
     //[TestCase(Name = "XslCompiledTransform .Load(IXPathNavigable) : Navigator, TextWriter", Desc = "NAVIGATOR,TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CLoadXPathNavigableTest : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -1760,6 +1767,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     /***********************************************************/
 
     //[TestCase(Name = "XslCompiledTransform.Load(Reader) : Reader, Stream", Desc = "READER,STREAM")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CLoadReaderTest : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -2149,6 +2157,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     //[TestCase(Name = "XslCompiledTransform.Transform() Integrity : Navigator, Stream", Desc = "NAVIGATOR,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Transform() Integrity : Navigator, Writer", Desc = "NAVIGATOR,WRITER")]
     //[TestCase(Name = "XslCompiledTransform.Transform() Integrity : Navigator, TextWriter", Desc = "NAVIGATOR,TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CTransformTestGeneric : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -2404,6 +2413,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     //[TestCase(Name = "XslCompiledTransform.Transform(XmlResolver) : Navigator, Stream", Desc = "NAVIGATOR,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Transform(XmlResolver) : Navigator, Writer", Desc = "NAVIGATOR,WRITER")]
     //[TestCase(Name = "XslCompiledTransform.Transform(XmlResolver) : Navigator, TextWriter", Desc = "NAVIGATOR,TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CTransformResolverTest : XsltApiTestCaseBase2, IDisposable
     {
         private ITestOutputHelper _output;
@@ -2615,6 +2625,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     //[TestCase(Name = "XslCompiledTransform.Transform(String, String) : Reader , String", Desc = "READER,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Transform(String, String) : URI, String", Desc = "URI,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Transform(String, String) : Navigator, String", Desc = "NAVIGATOR,STREAM")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CTransformStrStrTest : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -2987,6 +2998,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     //[TestCase(Name = "XslCompiledTransform.Transform(String, String, Resolver) : Reader , String", Desc = "READER,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Transform(String, String, Resolver) : URI, String", Desc = "URI,STREAM")]
     //[TestCase(Name = "XslCompiledTransform.Transform(String, String, Resolver) : Navigator, String", Desc = "NAVIGATOR,STREAM")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CTransformStrStrResolverTest : XsltApiTestCaseBase2, IDisposable
     {
         private ITestOutputHelper _output;
@@ -3091,6 +3103,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 
     //[TestCase(Name = "XslCompiledTransform.Transform(IXPathNavigable, XsltArgumentList, XmlWriter, XmlResolver)", Desc = "Constructor Tests", Param = "IXPathNavigable")]
     //[TestCase(Name = "XslCompiledTransform.Transform(XmlReader, XsltArgumentList, XmlWriter, XmlResolver)", Desc = "Constructor Tests", Param = "XmlReader")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CTransformConstructorWithFourParametersTest : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -3295,6 +3308,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     // This testcase is for bugs 109429, 111075 and 109644 fixed in Everett SP1
     //[TestCase(Name = "NDP1_1SP1 Bugs (URI,STREAM)", Desc = "URI,STREAM")]
     //[TestCase(Name = "NDP1_1SP1 Bugs (NAVIGATOR,TEXTWRITER)", Desc = "NAVIGATOR,TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CNDP1_1SP1Test : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;
@@ -3386,6 +3400,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
     }
 
     //[TestCase(Name = "XslCompiledTransform Regression Tests for API", Desc = "XslCompiledTransform Regression Tests")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CTransformRegressionTest : XsltApiTestCaseBase2, IDisposable
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompilerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompilerTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.Xml.XslCompiledTransformApiTests
 {
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class XslCompilerTests
     {
         [Fact]

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
@@ -35,6 +35,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     }
 
     //[TestCase(Name = "Same instance testing: Transform() - READER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class SameInstanceXslTransformReader : SameInstanceXslTransformTestCase
     {
         private XPathDocument _xd;           // Loads XML file
@@ -318,6 +319,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     }
 
     //[TestCase(Name = "Same instance testing: Transform() - TEXTWRITER")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class SameInstanceXslTransformWriter : SameInstanceXslTransformTestCase
     {
         private XPathDocument _xd; // Loads XML file

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltApiV2.cs
@@ -37,6 +37,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     // Base class for test cases
     //
     ////////////////////////////////////////////////////////////////
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class XsltApiTestCaseBase2
     {
         // Generic data for all derived test cases

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
@@ -17,6 +17,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     /***********************************************************/
 
     //[TestCase(Name = "XsltArgumentList - GetParam", Desc = "Get Param Test Cases")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CArgIntegrity : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
@@ -55,6 +55,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     }
 
     //[TestCase(Name = "Same instance testing: XsltArgList - GetParam", Desc = "GetParam test cases")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CSameInstanceXsltArgumentListGetParam : CSameInstanceXsltArgTestCase2
     {
         private ITestOutputHelper _output;
@@ -140,6 +141,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     }
 
     //[TestCase(Name = "Same instance testing: XsltArgList - GetExtensionObject", Desc = "GetExtensionObject test cases")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CSameInstanceXsltArgumentListGetExtnObject : CSameInstanceXsltArgTestCase2
     {
         private ITestOutputHelper _output;
@@ -224,6 +226,7 @@ namespace System.Xml.XslCompiledTransformApiTests
     }
 
     //[TestCase(Name = "Same instance testing: XsltArgList - Transform", Desc = "Multiple transforms")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CSameInstanceXsltArgumentListTransform : CSameInstanceXsltArgTestCase2
     {
         private ITestOutputHelper _output;

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltSettings.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltSettings.cs
@@ -13,6 +13,7 @@ namespace System.Xml.XslCompiledTransformApiTests
 {
     //[TestCase(Name = "XsltSettings-Retail", Desc = "This testcase tests the different settings on XsltSettings and the corresponding behavior in retail mode", Param = "Retail")]
     //[TestCase(Name = "XsltSettings-Debug", Desc = "This testcase tests the different settings on XsltSettings and the corresponding behavior in debug mode", Param = "Debug")]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
     public class CXsltSettings : XsltApiTestCaseBase2
     {
         private ITestOutputHelper _output;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -245,9 +245,6 @@
   <ItemGroup Condition="'$(TargetOS)' == 'iOS' and '$(RunDisablediOSTests)' != 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
 
-    <!-- Ref.Emit in XSLCompiledTransform -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
-
     <!-- Functional tests on devices have problems with return codes from mlaunch -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\$(TargetOS)\Device\**\*.Test.csproj" />
   </ItemGroup>
@@ -258,8 +255,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'tvOS' and '$(RunDisablediOSTests)' != 'true'">
-    <!-- Ref.Emit in XSLCompiledTransform -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Emit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.Emit.ILGeneration/tests/System.Reflection.Emit.ILGeneration.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.Emit.Lightweight/tests/System.Reflection.Emit.Lightweight.Tests.csproj" />
@@ -493,9 +488,6 @@
 
     <!-- More than two thirds of tests failing due to ref emit -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj" />
-
-    <!-- Xslt is ref.emit -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
 
     <!-- These are failing in localized runs due to satellite assembly reflection in the test. Work fine otherwise. -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj"

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -470,7 +470,6 @@
 
     <!-- Many test failures due to trimming and MakeGeneric. XmlSerializer is not currently supported with NativeAOT. Low priority -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.XmlSerializer.Generator\tests\Microsoft.XmlSerializer.Generator.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSerializer\System.Xml.XmlSerializer.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ServiceModel.Syndication\tests\System.ServiceModel.Syndication.Tests.csproj" />
 
     <!-- Not supported with trimming. Low priority -->


### PR DESCRIPTION
Guard tests appropriately with `PlatformDetection.IsReflectionEmitSupported` condition. 

Fixes https://github.com/dotnet/runtime/issues/75699
Based on #75730 with additional fix for non-English locales.