### PR TITLE
Disabling disasm checks under certain testing environments

### DIFF
--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -235,16 +235,18 @@ IF NOT DEFINED DoLink (
 
       <BashCLRTestPreCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
 if [[ "$COMPlus_TieredPGO" != "1" ]]; then
-  @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
-    ERRORLEVEL=$?
-    export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
-    export COMPlus_JitDiffableDasm=1
-    export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
-    if [[ $ERRORLEVEL -ne 0 ]]
-    then
-      echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
-      exit 1
-    fi', '%0a')
+  if [[ -n $COMPlus_JitDisasm ]]; then
+    @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
+      ERRORLEVEL=$?
+      export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
+      export COMPlus_JitDiffableDasm=1
+      export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
+      if [[ $ERRORLEVEL -ne 0 ]]
+      then
+        echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
+        exit 1
+      fi', '%0a')
+  fi
 fi
 ]]>
       </BashCLRTestPreCommands>

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -222,7 +222,7 @@ IF NOT DEFINED DoLink (
           DependsOnTargets="GetDisasmCheckData">
     <PropertyGroup>
       <HasBashDisasmCheck>false</HasBashDisasmCheck>
-      <HasBashDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and '$(RunCrossGen2)' != 'true' and '$(RuntimeIdentifier)' != 'linux-musl-arm64' and '$(RuntimeIdentifier)' != 'linux-musl-arm'">true</HasBashDisasmCheck>
+      <HasBashDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and '$(RunCrossGen2)' != 'true' and '$(RuntimeIdentifier)' != 'linux-musl-arm64' and '$(RuntimeIdentifier)' != 'linux-musl-arm' and '$(RuntimeIdentifier)' != 'linux-musl-x64'">true</HasBashDisasmCheck>
 
       <GCStressIncompatible Condition="'$(HasBashDisasmCheck)' == 'true'">true</GCStressIncompatible>
       <HeapVerifyIncompatible Condition="'$(HasBashDisasmCheck)' == 'true'">true</HeapVerifyIncompatible>

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -222,7 +222,10 @@ IF NOT DEFINED DoLink (
           DependsOnTargets="GetDisasmCheckData">
     <PropertyGroup>
       <HasBashDisasmCheck>false</HasBashDisasmCheck>
-      <HasBashDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')">true</HasBashDisasmCheck>
+      <HasBashDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and '$(RunCrossGen2)' != 'true' and '$(RuntimeIdentifier)' != 'linux-musl-arm64' and '$(RuntimeIdentifier)' != 'linux-musl-arm'">true</HasBashDisasmCheck>
+
+      <GCStressIncompatible Condition="'$(HasBashDisasmCheck)' == 'true'">true</GCStressIncompatible>
+      <HeapVerifyIncompatible Condition="'$(HasBashDisasmCheck)' == 'true'">true</HeapVerifyIncompatible>
 
       <BashDisasmOutputFile>/dev/null</BashDisasmOutputFile>
       <BashDisasmOutputFile Condition="'$(HasBashDisasmCheck)' == 'true'">$(scriptPath)__jit_disasm.out</BashDisasmOutputFile>
@@ -231,29 +234,33 @@ IF NOT DEFINED DoLink (
       <BashDisasmListOutputFile Condition="'$(HasBashDisasmCheck)' == 'true'">$(scriptPath)__jit_disasm_list.out</BashDisasmListOutputFile>
 
       <BashCLRTestPreCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
-@(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
-  ERRORLEVEL=$?
-  export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
-  export COMPlus_JitDiffableDasm=1
-  export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
-  if [[ $ERRORLEVEL -ne 0 ]]
-  then
-    echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
-    exit 1
-  fi', '%0a')
-]]>
-      </BashCLRTestPreCommands>
-
-      <BashDisasmCheckPostCommands></BashDisasmCheckPostCommands>
-      <BashDisasmCheckPostCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
-if [[ -n $COMPlus_JitDisasm ]]; then
-  @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BashDisasmOutputFile)"
+if [[ "$COMPlus_TieredPGO" != "1" ]]; then
+  @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
     ERRORLEVEL=$?
+    export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
+    export COMPlus_JitDiffableDasm=1
+    export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
     if [[ $ERRORLEVEL -ne 0 ]]
     then
       echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
       exit 1
     fi', '%0a')
+fi
+]]>
+      </BashCLRTestPreCommands>
+
+      <BashDisasmCheckPostCommands></BashDisasmCheckPostCommands>
+      <BashDisasmCheckPostCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
+if [[ "$COMPlus_TieredPGO" != "1" ]]; then
+  if [[ -n $COMPlus_JitDisasm ]]; then
+    @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BashDisasmOutputFile)"
+      ERRORLEVEL=$?
+      if [[ $ERRORLEVEL -ne 0 ]]
+      then
+        echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
+        exit 1
+      fi', '%0a')
+  fi
 fi
 ]]>
       </BashDisasmCheckPostCommands>
