### PR TITLE
Remove redundant tmp check

### DIFF
--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -181,7 +181,7 @@ void    AsmMan::AddFile(_In_ __nullterminated char* szName, DWORD dwAttr, BinStr
         tmp->tkTok = TokenFromRid(m_FileLst.COUNT(),mdtFile);
     }
     pAsm->m_tkCurrentCVOwner = 0;
-    if(tmp) pAsm->m_pCustomDescrList = &(tmp->m_CustomDescrList);
+    pAsm->m_pCustomDescrList = &(tmp->m_CustomDescrList);
 }
 //==============================================================================================================
 


### PR DESCRIPTION
The function has an early return if tmp is ever null, so there is no need to have this check here.