### PR TITLE
Add DiagnosticSource.Write<T> API to assist with trimming 

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Extensions.Hosting
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
             Justification = "The values being passed into Write are being consumed by the application already.")]
-        private static void Write<T>(
+        private static void Write<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
             DiagnosticSource diagnosticSource,
             string name,
             T value)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -30,6 +30,6 @@ namespace System.Diagnostics
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public abstract void Write(string name, object? value);
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The type of object being written to DiagnosticSource cannot be discovered statically.")]
-        public void Write<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, T? value) { }
+        public void Write<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, T value) { }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -29,5 +29,7 @@ namespace System.Diagnostics
         public virtual bool IsEnabled(string name, object? arg1, object? arg2 = null) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public abstract void Write(string name, object? value);
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public void Write<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, T? value) { }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.cs
@@ -29,7 +29,7 @@ namespace System.Diagnostics
         public virtual bool IsEnabled(string name, object? arg1, object? arg2 = null) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public abstract void Write(string name, object? value);
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Only the properties of the T type will be preserved. Properties of referenced types and properties of derived types may be trimmed.")]
         public void Write<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, T value) { }
     }
 }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <CLSCompliant>false</CLSCompliant>
@@ -11,6 +11,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs"  />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" />
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -199,11 +199,11 @@ namespace System.Diagnostics
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public System.Diagnostics.Activity StartActivity(System.Diagnostics.Activity activity, object? args) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
-        public System.Diagnostics.Activity StartActivity<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T? args) { throw null; }
+        public System.Diagnostics.Activity StartActivity<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T args) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public void StopActivity(System.Diagnostics.Activity activity, object? args) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
-        public void StopActivity<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T? args) { throw null; }
+        public void StopActivity<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T args) { throw null; }
     }
     public enum ActivitySamplingResult
     {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -198,11 +198,11 @@ namespace System.Diagnostics
         public virtual void OnActivityImport(System.Diagnostics.Activity activity, object? payload) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public System.Diagnostics.Activity StartActivity(System.Diagnostics.Activity activity, object? args) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Only the properties of the T type will be preserved. Properties of referenced types and properties of derived types may be trimmed.")]
         public System.Diagnostics.Activity StartActivity<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T args) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public void StopActivity(System.Diagnostics.Activity activity, object? args) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Only the properties of the T type will be preserved. Properties of referenced types and properties of derived types may be trimmed.")]
         public void StopActivity<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T args) { throw null; }
     }
     public enum ActivitySamplingResult

--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -199,7 +199,11 @@ namespace System.Diagnostics
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public System.Diagnostics.Activity StartActivity(System.Diagnostics.Activity activity, object? args) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public System.Diagnostics.Activity StartActivity<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T? args) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
         public void StopActivity(System.Diagnostics.Activity activity, object? args) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public void StopActivity<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T? args) { throw null; }
     }
     public enum ActivitySamplingResult
     {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -99,6 +99,7 @@ System.Diagnostics.DiagnosticSource</PackageDescription>
 
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicDependencyAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\RequiresUnreferencedCodeAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -40,7 +40,7 @@ namespace System.Diagnostics
         /// <inheritdoc cref="Write"/>
         /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
         [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
-        public void Write<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, T? value) =>
+        public void Write<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, T value) =>
             Write(name, (object?)value);
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -37,6 +37,12 @@ namespace System.Diagnostics
         [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
         public abstract void Write(string name, object? value);
 
+        /// <inheritdoc cref="Write"/>
+        /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
+        [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
+        public void Write<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, T? value) =>
+            Write(name, (object?)value);
+
         /// <summary>
         /// Optional: if there is expensive setup for the notification, you can call IsEnabled
         /// before doing this setup.   Consumers should not be assuming that they only get notifications

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSource.cs
@@ -17,6 +17,7 @@ namespace System.Diagnostics
     public abstract partial class DiagnosticSource
     {
         internal const string WriteRequiresUnreferencedCode = "The type of object being written to DiagnosticSource cannot be discovered statically.";
+        internal const string WriteOfTRequiresUnreferencedCode = "Only the properties of the T type will be preserved. Properties of referenced types and properties of derived types may be trimmed.";
 
         /// <summary>
         /// Write is a generic way of logging complex payloads.  Each notification
@@ -39,7 +40,7 @@ namespace System.Diagnostics
 
         /// <inheritdoc cref="Write"/>
         /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
-        [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
+        [RequiresUnreferencedCode(WriteOfTRequiresUnreferencedCode)]
         public void Write<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string name, T value) =>
             Write(name, (object?)value);
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
@@ -33,6 +33,12 @@ namespace System.Diagnostics
             return activity;
         }
 
+        /// <inheritdoc cref="StartActivity"/>
+        /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
+        [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
+        public Activity StartActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T? args)
+            => StartActivity(activity, (object?)args);
+
         /// <summary>
         /// Stops given Activity: maintains global Current Activity and notifies consumers
         /// that Activity was stopped. Consumers could access <see cref="Activity.Current"/>
@@ -53,6 +59,12 @@ namespace System.Diagnostics
             Write(activity.OperationName + ".Stop", args);
             activity.Stop();    // Resets Activity.Current (we want this after the Write)
         }
