### PR TITLE
SPMI: Improve speed significantly for large diffs

### DIFF
--- a/src/coreclr/inc/clr_std/vector
+++ b/src/coreclr/inc/clr_std/vector
@@ -225,7 +225,6 @@ namespace std
                 , m_isBufferOwner(v.m_isBufferOwner)
             {
                 v.m_isBufferOwner = false;
-                return *this;
             }
 
             vector<T>& operator=(vector<T>&& v) noexcept

--- a/src/coreclr/inc/clr_std/vector
+++ b/src/coreclr/inc/clr_std/vector
@@ -215,6 +215,34 @@ namespace std
                 }
             }
 
+            vector(const vector<T>&) = delete;
+            vector<T>& operator=(const vector<T>&) = delete;
+
+            vector(vector<T>&& v) noexcept
+                : m_size(v.m_size)
+                , m_capacity(v.m_capacity)
+                , m_pelements(v.m_pelements)
+                , m_isBufferOwner(v.m_isBufferOwner)
+            {
+                v.m_isBufferOwner = false;
+                return *this;
+            }
+
+            vector<T>& operator=(vector<T>&& v) noexcept
+            {
+                if (m_isBufferOwner)
+                {
+                    erase(m_pelements, 0, m_size);
+                    delete [] (BYTE*)m_pelements;
+                }
+
+                m_size = v.m_size;
+                m_capacity = v.m_capacity;
+                m_pelements = v.m_pelements;
+                m_isBufferOwner = v.m_isBufferOwner;
+                v.m_isBufferOwner = false;
+                return *this;
+            }
 
             size_t size() const
             {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1696,9 +1696,13 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
         //
         JITDUMP("  [%06u] -> #%d", expensiveArg->GetNode()->gtTreeID, begTab);
         if (argsRemaining == 1)
+        {
             JITDUMP(" (last arg)\n");
+        }
         else
+        {
             JITDUMP(" (cost %u)\n", expensiveArgCost);
+        }
 
         if (expensiveArgIndex != begTab)
         {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1279,12 +1279,12 @@ static regMaskTP EstimateRegisterUses(Compiler* comp, GenTree* tree)
             LclVarDsc*           desc = m_compiler->lvaGetDesc(node);
             if (!desc->lvDoNotEnregister && desc->lvIsRegArg)
             {
-                if (desc->GetArgReg() != REG_NA)
+                if ((desc->GetArgReg() != REG_NA) && (desc->GetArgReg() != REG_STK))
                 {
                     Registers |= genRegMask(desc->GetArgReg());
                 }
 #if FEATURE_MULTIREG_ARGS
-                if (desc->GetOtherArgReg() != REG_NA)
+                if ((desc->GetOtherArgReg() != REG_NA) && (desc->GetOtherArgReg() != REG_STK))
                 {
                     Registers |= genRegMask(desc->GetOtherArgReg());
                 }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1298,17 +1298,17 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
     }
 
     //// Set the beginning and end for the new argument table
-    //unsigned curInx;
-    //int      regCount      = 0;
-    //unsigned begTab        = 0;
-    //unsigned endTab        = argCount - 1;
-    //unsigned argsRemaining = argCount;
+    // unsigned curInx;
+    // int      regCount      = 0;
+    // unsigned begTab        = 0;
+    // unsigned endTab        = argCount - 1;
+    // unsigned argsRemaining = argCount;
 
     //// First take care of arguments that are constants.
     //// [We use a backward iterator pattern]
     ////
-    //curInx = argCount;
-    //do
+    // curInx = argCount;
+    // do
     //{
     //    curInx--;
 
@@ -1350,7 +1350,7 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
     //    }
     //} while (curInx > 0);
 
-    //if (argsRemaining > 0)
+    // if (argsRemaining > 0)
     //{
     //    // Next take care of arguments that are calls.
     //    // [We use a forward iterator pattern]
@@ -1387,7 +1387,7 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
     //    }
     //}
 
-    //if (argsRemaining > 0)
+    // if (argsRemaining > 0)
     //{
     //    // Next take care arguments that are temps.
     //    // These temps come before the arguments that are
@@ -1423,7 +1423,7 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
     //    }
     //}
 
-    //if (argsRemaining > 0)
+    // if (argsRemaining > 0)
     //{
     //    // Next take care of local var and local field arguments.
     //    // These are moved towards the end of the argument evaluation.
@@ -1467,8 +1467,8 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
 
     //// Finally, take care of all the remaining arguments.
     //// Note that we fill in one arg at a time using a while loop.
-    //bool costsPrepared = false; // Only prepare tree costs once, the first time through this loop
-    //while (argsRemaining > 0)
+    // bool costsPrepared = false; // Only prepare tree costs once, the first time through this loop
+    // while (argsRemaining > 0)
     //{
     //    /* Find the most expensive arg remaining and evaluate it next */
 
@@ -1545,8 +1545,8 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
 
     //// The table should now be completely filled and thus begTab should now be adjacent to endTab
     //// and regArgsRemaining should be zero
-    //assert(begTab == (endTab + 1));
-    //assert(argsRemaining == 0);
+    // assert(begTab == (endTab + 1));
+    // assert(argsRemaining == 0);
 }
 
 //------------------------------------------------------------------------------

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1297,256 +1297,256 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
         sortedArgs[argCount++] = &arg;
     }
 
-    //// Set the beginning and end for the new argument table
-    // unsigned curInx;
-    // int      regCount      = 0;
-    // unsigned begTab        = 0;
-    // unsigned endTab        = argCount - 1;
-    // unsigned argsRemaining = argCount;
+    // Set the beginning and end for the new argument table
+    unsigned curInx;
+    int      regCount      = 0;
+    unsigned begTab        = 0;
+    unsigned endTab        = argCount - 1;
+    unsigned argsRemaining = argCount;
 
-    //// First take care of arguments that are constants.
-    //// [We use a backward iterator pattern]
-    ////
-    // curInx = argCount;
-    // do
-    //{
-    //    curInx--;
+    // First take care of arguments that are constants.
+    // [We use a backward iterator pattern]
+    //
+    curInx = argCount;
+    do
+    {
+        curInx--;
 
-    //    CallArg* arg = sortedArgs[curInx];
+        CallArg* arg = sortedArgs[curInx];
 
-    //    if (arg->AbiInfo.GetRegNum() != REG_STK)
-    //    {
-    //        regCount++;
-    //    }
+        if (arg->AbiInfo.GetRegNum() != REG_STK)
+        {
+            regCount++;
+        }
 
-    //    assert(arg->GetLateNode() == nullptr);
+        assert(arg->GetLateNode() == nullptr);
 
-    //    // Skip any already processed args
-    //    //
-    //    if (!arg->m_processed)
-    //    {
-    //        GenTree* argx = arg->GetEarlyNode();
+        // Skip any already processed args
+        //
+        if (!arg->m_processed)
+        {
+            GenTree* argx = arg->GetEarlyNode();
 
-    //        assert(argx != nullptr);
-    //        // put constants at the end of the table
-    //        //
-    //        if (argx->gtOper == GT_CNS_INT)
-    //        {
-    //            noway_assert(curInx <= endTab);
+            assert(argx != nullptr);
+            // put constants at the end of the table
+            //
+            if (argx->gtOper == GT_CNS_INT)
+            {
+                noway_assert(curInx <= endTab);
 
-    //            arg->m_processed = true;
+                arg->m_processed = true;
 
-    //            // place curArgTabEntry at the endTab position by performing a swap
-    //            //
-    //            if (curInx != endTab)
-    //            {
-    //                sortedArgs[curInx] = sortedArgs[endTab];
-    //                sortedArgs[endTab] = arg;
-    //            }
+                // place curArgTabEntry at the endTab position by performing a swap
+                //
+                if (curInx != endTab)
+                {
+                    sortedArgs[curInx] = sortedArgs[endTab];
+                    sortedArgs[endTab] = arg;
+                }
 
-    //            endTab--;
-    //            argsRemaining--;
-    //        }
-    //    }
-    //} while (curInx > 0);
+                endTab--;
+                argsRemaining--;
+            }
+        }
+    } while (curInx > 0);
 
