### PR TITLE
Support containing HWIntrinsics that can operate like a store

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -1654,75 +1654,7 @@ void CodeGen::genConsumeRegs(GenTree* tree)
         else if (tree->OperIs(GT_HWINTRINSIC))
         {
             GenTreeHWIntrinsic* hwintrinsic = tree->AsHWIntrinsic();
-            NamedIntrinsic      intrinsicId = hwintrinsic->GetHWIntrinsicId();
-            size_t              numArgs     = hwintrinsic->GetOperandCount();
-            HWIntrinsicCategory category    = HWIntrinsicInfo::lookupCategory(intrinsicId);
-
-            if (category == HW_Category_MemoryLoad)
-            {
-                assert(numArgs == 1);
-
-                GenTree* op1 = hwintrinsic->Op(1);
-                genConsumeAddress(op1);
-            }
-            else if (category == HW_Category_MemoryStore)
-            {
-                assert(numArgs == 2);
-
-                GenTree* op1 = hwintrinsic->Op(1);
-                genConsumeAddress(op1);
-
-                GenTree* op2 = hwintrinsic->Op(2);
-                assert(op2->isContained());
-
-                genConsumeReg(op2);
-            }
-            else
-            {
-                switch (intrinsicId)
-                {
-                    case NI_SSE2_ConvertToInt32:
-                    case NI_SSE2_ConvertToUInt32:
-                    case NI_SSE2_X64_ConvertToInt64:
-                    case NI_SSE2_X64_ConvertToUInt64:
-                    case NI_AVX2_ConvertToInt32:
-                    case NI_AVX2_ConvertToUInt32:
-                    {
-                        // These intrinsics are "ins reg/mem, xmm"
-                        assert(numArgs == 1);
-
-                        GenTree* op1 = hwintrinsic->Op(1);
-                        assert(!op1->isContained());
-                        genConsumeReg(op1);
-
-                        break;
-                    }
-
-                    case NI_SSE2_Extract:
-                    case NI_SSE41_Extract:
-                    case NI_SSE41_X64_Extract:
-                    case NI_AVX_ExtractVector128:
-                    case NI_AVX2_ExtractVector128:
-                    {
-                        // These intrinsics are "ins reg/mem, xmm, imm8"
-                        assert(numArgs == 2);
-
-                        GenTree* op1 = hwintrinsic->Op(1);
-                        assert(!op1->isContained());
-                        genConsumeReg(op1);
-
-                        GenTree* op2 = hwintrinsic->Op(2);
-                        assert(op2->isContained() && op2->IsCnsIntOrI());
-
-                        break;
-                    }
-
-                    default:
-                    {
-                        unreached();
-                    }
-                }
-            }
+            genConsumeMultiOpOperands(hwintrinsic);
         }
 #endif // FEATURE_HW_INTRINSICS
 #endif // TARGET_XARCH

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -5291,6 +5291,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
                 {
                     ins = INS_movbe;
                 }
+#if defined(FEATURE_HW_INTRINSICS)
                 else if (data->OperIsHWIntrinsic())
                 {
                     GenTreeHWIntrinsic* hwintrinsic = data->AsHWIntrinsic();
@@ -5336,6 +5337,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
                         }
                     }
                 }
