### PR TITLE
Improve vectorization of Enumerable.Min/Max

### DIFF
--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -74,6 +74,7 @@
     <Compile Include="System\Linq\Last.cs" />
     <Compile Include="System\Linq\Lookup.cs" />
     <Compile Include="System\Linq\Max.cs" />
+    <Compile Include="System\Linq\MaxMin.cs" />
     <Compile Include="System\Linq\Min.cs" />
     <Compile Include="System\Linq\OrderBy.cs" />
     <Compile Include="System\Linq\OrderedEnumerable.cs" />
@@ -104,5 +105,6 @@
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Runtime.Intrinsics" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
+++ b/src/libraries/System.Linq/src/System/Linq/MaxMin.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+
+namespace System.Linq
+{
+    public static partial class Enumerable
+    {
+        private interface IMinMaxCalc<T> where T : struct, IBinaryInteger<T>
+        {
+            public static abstract bool Compare(T left, T right);
+            public static abstract Vector128<T> Compare(Vector128<T> left, Vector128<T> right);
+            public static abstract Vector256<T> Compare(Vector256<T> left, Vector256<T> right);
+        }
+
+        private static T MinMaxInteger<T, TMinMax>(this IEnumerable<T> source)
+            where T : struct, IBinaryInteger<T>
+            where TMinMax : IMinMaxCalc<T>
+        {
+            T value;
+
+            if (source.TryGetSpan(out ReadOnlySpan<T> span))
+            {
+                if (span.IsEmpty)
+                {
+                    ThrowHelper.ThrowNoElementsException();
+                }
+
+                if (!Vector128.IsHardwareAccelerated || span.Length < Vector128<T>.Count)
+                {
+                    value = span[0];
+                    for (int i = 1; i < span.Length; i++)
+                    {
+                        if (TMinMax.Compare(span[i], value))
+                        {
+                            value = span[i];
+                        }
+                    }
+                }
+                else if (!Vector256.IsHardwareAccelerated || span.Length < Vector256<T>.Count)
+                {
+                    ref T current = ref MemoryMarshal.GetReference(span);
+                    ref T lastVectorStart = ref Unsafe.Add(ref current, span.Length - Vector128<T>.Count);
+
+                    Vector128<T> best = Vector128.LoadUnsafe(ref current);
+                    current = ref Unsafe.Add(ref current, Vector128<T>.Count);
+
+                    while (Unsafe.IsAddressLessThan(ref current, ref lastVectorStart))
+                    {
+                        best = TMinMax.Compare(best, Vector128.LoadUnsafe(ref current));
+                        current = ref Unsafe.Add(ref current, Vector128<T>.Count);
+                    }
+                    best = TMinMax.Compare(best, Vector128.LoadUnsafe(ref lastVectorStart));
+
+                    value = best[0];
+                    for (int i = 1; i < Vector128<T>.Count; i++)
+                    {
+                        if (TMinMax.Compare(best[i], value))
+                        {
+                            value = best[i];
+                        }
+                    }
+                }
+                else
+                {
+                    ref T current = ref MemoryMarshal.GetReference(span);
+                    ref T lastVectorStart = ref Unsafe.Add(ref current, span.Length - Vector256<T>.Count);
+
+                    Vector256<T> best = Vector256.LoadUnsafe(ref current);
+                    current = ref Unsafe.Add(ref current, Vector256<T>.Count);
+
+                    while (Unsafe.IsAddressLessThan(ref current, ref lastVectorStart))
+                    {
+                        best = TMinMax.Compare(best, Vector256.LoadUnsafe(ref current));
+                        current = ref Unsafe.Add(ref current, Vector256<T>.Count);
+                    }
+                    best = TMinMax.Compare(best, Vector256.LoadUnsafe(ref lastVectorStart));
+
+                    value = best[0];
+                    for (int i = 1; i < Vector256<T>.Count; i++)
+                    {
+                        if (TMinMax.Compare(best[i], value))
+                        {
+                            value = best[i];
+                        }
+                    }
+                }
+            }
+            else
+            {
+                using (IEnumerator<T> e = source.GetEnumerator())
+                {
+                    if (!e.MoveNext())
+                    {
+                        ThrowHelper.ThrowNoElementsException();
+                    }
+
+                    value = e.Current;
+                    while (e.MoveNext())
+                    {
+                        T x = e.Current;
+                        if (TMinMax.Compare(x, value))
+                        {
+                            value = x;
+                        }
+                    }
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/libraries/System.Linq/tests/MaxTests.cs
+++ b/src/libraries/System.Linq/tests/MaxTests.cs
@@ -2,12 +2,74 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Numerics;
 using Xunit;
 
 namespace System.Linq.Tests
 {
     public class MaxTests : EnumerableTests
     {
+        public static IEnumerable<object[]> Max_AllTypes_TestData()
+        {
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i)), (byte)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i).ToArray()), (byte)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i)), (sbyte)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i).ToArray()), (sbyte)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i)), (ushort)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i).ToArray()), (ushort)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (short)i)), (short)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (short)i).ToArray()), (short)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (uint)i)), (uint)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (uint)i).ToArray()), (uint)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (int)i)), (int)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (int)i).ToArray()), (int)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ulong)i)), (ulong)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ulong)i).ToArray()), (ulong)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i)), (long)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i).ToArray()), (long)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i)), (float)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i).ToArray()), (float)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i)), (double)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i).ToArray()), (double)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i)), (decimal)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i).ToArray()), (decimal)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (nuint)i)), (nuint)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (nuint)i).ToArray()), (nuint)(length + length - 1) };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (nint)i)), (nint)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (nint)i).ToArray()), (nint)(length + length - 1) };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Max_AllTypes_TestData))]
+        public void Max_AllTypes<T>(IEnumerable<T> source, T expected) where T : INumber<T>
+        {
+            Assert.Equal(expected, source.Max());
+
+            Assert.Equal(expected, source.Max(comparer: null));
+            Assert.Equal(expected, source.Max(Comparer<T>.Default));
+            Assert.Equal(expected, source.Max(Comparer<T>.Create(Comparer<T>.Default.Compare)));
+
+            T first = source.First();
+            Assert.Equal(first, source.Max(Comparer<T>.Create((x, y) => x == first ? 1 : -1)));
+
+            Assert.Equal(expected + T.One, source.Max(x => x + T.One));
+        }
+
         [Fact]
         public void SameResultsRepeatCallsIntQuery()
         {
@@ -64,12 +126,6 @@ namespace System.Linq.Tests
                 yield return new object[] { new TestEnumerable<int>(array), expected };
                 yield return new object[] { array, expected };
             }
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length)), length + length - 1 };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).ToArray()), length + length - 1 };
-            }
         }
 
         [Theory]
