### PR TITLE
Fix value type with static method fails to load

### DIFF
--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -2659,14 +2659,6 @@ MethodTableBuilder::EnumerateClassMethods()
         METHOD_IMPL_TYPE implType;
         LPSTR strMethodName;
 
-#ifdef FEATURE_TYPEEQUIVALENCE
-        // TypeEquivalent structs must not have methods
-        if (bmtProp->fIsTypeEquivalent && fIsClassValueType)
-        {
-            BuildMethodTableThrowException(IDS_CLASSLOAD_EQUIVALENTSTRUCTMETHODS);
-        }
-#endif
-
         //
         // Go to the next method and retrieve its attributes.
         //
@@ -2685,6 +2677,14 @@ MethodTableBuilder::EnumerateClassMethods()
         {
             BuildMethodTableThrowException(IDS_CLASSLOAD_BADFORMAT);
         }
+
+#ifdef FEATURE_TYPEEQUIVALENCE
+        // TypeEquivalent structs must not have non-static methods
+        if (!IsMdStatic(dwMemberAttrs) && bmtProp->fIsTypeEquivalent && fIsClassValueType)
+        {
+            BuildMethodTableThrowException(IDS_CLASSLOAD_EQUIVALENTSTRUCTMETHODS);
+        }
+#endif
 
         bool isVtblGap = false;
         if (IsMdRTSpecialName(dwMemberAttrs) || IsMdVirtual(dwMemberAttrs) || IsDelegate())

--- a/src/tests/baseservices/typeequivalence/pia/PIAContract.csproj
+++ b/src/tests/baseservices/typeequivalence/pia/PIAContract.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Types.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/typeequivalence/pia/Types.cs
+++ b/src/tests/baseservices/typeequivalence/pia/Types.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+[assembly: PrimaryInteropAssembly(1, 0)]
+
+public struct ValueTypeWithStaticMethod
+{
+    public int F;
+    public static void M() { }
+}

--- a/src/tests/baseservices/typeequivalence/pia/Types.cs
+++ b/src/tests/baseservices/typeequivalence/pia/Types.cs
@@ -11,3 +11,9 @@ public struct ValueTypeWithStaticMethod
     public int F;
     public static void M() { }
 }
+
+public struct ValueTypeWithInstanceMethod
+{
+    public int F;
+    public void M() { }
+}

--- a/src/tests/baseservices/typeequivalence/simple/Simple.cs
+++ b/src/tests/baseservices/typeequivalence/simple/Simple.cs
@@ -255,10 +255,17 @@ public class Simple
     }
 
     [MethodImpl (MethodImplOptions.NoInlining)]
-    private static void TestLoadingValueTypeWithStaticMethod() 
+    private static void TestLoadingValueTypesWithMethod() 
     {
-        Console.WriteLine($"{nameof(TestLoadingValueTypeWithStaticMethod)}");
+        Console.WriteLine($"{nameof(TestLoadingValueTypesWithMethod)}");
         Console.WriteLine($"-- {typeof(ValueTypeWithStaticMethod).Name}");
+        Assert.Throws<TypeLoadException>(() => LoadInvalidType());
+    }
+
+    [MethodImpl (MethodImplOptions.NoInlining)]
+    private static void LoadInvalidType()
+    {
+        Console.WriteLine($"-- {typeof(ValueTypeWithInstanceMethod).Name}");
     }
 
     public static int Main(string[] noArgs)
@@ -278,7 +285,7 @@ public class Simple
             TestGenericClassNonEquivalence();
             TestGenericInterfaceEquivalence();
             TestTypeEquivalenceWithTypePunning();
-            TestLoadingValueTypeWithStaticMethod();
+            TestLoadingValueTypesWithMethod();
         }
         catch (Exception e)
         {

--- a/src/tests/baseservices/typeequivalence/simple/Simple.cs
+++ b/src/tests/baseservices/typeequivalence/simple/Simple.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Text;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using Xunit;
@@ -253,6 +254,13 @@ public class Simple
         }
     }
 
+    [MethodImpl (MethodImplOptions.NoInlining)]
+    private static void TestLoadingValueTypeWithStaticMethod() 
+    {
+        Console.WriteLine($"{nameof(TestLoadingValueTypeWithStaticMethod)}");
+        Console.WriteLine($"-- {typeof(ValueTypeWithStaticMethod).Name}");
+    }
+
     public static int Main(string[] noArgs)
     {
         if (!OperatingSystem.IsWindows())
@@ -270,6 +278,7 @@ public class Simple
             TestGenericClassNonEquivalence();
             TestGenericInterfaceEquivalence();
             TestTypeEquivalenceWithTypePunning();
+            TestLoadingValueTypeWithStaticMethod();
         }
         catch (Exception e)
         {

--- a/src/tests/baseservices/typeequivalence/simple/Simple.csproj
+++ b/src/tests/baseservices/typeequivalence/simple/Simple.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="../impl/TypeImpl.csproj" />
     <ProjectReference Include="../impl/PunningLib.ilproj" />
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../pia/PIAContract.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(TypeEquivalence.targets))" />
 </Project>


### PR DESCRIPTION
fixes #73322

Allows static methods if checking type equivalence when marked with `PrimaryInteropAssemblyAttribute`