### PR TITLE
[wasm] Update templates to work for multiple versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
     <SdkBandVersion>8.0.100</SdkBandVersion>
     <PackageVersionNet6>6.0.10</PackageVersionNet6>
     <!-- problematic until NetCoreAppCurrent is net8.0 <PackageVersionNet7>7.0.0</PackageVersionNet7> -->
-    <PackageVersionForTemplates7>7.0.0-rc.2.22458.4</PackageVersionForTemplates7>
+    <PackageVersionForTemplates7>7.0.0-rtm.22476.8</PackageVersionForTemplates7>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Set assembly version to align with major and minor version,

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,6 +9,7 @@
     <SdkBandVersion>8.0.100</SdkBandVersion>
     <PackageVersionNet6>6.0.10</PackageVersionNet6>
     <!-- problematic until NetCoreAppCurrent is net8.0 <PackageVersionNet7>7.0.0</PackageVersionNet7> -->
+    <PackageVersionForTemplates7>7.0.0-rc.2.22458.4</PackageVersionForTemplates7>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Set assembly version to align with major and minor version,

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest.pkgproj
@@ -38,6 +38,11 @@
       <_WorkloadManifestValues Include="WorkloadVersion" Value="$(PackageVersion)" />
       <_WorkloadManifestValues Include="PackageVersionNet7" Value="$(PackageVersionNet7)" Condition="'$(PackageVersionNet7)' != ''" />
       <_WorkloadManifestValues Include="PackageVersionNet7" Value="$(PackageVersion)" Condition="'$(PackageVersionNet7)' == ''" />
+
+      <!-- We need to use a different version for net7 templates, to differentiate from net8 ones -->
+      <_WorkloadManifestValues Include="PackageVersionForTemplates7" Value="$(PackageVersionForTemplates7)" Condition="'$(PackageVersionNet7)' == ''" />
+      <_WorkloadManifestValues Include="PackageVersionForTemplates7" Value="$(PackageVersionNet7)" Condition="'$(PackageVersionNet7)' != ''" />
+
       <_WorkloadManifestValues Include="EmscriptenVersion" Value="$(MicrosoftNETRuntimeEmscriptenVersion)" />
       <_WorkloadManifestValues Include="NetCoreAppCurrent" Value="$(NetCoreAppCurrent)" />
     </ItemGroup>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/WorkloadManifest.json.in
@@ -170,7 +170,7 @@
     },
     "Microsoft.NET.Runtime.WebAssembly.Templates.net7": {
       "kind": "template",
-      "version": "${PackageVersionNet7}",
+      "version": "${PackageVersionForTemplates7}",
       "alias-to": {
         "any": "Microsoft.NET.Runtime.WebAssembly.Templates"
       }

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -140,6 +140,8 @@ build-dbg-proxy:
 	$(DOTNET) build $(TOP)/src/mono/wasm/debugger/BrowserDebugHost $(MSBUILD_ARGS)
 build-dbg-testsuite:
 	$(DOTNET) build $(TOP)/src/mono/wasm/debugger/DebuggerTestSuite $(MSBUILD_ARGS)
+build-app-host:
+	$(DOTNET) build $(TOP)/src/mono/wasm/host $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
 patch-deterministic:
 	cd emsdk/upstream/emscripten/ && patch -p1 < ../../../runtime/deterministic.diff

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Wasm.Tests.Internal;
+using Xunit.Abstractions;
 
 namespace Wasm.Build.Tests;
 
@@ -29,6 +30,9 @@ internal class BrowserRunner : IAsyncDisposable
     public Task<CommandResult>? RunTask { get; private set; }
     public IList<string> OutputLines { get; private set; } = new List<string>();
     private TaskCompletionSource<int> _exited = new();
+    private readonly ITestOutputHelper _testOutput;
+
+    public BrowserRunner(ITestOutputHelper testOutput) => _testOutput = testOutput;
 
     // FIXME: options
     public async Task<IPage> RunAsync(ToolCommand cmd, string args, bool headless = true)
@@ -78,7 +82,7 @@ internal class BrowserRunner : IAsyncDisposable
         var url = new Uri(urlAvailable.Task.Result);
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
         string[] chromeArgs = new[] { $"--explicitly-allowed-ports={url.Port}" };
-        Console.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', chromeArgs)}");
+        _testOutput.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', chromeArgs)}");
         Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions{
             ExecutablePath = s_chromePath.Value,
             Headless = headless,
@@ -99,7 +103,7 @@ internal class BrowserRunner : IAsyncDisposable
         await Task.WhenAny(RunTask!, _exited.Task, Task.Delay(timeout));
         if (_exited.Task.IsCompleted)
         {
-            Console.WriteLine ($"Exited with {await _exited.Task}");
+            _testOutput.WriteLine ($"Exited with {await _exited.Task}");
             return;
         }
 
@@ -114,7 +118,7 @@ internal class BrowserRunner : IAsyncDisposable
         await Task.WhenAny(RunTask!, _exited.Task, Task.Delay(timeout));
         if (RunTask.IsCanceled)
         {
-            Console.WriteLine ($"Exited with {(await RunTask).ExitCode}");
+            _testOutput.WriteLine ($"Exited with {(await RunTask).ExitCode}");
             return;
         }
 

--- a/src/mono/wasm/Wasm.Build.Tests/BuildEnvironment.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildEnvironment.cs
@@ -27,6 +27,7 @@ namespace Wasm.Build.Tests
         public static readonly string           RelativeTestAssetsPath = @"..\testassets\";
         public static readonly string           TestAssetsPath = Path.Combine(AppContext.BaseDirectory, "testassets");
         public static readonly string           TestDataPath = Path.Combine(AppContext.BaseDirectory, "data");
+        public static readonly string           TmpPath = Path.Combine(Path.GetTempPath(), "wasmbuildtests");
 
         private static readonly Dictionary<string, string> s_runtimePackVersions = new();
 
@@ -141,6 +142,10 @@ namespace Wasm.Build.Tests
             {
                 LogRootPath = Environment.CurrentDirectory;
             }
+
+            if (Directory.Exists(TmpPath))
+                Directory.Delete(TmpPath, recursive: true);
+            Directory.CreateDirectory(TmpPath);
         }
 
         // FIXME: error checks

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -444,7 +444,7 @@ namespace Wasm.Build.Tests
             return contents.Replace(s_nugetInsertionTag, $@"<add key=""nuget-local"" value=""{localNuGetsPath}"" />");
         }
 