-    // if (argsRemaining > 0)
-    //{
-    //    // Next take care of arguments that are calls.
-    //    // [We use a forward iterator pattern]
-    //    //
-    //    for (curInx = begTab; curInx <= endTab; curInx++)
-    //    {
-    //        CallArg* arg = sortedArgs[curInx];
+    if (argsRemaining > 0)
+    {
+        // Next take care of arguments that are calls.
+        // [We use a forward iterator pattern]
+        //
+        for (curInx = begTab; curInx <= endTab; curInx++)
+        {
+            CallArg* arg = sortedArgs[curInx];
 
-    //        // Skip any already processed args
-    //        //
-    //        if (!arg->m_processed)
-    //        {
-    //            GenTree* argx = arg->GetEarlyNode();
-    //            assert(argx != nullptr);
+            // Skip any already processed args
+            //
+            if (!arg->m_processed)
+            {
+                GenTree* argx = arg->GetEarlyNode();
+                assert(argx != nullptr);
 
-    //            // put calls at the beginning of the table
-    //            //
-    //            if (argx->gtFlags & GTF_CALL)
-    //            {
-    //                arg->m_processed = true;
+                // put calls at the beginning of the table
+                //
+                if (argx->gtFlags & GTF_CALL)
+                {
+                    arg->m_processed = true;
 
-    //                // place curArgTabEntry at the begTab position by performing a swap
-    //                //
-    //                if (curInx != begTab)
-    //                {
-    //                    sortedArgs[curInx] = sortedArgs[begTab];
-    //                    sortedArgs[begTab] = arg;
-    //                }
+                    // place curArgTabEntry at the begTab position by performing a swap
+                    //
+                    if (curInx != begTab)
+                    {
+                        sortedArgs[curInx] = sortedArgs[begTab];
+                        sortedArgs[begTab] = arg;
+                    }
 
-    //                begTab++;
-    //                argsRemaining--;
-    //            }
-    //        }
-    //    }
-    //}
+                    begTab++;
+                    argsRemaining--;
+                }
+            }
+        }
+    }
 
-    // if (argsRemaining > 0)
-    //{
-    //    // Next take care arguments that are temps.
-    //    // These temps come before the arguments that are
-    //    // ordinary local vars or local fields
-    //    // since this will give them a better chance to become
-    //    // enregistered into their actual argument register.
-    //    // [We use a forward iterator pattern]
-    //    //
-    //    for (curInx = begTab; curInx <= endTab; curInx++)
-    //    {
-    //        CallArg* arg = sortedArgs[curInx];
+    if (argsRemaining > 0)
+    {
+        // Next take care arguments that are temps.
+        // These temps come before the arguments that are
+        // ordinary local vars or local fields
+        // since this will give them a better chance to become
+        // enregistered into their actual argument register.
+        // [We use a forward iterator pattern]
+        //
+        for (curInx = begTab; curInx <= endTab; curInx++)
+        {
+            CallArg* arg = sortedArgs[curInx];
 
-    //        // Skip any already processed args
-    //        //
-    //        if (!arg->m_processed)
-    //        {
-    //            if (arg->m_needTmp)
-    //            {
-    //                arg->m_processed = true;
+            // Skip any already processed args
+            //
+            if (!arg->m_processed)
+            {
+                if (arg->m_needTmp)
+                {
+                    arg->m_processed = true;
 
-    //                // place curArgTabEntry at the begTab position by performing a swap
-    //                //
-    //                if (curInx != begTab)
-    //                {
-    //                    sortedArgs[curInx] = sortedArgs[begTab];
-    //                    sortedArgs[begTab] = arg;
-    //                }
+                    // place curArgTabEntry at the begTab position by performing a swap
+                    //
+                    if (curInx != begTab)
+                    {
+                        sortedArgs[curInx] = sortedArgs[begTab];
+                        sortedArgs[begTab] = arg;
+                    }
 
-    //                begTab++;
-    //                argsRemaining--;
-    //            }
-    //        }
-    //    }
-    //}
+                    begTab++;
+                    argsRemaining--;
+                }
+            }
+        }
+    }
 
-    // if (argsRemaining > 0)
-    //{
-    //    // Next take care of local var and local field arguments.
-    //    // These are moved towards the end of the argument evaluation.
-    //    // [We use a backward iterator pattern]
-    //    //
-    //    curInx = endTab + 1;
-    //    do
-    //    {
-    //        curInx--;
+    if (argsRemaining > 0)
+    {
+        // Next take care of local var and local field arguments.
+        // These are moved towards the end of the argument evaluation.
+        // [We use a backward iterator pattern]
+        //
+        curInx = endTab + 1;
+        do
+        {
+            curInx--;
 
-    //        CallArg* arg = sortedArgs[curInx];
+            CallArg* arg = sortedArgs[curInx];
 
-    //        // Skip any already processed args
-    //        //
-    //        if (!arg->m_processed)
-    //        {
-    //            GenTree* argx = arg->GetEarlyNode();
-    //            assert(argx != nullptr);
+            // Skip any already processed args
+            //
+            if (!arg->m_processed)
+            {
+                GenTree* argx = arg->GetEarlyNode();
+                assert(argx != nullptr);
 
-    //            // As a CQ heuristic, sort TYP_STRUCT args using the cost estimation below.
-    //            if (!argx->TypeIs(TYP_STRUCT) && argx->OperIs(GT_LCL_VAR, GT_LCL_FLD))
-    //            {
-    //                noway_assert(curInx <= endTab);
+                // As a CQ heuristic, sort TYP_STRUCT args using the cost estimation below.
+                if (!argx->TypeIs(TYP_STRUCT) && argx->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+                {
+                    noway_assert(curInx <= endTab);
 
-    //                arg->m_processed = true;
+                    arg->m_processed = true;
 
-    //                // place curArgTabEntry at the endTab position by performing a swap
-    //                //
-    //                if (curInx != endTab)
-    //                {
-    //                    sortedArgs[curInx] = sortedArgs[endTab];
-    //                    sortedArgs[endTab] = arg;
-    //                }
+                    // place curArgTabEntry at the endTab position by performing a swap
+                    //
+                    if (curInx != endTab)
+                    {
+                        sortedArgs[curInx] = sortedArgs[endTab];
+                        sortedArgs[endTab] = arg;
+                    }
 
-    //                endTab--;
-    //                argsRemaining--;
-    //            }
-    //        }
-    //    } while (curInx > begTab);
-    //}
+                    endTab--;
+                    argsRemaining--;
+                }
+            }
+        } while (curInx > begTab);
+    }
 
-    //// Finally, take care of all the remaining arguments.
-    //// Note that we fill in one arg at a time using a while loop.
-    // bool costsPrepared = false; // Only prepare tree costs once, the first time through this loop
-    // while (argsRemaining > 0)
-    //{
-    //    /* Find the most expensive arg remaining and evaluate it next */
+    // Finally, take care of all the remaining arguments.
+    // Note that we fill in one arg at a time using a while loop.
+    bool costsPrepared = false; // Only prepare tree costs once, the first time through this loop
+    while (argsRemaining > 0)
+    {
+        /* Find the most expensive arg remaining and evaluate it next */
 
-    //    CallArg* expensiveArg      = nullptr;
-    //    unsigned expensiveArgIndex = UINT_MAX;
-    //    unsigned expensiveArgCost  = 0;
+        CallArg* expensiveArg      = nullptr;
+        unsigned expensiveArgIndex = UINT_MAX;
+        unsigned expensiveArgCost  = 0;
 
-    //    // [We use a forward iterator pattern]
-    //    //
-    //    for (curInx = begTab; curInx <= endTab; curInx++)
-    //    {
-    //        CallArg* arg = sortedArgs[curInx];
+        // [We use a forward iterator pattern]
+        //
+        for (curInx = begTab; curInx <= endTab; curInx++)
+        {
+            CallArg* arg = sortedArgs[curInx];
 
-    //        // Skip any already processed args
-    //        //
-    //        if (!arg->m_processed)
-    //        {
-    //            GenTree* argx = arg->GetEarlyNode();
-    //            assert(argx != nullptr);
+            // Skip any already processed args
+            //
+            if (!arg->m_processed)
+            {
+                GenTree* argx = arg->GetEarlyNode();
+                assert(argx != nullptr);
 
-    //            // We should have already handled these kinds of args
-    //            assert((!argx->OperIs(GT_LCL_VAR, GT_LCL_FLD) || argx->TypeIs(TYP_STRUCT)) &&
-    //                   !argx->OperIs(GT_CNS_INT));
+                // We should have already handled these kinds of args
+                assert((!argx->OperIs(GT_LCL_VAR, GT_LCL_FLD) || argx->TypeIs(TYP_STRUCT)) &&
+                       !argx->OperIs(GT_CNS_INT));
 
-    //            // This arg should either have no persistent side effects or be the last one in our table
-    //            // assert(((argx->gtFlags & GTF_PERSISTENT_SIDE_EFFECTS) == 0) || (curInx == (argCount-1)));
+                // This arg should either have no persistent side effects or be the last one in our table
+                // assert(((argx->gtFlags & GTF_PERSISTENT_SIDE_EFFECTS) == 0) || (curInx == (argCount-1)));
 
-    //            if (argsRemaining == 1)
-    //            {
-    //                // This is the last arg to place
-    //                expensiveArgIndex = curInx;
-    //                expensiveArg      = arg;
-    //                assert(begTab == endTab);
-    //                break;
-    //            }
-    //            else
-    //            {
-    //                if (!costsPrepared)
-    //                {
-    //                    /* We call gtPrepareCost to measure the cost of evaluating this tree */
-    //                    comp->gtPrepareCost(argx);
-    //                }
+                if (argsRemaining == 1)
+                {
+                    // This is the last arg to place
+                    expensiveArgIndex = curInx;
+                    expensiveArg      = arg;
+                    assert(begTab == endTab);
+                    break;
+                }
+                else
+                {
+                    if (!costsPrepared)
+                    {
+                        /* We call gtPrepareCost to measure the cost of evaluating this tree */
+                        comp->gtPrepareCost(argx);
+                    }
 
-    //                if (argx->GetCostEx() > expensiveArgCost)
-    //                {
-    //                    // Remember this arg as the most expensive one that we have yet seen
-    //                    expensiveArgCost  = argx->GetCostEx();
-    //                    expensiveArgIndex = curInx;
-    //                    expensiveArg      = arg;
-    //                }
-    //            }
-    //        }
-    //    }
+                    if (argx->GetCostEx() > expensiveArgCost)
+                    {
+                        // Remember this arg as the most expensive one that we have yet seen
+                        expensiveArgCost  = argx->GetCostEx();
+                        expensiveArgIndex = curInx;
+                        expensiveArg      = arg;
+                    }
+                }
+            }
+        }
 
-    //    noway_assert(expensiveArgIndex != UINT_MAX);
+        noway_assert(expensiveArgIndex != UINT_MAX);
 
-    //    // put the most expensive arg towards the beginning of the table
+        // put the most expensive arg towards the beginning of the table
 
-    //    expensiveArg->m_processed = true;
+        expensiveArg->m_processed = true;
 
-    //    // place expensiveArgTabEntry at the begTab position by performing a swap
-    //    //
-    //    if (expensiveArgIndex != begTab)
-    //    {
-    //        sortedArgs[expensiveArgIndex] = sortedArgs[begTab];
-    //        sortedArgs[begTab]            = expensiveArg;
-    //    }
+        // place expensiveArgTabEntry at the begTab position by performing a swap
+        //
+        if (expensiveArgIndex != begTab)
+        {
+            sortedArgs[expensiveArgIndex] = sortedArgs[begTab];
+            sortedArgs[begTab]            = expensiveArg;
+        }
 
-    //    begTab++;
-    //    argsRemaining--;
+        begTab++;
+        argsRemaining--;
 
-    //    costsPrepared = true; // If we have more expensive arguments, don't re-evaluate the tree cost on the next loop
-    //}
+        costsPrepared = true; // If we have more expensive arguments, don't re-evaluate the tree cost on the next loop
+    }
 
-    //// The table should now be completely filled and thus begTab should now be adjacent to endTab
-    //// and regArgsRemaining should be zero
-    // assert(begTab == (endTab + 1));
-    // assert(argsRemaining == 0);
+    // The table should now be completely filled and thus begTab should now be adjacent to endTab
+    // and regArgsRemaining should be zero
+    assert(begTab == (endTab + 1));
+    assert(argsRemaining == 0);
 }
 
 //------------------------------------------------------------------------------

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1297,256 +1297,256 @@ void CallArgs::SortArgs(Compiler* comp, GenTreeCall* call, CallArg** sortedArgs)
         sortedArgs[argCount++] = &arg;
     }
 
