### PR TITLE
Remove the GenericComPlusCall mechanism

### DIFF
--- a/src/coreclr/vm/arm/asmconstants.h
+++ b/src/coreclr/vm/arm/asmconstants.h
@@ -123,9 +123,6 @@ ASMCONSTANTS_C_ASSERT(MethodDesc__mdcClassification == mdcClassification)
 
 #ifdef FEATURE_COMINTEROP
 
-#define MethodDesc__mcComInterop 0x6
-ASMCONSTANTS_C_ASSERT(MethodDesc__mcComInterop == mcComInterop)
-
 #define Stub__m_pCode DBG_FRE(0x10, 0x0c)
 ASMCONSTANTS_C_ASSERT(Stub__m_pCode == sizeof(Stub))
 

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -530,7 +530,7 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
                             + 3;        // for rank specific Get, Set, Address
 
         MethodDescChunk * pChunks = MethodDescChunk::CreateChunk(pAllocator->GetHighFrequencyHeap(),
-                            dwMethodDescs, mcArray, FALSE /* fNonVtableSlot*/, FALSE /* fNativeCodeSlot */, FALSE /* fComPlusCallInfo */,
+                            dwMethodDescs, mcArray, FALSE /* fNonVtableSlot*/, FALSE /* fNativeCodeSlot */,
                             pMT, pamTracker);
         pClass->SetChunks(pChunks);
 

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -591,7 +591,6 @@ HRESULT EEClass::AddMethod(MethodTable * pMT, mdMethodDef methodDef, RVA newRVA,
                                                            mcInstantiated,
                                                            TRUE /* fNonVtableSlot */,
                                                            TRUE /* fNativeCodeSlot */,
-                                                           FALSE /* fComPlusCallInfo */,
                                                            pMT,
                                                            &dummyAmTracker);
 

--- a/src/coreclr/vm/clrtocomcall.cpp
+++ b/src/coreclr/vm/clrtocomcall.cpp
@@ -168,7 +168,7 @@ PCODE ComPlusCall::GetStubForILStub(MethodDesc* pMD, MethodDesc** ppStubMD)
 {
     STANDARD_VM_CONTRACT;
 
-    _ASSERTE(pMD->IsComPlusCall() || pMD->IsGenericComPlusCall());
+    _ASSERTE(pMD->IsComPlusCall());
     _ASSERTE(*ppStubMD == NULL);
 
     DWORD dwStubFlags;

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5641,7 +5641,7 @@ PCODE GetStubForInteropMethod(MethodDesc* pMD, DWORD dwStubFlags)
         STANDARD_VM_CHECK;
 
         PRECONDITION(CheckPointer(pMD));
-        PRECONDITION(pMD->IsNDirect() || pMD->IsComPlusCall() || pMD->IsGenericComPlusCall() || pMD->IsEEImpl() || pMD->IsIL());
+        PRECONDITION(pMD->IsNDirect() || pMD->IsComPlusCall() || pMD->IsEEImpl() || pMD->IsIL());
     }
     CONTRACT_END;
 
@@ -5655,7 +5655,7 @@ PCODE GetStubForInteropMethod(MethodDesc* pMD, DWORD dwStubFlags)
     }
 #ifdef FEATURE_COMINTEROP
     else
-    if (pMD->IsComPlusCall() || pMD->IsGenericComPlusCall())
+    if (pMD->IsComPlusCall())
     {
         pStub = ComPlusCall::GetStubForILStub(pMD, &pStubMD);
     }

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -162,7 +162,7 @@ void DynamicMethodTable::AddMethodsToList()
     // allocate as many chunks as needed to hold the methods
     //
     MethodDescChunk* pChunk = MethodDescChunk::CreateChunk(pHeap, 0 /* one chunk of maximum size */,
-        mcDynamic, TRUE /* fNonVtableSlot */, TRUE /* fNativeCodeSlot */, FALSE /* fComPlusCallInfo */, m_pMethodTable, &amt);
+        mcDynamic, TRUE /* fNonVtableSlot */, TRUE /* fNativeCodeSlot */, m_pMethodTable, &amt);
     if (m_DynamicMethodList) RETURN;
 
     int methodCount = pChunk->GetCount();

