### PR TITLE
Dispose key when importing X.509 PEM 

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -1433,16 +1433,18 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     if (label.SequenceEqual(eligibleLabel))
                     {
-                        TAlg key = factory();
-                        key.ImportFromPem(contents[fields.Location]);
+                        using (TAlg key = factory())
+                        {
+                            key.ImportFromPem(contents[fields.Location]);
 
-                        try
-                        {
-                            return import(key);
-                        }
-                        catch (ArgumentException ae)
-                        {
-                            throw new CryptographicException(SR.Cryptography_X509_NoOrMismatchedPemKey, ae);
+                            try
+                            {
+                                return import(key);
+                            }
+                            catch (ArgumentException ae)
+                            {
+                                throw new CryptographicException(SR.Cryptography_X509_NoOrMismatchedPemKey, ae);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The `import` delegate is always going to be pointing to some `CopyWithPrivateKey`. Since those retain the key into the new certificate, we have a lingering copy lying around during the import which ends up getting finalized.

Based on comment via https://github.com/dotnet/runtime/pull/76277#issuecomment-1261382010.