### PR TITLE
global.json: Bump sdk to 7.0.100-rtm.22476.1 to pick up a msbuild fix 

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -89,7 +89,6 @@ jobs:
         sudo apt-get update &&
         sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates &&
         $(HelixPreCommandsWasmOnLinux) &&
-        export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1 &&
         export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)"
         || export PERF_PREREQS_INSTALL_FAILED=1;
         test "x$PERF_PREREQS_INSTALL_FAILED" = "x1" && echo "** Error: Failed to install prerequites **"

--- a/eng/testing/performance/microbenchmarks.proj
+++ b/eng/testing/performance/microbenchmarks.proj
@@ -34,8 +34,7 @@
     <Python>python3</Python>
     <CoreRun>$(BaseDirectory)/Core_Root/corerun</CoreRun>
     <BaselineCoreRun>$(BaseDirectory)/Baseline_Core_Root/corerun</BaselineCoreRun>
-    <!-- Set DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1 as a workaround for https://github.com/dotnet/runtime/issues/74328 -->
-    <HelixPreCommands>$(HelixPreCommands);chmod +x $(PerformanceDirectory)/tools/machine-setup.sh;. $(PerformanceDirectory)/tools/machine-setup.sh;export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1</HelixPreCommands>
+    <HelixPreCommands>$(HelixPreCommands);chmod +x $(PerformanceDirectory)/tools/machine-setup.sh;. $(PerformanceDirectory)/tools/machine-setup.sh</HelixPreCommands>
     <ArtifactsDirectory>$HELIX_WORKITEM_ROOT/artifacts/BenchmarkDotNet.Artifacts</ArtifactsDirectory>
     <BaselineArtifactsDirectory>$HELIX_WORKITEM_ROOT/artifacts/BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
     <ResultsComparer>$(PerformanceDirectory)/src/tools/ResultsComparer/ResultsComparer.csproj</ResultsComparer>

--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -60,16 +60,12 @@
     <SetScriptCommands Condition="'$(JSEngine)' != ''" Include="export JS_ENGINE=--engine=$(JSEngine)" />
     <SetScriptCommands Condition="'$(JSEngineArgs)' != ''" Include="export JS_ENGINE_ARGS=$(JSEngineArgs)" />
     <SetScriptCommands Condition="'$(_WasmMainJSFileName)' != ''" Include="export MAIN_JS=--js-file=$(_WasmMainJSFileName)" />
-    <!-- Workaround for https://github.com/dotnet/runtime/issues/74328 -->
-    <SetScriptCommands Condition="'$(BuildAOTTestsOnHelix)' == 'true'" Include="export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <SetScriptCommands Condition="'$(Scenario)' != '' and '$(ContinuousIntegrationBuild)' != 'true'" Include="set &quot;SCENARIO=$(Scenario)&quot;" />
     <SetScriptCommands Condition="'$(JSEngine)' != ''" Include="set &quot;JS_ENGINE=--engine^=$(JSEngine)&quot;" />
     <SetScriptCommands Condition="'$(JSEngineArgs)' != ''" Include="set &quot;JS_ENGINE_ARGS=$(JSEngineArgs)&quot;" />
     <SetScriptCommands Condition="'$(_WasmMainJSFileName)' != ''" Include="set &quot;MAIN_JS=--js-file^=$(_WasmMainJSFileName)&quot;" />
-    <!-- Workaround for https://github.com/dotnet/runtime/issues/74328 -->
-    <SetScriptCommands Condition="'$(BuildAOTTestsOnHelix)' == 'true'" Include="set DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "7.0.100-rc.1.22431.11"
+    "dotnet": "7.0.100-rtm.22476.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22457.4",

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "7.0.100-rtm.22476.1",
+    "version": "7.0.100-rtm.22478.12",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "7.0.100-rtm.22476.1"
+    "dotnet": "7.0.100-rtm.22478.12"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22457.4",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.1.22431.11",
+    "version": "7.0.100-rtm.22476.1",
     "allowPrerelease": true,
     "rollForward": "major"
   },

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildEnvironment.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildEnvironment.cs
@@ -117,12 +117,6 @@ namespace Wasm.Build.Tests
             // helps with debugging
             EnvVars["WasmNativeStrip"] = "false";
 
-            // Works around an issue in msbuild due to which
-            // second, and subsequent builds fail without any details
-            // in the logs
-            EnvVars["DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER"] = "1";
-            DefaultBuildArgs += " /nr:false";
-
             if (OperatingSystem.IsWindows())
             {
                 EnvVars["WasmCachePath"] = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -515,7 +515,6 @@ namespace Wasm.Build.Tests
                 $"-bl:{logPath}",
                 $"-p:Configuration={config}",
                 "-p:BlazorEnableCompression=false",
-                "-nr:false",
                 setWasmDevel ? "-p:_WasmDevel=true" : string.Empty
             }.Concat(extraArgs).ToArray();
 

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/DotNetCommand.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/DotNetCommand.cs
@@ -16,8 +16,6 @@ namespace Wasm.Build.Tests
             _useDefaultArgs = useDefaultArgs;
             if (useDefaultArgs)
                 WithEnvironmentVariables(buildEnv.EnvVars);
-            // workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
-            WithEnvironmentVariable("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER", "1");
         }
 
         protected override string GetFullArgs(params string[] args)

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/RunCommand.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/RunCommand.cs
@@ -14,7 +14,5 @@ public class RunCommand : DotNetCommand
         WithEnvironmentVariable("DOTNET_INSTALL_DIR", Path.GetDirectoryName(buildEnv.DotNet)!);
         WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0");
         WithEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
-        // workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
-        WithEnvironmentVariable("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER", "1");
     }
 }

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -286,9 +286,6 @@ else
   __Command+=" dotnet"
 fi
 
-# workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
-export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
-
 $__Command msbuild $CORE_ROOT/wasm-test-runner/WasmTestRunner.proj /p:NetCoreAppCurrent=$(NetCoreAppCurrent) /p:TestAssemblyFileName=$(MsBuildProjectName).dll /p:TestBinDir=`pwd` $(CLRTestMSBuildArgs) || exit $?
 
    ]]>


### PR DESCRIPTION
And remove the workarounds