### PR TITLE
[mono][arm] Fix rethrow instruction size

### DIFF
--- a/src/mono/mono/mini/cpu-arm.mdesc
+++ b/src/mono/mono/mini/cpu-arm.mdesc
@@ -60,7 +60,7 @@ seq_point: len:52 clob:c
 il_seq_point: len:0
 
 throw: src1:i len:24
-rethrow: src1:i len:20
+rethrow: src1:i len:24
 start_handler: len:20
 endfinally: len:32
 call_handler: len:16 clob:c


### PR DESCRIPTION
It is the same as throw

Fixes https://github.com/dotnet/runtime/issues/76192