-    // Set the beginning and end for the new argument table
-    unsigned curInx;
-    int      regCount      = 0;
-    unsigned begTab        = 0;
-    unsigned endTab        = argCount - 1;
-    unsigned argsRemaining = argCount;
+    //// Set the beginning and end for the new argument table
+    //unsigned curInx;
+    //int      regCount      = 0;
+    //unsigned begTab        = 0;
+    //unsigned endTab        = argCount - 1;
+    //unsigned argsRemaining = argCount;
 
-    // First take care of arguments that are constants.
-    // [We use a backward iterator pattern]
-    //
-    curInx = argCount;
-    do
-    {
-        curInx--;
+    //// First take care of arguments that are constants.
+    //// [We use a backward iterator pattern]
+    ////
+    //curInx = argCount;
+    //do
+    //{
+    //    curInx--;
 
-        CallArg* arg = sortedArgs[curInx];
+    //    CallArg* arg = sortedArgs[curInx];
 
-        if (arg->AbiInfo.GetRegNum() != REG_STK)
-        {
-            regCount++;
-        }
+    //    if (arg->AbiInfo.GetRegNum() != REG_STK)
+    //    {
+    //        regCount++;
+    //    }
 
-        assert(arg->GetLateNode() == nullptr);
+    //    assert(arg->GetLateNode() == nullptr);
 
-        // Skip any already processed args
-        //
-        if (!arg->m_processed)
-        {
-            GenTree* argx = arg->GetEarlyNode();
+    //    // Skip any already processed args
+    //    //
+    //    if (!arg->m_processed)
+    //    {
+    //        GenTree* argx = arg->GetEarlyNode();
 
-            assert(argx != nullptr);
-            // put constants at the end of the table
-            //
-            if (argx->gtOper == GT_CNS_INT)
-            {
-                noway_assert(curInx <= endTab);
+    //        assert(argx != nullptr);
+    //        // put constants at the end of the table
+    //        //
+    //        if (argx->gtOper == GT_CNS_INT)
+    //        {
+    //            noway_assert(curInx <= endTab);
 
-                arg->m_processed = true;
+    //            arg->m_processed = true;
 
-                // place curArgTabEntry at the endTab position by performing a swap
-                //
-                if (curInx != endTab)
-                {
-                    sortedArgs[curInx] = sortedArgs[endTab];
-                    sortedArgs[endTab] = arg;
-                }
+    //            // place curArgTabEntry at the endTab position by performing a swap
+    //            //
+    //            if (curInx != endTab)
+    //            {
+    //                sortedArgs[curInx] = sortedArgs[endTab];
+    //                sortedArgs[endTab] = arg;
+    //            }
 
-                endTab--;
-                argsRemaining--;
-            }
-        }
-    } while (curInx > 0);
+    //            endTab--;
+    //            argsRemaining--;
+    //        }
+    //    }
+    //} while (curInx > 0);
 
-    if (argsRemaining > 0)
-    {
-        // Next take care of arguments that are calls.
-        // [We use a forward iterator pattern]
-        //
-        for (curInx = begTab; curInx <= endTab; curInx++)
-        {
-            CallArg* arg = sortedArgs[curInx];
+    //if (argsRemaining > 0)
+    //{
+    //    // Next take care of arguments that are calls.
+    //    // [We use a forward iterator pattern]
+    //    //
+    //    for (curInx = begTab; curInx <= endTab; curInx++)
+    //    {
+    //        CallArg* arg = sortedArgs[curInx];
 
-            // Skip any already processed args
-            //
-            if (!arg->m_processed)
-            {
-                GenTree* argx = arg->GetEarlyNode();
-                assert(argx != nullptr);
+    //        // Skip any already processed args
+    //        //
+    //        if (!arg->m_processed)
+    //        {
+    //            GenTree* argx = arg->GetEarlyNode();
+    //            assert(argx != nullptr);
 
-                // put calls at the beginning of the table
-                //
-                if (argx->gtFlags & GTF_CALL)
-                {
-                    arg->m_processed = true;
+    //            // put calls at the beginning of the table
+    //            //
+    //            if (argx->gtFlags & GTF_CALL)
+    //            {
+    //                arg->m_processed = true;
 
-                    // place curArgTabEntry at the begTab position by performing a swap
-                    //
-                    if (curInx != begTab)
-                    {
-                        sortedArgs[curInx] = sortedArgs[begTab];
-                        sortedArgs[begTab] = arg;
-                    }
+    //                // place curArgTabEntry at the begTab position by performing a swap
+    //                //
+    //                if (curInx != begTab)
+    //                {
+    //                    sortedArgs[curInx] = sortedArgs[begTab];
+    //                    sortedArgs[begTab] = arg;
+    //                }
 
-                    begTab++;
-                    argsRemaining--;
-                }
-            }
-        }
-    }
+    //                begTab++;
+    //                argsRemaining--;
+    //            }
+    //        }
+    //    }
+    //}
 
