### PR TITLE
JIT: Don't use write barriers for frozen objects

### DIFF
--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -252,6 +252,12 @@ GCInfo::WriteBarrierForm GCInfo::gcIsWriteBarrierCandidate(GenTreeStoreInd* stor
         return WBF_NoBarrier;
     }
 
+    if (store->Data()->IsIconHandle(GTF_ICON_OBJ_HDL))
+    {
+        // Ignore frozen objects
+        return WBF_NoBarrier;
+    }
+
     WriteBarrierForm wbf = gcWriteBarrierFormFromTargetAddress(store->Addr());
 
     if (wbf == WBF_BarrierUnknown)


### PR DESCRIPTION
This PR implements @jkotas's idea https://github.com/dotnet/runtime/pull/76112#issuecomment-1256853082 to skip write-barriers for frozen objects, e.g.:
```csharp
string field;

void Test(string[] array)
{
    array[0] = "str1";

    field = "str";
    // and same for `typeof(X)` and all future uses of FOH
}
```
codegen diff: https://www.diffchecker.com/J1FH2GlX

jit-diffs/spmi diffs are promising (up to `Total bytes of delta: -719913 (-0.62 % of base)`)

https://dev.azure.com/dnceng-public/public/_build/results?buildId=28997&view=ms.vss-build-web.run-extensions-tab

TODO:
1) See if we can use VN here to handle locals (if they're of TYP_REF type and non-null) since CSE is enabled for const handles.
2) Not now: during inlining if we pass a const string to a callee where that string is passed to a field we can give an additional boost (to avoid wb)

I decided to file a separate PR since it's not directly related to https://github.com/dotnet/runtime/pull/76112 and also, it's not possible to run CI diffs in that PR due to JIT-EE changes.