### PR TITLE
Adding a debug only config knob for testing loop unrolling limits

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2427,7 +2427,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.compJitAlignLoopMaxCodeSize        = (unsigned short)JitConfig.JitAlignLoopMaxCodeSize();
     opts.compJitHideAlignBehindJmp          = JitConfig.JitHideAlignBehindJmp() == 1;
     opts.compJitOptimizeStructHiddenBuffer  = JitConfig.JitOptimizeStructHiddenBuffer() == 1;
-    opts.compJitUnrollLoopMaxIterationCount = (unsigned short)JitConfig.JitUnrollLoopLimit();
+    opts.compJitUnrollLoopMaxIterationCount = (unsigned short)JitConfig.JitUnrollLoopMaxIterationCount();
 #else
     opts.compJitAlignLoopAdaptive           = true;
     opts.compJitAlignLoopBoundary           = DEFAULT_ALIGN_LOOP_BOUNDARY;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2252,7 +2252,7 @@ void Compiler::compSetProcessor()
     opts.compUseCMOV = jitFlags.IsSet(JitFlags::JIT_FLAG_USE_CMOV);
 #ifdef DEBUG
     if (opts.compUseCMOV)
-        opts.compUseCMOV                   = !compStressCompile(STRESS_USE_CMOV, 50);
+        opts.compUseCMOV                    = !compStressCompile(STRESS_USE_CMOV, 50);
 #endif // DEBUG
 
 #endif // TARGET_X86

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2423,19 +2423,19 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.compJitAlignLoopBoundary       = (unsigned short)JitConfig.JitAlignLoopBoundary();
     opts.compJitAlignLoopMinBlockWeight = (unsigned short)JitConfig.JitAlignLoopMinBlockWeight();
 
-    opts.compJitAlignLoopForJcc            = JitConfig.JitAlignLoopForJcc() == 1;
-    opts.compJitAlignLoopMaxCodeSize       = (unsigned short)JitConfig.JitAlignLoopMaxCodeSize();
-    opts.compJitHideAlignBehindJmp         = JitConfig.JitHideAlignBehindJmp() == 1;
-    opts.compJitOptimizeStructHiddenBuffer = JitConfig.JitOptimizeStructHiddenBuffer() == 1;
-    opts.compJitUnrollLoopIterationLimit   = (unsigned short)JitConfig.JitUnrollLoopLimit();
+    opts.compJitAlignLoopForJcc             = JitConfig.JitAlignLoopForJcc() == 1;
+    opts.compJitAlignLoopMaxCodeSize        = (unsigned short)JitConfig.JitAlignLoopMaxCodeSize();
+    opts.compJitHideAlignBehindJmp          = JitConfig.JitHideAlignBehindJmp() == 1;
+    opts.compJitOptimizeStructHiddenBuffer  = JitConfig.JitOptimizeStructHiddenBuffer() == 1;
+    opts.compJitUnrollLoopMaxIterationCount = (unsigned short)JitConfig.JitUnrollLoopLimit();
 #else
-    opts.compJitAlignLoopAdaptive          = true;
-    opts.compJitAlignLoopBoundary          = DEFAULT_ALIGN_LOOP_BOUNDARY;
-    opts.compJitAlignLoopMinBlockWeight    = DEFAULT_ALIGN_LOOP_MIN_BLOCK_WEIGHT;
-    opts.compJitAlignLoopMaxCodeSize       = DEFAULT_MAX_LOOPSIZE_FOR_ALIGN;
-    opts.compJitHideAlignBehindJmp         = true;
-    opts.compJitOptimizeStructHiddenBuffer = true;
-    opts.compJitUnrollLoopIterationLimit   = DEFAULT_UNROLL_LOOP_LIMIT;
+    opts.compJitAlignLoopAdaptive           = true;
+    opts.compJitAlignLoopBoundary           = DEFAULT_ALIGN_LOOP_BOUNDARY;
+    opts.compJitAlignLoopMinBlockWeight     = DEFAULT_ALIGN_LOOP_MIN_BLOCK_WEIGHT;
+    opts.compJitAlignLoopMaxCodeSize        = DEFAULT_MAX_LOOPSIZE_FOR_ALIGN;
+    opts.compJitHideAlignBehindJmp          = true;
+    opts.compJitOptimizeStructHiddenBuffer  = true;
+    opts.compJitUnrollLoopMaxIterationCount = DEFAULT_UNROLL_LOOP_MAX_ITERATION_COUNT;
 #endif
 
 #ifdef TARGET_XARCH

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2427,6 +2427,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.compJitAlignLoopMaxCodeSize       = (unsigned short)JitConfig.JitAlignLoopMaxCodeSize();
     opts.compJitHideAlignBehindJmp         = JitConfig.JitHideAlignBehindJmp() == 1;
     opts.compJitOptimizeStructHiddenBuffer = JitConfig.JitOptimizeStructHiddenBuffer() == 1;
