### PR TITLE
Bring back ReadOnlySpan in QuicStream

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.Stream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.Stream.cs
@@ -169,7 +169,7 @@ public partial class QuicStream : Stream
     /// <inheritdoc />
     public override void WriteByte(byte value)
     {
-        Write(MemoryMarshal.CreateReadOnlySpan(ref value, 1));
+        Write(new ReadOnlySpan<byte>(in value));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Was done in #71589 but unintentionally changed in #71969.
/cc @stephentoub