### PR TITLE
HttpStress do not use SYS_PTRACE cap for docker runs

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -346,6 +346,11 @@ namespace HttpStress
 
             public void PrintCurrentResults(TimeSpan runtime)
             {
+                if (runtime.TotalMinutes > 2.0)
+                {
+                    System.Environment.Exit(1);
+                }
+
                 Console.ForegroundColor = ConsoleColor.Cyan;
                 Console.Write("[" + DateTime.Now + "]");
                 Console.ResetColor();

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -346,11 +346,6 @@ namespace HttpStress
 
             public void PrintCurrentResults(TimeSpan runtime)
             {
-                if (runtime.TotalMinutes > 2.0)
-                {
-                    System.Environment.Exit(1);
-                }
-
                 Console.ForegroundColor = ConsoleColor.Cyan;
                 Console.Write("[" + DateTime.Now + "]");
                 Console.ResetColor();

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     image: httpstress
     volumes:
       - "${CLIENT_DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"
-    cap_add:
-      - SYS_PTRACE
     links:
       - server
     environment:
@@ -20,8 +18,6 @@ services:
     image: httpstress
     volumes:
       - "${SERVER_DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"
-    cap_add:
-      - SYS_PTRACE
     ports:
       - "5001:5001"
     environment:

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     image: httpstress
     volumes:
       - "${SERVER_DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"
+    cap_add:
+      - SYS_PTRACE
     ports:
       - "5001:5001"
     environment:

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/docker-compose.yml
@@ -20,8 +20,6 @@ services:
     image: httpstress
     volumes:
       - "${SERVER_DUMPS_SHARE}:${DUMPS_SHARE_MOUNT_ROOT}"
-    cap_add:
-      - SYS_PTRACE
     ports:
       - "5001:5001"
     environment:


### PR DESCRIPTION
According to an offline discussion with engineering folks, there is no need for SYS_PTRACE on newer Linux kernels, so we can remove it for all platforms.

The PR is marked as draft because ~it contains an emulated crash to test dump creation. If everything works fine, I will remove it.~

Fixes #76045