+    opts.compJitUnrollLoopIterationLimit   = (unsigned short)JitConfig.JitUnrollLoopLimit();
 #else
     opts.compJitAlignLoopAdaptive          = true;
     opts.compJitAlignLoopBoundary          = DEFAULT_ALIGN_LOOP_BOUNDARY;
@@ -2434,6 +2435,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.compJitAlignLoopMaxCodeSize       = DEFAULT_MAX_LOOPSIZE_FOR_ALIGN;
     opts.compJitHideAlignBehindJmp         = true;
     opts.compJitOptimizeStructHiddenBuffer = true;
+    opts.compJitUnrollLoopIterationLimit   = DEFAULT_UNROLL_LOOP_LIMIT;
 #endif
 
 #ifdef TARGET_XARCH

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9303,6 +9303,9 @@ public:
 // likely complicated enough that loop alignment will not impact performance.
 #define DEFAULT_MAX_LOOPSIZE_FOR_ALIGN DEFAULT_ALIGN_LOOP_BOUNDARY * 3
 
+// By default only single iteration loops will be unrolled
+#define DEFAULT_UNROLL_LOOP_LIMIT 1
+
 #ifdef DEBUG
         // Loop alignment variables
 
@@ -9330,6 +9333,9 @@ public:
 
         // If set, tracks the hidden return buffer for struct arg.
         bool compJitOptimizeStructHiddenBuffer;
+
+        // Iteration limit to unroll a loop.
+        unsigned short compJitUnrollLoopIterationLimit;
 
 #ifdef LATE_DISASM
         bool doLateDisasm; // Run the late disassembler

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9304,7 +9304,7 @@ public:
 #define DEFAULT_MAX_LOOPSIZE_FOR_ALIGN DEFAULT_ALIGN_LOOP_BOUNDARY * 3
 
 // By default only single iteration loops will be unrolled
-#define DEFAULT_UNROLL_LOOP_LIMIT 1
+#define DEFAULT_UNROLL_LOOP_MAX_ITERATION_COUNT 1
 
 #ifdef DEBUG
         // Loop alignment variables
@@ -9335,7 +9335,7 @@ public:
         bool compJitOptimizeStructHiddenBuffer;
 
         // Iteration limit to unroll a loop.
