### PR TITLE
Enable System.IO.FileSystem tests for native aot

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.Windows.cs
@@ -95,7 +95,6 @@ namespace System.IO.Tests
                 // the "Server Service" allows for file sharing. It can be disabled on some machines.
                 using (ServiceController sharingService = new ServiceController("Server"))
                 {
-                    Console.WriteLine(sharingService.Status == ServiceControllerStatus.Running);
                     return sharingService.Status == ServiceControllerStatus.Running;
                 }
             }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/FileStreamConformanceTests.Windows.cs
@@ -85,15 +85,24 @@ namespace System.IO.Tests
 
         private static Lazy<bool> _canShareFiles = new Lazy<bool>(() =>
         {
-            if (!PlatformDetection.IsWindowsAndElevated || PlatformDetection.IsWindowsNanoServer)
+            if (!PlatformDetection.IsWindowsAndElevated)
             {
                 return false;
             }
 
-            // the "Server Service" allows for file sharing. It can be disabled on some of our CI machines.
-            using (ServiceController sharingService = new ServiceController("Server"))
+            try
             {
-                return sharingService.Status == ServiceControllerStatus.Running;
+                // the "Server Service" allows for file sharing. It can be disabled on some machines.
+                using (ServiceController sharingService = new ServiceController("Server"))
+                {
+                    Console.WriteLine(sharingService.Status == ServiceControllerStatus.Running);
+                    return sharingService.Status == ServiceControllerStatus.Running;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // The service is not installed.
+                return false;
             }
         });
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -485,8 +485,6 @@
     <!-- More than two thirds of tests failing due to ref emit -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj" />
 
-    <!--This test fails on Windows.10.Amd64.Server2022 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />
     <!--Needs work to get these tests to pass -->
     <!--These tests have failures-->
     <!-- Looks like our xunit runner doesn't respect tests that don't want to be multithreaded -->


### PR DESCRIPTION
Suppress file sharing tests on machines that do not have file sharing service installed.