### PR TITLE
Quote Windows DirectPInvokeList path

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.targets
@@ -68,7 +68,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
-      <DirectPInvokeList Include="$(MSBuildThisFileDirectory)WindowsAPIs.txt" />
+      <DirectPInvokeList Include="&quot;$(MSBuildThisFileDirectory)WindowsAPIs.txt&quot;" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
When using PublishAot=true with a .NET SDK installed to `C:\Program Files\dotnet`, the command fails because there is a space in the path.

The error appears to be caused by updating to System.CommandLine (#72082). Previously, we must have been reading the whole file path even without it being quoted.

Error:

```
  Generating compatible native code. To optimize for size or speed, visit https://aka.ms/OptimizeNativeAOT
  Unhandled exception. System.CommandLine.CommandLineException: No files matching Files\dotnet\sdk\7.0.100-preview
  .7.22377.5\Sdks\Microsoft.DotNet.ILCompiler\build\WindowsAPIs.txt
     at System.CommandLine.Helpers.AppendExpandedPaths(Dictionary`2, String, Boolean) in C:\git\runtime2\src\corec
  lr\tools\Common\CommandLineHelpers.cs:line 282
     at System.CommandLine.Helpers.BuildPathDictionay(IReadOnlyList`1, Boolean) in C:\git\runtime2\src\coreclr\too
  ls\Common\CommandLineHelpers.cs:line 33
     at System.CommandLine.Argument`1.<>c__DisplayClass5_0.<.ctor>b__1(ArgumentResult, Object& )
     at System.CommandLine.Parsing.ArgumentResult.Convert(Argument)
     at System.CommandLine.Parsing.ArgumentResult.GetArgumentConversionResult()
     at System.CommandLine.Parsing.ParseResultVisitor.ValidateAndConvertArgumentResult(ArgumentResult)
     at System.CommandLine.Parsing.ParseResultVisitor.ValidateAndConvertArgumentResults(IReadOnlyList`1, Int32)
     at System.CommandLine.Parsing.ParseResultVisitor.Stop()
     at System.CommandLine.Parsing.Parser.Parse(IReadOnlyList`1, String )
     at ILCompiler.Program.Main(String[]) in C:\git\runtime2\src\coreclr\tools\aot\ILCompiler\Program.cs:line 763
```