### PR TITLE
Return s_defaultResultTask from Task.FromResult in more cases

### DIFF
--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
@@ -512,6 +512,21 @@ namespace System.Threading.Tasks.Tests
             Assert.Same(Task.FromResult(UIntPtr.Zero), Task.FromResult(UIntPtr.Zero));
             Assert.Equal(UIntPtr.Zero, Task.FromResult(UIntPtr.Zero).Result);
 
+            Assert.Same(Task.FromResult((Half)default), Task.FromResult((Half)default));
+            Assert.Equal((Half)default, Task.FromResult((Half)default).Result);
+
+            Assert.Same(Task.FromResult((float)default), Task.FromResult((float)default));
+            Assert.Equal((float)default, Task.FromResult((float)default).Result);
+
+            Assert.Same(Task.FromResult((double)default), Task.FromResult((double)default));
+            Assert.Equal((double)default, Task.FromResult((double)default).Result);
+
+            Assert.Same(Task.FromResult((TimeSpan)default), Task.FromResult((TimeSpan)default));
+            Assert.Equal((TimeSpan)default, Task.FromResult((TimeSpan)default).Result);
+
+            Assert.Same(Task.FromResult((DateTime)default), Task.FromResult((DateTime)default));
+            Assert.Equal((DateTime)default, Task.FromResult((DateTime)default).Result);
+
             Assert.Same(Task.FromResult((object)null), Task.FromResult((object)null));
             Assert.Null(Task.FromResult((object)null).Result);
 
@@ -526,10 +541,11 @@ namespace System.Threading.Tasks.Tests
                 Assert.Equal(i, Task.FromResult(i).Result);
             }
 
-            Assert.NotSame(Task.FromResult((double)0), Task.FromResult((double)0));
-            Assert.NotSame(Task.FromResult((float)0), Task.FromResult((float)0));
-            Assert.NotSame(Task.FromResult((decimal)0), Task.FromResult((decimal)0));
-            Assert.NotSame(Task.FromResult((Half)0), Task.FromResult((Half)0));
+            Assert.NotSame(Task.FromResult((double)(+0.0)), Task.FromResult((double)(-0.0)));
+            Assert.NotSame(Task.FromResult((float)(+0.0)), Task.FromResult((float)(-0.0)));
+            Assert.NotSame(Task.FromResult((Half)(+0.0)), Task.FromResult((Half)(-0.0)));
+
+            Assert.NotSame(Task.FromResult((decimal)default), Task.FromResult((decimal)default));
         }
 
         [Fact]


### PR DESCRIPTION
Today we return a cached task from Task.FromResult when the TResult is a primitive and its value is 0.  But it needn't be constrained to only being a primitive; what matters is that we need to be able to efficiently compare its bit pattern to 0.  And we can do that easily now by using Unsafe.SizeOf to check if the size is the same as a primitive, Unsafe casting to that primitive, and then comparing against 0.

```C#
[Benchmark]
public async Task<TimeSpan> Cached() => TimeSpan.Zero;
```

| Method |         Toolchain |     Mean | Ratio | Allocated | Alloc Ratio |
|------- |------------------ |---------:|------:|----------:|------------:|
| Cached | \main\corerun.exe | 19.54 ns |  1.00 |      72 B |        1.00 |
| Cached |   \pr\corerun.exe | 12.47 ns |  0.64 |         - |        0.00 |