### PR TITLE
Fix filtered exceptions when checking for ip forwarding

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPv4InterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPv4InterfaceProperties.cs
@@ -52,8 +52,7 @@ namespace System.Net.NetworkInformation
                 {
                     return StringParsingHelpers.ParseRawIntFile(paths[i]) == 1;
                 }
-                catch (IOException) { }
-                catch (UnauthorizedAccessException) { }
+                catch (NetworkInformationException ex) when (ex.InnerException is IOException or UnauthorizedAccessException) { }
             }
 
             return false;


### PR DESCRIPTION
Fixes #75883.

Originally broken by #63696 which changed/unified the exception type.