### PR TITLE
[release/7.0][wasm] Update templates to add framework argument

### DIFF
--- a/src/mono/wasm/templates/templates/browser/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/browser/.template.config/template.json
@@ -2,7 +2,11 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [ "Web", "WebAssembly", "Browser" ],
-  "identity": "WebAssembly.Browser",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "WebAssembly.Browser",
+  "precedence": 7000,
+  "identity": "WebAssembly.Browser.7.0",
+  "description": "WebAssembly Browser App",
   "name": "WebAssembly Browser App",
   "shortName": "wasmbrowser",
   "sourceName": "browser.0",
@@ -10,5 +14,21 @@
   "tags": {
     "language": "C#",
     "type": "project"
+  },
+  "symbols": {
+    "framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0",
+          "displayName": ".NET 7.0"
+        }
+      ],
+      "defaultValue": "net7.0",
+      "displayName": "framework"
+    }
   }
 }

--- a/src/mono/wasm/templates/templates/console/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/console/.template.config/template.json
@@ -2,7 +2,10 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [ "Web", "WebAssembly", "Console" ],
-  "identity": "WebAssembly.Console",
+  "groupIdentity": "WebAssembly.Console",
+  "precedence": 7000,
+  "identity": "WebAssembly.Console.7.0",
+  "description": "WebAssembly Console App",
   "name": "WebAssembly Console App",
   "shortName": "wasmconsole",
   "sourceName": "console.0",
@@ -10,5 +13,21 @@
   "tags": {
     "language": "C#",
     "type": "project"
+  },
+  "symbols": {
+    "framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0",
+          "displayName": ".NET 7.0"
+        }
+      ],
+      "defaultValue": "net7.0",
+      "displayName": "framework"
+    }
   }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -442,7 +442,7 @@ namespace Wasm.Build.Tests
             return contents.Replace(s_nugetInsertionTag, $@"<add key=""nuget-local"" value=""{localNuGetsPath}"" />");
         }
 
-        public string CreateWasmTemplateProject(string id, string template = "wasmbrowser")
+        public string CreateWasmTemplateProject(string id, string template = "wasmbrowser", string extraArgs = "")
         {
             InitPaths(id);
             InitProjectDir(id);
@@ -459,7 +459,7 @@ namespace Wasm.Build.Tests
 
             new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
                     .WithWorkingDirectory(_projectDir!)
-                    .ExecuteWithCapturedOutput($"new {template}")
+                    .ExecuteWithCapturedOutput($"new {template} {extraArgs}")
                     .EnsureSuccessful();
 
             return Path.Combine(_projectDir!, $"{id}.csproj");

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmTemplateTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/WasmTemplateTests.cs
@@ -182,10 +182,18 @@ namespace Wasm.Build.Tests
         [InlineData("Debug", true)]
         [InlineData("Release", false)]
         [InlineData("Release", true)]
-        public void ConsoleBuildAndRun(string config, bool relinking)
+        public void ConsoleBuildAndRunDefault(string config, bool relinking)
+            => ConsoleBuildAndRun(config, relinking, string.Empty);
+
+        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [InlineData("Debug", "-f net7.0")]
+        public void ConsoleBuildAndRunForSpecificTFM(string config, string extraNewArgs)
+            => ConsoleBuildAndRun(config, false, extraNewArgs);
+
+        private void ConsoleBuildAndRun(string config, bool relinking, string extraNewArgs)
         {
             string id = $"{config}_{Path.GetRandomFileName()}";
-            string projectFile = CreateWasmTemplateProject(id, "wasmconsole");
+            string projectFile = CreateWasmTemplateProject(id, "wasmconsole", extraNewArgs);
             string projectName = Path.GetFileNameWithoutExtension(projectFile);
 
             UpdateProgramCS();
@@ -432,12 +440,14 @@ namespace Wasm.Build.Tests
             Assert.Equal("Current count: 1", txt);
         }
 
-        [ConditionalFact(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
-        public async Task BrowserTest()
+        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [InlineData("")]
+        [InlineData("-f net7.0")]
+        public async Task BrowserBuildAndRun(string extraNewArgs)
         {
             string config = "Debug";
             string id = $"browser_{config}_{Path.GetRandomFileName()}";
-            CreateWasmTemplateProject(id, "wasmbrowser");
+            CreateWasmTemplateProject(id, "wasmbrowser", extraNewArgs);
 
             // var buildArgs = new BuildArgs(projectName, config, false, id, null);
             // buildArgs = ExpandBuildArgs(buildArgs);


### PR DESCRIPTION
For supporting templates installed from two different wasm workloads, like `wasm-experimental`, and `wasm-experimental-7`, they need to be differentiated.

- Update `identity` to be unique with `.7.0` suffix
- Add a framework parameter with default value of `net7.0`

```
$ dotnet new wasmbrowser -h
Template options:
Template options:
  -F, --Framework <net7.0>  The target framework for the project.
                            Type: choice
                              net7.0  Target net7.0
                            Default: net7.0
```