### PR TITLE
Resolve missing triple-slash in Microsoft.Extensions.Primitives

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.Extensions.Primitives

--- a/src/libraries/Microsoft.Extensions.Primitives/src/Extensions.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/Extensions.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace Microsoft.Extensions.Primitives
 {
     /// <summary>
-    /// Extenstion methods for the <see cref="Primitives"/> namespace
+    /// Provides extensions methods for the <see cref="Primitives"/> namespace.
     /// </summary>
     public static class Extensions
     {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/Extensions.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/Extensions.cs
@@ -5,6 +5,9 @@ using System.Text;
 
 namespace Microsoft.Extensions.Primitives
 {
+    /// <summary>
+    /// Extenstion methods for the <see cref="Primitives"/> namespace
+    /// </summary>
     public static class Extensions
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Extensions.Primitives
         }
 
         /// <summary>
-        /// Returns a hash code for a <see cref="StringSegment"/>.
+        /// Returns a hash code for a <see cref="StringSegment"/> object.
         /// </summary>
-        /// <param name="obj">The <see cref="StringSegment"/> to get a hash code from.</param>
+        /// <param name="obj">The <see cref="StringSegment"/> to get a hash code for.</param>
         /// <returns>A hash code for a <see cref="StringSegment"/>, suitable for use in hashing algorithms and data structures like a hash table.</returns>
         public int GetHashCode(StringSegment obj)
         {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
@@ -6,11 +6,20 @@ using System.Collections.Generic;
 
 namespace Microsoft.Extensions.Primitives
 {
+    /// <summary>
+    /// Compares two <see cref="StringSegment"/>.
+    /// </summary>
     public class StringSegmentComparer : IComparer<StringSegment>, IEqualityComparer<StringSegment>
     {
+        /// <summary>
+        /// Gets a <see cref="StringSegmentComparer"/> object that performs a case-sensitive ordinal <see cref="StringSegment"/> comparison.
+        /// </summary>
         public static StringSegmentComparer Ordinal { get; }
             = new StringSegmentComparer(StringComparison.Ordinal, StringComparer.Ordinal);
 
+        /// <summary>
+        /// Gets a <see cref="StringSegmentComparer"/> object that performs a case-insensitive ordinal <see cref="StringSegment"/> comparison.
+        /// </summary>
         public static StringSegmentComparer OrdinalIgnoreCase { get; }
             = new StringSegmentComparer(StringComparison.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase);
 
@@ -33,6 +42,12 @@ namespace Microsoft.Extensions.Primitives
             return StringSegment.Equals(x, y, Comparison);
         }
 
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
         public int GetHashCode(StringSegment obj)
         {
 #if NETCOREAPP || NETSTANDARD2_1

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Microsoft.Extensions.Primitives
 {
     /// <summary>
-    /// Compares two <see cref="StringSegment"/>.
+    /// Compares two <see cref="StringSegment"/> instances.
     /// </summary>
     public class StringSegmentComparer : IComparer<StringSegment>, IEqualityComparer<StringSegment>
     {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace Microsoft.Extensions.Primitives
 {
     /// <summary>
-    /// Compares two <see cref="StringSegment"/> instances.
+    /// Compares two <see cref="StringSegment"/> objects.
     /// </summary>
     public class StringSegmentComparer : IComparer<StringSegment>, IEqualityComparer<StringSegment>
     {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegmentComparer.cs
@@ -43,11 +43,10 @@ namespace Microsoft.Extensions.Primitives
         }
 
         /// <summary>
-        /// Returns a hash code for this instance.
+        /// Returns a hash code for a <see cref="StringSegment"/>.
         /// </summary>
-        /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
-        /// </returns>
+        /// <param name="obj">The <see cref="StringSegment"/> to get a hash code from.</param>
+        /// <returns>A hash code for a <see cref="StringSegment"/>, suitable for use in hashing algorithms and data structures like a hash table.</returns>
         public int GetHashCode(StringSegment obj)
         {
 #if NETCOREAPP || NETSTANDARD2_1

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringTokenizer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringTokenizer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.Primitives
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
-        /// Enumerates the <see cref="string"/> tokens represented by <see cref="StringSegment"/>
+        /// Enumerates the <see cref="string"/> tokens represented by <see cref="StringSegment"/>.
         /// </summary>
         public struct Enumerator : IEnumerator<StringSegment>
         {

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringTokenizer.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringTokenizer.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Primitives
     /// <summary>
     /// Tokenizes a <see cref="string"/> into <see cref="StringSegment"/>s.
     /// </summary>
-    public readonly struct StringTokenizer :  IEnumerable<StringSegment>
+    public readonly struct StringTokenizer : IEnumerable<StringSegment>
     {
         private readonly StringSegment _value;
         private readonly char[] _separators;
@@ -57,12 +57,19 @@ namespace Microsoft.Extensions.Primitives
             _separators = separators;
         }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="Enumerator"/>.
+        /// </summary>
+        /// <returns>An <see cref="Enumerator"/> based on the <see cref="StringTokenizer"/>'s value and separators.</returns>
         public Enumerator GetEnumerator() => new Enumerator(in _value, _separators);
 
         IEnumerator<StringSegment> IEnumerable<StringSegment>.GetEnumerator() => GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+        /// <summary>
+        /// Enumerates the <see cref="string"/> tokens represented by <see cref="StringSegment"/>
+        /// </summary>
         public struct Enumerator : IEnumerator<StringSegment>
         {
             private readonly StringSegment _value;
@@ -77,6 +84,10 @@ namespace Microsoft.Extensions.Primitives
                 _index = 0;
             }
 
+            /// <summary>
+            /// Initializes an <see cref="Enumerator"/> using a <see cref="StringTokenizer"/>.
+            /// </summary>
+            /// <param name="tokenizer"><see cref="StringTokenizer"/> containing value and separators for enumeration.</param>
             public Enumerator(ref StringTokenizer tokenizer)
             {
                 _value = tokenizer._value;

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -727,7 +727,12 @@ namespace Microsoft.Extensions.Primitives
             return false;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
         public override int GetHashCode()
         {
             object? value = _values;
@@ -774,6 +779,10 @@ namespace Microsoft.Extensions.Primitives
                 _index = 0;
             }
 
+            /// <summary>
+            /// Instantiates an <see cref="Enumerator"/> using a <see cref="StringValues"/>.
+            /// </summary>
+            /// <param name="values">The <see cref="StringValues"/> to enumerate.</param>
             public Enumerator(ref StringValues values) : this(values._values)
             { }
 


### PR DESCRIPTION
Resolves much of the missing triple-slash as documented in #43920. Namespace description still is a TODO, and a separate PR will be opened in the api docs repo for it.

To my knowledge, the following are obsolete:

 - M:Microsoft.Extensions.Primitives.InplaceStringBuilder.#ctor(System.Int32)
 - M:Microsoft.Extensions.Primitives.InplaceStringBuilder.Append(Microsoft.Extensions.Primitives.StringSegment)
 - M:Microsoft.Extensions.Primitives.InplaceStringBuilder.Append(System.Char)
 - M:Microsoft.Extensions.Primitives.InplaceStringBuilder.Append(System.String)
 - M:Microsoft.Extensions.Primitives.InplaceStringBuilder.Append(System.String,System.Int32,System.Int32)
 - P:Microsoft.Extensions.Primitives.InplaceStringBuilder.Capacity
 - T:Microsoft.Extensions.Primitives.InplaceStringBuilder
 - M:Microsoft.Extensions.Primitives.InplaceStringBuilder.ToString