-    if (argsRemaining > 0)
-    {
-        // Next take care arguments that are temps.
-        // These temps come before the arguments that are
-        // ordinary local vars or local fields
-        // since this will give them a better chance to become
-        // enregistered into their actual argument register.
-        // [We use a forward iterator pattern]
-        //
-        for (curInx = begTab; curInx <= endTab; curInx++)
-        {
-            CallArg* arg = sortedArgs[curInx];
+    //if (argsRemaining > 0)
+    //{
+    //    // Next take care arguments that are temps.
+    //    // These temps come before the arguments that are
+    //    // ordinary local vars or local fields
+    //    // since this will give them a better chance to become
+    //    // enregistered into their actual argument register.
+    //    // [We use a forward iterator pattern]
+    //    //
+    //    for (curInx = begTab; curInx <= endTab; curInx++)
+    //    {
+    //        CallArg* arg = sortedArgs[curInx];
 
-            // Skip any already processed args
-            //
-            if (!arg->m_processed)
-            {
-                if (arg->m_needTmp)
-                {
-                    arg->m_processed = true;
+    //        // Skip any already processed args
+    //        //
+    //        if (!arg->m_processed)
+    //        {
+    //            if (arg->m_needTmp)
+    //            {
+    //                arg->m_processed = true;
 
-                    // place curArgTabEntry at the begTab position by performing a swap
-                    //
-                    if (curInx != begTab)
-                    {
-                        sortedArgs[curInx] = sortedArgs[begTab];
-                        sortedArgs[begTab] = arg;
-                    }
+    //                // place curArgTabEntry at the begTab position by performing a swap
+    //                //
+    //                if (curInx != begTab)
+    //                {
+    //                    sortedArgs[curInx] = sortedArgs[begTab];
+    //                    sortedArgs[begTab] = arg;
+    //                }
 
-                    begTab++;
-                    argsRemaining--;
-                }
-            }
-        }
-    }
+    //                begTab++;
+    //                argsRemaining--;
+    //            }
+    //        }
+    //    }
+    //}
 
-    if (argsRemaining > 0)
-    {
-        // Next take care of local var and local field arguments.
-        // These are moved towards the end of the argument evaluation.
-        // [We use a backward iterator pattern]
-        //
-        curInx = endTab + 1;
-        do
-        {
-            curInx--;
+    //if (argsRemaining > 0)
+    //{
+    //    // Next take care of local var and local field arguments.
+    //    // These are moved towards the end of the argument evaluation.
+    //    // [We use a backward iterator pattern]
+    //    //
+    //    curInx = endTab + 1;
+    //    do
+    //    {
+    //        curInx--;
 
-            CallArg* arg = sortedArgs[curInx];
+    //        CallArg* arg = sortedArgs[curInx];
 
-            // Skip any already processed args
-            //
-            if (!arg->m_processed)
-            {
-                GenTree* argx = arg->GetEarlyNode();
-                assert(argx != nullptr);
+    //        // Skip any already processed args
+    //        //
+    //        if (!arg->m_processed)
+    //        {
+    //            GenTree* argx = arg->GetEarlyNode();
+    //            assert(argx != nullptr);
 
-                // As a CQ heuristic, sort TYP_STRUCT args using the cost estimation below.
-                if (!argx->TypeIs(TYP_STRUCT) && argx->OperIs(GT_LCL_VAR, GT_LCL_FLD))
-                {
-                    noway_assert(curInx <= endTab);
+    //            // As a CQ heuristic, sort TYP_STRUCT args using the cost estimation below.
+    //            if (!argx->TypeIs(TYP_STRUCT) && argx->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+    //            {
+    //                noway_assert(curInx <= endTab);
 
-                    arg->m_processed = true;
+    //                arg->m_processed = true;
 
-                    // place curArgTabEntry at the endTab position by performing a swap
-                    //
-                    if (curInx != endTab)
-                    {
-                        sortedArgs[curInx] = sortedArgs[endTab];
-                        sortedArgs[endTab] = arg;
-                    }
+    //                // place curArgTabEntry at the endTab position by performing a swap
+    //                //
+    //                if (curInx != endTab)
+    //                {
+    //                    sortedArgs[curInx] = sortedArgs[endTab];
+    //                    sortedArgs[endTab] = arg;
+    //                }
 
-                    endTab--;
-                    argsRemaining--;
-                }
-            }
-        } while (curInx > begTab);
-    }
+    //                endTab--;
+    //                argsRemaining--;
+    //            }
+    //        }
+    //    } while (curInx > begTab);
+    //}
 
-    // Finally, take care of all the remaining arguments.
-    // Note that we fill in one arg at a time using a while loop.
-    bool costsPrepared = false; // Only prepare tree costs once, the first time through this loop
-    while (argsRemaining > 0)
-    {
-        /* Find the most expensive arg remaining and evaluate it next */
+    //// Finally, take care of all the remaining arguments.
+    //// Note that we fill in one arg at a time using a while loop.
+    //bool costsPrepared = false; // Only prepare tree costs once, the first time through this loop
+    //while (argsRemaining > 0)
+    //{
+    //    /* Find the most expensive arg remaining and evaluate it next */
 
-        CallArg* expensiveArg      = nullptr;
-        unsigned expensiveArgIndex = UINT_MAX;
-        unsigned expensiveArgCost  = 0;
+    //    CallArg* expensiveArg      = nullptr;
+    //    unsigned expensiveArgIndex = UINT_MAX;
+    //    unsigned expensiveArgCost  = 0;
 
-        // [We use a forward iterator pattern]
-        //
-        for (curInx = begTab; curInx <= endTab; curInx++)
-        {
-            CallArg* arg = sortedArgs[curInx];
+    //    // [We use a forward iterator pattern]
+    //    //
+    //    for (curInx = begTab; curInx <= endTab; curInx++)
+    //    {
+    //        CallArg* arg = sortedArgs[curInx];
 
-            // Skip any already processed args
-            //
-            if (!arg->m_processed)
-            {
-                GenTree* argx = arg->GetEarlyNode();
-                assert(argx != nullptr);
+    //        // Skip any already processed args
+    //        //
+    //        if (!arg->m_processed)
+    //        {
+    //            GenTree* argx = arg->GetEarlyNode();
+    //            assert(argx != nullptr);
 
-                // We should have already handled these kinds of args
-                assert((!argx->OperIs(GT_LCL_VAR, GT_LCL_FLD) || argx->TypeIs(TYP_STRUCT)) &&
-                       !argx->OperIs(GT_CNS_INT));
+    //            // We should have already handled these kinds of args
+    //            assert((!argx->OperIs(GT_LCL_VAR, GT_LCL_FLD) || argx->TypeIs(TYP_STRUCT)) &&
+    //                   !argx->OperIs(GT_CNS_INT));
 
-                // This arg should either have no persistent side effects or be the last one in our table
-                // assert(((argx->gtFlags & GTF_PERSISTENT_SIDE_EFFECTS) == 0) || (curInx == (argCount-1)));
+    //            // This arg should either have no persistent side effects or be the last one in our table
+    //            // assert(((argx->gtFlags & GTF_PERSISTENT_SIDE_EFFECTS) == 0) || (curInx == (argCount-1)));
 
-                if (argsRemaining == 1)
-                {
-                    // This is the last arg to place
-                    expensiveArgIndex = curInx;
-                    expensiveArg      = arg;
-                    assert(begTab == endTab);
-                    break;
-                }
-                else
-                {
-                    if (!costsPrepared)
-                    {
-                        /* We call gtPrepareCost to measure the cost of evaluating this tree */
-                        comp->gtPrepareCost(argx);
-                    }
+    //            if (argsRemaining == 1)
+    //            {
+    //                // This is the last arg to place
+    //                expensiveArgIndex = curInx;
+    //                expensiveArg      = arg;
+    //                assert(begTab == endTab);
+    //                break;
+    //            }
+    //            else
+    //            {
+    //                if (!costsPrepared)
+    //                {
+    //                    /* We call gtPrepareCost to measure the cost of evaluating this tree */
+    //                    comp->gtPrepareCost(argx);
+    //                }
 
-                    if (argx->GetCostEx() > expensiveArgCost)
-                    {
-                        // Remember this arg as the most expensive one that we have yet seen
-                        expensiveArgCost  = argx->GetCostEx();
-                        expensiveArgIndex = curInx;
-                        expensiveArg      = arg;
-                    }
-                }
-            }
-        }
+    //                if (argx->GetCostEx() > expensiveArgCost)
+    //                {
+    //                    // Remember this arg as the most expensive one that we have yet seen
+    //                    expensiveArgCost  = argx->GetCostEx();
+    //                    expensiveArgIndex = curInx;
+    //                    expensiveArg      = arg;
+    //                }
+    //            }
+    //        }
+    //    }
 
-        noway_assert(expensiveArgIndex != UINT_MAX);
+    //    noway_assert(expensiveArgIndex != UINT_MAX);
 
-        // put the most expensive arg towards the beginning of the table
+    //    // put the most expensive arg towards the beginning of the table
 
-        expensiveArg->m_processed = true;
+    //    expensiveArg->m_processed = true;
 
-        // place expensiveArgTabEntry at the begTab position by performing a swap
-        //
-        if (expensiveArgIndex != begTab)
-        {
-            sortedArgs[expensiveArgIndex] = sortedArgs[begTab];
-            sortedArgs[begTab]            = expensiveArg;
-        }
+    //    // place expensiveArgTabEntry at the begTab position by performing a swap
+    //    //
+    //    if (expensiveArgIndex != begTab)
+    //    {
+    //        sortedArgs[expensiveArgIndex] = sortedArgs[begTab];
+    //        sortedArgs[begTab]            = expensiveArg;
+    //    }
 
-        begTab++;
-        argsRemaining--;
+    //    begTab++;
+    //    argsRemaining--;
 
-        costsPrepared = true; // If we have more expensive arguments, don't re-evaluate the tree cost on the next loop
-    }
+    //    costsPrepared = true; // If we have more expensive arguments, don't re-evaluate the tree cost on the next loop
+    //}
 