-        public string CreateWasmTemplateProject(string id, string template = "wasmbrowser")
+        public string CreateWasmTemplateProject(string id, string template = "wasmbrowser", string extraArgs = "")
         {
             InitPaths(id);
             InitProjectDir(id);
@@ -464,7 +464,7 @@ namespace Wasm.Build.Tests
 
             new DotNetCommand(s_buildEnv, _testOutput, useDefaultArgs: false)
                     .WithWorkingDirectory(_projectDir!)
-                    .ExecuteWithCapturedOutput($"new {template}")
+                    .ExecuteWithCapturedOutput($"new {template} {extraArgs}")
                     .EnsureSuccessful();
 
             return Path.Combine(_projectDir!, $"{id}.csproj");

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -290,13 +290,25 @@ namespace Wasm.Build.Tests
             Directory.CreateDirectory(_logPath);
         }
 
-        protected static void InitProjectDir(string dir)
+        protected static void InitProjectDir(string dir, bool addNuGetSourceForLocalPackages = false)
         {
             Directory.CreateDirectory(dir);
             File.WriteAllText(Path.Combine(dir, "Directory.Build.props"), s_buildEnv.DirectoryBuildPropsContents);
             File.WriteAllText(Path.Combine(dir, "Directory.Build.targets"), s_buildEnv.DirectoryBuildTargetsContents);
 
-            File.Copy(Path.Combine(BuildEnvironment.TestDataPath, NuGetConfigFileNameForDefaultFramework), Path.Combine(dir, "nuget.config"));
+            string targetNuGetConfigPath = Path.Combine(dir, "nuget.config");
+            if (addNuGetSourceForLocalPackages)
+            {
+                File.WriteAllText(targetNuGetConfigPath,
+                                    GetNuGetConfigWithLocalPackagesPath(
+                                                Path.Combine(BuildEnvironment.TestDataPath, NuGetConfigFileNameForDefaultFramework),
+                                                s_buildEnv.BuiltNuGetsPath));
+            }
+            else
+            {
+                File.Copy(Path.Combine(BuildEnvironment.TestDataPath, NuGetConfigFileNameForDefaultFramework),
+                            targetNuGetConfigPath);
+            }
             Directory.CreateDirectory(Path.Combine(dir, ".nuget"));
         }
 
