### PR TITLE
[mono] Fix missing defined and SIMD checks in Sqrt, Floor, Ceiling intrinsics

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1170,7 +1170,7 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 #ifdef TARGET_ARM64
 		int ceil_or_floor = id == SN_Ceiling ? INTRINS_AARCH64_ADV_SIMD_FRINTP : INTRINS_AARCH64_ADV_SIMD_FRINTM;
 		return emit_simd_ins_for_sig (cfg, klass, OP_XOP_OVR_X_X, ceil_or_floor, arg0_type, fsig, args);
-#elif TARGET_AMD64
+#elif defined(TARGET_AMD64)
 		MonoClass* arg_class = mono_class_from_mono_type_internal (fsig->params [0]);
 		int size = mono_class_value_size (arg_class, NULL);
 		if (size != 16) 	// Supported only on Vector128
@@ -1508,7 +1508,7 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 			return NULL;
 #ifdef TARGET_ARM64
 		return emit_simd_ins_for_sig (cfg, klass, OP_XOP_OVR_X_X, INTRINS_AARCH64_ADV_SIMD_FSQRT, arg0_type, fsig, args);
-#elif TARGET_AMD64
+#elif defined(TARGET_AMD64)
 		MonoClass *arg_class = mono_class_from_mono_type_internal (fsig->params [0]);
 		int size = mono_class_value_size (arg_class, NULL);
 		if ( size != 16 ) 		// Only works with Vector128

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -4253,7 +4253,7 @@ arch_emit_simd_intrinsics (const char *class_ns, const char *class_name, MonoCom
 
 	return NULL;
 }
-#elif TARGET_AMD64
+#elif defined(TARGET_AMD64)
 // TODO: test and enable for x86 too
 static
 MonoInst*
@@ -4280,7 +4280,7 @@ arch_emit_simd_intrinsics (const char *class_ns, const char *class_name, MonoCom
 		cfg->uses_simd_intrinsics |= MONO_CFG_USES_SIMD_INTRINSICS;
 	return simd_inst;
 }
-#elif TARGET_WASM
+#elif defined(TARGET_WASM)
 static
 MonoInst*
 arch_emit_simd_intrinsics (const char *class_ns, const char *class_name, MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1514,7 +1514,7 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 #elif defined(TARGET_AMD64)
 		MonoClass *arg_class = mono_class_from_mono_type_internal (fsig->params [0]);
 		int size = mono_class_value_size (arg_class, NULL);
-		if ( size != 16 ) 		// Only works with Vector128
+		if (size != 16) 		// Only works with Vector128
 			return NULL;
 
 		int instc0 = INTRINS_SSE_SQRT_PD;
@@ -1523,7 +1523,6 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 			instc0 = INTRINS_SSE_SQRT_PS;
 			feature = MONO_CPU_X86_SSE;
 		}
-
 		if (!is_SIMD_feature_supported (cfg, feature))
 			return NULL;
 

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1176,6 +1176,9 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 		if (size != 16) 	// Supported only on Vector128
 			return NULL;
 
+		if (!is_SIMD_feature_supported (ctr, MONO_CPU_X86_SSE41))
+			return NULL;
+
 		int ceil_or_floor = id == SN_Ceiling ? 10 : 9;
 		return emit_simd_ins_for_sig (cfg, klass, OP_SSE41_ROUNDP, ceil_or_floor, arg0_type, fsig, args);
 #else
@@ -1514,7 +1517,15 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 		if ( size != 16 ) 		// Only works with Vector128
 			return NULL;
 
-		int instc0 = arg0_type == MONO_TYPE_R4 ? INTRINS_SSE_SQRT_PS : INTRINS_SSE_SQRT_PD;
+		int instc0 = INTRINS_SSE_SQRT_PD;
+		MonoCPUFeatures feature = MONO_CPU_X86_SSE2;
+		if (arg0_type == MONO_TYPE_R4) {
+			instc0 = INTRINS_SSE_SQRT_PS;
+			feature = MONO_CPU_X86_SSE;
+		}
+
+		if (!is_SIMD_feature_supported (cfg, feature))
+			return NULL;
 
 		return emit_simd_ins_for_sig (cfg, klass, OP_XOP_X_X, instc0, arg0_type, fsig, args);
 #else

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1517,14 +1517,7 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 		if (size != 16) 		// Only works with Vector128
 			return NULL;
 
-		int instc0 = INTRINS_SSE_SQRT_PD;
-		MonoCPUFeatures feature = MONO_CPU_X86_SSE2;
-		if (arg0_type == MONO_TYPE_R4) {
-			instc0 = INTRINS_SSE_SQRT_PS;
-			feature = MONO_CPU_X86_SSE;
-		}
-		if (!is_SIMD_feature_supported (cfg, feature))
-			return NULL;
+		int instc0 = arg0_type == MONO_TYPE_R4 ? INTRINS_SSE_SQRT_PS : INTRINS_SSE_SQRT_PD;
 
 		return emit_simd_ins_for_sig (cfg, klass, OP_XOP_X_X, instc0, arg0_type, fsig, args);
 #else

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1176,7 +1176,7 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 		if (size != 16) 	// Supported only on Vector128
 			return NULL;
 
-		if (!is_SIMD_feature_supported (ctr, MONO_CPU_X86_SSE41))
+		if (!is_SIMD_feature_supported (cfg, MONO_CPU_X86_SSE41))
 			return NULL;
 
 		int ceil_or_floor = id == SN_Ceiling ? 10 : 9;


### PR DESCRIPTION
Fix Sqrt, Floor, Ceiling intrinsics on Vector128 on amd64:

- Add missing defined for amd64
- Add SIMD feature checks