### PR TITLE
Remove unnecessary encoding allocations in System.Private.DataContractSerialization

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1768,7 +1768,7 @@ namespace System.Runtime.Serialization.DataContracts
 
         private static string GetNamespacesDigest(string namespaces)
         {
-            byte[] namespaceBytes = DataContractSerializer.SafeUTF8.GetBytes(namespaces);
+            byte[] namespaceBytes = Encoding.UTF8.GetBytes(namespaces);
             byte[] digestBytes = ComputeHash(namespaceBytes);
             char[] digestChars = new char[24];
             const int digestLen = 6;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1768,7 +1768,7 @@ namespace System.Runtime.Serialization.DataContracts
 
         private static string GetNamespacesDigest(string namespaces)
         {
-            byte[] namespaceBytes = Encoding.UTF8.GetBytes(namespaces);
+            byte[] namespaceBytes = DataContractSerializer.SafeUTF8.GetBytes(namespaces);
             byte[] digestBytes = ComputeHash(namespaceBytes);
             char[] digestChars = new char[24];
             const int digestLen = 6;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -33,16 +33,16 @@ namespace System.Runtime.Serialization
         private static SerializationOption s_option = IsReflectionBackupAllowed() ? SerializationOption.ReflectionAsBackup : SerializationOption.CodeGenOnly;
         private static bool s_optionAlreadySet;
 
-        internal static readonly UTF8Encoding SafeUTF8 = new UTF8Encoding(false, false);
-        internal static readonly UTF8Encoding ValidatingUTF8 = new UTF8Encoding(false, true);
+        internal static UTF8Encoding UTF8NoBom { get; } = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+        internal static UTF8Encoding ValidatingUTF8 { get; } = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
-        internal static readonly UnicodeEncoding SafeUTF16 = new UnicodeEncoding(false, false, false);
-        internal static readonly UnicodeEncoding SafeBEUTF16 = new UnicodeEncoding(true, false, false);
-        internal static readonly UnicodeEncoding ValidatingUTF16 = new UnicodeEncoding(false, false, true);
-        internal static readonly UnicodeEncoding ValidatingBEUTF16 = new UnicodeEncoding(true, false, true);
+        internal static UnicodeEncoding UTF16NoBom { get; } = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: false);
+        internal static UnicodeEncoding BEUTF16NoBom { get; } = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: false);
+        internal static UnicodeEncoding ValidatingUTF16 { get; } = new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: true);
+        internal static UnicodeEncoding ValidatingBEUTF16 { get; } = new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: true);
 