@@ -265,7 +272,10 @@ fi
           DependsOnTargets="GetDisasmCheckData">
     <PropertyGroup>
       <HasBatchDisasmCheck>false</HasBatchDisasmCheck>
-      <HasBatchDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">true</HasBatchDisasmCheck>
+      <HasBatchDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and '$(RunCrossGen2)' != 'true'">true</HasBatchDisasmCheck>
+
+      <GCStressIncompatible Condition="'$(HasBatchDisasmCheck)' == 'true'">true</GCStressIncompatible>
+      <HeapVerifyIncompatible Condition="'$(HasBatchDisasmCheck)' == 'true'">true</HeapVerifyIncompatible>
 
       <BatchDisasmOutputFile>NUL</BatchDisasmOutputFile>
       <BatchDisasmOutputFile Condition="'$(HasBatchDisasmCheck)' == 'true'">$(scriptPath)__jit_disasm.out</BatchDisasmOutputFile>
@@ -276,25 +286,29 @@ fi
       <CLRTestBatchPreCommands Condition="'$(HasBatchDisasmCheck)' == 'true'">
 <![CDATA[
       $(CLRTestBatchPreCommands)
-@(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BatchDisasmListOutputFile)"
-  IF NOT "!ERRORLEVEL!" == "0" (
-    ECHO EXECUTION OF FILECHECK LISTING METHOD NAMES - FAILED !ERRORLEVEL!
-    Exit /b 1
-  )', '%0d%0a')
-  for /F "delims=" %%g in ($(BatchDisasmListOutputFile)) do set COMPlus_JitDisasm=%%g
-  set COMPlus_JitDiffableDasm=1
-  set COMPlus_JitStdOutFile=$(BatchDisasmOutputFile)
+IF NOT "%COMPlus_TieredPGO%" == "1" (
+  @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BatchDisasmListOutputFile)"
+    IF NOT "!ERRORLEVEL!" == "0" (
+      ECHO EXECUTION OF FILECHECK LISTING METHOD NAMES - FAILED !ERRORLEVEL!
+      Exit /b 1
+    )', '%0d%0a')
+    for /F "delims=" %%g in ($(BatchDisasmListOutputFile)) do set COMPlus_JitDisasm=%%g
+    set COMPlus_JitDiffableDasm=1
+    set COMPlus_JitStdOutFile=$(BatchDisasmOutputFile)
+)
 ]]>
       </CLRTestBatchPreCommands>
 
       <BatchDisasmCheckPostCommands></BatchDisasmCheckPostCommands>
       <BatchDisasmCheckPostCommands Condition="'$(HasBatchDisasmCheck)' == 'true'"><![CDATA[
-IF NOT "%COMPlus_JitDisasm%" == "" (
-  @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BatchDisasmOutputFile)"
-    IF NOT "!ERRORLEVEL!" == "0" (
-      ECHO EXECUTION OF FILECHECK - FAILED !ERRORLEVEL!
-      Exit /b 1
-    )', '%0d%0a')
+IF NOT "%COMPlus_TieredPGO%" == "1" (
+  IF NOT "%COMPlus_JitDisasm%" == "" (
+    @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BatchDisasmOutputFile)"
+      IF NOT "!ERRORLEVEL!" == "0" (
+        ECHO EXECUTION OF FILECHECK - FAILED !ERRORLEVEL!
+        Exit /b 1
+      )', '%0d%0a')
+  )
 )
 ]]>
       </BatchDisasmCheckPostCommands>

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -222,7 +222,7 @@ IF NOT DEFINED DoLink (
           DependsOnTargets="GetDisasmCheckData">
     <PropertyGroup>
       <HasBashDisasmCheck>false</HasBashDisasmCheck>
-      <HasBashDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and '$(RunCrossGen2)' != 'true' and '$(RuntimeIdentifier)' != 'linux-musl-arm64' and '$(RuntimeIdentifier)' != 'linux-musl-arm' and '$(RuntimeIdentifier)' != 'linux-musl-x64'">true</HasBashDisasmCheck>
+      <HasBashDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and '$(RunCrossGen2)' != 'true'">true</HasBashDisasmCheck>
 
       <GCStressIncompatible Condition="'$(HasBashDisasmCheck)' == 'true'">true</GCStressIncompatible>
       <HeapVerifyIncompatible Condition="'$(HasBashDisasmCheck)' == 'true'">true</HeapVerifyIncompatible>

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -234,15 +234,13 @@ IF NOT DEFINED DoLink (
       <BashDisasmListOutputFile Condition="'$(HasBashDisasmCheck)' == 'true'">$(scriptPath)__jit_disasm_list.out</BashDisasmListOutputFile>
 
       <BashCLRTestPreCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
-CAN_RUN_DISASM_CHECKS=0
 if [[ ( -z "$COMPlus_JitStress" ) && ( -z "$COMPlus_JitStressRegs" ) && ( -z "$COMPlus_TailcallStress" ) && ( "$COMPlus_TieredPGO" != "1" ) ]]; then
   @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
     ERRORLEVEL=$?
+    export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
+    export COMPlus_JitDiffableDasm=1
+    export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
     if [[ $ERRORLEVEL -ne 0 ]]
-      export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
-      export COMPlus_JitDiffableDasm=1
-      export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
-      CAN_RUN_DISASM_CHECKS=1
     then
       echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
       exit 1
@@ -253,16 +251,14 @@ fi
 
       <BashDisasmCheckPostCommands></BashDisasmCheckPostCommands>
       <BashDisasmCheckPostCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
-if [[ CAN_RUN_DISASM_CHECKS == 1 ]]; then
-  if [[ -n $COMPlus_JitDisasm ]]; then
-    @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BashDisasmOutputFile)"
-      ERRORLEVEL=$?
-      if [[ $ERRORLEVEL -ne 0 ]]
-      then
-        echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
-        exit 1
-      fi', '%0a')
-  fi
+if [[ -n $COMPlus_JitDisasm ]]; then
+  @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BashDisasmOutputFile)"
+    ERRORLEVEL=$?
+    if [[ $ERRORLEVEL -ne 0 ]]
+    then
+      echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
+      exit 1
+    fi', '%0a')
 fi
 ]]>
       </BashDisasmCheckPostCommands>
