### PR TITLE
perf-pipeline: Remove unnecessary jobs

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -39,6 +39,7 @@ jobs:
 
 - template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
   parameters:
+    collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
     ${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
       runProfile: 'non-v8'
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -20,13 +20,20 @@ trigger:
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-schedules:
-- cron: "30 2 * * *"
-  displayName: Every night at 2:30AM
-  branches:
-    include:
-    - main
-  always: true
+#
+# For the 'schedule' case, only wasm/jsc perf jobs are run.
+# And the rest are build jobs - wasm, mono, coreclr, and libraries.
+#
+# Since, we are not running *any* perf jobs, none of these builds are needed,
+# thus the whole scheduled run can be disabled.
+#
+#schedules:
+#- cron: "30 2 * * *"
+  #displayName: Every night at 2:30AM
+  #branches:
+    #include:
+    #- main
+  #always: true
 
 jobs:
 

--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -107,6 +107,7 @@ jobs:
         - AdditionalHelixPreCommands: $(HelixPreCommandOSX)
         - AdditionalHelixPostCommands: $(HelixPostCommandOSX)
 
+    - ExtraSetupArguments: ''
     - name: ExtraSetupArguments
       ${{ if ne(parameters.runtimeType, 'wasm') }}:
         value: --install-dir $(PayloadDirectory)/dotnet


### PR DESCRIPTION
`dotnet-runtime-perf` runs:

1. batched builds
2. scheduled builds at 2:30am every night

For the 'scheduled' case, only wasm/jsc perf jobs are run.
And the rest are build jobs - wasm, mono, coreclr, and libraries.

The wasm/jsc runs are known to be broken right now, thus they can be
disabled. And since there are no other perf jobs, none of the remaining
builds are needed, thus the whole scheduled run can be disabled.

Also:
- fix `line 1: ExtraSetupArguments: command not found` when `running performance/scripts/ci_setup.py`
- Collect bin logs for perf runs, on `dotnet-runtime-perf` also