### PR TITLE
Remove encoding allocations for System.Security.Xml

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXml.cs
@@ -113,7 +113,7 @@ namespace System.Security.Cryptography.Xml
         {
             StringBuilder sb = new StringBuilder();
             _c14nDoc.Write(sb, DocPosition.BeforeRootElement, _ancMgr);
-            return Utils.DefaultEncoding.GetBytes(sb.ToString());
+            return Encoding.UTF8.GetBytes(sb.ToString());
         }
 
         internal byte[] GetDigestedBytes(HashAlgorithm hash)

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXml.cs
@@ -113,8 +113,7 @@ namespace System.Security.Cryptography.Xml
         {
             StringBuilder sb = new StringBuilder();
             _c14nDoc.Write(sb, DocPosition.BeforeRootElement, _ancMgr);
-            UTF8Encoding utf8 = new UTF8Encoding(false);
-            return utf8.GetBytes(sb.ToString());
+            return Utils.DefaultEncoding.GetBytes(sb.ToString());
         }
 
         internal byte[] GetDigestedBytes(HashAlgorithm hash)

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlAttribute.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlAttribute.cs
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography.Xml
 
         public void WriteHash(HashAlgorithm hash, DocPosition docPos, AncestralNamespaceContextManager anc)
         {
-            UTF8Encoding utf8 = new UTF8Encoding(false);
+            Encoding utf8 = Utils.DefaultEncoding;
             byte[] rgbData = utf8.GetBytes(" " + Name + "=\"");
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             rgbData = utf8.GetBytes(Utils.EscapeAttributeValue(Value));

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlAttribute.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlAttribute.cs
@@ -32,12 +32,12 @@ namespace System.Security.Cryptography.Xml
 
         public void WriteHash(HashAlgorithm hash, DocPosition docPos, AncestralNamespaceContextManager anc)
         {
-            Encoding utf8 = Utils.DefaultEncoding;
-            byte[] rgbData = utf8.GetBytes(" " + Name + "=\"");
+            byte[] rgbData = Encoding.UTF8.GetBytes(" " + Name + "=\"");
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = utf8.GetBytes(Utils.EscapeAttributeValue(Value));
+            rgbData = Encoding.UTF8.GetBytes(Utils.EscapeAttributeValue(Value));
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = utf8.GetBytes("\"");
+
+            rgbData = "\""u8.ToArray();
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
         }
     }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlCDataSection.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlCDataSection.cs
