### PR TITLE
SuperPMI collections: exclude more files/directories

### DIFF
--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -568,11 +568,11 @@ def main(main_args):
 
         input_artifacts = os.path.join(workitem_payload_directory, "collectAssembliesDirectory", coreclr_args.collection_name)
 
-        exclude_directories = directories_to_ignore
+        exclude_directories = list(directories_to_ignore)
         if coreclr_args.collection_name == "coreclr_tests":
             exclude_directories += ['Core_Root']
 
-        exclude_files = native_binaries_to_ignore
+        exclude_files = list(native_binaries_to_ignore)
         if coreclr_args.collection_type == "crossgen2":
             print('Adding exclusions for crossgen2')
             # Currently, trying to crossgen2 R2RTest\Microsoft.Build.dll causes a pop-up failure, so exclude it.

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -62,6 +62,10 @@ is_windows = platform.system() == "Windows"
 
 legal_collection_types = [ "crossgen2", "pmi", "run" ]
 
+directories_to_ignore = [
+    "runtimes", # This appears to be the result of a nuget package that includes a bunch of native code
+]
+
 native_binaries_to_ignore = [
     "api-ms-win-core-console-l1-1-0.dll",
     "api-ms-win-core-datetime-l1-1-0.dll",
@@ -106,6 +110,12 @@ native_binaries_to_ignore = [
     "clretwrc.dll",
     "clrgc.dll",
     "clrjit.dll",
+    "clrjit_universal_arm_arm.dll",
+    "clrjit_universal_arm_arm64.dll",
+    "clrjit_universal_arm_x64.dll",
+    "clrjit_universal_arm_x86.dll",
+    "clrjit_universal_arm64_arm64.dll",
+    "clrjit_universal_arm64_x64.dll",
     "clrjit_unix_arm_arm.dll",
     "clrjit_unix_arm_arm64.dll",
     "clrjit_unix_arm_x64.dll",
@@ -132,12 +142,6 @@ native_binaries_to_ignore = [
     "clrjit_win_x86_arm64.dll",
     "clrjit_win_x86_x64.dll",
     "clrjit_win_x86_x86.dll",
-    "clrjit_universal_arm_arm.dll",
-    "clrjit_universal_arm_arm64.dll",
-    "clrjit_universal_arm_x64.dll",
-    "clrjit_universal_arm_x86.dll",
-    "clrjit_universal_arm64_arm64.dll",
-    "clrjit_universal_arm64_x64.dll",
     "coreclr.dll",
     "CoreConsole.exe",
     "coredistools.dll",
@@ -147,6 +151,8 @@ native_binaries_to_ignore = [
     "crossgen.exe",
     "crossgen2.exe",
     "dbgshim.dll",
+    "e_sqlite3.dll",
+    "FileCheck.exe",
     "ilasm.exe",
     "ildasm.exe",
     "jitinterface_arm.dll",
@@ -155,6 +161,7 @@ native_binaries_to_ignore = [
     "jitinterface_x86.dll",
     "KernelTraceControl.dll",
     "KernelTraceControl.Win61.dll",
+    "llvm-mca.exe",
     "mcs.exe",
     "Microsoft.DiaSymReader.Native.amd64.dll",
     "Microsoft.DiaSymReader.Native.x86.dll",
@@ -164,20 +171,21 @@ native_binaries_to_ignore = [
     "msdia140.dll",
     "msquic.dll",
     "msvcp140.dll",
-    "vcruntime140.dll",
-    "vcruntime140_1.dll",
+    "NativeLibrary.dll",
     "R2RDump.exe",
     "R2RTest.exe",
-    "FileCheck.exe",
+    "sni.dll",
     "SuperFileCheck.exe",
-    "llvm-mca.exe",
-    "superpmi.exe",
     "superpmi-shim-collector.dll",
     "superpmi-shim-counter.dll",
     "superpmi-shim-simple.dll",
+    "superpmi.exe",
     "System.CommandLine.resources.dll", # Managed, but uninteresting
     "System.IO.Compression.Native.dll",
     "ucrtbase.dll",
+    "UnloadableAssembly.dll",
+    "vcruntime140.dll",
+    "vcruntime140_1.dll",
     "xunit.console.exe",
 ]
 
@@ -559,7 +567,11 @@ def main(main_args):
         #     copy_directory(dotnet_src_directory, dotnet_dst_directory, verbose_output=False)
 
         input_artifacts = os.path.join(workitem_payload_directory, "collectAssembliesDirectory", coreclr_args.collection_name)
-        exclude_directory = ['Core_Root'] if coreclr_args.collection_name == "coreclr_tests" else []
+
+        exclude_directories = directories_to_ignore
+        if coreclr_args.collection_name == "coreclr_tests":
+            exclude_directories += ['Core_Root']
+
         exclude_files = native_binaries_to_ignore
         if coreclr_args.collection_type == "crossgen2":
             print('Adding exclusions for crossgen2')
@@ -572,7 +584,7 @@ def main(main_args):
             exclude_files += [item for item in os.listdir(core_root_dir)
                               if os.path.isfile(os.path.join(core_root_dir, item)) and (item.endswith(".dll") or item.endswith(".exe"))]
 
-        partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directory,
+        partition_files(coreclr_args.input_directory, input_artifacts, coreclr_args.max_size, exclude_directories,
                         exclude_files)
 
     # Set variables


### PR DESCRIPTION
Exclude a few more native code files and the 'runtimes' directory that contains uninteresting files, including native code files, to reduce the number of PMI exceptions during collections.