### PR TITLE
[metadata] Skip null vtable entries when checking covariant return overrides

### DIFF
--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1656,6 +1656,10 @@ check_vtable_covariant_override_impls (MonoClass *klass, MonoMethod **vtable, in
 				break;
 			MonoMethod *prev_impl = cur_class->vtable[slot];
 
+			// if the current class re-abstracted the method, it may not be there.
+			if (!prev_impl)
+				continue;
+
 			if (prev_impl != last_checked_prev_override) {
 				/*
 				 * the new impl should be subsumed by the prior one, ie this

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/OverrideReabstracted.cs
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/OverrideReabstracted.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System;
 
 

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/OverrideReabstracted.cs
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/OverrideReabstracted.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+
+namespace ReproMAUI6811;
+
+public static class Program
+{
+    public static int Main()
+    {
+        Leaf l = new Leaf();
+
+        if (l.getI().ToString() != "Leaf")
+                return 1;
+        if (((Intermediate)l).getI().ToString() != "Leaf")
+                return 2;
+        if (((PseudoBase)l).getI().ToString() != "Leaf")
+                return 3;
+        if (((Base)l).getI().ToString() != "Leaf")
+                return 4;
+        return 100;
+    }
+}
+
+public abstract class Base {
+    public abstract I getI();
+}
+
+public class PseudoBase : Base {
+        public override I getI() => new C ("PseudoBase");
+}
+
+public abstract class Intermediate : PseudoBase {
+    public override abstract I getI();
+}
+
+public class Leaf : Intermediate {
+    public Leaf() {}
+    public override C getI() { return new C ("Leaf"); }
+}
+
+public interface I {}
+
+public class C : I {
+        private readonly string _repr;
+        public C(string s) { _repr = s; }
+        public override string ToString() => _repr;
+}
+
+

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/OverrideReabstracted.cs
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/OverrideReabstracted.cs
@@ -29,7 +29,7 @@ public abstract class Base {
 }
 
 public class PseudoBase : Base {
-        public override I getI() => new C ("PseudoBase");
+    public override I getI() => new C ("PseudoBase");
 }
 
 public abstract class Intermediate : PseudoBase {
@@ -44,9 +44,9 @@ public class Leaf : Intermediate {
 public interface I {}
 
 public class C : I {
-        private readonly string _repr;
-        public C(string s) { _repr = s; }
-        public override string ToString() => _repr;
+    private readonly string _repr;
+    public C(string s) { _repr = s; }
+    public override string ToString() => _repr;
 }
 
 

--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/OverrideReabstracted.csproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/OverrideReabstracted.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When there are covariant return overrides, we check the vtable slot in every parent class for signature compatibility with the proposed override.

However if one of the ancestor classes is abstract, it could have an abstract override for the method:

```csharp
    class Base {
      public virtual Base Method() => this;
    }
    public abstract Intermediate : Base {
      public override abstract Base Method();
    }
    public Leaf : Intermediate {
      public override Leaf Method() => this;
    }
```
In this case when we're checking that `Leaf.Method` is compatible with the vtable slot in `Intermediate`, we will see a null method (since `Intermediate.Method` is abstract).  In such cases we can skip over the class and continue with its parent.

Fixes
https://github.com/dotnet/runtime/issues/76312