### PR TITLE
SmtpClientTest Assertion Fail Fix

### DIFF
--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -473,7 +473,7 @@ namespace System.Net.Mail.Tests
 
             var message = new MailMessage("foo@internet.com", "bar@internet.com", "Foo", "Bar");
 
-            Task sendTask = client.SendMailAsync(message, cts.Token);
+            Task sendTask = Task.Run(() => client.SendMailAsync(message, cts.Token));
 
             cts.Cancel();
             await Task.Delay(500);
@@ -482,7 +482,7 @@ namespace System.Net.Mail.Tests
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask).WaitAsync(TestHelper.PassingTestTimeout);
 
             // We should still be able to send mail on the SmtpClient instance
-            await client.SendMailAsync(message).WaitAsync(TestHelper.PassingTestTimeout);
+            await Task.Run(() => client.SendMailAsync(message)).WaitAsync(TestHelper.PassingTestTimeout);
 
             Assert.Equal("<foo@internet.com>", server.MailFrom);
             Assert.Equal("<bar@internet.com>", server.MailTo);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -476,7 +476,7 @@ namespace System.Net.Mail.Tests
             Task sendTask = client.SendMailAsync(message, cts.Token);
 
             cts.Cancel();
-            await Task.Delay(new Random().Next(300, 700));
+            await Task.Delay(500);
             serverMre.Set();
 
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask).WaitAsync(TestHelper.PassingTestTimeout);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -476,7 +476,7 @@ namespace System.Net.Mail.Tests
             Task sendTask = client.SendMailAsync(message, cts.Token);
 
             cts.Cancel();
-            await Task.Delay(new Random().Next(500));
+            await Task.Delay(new Random().Next(300, 700));
             serverMre.Set();
 
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask).WaitAsync(TestHelper.PassingTestTimeout);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -476,7 +476,7 @@ namespace System.Net.Mail.Tests
             Task sendTask = client.SendMailAsync(message, cts.Token);
 
             cts.Cancel();
-            await Task.Delay(500);
+            await Task.Delay(new Random().Next(500));
             serverMre.Set();
 
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask).WaitAsync(TestHelper.PassingTestTimeout);
@@ -497,11 +497,6 @@ namespace System.Net.Mail.Tests
         [InlineData(3)]
         [InlineData(4)]
         [InlineData(5)]
-        [InlineData(6)]
-        [InlineData(7)]
-        [InlineData(8)]
-        [InlineData(9)]
-        [InlineData(10)]
         public async Task SendMailAsync_CanBeCanceled_CancellationToken_Loop(int ignore)
         {
             

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -491,16 +491,13 @@ namespace System.Net.Mail.Tests
             Assert.Equal(GetClientDomain(), server.ClientDomain);
         }
 
-        [Theory]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        public async Task SendMailAsync_CanBeCanceled_CancellationToken_Loop(int ignore)
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Windows, "This test only fails on Unix-like")]
+        public async Task SendMailAsync_CanBssseCanceled_CancellationToken_Loop()
         {
             
-            for (int i = 0; i < ignore * 100; ++i)
+            for (int i = 0; i < 1000; ++i)
             {
                 await SendMailAsync_CanBeCanceled_CancellationToken();
             }

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -491,18 +491,6 @@ namespace System.Net.Mail.Tests
             Assert.Equal(GetClientDomain(), server.ClientDomain);
         }
 
-
-        [Fact]
-        [SkipOnPlatform(TestPlatforms.Windows, "This test only fails on Unix-like")]
-        public async Task SendMailAsync_CanBssseCanceled_CancellationToken_Loop()
-        {
-            
-            for (int i = 0; i < 1000; ++i)
-            {
-                await SendMailAsync_CanBeCanceled_CancellationToken();
-            }
-        }
-
         private static string GetClientDomain() => IPGlobalProperties.GetIPGlobalProperties().HostName.Trim().ToLower();
 
         [Theory]

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -491,10 +491,21 @@ namespace System.Net.Mail.Tests
             Assert.Equal(GetClientDomain(), server.ClientDomain);
         }
 
-        [Fact]
-        public async Task SendMailAsync_CanBeCanceled_CancellationToken_Loop()
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        public async Task SendMailAsync_CanBeCanceled_CancellationToken_Loop(int ignore)
         {
-            for (int i = 0; i < 1000; ++i)
+            
+            for (int i = 0; i < ignore * 100; ++i)
             {
                 await SendMailAsync_CanBeCanceled_CancellationToken();
             }

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -473,7 +473,7 @@ namespace System.Net.Mail.Tests
 
             var message = new MailMessage("foo@internet.com", "bar@internet.com", "Foo", "Bar");
 
-            Task sendTask = Task.Run(() => client.SendMailAsync(message, cts.Token));
+            Task sendTask = client.SendMailAsync(message, cts.Token);
 
             cts.Cancel();
             await Task.Delay(500);
@@ -482,7 +482,7 @@ namespace System.Net.Mail.Tests
             await Assert.ThrowsAsync<TaskCanceledException>(async () => await sendTask).WaitAsync(TestHelper.PassingTestTimeout);
 
             // We should still be able to send mail on the SmtpClient instance
-            await Task.Run(() => client.SendMailAsync(message)).WaitAsync(TestHelper.PassingTestTimeout);
+            await client.SendMailAsync(message).WaitAsync(TestHelper.PassingTestTimeout);
 
             Assert.Equal("<foo@internet.com>", server.MailFrom);
             Assert.Equal("<bar@internet.com>", server.MailTo);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -491,6 +491,15 @@ namespace System.Net.Mail.Tests
             Assert.Equal(GetClientDomain(), server.ClientDomain);
         }
 
