### PR TITLE
perfcollect docs: run two commands instead of three

### DIFF
--- a/docs/project/linux-performance-tracing.md
+++ b/docs/project/linux-performance-tracing.md
@@ -175,10 +175,10 @@ To install dotnet symbol issue the command
      dotnet tool install -g dotnet-symbol
 ```
 
-To download symbols for all native libraries and store them next to them:
+To download symbols for **all native libraries** (including .NET runtime/framework as well as any other installed frameworks like ASP.NET) and store them next to them:
 
 ```
-    sudo dotnet symbol --recurse-subdirectories --symbols '/usr/share/dotnet/lib*.so'
+    sudo dotnet symbol --recurse-subdirectories --symbols '/usr/share/dotnet/*.so'
 ```
 
 ## Collecting in a Docker Container ##

--- a/docs/project/linux-performance-tracing.md
+++ b/docs/project/linux-performance-tracing.md
@@ -165,28 +165,22 @@ symbols for these when it converts its data, but ONLY if the symbols for these n
 the library they are for).
 
 There is a global command called [dotnet symbol](https://github.com/dotnet/symstore/blob/master/src/dotnet-symbol/README.md#symbol-downloader-dotnet-cli-extension) which does this.   This tool was mostly desiged to download symbols
-for debugging, but it works for perfcollect as well.  There are three steps to getting the symbols
+for debugging, but it works for perfcollect as well.  There are two steps to getting the symbols:
 
-   1. Install dotnet symbol
+   1. Install dotnet symbol.
    2. Download the symbols.
-   3. Copy the symbols to the correct place
 
 To install dotnet symbol issue the command
 ```
      dotnet tool install -g dotnet-symbol
 ```
-With that installed download the symbols to a local directory.  if your installed version of the .NET Core runtime is
-2.1.0 the command to do this is
+
+To download symbols for all native libraries and store them next to them:
+
 ```
-    mkdir mySymbols
-    dotnet symbol --symbols --output mySymbols  /usr/share/dotnet/shared/Microsoft.NETCore.App/2.1.0/lib*.so
+    sudo dotnet symbol --recurse-subdirectories --symbols '/usr/share/dotnet/lib*.so'
 ```
-Now all the symbols for those native dlls are in mySymbols.   You then have to copy them (as super user next to the
-dlls that they are for.
-```
-    sudo cp mySymbols/* /usr/share/dotnet/shared/Microsoft.NETCore.App/2.1.0
-```
-After this, you should get symbolic names for the native dlls when you run perfcollect.
+
 ## Collecting in a Docker Container ##
 Perfcollect can be used to collect data for an application running inside a Docker container.  The main thing to know is that collecting a trace requires elevated privileges because the [default seccomp profile](https://docs.docker.com/engine/security/seccomp/) blocks a required syscall - perf_events_open.
 


### PR DESCRIPTION
While working on https://github.com/dotnet/BenchmarkDotNet/pull/2117 I've realized that:

- by default `dotnet symbol` writes the symbol files next to the input files, so we can reduce the process by one step
- it supports recursive search, which allows us to provide a version-independent command

Sample output (I am also asking for `dotnet` exe symbols as I am pedantic and want to have all symbols solved)

```log
// start /tmp/BenchmarkDotNet/symbols/dotnet-symbol --recurse-subdirectories --symbols "/home/robox/adsitnik/performance/tools/dotnet/arm64/dotnet" "/home/robox/adsitnik/performance/tools/dotnet/arm64/lib*.so" in
Downloading from https://msdl.microsoft.com/download/symbols/
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/dotnet.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/host/fxr/6.0.9/libhostfxr.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libmscordbi.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libSystem.Net.Security.Native.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libSystem.Native.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libmscordaccore.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libSystem.Globalization.Native.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libhostpolicy.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libSystem.Security.Cryptography.Native.OpenSsl.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libcoreclrtraceptprovider.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libcoreclr.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libSystem.IO.Compression.Native.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libclrjit.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App/6.0.9/libdbgshim.so.dbg
Writing: /home/robox/adsitnik/performance/tools/dotnet/arm64/packs/Microsoft.NETCore.App.Host.linux-arm64/6.0.9/runtimes/linux-arm64/native/libnethost.so.dbg
```