### PR TITLE
[release/7.0] Remove VS nupkg push

### DIFF
--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -453,20 +453,6 @@ jobs:
       continueOnError: true
       condition: succeededOrFailed()
 
-  - ${{ if and(eq(parameters.osGroup, 'windows'), eq(parameters.isOfficialBuild, true)) }}:
-    - task: NuGetCommand@2
-      displayName: Push Visual Studio NuPkgs
-      inputs:
-        command: push
-        packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
-        nuGetFeedType: external
-        publishFeedCredentials: 'DevDiv - VS package feed'
-      condition: and(
-        succeeded(),
-        eq(variables['_BuildConfig'], 'Release'),
-        ne(variables['DisableVSPublish'], 'true'),
-        ne(variables['PostBuildSign'], 'true'))
-
   - template: steps/upload-job-artifacts.yml
     parameters:
       name: ${{ coalesce(parameters.name, parameters.platform) }}


### PR DESCRIPTION
Signing happens at the end of the build now, even with in-build signing. The staging pipeline pushes the nupkgs. This step is not necessary, and pushes unsigned nupkgs.