--- a/src/coreclr/vm/genmeth.cpp
+++ b/src/coreclr/vm/genmeth.cpp
@@ -67,7 +67,6 @@ static MethodDesc* CreateMethodDesc(LoaderAllocator *pAllocator,
                                     MethodDesc *pTemplateMD,
                                     DWORD classification,
                                     BOOL fNativeCodeSlot,
-                                    BOOL fComPlusCallInfo,
                                     AllocMemTracker *pamTracker)
 {
     CONTRACTL
@@ -92,7 +91,6 @@ static MethodDesc* CreateMethodDesc(LoaderAllocator *pAllocator,
                                      classification,
                                      TRUE /* fNonVtableSlot*/,
                                      fNativeCodeSlot,
-                                     fComPlusCallInfo,
                                      pMT,
                                      pamTracker);
 
@@ -407,8 +405,6 @@ InstantiatedMethodDesc::NewInstantiatedMethodDesc(MethodTable *pExactMT,
             }
         }
 
-        BOOL forComInterop = FALSE;
-
         // Create a new singleton chunk for the new instantiated method descriptor
         // Notice that we've passed in the method table pointer; this gets
         // used in some of the subsequent setup methods for method descs.
@@ -418,7 +414,6 @@ InstantiatedMethodDesc::NewInstantiatedMethodDesc(MethodTable *pExactMT,
                                                              pGenericMDescInRepMT,
                                                              mcInstantiated,
                                                              !pWrappedMD, // This is pesimistic estimate for fNativeCodeSlot
-                                                             forComInterop,
                                                              &amt));
 
         // Initialize the MD the way it needs to be
@@ -899,7 +894,6 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                                  pMDescInCanonMT,
                                                  mcInstantiated,
                                                  FALSE /* fNativeCodeSlot */,
-                                                 FALSE /* fComPlusCallInfo */,
                                                  &amt);
 
                     // Indicate that this is a stub method which takes a BOXed this pointer.
@@ -981,7 +975,6 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                                  pNonUnboxingStub,
                                                  mcInstantiated,
                                                  FALSE /* fNativeCodeSlot */,
-                                                 FALSE /* fComPlusCallInfo */,
                                                  &amt);
 
                     pResultMD->SetIsUnboxingStub();

--- a/src/coreclr/vm/i386/asmconstants.h
+++ b/src/coreclr/vm/i386/asmconstants.h
@@ -242,9 +242,6 @@ ASMCONSTANTS_C_ASSERT(MethodDesc_m_wFlags == offsetof(MethodDesc, m_wFlags))
 #define MethodDesc_mdcClassification          7
 ASMCONSTANTS_C_ASSERT(MethodDesc_mdcClassification == mdcClassification)
 
-#define MethodDesc_mcComInterop               6
-ASMCONSTANTS_C_ASSERT(MethodDesc_mcComInterop == mcComInterop)
-
 #define ComPlusCallMethodDesc__m_pComPlusCallInfo DBG_FRE(0x1C, 0x8)
 ASMCONSTANTS_C_ASSERT(ComPlusCallMethodDesc__m_pComPlusCallInfo == offsetof(ComPlusCallMethodDesc, m_pComPlusCallInfo))
 

--- a/src/coreclr/vm/ilstubcache.cpp
+++ b/src/coreclr/vm/ilstubcache.cpp
@@ -184,7 +184,6 @@ MethodDesc* ILStubCache::CreateNewMethodDesc(LoaderHeap* pCreationHeap, MethodTa
                                                            mcDynamic,
                                                            TRUE /* fNonVtableSlot */,
                                                            TRUE /* fNativeCodeSlot */,
-                                                           FALSE /* fComPlusCallInfo */,
                                                            pMT,
                                                            pamTracker);
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -135,9 +135,6 @@ SIZE_T MethodDesc::SizeOf()
         (mdcClassification
         | mdcHasNonVtableSlot
         | mdcMethodImpl
-#ifdef FEATURE_COMINTEROP
-        | mdcHasComPlusCallInfo
-#endif
         | mdcHasNativeCodeSlot)];
 
     return size;
@@ -1691,7 +1688,7 @@ MethodDesc* MethodDesc::StripMethodInstantiation()
 
 //*******************************************************************************
 MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDescCount,
