### PR TITLE
[release/7.0] Disable NativeAOT subset for source-build.

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -51,7 +51,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools+host.native</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.crossarchtools+host.native</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets Condition="'$(DotNetBuildFromSource)' != 'true'">$(DefaultCoreClrSubsets)+clr.nativeaotlibs</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -51,8 +51,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.crossarchtools+host.native</DefaultCoreClrSubsets>
-    <DefaultCoreClrSubsets Condition="'$(DotNetBuildFromSource)' != 'true'">$(DefaultCoreClrSubsets)+clr.nativeaotlibs</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.crossarchtools+host.native</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
@@ -48,12 +48,14 @@
 
     <!-- CoreDisTools are used in debugging visualizers. -->
     <IncludeCoreDisTools Condition="'$(Configuration)' != 'Release' and '$(CrossHostArch)' == ''">true</IncludeCoreDisTools>
+    <!-- source-build doesn't use ObjWriter for the ILCompiler.  the end-user will end up pulling Microsoft-built bits for NativeAOT anyway.  -->
+    <IncludeObjWriter Condition="'$(DotNetBuildFromSource)' != 'true'">true</IncludeObjWriter>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)coredistools.targets" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(IncludeCoreDisTools)' == 'true'" />
 
   <ItemGroup>
-    <PackageReference Include="runtime.$(ObjWriterRid).Microsoft.NETCore.Runtime.ObjWriter">
+    <PackageReference Include="runtime.$(ObjWriterRid).Microsoft.NETCore.Runtime.ObjWriter" Condition="'$(IncludeObjWriter)' == 'true'">
       <Version>$(ObjWriterVersion)</Version>
     </PackageReference>
 
@@ -62,7 +64,7 @@
       <Version>$(NetStandardLibraryVersion)</Version>
     </PackageReference>
 
-    <Content Include="$(NuGetPackageRoot)runtime.$(ObjWriterRid).microsoft.netcore.runtime.objwriter\$(ObjWriterVersion)\runtimes\$(ObjWriterRid)\native\$(LibPrefix)objwriter$(LibSuffix)">
+    <Content Include="$(NuGetPackageRoot)runtime.$(ObjWriterRid).microsoft.netcore.runtime.objwriter\$(ObjWriterVersion)\runtimes\$(ObjWriterRid)\native\$(LibPrefix)objwriter$(LibSuffix)" Condition="'$(IncludeObjWriter)' == 'true'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/71853.
Tracking issue in source-build is https://github.com/dotnet/source-build/issues/2885.
If merged obsoletes https://github.com/dotnet/runtime/issues/74505.

The source-build understanding is:
- We are currently using the Microsoft-built NativeAOT bits in the final SDK when an end-user wants to publish a NativeAOT project.  These aren't shipped with the SDK but are pulled down when an end-user wants to publish a NativeAOT project.
- There are more extensive changes necessary to NativeAOT in general if it will ever be supported as a source-built component due to the difference in how source-build uses primarily RID-specific assets vs the portable assets generally used in the Microsoft-build (from issues https://github.com/dotnet/runtime/issues/66859 and https://github.com/dotnet/source-build/issues/1215).
- Our partners view this as an acceptable trade-off at least for the time being.
- We would like to eliminate the remaining patches and churn/risk of building llvm-project.
- We would like to continue building, for example, crossgen2 and other native-related projects.

I would like to make the minimal change necessary to disable the dependency on llvm-project in runtime without breaking any end-user functionality and this subset seems like it should fit that bill - please let me know if I'm wrong.