@@ -99,12 +155,6 @@ namespace System.Linq.Tests
             {
                 yield return new object[] { new TestEnumerable<long>(array), expected };
                 yield return new object[] { array, expected };
-            }
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i)), (long)(length + length - 1) };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i).ToArray()), (long)(length + length - 1) };
             }
         }
 
@@ -167,12 +217,6 @@ namespace System.Linq.Tests
                 yield return new object[] { new TestEnumerable<float>(array), expected };
                 yield return new object[] { array, expected };
             }
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i)), (float)(length + length - 1) };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i).ToArray()), (float)(length + length - 1) };
-            }
         }
 
         [Theory]
@@ -195,6 +239,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<float>().Max());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<float>().Max(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<float>().Max());
+            Assert.Throws<InvalidOperationException>(() => new List<float>().Max());
         }
 
         [Fact]
@@ -251,12 +297,6 @@ namespace System.Linq.Tests
                 yield return new object[] { new TestEnumerable<double>(array), expected };
                 yield return new object[] { array, expected };
             }
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i)), (double)(length + length - 1) };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i).ToArray()), (double)(length + length - 1) };
-            }
         }
 
         [Theory]
@@ -279,6 +319,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<double>().Max());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<double>().Max(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<double>().Max());
+            Assert.Throws<InvalidOperationException>(() => new List<double>().Max());
         }
 
         [Fact]