@@ -447,7 +459,7 @@ namespace Wasm.Build.Tests
         public string CreateWasmTemplateProject(string id, string template = "wasmbrowser", string extraArgs = "")
         {
             InitPaths(id);
-            InitProjectDir(id);
+            InitProjectDir(id, addNuGetSourceForLocalPackages: true);
 
             File.WriteAllText(Path.Combine(_projectDir, "Directory.Build.props"), "<Project />");
             File.WriteAllText(Path.Combine(_projectDir, "Directory.Build.targets"),

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
@@ -274,7 +274,7 @@ namespace Wasm.Build.Tests
                 using var runCommand = new RunCommand(s_buildEnv, _testOutput)
                                             .WithWorkingDirectory(workingDir);
 
-                await using var runner = new BrowserRunner();
+                await using var runner = new BrowserRunner(_testOutput);
                 var page = await runner.RunAsync(runCommand, $"run -c {config} --project {projectFile} --forward-console");
                 await runner.WaitForExitMessageAsync(TimeSpan.FromMinutes(2));
                 Assert.Contains("Hello, Browser!", string.Join(Environment.NewLine, runner.OutputLines));
@@ -284,7 +284,7 @@ namespace Wasm.Build.Tests
                 using var runCommand = new RunCommand(s_buildEnv, _testOutput)
                                             .WithWorkingDirectory(workingDir);
 
-                await using var runner = new BrowserRunner();
+                await using var runner = new BrowserRunner(_testOutput);
                 var page = await runner.RunAsync(runCommand, $"run -c {config} --no-build --project {projectFile} --forward-console");
                 await runner.WaitForExitMessageAsync(TimeSpan.FromMinutes(2));
                 Assert.Contains("Hello, Browser!", string.Join(Environment.NewLine, runner.OutputLines));
@@ -429,7 +429,7 @@ namespace Wasm.Build.Tests
             using var runCommand = new RunCommand(s_buildEnv, _testOutput)
                                         .WithWorkingDirectory(_projectDir!);
 
-            await using var runner = new BrowserRunner();
+            await using var runner = new BrowserRunner(_testOutput);
             var page = await runner.RunAsync(runCommand, $"run -c {config} --no-build");
 
             await page.Locator("text=Counter").ClickAsync();
@@ -461,7 +461,7 @@ namespace Wasm.Build.Tests
             using var runCommand = new RunCommand(s_buildEnv, _testOutput)
                                         .WithWorkingDirectory(_projectDir!);
 
-            await using var runner = new BrowserRunner();
+            await using var runner = new BrowserRunner(_testOutput);
             var page = await runner.RunAsync(runCommand, $"run -c {config} --no-build -r browser-wasm --forward-console");
             await runner.WaitForExitMessageAsync(TimeSpan.FromMinutes(2));
             Assert.Contains("Hello, Browser!", string.Join(Environment.NewLine, runner.OutputLines));

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
@@ -189,7 +189,7 @@ namespace Wasm.Build.Tests
             => ConsoleBuildAndRun(config, relinking, string.Empty);
 
         [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
-        // [InlineData("Debug", "-f net7.0")] FIXME: -- enable when updated template packages are available
+        [InlineData("Debug", "-f net7.0")]//FIXME: -- enable when updated template packages are available
         [InlineData("Debug", "-f net8.0")]
         public void ConsoleBuildAndRunForSpecificTFM(string config, string extraNewArgs)
             => ConsoleBuildAndRun(config, false, extraNewArgs);
@@ -443,7 +443,7 @@ namespace Wasm.Build.Tests
 
         [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
         [InlineData("")]
-        // [InlineData("-f net7.0")] FIXME: -- enable when updated template packages are available
+        [InlineData("-f net7.0")] //FIXME: -- enable when updated template packages are available
         [InlineData("-f net8.0")]
         public async Task BrowserBuildAndRun(string extraNewArgs)
         {

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
@@ -185,10 +185,19 @@ namespace Wasm.Build.Tests
         [InlineData("Debug", true)]
         [InlineData("Release", false)]
         [InlineData("Release", true)]
-        public void ConsoleBuildAndRun(string config, bool relinking)
+        public void ConsoleBuildAndRunDefault(string config, bool relinking)
+            => ConsoleBuildAndRun(config, relinking, string.Empty);
+
+        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        // [InlineData("Debug", "-f net7.0")] FIXME: -- enable when updated template packages are available
+        [InlineData("Debug", "-f net8.0")]
+        public void ConsoleBuildAndRunForSpecificTFM(string config, string extraNewArgs)
+            => ConsoleBuildAndRun(config, false, extraNewArgs);
+
+        private void ConsoleBuildAndRun(string config, bool relinking, string extraNewArgs)
         {
             string id = $"{config}_{Path.GetRandomFileName()}";
-            string projectFile = CreateWasmTemplateProject(id, "wasmconsole");
+            string projectFile = CreateWasmTemplateProject(id, "wasmconsole", extraNewArgs);
             string projectName = Path.GetFileNameWithoutExtension(projectFile);
 
             UpdateProgramCS();
@@ -432,12 +441,15 @@ namespace Wasm.Build.Tests
             Assert.Equal("Current count: 1", txt);
         }
 
-        [ConditionalFact(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
-        public async Task BrowserTest()
+        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [InlineData("")]
+        // [InlineData("-f net7.0")] FIXME: -- enable when updated template packages are available
+        [InlineData("-f net8.0")]
+        public async Task BrowserBuildAndRun(string extraNewArgs)
         {
             string config = "Debug";
             string id = $"browser_{config}_{Path.GetRandomFileName()}";
-            CreateWasmTemplateProject(id, "wasmbrowser");
+            CreateWasmTemplateProject(id, "wasmbrowser", extraNewArgs);
 
             UpdateBrowserMainJs(DefaultTargetFramework);
 

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
@@ -189,7 +189,7 @@ namespace Wasm.Build.Tests
             => ConsoleBuildAndRun(config, relinking, string.Empty);
 
         [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
-        [InlineData("Debug", "-f net7.0")]//FIXME: -- enable when updated template packages are available
+        [InlineData("Debug", "-f net7.0")]
         [InlineData("Debug", "-f net8.0")]
         public void ConsoleBuildAndRunForSpecificTFM(string config, string extraNewArgs)
             => ConsoleBuildAndRun(config, false, extraNewArgs);
@@ -243,9 +243,9 @@ namespace Wasm.Build.Tests
                 //data.Add(runOutsideProjectDirectory, forConsole, string.Empty);
 
                 data.Add(runOutsideProjectDirectory, forConsole,
-                                $"<OutputPath>{Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())}</OutputPath>");
+                                $"<OutputPath>{Path.Combine(BuildEnvironment.TmpPath, Path.GetRandomFileName())}</OutputPath>");
                 data.Add(runOutsideProjectDirectory, forConsole,
-                                $"<WasmAppDir>{Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())}</WasmAppDir>");
+                                $"<WasmAppDir>{Path.Combine(BuildEnvironment.TmpPath, Path.GetRandomFileName())}</WasmAppDir>");
             }
 
             return data;
@@ -268,7 +268,7 @@ namespace Wasm.Build.Tests
             if (!string.IsNullOrEmpty(extraProperties))
                 AddItemsPropertiesToProject(projectFile, extraProperties: extraProperties);
 
-            string workingDir = runOutsideProjectDirectory ? Path.GetTempPath() : _projectDir!;
+            string workingDir = runOutsideProjectDirectory ? BuildEnvironment.TmpPath : _projectDir!;
 
             {
                 using var runCommand = new RunCommand(s_buildEnv, _testOutput)
@@ -302,7 +302,7 @@ namespace Wasm.Build.Tests
             if (!string.IsNullOrEmpty(extraProperties))
                 AddItemsPropertiesToProject(projectFile, extraProperties: extraProperties);
 
-            string workingDir = runOutsideProjectDirectory ? Path.GetTempPath() : _projectDir!;
+            string workingDir = runOutsideProjectDirectory ? BuildEnvironment.TmpPath : _projectDir!;
 
             {
                 string runArgs = $"run -c {config} --project {projectFile}";
@@ -443,7 +443,7 @@ namespace Wasm.Build.Tests
 
         [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
         [InlineData("")]
-        [InlineData("-f net7.0")] //FIXME: -- enable when updated template packages are available
+        [InlineData("-f net7.0")]
         [InlineData("-f net8.0")]
         public async Task BrowserBuildAndRun(string extraNewArgs)
         {

--- a/src/mono/wasm/debugger/BrowserDebugHost/DebugProxyHost.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/DebugProxyHost.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.ExceptionServices;

--- a/src/mono/wasm/host/BrowserHost.cs
+++ b/src/mono/wasm/host/BrowserHost.cs
@@ -72,8 +72,8 @@ internal sealed class BrowserHost
         runArgsJson.Save(Path.Combine(_args.CommonConfig.AppPath, "runArgs.json"));
 
         var urls = new string[] { $"http://localhost:{_args.CommonConfig.HostProperties.WebServerPort}", "https://localhost:0" };
-        if (envVars["ASPNETCORE_URLS"] is not null)
-            urls = envVars["ASPNETCORE_URLS"].Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        if (envVars.TryGetValue("ASPNETCORE_URLS", out string? aspnetUrls))
+            urls = aspnetUrls.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 
         (ServerURLs serverURLs, IWebHost host) = await StartWebServerAsync(_args.CommonConfig.AppPath,
                                                                            _args.ForwardConsoleOutput ?? false,

--- a/src/mono/wasm/host/BrowserHost.cs
+++ b/src/mono/wasm/host/BrowserHost.cs
@@ -71,9 +71,9 @@ internal sealed class BrowserHost
                                                debugging: _args.CommonConfig.Debugging);
         runArgsJson.Save(Path.Combine(_args.CommonConfig.AppPath, "runArgs.json"));
 
-        var urls = new string[] { $"http://localhost:{_args.CommonConfig.HostProperties.WebServerPort}", "https://localhost:0" };
-        if (envVars.TryGetValue("ASPNETCORE_URLS", out string? aspnetUrls))
-            urls = aspnetUrls.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        string[] urls = envVars.TryGetValue("ASPNETCORE_URLS", out string? aspnetUrls)
+                            ? aspnetUrls.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                            : new string[] { $"http://127.0.0.1:{_args.CommonConfig.HostProperties.WebServerPort}", "https://127.0.0.1:0" };
 
         (ServerURLs serverURLs, IWebHost host) = await StartWebServerAsync(_args.CommonConfig.AppPath,
                                                                            _args.ForwardConsoleOutput ?? false,

--- a/src/mono/wasm/templates/templates/browser/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/browser/.template.config/template.json
@@ -3,7 +3,10 @@
   "author": "Microsoft",
   "classifications": [ "Web", "WebAssembly", "Browser" ],
   "generatorVersions": "[1.0.0.0-*)",
-  "identity": "WebAssembly.Browser",
+  "groupIdentity": "WebAssembly.Browser",
+  "precedence": 8000,
+  "identity": "WebAssembly.Browser.8.0",
+  "description": "WebAssembly Browser App",
   "name": "WebAssembly Browser App",
   "shortName": "wasmbrowser",
   "sourceName": "browser.0",
@@ -20,7 +23,7 @@
         "low": 5000,
         "high": 5300
       },
-	    "replaces": "5000"
+      "replaces": "5000"
     },
     "kestrelHttpsPortGenerated": {
       "type": "generated",
@@ -29,7 +32,21 @@
         "low": 7000,
         "high": 7300
       },
-	    "replaces": "5001"
+      "replaces": "5001"
+    },
+    "framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "description": "Target net8.0",
+          "displayName": ".NET 8.0"
+        }
+      ],
+      "defaultValue": "net8.0",
+      "displayName": "framework"
     }
   }
 }

--- a/src/mono/wasm/templates/templates/console/.template.config/template.json
+++ b/src/mono/wasm/templates/templates/console/.template.config/template.json
@@ -2,7 +2,10 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [ "Web", "WebAssembly", "Console" ],
-  "identity": "WebAssembly.Console",
+  "groupIdentity": "WebAssembly.Console",
+  "precedence": 8000,
+  "identity": "WebAssembly.Console.8.0",
+  "description": "WebAssembly Console App",
   "name": "WebAssembly Console App",
   "shortName": "wasmconsole",
   "sourceName": "console.0",
@@ -10,5 +13,21 @@
   "tags": {
     "language": "C#",
     "type": "project"
+  },
+  "symbols": {
+    "framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net8.0",
+          "description": "Target net8.0",
+          "displayName": ".NET 8.0"
+        }
+      ],
+      "defaultValue": "net8.0",
+      "displayName": "framework"
+    }
   }
 }


### PR DESCRIPTION
For supporting templates installed from two different wasm workloads, like `wasm-experimental`, and `wasm-experimental-7`, they need to be differentiated.

- Update `identity` to be unique with `.8.0` suffix
- Add a framework parameter with default value of `net8.0`
   - this has been added for net7 templates also, and `dotnet new` will show both as options.

```
$ dotnet new wasmbrowser -h
...
  -f, --framework <net7.0|net8.0>  The target framework for the project.
                                   Type: choice
                                     net8.0  Target net8.0
                                     net7.0  Target net7.0
                                   Default: net8.0
```