-        unsigned short compJitUnrollLoopIterationLimit;
+        unsigned short compJitUnrollLoopMaxIterationCount;
 
 #ifdef LATE_DISASM
         bool doLateDisasm; // Run the late disassembler

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -76,7 +76,9 @@ CONFIG_INTEGER(JitHideAlignBehindJmp,
 CONFIG_INTEGER(JitOptimizeStructHiddenBuffer, W("JitOptimizeStructHiddenBuffer"), 1) // Track assignments to locals done
                                                                                      // through return buffers.
 
-CONFIG_INTEGER(JitUnrollLoopMaxIterationCount, W("JitUnrollLoopMaxIterationCount"), DEFAULT_UNROLL_LOOP_MAX_ITERATION_COUNT)
+CONFIG_INTEGER(JitUnrollLoopMaxIterationCount,
+               W("JitUnrollLoopMaxIterationCount"),
+               DEFAULT_UNROLL_LOOP_MAX_ITERATION_COUNT)
 
 // Print the alignment boundaries in disassembly.
 CONFIG_INTEGER(JitDasmWithAlignmentBoundaries, W("JitDasmWithAlignmentBoundaries"), 0)

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -76,6 +76,8 @@ CONFIG_INTEGER(JitHideAlignBehindJmp,
 CONFIG_INTEGER(JitOptimizeStructHiddenBuffer, W("JitOptimizeStructHiddenBuffer"), 1) // Track assignments to locals done
                                                                                      // through return buffers.
 
+CONFIG_INTEGER(JitUnrollLoopLimit, W("JitUnrollLoopLimit"), DEFAULT_UNROLL_LOOP_LIMIT)
+
 // Print the alignment boundaries in disassembly.
 CONFIG_INTEGER(JitDasmWithAlignmentBoundaries, W("JitDasmWithAlignmentBoundaries"), 0)
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -76,7 +76,7 @@ CONFIG_INTEGER(JitHideAlignBehindJmp,
 CONFIG_INTEGER(JitOptimizeStructHiddenBuffer, W("JitOptimizeStructHiddenBuffer"), 1) // Track assignments to locals done
                                                                                      // through return buffers.
 
-CONFIG_INTEGER(JitUnrollLoopLimit, W("JitUnrollLoopLimit"), DEFAULT_UNROLL_LOOP_MAX_ITERATION_COUNT)
+CONFIG_INTEGER(JitUnrollLoopMaxIterationCount, W("JitUnrollLoopMaxIterationCount"), DEFAULT_UNROLL_LOOP_MAX_ITERATION_COUNT)
 
 // Print the alignment boundaries in disassembly.
 CONFIG_INTEGER(JitDasmWithAlignmentBoundaries, W("JitDasmWithAlignmentBoundaries"), 0)

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -76,7 +76,7 @@ CONFIG_INTEGER(JitHideAlignBehindJmp,
 CONFIG_INTEGER(JitOptimizeStructHiddenBuffer, W("JitOptimizeStructHiddenBuffer"), 1) // Track assignments to locals done
                                                                                      // through return buffers.
 
-CONFIG_INTEGER(JitUnrollLoopLimit, W("JitUnrollLoopLimit"), DEFAULT_UNROLL_LOOP_LIMIT)
+CONFIG_INTEGER(JitUnrollLoopLimit, W("JitUnrollLoopLimit"), DEFAULT_UNROLL_LOOP_MAX_ITERATION_COUNT)
 
 // Print the alignment boundaries in disassembly.
 CONFIG_INTEGER(JitDasmWithAlignmentBoundaries, W("JitDasmWithAlignmentBoundaries"), 0)

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4203,11 +4203,11 @@ PhaseStatus Compiler::optUnrollLoops()
         }
         else if (totalIter <= opts.compJitUnrollLoopMaxIterationCount)
         {
-          // We can unroll this
+            // We can unroll this
         }
         else if ((loopFlags & LPFLG_SIMD_LIMIT) != 0)
         {
-          // We can unroll this
+            // We can unroll this
         }
         else
         {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4201,7 +4201,7 @@ PhaseStatus Compiler::optUnrollLoops()
             // If there is no iteration (totalIter == 0), we will remove the loop body entirely.
             unrollLimitSz = INT_MAX;
         }
-        else if (totalIter <= opts.compJitUnrollMaxIterationCount)
+        else if (totalIter <= opts.compJitUnrollLoopMaxIterationCount)
         {
           // We can unroll this
         }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4201,12 +4201,15 @@ PhaseStatus Compiler::optUnrollLoops()
             // If there is no iteration (totalIter == 0), we will remove the loop body entirely.
             unrollLimitSz = INT_MAX;
         }
-        else if (!(loopFlags & LPFLG_SIMD_LIMIT))
+        else if ((loopFlags & LPFLG_SIMD_LIMIT) == 0)
         {
-            // Otherwise unroll only if limit is Vector_.Length
-            // (as a heuristic, not for correctness/structural reasons)
-            JITDUMP("Failed to unroll loop " FMT_LP ": constant limit isn't Vector<T>.Length (heuristic)\n", lnum);
-            continue;
+            if (loop.lpConstLimit() > opts.compJitUnrollLoopIterationLimit)
+            {
+                // Otherwise unroll only if limit is constant and less than or equal to the limit
+                JITDUMP("Failed to unroll loop " FMT_LP ": constant limit is greater than %d (heuristic)\n", lnum,
+                        opts.compJitUnrollLoopIterationLimit);
+                continue;
+            }
         }
 
         GenTree* incr = incrStmt->GetRootNode();

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4211,8 +4211,8 @@ PhaseStatus Compiler::optUnrollLoops()
         }
         else
         {
-          JITDUMP("Failed to unroll loop " FMT_LP ": insufficiently simple loop (heuristic)\n", lnum);
-          continue;
+            JITDUMP("Failed to unroll loop " FMT_LP ": insufficiently simple loop (heuristic)\n", lnum);
+            continue;
         }
 
         GenTree* incr = incrStmt->GetRootNode();

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4201,15 +4201,18 @@ PhaseStatus Compiler::optUnrollLoops()
             // If there is no iteration (totalIter == 0), we will remove the loop body entirely.
             unrollLimitSz = INT_MAX;
         }
-        else if ((loopFlags & LPFLG_SIMD_LIMIT) == 0)
+        else if (totalIter <= opts.compJitUnrollMaxIterationCount)
         {
-            if (loop.lpConstLimit() > opts.compJitUnrollLoopIterationLimit)
-            {
-                // Otherwise unroll only if limit is constant and less than or equal to the limit
-                JITDUMP("Failed to unroll loop " FMT_LP ": constant limit is greater than %d (heuristic)\n", lnum,
-                        opts.compJitUnrollLoopIterationLimit);
-                continue;
-            }
+          // We can unroll this
+        }
+        else if ((loopFlags & LPFLG_SIMD_LIMIT) != 0)
+        {
+          // We can unroll this
+        }
+        else
+        {
+          JITDUMP("Failed to unroll loop " FMT_LP ": insufficiently simple loop (heuristic)\n", lnum);
+          continue;
         }
 
         GenTree* incr = incrStmt->GetRootNode();


### PR DESCRIPTION
This will allow easy testing of different loop unroll counts by simply specifying `COMPlus_JitUnrollLoopMaxIterationCount=#`

The AMD, Arm, and Intel architecture manuals all recommend unrolling small loops. However, the limit and size of these loops can differ based on CPU. All of them agree on 4-8 for "small" loops and so I expect this may be a good starting point for doing some benchmarks.

CC. @BruceForstall 