### PR TITLE
Increase number of Apple trampolines to 40000

### DIFF
--- a/src/mono/msbuild/apple/build/AppleApp.targets
+++ b/src/mono/msbuild/apple/build/AppleApp.targets
@@ -63,7 +63,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="nrgctx-fetch-trampolines=256" />
       <MonoAOTCompilerDefaultAotArguments Include="ngsharedvt-trampolines=4400" />
       <MonoAOTCompilerDefaultAotArguments Include="nftnptr-arg-trampolines=4000" />
-      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=31000" />
+      <MonoAOTCompilerDefaultAotArguments Include="nrgctx-trampolines=40000" />
 
       <MonoAOTCompilerDefaultProcessArguments Include="-O=gsharedvt" />
     </ItemGroup>


### PR DESCRIPTION
Fixing https://github.com/dotnet/runtime/issues/76245 by increasing the number of available trampolines for Apple MonoAOT.