+#endif // FEATURE_HW_INTRINSICS
             }
 
             if (ins == INS_invalid)

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -5282,10 +5282,68 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
         }
         else
         {
-            GetEmitter()->emitInsStoreInd(data->OperIs(GT_BSWAP, GT_BSWAP16) && data->isContained()
-                                              ? INS_movbe
-                                              : ins_Store(data->TypeGet()),
-                                          emitTypeSize(tree), tree);
+            instruction ins  = INS_invalid;
+            emitAttr    attr = emitTypeSize(tree);
+
+            if (data->isContained())
+            {
+                if (data->OperIs(GT_BSWAP, GT_BSWAP16))
+                {
+                    ins = INS_movbe;
+                }
+                else if (data->OperIsHWIntrinsic())
+                {
+                    GenTreeHWIntrinsic* hwintrinsic = data->AsHWIntrinsic();
+                    NamedIntrinsic      intrinsicId = hwintrinsic->GetHWIntrinsicId();
+                    var_types           baseType    = hwintrinsic->GetSimdBaseType();
+
+                    switch (intrinsicId)
+                    {
+                        case NI_SSE2_ConvertToInt32:
+                        case NI_SSE2_ConvertToUInt32:
+                        case NI_SSE2_X64_ConvertToInt64:
+                        case NI_SSE2_X64_ConvertToUInt64:
+                        case NI_AVX2_ConvertToInt32:
+                        case NI_AVX2_ConvertToUInt32:
+                        {
+                            // These intrinsics are "ins reg/mem, xmm"
+                            ins  = HWIntrinsicInfo::lookupIns(intrinsicId, baseType);
+                            attr = emitActualTypeSize(baseType);
+                            break;
+                        }
+
+                        case NI_SSE2_Extract:
+                        case NI_SSE41_Extract:
+                        case NI_SSE41_X64_Extract:
+                        case NI_AVX_ExtractVector128:
+                        case NI_AVX2_ExtractVector128:
+                        {
+                            // These intrinsics are "ins reg/mem, xmm, imm8"
+                            ins  = HWIntrinsicInfo::lookupIns(intrinsicId, baseType);
+                            attr = emitActualTypeSize(Compiler::getSIMDTypeForSize(hwintrinsic->GetSimdSize()));
+
+                            if (intrinsicId == NI_SSE2_Extract)
+                            {
+                                // The encoding that supports containment is SSE4.1 only
+                                ins = INS_pextrw_sse41;
+                            }
+                            break;
+                        }
+
+                        default:
+                        {
+                            unreached();
+                        }
+                    }
+                }
+            }
+
+            if (ins == INS_invalid)
+            {
+                ins = ins_Store(data->TypeGet());
+            }
+
+            GetEmitter()->emitInsStoreInd(ins, attr, tree);
         }
     }
 }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -3399,7 +3399,6 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
     if (data->OperIs(GT_BSWAP, GT_BSWAP16) && data->isContained())
     {
         assert(ins == INS_movbe);
-
         data = data->gtGetOp1();
     }
 