@@ -320,12 +362,6 @@ namespace System.Linq.Tests
             {
                 yield return new object[] { new TestEnumerable<decimal>(array), expected };
                 yield return new object[] { array, expected };
-            }
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i)), (decimal)(length + length - 1) };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i).ToArray()), (decimal)(length + length - 1) };
             }
         }
 

--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -2,12 +2,74 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Numerics;
 using Xunit;
 
 namespace System.Linq.Tests
 {
     public class MinTests : EnumerableTests
     {
+        public static IEnumerable<object[]> Min_AllTypes_TestData()
+        {
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i)), (byte)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (byte)i).ToArray()), (byte)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i)), (sbyte)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (sbyte)i).ToArray()), (sbyte)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i)), (ushort)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ushort)i).ToArray()), (ushort)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (short)i)), (short)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (short)i).ToArray()), (short)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (uint)i)), (uint)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (uint)i).ToArray()), (uint)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (int)i)), (int)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (int)i).ToArray()), (int)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ulong)i)), (ulong)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (ulong)i).ToArray()), (ulong)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i)), (long)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i).ToArray()), (long)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i)), (float)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i).ToArray()), (float)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i)), (double)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i).ToArray()), (double)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i)), (decimal)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i).ToArray()), (decimal)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (nuint)i)), (nuint)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (nuint)i).ToArray()), (nuint)length };
+
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (nint)i)), (nint)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (nint)i).ToArray()), (nint)length };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Min_AllTypes_TestData))]
+        public void Min_AllTypes<T>(IEnumerable<T> source, T expected) where T : INumber<T>
+        {
+            Assert.Equal(expected, source.Min());
+
+            Assert.Equal(expected, source.Min(comparer: null));
+            Assert.Equal(expected, source.Min(Comparer<T>.Default));
+            Assert.Equal(expected, source.Min(Comparer<T>.Create(Comparer<T>.Default.Compare)));
+
+            T first = source.First();
+            Assert.Equal(first, source.Min(Comparer<T>.Create((x, y) => x == first ? -1 : 1)));
+
+            Assert.Equal(expected + T.One, source.Min(x => x + T.One));
+        }
+
         [Fact]
         public void SameResultsRepeatCallsIntQuery()
         {
@@ -48,12 +110,6 @@ namespace System.Linq.Tests
             {
                 yield return new object[] { new TestEnumerable<int>(array), expected };
                 yield return new object[] { array, expected };
-            }
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length)), length };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).ToArray()), length };
             }
         }
 
@@ -100,12 +156,6 @@ namespace System.Linq.Tests
             {
                 yield return new object[] { new TestEnumerable<long>(array), expected };
                 yield return new object[] { array, expected };
-            }
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i)), (long)length };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i).ToArray()), (long)length };
             }
         }
 
@@ -175,12 +225,6 @@ namespace System.Linq.Tests
             // a long time.
             yield return new object[] { Enumerable.Repeat(float.NaN, int.MaxValue), float.NaN };
             yield return new object[] { Enumerable.Repeat(float.NaN, 3).ToArray(), float.NaN };
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i)), (float)length };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (float)i).ToArray()), (float)length };
-            }
         }
 
         [Theory]
@@ -247,12 +291,6 @@ namespace System.Linq.Tests
             // Without this optimization, we would iterate through int.MaxValue elements, which takes
             // a long time.
             yield return new object[] { Enumerable.Repeat(double.NaN, int.MaxValue), double.NaN };
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i)), (double)length };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (double)i).ToArray()), (double)length };
-            }
         }
 
         [Theory]
