### PR TITLE
docs: add missing document to microsoft.extensions.options

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/IConfigureNamedOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IConfigureNamedOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.Options
     /// <summary>
     /// Represents something that configures the <typeparamref name="TOptions"/> type.
     /// </summary>
-    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TOptions">Options type being configured.</typeparam>
     public interface IConfigureNamedOptions<in TOptions> : IConfigureOptions<TOptions> where TOptions : class
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IConfigureNamedOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IConfigureNamedOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.Options
     /// <summary>
     /// Represents something that configures the <typeparamref name="TOptions"/> type.
     /// </summary>
-    /// <typeparam name="TOptions">Options type being configured.</typeparam>
+    /// <typeparam name="TOptions">The options type being configured.</typeparam>
     public interface IConfigureNamedOptions<in TOptions> : IConfigureOptions<TOptions> where TOptions : class
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IConfigureOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Options
     /// Represents something that configures the <typeparamref name="TOptions"/> type.
     /// Note: These are run before all <see cref="IPostConfigureOptions{TOptions}"/>.
     /// </summary>
-    /// <typeparam name="TOptions"></typeparam>
+    /// <typeparam name="TOptions">Options type being configuring.</typeparam>
     public interface IConfigureOptions<in TOptions> where TOptions : class
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IConfigureOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Options
     /// Represents something that configures the <typeparamref name="TOptions"/> type.
     /// Note: These are run before all <see cref="IPostConfigureOptions{TOptions}"/>.
     /// </summary>
-    /// <typeparam name="TOptions">The options type being configuring.</typeparam>
+    /// <typeparam name="TOptions">The options type being configured.</typeparam>
     public interface IConfigureOptions<in TOptions> where TOptions : class
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IConfigureOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Options
     /// Represents something that configures the <typeparamref name="TOptions"/> type.
     /// Note: These are run before all <see cref="IPostConfigureOptions{TOptions}"/>.
     /// </summary>
-    /// <typeparam name="TOptions">Options type being configuring.</typeparam>
+    /// <typeparam name="TOptions">The options type being configuring.</typeparam>
     public interface IConfigureOptions<in TOptions> where TOptions : class
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsChangeTokenSource.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsChangeTokenSource.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Options
     /// <summary>
     /// Used to fetch <see cref="IChangeToken"/> used for tracking options changes.
     /// </summary>
-    /// <typeparam name="TOptions">Options type.</typeparam>
+    /// <typeparam name="TOptions">Options type being changed.</typeparam>
     public interface IOptionsChangeTokenSource<out TOptions>
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsChangeTokenSource.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsChangeTokenSource.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Options
     /// <summary>
     /// Used to fetch <see cref="IChangeToken"/> used for tracking options changes.
     /// </summary>
-    /// <typeparam name="TOptions">Options type being changed.</typeparam>
+    /// <typeparam name="TOptions">The options type being changed.</typeparam>
     public interface IOptionsChangeTokenSource<out TOptions>
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.Options
@@ -13,8 +14,12 @@ namespace Microsoft.Extensions.Options
         where TOptions : class
     {
         /// <summary>
-        /// Returns a configured <typeparamref name="TOptions"/> instance with the given name.
+        /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
+        /// <param name="name">The name of <typeparamref name="TOptions"/> instance to create.</param>
+        /// <returns>The created <typeparamref name="TOptions"/> instance with thw given <paramref name="name"/>.</returns>
+        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         TOptions Create(string name);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsFactory.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Extensions.Options
         /// </summary>
         /// <param name="name">The name of <typeparamref name="TOptions"/> instance to create.</param>
         /// <returns>The created <typeparamref name="TOptions"/> instance with thw given <paramref name="name"/>.</returns>
-        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
-        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         TOptions Create(string name);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The name of <typeparamref name="TOptions"/> instance to create.</param>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
         /// <returns>The created <typeparamref name="TOptions"/> instance with thw given <paramref name="name"/>.</returns>
         TOptions Create(string name);
     }

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsMonitor.cs
@@ -18,8 +18,12 @@ namespace Microsoft.Extensions.Options
         TOptions CurrentValue { get; }
 
         /// <summary>
-        /// Returns a configured <typeparamref name="TOptions"/> instance with the given name.
+        /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instances with given <paramref name="name"/>.</returns>
+        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         TOptions Get(string? name);
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsMonitor.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Extensions.Options
         /// </summary>
         /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
         /// <returns>The <typeparamref name="TOptions"/> instances with given <paramref name="name"/>.</returns>
