### PR TITLE
JIT: refactor and enhance the redundant branch optimizer

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6969,6 +6969,7 @@ public:
     bool optRedundantRelop(BasicBlock* const block);
     bool optRedundantBranch(BasicBlock* const block);
     bool optJumpThread(BasicBlock* const block, BasicBlock* const domBlock, bool domIsSameRelop);
+    bool optJumpThreadCheck(BasicBlock* const block, BasicBlock* const domBlock);
     bool optJumpThreadCore(JumpThreadInfo& jti);
     bool optReachable(BasicBlock* const fromBlock, BasicBlock* const toBlock, BasicBlock* const excludedBlock);
     BitVecTraits* optReachableBitVecTraits;


### PR DESCRIPTION
One more preparatory step before introducing the new phi-based disambiguation.

* handle some cases of ambiguous preds better
* split out the jump threading pre checks into a helper
* properly support updating switch preds
* generalize retry logic a bit to handle more cases

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=30638&view=ms.vss-build-web.run-extensions-tab)