### PR TITLE
Don't run SPMI unit test if it appears a SPMI collection is in progress

### DIFF
--- a/src/tests/JIT/superpmi/superpmicollect.cs
+++ b/src/tests/JIT/superpmi/superpmicollect.cs
@@ -603,7 +603,7 @@ namespace SuperPMICollection
             Console.WriteLine("If -mch is not given, all generated files are deleted, and the result is simply the exit code");
             Console.WriteLine("indicating whether the collection succeeded. This is useful as a test.");
             Console.WriteLine("");
-            Console.WriteLine("If the COMPlus_JitName variable is already set, it is assumed SuperPMI collection is already happening,");
+            Console.WriteLine("If the COMPlus_JitName or COMPlus_JitPath variable is already set, it is assumed SuperPMI collection is already happening,");
             Console.WriteLine("and the program exits with success.");
             Console.WriteLine("");
             Console.WriteLine("On success, the return code is 100.");
@@ -700,15 +700,19 @@ namespace SuperPMICollection
 
             // Done with argument parsing.
 
-            string jitnamevar = System.Environment.GetEnvironmentVariable("COMPlus_JitName");
-            if (!String.IsNullOrEmpty(jitnamevar))
-            {
-                // Someone already has the COMPlus_JitName variable set. We don't want to override
-                // that. Perhaps someone is already doing a SuperPMI collection and invokes this
-                // program as part of a full test path in which this program exists.
+            // If someone already has one of the COMPlus_JitName/DOTNET_JitName/COMPlus_JitPath/DOTNET_JitPath variables set,
+            // We don't want to override that. Perhaps someone is already doing a SuperPMI collection and invokes this
+            // program as part of a full test path in which this program exists.
 
-                Console.WriteLine("COMPlus_JitName already exists: skipping SuperPMI collection and returning success");
-                return 100;
+            string[] checkVars = { "COMPlus_JitName", "DOTNET_JitName", "COMPlus_JitPath", "DOTNET_JitPath" };
+            foreach (string varName in checkVars)
+            {
+                string envVar = System.Environment.GetEnvironmentVariable(varName);
+                if (!String.IsNullOrEmpty(envVar))
+                {
+                    Console.WriteLine($"{varName} already exists (set to {envVar}): skipping SuperPMI collection and returning success");
+                    return 100;
+                }
             }
 
             int result;


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/75765 stopped setting JitName, but we should check for JitPath as well.