-    // The table should now be completely filled and thus begTab should now be adjacent to endTab
-    // and regArgsRemaining should be zero
-    assert(begTab == (endTab + 1));
-    assert(argsRemaining == 0);
+    //// The table should now be completely filled and thus begTab should now be adjacent to endTab
+    //// and regArgsRemaining should be zero
+    //assert(begTab == (endTab + 1));
+    //assert(argsRemaining == 0);
 }
 
 //------------------------------------------------------------------------------

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -342,7 +342,6 @@ asm_diff_parser.add_argument("--gcinfo", action="store_true", help="Include GC i
 asm_diff_parser.add_argument("--debuginfo", action="store_true", help="Include debug info after disassembly (sets COMPlus_JitDebugDump).")
 asm_diff_parser.add_argument("-tag", help="Specify a word to add to the directory name where the asm diffs will be placed")
 asm_diff_parser.add_argument("-metrics", action="append", help="Metrics option to pass to jit-analyze. Can be specified multiple times, or pass comma-separated values.")
-asm_diff_parser.add_argument("-retainOnlyTopFiles", action="store_true", help="Retain only top .dasm files with largest improvements or regressions and delete remaining files.")
 asm_diff_parser.add_argument("--diff_with_release", action="store_true", help="Specify if this is asmdiff using release binaries.")
 asm_diff_parser.add_argument("--git_diff", action="store_true", help="Produce a '.diff' file from 'base' and 'diff' folders if there were any differences.")
 
@@ -1769,8 +1768,6 @@ class SuperPMIReplayAsmDiffs:
                                 # It appears we have a built jit-analyze on the path, so try to run it.
                                 jit_analyze_summary_file = os.path.join(asm_root_dir, "summary.md")
                                 command = [ jit_analyze_path, "--md", jit_analyze_summary_file, "-r", "--base", base_asm_location, "--diff", diff_asm_location ]
-                                if self.coreclr_args.retainOnlyTopFiles:
-                                    command += [ "--retainOnlyTopFiles" ]
                                 if self.coreclr_args.metrics:
                                     command += [ "--metrics", ",".join(self.coreclr_args.metrics) ]
                                 elif base_bytes is not None and diff_bytes is not None:
@@ -3969,11 +3966,6 @@ def setup_args(args):
                             "metrics",
                             lambda unused: True,
                             "Unable to set metrics.")
-
-        coreclr_args.verify(args,
-                            "retainOnlyTopFiles",
-                            lambda unused: True,
-                            "Unable to set retainOnlyTopFiles.")
 
         coreclr_args.verify(args,
                             "diff_with_release",

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1718,7 +1718,7 @@ class SuperPMIReplayAsmDiffs:
                         logging.info("Creating JitDump files: %s %s", base_dump_location, diff_dump_location)
                         subproc_helper.run_to_completion(create_replay_artifacts, self, mch_file, jit_dump_complus_vars_full_env, jit_dump_differences, base_dump_location, diff_dump_location, ".txt")
 
-                    logging.info("Contexts with differences found. To replay SuperPMI use:".format(len(diffs)))
+                    logging.info("Differences found. To replay SuperPMI use:".format(len(diffs)))
 
                     logging.info("")
                     for var, value in asm_complus_vars.items():
@@ -1734,7 +1734,7 @@ class SuperPMIReplayAsmDiffs:
                         logging.info("%s %s -c ### %s %s", self.superpmi_path, " ".join(altjit_replay_flags), self.diff_jit_path, mch_file)
                         logging.info("")
 
-                    smallest = sorted(diffs, key=lambda r: int(r["Context size"]))[20:]
+                    smallest = sorted(diffs, key=lambda r: int(r["Context size"]))[:20]
                     logging.debug("Smallest {} contexts with binary differences:".format(len(smallest)))
                     for diff in smallest:
                         logging.debug(diff["Context"])

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -216,8 +216,7 @@ def main(main_args):
         "-spmi_location", spmi_location,
         "-error_limit", "100",
         "-log_level", "debug",
-        "-log_file", log_file,
-        "-retainOnlyTopFiles"])
+        "-log_file", log_file)
 
     print("Running superpmi.py tpdiff")
 

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -216,7 +216,7 @@ def main(main_args):
         "-spmi_location", spmi_location,
         "-error_limit", "100",
         "-log_level", "debug",
-        "-log_file", log_file)
+        "-log_file", log_file])
 
     print("Running superpmi.py tpdiff")
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/standardpch.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/standardpch.h
@@ -62,6 +62,7 @@
 
 // Getting STL to work with PAL is difficult, so reimplement STL functionality to not require it.
 #ifdef TARGET_UNIX
+#include "clr_std/utility"
 #include "clr_std/string"
 #include "clr_std/algorithm"
 #include "clr_std/vector"
@@ -69,6 +70,7 @@
 #ifndef USE_STL
 #define USE_STL
 #endif // USE_STL
+#include <utility>
 #include <string>
 #include <algorithm>
 #include <vector>

--- a/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SUPERPMI_SOURCES
     neardiffer.cpp
     parallelsuperpmi.cpp
     superpmi.cpp
+    fileio.cpp
     jithost.cpp
     ../superpmi-shared/callutils.cpp
     ../superpmi-shared/compileresult.cpp

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -318,7 +318,7 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
 
                 o->mclFilename = argv[i];
             }
-            else if ((_strnicmp(&argv[i][1], "diffMCList", 10) == 0))
+            else if ((_strnicmp(&argv[i][1], "diffsInfo", 9) == 0))
             {
                 if (++i >= argc)
                 {
@@ -326,7 +326,7 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                     return false;
                 }
 
-                o->diffMCLFilename = argv[i];
+                o->diffsInfo = argv[i];
             }
             else if ((_strnicmp(&argv[i][1], "target", 6) == 0))
             {
@@ -641,9 +641,9 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
         DumpHelp(argv[0]);
         return false;
     }
-    if (o->diffMCLFilename != nullptr && !o->applyDiff)
+    if (o->diffsInfo != nullptr && !o->applyDiff)
     {
-        LogError("-diffMCList specified without -applyDiff.");
+        LogError("-diffsInfo specified without -applyDiff.");
         DumpHelp(argv[0]);
         return false;
     }

--- a/src/coreclr/tools/superpmi/superpmi/commandline.h
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.h
@@ -39,7 +39,7 @@ public:
             , baseMetricsSummaryFile(nullptr)
             , diffMetricsSummaryFile(nullptr)
             , mclFilename(nullptr)
-            , diffMCLFilename(nullptr)
+            , diffsInfo(nullptr)
             , targetArchitecture(nullptr)
             , compileList(nullptr)
             , offset(-1)