-    DWORD classification, BOOL fNonVtableSlot, BOOL fNativeCodeSlot, BOOL fComPlusCallInfo, MethodTable *pInitialMT, AllocMemTracker *pamTracker)
+    DWORD classification, BOOL fNonVtableSlot, BOOL fNativeCodeSlot, MethodTable *pInitialMT, AllocMemTracker *pamTracker)
 {
     CONTRACT(MethodDescChunk *)
     {
@@ -1714,13 +1711,6 @@ MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDes
 
     if (fNativeCodeSlot)
         oneSize += sizeof(MethodDesc::NativeCodeSlot);
-
-#ifdef FEATURE_COMINTEROP
-    if (fComPlusCallInfo)
-        oneSize += sizeof(ComPlusCallInfo);
-#else // FEATURE_COMINTEROP
-    _ASSERTE(!fComPlusCallInfo);
-#endif // FEATURE_COMINTEROP
 
     _ASSERTE((oneSize & MethodDesc::ALIGNMENT_MASK) == 0);
 
@@ -1761,10 +1751,6 @@ MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDes
                 pMD->SetHasNonVtableSlot();
             if (fNativeCodeSlot)
                 pMD->SetHasNativeCodeSlot();
-#ifdef FEATURE_COMINTEROP
-            if (fComPlusCallInfo)
-                pMD->SetupGenericComPlusCall();
-#endif // FEATURE_COMINTEROP
 
             _ASSERTE(pMD->SizeOf() == oneSize);
 
@@ -2295,7 +2281,7 @@ BOOL MethodDesc::RequiresMethodDescCallingConvention(BOOL fEstimateForChunk /*=F
     LIMITED_METHOD_CONTRACT;
 
     // Interop marshaling is implemented using shared stubs
-    if (IsNDirect() || IsComPlusCall() || IsGenericComPlusCall())
+    if (IsNDirect() || IsComPlusCall())
         return TRUE;
 
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -138,11 +138,7 @@ enum MethodDescClassification
     // Has slot for native code
     mdcHasNativeCodeSlot                = 0x0020,
 
-#ifdef FEATURE_COMINTEROP
-    mdcHasComPlusCallInfo               = 0x0040,
-#else
     // unused                           = 0x0040,
-#endif
 
     // Method is static
     mdcStatic                           = 0x0080,
@@ -657,16 +653,9 @@ public:
         WRAPPER_NO_CONTRACT;
         return mcComInterop == GetClassification();
     }
-    inline DWORD IsGenericComPlusCall();
-    inline void SetupGenericComPlusCall();
 #else // !FEATURE_COMINTEROP
      // hardcoded to return FALSE to improve code readability
     inline DWORD IsComPlusCall()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return FALSE;
-    }
-    inline DWORD IsGenericComPlusCall()
     {
         LIMITED_METHOD_CONTRACT;
         return FALSE;
@@ -2185,7 +2174,6 @@ public:
                                         DWORD classification,
                                         BOOL fNonVtableSlot,
                                         BOOL fNativeCodeSlot,
-                                        BOOL fComPlusCallInfo,
                                         MethodTable *initialMT,
                                         class AllocMemTracker *pamTracker);
 
@@ -3374,25 +3362,6 @@ public:
         return FALSE;
 #endif
     }
-
-#ifdef FEATURE_COMINTEROP
-    void IMD_SetupGenericComPlusCall()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        IMD_GetComPlusCallInfo()->InitStackArgumentSize();
-    }
-
-    PTR_ComPlusCallInfo IMD_GetComPlusCallInfo()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        _ASSERTE(IsGenericComPlusCall());
-        SIZE_T size = s_ClassificationSizeTable[m_wFlags & (mdcClassification | mdcHasNonVtableSlot | mdcMethodImpl | mdcHasNativeCodeSlot)];
-
-        return dac_cast<PTR_ComPlusCallInfo>(dac_cast<TADDR>(this) + size);
-    }
-#endif // FEATURE_COMINTEROP
 
     PTR_DictionaryLayout GetDictLayoutRaw()
     {

--- a/src/coreclr/vm/method.inl
+++ b/src/coreclr/vm/method.inl
@@ -112,23 +112,6 @@ inline BOOL MethodDesc::IsQCall()
 }
 
 #ifdef FEATURE_COMINTEROP
-FORCEINLINE DWORD MethodDesc::IsGenericComPlusCall()
-{
-    LIMITED_METHOD_CONTRACT;
-    return m_wFlags & mdcHasComPlusCallInfo;
-}
-
-inline void MethodDesc::SetupGenericComPlusCall()
-{
-    LIMITED_METHOD_CONTRACT;
-    m_wFlags |= mdcHasComPlusCallInfo;
-
-    AsInstantiatedMethodDesc()->IMD_SetupGenericComPlusCall();
-}
-#endif // FEATURE_COMINTEROP
-
-
-#ifdef FEATURE_COMINTEROP
 
 // static
 inline ComPlusCallInfo *ComPlusCallInfo::FromMethodDesc(MethodDesc *pMD)
@@ -138,14 +121,10 @@ inline ComPlusCallInfo *ComPlusCallInfo::FromMethodDesc(MethodDesc *pMD)
     {
         return ((ComPlusCallMethodDesc *)pMD)->m_pComPlusCallInfo;
     }
-    else if (pMD->IsEEImpl())
-    {
-        return ((DelegateEEClass *)pMD->GetClass())->m_pComPlusCallInfo;
-    }
     else
     {
-        _ASSERTE(pMD->IsGenericComPlusCall());
-        return pMD->AsInstantiatedMethodDesc()->IMD_GetComPlusCallInfo();
+        _ASSERTE(pMD->IsEEImpl());
+        return ((DelegateEEClass *)pMD->GetClass())->m_pComPlusCallInfo;
     }
 }
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -2698,7 +2698,7 @@ MethodTableBuilder::EnumerateClassMethods()
                 BuildMethodTableThrowException(BFA_METHOD_NAME_TOO_LONG);
             }
 
-            isVtblGap = IsMdRTSpecialName(dwMemberAttrs) && strncmp(strMethodName, "_VtblGap", 8) == 0;
+            isVtblGap = IsMdRTSpecialName(dwMemberAttrs) && IsVtblGapName(strMethodName);
         }
         else
         {
@@ -2737,9 +2737,6 @@ MethodTableBuilder::EnumerateClassMethods()
                 }
 
                 numGenericMethodArgs = hEnumTyPars.EnumGetCount();
-
-                // We do not want to support context-bound objects with generic methods.
-
                 if (numGenericMethodArgs != 0)
                 {
                     HENUMInternalHolder hEnumGenericPars(pMDInternalImport);
@@ -2799,7 +2796,7 @@ MethodTableBuilder::EnumerateClassMethods()
             //   the '_'. We ignore this.
             //
 
-            LPCSTR pos = strMethodName + 8;
+            LPCSTR pos = strMethodName + COR_VTABLEGAP_NAME_LENGTH;
 
             // Skip optional number.
             while (IS_DIGIT(*pos))
@@ -3191,7 +3188,6 @@ MethodTableBuilder::EnumerateClassMethods()
             else
 #endif // !FEATURE_COMINTEROP
             {
-                // This codepath is used by remoting
                 type = METHOD_TYPE_NORMAL;
             }
         }
@@ -9999,7 +9995,7 @@ void MethodTableBuilder::CheckForSystemTypes()
             // * UInt128: unsigned __int128
             //
             // This behavior matches the ABI standard on various Unix platforms
-            // On Windows, no standard for Int128 has been established yet, 
+            // On Windows, no standard for Int128 has been established yet,
             // although applying 16 byte alignment is consistent with treatment of 128 bit SSE types
             // even on X86
             pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16; // sizeof(__int128)

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2078,7 +2078,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
     // they are not your every day method descriptors, for example
     // they don't have an IL or code.
     */
-    if (IsComPlusCall() || IsGenericComPlusCall())
+    if (IsComPlusCall())
     {
         pCode = GetStubForInteropMethod(this);
 

--- a/src/coreclr/vm/stubhelpers.cpp
+++ b/src/coreclr/vm/stubhelpers.cpp
@@ -294,7 +294,7 @@ FCIMPL4(IUnknown*, StubHelpers::GetCOMIPFromRCW, Object* pSrcUNSAFE, MethodDesc*
     CONTRACTL
     {
         FCALL_CHECK;
-        PRECONDITION(pMD->IsComPlusCall() || pMD->IsGenericComPlusCall() || pMD->IsEEImpl());
+        PRECONDITION(pMD->IsComPlusCall() || pMD->IsEEImpl());
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
Remove unused asm constants.
Remove comments about context-bound objects and remoting. Use common constants for VtblGap concept.

/cc @dotnet/interop-contrib 