@@ -31,8 +31,7 @@ namespace System.Security.Cryptography.Xml
         {
             if (IsInNodeSet)
             {
-                UTF8Encoding utf8 = new UTF8Encoding(false);
-                byte[] rgbData = utf8.GetBytes(Utils.EscapeCData(Data));
+                byte[] rgbData = Utils.DefaultEncoding.GetBytes(Utils.EscapeCData(Data));
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlCDataSection.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlCDataSection.cs
@@ -31,7 +31,7 @@ namespace System.Security.Cryptography.Xml
         {
             if (IsInNodeSet)
             {
-                byte[] rgbData = Utils.DefaultEncoding.GetBytes(Utils.EscapeCData(Data));
+                byte[] rgbData = Encoding.UTF8.GetBytes(Utils.EscapeCData(Data));
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlComment.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlComment.cs
@@ -49,19 +49,19 @@ namespace System.Security.Cryptography.Xml
             if (!IsInNodeSet || !IncludeComments)
                 return;
 
-            UTF8Encoding utf8 = new UTF8Encoding(false);
-            byte[] rgbData = utf8.GetBytes("(char) 10");
+            Encoding encoding = Utils.DefaultEncoding;
+            byte[] rgbData = encoding.GetBytes("(char) 10");
             if (docPos == DocPosition.AfterRootElement)
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = utf8.GetBytes("<!--");
+            rgbData = encoding.GetBytes("<!--");
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = utf8.GetBytes(Value!);
+            rgbData = encoding.GetBytes(Value!);
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = utf8.GetBytes("-->");
+            rgbData = encoding.GetBytes("-->");
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             if (docPos == DocPosition.BeforeRootElement)
             {
-                rgbData = utf8.GetBytes("(char) 10");
+                rgbData = encoding.GetBytes("(char) 10");
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlComment.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlComment.cs
@@ -49,19 +49,22 @@ namespace System.Security.Cryptography.Xml
             if (!IsInNodeSet || !IncludeComments)
                 return;
 
-            Encoding encoding = Utils.DefaultEncoding;
-            byte[] rgbData = encoding.GetBytes("(char) 10");
+            byte[] rgbData;
             if (docPos == DocPosition.AfterRootElement)
+            {
+                rgbData = "(char) 10"u8.ToArray();
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = encoding.GetBytes("<!--");
+            }
+
+            rgbData = "<!--"u8.ToArray();
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = encoding.GetBytes(Value!);
+            rgbData = Encoding.UTF8.GetBytes(Value!);
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = encoding.GetBytes("-->");
+            rgbData = "-->"u8.ToArray();
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             if (docPos == DocPosition.BeforeRootElement)
             {
-                rgbData = encoding.GetBytes("(char) 10");
+                rgbData = "(char) 10"u8.ToArray();
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlElement.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlElement.cs
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography.Xml
             Hashtable nsLocallyDeclared = new Hashtable();
             SortedList nsListToRender = new SortedList(new NamespaceSortOrder());
             SortedList attrListToRender = new SortedList(new AttributeSortOrder());
-            UTF8Encoding utf8 = new UTF8Encoding(false);
+            Encoding encoding = Utils.DefaultEncoding;
             byte[] rgbData;
 
             XmlAttributeCollection attrList = Attributes;
@@ -137,7 +137,7 @@ namespace System.Security.Cryptography.Xml
             if (IsInNodeSet)
             {
                 anc.GetNamespacesToRender(this, attrListToRender, nsListToRender, nsLocallyDeclared);
-                rgbData = utf8.GetBytes("<" + Name);
+                rgbData = encoding.GetBytes("<" + Name);
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
                 foreach (object attr in nsListToRender.GetKeyList())
                 {
@@ -147,7 +147,7 @@ namespace System.Security.Cryptography.Xml
                 {
                     (attr as CanonicalXmlAttribute)!.WriteHash(hash, docPos, anc);
                 }
-                rgbData = utf8.GetBytes(">");
+                rgbData = encoding.GetBytes(">");
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
 
@@ -165,7 +165,7 @@ namespace System.Security.Cryptography.Xml
 
             if (IsInNodeSet)
             {
-                rgbData = utf8.GetBytes("</" + Name + ">");
+                rgbData = encoding.GetBytes("</" + Name + ">");
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlElement.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlElement.cs
@@ -100,7 +100,6 @@ namespace System.Security.Cryptography.Xml
             Hashtable nsLocallyDeclared = new Hashtable();
             SortedList nsListToRender = new SortedList(new NamespaceSortOrder());
             SortedList attrListToRender = new SortedList(new AttributeSortOrder());
-            Encoding encoding = Utils.DefaultEncoding;
             byte[] rgbData;
 
             XmlAttributeCollection attrList = Attributes;
@@ -137,7 +136,7 @@ namespace System.Security.Cryptography.Xml
             if (IsInNodeSet)
             {
                 anc.GetNamespacesToRender(this, attrListToRender, nsListToRender, nsLocallyDeclared);
-                rgbData = encoding.GetBytes("<" + Name);
+                rgbData = Encoding.UTF8.GetBytes("<" + Name);
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
                 foreach (object attr in nsListToRender.GetKeyList())
                 {
@@ -147,7 +146,7 @@ namespace System.Security.Cryptography.Xml
                 {
                     (attr as CanonicalXmlAttribute)!.WriteHash(hash, docPos, anc);
                 }
-                rgbData = encoding.GetBytes(">");
+                rgbData = ">"u8.ToArray();
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
 
@@ -165,7 +164,7 @@ namespace System.Security.Cryptography.Xml
 
             if (IsInNodeSet)
             {
-                rgbData = encoding.GetBytes("</" + Name + ">");
+                rgbData = Encoding.UTF8.GetBytes("</" + Name + ">");
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlProcessingInstruction.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlProcessingInstruction.cs
@@ -44,27 +44,31 @@ namespace System.Security.Cryptography.Xml
             if (!IsInNodeSet)
                 return;
 
-            Encoding utf8 = Utils.DefaultEncoding;
             byte[] rgbData;
             if (docPos == DocPosition.AfterRootElement)
             {
-                rgbData = utf8.GetBytes("(char) 10");
+                rgbData = "(char) 10"u8.ToArray();
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
-            rgbData = utf8.GetBytes("<?");
+
+            rgbData = "<?"u8.ToArray();
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
-            rgbData = utf8.GetBytes((Name));
+
+            rgbData = Encoding.UTF8.GetBytes(Name);
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
+
             if ((Value != null) && (Value.Length > 0))
             {
-                rgbData = utf8.GetBytes(" " + Value);
+                rgbData = Encoding.UTF8.GetBytes(" " + Value);
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
-            rgbData = utf8.GetBytes("?>");
+
+            rgbData = "?>"u8.ToArray();
             hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
+
             if (docPos == DocPosition.BeforeRootElement)
             {
-                rgbData = utf8.GetBytes("(char) 10");
+                rgbData = "(char) 10"u8.ToArray();
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlProcessingInstruction.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlProcessingInstruction.cs
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography.Xml
             if (!IsInNodeSet)
                 return;
 
-            UTF8Encoding utf8 = new UTF8Encoding(false);
+            Encoding utf8 = Utils.DefaultEncoding;
             byte[] rgbData;
             if (docPos == DocPosition.AfterRootElement)
             {

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlSignificantWhitespace.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlSignificantWhitespace.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.Xml
         {
             if (IsInNodeSet && docPos == DocPosition.InRootElement)
             {
-                byte[] rgbData = Utils.DefaultEncoding.GetBytes(Utils.EscapeWhitespaceData(Value));
+                byte[] rgbData = Encoding.UTF8.GetBytes(Utils.EscapeWhitespaceData(Value));
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlSignificantWhitespace.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlSignificantWhitespace.cs
@@ -33,8 +33,7 @@ namespace System.Security.Cryptography.Xml
         {
             if (IsInNodeSet && docPos == DocPosition.InRootElement)
             {
-                UTF8Encoding utf8 = new UTF8Encoding(false);
-                byte[] rgbData = utf8.GetBytes(Utils.EscapeWhitespaceData(Value));
+                byte[] rgbData = Utils.DefaultEncoding.GetBytes(Utils.EscapeWhitespaceData(Value));
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlText.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlText.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.Xml
         {
             if (IsInNodeSet)
             {
-                byte[] rgbData = Utils.DefaultEncoding.GetBytes(Utils.EscapeTextData(Value));
+                byte[] rgbData = Encoding.UTF8.GetBytes(Utils.EscapeTextData(Value));
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlText.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlText.cs
@@ -33,8 +33,7 @@ namespace System.Security.Cryptography.Xml
         {
             if (IsInNodeSet)
             {
-                UTF8Encoding utf8 = new UTF8Encoding(false);
-                byte[] rgbData = utf8.GetBytes(Utils.EscapeTextData(Value));
+                byte[] rgbData = Utils.DefaultEncoding.GetBytes(Utils.EscapeTextData(Value));
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlWhitespace.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlWhitespace.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.Xml
         {
             if (IsInNodeSet && docPos == DocPosition.InRootElement)
             {
-                byte[] rgbData = Utils.DefaultEncoding.GetBytes(Utils.EscapeWhitespaceData(Value));
+                byte[] rgbData = Encoding.UTF8.GetBytes(Utils.EscapeWhitespaceData(Value));
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlWhitespace.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlWhitespace.cs
@@ -33,8 +33,7 @@ namespace System.Security.Cryptography.Xml
         {
             if (IsInNodeSet && docPos == DocPosition.InRootElement)
             {
-                UTF8Encoding utf8 = new UTF8Encoding(false);
-                byte[] rgbData = utf8.GetBytes(Utils.EscapeWhitespaceData(Value));
+                byte[] rgbData = Utils.DefaultEncoding.GetBytes(Utils.EscapeWhitespaceData(Value));
                 hash.TransformBlock(rgbData, 0, rgbData.Length, rgbData, 0);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcCanonicalXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcCanonicalXml.cs
@@ -61,8 +61,7 @@ namespace System.Security.Cryptography.Xml
         {
             StringBuilder sb = new StringBuilder();
             _c14nDoc.Write(sb, DocPosition.BeforeRootElement, _ancMgr);
-            UTF8Encoding utf8 = new UTF8Encoding(false);
-            return utf8.GetBytes(sb.ToString());
+            return Utils.DefaultEncoding.GetBytes(sb.ToString());
         }
 
         internal byte[] GetDigestedBytes(HashAlgorithm hash)

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcCanonicalXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcCanonicalXml.cs
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.Xml
         {
             StringBuilder sb = new StringBuilder();
             _c14nDoc.Write(sb, DocPosition.BeforeRootElement, _ancMgr);
-            return Utils.DefaultEncoding.GetBytes(sb.ToString());
+            return Encoding.UTF8.GetBytes(sb.ToString());
         }
 
         internal byte[] GetDigestedBytes(HashAlgorithm hash)

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -23,6 +23,8 @@ namespace System.Security.Cryptography.Xml
         // Keeping this number low will preserve some stack space
         internal const int XmlDsigSearchDepth = 20;
 
+        internal static readonly Encoding DefaultEncoding = new UTF8Encoding(false);
+
         private static bool HasNamespace(XmlElement element, string prefix, string value)
         {
             if (IsCommittedNamespace(element, prefix, value)) return true;

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -23,8 +23,6 @@ namespace System.Security.Cryptography.Xml
         // Keeping this number low will preserve some stack space
         internal const int XmlDsigSearchDepth = 20;
 
-        internal static readonly Encoding DefaultEncoding = new UTF8Encoding(false);
-
         private static bool HasNamespace(XmlElement element, string prefix, string value)
         {
             if (IsCommittedNamespace(element, prefix, value)) return true;

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
@@ -97,8 +97,8 @@ namespace System.Security.Cryptography.Xml
                 if (result != null)
                     sb.Append(result.OuterXml);
             }
-            UTF8Encoding utf8 = new UTF8Encoding(false);
-            byte[] buffer = utf8.GetBytes(sb.ToString());
+
+            byte[] buffer = Utils.DefaultEncoding.GetBytes(sb.ToString());
             int i;
             int j = 0;
             while ((j < buffer.Length) && (!char.IsWhiteSpace((char)buffer[j]))) j++;

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
@@ -98,7 +98,7 @@ namespace System.Security.Cryptography.Xml
                     sb.Append(result.OuterXml);
             }
 
-            byte[] buffer = Utils.DefaultEncoding.GetBytes(sb.ToString());
+            byte[] buffer = Encoding.UTF8.GetBytes(sb.ToString());
             int i;
             int j = 0;
             while ((j < buffer.Length) && (!char.IsWhiteSpace((char)buffer[j]))) j++;


### PR DESCRIPTION
Remove allocations of Utf8Encoding on every usage in System.Security.Xml.

This will make it easier to move forward: https://github.com/dotnet/runtime/issues/51353

cc: @stephentoub 