+
+        /// <inheritdoc cref="StartActivity"/>
+        /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
+        [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
+        public void StopActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T? args)
+            => StopActivity(activity, (object?)args);
 
         /// <summary>
         /// Optional: If an instrumentation site creating an new activity that was caused

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
@@ -35,7 +35,7 @@ namespace System.Diagnostics
 
         /// <inheritdoc cref="StartActivity"/>
         /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
-        [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
+        [RequiresUnreferencedCode(WriteOfTRequiresUnreferencedCode)]
         public Activity StartActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T args)
             => StartActivity(activity, (object?)args);
 
@@ -62,7 +62,7 @@ namespace System.Diagnostics
 
         /// <inheritdoc cref="StartActivity"/>
         /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
-        [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
+        [RequiresUnreferencedCode(WriteOfTRequiresUnreferencedCode)]
         public void StopActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T args)
             => StopActivity(activity, (object?)args);
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceActivity.cs
@@ -36,7 +36,7 @@ namespace System.Diagnostics
         /// <inheritdoc cref="StartActivity"/>
         /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
         [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
-        public Activity StartActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T? args)
+        public Activity StartActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T args)
             => StartActivity(activity, (object?)args);
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace System.Diagnostics
         /// <inheritdoc cref="StartActivity"/>
         /// <typeparam name="T">The type of the value being passed as a payload for the event.</typeparam>
         [RequiresUnreferencedCode(WriteRequiresUnreferencedCode)]
-        public void StopActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T? args)
+        public void StopActivity<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Activity activity, T args)
             => StopActivity(activity, (object?)args);
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -42,6 +42,34 @@ namespace System.Diagnostics.Tests
         }
 
         /// <summary>
+        /// Trivial example of passing an object
+        /// </summary>
+        [Fact]
+        public void ObjectPayload()
+        {
+            using (DiagnosticListener listener = new DiagnosticListener("TestingObjectPayload"))
+            {
+                DiagnosticSource source = listener;
+                var result = new List<KeyValuePair<string, object>>();
+                var observer = new ObserverToList<TelemData>(result);
+
+                using (listener.Subscribe(new ObserverToList<TelemData>(result)))
+                {
+                    object o = new object();
+
+                    listener.Write("ObjectPayload", o);
+                    Assert.Equal(1, result.Count);
+                    Assert.Equal("ObjectPayload", result[0].Key);
+                    Assert.Same(o, result[0].Value);
+                }   // unsubscribe
+
+                // Make sure that after unsubscribing, we don't get more events.
+                source.Write("ObjectPayload", new object());
+                Assert.Equal(1, result.Count);
+            }
+        }
+
+        /// <summary>
         /// slightly less trivial of passing a structure with a couple of fields
         /// </summary>
         [Fact]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/TrimmingTests/System.Diagnostics.DiagnosticSource.proj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/TrimmingTests/System.Diagnostics.DiagnosticSource.proj
@@ -1,0 +1,9 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <ItemGroup>
+    <TestConsoleAppSourceFiles Include="WritePreservesAnonymousProperties.cs" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -217,7 +217,6 @@ namespace System.Net.Http
             // matches the properties selected in https://github.com/dotnet/diagnostics/blob/ffd0254da3bcc47847b1183fa5453c0877020abd/src/Microsoft.Diagnostics.Monitoring.EventPipe/Configuration/HttpRequestSourceConfiguration.cs#L36-L40
             [DynamicDependency(nameof(HttpRequestMessage.RequestUri), typeof(HttpRequestMessage))]
             [DynamicDependency(nameof(HttpRequestMessage.Method), typeof(HttpRequestMessage))]
-            [DynamicDependency(nameof(HttpRequestMessage.RequestUri), typeof(HttpRequestMessage))]
             [DynamicDependency(nameof(Uri.Host), typeof(Uri))]
             [DynamicDependency(nameof(Uri.Port), typeof(Uri))]
             internal ActivityStartData(HttpRequestMessage request)
@@ -251,7 +250,6 @@ namespace System.Net.Http
             // preserve the same properties as ActivityStartData above + common Exception properties
             [DynamicDependency(nameof(HttpRequestMessage.RequestUri), typeof(HttpRequestMessage))]
             [DynamicDependency(nameof(HttpRequestMessage.Method), typeof(HttpRequestMessage))]
-            [DynamicDependency(nameof(HttpRequestMessage.RequestUri), typeof(HttpRequestMessage))]
             [DynamicDependency(nameof(Uri.Host), typeof(Uri))]
             [DynamicDependency(nameof(Uri.Port), typeof(Uri))]
             [DynamicDependency(nameof(System.Exception.Message), typeof(Exception))]
@@ -273,7 +271,6 @@ namespace System.Net.Http
             // preserve the same properties as ActivityStartData above
             [DynamicDependency(nameof(HttpRequestMessage.RequestUri), typeof(HttpRequestMessage))]
             [DynamicDependency(nameof(HttpRequestMessage.Method), typeof(HttpRequestMessage))]
-            [DynamicDependency(nameof(HttpRequestMessage.RequestUri), typeof(HttpRequestMessage))]
             [DynamicDependency(nameof(Uri.Host), typeof(Uri))]
             [DynamicDependency(nameof(Uri.Port), typeof(Uri))]
             internal RequestData(HttpRequestMessage request, Guid loggingRequestId, long timestamp)


### PR DESCRIPTION
Add strongly typed APIs to  DiagnosticSource to help preserve the public properties of the args being written. This doesn't fully solve the trimming problem, but it assists developers by at least preserving the top level properties in their types.

Fix #50454