### PR TITLE
Temporarily patch out native sourcelink file check in source-build.

### DIFF
--- a/src/coreclr/runtime-prereqs.proj
+++ b/src/coreclr/runtime-prereqs.proj
@@ -6,7 +6,7 @@
     <RuntimeVersionFile>$(ArtifactsObjDir)runtime_version.h</RuntimeVersionFile>
     <NativeSourceLinkFile>$(ArtifactsObjDir)native.sourcelink.json</NativeSourceLinkFile>
     <VerifySourceLinkFileExists>false</VerifySourceLinkFileExists>
-    <VerifySourceLinkFileExists Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</VerifySourceLinkFileExists>
+    <VerifySourceLinkFileExists Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(DotNetBuildFromSource)' != 'true'">true</VerifySourceLinkFileExists>
     <AssemblyName>.NET Runtime</AssemblyName>
   </PropertyGroup>
 


### PR DESCRIPTION
This returns source-build to its old behavior.

Issue for enabling native SourceLink in source-build: https://github.com/dotnet/source-build/issues/2883.