-        internal static readonly Base64Encoding Base64Encoding = new Base64Encoding();
-        internal static readonly BinHexEncoding BinHexEncoding = new BinHexEncoding();
+        internal static Base64Encoding Base64Encoding { get; } = new Base64Encoding();
+        internal static BinHexEncoding BinHexEncoding { get; } = new BinHexEncoding();
 
         internal static SerializationOption Option
         {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -1,12 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization.DataContracts;
+using System.Text;
 using System.Xml;
 
 using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, System.Runtime.Serialization.DataContracts.DataContract>;
@@ -32,6 +32,18 @@ namespace System.Runtime.Serialization
 
         private static SerializationOption s_option = IsReflectionBackupAllowed() ? SerializationOption.ReflectionAsBackup : SerializationOption.CodeGenOnly;
         private static bool s_optionAlreadySet;
+
+        internal static readonly UTF8Encoding SafeUTF8 = new UTF8Encoding(false, false);
+        internal static readonly UTF8Encoding ValidatingUTF8 = new UTF8Encoding(false, true);
+
+        internal static readonly UnicodeEncoding SafeUTF16 = new UnicodeEncoding(false, false, false);
+        internal static readonly UnicodeEncoding SafeBEUTF16 = new UnicodeEncoding(true, false, false);
+        internal static readonly UnicodeEncoding ValidatingUTF16 = new UnicodeEncoding(false, false, true);
+        internal static readonly UnicodeEncoding ValidatingBEUTF16 = new UnicodeEncoding(true, false, true);
+
+        internal static readonly Base64Encoding Base64Encoding = new Base64Encoding();
+        internal static readonly BinHexEncoding BinHexEncoding = new BinHexEncoding();
+
         internal static SerializationOption Option
         {
             get { return RuntimeFeature.IsDynamicCodeSupported ? s_option : SerializationOption.ReflectionOnly; }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -14,11 +14,6 @@ namespace System.Runtime.Serialization.Json
     // ASSUMPTION (Microsoft): This class will only be used for EITHER reading OR writing.  It can be done, it would just mean more buffers.
     internal sealed class JsonEncodingStreamWrapper : Stream
     {
-        private static readonly UnicodeEncoding s_validatingBEUTF16 = new UnicodeEncoding(true, false, true);
-
-        private static readonly UnicodeEncoding s_validatingUTF16 = new UnicodeEncoding(false, false, true);
-
-        private static readonly UTF8Encoding s_validatingUTF8 = new UTF8Encoding(false, true);
         private const int BufferLength = 128;
 
         private readonly byte[] _byteBuffer = new byte[1];
@@ -154,7 +149,7 @@ namespace System.Runtime.Serialization.Json
 
                 // Convert to UTF-8
                 return
-                    new ArraySegment<byte>(s_validatingUTF8.GetBytes(GetEncoding(dataEnc).GetChars(buffer, offset, count)));
+                    new ArraySegment<byte>(DataContractSerializer.ValidatingUTF8.GetBytes(GetEncoding(dataEnc).GetChars(buffer, offset, count)));
             }
             catch (DecoderFallbackException e)
             {
@@ -286,9 +281,9 @@ namespace System.Runtime.Serialization.Json
         private static Encoding GetEncoding(SupportedEncoding e) =>
             e switch
             {
-                SupportedEncoding.UTF8 => s_validatingUTF8,
-                SupportedEncoding.UTF16LE => s_validatingUTF16,
-                SupportedEncoding.UTF16BE => s_validatingBEUTF16,
+                SupportedEncoding.UTF8 => DataContractSerializer.ValidatingUTF8,
+                SupportedEncoding.UTF16LE => DataContractSerializer.ValidatingUTF16,
+                SupportedEncoding.UTF16BE => DataContractSerializer.ValidatingBEUTF16,
                 _ => throw new XmlException(SR.JsonEncodingNotSupported),
             };
 
@@ -307,15 +302,15 @@ namespace System.Runtime.Serialization.Json
             {
                 return SupportedEncoding.None;
             }
-            if (encoding.WebName == s_validatingUTF8.WebName)
+            if (encoding.WebName == DataContractSerializer.ValidatingUTF8.WebName)
             {
                 return SupportedEncoding.UTF8;
             }
-            else if (encoding.WebName == s_validatingUTF16.WebName)
+            else if (encoding.WebName == DataContractSerializer.ValidatingUTF16.WebName)
             {
                 return SupportedEncoding.UTF16LE;
             }
-            else if (encoding.WebName == s_validatingBEUTF16.WebName)
+            else if (encoding.WebName == DataContractSerializer.ValidatingBEUTF16.WebName)
             {
                 return SupportedEncoding.UTF16BE;
             }
@@ -451,7 +446,7 @@ namespace System.Runtime.Serialization.Json
                     CleanupCharBreak();
                     int count = _encoding.GetChars(_bytes, _byteOffset, _byteCount, _chars, 0);
                     _byteOffset = 0;
-                    _byteCount = s_validatingUTF8.GetBytes(_chars, 0, count, _bytes, 0);
+                    _byteCount = DataContractSerializer.ValidatingUTF8.GetBytes(_chars, 0, count, _bytes, 0);
                 }
             }
             catch (DecoderFallbackException ex)
@@ -471,7 +466,7 @@ namespace System.Runtime.Serialization.Json
             if (_encodingCode != SupportedEncoding.UTF8)
             {
                 EnsureBuffers();
-                _dec = s_validatingUTF8.GetDecoder();
+                _dec = DataContractSerializer.ValidatingUTF8.GetDecoder();
                 _enc = _encoding.GetEncoder();
             }
         }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonGlobals.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonGlobals.cs
@@ -19,9 +19,6 @@ namespace System.Runtime.Serialization.Json
         public static readonly int DataContractXsdBaseNamespaceLength = Globals.DataContractXsdBaseNamespace.Length;
         public static readonly long unixEpochTicks = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
         public static readonly SecurityException SecurityException = new SecurityException();
-        public static readonly UnicodeEncoding ValidatingBEUTF16 = new UnicodeEncoding(true, false, true);
-        public static readonly UnicodeEncoding ValidatingUTF16 = new UnicodeEncoding(false, false, true);
-        public static readonly UTF8Encoding ValidatingUTF8 = new UTF8Encoding(false, true);
         public const string PositiveInf = "INF";
         public const string NegativeInf = "-INF";
         public const string typeString = "type";

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -63,8 +63,6 @@ namespace System.Runtime.Serialization.Json
             "\\u001f"
         };
 
