### PR TITLE
Replace GetFile() with GetPEAssembly() call in gdb

### DIFF
--- a/src/coreclr/vm/gdbjit.cpp
+++ b/src/coreclr/vm/gdbjit.cpp
@@ -508,7 +508,7 @@ GetDebugInfoFromPDB(MethodDesc* methodDescPtr,
         return E_FAIL;
 
     const Module* mod = methodDescPtr->GetMethodTable()->GetModule();
-    SString modName = mod->GetFile()->GetPath();
+    SString modName = mod->GetPEAssembly()->GetPath();
     if (modName.IsEmpty())
         return E_FAIL;
 
@@ -2533,7 +2533,7 @@ void NotifyGdb::OnMethodPrepared(MethodDesc* methodDescPtr)
 
     /* Get module name */
     const Module* mod = methodDescPtr->GetMethodTable()->GetModule();
-    SString modName = mod->GetFile()->GetPath();
+    SString modName = mod->GetPEAssembly()->GetPath();
     const char* szModName = modName.GetUTF8();
     const char* szModuleFile = SplitFilename(szModName);
 


### PR DESCRIPTION
Fixes #76291

`GetFile()` is not a member of module, it was dropped after .net6, replaced with `GetPEAssembly()`

This PR should be back ported to .NET7 and main