+        [Fact]
+        public async Task SendMailAsync_CanBeCanceled_CancellationToken_Loop()
+        {
+            for (int i = 0; i < 1000; ++i)
+            {
+                await SendMailAsync_CanBeCanceled_CancellationToken();
+            }
+        }
+
         private static string GetClientDomain() => IPGlobalProperties.GetIPGlobalProperties().HostName.Trim().ToLower();
 
         [Theory]

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -137,7 +137,9 @@ namespace System.Net.Sockets
 
             // Then replace the handle with a new one
             SafeSocketHandle oldHandle = _handle;
-            SocketError errorCode = SocketPal.CreateSocket(_addressFamily, _socketType, _protocolType, out _handle);
+            SafeSocketHandle newHandle;
+            SocketError errorCode = SocketPal.CreateSocket(_addressFamily, _socketType, _protocolType, out newHandle);
+            _handle = newHandle;
             oldHandle.TransferTrackedState(_handle);
             oldHandle.Dispose();
             if (errorCode != SocketError.Success)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -140,7 +140,6 @@ namespace System.Net.Sockets
             SafeSocketHandle newHandle;
             SocketError errorCode = SocketPal.CreateSocket(_addressFamily, _socketType, _protocolType, out newHandle);
             _handle.TransferTrackedState(newHandle);
-            _handle.Dispose();
             if (errorCode != SocketError.Success)
             {
                 return errorCode;
@@ -160,7 +159,9 @@ namespace System.Net.Sockets
             if (newHandle.IsTrackedOption(TrackedSocketOptions.SendTimeout)) SendTimeout = sendTimeout;
             if (newHandle.IsTrackedOption(TrackedSocketOptions.Ttl)) Ttl = ttl;
 
+            SafeSocketHandle oldHandle = _handle;
             Volatile.Write(ref _handle, newHandle);
+            oldHandle.Dispose();
 
             if (Volatile.Read(ref _disposed) != 0)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -8,6 +8,7 @@ using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 using System.Reflection;
 using System.Collections;
+using System.Threading;
 
 namespace System.Net.Sockets
 {
@@ -136,12 +137,10 @@ namespace System.Net.Sockets
             if (_handle.IsTrackedOption(TrackedSocketOptions.Ttl)) ttl = Ttl;
 
             // Then replace the handle with a new one
-            SafeSocketHandle oldHandle = _handle;
             SafeSocketHandle newHandle;
             SocketError errorCode = SocketPal.CreateSocket(_addressFamily, _socketType, _protocolType, out newHandle);
-            _handle = newHandle;
-            oldHandle.TransferTrackedState(_handle);
-            oldHandle.Dispose();
+            _handle.TransferTrackedState(newHandle);
+            _handle.Dispose();
             if (errorCode != SocketError.Success)
             {
                 return errorCode;
@@ -150,16 +149,23 @@ namespace System.Net.Sockets
             // And put back the copied settings.  For DualMode, we use the value stored in the _handle
             // rather than querying the socket itself, as on Unix stacks binding a dual-mode socket to
             // an IPv6 address may cause the IPv6Only setting to revert to true.
-            if (_handle.IsTrackedOption(TrackedSocketOptions.DualMode)) DualMode = _handle.DualMode;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.DontFragment)) DontFragment = dontFragment;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.EnableBroadcast)) EnableBroadcast = broadcast;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.LingerState)) LingerState = linger!;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.NoDelay)) NoDelay = noDelay;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.ReceiveBufferSize)) ReceiveBufferSize = receiveSize;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.ReceiveTimeout)) ReceiveTimeout = receiveTimeout;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.SendBufferSize)) SendBufferSize = sendSize;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.SendTimeout)) SendTimeout = sendTimeout;
-            if (_handle.IsTrackedOption(TrackedSocketOptions.Ttl)) Ttl = ttl;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.DualMode)) DualMode = _handle.DualMode;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.DontFragment)) DontFragment = dontFragment;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.EnableBroadcast)) EnableBroadcast = broadcast;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.LingerState)) LingerState = linger!;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.NoDelay)) NoDelay = noDelay;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.ReceiveBufferSize)) ReceiveBufferSize = receiveSize;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.ReceiveTimeout)) ReceiveTimeout = receiveTimeout;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.SendBufferSize)) SendBufferSize = sendSize;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.SendTimeout)) SendTimeout = sendTimeout;
+            if (newHandle.IsTrackedOption(TrackedSocketOptions.Ttl)) Ttl = ttl;
+
+            Volatile.Write(ref _handle, newHandle);
+
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                _handle.Dispose();
+            }
 
             return SocketError.Success;
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -151,7 +151,7 @@ namespace System.Net.Sockets
             if (Volatile.Read(ref _disposed) != 0)
             {
                 _handle.Dispose();
-                ThrowIfDisposed();
+                throw new ObjectDisposedException(GetType().FullName);
             }
 
             // And put back the copied settings.  For DualMode, we use the value stored in the _handle


### PR DESCRIPTION
`ReplaceHandle` is the only function that we're changing the `_handle` member variable outside of the constructor.
This change worth to try.
Fixes #72830 