### PR TITLE
Disable failing test SignedXmlTest.VerifyXmlResolver

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -1594,6 +1594,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/74115")]
         public void VerifyXmlResolver(bool provideResolver)
         {
             TcpListener listener = new TcpListener(IPAddress.Loopback, 0);


### PR DESCRIPTION
PR #75369 tried to fix the problem and re-enabled the test, but it is still failing. Tracked by #74115