### PR TITLE
Remove duplicate length words from xmldoc

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="start">The zero-based starting character position in this <see cref="StringSegment"/>.</param>
         /// <param name="length">The number of characters in the span.</param>
-        /// <returns>A <see cref="ReadOnlySpan{T}"/> with length <paramref name="length"/> that begins at
+        /// <returns>A <see cref="ReadOnlySpan{T}"/> with <paramref name="length"/> that begins at
         /// <paramref name="start"/> in this <see cref="StringSegment"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="start"/> or <paramref name="length"/> is less than zero, or <paramref name="start"/> + <paramref name="length"/> is
@@ -387,7 +387,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
         /// <param name="length">The number of characters in the substring.</param>
-        /// <returns>A <see cref="string"/> that is equivalent to the substring of length <paramref name="length"/> that begins at
+        /// <returns>A <see cref="string"/> that is equivalent to the substring of <paramref name="length"/> that begins at
         /// <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> or <paramref name="length"/> is less than zero, or <paramref name="offset"/> + <paramref name="length"/> is
@@ -422,7 +422,7 @@ namespace Microsoft.Extensions.Primitives
         /// </summary>
         /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
         /// <param name="length">The number of characters in the substring.</param>
-        /// <returns>A <see cref="StringSegment"/> that is equivalent to the substring of length <paramref name="length"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
+        /// <returns>A <see cref="StringSegment"/> that is equivalent to the substring of <paramref name="length"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> or <paramref name="length"/> is less than zero, or <paramref name="offset"/> + <paramref name="length"/> is
         /// greater than <see cref="Length"/>.


### PR DESCRIPTION
This is how `string.Substring(int startIndex, int length)` renders in Visual Studio 2022:

<img width="742" alt="image" src="https://user-images.githubusercontent.com/1012917/192848314-bea05913-b24f-406f-9c28-af632937df3f.png">