@@ -72,7 +72,7 @@ public:
         char* baseMetricsSummaryFile;
         char* diffMetricsSummaryFile;
         char* mclFilename;
-        char* diffMCLFilename;
+        char* diffsInfo;
         char* targetArchitecture;
         char* compileList;
         int   offset;

--- a/src/coreclr/tools/superpmi/superpmi/fileio.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/fileio.cpp
@@ -1,0 +1,115 @@
+#include "standardpch.h"
+#include "fileio.h"
+
+bool FileWriter::Printf(const char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+
+    char stackBuffer[512];
+    size_t bufferSize = sizeof(stackBuffer);
+    char* pBuffer = stackBuffer;
+    while (true)
+    {
+        va_list argsCopy;
+        va_copy(argsCopy, args);
+        int printed = _vsnprintf_s(pBuffer, bufferSize, _TRUNCATE, fmt, argsCopy);
+        va_end(argsCopy);
+
+        if (printed < 0)
+        {
+            // buffer too small
+            if (pBuffer != stackBuffer)
+                delete[] pBuffer;
+
+            bufferSize *= 2;
+            pBuffer = new char[bufferSize];
+        }
+        else
+        {
+            DWORD numWritten;
+            bool result =
+                WriteFile(m_file.Get(), pBuffer, static_cast<DWORD>(printed), &numWritten, nullptr) &&
+                (numWritten == static_cast<DWORD>(printed));
+
+            if (pBuffer != stackBuffer)
+                delete[] pBuffer;
+
+            va_end(args);
+            return result;
+        }
+    }
+}
+
+bool FileWriter::CreateNew(const char* path, FileWriter* fw)
+{
+    FileHandle handle(CreateFile(path, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!handle.IsValid())
+    {
+        return false;
+    }
+
+    *fw = FileWriter(std::move(handle));
+    return true;
+}
+
+bool FileLineReader::Open(const char* path, FileLineReader* fr)
+{
+    FileHandle file(CreateFile(path, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!file.IsValid())
+    {
+        return false;
+    }
+
+    LARGE_INTEGER size;
+    if (!GetFileSizeEx(file.Get(), &size))
+    {
+        return false;
+    }
+
+    if (static_cast<ULONGLONG>(size.QuadPart) > SIZE_MAX)
+    {
+        return false;
+    }
+
+    FileMappingHandle mapping(CreateFileMapping(file.Get(), nullptr, PAGE_READONLY, size.u.HighPart, size.u.LowPart, nullptr));
+    if (!mapping.IsValid())
+    {
+        return false;
+    }
+
+    FileViewHandle view(MapViewOfFile(mapping.Get(), FILE_MAP_READ, 0, 0, 0));
+    if (!view.IsValid())
+    {
+        return false;
+    }
+
+    *fr = FileLineReader(std::move(file), std::move(mapping), std::move(view), static_cast<size_t>(size.QuadPart));
+    return true;
+}
+
+bool FileLineReader::AdvanceLine()
+{
+    if (m_cur >= m_end)
+    {
+        return false;
+    }
+
+    char* end = m_cur;
+    while (end < m_end && *end != '\r' && *end != '\n')
+    {
+        end++;
+    }
+
+    m_currentLine.resize(end - m_cur + 1);
+    memcpy(m_currentLine.data(), m_cur, end - m_cur);
+    m_currentLine[end - m_cur] = '\0';
+
+    m_cur = end;
+    if (m_cur < m_end && *m_cur == '\r')
+        m_cur++;
+    if (m_cur < m_end && *m_cur == '\n')
+        m_cur++;
+
+    return true;
+}

--- a/src/coreclr/tools/superpmi/superpmi/fileio.h
+++ b/src/coreclr/tools/superpmi/superpmi/fileio.h
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef _FileIO
+#define _FileIO
+
+template<typename HandleType, HandleType InvalidHandleValue, typename FreeFunction>
+struct HandleWrapper
+{
+    HandleWrapper()
+        : m_handle(InvalidHandleValue)
+    {
+    }
+
+    explicit HandleWrapper(HandleType handle)
+        : m_handle(handle)
+    {
+    }
+
+    ~HandleWrapper()
+    {
+        if (m_handle != InvalidHandleValue)
+        {
+            FreeFunction{}(m_handle);
+
+            m_handle = InvalidHandleValue;
+        }
+    }
+
+    HandleWrapper(const HandleWrapper&) = delete;
+    HandleWrapper& operator=(HandleWrapper&) = delete;
+
+    HandleWrapper(HandleWrapper&& hw)
+        : m_handle(hw.m_handle)
+    {
+        hw.m_handle = INVALID_HANDLE_VALUE;
+    }
+
+    HandleWrapper& operator=(HandleWrapper&& hw)
+    {
+        if (m_handle != InvalidHandleValue)
+            CloseHandle(m_handle);
+
+        m_handle = hw.m_handle;
+        hw.m_handle = InvalidHandleValue;
+        return *this;
+    }
+
+    bool IsValid() { return m_handle != InvalidHandleValue; }
+    HandleType Get() { return m_handle; }
+
+private:
+    HandleType m_handle;
+};
+
+struct CloseHandleFunctor
+{
+    void operator()(HANDLE handle)
+    {
+        CloseHandle(handle);
+    }
+};
+
+struct UnmapViewOfFileFunctor
+{
+    void operator()(LPVOID view)
+    {
+        UnmapViewOfFile(view);
+    }
+};
+
+typedef HandleWrapper<HANDLE, INVALID_HANDLE_VALUE, CloseHandleFunctor> FileHandle;
+typedef HandleWrapper<HANDLE, nullptr, CloseHandleFunctor> FileMappingHandle;
+typedef HandleWrapper<LPVOID, nullptr, UnmapViewOfFileFunctor> FileViewHandle;
+
+class FileWriter
+{
+    FileHandle m_file;
+
+    FileWriter(FileHandle file)
+        : m_file(std::move(file))
+    {
+    }
+
+public:
+    FileWriter()
+    {
+    }
+
+    bool Printf(const char* fmt, ...);
+
+    static bool CreateNew(const char* path, FileWriter* fw);
+};
+
+class FileLineReader
+{
+    FileHandle m_file;
+    FileMappingHandle m_fileMapping;
+    FileViewHandle m_view;
+
+    char* m_cur;
+    char* m_end;
+    std::vector<char> m_currentLine;
+
+    FileLineReader(FileHandle file, FileMappingHandle fileMapping, FileViewHandle view, size_t size)
+        : m_file(std::move(file))
+        , m_fileMapping(std::move(fileMapping))
+        , m_view(std::move(view))
+        , m_cur(static_cast<char*>(m_view.Get()))
+        , m_end(static_cast<char*>(m_view.Get()) + size)
+    {
+    }
+
+public:
+    FileLineReader()
+    {
+    }
+
+    bool AdvanceLine();
+    const char* GetCurrentLine() { return m_currentLine.data(); }
+
+    static bool Open(const char* path, FileLineReader* fr);
+};
+
+#endif

--- a/src/coreclr/tools/superpmi/superpmi/metricssummary.h
+++ b/src/coreclr/tools/superpmi/superpmi/metricssummary.h
@@ -39,7 +39,7 @@ public:
     bool SaveToFile(const char* path);
     static bool LoadFromFile(const char* path, MetricsSummaries* metrics);
 private:
-    static bool WriteRow(HANDLE hFile, const char* name, const MetricsSummary& summary);
+    static bool WriteRow(class FileWriter& fw, const char* name, const MetricsSummary& summary);
 };
 
 #endif

--- a/src/coreclr/tools/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/parallelsuperpmi.cpp
@@ -9,6 +9,7 @@
 #include "commandline.h"
 #include "errorhandling.h"
 #include "metricssummary.h"
+#include "fileio.h"
 
 #define MAX_LOG_LINE_SIZE 0x1000 // 4 KB
 
@@ -349,7 +350,7 @@ struct PerWorkerData
     HANDLE hStdError;
 
     char* failingMCListPath;
-    char* diffMCListPath;
+    char* diffsInfoPath;
     char* stdOutputPath;
     char* stdErrorPath;
     char* baseMetricsSummaryPath;
@@ -359,7 +360,7 @@ struct PerWorkerData
         : hStdOutput(INVALID_HANDLE_VALUE)
         , hStdError(INVALID_HANDLE_VALUE)
         , failingMCListPath(nullptr)
-        , diffMCListPath(nullptr)
+        , diffsInfoPath(nullptr)
         , stdOutputPath(nullptr)
         , stdErrorPath(nullptr)
         , baseMetricsSummaryPath(nullptr)
@@ -368,7 +369,7 @@ struct PerWorkerData
     }
 };
 
