### PR TITLE
Make "Personal" on Android also point to a Documents folder

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Android.cs
@@ -54,7 +54,6 @@ namespace System
 
             switch (folder)
             {
-                case SpecialFolder.Personal:
                 case SpecialFolder.LocalApplicationData:
                     return home;
 
@@ -64,6 +63,9 @@ namespace System
                 case SpecialFolder.Desktop:
                 case SpecialFolder.DesktopDirectory:
                     return Path.Combine(home, "Desktop");
+
+                case SpecialFolder.MyDocuments:     // Same value as Personal
+                    return Path.Combine(home, "Documents");
 
                 case SpecialFolder.MyMusic:
                     return Path.Combine(home, "Music");


### PR DESCRIPTION
#68610 moved `Personal`/`MyDocuments` on Unix systems from HOME to the documents folder. However, it didn't do so for Android systems, which was only noticed after tests later failed. This PR fixes it.

If this gets merged, https://github.com/dotnet/docs/issues/31423 should get adjusted to include Android as well.