@@ -298,12 +336,6 @@ namespace System.Linq.Tests
             {
                 yield return new object[] { new TestEnumerable<decimal>(array), expected };
                 yield return new object[] { array, expected };
-            }
-
-            for (int length = 2; length < 33; length++)
-            {
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i)), (decimal)length };
-                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (decimal)i).ToArray()), (decimal)length };
             }
         }
 


### PR DESCRIPTION
- Expand it to all vectorizable comparable types with `Enumerable.Min<T>`/`Max<T>` (byte, sbyte, short, ushort, uint, ulong, nuint, nint) beyond the int/long already supported
- Combine Min/Max into a single method using a static abstract interface with generic specialization to differentiate the operations
- Use `Vector128<T>` and `Vector256<T>` instead of `Vector<T>`
- Process any remaining elements as part of a single final vector rather than falling back to a scalar loop
- Improve test coverage

#### // Int32Tests (int was previously vectorized)

| Method |         Toolchain | Count |      Mean | Ratio |
|------- |------------------ |------ |----------:|------:|
|    Max | \main\corerun.exe |     1 |  2.111 ns |  1.00 |
|    Max |   \pr\corerun.exe |     1 |  1.978 ns |  0.94 |
|        |                   |       |           |       |
|    Max | \main\corerun.exe |     4 |  4.719 ns |  1.00 |
|    Max |   \pr\corerun.exe |     4 |  3.186 ns |  0.67 |
|        |                   |       |           |       |
|    Max | \main\corerun.exe |     7 |  7.473 ns |  1.00 |
|    Max |   \pr\corerun.exe |     7 |  3.372 ns |  0.45 |
|        |                   |       |           |       |
|    Max | \main\corerun.exe |    23 | 11.092 ns |  1.00 |
|    Max |   \pr\corerun.exe |    23 |  4.940 ns |  0.45 |
|        |                   |       |           |       |
|    Max | \main\corerun.exe |  1024 | 99.851 ns |  1.00 |
|    Max |   \pr\corerun.exe |  1024 | 43.150 ns |  0.43 |

#### // ByteTests (bytes weren't previously vectorized)

| Method |         Toolchain | Count |          Mean | Ratio |
|------- |------------------ |------ |--------------:|------:|
|    Max | \main\corerun.exe |     1 |     16.055 ns |  1.00 |
|    Max |   \pr\corerun.exe |     1 |      3.556 ns |  0.22 |
|        |                   |       |               |       |
|    Max | \main\corerun.exe |    16 |     73.951 ns |  1.00 |
|    Max |   \pr\corerun.exe |    16 |     15.251 ns |  0.21 |
|        |                   |       |               |       |
|    Max | \main\corerun.exe |    28 |    126.087 ns |  1.00 |
|    Max |   \pr\corerun.exe |    28 |     15.454 ns |  0.12 |
|        |                   |       |               |       |
|    Max | \main\corerun.exe |    92 |    387.411 ns |  1.00 |
|    Max |   \pr\corerun.exe |    92 |     29.735 ns |  0.08 |
|        |                   |       |               |       |
|    Max | \main\corerun.exe |  4096 | 16,702.786 ns | 1.000 |
|    Max |   \pr\corerun.exe |  4096 |     69.616 ns | 0.004 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Linq;

public partial class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
}

public class Int32Tests
{
    [Params(1, 4, 7, 23, 1024)]
    public int Count { get; set; }

    private int[] _values;

    [GlobalSetup]
    public void Setup()
    {
        var r = new Random(42);
        _values = Enumerable.Range(0, Count).Select(_ => r.Next()).ToArray();
    }

    [Benchmark]
    public int Max() => _values.Max();
}

public class ByteTests
{
    [Params(1, 16, 28, 92, 4096)]
    public int Count { get; set; }

    private byte[] _values;

    [GlobalSetup]
    public void Setup()
    {
        var r = new Random(42);
        _values = Enumerable.Range(0, Count).Select(_ => (byte)r.Next()).ToArray();
    }

    [Benchmark]
    public byte Max() => _values.Max();
}
```