### PR TITLE
[release/7.0] WasmAppHost: Fix crash when starting wasmbrowser project

### DIFF
--- a/src/mono/wasm/host/WebServer.cs
+++ b/src/mono/wasm/host/WebServer.cs
@@ -16,7 +16,7 @@ public class WebServer
 {
     internal static async Task<(ServerURLs, IWebHost)> StartAsync(WebServerOptions options, ILogger logger, CancellationToken token)
     {
-        string[]? urls = new string[] { $"http://127.0.0.1:{options.Port}", "https://127.0.0.1:0" };
+        string[] urls = options.Urls;
         TaskCompletionSource<ServerURLs> realUrlsAvailableTcs = new();
 
         IWebHostBuilder builder = new WebHostBuilder()

--- a/src/mono/wasm/host/WebServer.cs
+++ b/src/mono/wasm/host/WebServer.cs
@@ -1,13 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -21,6 +17,7 @@ public class WebServer
     internal static async Task<(ServerURLs, IWebHost)> StartAsync(WebServerOptions options, ILogger logger, CancellationToken token)
     {
         string[]? urls = new string[] { $"http://127.0.0.1:{options.Port}", "https://127.0.0.1:0" };
+        TaskCompletionSource<ServerURLs> realUrlsAvailableTcs = new();
 
         IWebHostBuilder builder = new WebHostBuilder()
             .UseKestrel()
@@ -43,6 +40,7 @@ public class WebServer
                 }
                 services.AddSingleton(logger);
                 services.AddSingleton(Options.Create(options));
+                services.AddSingleton(realUrlsAvailableTcs);
                 services.AddRouting();
             })
             .UseUrls(urls);
@@ -53,27 +51,11 @@ public class WebServer
         IWebHost? host = builder.Build();
         await host.StartAsync(token);
 
-        ICollection<string>? addresses = host.ServerFeatures
-                            .Get<IServerAddressesFeature>()?
-                            .Addresses;
+        if (token.CanBeCanceled)
+            token.Register(async () => await host.StopAsync());
 
-        string? ipAddress =
-                        addresses?
-                        .Where(a => a.StartsWith("http:", StringComparison.InvariantCultureIgnoreCase))
-                        .Select(a => new Uri(a))
-                        .Select(uri => uri.ToString())
-                        .FirstOrDefault();
-
-        string? ipAddressSecure =
-                        addresses?
-                        .Where(a => a.StartsWith("https:", StringComparison.OrdinalIgnoreCase))
-                        .Select(a => new Uri(a))
-                        .Select(uri => uri.ToString())
-                        .FirstOrDefault();
-
-        return ipAddress == null || ipAddressSecure == null
-            ? throw new InvalidOperationException("Failed to determine web server's IP address or port")
-            : (new ServerURLs(ipAddress, ipAddressSecure), host);
+        ServerURLs serverUrls = await realUrlsAvailableTcs.Task;
+        return (serverUrls, host);
     }
 
 }

--- a/src/mono/wasm/host/WebServerStartup.cs
+++ b/src/mono/wasm/host/WebServerStartup.cs
@@ -1,12 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using System.Net.WebSockets;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 #nullable enable
@@ -16,11 +23,17 @@ namespace Microsoft.WebAssembly.AppHost;
 internal sealed class WebServerStartup
 {
     private readonly IWebHostEnvironment _hostingEnvironment;
+    private ILogger? _logger;
 
     public WebServerStartup(IWebHostEnvironment hostingEnvironment) => _hostingEnvironment = hostingEnvironment;
 
-    public void Configure(IApplicationBuilder app, IOptions<WebServerOptions> optionsContainer)
+    public void Configure(IApplicationBuilder app,
+                          IOptions<WebServerOptions> optionsContainer,
+                          TaskCompletionSource<ServerURLs> realUrlsAvailableTcs,
+                          ILogger logger,
+                          IHostApplicationLifetime applicationLifetime)
     {
+        _logger = logger;
         var provider = new FileExtensionContentTypeProvider();
         provider.Mappings[".wasm"] = "application/wasm";
         provider.Mappings[".cjs"] = "text/javascript";
@@ -72,6 +85,43 @@ internal sealed class WebServerStartup
                 });
             });
         }
