### PR TITLE
Cache KeySizes array for EC types

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroid.cs
@@ -35,11 +35,7 @@ namespace System.Security.Cryptography
                 KeySizeValue = _key.KeySize;
             }
 
-            public override KeySizes[] LegalKeySizes =>
-                new[] {
-                    new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                    new KeySizes(minSize: 521, maxSize: 521, skipSize: 0)
-                };
+            public override KeySizes[] LegalKeySizes => s_defaultKeySizes.CloneKeySizesArray();
 
             protected override void Dispose(bool disposing)
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
@@ -66,17 +66,8 @@ namespace System.Security.Cryptography
             KeySizeValue = newKeySize;
         }
 
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                // Return the three sizes that can be explicitly set (for backwards compatibility)
-                return new[] {
-                    new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                    new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
-                };
-            }
-        }
+        // Return the three sizes that can be explicitly set (for backwards compatibility)
+        public override KeySizes[] LegalKeySizes => s_defaultKeySizes.CloneKeySizesArray();
 
         public override byte[] DeriveKeyFromHash(
             ECDiffieHellmanPublicKey otherPartyPublicKey,

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -45,11 +45,7 @@ namespace System.Security.Cryptography
             _key = new ECOpenSsl(this);
         }
 
-        public override KeySizes[] LegalKeySizes =>
-            new[] {
-                new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                new KeySizes(minSize: 521, maxSize: 521, skipSize: 0)
-            };
+        public override KeySizes[] LegalKeySizes => s_defaultKeySizes.CloneKeySizesArray();
 
         protected override void Dispose(bool disposing)
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
@@ -27,18 +27,8 @@ namespace System.Security.Cryptography
                 KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
             }
 
-            public override KeySizes[] LegalKeySizes
-            {
-                get
-                {
-                    // Return the three sizes that can be explicitly set (for backwards compatibility)
-                    return new[]
-                    {
-                        new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                        new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
-                    };
-                }
-            }
+            // Return the three sizes that can be explicitly set (for backwards compatibility)
+            public override KeySizes[] LegalKeySizes => s_defaultKeySizes.CloneKeySizesArray();
 
             public override int KeySize
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaAndroid.cs
@@ -68,17 +68,8 @@ namespace System.Security.Cryptography
                 KeySizeValue = newKeySize;
             }
 
-            public override KeySizes[] LegalKeySizes
-            {
-                get
-                {
-                    // Return the three sizes that can be explicitly set (for backwards compatibility)
-                    return new[] {
-                        new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                        new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
-                    };
-                }
-            }
+            // Return the three sizes that can be explicitly set (for backwards compatibility)
+            public override KeySizes[] LegalKeySizes => s_defaultKeySizes.CloneKeySizesArray();
 
             public override byte[] SignHash(byte[] hash)
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaCng.cs
@@ -83,16 +83,7 @@ namespace System.Security.Cryptography
             KeySizeValue = newKeySize;
         }
 
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                // Return the three sizes that can be explicitly set (for backwards compatibility)
-                return new[] {
-                    new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                    new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
-                };
-            }
-        }
+        // Return the three sizes that can be explicitly set (for backwards compatibility)
+        public override KeySizes[] LegalKeySizes => s_defaultKeySizes.CloneKeySizesArray();
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -78,17 +78,8 @@ namespace System.Security.Cryptography
             KeySizeValue = newKeySize;
         }
 
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                // Return the three sizes that can be explicitly set (for backwards compatibility)
-                return new[] {
-                    new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                    new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
-                };
-            }
-        }
+        // Return the three sizes that can be explicitly set (for backwards compatibility)
+        public override KeySizes[] LegalKeySizes => s_defaultKeySizes.CloneKeySizesArray();
 
         public override byte[] SignHash(byte[] hash)
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -28,17 +28,8 @@ namespace System.Security.Cryptography
                 KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
             }
 
-            public override KeySizes[] LegalKeySizes
-            {
-                get
-                {
-                    // Return the three sizes that can be explicitly set (for backwards compatibility)
-                    return new[] {
-                        new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
-                        new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
-                    };
-                }
-            }
+            // Return the three sizes that can be explicitly set (for backwards compatibility)
+            public override KeySizes[] LegalKeySizes => s_defaultKeySizes.CloneKeySizesArray();
 
             public override int KeySize
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECAlgorithm.cs
@@ -19,6 +19,11 @@ namespace System.Security.Cryptography
             // ECDH and ECMQV are not valid in this context.
         };
 
+        private protected static readonly KeySizes[] s_defaultKeySizes = new[] {
+            new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
+            new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
+        };
+
         /// <summary>
         /// When overridden in a derived class, exports the named or explicit <see cref="ECParameters" /> for an ECCurve.
         /// If the curve has a name, the Curve property will contain named curve parameters otherwise it will contain explicit parameters.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECAlgorithm.cs
@@ -19,7 +19,8 @@ namespace System.Security.Cryptography
             // ECDH and ECMQV are not valid in this context.
         };
 
-        private protected static readonly KeySizes[] s_defaultKeySizes = new[] {
+        private protected static readonly KeySizes[] s_defaultKeySizes =
+        {
             new KeySizes(minSize: 256, maxSize: 384, skipSize: 128),
             new KeySizes(minSize: 521, maxSize: 521, skipSize: 0),
         };


### PR DESCRIPTION
We can cache the `KeySizes` object instances since they themselves are immutable. Arrays are not, so continue to copy the array of references.