-        private static BinHexEncoding? s_binHexEncoding;
-
         private string? _attributeText;
         private JsonDataType _dataType;
         private int _depth;
@@ -165,9 +163,6 @@ namespace System.Runtime.Serialization.Json
         {
             get { return XmlSpace.None; }
         }
-
-        private static BinHexEncoding BinHexEncoding =>
-            s_binHexEncoding ??= new BinHexEncoding();
 
         private bool HasOpenAttribute => (_isWritingDataTypeAttribute || _isWritingServerTypeAttribute || IsWritingNameAttribute || _isWritingXmlnsAttribute);
 
@@ -401,7 +396,7 @@ namespace System.Runtime.Serialization.Json
             }
 
             StartText();
-            WriteEscapedJsonString(BinHexEncoding.GetString(buffer, index, count));
+            WriteEscapedJsonString(DataContractSerializer.BinHexEncoding.GetString(buffer, index, count));
         }
 
         public override void WriteCData(string? text)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
@@ -126,9 +126,9 @@ namespace System.Xml
         private static Encoding GetSafeEncoding(SupportedEncoding e) =>
             e switch
             {
-                SupportedEncoding.UTF8 => DataContractSerializer.SafeUTF8,
-                SupportedEncoding.UTF16LE => DataContractSerializer.SafeUTF16,
-                SupportedEncoding.UTF16BE => DataContractSerializer.SafeBEUTF16,
+                SupportedEncoding.UTF8 => DataContractSerializer.UTF8NoBom,
+                SupportedEncoding.UTF16LE => DataContractSerializer.UTF16NoBom,
+                SupportedEncoding.UTF16BE => DataContractSerializer.BEUTF16NoBom,
                 _ => throw new XmlException(SR.XmlEncodingNotSupported),
             };
 
@@ -394,15 +394,15 @@ namespace System.Xml
             else if (encCount == s_encodingUnicode.Length && CompareCaseInsensitive(s_encodingUnicode, buffer, encStart))
             {
                 if (e == SupportedEncoding.UTF8)
-                    ThrowEncodingMismatch(DataContractSerializer.SafeUTF8.GetString(buffer, encStart, encCount), DataContractSerializer.SafeUTF8.GetString(s_encodingUTF8, 0, s_encodingUTF8.Length));
+                    ThrowEncodingMismatch(DataContractSerializer.UTF8NoBom.GetString(buffer, encStart, encCount), DataContractSerializer.UTF8NoBom.GetString(s_encodingUTF8, 0, s_encodingUTF8.Length));
             }
             else
             {
-                ThrowEncodingMismatch(DataContractSerializer.SafeUTF8.GetString(buffer, encStart, encCount), e);
+                ThrowEncodingMismatch(DataContractSerializer.UTF8NoBom.GetString(buffer, encStart, encCount), e);
             }
 
             if (e != declEnc)
-                ThrowEncodingMismatch(DataContractSerializer.SafeUTF8.GetString(buffer, encStart, encCount), e);
+                ThrowEncodingMismatch(DataContractSerializer.UTF8NoBom.GetString(buffer, encStart, encCount), e);
         }
 
         private static bool CompareCaseInsensitive(byte[] key, byte[] buffer, int offset)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