@@ -3408,6 +3407,25 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         if (data->isContainedIntOrIImmed())
         {
             emitIns_C_I(ins, attr, addr->AsClsVar()->gtClsVarHnd, 0, (int)data->AsIntConCommon()->IconValue());
+        }
+        else if (data->OperIsHWIntrinsic() && data->isContained())
+        {
+            GenTreeHWIntrinsic* hwintrinsic   = data->AsHWIntrinsic();
+            NamedIntrinsic      intrinsicId   = hwintrinsic->GetHWIntrinsicId();
+            size_t              numArgs       = hwintrinsic->GetOperandCount();
+            GenTree*            op1           = hwintrinsic->Op(1);
+
+            if (numArgs == 1)
+            {
+                emitIns_C_R(ins, attr, addr->AsClsVar()->gtClsVarHnd, op1->GetRegNum(), 0);
+            }
+            else
+            {
+                assert(numArgs == 2);
+
+                int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntConCommon()->IconValue());
+                emitIns_C_R_I(ins, attr, addr->AsClsVar()->gtClsVarHnd, 0, op1->GetRegNum(), icon);
+            }
         }
         else
         {
@@ -3421,9 +3439,29 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
     {
         GenTreeLclVarCommon* varNode = addr->AsLclVarCommon();
         unsigned             offset  = varNode->GetLclOffs();
+
         if (data->isContainedIntOrIImmed())
         {
             emitIns_S_I(ins, attr, varNode->GetLclNum(), offset, (int)data->AsIntConCommon()->IconValue());
+        }
+        else if (data->OperIsHWIntrinsic() && data->isContained())
+        {
+            GenTreeHWIntrinsic* hwintrinsic   = data->AsHWIntrinsic();
+            NamedIntrinsic      intrinsicId   = hwintrinsic->GetHWIntrinsicId();
+            size_t              numArgs       = hwintrinsic->GetOperandCount();
+            GenTree*            op1           = hwintrinsic->Op(1);
+
+            if (numArgs == 1)
+            {
+                emitIns_S_R(ins, attr, op1->GetRegNum(), varNode->GetLclNum(), offset);
+            }
+            else
+            {
+                assert(numArgs == 2);
+
+                int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntConCommon()->IconValue());
+                emitIns_S_R_I(ins, attr, varNode->GetLclNum(), offset, op1->GetRegNum(), icon);
+            }
         }
         else
         {
@@ -3448,6 +3486,35 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         emitHandleMemOp(mem, id, IF_AWR_CNS, ins);
         sz = emitInsSizeAM(id, insCodeMI(ins), icon);
         id->idCodeSize(sz);
+    }
+    else if (data->OperIsHWIntrinsic() && data->isContained())
+    {
+        GenTreeHWIntrinsic* hwintrinsic   = data->AsHWIntrinsic();
+        NamedIntrinsic      intrinsicId   = hwintrinsic->GetHWIntrinsicId();
+        size_t              numArgs       = hwintrinsic->GetOperandCount();
+        GenTree*            op1           = hwintrinsic->Op(1);
+
+        if (numArgs == 1)
+        {
+            id = emitNewInstrAmd(attr, offset);
+            id->idIns(ins);
+            emitHandleMemOp(mem, id, IF_AWR_RRD, ins);
+            id->idReg1(op1->GetRegNum());
+            sz = emitInsSizeAM(id, insCodeMR(ins));
+            id->idCodeSize(sz);
+        }
+        else
+        {
+            assert(numArgs == 2);
+            int icon = static_cast<int>(hwintrinsic->Op(2)->AsIntConCommon()->IconValue());
+
+            id = emitNewInstrAmdCns(attr, offset, icon);
+            id->idIns(ins);
+            id->idReg1(op1->GetRegNum());
+            emitHandleMemOp(mem, id, IF_AWR_RRD_CNS, ins);
+            sz = emitInsSizeAM(id, insCodeMR(ins), icon);
+            id->idCodeSize(sz);
+        }
     }
     else
     {
@@ -6135,6 +6202,43 @@ void emitter::emitIns_AR_R(instruction ins, emitAttr attr, regNumber reg, regNum
 }
 
 //------------------------------------------------------------------------
+// emitIns_C_R_I: emits the code for an instruction that takes a static member,
+//                a register operand, and an immediate.
+//
+// Arguments:
+//    ins       - The instruction being emitted
+//    attr      - The emit attribute
+//    fldHnd    - The CORINFO_FIELD_HANDLE used for the memory address
+//    offs      - The offset for the stack operand
+//    reg       - The register operand
+//    ival      - The immediate value
+//
+void emitter::emitIns_C_R_I(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fldHnd, int offs, regNumber reg, int ival)
+{
+    assert(IsSSEOrAVXInstruction(ins));
+    assert(reg != REG_NA);
+
+    // Static always need relocs
+    if (!jitStaticFldIsGlobAddr(fldHnd))
+    {
+        attr = EA_SET_FLG(attr, EA_DSP_RELOC_FLG);
+    }
+
+    instrDesc* id = emitNewInstrCnsDsp(attr, ival, offs);
+
+    id->idIns(ins);
+    id->idInsFmt(IF_MWR_RRD_CNS);
+    id->idReg1(reg);
+    id->idAddr()->iiaFieldHnd = fldHnd;
+
+    UNATIVE_OFFSET sz = emitInsSizeCV(id, insCodeMR(ins), ival);
+    id->idCodeSize(sz);
+
+    dispIns(id);
+    emitCurIGsize += sz;
+}
+
+//------------------------------------------------------------------------
 // emitIns_S_R_I: emits the code for an instruction that takes a stack operand,
 //                a register operand, and an immediate.
 //
@@ -6148,9 +6252,9 @@ void emitter::emitIns_AR_R(instruction ins, emitAttr attr, regNumber reg, regNum
 //
 void emitter::emitIns_S_R_I(instruction ins, emitAttr attr, int varNum, int offs, regNumber reg, int ival)
 {
-    // This is only used for INS_vextracti128 and INS_vextractf128, and for these 'ival' must be 0 or 1.
-    assert(ins == INS_vextracti128 || ins == INS_vextractf128);
-    assert((ival == 0) || (ival == 1));
+    assert(IsSSEOrAVXInstruction(ins));
+    assert(reg != REG_NA);
+
     instrDesc* id = emitNewInstrAmdCns(attr, 0, ival);
 
     id->idIns(ins);
@@ -6168,10 +6272,20 @@ void emitter::emitIns_S_R_I(instruction ins, emitAttr attr, int varNum, int offs
     emitCurIGsize += sz;
 }
 
+//------------------------------------------------------------------------
+// emitIns_A_R_I: emits the code for an instruction that takes a static member,
+//                a register operand, and an immediate.
+//
+// Arguments:
+//    ins       - The instruction being emitted
+//    attr      - The emit attribute
+//    indir     - The GenTreeIndir used for the memory address
+//    reg       - The register operand
+//    ival      - The immediate value
+//
 void emitter::emitIns_A_R_I(instruction ins, emitAttr attr, GenTreeIndir* indir, regNumber reg, int imm)
 {
-    assert((ins == INS_vextracti128) || (ins == INS_vextractf128));
-    assert(attr == EA_32BYTE);
+    assert(IsSSEOrAVXInstruction(ins));
     assert(reg != REG_NA);
 
     instrDesc* id = emitNewInstrAmdCns(attr, indir->Offset(), imm);
@@ -9224,9 +9338,12 @@ void emitter::emitDispIns(
 
         case IF_AWR_RRD_CNS:
         {
-            assert(ins == INS_vextracti128 || ins == INS_vextractf128);
-            // vextracti/f128 extracts 128-bit data, so we fix sstr as "xmm ptr"
-            sstr = codeGen->genSizeStr(EA_ATTR(16));
+            if ((ins == INS_vextracti128) || (ins == INS_vextractf128))
+            {
+                // vextracti/f128 extracts 128-bit data, so we fix sstr as "xmm ptr"
+                sstr = codeGen->genSizeStr(EA_ATTR(16));
+            }
+
             printf(sstr);
             emitDispAddrMode(id);
             printf(", %s", emitRegName(id->idReg1(), attr));
@@ -9415,8 +9532,7 @@ void emitter::emitDispIns(
             break;
 
         case IF_SWR_RRD_CNS:
-            assert(ins == INS_vextracti128 || ins == INS_vextractf128);
-            assert(UseVEXEncoding());
+            assert(IsSSEOrAVXInstruction(ins));
             emitGetInsAmdCns(id, &cnsVal);
 
             printf("%s", sstr);
@@ -9778,9 +9894,12 @@ void emitter::emitDispIns(
 
         case IF_MWR_RRD_CNS:
         {
-            assert(ins == INS_vextracti128 || ins == INS_vextractf128);
-            // vextracti/f128 extracts 128-bit data, so we fix sstr as "xmm ptr"
-            sstr = codeGen->genSizeStr(EA_ATTR(16));
+            if ((ins == INS_vextracti128) || (ins == INS_vextractf128))
+            {
+                // vextracti/f128 extracts 128-bit data, so we fix sstr as "xmm ptr"
+                sstr = codeGen->genSizeStr(EA_ATTR(16));
+            }
+
             printf(sstr);
             offs = emitGetInsDsp(id);
             emitDispClsVar(id->idAddr()->iiaFieldHnd, offs, ID_INFO_DSP_RELOC);
@@ -14185,8 +14304,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             break;
 
         case IF_AWR_RRD_CNS:
-            assert(ins == INS_vextracti128 || ins == INS_vextractf128);
-            assert(UseVEXEncoding());
+            assert(IsSSEOrAVXInstruction(ins));
             emitGetInsAmdCns(id, &cnsVal);
             code = insCodeMR(ins);
             dst  = emitOutputAM(dst, id, code, &cnsVal);
@@ -14324,8 +14442,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             break;
 
         case IF_SWR_RRD_CNS:
-            assert(ins == INS_vextracti128 || ins == INS_vextractf128);
-            assert(UseVEXEncoding());
+            assert(IsSSEOrAVXInstruction(ins));
             emitGetInsAmdCns(id, &cnsVal);
             code = insCodeMR(ins);
             dst  = emitOutputSV(dst, id, insCodeMR(ins), &cnsVal);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -3408,6 +3408,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         {
             emitIns_C_I(ins, attr, addr->AsClsVar()->gtClsVarHnd, 0, (int)data->AsIntConCommon()->IconValue());
         }
+#if defined(FEATURE_HW_INTRINSICS)
         else if (data->OperIsHWIntrinsic() && data->isContained())
         {
             GenTreeHWIntrinsic* hwintrinsic = data->AsHWIntrinsic();
@@ -3427,6 +3428,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
                 emitIns_C_R_I(ins, attr, addr->AsClsVar()->gtClsVarHnd, 0, op1->GetRegNum(), icon);
             }
         }
+#endif // FEATURE_HW_INTRINSICS
         else
         {
             assert(!data->isContained());
@@ -3444,6 +3446,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         {
             emitIns_S_I(ins, attr, varNode->GetLclNum(), offset, (int)data->AsIntConCommon()->IconValue());
         }
+#if defined(FEATURE_HW_INTRINSICS)
         else if (data->OperIsHWIntrinsic() && data->isContained())
         {
             GenTreeHWIntrinsic* hwintrinsic = data->AsHWIntrinsic();
@@ -3463,6 +3466,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
                 emitIns_S_R_I(ins, attr, varNode->GetLclNum(), offset, op1->GetRegNum(), icon);
             }
         }
+#endif // FEATURE_HW_INTRINSICS
         else
         {
             assert(!data->isContained());
@@ -3487,6 +3491,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         sz = emitInsSizeAM(id, insCodeMI(ins), icon);
         id->idCodeSize(sz);
     }
+#if defined(FEATURE_HW_INTRINSICS)
     else if (data->OperIsHWIntrinsic() && data->isContained())
     {
         GenTreeHWIntrinsic* hwintrinsic = data->AsHWIntrinsic();
@@ -3516,6 +3521,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
             id->idCodeSize(sz);
         }
     }
+#endif // FEATURE_HW_INTRINSICS
     else
     {
         assert(!data->isContained());

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -3410,10 +3410,10 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         }
         else if (data->OperIsHWIntrinsic() && data->isContained())
         {
-            GenTreeHWIntrinsic* hwintrinsic   = data->AsHWIntrinsic();
-            NamedIntrinsic      intrinsicId   = hwintrinsic->GetHWIntrinsicId();
-            size_t              numArgs       = hwintrinsic->GetOperandCount();
-            GenTree*            op1           = hwintrinsic->Op(1);
+            GenTreeHWIntrinsic* hwintrinsic = data->AsHWIntrinsic();
+            NamedIntrinsic      intrinsicId = hwintrinsic->GetHWIntrinsicId();
+            size_t              numArgs     = hwintrinsic->GetOperandCount();
+            GenTree*            op1         = hwintrinsic->Op(1);
 
             if (numArgs == 1)
             {
@@ -3446,10 +3446,10 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
         }
         else if (data->OperIsHWIntrinsic() && data->isContained())
         {
-            GenTreeHWIntrinsic* hwintrinsic   = data->AsHWIntrinsic();
-            NamedIntrinsic      intrinsicId   = hwintrinsic->GetHWIntrinsicId();
-            size_t              numArgs       = hwintrinsic->GetOperandCount();
-            GenTree*            op1           = hwintrinsic->Op(1);
+            GenTreeHWIntrinsic* hwintrinsic = data->AsHWIntrinsic();
+            NamedIntrinsic      intrinsicId = hwintrinsic->GetHWIntrinsicId();
+            size_t              numArgs     = hwintrinsic->GetOperandCount();
+            GenTree*            op1         = hwintrinsic->Op(1);
 
             if (numArgs == 1)
             {
@@ -3489,10 +3489,10 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
     }
     else if (data->OperIsHWIntrinsic() && data->isContained())
     {
-        GenTreeHWIntrinsic* hwintrinsic   = data->AsHWIntrinsic();
-        NamedIntrinsic      intrinsicId   = hwintrinsic->GetHWIntrinsicId();
-        size_t              numArgs       = hwintrinsic->GetOperandCount();
-        GenTree*            op1           = hwintrinsic->Op(1);
+        GenTreeHWIntrinsic* hwintrinsic = data->AsHWIntrinsic();
+        NamedIntrinsic      intrinsicId = hwintrinsic->GetHWIntrinsicId();
+        size_t              numArgs     = hwintrinsic->GetOperandCount();
+        GenTree*            op1         = hwintrinsic->Op(1);
 
         if (numArgs == 1)
         {
@@ -6213,7 +6213,8 @@ void emitter::emitIns_AR_R(instruction ins, emitAttr attr, regNumber reg, regNum
 //    reg       - The register operand
 //    ival      - The immediate value
 //
-void emitter::emitIns_C_R_I(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fldHnd, int offs, regNumber reg, int ival)
+void emitter::emitIns_C_R_I(
+    instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fldHnd, int offs, regNumber reg, int ival)
 {
     assert(IsSSEOrAVXInstruction(ins));
     assert(reg != REG_NA);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -6280,7 +6280,7 @@ void emitter::emitIns_S_R_I(instruction ins, emitAttr attr, int varNum, int offs
 }
 
 //------------------------------------------------------------------------
-// emitIns_A_R_I: emits the code for an instruction that takes a static member,
+// emitIns_A_R_I: emits the code for an instruction that takes an address,
 //                a register operand, and an immediate.
 //
 // Arguments:

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -375,8 +375,9 @@ void emitIns_R_R_A_I(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, GenTreeIndir* indir, int ival, insFormat fmt);
 void emitIns_R_R_AR_I(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, regNumber base, int offs, int ival);
-void emitIns_S_R_I(instruction ins, emitAttr attr, int varNum, int offs, regNumber reg, int ival);
 
+void emitIns_C_R_I(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fldHnd, int offs, regNumber reg, int ival);
+void emitIns_S_R_I(instruction ins, emitAttr attr, int varNum, int offs, regNumber reg, int ival);
 void emitIns_A_R_I(instruction ins, emitAttr attr, GenTreeIndir* indir, regNumber reg, int imm);
 
 void emitIns_R_R_C_I(

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18638,9 +18638,24 @@ bool GenTree::isContainableHWIntrinsic() const
         case NI_SSE2_LoadVector128:
         case NI_AVX_LoadAlignedVector256:
         case NI_AVX_LoadVector256:
+        {
+            // These loads are contained as part of a HWIntrinsic operation
+            return true;
+        }
+
+        case NI_SSE2_ConvertToInt32:
+        case NI_SSE2_ConvertToUInt32:
+        case NI_SSE2_X64_ConvertToInt64:
+        case NI_SSE2_X64_ConvertToUInt64:
+        case NI_SSE2_Extract:
+        case NI_SSE41_Extract:
+        case NI_SSE41_X64_Extract:
         case NI_AVX_ExtractVector128:
+        case NI_AVX2_ConvertToInt32:
+        case NI_AVX2_ConvertToUInt32:
         case NI_AVX2_ExtractVector128:
         {
+            // These HWIntrinsic operations are contained as part of a store
             return true;
         }
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3130,13 +3130,23 @@ int LinearScan::BuildOperandUses(GenTree* node, regMaskTP candidates)
 #ifdef FEATURE_HW_INTRINSICS
     if (node->OperIsHWIntrinsic())
     {
-        if (node->AsHWIntrinsic()->OperIsMemoryLoad())
+        GenTreeHWIntrinsic* hwintrinsic = node->AsHWIntrinsic();
+
+        if (hwintrinsic->OperIsMemoryLoad())
         {
-            return BuildAddrUses(node->AsHWIntrinsic()->Op(1));
+            return BuildAddrUses(hwintrinsic->Op(1));
         }
 
-        assert(node->AsHWIntrinsic()->GetOperandCount() == 1);
-        BuildUse(node->AsHWIntrinsic()->Op(1), candidates);
+        size_t numArgs = hwintrinsic->GetOperandCount();
+
+        if (numArgs != 1)
+        {
+            assert(numArgs == 2);
+            assert(hwintrinsic->Op(2)->isContained());
+            assert(hwintrinsic->Op(2)->IsCnsIntOrI());
+        }
+
+        BuildUse(hwintrinsic->Op(1), candidates);
         return 1;
     }
 #endif // FEATURE_HW_INTRINSICS


### PR DESCRIPTION
This has some small codegen improvements:

Collection | Base size (bytes) | Diff size (bytes)
-- | -- | --
aspnet.run.windows.x64.checked.mch | 12,242,840 | -481
benchmarks.run.windows.x64.checked.mch | 9,904,411 | -21
coreclr_tests.run.windows.x64.checked.mch | 85,925,020 | -76
libraries.crossgen2.windows.x64.checked.mch | 36,586,987 | -26
libraries.pmi.windows.x64.checked.mch | 51,726,725 | -11
libraries_tests.pmi.windows.x64.checked.mch | 109,755,377 | -5

In the case of `aspnet.run.windows.x64.checked` most of the wins are in `TranscodeToUtf8/16`:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 22814547 (overridden on cmd)
Total bytes of diff: 22814066 (overridden on cmd)
Total bytes of delta: -481 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.

Top file improvements (bytes):
         -28 : 57085.dasm (-1.56 % of base)
         -20 : 62103.dasm (-1.13 % of base)
         -19 : 22470.dasm (-1.00 % of base)
         -16 : 21813.dasm (-0.63 % of base)
         -16 : 22311.dasm (-0.63 % of base)
         -15 : 60840.dasm (-0.65 % of base)
         -15 : 44332.dasm (-0.65 % of base)
         -15 : 62279.dasm (-0.64 % of base)
         -15 : 57391.dasm (-0.63 % of base)
         -15 : 60805.dasm (-0.88 % of base)
         -13 : 22880.dasm (-0.75 % of base)
         -13 : 26249.dasm (-0.52 % of base)
         -13 : 33985.dasm (-0.52 % of base)
          -6 : 34050.dasm (-0.34 % of base)
          -4 : 44083.dasm (-0.14 % of base)
          -4 : 56744.dasm (-0.14 % of base)
          -4 : 21406.dasm (-0.26 % of base)
          -4 : 22341.dasm (-0.28 % of base)
          -4 : 22834.dasm (-0.29 % of base)
          -4 : 26329.dasm (-0.27 % of base)

115 total files with Code Size differences (115 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -28 (-1.56 % of base) : 57085.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
         -20 (-1.13 % of base) : 62103.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
         -19 (-1.00 % of base) : 22470.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -16 (-0.63 % of base) : 21813.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -16 (-0.63 % of base) : 22311.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -15 (-0.65 % of base) : 60840.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -15 (-0.65 % of base) : 44332.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -15 (-0.64 % of base) : 62279.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -15 (-0.63 % of base) : 57391.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -15 (-0.88 % of base) : 60805.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
         -13 (-0.75 % of base) : 22880.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -13 (-0.52 % of base) : 26249.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
         -13 (-0.52 % of base) : 33985.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf16(ulong,int,ulong,int,byref,byref):int
          -6 (-0.34 % of base) : 34050.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
          -4 (-0.14 % of base) : 44083.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
          -4 (-0.14 % of base) : 56744.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
          -4 (-0.26 % of base) : 21406.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
          -4 (-0.28 % of base) : 22341.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
          -4 (-0.29 % of base) : 22834.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int
          -4 (-0.27 % of base) : 26329.dasm - System.Text.Unicode.Utf8Utility:TranscodeToUtf8(ulong,int,ulong,int,byref,byref):int

Top method improvements (percentages):
          -3 (-14.29 % of base) : 44305.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,uint)
          -3 (-14.29 % of base) : 38218.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,uint)
          -3 (-14.29 % of base) : 26209.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,uint)
          -3 (-14.29 % of base) : 32040.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,uint)
          -3 (-14.29 % of base) : 33960.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,uint)
          -3 (-14.29 % of base) : 62271.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,uint)
          -3 (-14.29 % of base) : 57382.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,uint)
          -3 (-14.29 % of base) : 60813.dasm - System.Text.ASCIIUtility:WidenFourAsciiBytesToUtf16AndWriteToBuffer(byref,uint)
          -2 (-10.53 % of base) : 11562.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 56887.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 64435.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 65290.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 44115.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 60675.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 61940.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 15048.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 17460.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 20913.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 21874.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)
          -2 (-10.53 % of base) : 26047.dasm - System.Text.ASCIIUtility:NarrowFourUtf16CharsToAsciiAndWriteToBuffer(byref,ulong)

115 total methods with Code Size differences (115 improved, 0 regressed), 0 unchanged.
```