### PR TITLE
[wasm][debugger] Pass-through all `scriptParsed` events, including those with empty URLs

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -214,15 +214,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "Debugger.scriptParsed":
                     {
                         string url = args?["url"]?.Value<string>() ?? "";
-
-                        switch (url)
-                        {
-                            case var _ when url == "":
-                            {
-                                logger.LogTrace($"ignoring empty: Debugger.scriptParsed {url}");
-                                return true;
-                            }
-                        }
                         logger.LogTrace($"proxying Debugger.scriptParsed ({sessionId.sessionId}) {url} {args}");
                         break;
                     }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -211,13 +211,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                         break;
                     }
 
-                case "Debugger.scriptParsed":
-                    {
-                        string url = args?["url"]?.Value<string>() ?? "";
-                        logger.LogTrace($"proxying Debugger.scriptParsed ({sessionId.sessionId}) {url} {args}");
-                        break;
-                    }
-
                 case "Target.attachedToTarget":
                     {
                         if (args["targetInfo"]["type"]?.ToString() == "page")


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/42340. 
We introduced the empty `url` check here: https://github.com/mono/mono/commit/dce53cc9f31aab3883ca85303ba42ec9b22caea7. After removing it I do not see any side effects when debugging, both native and user code.

Number of additional traffic caused by removing `return true`:
- startup: ~200 messages with empty URL
- hitting a breakpoint: ~30
- resume: 1
- remove breakpoint: 1
- set breakpoint: 3
- step over/ step into: ~20,
- onEval: ~40,
- getProperties: ~80.