### PR TITLE
Disable CheckProjects test on llvmaot.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3097,6 +3097,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_25468/GitHub_25468/**">
             <Issue>https://github.com/dotnet/runtime/issues/52977</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/CheckProjects/CheckProjects/**">
+            <Issue>https://github.com/dotnet/runtime/issues/52977</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-9/**">
             <Issue>https://github.com/dotnet/runtime/issues/67675</Issue>
         </ExcludeList>


### PR DESCRIPTION
This test is still failing on llvmaot (I enabled it think it worked). It needs to be disabled.

Fixes: https://github.com/dotnet/runtime/issues/76070#event-7447977381