@@ -302,14 +298,12 @@ IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_Tailc
 
       <BatchDisasmCheckPostCommands></BatchDisasmCheckPostCommands>
       <BatchDisasmCheckPostCommands Condition="'$(HasBatchDisasmCheck)' == 'true'"><![CDATA[
-IF "%CAN_RUN_DISASM_CHECKS%" == "1" (
-  IF NOT "%COMPlus_JitDisasm%" == "" (
-    @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BatchDisasmOutputFile)"
-      IF NOT "!ERRORLEVEL!" == "0" (
-        ECHO EXECUTION OF FILECHECK - FAILED !ERRORLEVEL!
-        Exit /b 1
-      )', '%0d%0a')
-  )
+IF NOT "%COMPlus_JitDisasm%" == "" (
+  @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BatchDisasmOutputFile)"
+    IF NOT "!ERRORLEVEL!" == "0" (
+      ECHO EXECUTION OF FILECHECK - FAILED !ERRORLEVEL!
+      Exit /b 1
+    )', '%0d%0a')
 )
 ]]>
       </BatchDisasmCheckPostCommands>

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -281,7 +281,6 @@ fi
       <CLRTestBatchPreCommands Condition="'$(HasBatchDisasmCheck)' == 'true'">
 <![CDATA[
       $(CLRTestBatchPreCommands)
-set CAN_RUN_DISASM_CHECKS=0
 IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_TailcallStress%"=="" IF NOT "%COMPlus_TieredPGO%" == "1" (
   @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BatchDisasmListOutputFile)"
     IF NOT "!ERRORLEVEL!" == "0" (
@@ -291,7 +290,6 @@ IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_Tailc
     for /F "delims=" %%g in ($(BatchDisasmListOutputFile)) do set COMPlus_JitDisasm=%%g
     set COMPlus_JitDiffableDasm=1
     set COMPlus_JitStdOutFile=$(BatchDisasmOutputFile)
-    set CAN_RUN_DISASM_CHECKS=1
 )
 ]]>
       </CLRTestBatchPreCommands>

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -199,7 +199,10 @@ IF NOT DEFINED DoLink (
     </ItemGroup>
     <PropertyGroup>
       <HasDisasmCheck>false</HasDisasmCheck>
-      <HasDisasmCheck Condition="@(DisasmCheckFiles->Count()) &gt; 0 And '$(CLRTestKind)' == 'BuildAndRun'">true</HasDisasmCheck>
+      <HasDisasmCheck Condition="@(DisasmCheckFiles->Count()) &gt; 0 And '$(CLRTestKind)' == 'BuildAndRun' and '$(RunCrossGen2)' != 'true'">true</HasDisasmCheck>
+
+      <GCStressIncompatible Condition="'$(HasDisasmCheck)' == 'true'">true</GCStressIncompatible>
+      <HeapVerifyIncompatible Condition="'$(HasDisasmCheck)' == 'true'">true</HeapVerifyIncompatible>
     </PropertyGroup>
   </Target>
 
@@ -222,10 +225,7 @@ IF NOT DEFINED DoLink (
           DependsOnTargets="GetDisasmCheckData">
     <PropertyGroup>
       <HasBashDisasmCheck>false</HasBashDisasmCheck>
-      <HasBashDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and '$(RunCrossGen2)' != 'true'">true</HasBashDisasmCheck>
-
-      <GCStressIncompatible Condition="'$(HasBashDisasmCheck)' == 'true'">true</GCStressIncompatible>
-      <HeapVerifyIncompatible Condition="'$(HasBashDisasmCheck)' == 'true'">true</HeapVerifyIncompatible>
+      <HasBashDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and ('$(TargetOS)' == 'Linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')">true</HasBashDisasmCheck>
 
       <BashDisasmOutputFile>/dev/null</BashDisasmOutputFile>
       <BashDisasmOutputFile Condition="'$(HasBashDisasmCheck)' == 'true'">$(scriptPath)__jit_disasm.out</BashDisasmOutputFile>
@@ -234,13 +234,15 @@ IF NOT DEFINED DoLink (
       <BashDisasmListOutputFile Condition="'$(HasBashDisasmCheck)' == 'true'">$(scriptPath)__jit_disasm_list.out</BashDisasmListOutputFile>
 
       <BashCLRTestPreCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
+CAN_RUN_DISASM_CHECKS=0
 if [[ ( -z "$COMPlus_JitStress" ) && ( -z "$COMPlus_JitStressRegs" ) && ( -z "$COMPlus_TailcallStress" ) && ( "$COMPlus_TieredPGO" != "1" ) ]]; then
   @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
     ERRORLEVEL=$?
-    export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
-    export COMPlus_JitDiffableDasm=1
-    export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
     if [[ $ERRORLEVEL -ne 0 ]]
+      export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
+      export COMPlus_JitDiffableDasm=1
+      export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
+      CAN_RUN_DISASM_CHECKS=1
     then
       echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
       exit 1
@@ -251,7 +253,7 @@ fi
 
       <BashDisasmCheckPostCommands></BashDisasmCheckPostCommands>
       <BashDisasmCheckPostCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
-if [[ ( -z "$COMPlus_JitStress" ) && ( -z "$COMPlus_JitStressRegs" ) && ( -z "$COMPlus_TailcallStress" ) && ( "$COMPlus_TieredPGO" != "1" ) ]]; then
+if [[ CAN_RUN_DISASM_CHECKS == 1 ]]; then
   if [[ -n $COMPlus_JitDisasm ]]; then
     @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BashDisasmOutputFile)"
       ERRORLEVEL=$?
@@ -272,10 +274,7 @@ fi
           DependsOnTargets="GetDisasmCheckData">
     <PropertyGroup>
       <HasBatchDisasmCheck>false</HasBatchDisasmCheck>
-      <HasBatchDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr' and '$(RunCrossGen2)' != 'true'">true</HasBatchDisasmCheck>
-
-      <GCStressIncompatible Condition="'$(HasBatchDisasmCheck)' == 'true'">true</GCStressIncompatible>
-      <HeapVerifyIncompatible Condition="'$(HasBatchDisasmCheck)' == 'true'">true</HeapVerifyIncompatible>
+      <HasBatchDisasmCheck Condition="'$(HasDisasmCheck)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">true</HasBatchDisasmCheck>
 
       <BatchDisasmOutputFile>NUL</BatchDisasmOutputFile>
       <BatchDisasmOutputFile Condition="'$(HasBatchDisasmCheck)' == 'true'">$(scriptPath)__jit_disasm.out</BatchDisasmOutputFile>
@@ -286,6 +285,7 @@ fi
       <CLRTestBatchPreCommands Condition="'$(HasBatchDisasmCheck)' == 'true'">
 <![CDATA[
       $(CLRTestBatchPreCommands)
+set CAN_RUN_DISASM_CHECKS=0
 IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_TailcallStress%"=="" IF NOT "%COMPlus_TieredPGO%" == "1" (
   @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BatchDisasmListOutputFile)"
     IF NOT "!ERRORLEVEL!" == "0" (
@@ -295,13 +295,14 @@ IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_Tailc
     for /F "delims=" %%g in ($(BatchDisasmListOutputFile)) do set COMPlus_JitDisasm=%%g
     set COMPlus_JitDiffableDasm=1
     set COMPlus_JitStdOutFile=$(BatchDisasmOutputFile)
+    set CAN_RUN_DISASM_CHECKS=1
 )
 ]]>
       </CLRTestBatchPreCommands>
 
       <BatchDisasmCheckPostCommands></BatchDisasmCheckPostCommands>
       <BatchDisasmCheckPostCommands Condition="'$(HasBatchDisasmCheck)' == 'true'"><![CDATA[
-IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_TailcallStress%"=="" IF NOT "%COMPlus_TieredPGO%" == "1" (
+IF "%CAN_RUN_DISASM_CHECKS%" == "1" (
   IF NOT "%COMPlus_JitDisasm%" == "" (
     @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BatchDisasmOutputFile)"
       IF NOT "!ERRORLEVEL!" == "0" (

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -235,18 +235,16 @@ IF NOT DEFINED DoLink (
 
       <BashCLRTestPreCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
 if [[ "$COMPlus_TieredPGO" != "1" ]]; then
-  if [[ -n $COMPlus_JitDisasm ]]; then
-    @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
-      ERRORLEVEL=$?
-      export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
-      export COMPlus_JitDiffableDasm=1
-      export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
-      if [[ $ERRORLEVEL -ne 0 ]]
-      then
-        echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
-        exit 1
-      fi', '%0a')
-  fi
+  @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
+    ERRORLEVEL=$?
+    export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
+    export COMPlus_JitDiffableDasm=1
+    export COMPlus_JitStdOutFile=$(BashDisasmOutputFile)
+    if [[ $ERRORLEVEL -ne 0 ]]
+    then
+      echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
+      exit 1
+    fi', '%0a')
 fi
 ]]>
       </BashCLRTestPreCommands>

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -234,7 +234,7 @@ IF NOT DEFINED DoLink (
       <BashDisasmListOutputFile Condition="'$(HasBashDisasmCheck)' == 'true'">$(scriptPath)__jit_disasm_list.out</BashDisasmListOutputFile>
 
       <BashCLRTestPreCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
-if [[ "$COMPlus_TieredPGO" != "1" ]]; then
+if [[ ( -z "$COMPlus_JitStress" ) && ( -z "$COMPlus_JitStressRegs" ) && ( -z "$COMPlus_TailcallStress" ) && ( "$COMPlus_TieredPGO" != "1" ) ]]; then
   @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BashDisasmListOutputFile)"
     ERRORLEVEL=$?
     export COMPlus_JitDisasm=`cat $(BashDisasmListOutputFile)`
@@ -251,7 +251,7 @@ fi
 
       <BashDisasmCheckPostCommands></BashDisasmCheckPostCommands>
       <BashDisasmCheckPostCommands Condition="'$(HasBashDisasmCheck)' == 'true'"><![CDATA[
-if [[ "$COMPlus_TieredPGO" != "1" ]]; then
+if [[ ( -z "$COMPlus_JitStress" ) && ( -z "$COMPlus_JitStressRegs" ) && ( -z "$COMPlus_TailcallStress" ) && ( "$COMPlus_TieredPGO" != "1" ) ]]; then
   if [[ -n $COMPlus_JitDisasm ]]; then
     @(DisasmCheckFiles -> '  dotnet $CORE_ROOT/SuperFileCheck/SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BashDisasmOutputFile)"
       ERRORLEVEL=$?
@@ -286,7 +286,7 @@ fi
       <CLRTestBatchPreCommands Condition="'$(HasBatchDisasmCheck)' == 'true'">
 <![CDATA[
       $(CLRTestBatchPreCommands)
-IF NOT "%COMPlus_TieredPGO%" == "1" (
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_TailcallStress%"=="" IF NOT "%COMPlus_TieredPGO%" == "1" (
   @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp-list-method-names "%(Identity)" --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) > "$(BatchDisasmListOutputFile)"
     IF NOT "!ERRORLEVEL!" == "0" (
       ECHO EXECUTION OF FILECHECK LISTING METHOD NAMES - FAILED !ERRORLEVEL!
@@ -301,7 +301,7 @@ IF NOT "%COMPlus_TieredPGO%" == "1" (
 
       <BatchDisasmCheckPostCommands></BatchDisasmCheckPostCommands>
       <BatchDisasmCheckPostCommands Condition="'$(HasBatchDisasmCheck)' == 'true'"><![CDATA[
-IF NOT "%COMPlus_TieredPGO%" == "1" (
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_TailcallStress%"=="" IF NOT "%COMPlus_TieredPGO%" == "1" (
   IF NOT "%COMPlus_JitDisasm%" == "" (
     @(DisasmCheckFiles -> '  dotnet %CORE_ROOT%\SuperFileCheck\SuperFileCheck.dll --csharp "%(Identity)" --allow-unused-prefixes --check-prefixes=CHECK,$(TargetArchitecture.ToUpperInvariant()),$(TargetArchitecture.ToUpperInvariant())-$(TargetOS.ToUpperInvariant()) --dump-input-context 25 --input-file "$(BatchDisasmOutputFile)"
       IF NOT "!ERRORLEVEL!" == "0" (

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34937/Runtime_34937.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34937/Runtime_34937.cs
@@ -24,7 +24,7 @@ class Program
         // X64-FULL-LINE-NEXT:         sar [[REG0]], 31
         // X64-FULL-LINE-NEXT:         and [[REG0]], 15
         // X64-FULL-LINE-NEXT:         add [[REG0]], [[REG1]]
-        // X64-FULL-LINE-NEXT:         and [[REG0]], -16
+        // X64-FULL-LINE-NEXT:         and [[REG1]], -16
         // X64-WINDOWS-FULL-LINE-NEXT: mov [[REG2:[a-z]+]], [[REG1]]
         // X64-WINDOWS-FULL-LINE-NEXT: sub [[REG2]], [[REG0]]
         // X64-WINDOWS-FULL-LINE-NEXT: mov [[REG0]], [[REG2]]

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34937/Runtime_34937.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34937/Runtime_34937.cs
@@ -24,7 +24,7 @@ class Program
         // X64-FULL-LINE-NEXT:         sar [[REG0]], 31
         // X64-FULL-LINE-NEXT:         and [[REG0]], 15
         // X64-FULL-LINE-NEXT:         add [[REG0]], [[REG1]]
-        // X64-FULL-LINE-NEXT:         and [[REG1]], -16
+        // X64-FULL-LINE-NEXT:         and [[REG0]], -16
         // X64-WINDOWS-FULL-LINE-NEXT: mov [[REG2:[a-z]+]], [[REG1]]
         // X64-WINDOWS-FULL-LINE-NEXT: sub [[REG2]], [[REG0]]
         // X64-WINDOWS-FULL-LINE-NEXT: mov [[REG0]], [[REG2]]


### PR DESCRIPTION
Should resolve:

- https://github.com/dotnet/runtime/issues/76158
- https://github.com/dotnet/runtime/issues/76150
- https://github.com/dotnet/runtime/issues/76159

**Description**

We need to disable disasm checks if we are running under GCStress, TieredPGO, R2R, JITStress.