-void MergeWorkerMCLs(char* mclFilename, PerWorkerData* workerData, int workerCount, char* PerWorkerData::*mclPath)
+static void MergeWorkerMCLs(char* mclFilename, PerWorkerData* workerData, int workerCount, char* PerWorkerData::*mclPath)
 {
     int **MCL = new int *[workerCount], *MCLCount = new int[workerCount], totalCount = 0;
 
@@ -394,6 +395,39 @@ void MergeWorkerMCLs(char* mclFilename, PerWorkerData* workerData, int workerCou
     // Write the merged MCL array back to disk
     if (!WriteArrayToMCL(mclFilename, mergedMCL, totalCount))
         LogError("Unable to write to MCL file %s.", mclFilename);
+}
+
+static void MergeWorkerCsvs(char* csvFilename, PerWorkerData* workerData, int workerCount, char* PerWorkerData::* csvPath)
+{
+    FileWriter fw;
+    if (!FileWriter::CreateNew(csvFilename, &fw))
+    {
+        LogError("Could not create file %s", csvFilename);
+        return;
+    }
+
+    bool hasHeader = false;
+    for (int i = 0; i < workerCount; i++)
+    {
+        FileLineReader reader;
+        if (!FileLineReader::Open(workerData[i].*csvPath, &reader))
+        {
+            LogError("Could not open child CSV file %s", workerData[i].*csvPath);
+            continue;
+        }
+
+        if (hasHeader && !reader.AdvanceLine())
+        {
+            continue;
+        }
+
+        while (reader.AdvanceLine())
+        {
+             fw.Printf("%s\n", reader.GetCurrentLine());
+        }
+
+        hasHeader = true;
+    }
 }
 
 #define MAX_CMDLINE_SIZE 0x1000 // 4 KB
@@ -528,8 +562,8 @@ int doParallelSuperPMI(CommandLine::Options& o)
     LogVerbose("Using child (%s) with args (%s)", spmiFilename, spmiArgs);
     if (o.mclFilename != nullptr)
         LogVerbose(" failingMCList=%s", o.mclFilename);
-    if (o.diffMCLFilename != nullptr)
-        LogVerbose(" diffMCLFilename=%s", o.diffMCLFilename);
+    if (o.diffsInfo != nullptr)
+        LogVerbose(" diffsInfo=%s", o.diffsInfo);
     LogVerbose(" workerCount=%d, skipCleanup=%d.", o.workerCount, o.skipCleanup);
 
     PerWorkerData* perWorkerData = new PerWorkerData[o.workerCount];
@@ -551,10 +585,10 @@ int doParallelSuperPMI(CommandLine::Options& o)
             sprintf_s(wd.failingMCListPath, MAX_PATH, "%sParallelSuperPMI-%u-%d.mcl", tempPath, randNumber, i);
         }
 
-        if (o.diffMCLFilename != nullptr)
+        if (o.diffsInfo != nullptr)
         {
-            wd.diffMCListPath = new char[MAX_PATH];
-            sprintf_s(wd.diffMCListPath, MAX_PATH, "%sParallelSuperPMI-Diff-%u-%d.mcl", tempPath, randNumber, i);
+            wd.diffsInfoPath = new char[MAX_PATH];
+            sprintf_s(wd.diffsInfoPath, MAX_PATH, "%sParallelSuperPMI-Diff-%u-%d.mcl", tempPath, randNumber, i);
         }
 
         if (o.baseMetricsSummaryFile != nullptr)
@@ -593,10 +627,10 @@ int doParallelSuperPMI(CommandLine::Options& o)
                                       wd.failingMCListPath);
         }
 
-        if (wd.diffMCListPath != nullptr)
+        if (wd.diffsInfoPath != nullptr)
         {
-            bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -diffMCList %s",
-                                      wd.diffMCListPath);
+            bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -diffsInfo %s",
+                                      wd.diffsInfoPath);
         }
 
         if (wd.baseMetricsSummaryPath != nullptr)
@@ -719,10 +753,10 @@ int doParallelSuperPMI(CommandLine::Options& o)
             MergeWorkerMCLs(o.mclFilename, perWorkerData, o.workerCount, &PerWorkerData::failingMCListPath);
         }
 
-        if (o.diffMCLFilename != nullptr && !usageError)
+        if (o.diffsInfo != nullptr && !usageError)
         {
             // Concat the resulting diff .mcl files
-            MergeWorkerMCLs(o.diffMCLFilename, perWorkerData, o.workerCount, &PerWorkerData::diffMCListPath);
+            MergeWorkerCsvs(o.diffsInfo, perWorkerData, o.workerCount, &PerWorkerData::diffsInfoPath);
         }
 
         if (o.baseMetricsSummaryFile != nullptr && !usageError)
@@ -761,9 +795,9 @@ int doParallelSuperPMI(CommandLine::Options& o)
             {
                 DeleteFile(wd.failingMCListPath);
             }
-            if (wd.diffMCListPath != nullptr)
+            if (wd.diffsInfoPath != nullptr)
             {
-                DeleteFile(wd.diffMCListPath);
+                DeleteFile(wd.diffsInfoPath);
             }
             if (wd.baseMetricsSummaryPath != nullptr)
             {

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -571,7 +571,6 @@ int __cdecl main(int argc, char* argv[])
                 {
                     NearDifferResult result = InvokeNearDiffer(&nearDiffer, &mc, &crl, &reader);
 
-                    bool addDiffsCsvRow = false;
                     switch (result)
                     {
                     case NearDifferResult::SuccessWithDiff:
@@ -586,18 +585,16 @@ int __cdecl main(int argc, char* argv[])
                         // Otherwise this will end up in failingMCList
                         if (o.diffsInfo != nullptr)
                         {
-                            addDiffsCsvRow = true;
+                            PrintDiffsCsvRow(
+                                diffCsv,
+                                reader->GetMethodContextIndex(),
+                                baseMetrics.NumCodeBytes, diffMetrics.NumCodeBytes,
+                                baseMetrics.NumExecutedInstructions, diffMetrics.NumExecutedInstructions,
+                                mcb.size);
                         }
                         else if (o.mclFilename != nullptr)
                         {
                             failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
-                        }
-
-                        break;
-                    case NearDifferResult::SuccessWithoutDiff:
-                        if (o.diffsInfo != nullptr)
-                        {
-                            addDiffsCsvRow = true;
                         }
 
                         break;
@@ -606,16 +603,6 @@ int __cdecl main(int argc, char* argv[])
                             failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
 
                         break;
-                    }
-
-                    if (addDiffsCsvRow)
-                    {
-                        PrintDiffsCsvRow(
-                            diffCsv,
-                            reader->GetMethodContextIndex(),
-                            baseMetrics.NumCodeBytes, diffMetrics.NumCodeBytes,
-                            baseMetrics.NumExecutedInstructions, diffMetrics.NumExecutedInstructions,
-                            mcb.size);
                     }
 
                     totalBaseMetrics.Overall.NumDiffedCodeBytes += baseMetrics.NumCodeBytes;

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -598,6 +598,8 @@ int __cdecl main(int argc, char* argv[])
                         }
 
                         break;
+                    case NearDifferResult::SuccessWithoutDiff:
+                        break;
                     case NearDifferResult::Failure:
                         if (o.mclFilename != nullptr)
                             failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -19,6 +19,7 @@
 #include "methodstatsemitter.h"
 #include "spmiutil.h"
 #include "metricssummary.h"
+#include "fileio.h"
 
 extern int doParallelSuperPMI(CommandLine::Options& o);
 
@@ -64,54 +65,47 @@ void SetSuperPmiTargetArchitecture(const char* targetArchitecture)
     }
 }
 
+enum class NearDifferResult
+{
+    SuccessWithoutDiff,
+    SuccessWithDiff,
+    Failure,
+};
+
 // This function uses PAL_TRY, so it can't be in the a function that requires object unwinding. Extracting it out here
 // avoids compiler error.
 //