@@ -21,12 +21,6 @@ namespace System.Xml
     internal sealed class EncodingStreamWrapper : Stream
     {
         private enum SupportedEncoding { UTF8, UTF16LE, UTF16BE, None }
-        private static readonly UTF8Encoding s_safeUTF8 = new UTF8Encoding(false, false);
-        private static readonly UnicodeEncoding s_safeUTF16 = new UnicodeEncoding(false, false, false);
-        private static readonly UnicodeEncoding s_safeBEUTF16 = new UnicodeEncoding(true, false, false);
-        private static readonly UTF8Encoding s_validatingUTF8 = new UTF8Encoding(false, true);
-        private static readonly UnicodeEncoding s_validatingUTF16 = new UnicodeEncoding(false, false, true);
-        private static readonly UnicodeEncoding s_validatingBEUTF16 = new UnicodeEncoding(true, false, true);
         private const int BufferLength = 128;
 
         // UTF-8 is fastpath, so that's how these are stored
@@ -91,7 +85,7 @@ namespace System.Xml
                     CleanupCharBreak();
                     int count = _encoding.GetChars(_bytes, _byteOffset, _byteCount, _chars, 0);
                     _byteOffset = 0;
-                    _byteCount = s_validatingUTF8.GetBytes(_chars, 0, count, _bytes, 0);
+                    _byteCount = DataContractSerializer.ValidatingUTF8.GetBytes(_chars, 0, count, _bytes, 0);
 
                     // Check for declaration
                     if (_bytes[1] == '?' && _bytes[0] == '<')
@@ -123,18 +117,18 @@ namespace System.Xml
         private static Encoding GetEncoding(SupportedEncoding e) =>
             e switch
             {
-                SupportedEncoding.UTF8 => s_validatingUTF8,
-                SupportedEncoding.UTF16LE => s_validatingUTF16,
-                SupportedEncoding.UTF16BE => s_validatingBEUTF16,
+                SupportedEncoding.UTF8 => DataContractSerializer.ValidatingUTF8,
+                SupportedEncoding.UTF16LE => DataContractSerializer.ValidatingUTF16,
+                SupportedEncoding.UTF16BE => DataContractSerializer.ValidatingBEUTF16,
                 _ => throw new XmlException(SR.XmlEncodingNotSupported),
             };
 
         private static Encoding GetSafeEncoding(SupportedEncoding e) =>
             e switch
             {
-                SupportedEncoding.UTF8 => s_safeUTF8,
-                SupportedEncoding.UTF16LE => s_safeUTF16,
-                SupportedEncoding.UTF16BE => s_safeBEUTF16,
+                SupportedEncoding.UTF8 => DataContractSerializer.SafeUTF8,
+                SupportedEncoding.UTF16LE => DataContractSerializer.SafeUTF16,
+                SupportedEncoding.UTF16BE => DataContractSerializer.SafeBEUTF16,
                 _ => throw new XmlException(SR.XmlEncodingNotSupported),
             };
 
@@ -151,11 +145,11 @@ namespace System.Xml
         {
             if (encoding == null)
                 return SupportedEncoding.None;
-            else if (encoding.WebName == s_validatingUTF8.WebName)
+            else if (encoding.WebName == DataContractSerializer.ValidatingUTF8.WebName)
                 return SupportedEncoding.UTF8;
-            else if (encoding.WebName == s_validatingUTF16.WebName)
+            else if (encoding.WebName == DataContractSerializer.ValidatingUTF16.WebName)
                 return SupportedEncoding.UTF16LE;
-            else if (encoding.WebName == s_validatingBEUTF16.WebName)
+            else if (encoding.WebName == DataContractSerializer.ValidatingBEUTF16.WebName)
                 return SupportedEncoding.UTF16BE;
             else
                 throw new XmlException(SR.XmlEncodingNotSupported);
@@ -174,7 +168,7 @@ namespace System.Xml
             if (_encodingCode != SupportedEncoding.UTF8)
             {
                 EnsureBuffers();
-                _dec = s_validatingUTF8.GetDecoder();
+                _dec = DataContractSerializer.ValidatingUTF8.GetDecoder();
                 _enc = _encoding.GetEncoder();
 
                 // Emit BOM
@@ -400,15 +394,15 @@ namespace System.Xml
             else if (encCount == s_encodingUnicode.Length && CompareCaseInsensitive(s_encodingUnicode, buffer, encStart))
             {
                 if (e == SupportedEncoding.UTF8)
-                    ThrowEncodingMismatch(s_safeUTF8.GetString(buffer, encStart, encCount), s_safeUTF8.GetString(s_encodingUTF8, 0, s_encodingUTF8.Length));
+                    ThrowEncodingMismatch(DataContractSerializer.SafeUTF8.GetString(buffer, encStart, encCount), DataContractSerializer.SafeUTF8.GetString(s_encodingUTF8, 0, s_encodingUTF8.Length));
             }
             else
             {
-                ThrowEncodingMismatch(s_safeUTF8.GetString(buffer, encStart, encCount), e);
+                ThrowEncodingMismatch(DataContractSerializer.SafeUTF8.GetString(buffer, encStart, encCount), e);
             }
 
             if (e != declEnc)
-                ThrowEncodingMismatch(s_safeUTF8.GetString(buffer, encStart, encCount), e);
+                ThrowEncodingMismatch(DataContractSerializer.SafeUTF8.GetString(buffer, encStart, encCount), e);
         }
 
         private static bool CompareCaseInsensitive(byte[] key, byte[] buffer, int offset)
@@ -470,8 +464,8 @@ namespace System.Xml
                 int inputCount = Math.Min(count, BufferLength * 2);
                 chars = new char[localEnc.GetMaxCharCount(inputCount)];
                 int ccount = localEnc.GetChars(buffer, offset, inputCount, chars, 0);
-                bytes = new byte[s_validatingUTF8.GetMaxByteCount(ccount)];
-                int bcount = s_validatingUTF8.GetBytes(chars, 0, ccount, bytes, 0);
+                bytes = new byte[DataContractSerializer.ValidatingUTF8.GetMaxByteCount(ccount)];
+                int bcount = DataContractSerializer.ValidatingUTF8.GetBytes(chars, 0, ccount, bytes, 0);
 
                 // Check for declaration
                 if (bytes[1] == '?' && bytes[0] == '<')
@@ -485,7 +479,7 @@ namespace System.Xml
                         throw new XmlException(SR.XmlDeclarationRequired);
                 }
 
-                seg = new ArraySegment<byte>(s_validatingUTF8.GetBytes(GetEncoding(declEnc).GetChars(buffer, offset, count)));
+                seg = new ArraySegment<byte>(DataContractSerializer.ValidatingUTF8.GetBytes(GetEncoding(declEnc).GetChars(buffer, offset, count)));
                 return seg;
             }
             catch (DecoderFallbackException e)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/ValueHandle.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.Serialization;
