### PR TITLE
Use existing variable for SpecialFolder.UserProfile on Android

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Android.cs
@@ -86,7 +86,7 @@ namespace System
                     return Path.Combine(home, ".fonts");
 
                 case SpecialFolder.UserProfile:
-                    return GetEnvironmentVariable("HOME");
+                    return home;
 
                 case SpecialFolder.CommonApplicationData:
                     return "/usr/share";


### PR DESCRIPTION
While looking at https://github.com/dotnet/runtime/pull/76250 I noticed that we were querying the HOME env variable for SpecialFolder.UserProfile but we're already doing that in PersistedFiles.GetHomeDirectory()