### PR TITLE
Improve early bail-out logic in GCInfoDecoder

### DIFF
--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -111,7 +111,7 @@ GcInfoDecoder::GcInfoDecoder(
 
     GcInfoHeaderFlags headerFlags;
     bool slimHeader = (m_Reader.ReadOneFast() == 0);
-    // Use flag mask to bail out early if we already decoded all the pieces tha caller requested
+    // Use flag mask to bail out early if we already decoded all the pieces that caller requested
     int remainingFlags = flags == DECODE_EVERYTHING ? ~0 : flags;
 
     if (slimHeader)


### PR DESCRIPTION
Speeds-up some common code paths like NativeAOT asking to decode `DECODE_RETURN_KIND | DECODE_HAS_TAILCALLS`.