### PR TITLE
Distributed transaction fixes

### DIFF
--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
@@ -30,6 +30,8 @@ internal sealed class DtcProxyShimFactory
     private readonly ConcurrentQueue<ITransactionTransmitter> _cachedTransmitters = new();
     private readonly ConcurrentQueue<ITransactionReceiver> _cachedReceivers = new();
 
+    private static readonly int _maxCachedInterfaces = Environment.ProcessorCount * 2;
+
     private readonly EventWaitHandle _eventHandle;
 
     private ITransactionDispenser _transactionDispenser = null!; // Late-initialized in ConnectToProxy
@@ -350,7 +352,13 @@ internal sealed class DtcProxyShimFactory
     }
 
     internal void ReturnCachedTransmitter(ITransactionTransmitter transmitter)
-        => _cachedTransmitters.Enqueue(transmitter);
+    {
+        if (_cachedTransmitters.Count < _maxCachedInterfaces)
+        {
+            transmitter.Reset();
+            _cachedTransmitters.Enqueue(transmitter);
+        }
+    }
 
     internal ITransactionReceiver GetCachedReceiver()
     {
@@ -366,5 +374,11 @@ internal sealed class DtcProxyShimFactory
     }
 
     internal void ReturnCachedReceiver(ITransactionReceiver receiver)
-        => _cachedReceivers.Enqueue(receiver);
+    {
+        if (_cachedReceivers.Count < _maxCachedInterfaces)
+        {
+            receiver.Reset();
+            _cachedReceivers.Enqueue(receiver);
+        }
+    }
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/DtcProxyShim/DtcProxyShimFactory.cs
@@ -30,7 +30,7 @@ internal sealed class DtcProxyShimFactory
     private readonly ConcurrentQueue<ITransactionTransmitter> _cachedTransmitters = new();
     private readonly ConcurrentQueue<ITransactionReceiver> _cachedReceivers = new();
 
-    private static readonly int _maxCachedInterfaces = Environment.ProcessorCount * 2;
+    private static readonly int s_maxCachedInterfaces = Environment.ProcessorCount * 2;
 
     private readonly EventWaitHandle _eventHandle;
 
@@ -353,7 +353,7 @@ internal sealed class DtcProxyShimFactory
 
     internal void ReturnCachedTransmitter(ITransactionTransmitter transmitter)
     {
-        if (_cachedTransmitters.Count < _maxCachedInterfaces)
+        if (_cachedTransmitters.Count < s_maxCachedInterfaces)
         {
             transmitter.Reset();
             _cachedTransmitters.Enqueue(transmitter);
@@ -375,7 +375,7 @@ internal sealed class DtcProxyShimFactory
 
     internal void ReturnCachedReceiver(ITransactionReceiver receiver)
     {
-        if (_cachedReceivers.Count < _maxCachedInterfaces)
+        if (_cachedReceivers.Count < s_maxCachedInterfaces)
         {
             receiver.Reset();
             _cachedReceivers.Enqueue(receiver);

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionState.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionState.cs
@@ -1867,7 +1867,6 @@ namespace System.Transactions
             return false;
         }
 
-
         internal override void CompleteBlockingClone(InternalTransaction tx)
         {
             // First try to complete one of the internal blocking clones
@@ -1900,16 +1899,22 @@ namespace System.Transactions
                     Monitor.Exit(tx);
                     try
                     {
-                        dtx.Complete();
+                        try
+                        {
+                            dtx.Complete();
+                        }
+                        finally
+                        {
+                            dtx.Dispose();
+                        }
                     }
                     finally
                     {
-                        dtx.Dispose();
+                        Monitor.Enter(tx);
                     }
                 }
             }
         }
-
 
         internal override void CompleteAbortingClone(InternalTransaction tx)
         {
@@ -1937,11 +1942,18 @@ namespace System.Transactions
                     Monitor.Exit(tx);
                     try
                     {
-                        dtx.Complete();
+                        try
+                        {
+                            dtx.Complete();
+                        }
+                        finally
+                        {
+                            dtx.Dispose();
+                        }
                     }
                     finally
                     {
-                        dtx.Dispose();
+                        Monitor.Enter(tx);
                     }
                 }
             }


### PR DESCRIPTION
  * Retake lock when using a dependent transaction from a TransactionScope ([#76010](https://github.com/dotnet/runtime/issues/76010)).
* Reset TransactionTransmitter and Receiver before reusing them ([#76010](https://github.com/dotnet/runtime/issues/76010)).
* Increase MSDTC startup timeout from 2.5 to 30 seconds ([#75822](https://github.com/dotnet/runtime/issues/75822))

Fixes #76010
Fixes #75822