### PR TITLE
Delete typeof caches from CoreCLR CoreLib

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -766,9 +766,6 @@ namespace System.Reflection
 
     internal static unsafe class CustomAttribute
     {
-        private static readonly RuntimeType Type_RuntimeType = (RuntimeType)typeof(RuntimeType);
-        private static readonly RuntimeType Type_Type = (RuntimeType)typeof(Type);
-
         #region Internal Static Members
         internal static bool IsDefined(RuntimeType type, RuntimeType? caType, bool inherit)
         {
@@ -1221,9 +1218,9 @@ namespace System.Reflection
                             if (type is null && value is not null)
                             {
                                 type = (RuntimeType)value.GetType();
-                                if (type == Type_RuntimeType)
+                                if (type == typeof(RuntimeType))
                                 {
-                                    type = Type_Type;
+                                    type = (RuntimeType)typeof(Type);
                                 }
                             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -106,11 +106,6 @@ namespace System.Reflection
         }
         #endregion
 
-        #region Private Statics
-        private static readonly Type s_DecimalConstantAttributeType = typeof(DecimalConstantAttribute);
-        private static readonly Type s_CustomConstantAttributeType = typeof(CustomConstantAttribute);
-        #endregion
-
         #region Private Data Members
         private int m_tkParamDef;
         private MetadataImport m_scope;
@@ -359,7 +354,7 @@ namespace System.Reflection
                         {
                             defaultValue = GetRawDecimalConstant(attr);
                         }
-                        else if (attrType!.IsSubclassOf(s_CustomConstantAttributeType))
+                        else if (attrType!.IsSubclassOf(typeof(CustomConstantAttribute)))
                         {
                             defaultValue = GetRawConstant(attr);
                         }
@@ -367,14 +362,14 @@ namespace System.Reflection
                 }
                 else
                 {
-                    object[] CustomAttrs = GetCustomAttributes(s_CustomConstantAttributeType, false);
+                    object[] CustomAttrs = GetCustomAttributes(typeof(CustomConstantAttribute), false);
                     if (CustomAttrs.Length != 0)
                     {
                         defaultValue = ((CustomConstantAttribute)CustomAttrs[0]).Value;
                     }
                     else
                     {
-                        CustomAttrs = GetCustomAttributes(s_DecimalConstantAttributeType, false);
+                        CustomAttrs = GetCustomAttributes(typeof(DecimalConstantAttribute), false);
                         if (CustomAttrs.Length != 0)
                         {
                             defaultValue = ((DecimalConstantAttribute)CustomAttrs[0]).Value;


### PR DESCRIPTION
Caching typeof is a de-optimization with frozen runtime types