### PR TITLE
Fix syntax error for `Unknown Architecture`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
@@ -53,27 +53,28 @@ namespace System.Runtime.InteropServices
 
         public static Architecture ProcessArchitecture
 #if TARGET_X86
-            => Architecture.X86;
+            => Architecture.X86
 #elif TARGET_AMD64
-            => Architecture.X64;
+            => Architecture.X64
 #elif TARGET_ARMV6
-            => Architecture.Armv6;
+            => Architecture.Armv6
 #elif TARGET_ARM
-            => Architecture.Arm;
+            => Architecture.Arm
 #elif TARGET_ARM64
-            => Architecture.Arm64;
+            => Architecture.Arm64
 #elif TARGET_WASM
-            => Architecture.Wasm;
+            => Architecture.Wasm
 #elif TARGET_S390X
-            => Architecture.S390x;
+            => Architecture.S390x
 #elif TARGET_LOONGARCH64
-            => Architecture.LoongArch64;
+            => Architecture.LoongArch64
 #elif TARGET_POWERPC64
-            => Architecture.Ppc64le;
+            => Architecture.Ppc64le
 #elif TARGET_RISCV64
-            => (Architecture)9; // TODO-RISCV64: go though API review for RiscV64
+            => (Architecture)9 // TODO-RISCV64: go though API review for RiscV64
 #else
 #error Unknown Architecture
 #endif
+        ;
     }
 }


### PR DESCRIPTION
We are getting `src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs(54,55): error CS1002: ; expected` when we fall into `Unknown Architecture`. This fixes it.