-using System.Diagnostics;
-using System.Globalization;
 using System.Text;
 using System.Diagnostics.CodeAnalysis;
 
@@ -71,7 +69,6 @@ namespace System.Xml
         private ValueHandleType _type;
         private int _offset;
         private int _length;
-        private static Base64Encoding? s_base64Encoding;
         private static readonly string[] s_constStrings = {
                                         "string",
                                         "number",
@@ -86,8 +83,6 @@ namespace System.Xml
             _bufferReader = bufferReader;
             _type = ValueHandleType.Empty;
         }
-
-        private static Base64Encoding Base64Encoding => s_base64Encoding ??= new Base64Encoding();
 
         public void SetConstantValue(ValueHandleConstStringType constStringType)
         {
@@ -444,7 +439,7 @@ namespace System.Xml
                         }
                     }
                     byte[] buffer = new byte[expectedLength];
-                    int actualLength = Base64Encoding.GetBytes(_bufferReader.Buffer, _offset, _length, buffer, 0);
+                    int actualLength = DataContractSerializer.Base64Encoding.GetBytes(_bufferReader.Buffer, _offset, _length, buffer, 0);
                     if (actualLength != buffer.Length)
                     {
                         byte[] newBuffer = new byte[actualLength];
@@ -460,7 +455,7 @@ namespace System.Xml
             }
             try
             {
-                return Base64Encoding.GetBytes(XmlConverter.StripWhitespace(GetString()));
+                return DataContractSerializer.Base64Encoding.GetBytes(XmlConverter.StripWhitespace(GetString()));
             }
             catch (FormatException exception)
             {
@@ -513,7 +508,7 @@ namespace System.Xml
                 case ValueHandleType.Base64:
                     byte[] bytes = ToByteArray();
                     DiagnosticUtility.DebugAssert(bytes != null, "");
-                    return Base64Encoding.GetString(bytes, 0, bytes.Length);
+                    return DataContractSerializer.Base64Encoding.GetString(bytes, 0, bytes.Length);
                 case ValueHandleType.List:
                     return XmlConverter.ToString(ToList());
                 case ValueHandleType.UniqueId:
@@ -675,7 +670,7 @@ namespace System.Xml
                 try
                 {
                     int charCount = Math.Min(count / 3 * 4, _length);
-                    actual = Base64Encoding.GetBytes(_bufferReader.Buffer, _offset, charCount, buffer, offset);
+                    actual = DataContractSerializer.Base64Encoding.GetBytes(_bufferReader.Buffer, _offset, charCount, buffer, offset);
                     _offset += charCount;
                     _length -= charCount;
                     return true;
@@ -709,7 +704,7 @@ namespace System.Xml
             int byteCount = _length;
             bool insufficientSpaceInCharsArray = false;
 
-            var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+            var encoding = DataContractSerializer.ValidatingUTF8;
             while (true)
             {
                 while (charCount > 0 && byteCount > 0)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
@@ -57,8 +57,6 @@ namespace System.Xml
         private static readonly XmlInitialNode s_initialNode = new XmlInitialNode(XmlBufferReader.Empty);
         private static readonly XmlEndOfFileNode s_endOfFileNode = new XmlEndOfFileNode(XmlBufferReader.Empty);
         private static readonly XmlClosedNode s_closedNode = new XmlClosedNode(XmlBufferReader.Empty);
-        private static Base64Encoding? s_base64Encoding;
-        private static BinHexEncoding? s_binHexEncoding;
         private const string xmlns = "xmlns";
         private const string xml = "xml";
         private const string xmlnsNamespace = "http://www.w3.org/2000/xmlns/";
@@ -75,11 +73,6 @@ namespace System.Xml
             _atomicTextNode = new XmlAtomicTextNode(_bufferReader);
             _node = s_closedNode;
         }
-
-
-        private static Base64Encoding Base64Encoding => s_base64Encoding ??= new Base64Encoding();
-
-        private static BinHexEncoding BinHexEncoding => s_binHexEncoding ??= new BinHexEncoding();
 
         protected XmlBufferReader BufferReader
         {
@@ -1187,7 +1180,7 @@ namespace System.Xml
                     }
                 }
             }
