### PR TITLE
[Release 7.0] Check if the string is null first before checking if it is a file

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
@@ -277,10 +277,10 @@ namespace System.Configuration
         // null means stream doesn't exist for this name
         public override Stream OpenStreamForRead(string streamName)
         {
+            if (streamName == null) return null;
+
             // the streamName can either be a file name, or a URI
             if (IsFile(streamName)) return Host.OpenStreamForRead(streamName);
-
-            if (streamName == null) return null;
 
 #pragma warning disable SYSLIB0014 // WebClient is obsolete.
             // scheme is http

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
@@ -293,18 +293,19 @@ namespace System.Configuration
             }
             catch { }
 
-            byte[] fileData = null;
+            Stream fileData = null;
             try
             {
-                fileData = client.DownloadData(streamName);
+                fileData = client.OpenRead(streamName);
             }
-            catch { }
+            catch 
+            {
+                fileData?.close();
+                return null;
+            }
 #pragma warning restore SYSLIB0014
 
-            if (fileData == null) return null;
-
-            MemoryStream stream = new MemoryStream(fileData);
-            return stream;
+            return fileData;
         }
 
         public override Stream OpenStreamForWrite(string streamName, string templateStreamName, ref object writeContext)


### PR DESCRIPTION
It makes more sense that null is the first thing checked, especially since I cannot verify the behavior of IsFile() when a null string is passed.