### PR TITLE
Fix assertion in corhlpr

### DIFF
--- a/src/coreclr/inc/corhlpr.cpp
+++ b/src/coreclr/inc/corhlpr.cpp
@@ -140,7 +140,9 @@ unsigned __stdcall IlmethodEmit(unsigned size, COR_ILMETHOD_FAT* header,
         fatHeader->SetSize(sizeof(COR_ILMETHOD_FAT) / 4);
     }
 #ifndef SOS_INCLUDE
+#ifdef _DEBUG
     assert(&origBuff[size] == outBuff);
+#endif
 #endif // !SOS_INCLUDE
     return(size);
 }


### PR DESCRIPTION
`origBuff` is only defined in Debug, but the assertion that uses it is always defined (assuming SOS_INCLUDE is not defined). Depending on how `assert` is defined, this can cause compilation errors in release mode.