### PR TITLE
[wasm] Delete malformed package.json used for tests, it confuses Component Governance tooling

### DIFF
--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -332,6 +332,9 @@
     <!-- npm install is faster on dev machine as it doesn't wipe node_modules folder -->
     <RunWithEmSdkEnv Condition="'$(ContinuousIntegrationBuild)' != 'true'" Command="npm install" EmSdkPath="$(EMSDK_PATH)" IgnoreStandardErrorWarningFormat="true" WorkingDirectory="$(MonoProjectRoot)wasm/runtime/"/>
 
+    <!-- Delete malformed package.json used for tests, it confuses Component Governance tooling -->
+    <Delete Files="$(MonoProjectRoot)wasm/runtime/node_modules/resolve/test/resolver/malformed_package_json/package.json" ContinueOnError="true" />
+
     <Touch Files="$(MonoProjectRoot)wasm/runtime/node_modules/.npm-stamp" AlwaysCreate="true" />
   </Target>
 


### PR DESCRIPTION
We were seeing these warnings in the official build:

```
##[warning]Could not parse Jtokens from file /__w/1/s/src/mono/wasm/runtime/node_modules/resolve/test/resolver/malformed_package_json/package.json.
```