-        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
-        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         TOptions Get(string? name);
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsMonitor.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
-        /// <returns>The <typeparamref name="TOptions"/> instances with given <paramref name="name"/>.</returns>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if a <see langword="null"/> <see cref="Options.DefaultName"/> is used.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instance that matches the given <paramref name="name"/>.</returns>
         TOptions Get(string? name);
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsSnapshot.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsSnapshot.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.Options
@@ -14,8 +15,12 @@ namespace Microsoft.Extensions.Options
         where TOptions : class
     {
         /// <summary>
-        /// Returns a configured <typeparamref name="TOptions"/> instance with the given name.
+        /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.</returns>
+        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         TOptions Get(string? name);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsSnapshot.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsSnapshot.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
-        /// <returns>The <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.</returns>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if <see langword="null"/> <see cref="Options.DefaultName"/> is used.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instance that matches the given <paramref name="name"/>.</returns>
         TOptions Get(string? name);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/IOptionsSnapshot.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IOptionsSnapshot.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.Options
@@ -19,8 +18,6 @@ namespace Microsoft.Extensions.Options
         /// </summary>
         /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
         /// <returns>The <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.</returns>
-        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
-        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         TOptions Get(string? name);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsBuilder.cs
@@ -179,6 +179,7 @@ namespace Microsoft.Extensions.Options
         /// Note: These are run after all <seealso cref="Configure(Action{TOptions})"/>.
         /// </summary>
         /// <param name="configureOptions">The action used to configure the options.</param>
+        /// <returns>The current <see cref="OptionsBuilder{TOptions}"/>.</returns>
         public virtual OptionsBuilder<TOptions> PostConfigure(Action<TOptions> configureOptions)
         {
             ThrowHelper.ThrowIfNull(configureOptions);

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
@@ -48,6 +48,10 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
+        /// <param name="name">The name of <typeparamref name="TOptions"/> instance to create.</param>
+        /// <returns>The created <typeparamref name="TOptions"/> instance with thw given <paramref name="name"/>.</returns>
+        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public TOptions Create(string name)
         {
             TOptions options = CreateInstance(name);
@@ -90,6 +94,9 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Creates a new instance of options type
         /// </summary>
+        /// <param name="name">The name of <typeparamref name="TOptions"/> instance.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instance been created.</returns>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         protected virtual TOptions CreateInstance(string name)
         {
             return Activator.CreateInstance<TOptions>();

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The name of <typeparamref name="TOptions"/> instance to create.</param>
-        /// <returns>The created <typeparamref name="TOptions"/> instance with thw given <paramref name="name"/>.</returns>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
+        /// <returns>The created <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.</returns>
         /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public TOptions Create(string name)
@@ -92,10 +92,10 @@ namespace Microsoft.Extensions.Options
         }
 
         /// <summary>
-        /// Creates a new instance of options type
+        /// Creates a new instance of options type.
         /// </summary>
-        /// <param name="name">The name of <typeparamref name="TOptions"/> instance.</param>
-        /// <returns>The <typeparamref name="TOptions"/> instance been created.</returns>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
+        /// <returns>The created <typeparamref name="TOptions"/> instance.</returns>
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         protected virtual TOptions CreateInstance(string name)
         {

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsManager.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsManager.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.Options
@@ -34,6 +35,10 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.</returns>
+        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public virtual TOptions Get(string? name)
         {
             name ??= Options.DefaultName;

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsManager.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsManager.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
-        /// <returns>The <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.</returns>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if <see langword="null"/> <see cref="Options.DefaultName"/> is used.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instance that matches the given <paramref name="name"/>.</returns>
         /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public virtual TOptions Get(string? name)

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
@@ -70,8 +70,10 @@ namespace Microsoft.Extensions.Options
         }
 
         /// <summary>
-        /// The present value of the options.
+        /// The present value of the options, equivalent to <c>Get(Options.CurrentValue)</c>.
         /// </summary>
+        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public TOptions CurrentValue
         {
             get => Get(Options.DefaultName);
@@ -80,6 +82,10 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instances with given <paramref name="name"/>.</returns>
+        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
+        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public virtual TOptions Get(string? name)
         {
             if (_cache is not OptionsCache<TOptions> optionsCache)

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.Options
         }
 
         /// <summary>
-        /// The present value of the options, equivalent to <c>Get(Options.CurrentValue)</c>.
+        /// The present value of the options, equivalent to <c>Get(Options.DefaultName)</c>.
         /// </summary>
         /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if null <see cref="Options.DefaultName"/> is used.</param>
-        /// <returns>The <typeparamref name="TOptions"/> instances with given <paramref name="name"/>.</returns>
+        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance, if <see langword="null"/> <see cref="Options.DefaultName"/> is used.</param>
+        /// <returns>The <typeparamref name="TOptions"/> instance that matches the given <paramref name="name"/>.</returns>
         /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
         /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
         public virtual TOptions Get(string? name)

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitorExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitorExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.Options
         /// <summary>
         /// Registers a listener to be called whenever <typeparamref name="TOptions"/> changes.
         /// </summary>
+        /// <typeparam name="TOptions">The type of options instance being monitored.</typeparam>
         /// <param name="monitor">The IOptionsMonitor.</param>
         /// <param name="listener">The action to be invoked when <typeparamref name="TOptions"/> has changed.</param>
         /// <returns>An <see cref="IDisposable"/> which should be disposed to stop listening for changes.</returns>


### PR DESCRIPTION
I couldn't find some of the apis, maybe they are no longer valid, or I missed something.

- ``M:Microsoft.Extensions.Options.OptionsWrapper`1.Add(System.String,`0)`` (No such method in `OptionsWrapper`)
- ``M:Microsoft.Extensions.Options.OptionsWrapper`1.Remove(System.String)`` (No such method in `OptionsWrapper`)
- ``M:Microsoft.Extensions.Options.OptionsCache`1.#ctor`` (``OptionsCache`` uses default constructor)
- ``M:Microsoft.Extensions.Options.ValidateOptionsResult.#ctor`` (``ValidateOptionsResult`` uses default constructor)
- `T:Microsoft.Extensions.Options.OptionsSnapshot` (No such type)

Contributes to https://github.com/dotnet/runtime/issues/43919