### PR TITLE
JIT: Skip args sort in MinOpts

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1297,6 +1297,11 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
         sortedArgs[argCount++] = &arg;
     }
 
+    if (comp->opts.OptimizationDisabled())
+    {
+        return;
+    }
+
     // Set the beginning and end for the new argument table
     unsigned curInx;
     int      regCount      = 0;


### PR DESCRIPTION
Curious to see TP diffs. Will probably need to collect ASM diffs manually.