### PR TITLE
Generate single interface dispatch map per canonical form

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -38,7 +38,8 @@ namespace ILCompiler.DependencyAnalysis
 
             if (MightHaveInterfaceDispatchMap(factory))
             {
-                dependencyList.Add(factory.InterfaceDispatchMap(_type), "Interface dispatch map");
+                TypeDesc canonType = _type.ConvertToCanonForm(CanonicalFormKind.Specific);
+                dependencyList.Add(factory.InterfaceDispatchMap(canonType), "Interface dispatch map");
             }
 
             if (_type.IsArray)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1056,7 +1056,8 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (!relocsOnly && MightHaveInterfaceDispatchMap(factory))
             {
-                _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldTag.DispatchMap, checked((uint)factory.InterfaceDispatchMapIndirection(Type).IndexFromBeginningOfArray));
+                TypeDesc canonType = _type.ConvertToCanonForm(CanonicalFormKind.Specific);
+                _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldTag.DispatchMap, checked((uint)factory.InterfaceDispatchMapIndirection(canonType).IndexFromBeginningOfArray));
             }
 
             ComputeRareFlags(factory, relocsOnly);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -22,6 +22,7 @@ namespace ILCompiler.DependencyAnalysis
             // Pointer arrays also follow the same path
             Debug.Assert(!type.IsArrayTypeWithoutGenericInterfaces());
             Debug.Assert(MightHaveInterfaceDispatchMap(type, factory));
+            Debug.Assert(type.ConvertToCanonForm(CanonicalFormKind.Specific) == type);
 
             _type = type;
         }


### PR DESCRIPTION
The dispatch maps are identical because canonically-equivalent types have the same vtable layouts (the template type loader depends on that).

We would probably end up folding them in the linker because they go into a COMDAT foldable section, but computing the data is useless work.

Cc @dotnet/ilc-contrib 