-            return ReadBytes(Base64Encoding, 3, 4, buffer, offset, Math.Min(count, 512), false);
+            return ReadBytes(DataContractSerializer.Base64Encoding, 3, 4, buffer, offset, Math.Min(count, 512), false);
         }
 
         public override string ReadElementContentAsString()
@@ -1381,7 +1374,7 @@ namespace System.Xml
             XmlNodeType nodeType = _node.NodeType;
             if (nodeType == XmlNodeType.Element || nodeType == XmlNodeType.EndElement)
                 return 0;
-            return ReadBytes(Base64Encoding, 3, 4, buffer, offset, Math.Min(count, 512), true);
+            return ReadBytes(DataContractSerializer.Base64Encoding, 3, 4, buffer, offset, Math.Min(count, 512), true);
         }
 
         public override byte[] ReadContentAsBinHex()
@@ -1403,7 +1396,7 @@ namespace System.Xml
                 throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new ArgumentOutOfRangeException(nameof(count), SR.Format(SR.SizeExceedsRemainingBufferSpace, buffer.Length - offset)));
             if (count == 0)
                 return 0;
-            return ReadBytes(BinHexEncoding, 1, 2, buffer, offset, Math.Min(count, 512), true);
+            return ReadBytes(DataContractSerializer.BinHexEncoding, 1, 2, buffer, offset, Math.Min(count, 512), true);
         }
 
         public override int ReadElementContentAsBinHex(byte[] buffer, int offset, int count)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
@@ -36,7 +36,6 @@ namespace System.Xml
         private bool _inList;
         private const string xmlnsNamespace = "http://www.w3.org/2000/xmlns/";
         private const string xmlNamespace = "http://www.w3.org/XML/1998/namespace";
-        private static BinHexEncoding? _binhexEncoding;
         private static readonly string[] s_prefixes = { "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z" };
 
         protected XmlBaseWriter()
@@ -120,8 +119,6 @@ namespace System.Xml
         {
             throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.XmlWriterClosed));
         }
-
-        private static BinHexEncoding BinHexEncoding => _binhexEncoding ??= new BinHexEncoding();
 
         public override string? XmlLang
         {
@@ -1472,7 +1469,7 @@ namespace System.Xml
 
             EnsureBufferBounds(buffer, offset, count);
 
-            WriteRaw(BinHexEncoding.GetString(buffer, offset, count));
+            WriteRaw(DataContractSerializer.BinHexEncoding.GetString(buffer, offset, count));
         }
 
         public override void WriteBase64(byte[] buffer, int offset, int count)