-static void InvokeNearDiffer(NearDiffer*           nearDiffer,
-                             CommandLine::Options* o,
-                             MethodContext**       mc,
-                             CompileResult**       crl,
-                             bool*                 hasDiff,
-                             MethodContextReader** reader,
-                             MCList*               failingMCL,
-                             MCList*               diffMCL)
+static NearDifferResult InvokeNearDiffer(NearDiffer*           nearDiffer,
+                                   MethodContext**       mc,
+                                   CompileResult**       crl,
+                                   MethodContextReader** reader)
 {
+
     struct Param : FilterSuperPMIExceptionsParam_CaptureException
     {
         NearDiffer*           nearDiffer;
-        CommandLine::Options* o;
         MethodContext**       mc;
         CompileResult**       crl;
-        bool*                 hasDiff;
         MethodContextReader** reader;
-        MCList*               failingMCL;
-        MCList*               diffMCL;
+        NearDifferResult      result;
     } param;
     param.nearDiffer = nearDiffer;
-    param.o          = o;
     param.mc         = mc;
     param.crl        = crl;
-    param.hasDiff    = hasDiff;
     param.reader     = reader;
-    param.failingMCL = failingMCL;
-    param.diffMCL    = diffMCL;
-    *hasDiff = false;
+    param.result     = NearDifferResult::Failure;
 
     PAL_TRY(Param*, pParam, &param)
     {
         if (!pParam->nearDiffer->compare(*pParam->mc, *pParam->crl, (*pParam->mc)->cr))
         {
-            *pParam->hasDiff = true;
+            pParam->result = NearDifferResult::SuccessWithDiff;
             LogIssue(ISSUE_ASM_DIFF, "main method %d of size %d differs", (*pParam->reader)->GetMethodContextIndex(),
                      (*pParam->mc)->methodSize);
-
-            // This is a difference in ASM outputs from Jit1 & Jit2 and not a playback failure
-            // We will add this MC to the diffMCList if one is requested
-            // Otherwise this will end up in failingMCList
-            if ((*pParam->o).diffMCLFilename != nullptr)
-                (*pParam->diffMCL).AddMethodToMCL((*pParam->reader)->GetMethodContextIndex());
-            else if ((*pParam->o).mclFilename != nullptr)
-                (*pParam->failingMCL).AddMethodToMCL((*pParam->reader)->GetMethodContextIndex());
+        }
+        else
+        {
+            pParam->result = NearDifferResult::SuccessWithoutDiff;
         }
     }
     PAL_EXCEPT_FILTER(FilterSuperPMIExceptions_CaptureExceptionAndStop)
@@ -121,10 +115,26 @@ static void InvokeNearDiffer(NearDiffer*           nearDiffer,
         LogError("main method %d of size %d failed to load and compile correctly.", (*reader)->GetMethodContextIndex(),
                  (*mc)->methodSize);
         e.ShowAndDeleteMessage();
-        if ((*o).mclFilename != nullptr)
-            (*failingMCL).AddMethodToMCL((*reader)->GetMethodContextIndex());
+        param.result = NearDifferResult::Failure;
     }
     PAL_ENDTRY
+
+    return param.result;
+}
+
+static bool PrintDiffsCsvHeader(FileWriter& fw)
+{
+    return fw.Printf("Context,Base size,Diff size,Base instructions,Diff instructions,Context size\n");
+}
+
+static bool PrintDiffsCsvRow(
+    FileWriter& fw,
+    int context,
+    long long baseSize, long long diffSize,
+    long long baseInstructions, long long diffInstructions,
+    uint32_t contextSize)
+{
+    return fw.Printf("%d,%lld,%lld,%lld,%lld,%u\n", context, baseSize, diffSize, baseInstructions, diffInstructions, contextSize);
 }
 
 // Run superpmi. The return value is as follows:
@@ -171,7 +181,8 @@ int __cdecl main(int argc, char* argv[])
 #endif
 
     bool   collectThroughput = false;
-    MCList failingToReplayMCL, diffMCL;
+    MCList failingToReplayMCL;
+    FileWriter diffCsv;
 
     CommandLine::Options o;
     if (!CommandLine::Parse(argc, argv, &o))
@@ -230,9 +241,13 @@ int __cdecl main(int argc, char* argv[])
     {
         failingToReplayMCL.InitializeMCL(o.mclFilename);
     }
-    if (o.diffMCLFilename != nullptr)
+    if (o.diffsInfo != nullptr)
     {
-        diffMCL.InitializeMCL(o.diffMCLFilename);
+        if (!FileWriter::CreateNew(o.diffsInfo, &diffCsv))
+        {
+            LogError("Could not create file %s", o.diffsInfo);
+            return (int)SpmiResult::GeneralFailure;
+        }
     }
 
     SetDebugDumpVariables();
@@ -264,6 +279,8 @@ int __cdecl main(int argc, char* argv[])
         {
             return (int)SpmiResult::GeneralFailure;
         }
+
+        PrintDiffsCsvHeader(diffCsv);
     }
 
     MetricsSummaries totalBaseMetrics;
@@ -552,16 +569,53 @@ int __cdecl main(int argc, char* argv[])
                 }
                 else
                 {
-                    bool hasDiff;
-                    InvokeNearDiffer(&nearDiffer, &o, &mc, &crl, &hasDiff, &reader, &failingToReplayMCL, &diffMCL);
+                    NearDifferResult result = InvokeNearDiffer(&nearDiffer, &mc, &crl, &reader);
 
-                    if (hasDiff)
+                    bool addDiffsCsvRow = false;
+                    switch (result)
                     {
+                    case NearDifferResult::SuccessWithDiff:
                         totalBaseMetrics.Overall.NumContextsWithDiffs++;
                         totalDiffMetrics.Overall.NumContextsWithDiffs++;
 
                         totalBaseMetricsOpts.NumContextsWithDiffs++;
                         totalDiffMetricsOpts.NumContextsWithDiffs++;
+
+                        // This is a difference in ASM outputs from Jit1 & Jit2 and not a playback failure
+                        // We will add this MC to the diffs info if there is one.
+                        // Otherwise this will end up in failingMCList
+                        if (o.diffsInfo != nullptr)
+                        {
+                            addDiffsCsvRow = true;
+                        }
+                        else if (o.mclFilename != nullptr)
+                        {
+                            failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
+                        }
+
+                        break;
+                    case NearDifferResult::SuccessWithoutDiff:
+                        if (o.diffsInfo != nullptr)
+                        {
+                            addDiffsCsvRow = true;
+                        }
+
+                        break;
+                    case NearDifferResult::Failure:
+                        if (o.mclFilename != nullptr)
+                            failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
+
+                        break;
+                    }
+
+                    if (addDiffsCsvRow)
+                    {
+                        PrintDiffsCsvRow(
+                            diffCsv,
+                            reader->GetMethodContextIndex(),
+                            baseMetrics.NumCodeBytes, diffMetrics.NumCodeBytes,
+                            baseMetrics.NumExecutedInstructions, diffMetrics.NumExecutedInstructions,
+                            mcb.size);
                     }
 
                     totalBaseMetrics.Overall.NumDiffedCodeBytes += baseMetrics.NumCodeBytes;
@@ -625,7 +679,7 @@ int __cdecl main(int argc, char* argv[])
                 if (o.breakOnError)
                 {
                     if (o.indexCount == -1)
-                        LogInfo("HINT: to repro add '/c %d' to cmdline", reader->GetMethodContextIndex());
+                        LogInfo("HINT: to repro add '-c %d' to cmdline", reader->GetMethodContextIndex());
                     __debugbreak();
                 }
             }
@@ -673,10 +727,6 @@ int __cdecl main(int argc, char* argv[])
     if (o.mclFilename != nullptr)
     {
         failingToReplayMCL.CloseMCL();
-    }
-    if (o.diffMCLFilename != nullptr)
-    {
-        diffMCL.CloseMCL();
     }
     Logger::Shutdown();
 


### PR DESCRIPTION
This starts communicating more information about diffs back from
superpmi and starts using it in the driver. The current information is
the base size, diff size, base instructions, diff instructions and
context size.

The driver uses the base size/diff size to pick a small number of
interesting contexts and only creates disassembly for these contexts.
jit-analyze is then also invoked on only these contexts, but the
contexts are picked so that they overlap with what jit-analyze would
display. Additionally, we also pick the 20 smallest contexts (in
terms of context size) -- I frequently use the smallest contexts with
diffs to investigate my changes.

The new behavior is only enabled when no custom metrics are specified.
If custom metrics are specified we fall back to producing all
disassembly files and leave it up to jit-analyze to extract and analyze
the metrics specified.

Also, the retainTopFilesOnly option is no longer necessary since our CI
pipeline will at most produce 100 .dasm files now. Another benefit is that
this means that all contexts mentioned in the jit-analyze output will now be
part of the artifacts.

The net result is that we can now get SPMI diffs for changes with even
hundreds of thousands of diffs in the same time as it takes to get diffs
for a small change.

Fix #76178