+
+        applicationLifetime.ApplicationStarted.Register(() =>
+        {
+            TaskCompletionSource<ServerURLs> tcs = realUrlsAvailableTcs;
+            try
+            {
+                ICollection<string>? addresses = app.ServerFeatures
+                                                    .Get<IServerAddressesFeature>()
+                                                    ?.Addresses;
+
+                string? ipAddress = null;
+                string? ipAddressSecure = null;
+                if (addresses is not null)
+                {
+                    ipAddress = GetHttpServerAddress(addresses, secure: false);
+                    ipAddressSecure = GetHttpServerAddress(addresses, secure: true);
+                }
+
+                if (ipAddress == null)
+                    tcs.SetException(new InvalidOperationException("Failed to determine web server's IP address or port"));
+                else
+                    tcs.SetResult(new ServerURLs(ipAddress, ipAddressSecure));
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError($"Failed to get urls for the webserver: {ex}");
+                tcs.TrySetException(ex);
+                throw;
+            }
+
+            static string? GetHttpServerAddress(ICollection<string> addresses, bool secure)
+                => addresses?
+                        .Where(a => a.StartsWith(secure ? "https:" : "http:", StringComparison.InvariantCultureIgnoreCase))
+                        .Select(a => new Uri(a))
+                        .Select(uri => uri.ToString())
+                        .FirstOrDefault();
+        });
 
         // app.UseEndpoints(endpoints =>
         // {

--- a/src/mono/wasm/host/WebServerStartup.cs
+++ b/src/mono/wasm/host/WebServerStartup.cs
@@ -158,7 +158,6 @@ internal sealed class WebServerStartup
 
         applicationLifetime.ApplicationStarted.Register(() =>
         {
-            TaskCompletionSource<ServerURLs> tcs = realUrlsAvailableTcs;
             try
             {
                 ICollection<string>? addresses = app.ServerFeatures
@@ -174,14 +173,14 @@ internal sealed class WebServerStartup
                 }
 
                 if (ipAddress == null)
-                    tcs.SetException(new InvalidOperationException("Failed to determine web server's IP address or port"));
+                    realUrlsAvailableTcs.SetException(new InvalidOperationException("Failed to determine web server's IP address or port"));
                 else
-                    tcs.SetResult(new ServerURLs(ipAddress, ipAddressSecure));
+                    realUrlsAvailableTcs.SetResult(new ServerURLs(ipAddress, ipAddressSecure));
             }
             catch (Exception ex)
             {
                 _logger?.LogError($"Failed to get urls for the webserver: {ex}");
-                tcs.TrySetException(ex);
+                realUrlsAvailableTcs.TrySetException(ex);
                 throw;
             }
 


### PR DESCRIPTION
/cc @lewing @thaystg @pavelsavara 

## Customer impact

On 7.0, we created a new template to create a wasm browser app without using blazor, but running it would crash because we try to read the web server addresses right after `await host.StartAsync`, but they might not be available at that time. Instead, we now read the addresses in response to the `ApplicationStarted` event.

This could fail like:
```
WasmAppHost --runtime-config /tmp/cc/bin/Debug/net7.0/browser-wasm/AppBundle/cc.runtimeconfig.json --forward-console
Unhandled exception. System.InvalidOperationException: Failed to determine web server's IP address or port
   at Microsoft.WebAssembly.AppHost.WebServer.StartAsync(WebServerOptions options, ILogger logger, CancellationToken token)
   at Microsoft.WebAssembly.AppHost.BrowserHost.StartWebServerAsync(String appPath, Boolean forwardConsole, String[] urls, CancellationToken token)
   at Microsoft.WebAssembly.AppHost.BrowserHost.RunAsync(ILoggerFactory loggerFactory, CancellationToken token)
   at Microsoft.WebAssembly.AppHost.BrowserHost.InvokeAsync(CommonConfiguration commonArgs, ILoggerFactory loggerFactory, ILogger logger, CancellationToken token)
   at Microsoft.WebAssembly.AppHost.WasmAppHost.Main(String[] args)
   at Microsoft.WebAssembly.AppHost.WasmAppHost.<Main>(String[] args)
```

## Testing

Unit tests with workloads, and manual testing.

## Risk

Low risk, prevents a crash.