@@ -1502,8 +1499,8 @@ namespace System.Xml
                 {
                     if (_attributeValue != null)
                     {
-                        WriteAttributeText(XmlConverter.Base64Encoding.GetString(_trailBytes, 0, _trailByteCount));
-                        WriteAttributeText(XmlConverter.Base64Encoding.GetString(buffer, offset, actualByteCount - _trailByteCount));
+                        WriteAttributeText(DataContractSerializer.Base64Encoding.GetString(_trailBytes, 0, _trailByteCount));
+                        WriteAttributeText(DataContractSerializer.Base64Encoding.GetString(buffer, offset, actualByteCount - _trailByteCount));
                     }
 
                     if (!_isXmlnsAttribute)
@@ -1561,8 +1558,8 @@ namespace System.Xml
                 {
                     if (_attributeValue != null)
                     {
-                        WriteAttributeText(XmlConverter.Base64Encoding.GetString(_trailBytes, 0, _trailByteCount));
-                        WriteAttributeText(XmlConverter.Base64Encoding.GetString(buffer, offset, actualByteCount - _trailByteCount));
+                        WriteAttributeText(DataContractSerializer.Base64Encoding.GetString(_trailBytes, 0, _trailByteCount));
+                        WriteAttributeText(DataContractSerializer.Base64Encoding.GetString(buffer, offset, actualByteCount - _trailByteCount));
                     }
                     if (!_isXmlnsAttribute)
                     {
@@ -1765,7 +1762,7 @@ namespace System.Xml
             Debug.Assert(_trailBytes != null);
 
             if (_attributeValue != null)
-                WriteAttributeText(XmlConverter.Base64Encoding.GetString(_trailBytes, 0, _trailByteCount));
+                WriteAttributeText(DataContractSerializer.Base64Encoding.GetString(_trailBytes, 0, _trailByteCount));
 
             if (!_isXmlnsAttribute)
             {
@@ -1781,7 +1778,7 @@ namespace System.Xml
             Debug.Assert(_trailBytes != null);
 
             if (_attributeValue != null)
-                WriteAttributeText(XmlConverter.Base64Encoding.GetString(_trailBytes, 0, _trailByteCount));
+                WriteAttributeText(DataContractSerializer.Base64Encoding.GetString(_trailBytes, 0, _trailByteCount));
 
             if (!_isXmlnsAttribute)
             {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -1102,7 +1102,7 @@ namespace System.Xml
                     ArraySegment<byte> arraySegment;
                     bool result = _captureStream.TryGetBuffer(out arraySegment);
                     DiagnosticUtility.DebugAssert(result, "");
-                    _captureText = XmlConverter.Base64Encoding.GetString(arraySegment.Array!, arraySegment.Offset, arraySegment.Count);
+                    _captureText = DataContractSerializer.Base64Encoding.GetString(arraySegment.Array!, arraySegment.Offset, arraySegment.Count);
                     _captureStream = null;
                 }
 
@@ -1140,9 +1140,9 @@ namespace System.Xml
                 {
                     if (trailByteCount > 0)
                     {
-                        WriteText(XmlConverter.Base64Encoding.GetString(trailBytes!, 0, trailByteCount));
+                        WriteText(DataContractSerializer.Base64Encoding.GetString(trailBytes!, 0, trailByteCount));
                     }
-                    WriteText(XmlConverter.Base64Encoding.GetString(buffer, offset, count));
+                    WriteText(DataContractSerializer.Base64Encoding.GetString(buffer, offset, count));
                 }
                 else
                 {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlConverter.cs
@@ -30,17 +30,6 @@ namespace System.Xml
         public const int MaxUInt64Chars = 32;
         public const int MaxPrimitiveChars = MaxDateTimeChars;
 
-        private static UTF8Encoding? s_utf8Encoding;
-        private static UnicodeEncoding? s_unicodeEncoding;
-
-        private static Base64Encoding? s_base64Encoding;
-
-        public static Base64Encoding Base64Encoding => s_base64Encoding ??= new Base64Encoding();
-
-        private static UTF8Encoding UTF8Encoding => s_utf8Encoding ??= new UTF8Encoding(false, true);
-
-        private static UnicodeEncoding UnicodeEncoding => s_unicodeEncoding ??= new UnicodeEncoding(false, false, true);
-
         public static bool ToBoolean(string value)
         {
             try
@@ -343,7 +332,7 @@ namespace System.Xml
         {
             try
             {
-                return UTF8Encoding.GetString(buffer, offset, count);
+                return DataContractSerializer.ValidatingUTF8.GetString(buffer, offset, count);
             }
             catch (DecoderFallbackException exception)
             {
@@ -355,7 +344,7 @@ namespace System.Xml
         {
             try
             {
-                return UnicodeEncoding.GetString(buffer, offset, count);
+                return DataContractSerializer.ValidatingUTF16.GetString(buffer, offset, count);
             }
             catch (DecoderFallbackException exception)
             {
@@ -368,7 +357,7 @@ namespace System.Xml
         {
             try
             {
-                return UTF8Encoding.GetBytes(value);
+                return DataContractSerializer.ValidatingUTF8.GetBytes(value);
             }
             catch (DecoderFallbackException exception)
             {
@@ -380,7 +369,7 @@ namespace System.Xml
         {
             try
             {
-                return UTF8Encoding.GetChars(buffer, offset, count, chars, charOffset);
+                return DataContractSerializer.ValidatingUTF8.GetChars(buffer, offset, count, chars, charOffset);
             }
             catch (DecoderFallbackException exception)
             {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
@@ -41,7 +41,7 @@ namespace System.Xml
 
         public static XmlDictionaryWriter CreateTextWriter(Stream stream)
         {
-            return CreateTextWriter(stream, DataContractSerializer.SafeUTF8, true);
+            return CreateTextWriter(stream, DataContractSerializer.UTF8NoBom, true);
         }
 
         public static XmlDictionaryWriter CreateTextWriter(Stream stream, Encoding encoding)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryWriter.cs
@@ -39,10 +39,9 @@ namespace System.Xml
             return writer;
         }
 
-        private static readonly Encoding s_UTF8Encoding = new UTF8Encoding(false);
         public static XmlDictionaryWriter CreateTextWriter(Stream stream)
         {
-            return CreateTextWriter(stream, s_UTF8Encoding, true);
+            return CreateTextWriter(stream, DataContractSerializer.SafeUTF8, true);
         }
 
         public static XmlDictionaryWriter CreateTextWriter(Stream stream, Encoding encoding)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlSigningNodeWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlSigningNodeWriter.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace System.Xml
@@ -353,7 +354,7 @@ namespace System.Xml
         private void WriteBase64Text(byte[] buffer, int offset, int count)
         {
             _base64Chars ??= new byte[512];
-            Base64Encoding encoding = XmlConverter.Base64Encoding;
+            Base64Encoding encoding = DataContractSerializer.Base64Encoding;
             while (count >= 3)
             {
                 int byteCount = Math.Min(_base64Chars.Length / 4 * 3, count - count % 3);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
@@ -16,7 +16,6 @@ namespace System.Xml
         private const int bufferLength = 512;
         private const int maxBytesPerChar = 3;
         private Encoding? _encoding;
-        private static readonly UTF8Encoding s_UTF8Encoding = new UTF8Encoding(false, true);
 
         protected XmlStreamNodeWriter()
         {
@@ -362,7 +361,7 @@ namespace System.Xml
             if (chars == charsMax)
                 return charCount;
 
-            return (int)(chars - (charsMax - charCount)) + (_encoding ?? s_UTF8Encoding).GetByteCount(chars, (int)(charsMax - chars));
+            return (int)(chars - (charsMax - charCount)) + (_encoding ?? DataContractSerializer.ValidatingUTF8).GetByteCount(chars, (int)(charsMax - chars));
         }
 
         protected unsafe int UnsafeGetUTF8Chars(char* chars, int charCount, byte[] buffer, int offset)
@@ -397,7 +396,7 @@ namespace System.Xml
                             chars++;
                         }
 
-                        bytes += (_encoding ?? s_UTF8Encoding).GetBytes(charsStart, (int)(chars - charsStart), bytes, (int)(bytesMax - bytes));
+                        bytes += (_encoding ?? DataContractSerializer.ValidatingUTF8).GetBytes(charsStart, (int)(chars - charsStart), bytes, (int)(bytesMax - bytes));
 
                         if (chars >= charsMax)
                             break;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -732,7 +733,7 @@ namespace System.Xml
 
         private void InternalWriteBase64Text(byte[] buffer, int offset, int count)
         {
-            Base64Encoding encoding = XmlConverter.Base64Encoding;
+            Base64Encoding encoding = DataContractSerializer.Base64Encoding;
             while (count >= 3)
             {
                 int byteCount = Math.Min(bufferLength / 4 * 3, count - count % 3);
@@ -753,7 +754,7 @@ namespace System.Xml
 
         private async Task InternalWriteBase64TextAsync(byte[] buffer, int offset, int count)
         {
-            Base64Encoding encoding = XmlConverter.Base64Encoding;
+            Base64Encoding encoding = DataContractSerializer.Base64Encoding;
             while (count >= 3)
             {
                 int byteCount = Math.Min(bufferLength / 4 * 3, count - count % 3);


### PR DESCRIPTION
Makes it easier to move forward with https://github.com/dotnet/runtime/issues/51353

cc: @stephentoub 