### PR TITLE
Fix using DependencyGraphViewer with AOT compilers

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
@@ -25,7 +25,7 @@ namespace ILCompiler.DependencyAnalysisFramework
     public sealed class DependencyAnalyzer<MarkStrategy, DependencyContextType> : DependencyAnalyzerBase<DependencyContextType> where MarkStrategy : struct, IDependencyAnalysisMarkStrategy<DependencyContextType>
     {
 #pragma warning disable SA1129 // Do not use default value type constructor
-        private readonly MarkStrategy _marker = new MarkStrategy();
+        private MarkStrategy _marker = new MarkStrategy();
 #pragma warning restore SA1129 // Do not use default value type constructor
         private DependencyContextType _dependencyContext;
         private IComparer<DependencyNodeCore<DependencyContextType>> _resultSorter;


### PR DESCRIPTION
The `readonly` was added in #74825. `MarkStrategy` can have mutable state that was getting lost because Roslyn considers it necessary to put `_marker` into a temporary before calling instance methods on it.

This resulted in DependencyGraphViewer hanging after seeing tens of thousands of new graphs being added.

Cc @dotnet/ilc-contrib 