### PR TITLE
[release/7.0] Do not run DynamicGenerics on mac (#74618)

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -921,7 +921,14 @@
         </ExcludeList>
     </ItemGroup>
 
-      <!-- NativeAOT specific -->
+    <!-- All OSX targets on NativeAOT -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsOSX)' == 'true' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr' ">
+        <ExcludeList Include="$(XunitTestBinBase)/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics/*">
+            <Issue>https://github.com/dotnet/runtime/issues/73299</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
+    <!-- NativeAOT specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TestBuildMode)' == 'nativeaot' and '$(RuntimeFlavor)' == 'coreclr'">
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/NegativeTestCases/**">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Compatible TypeLoadException for invalid inputs</Issue>


### PR DESCRIPTION
Test-only change. Port #74618 to release/7.0. 

Disabling intermittently failing native AOT test for macOS. macOS is not supported native aot platform for .NET 7.0. 

Fixes #73299