### PR TITLE
Quick disasm check CI JitStress fix

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_33972/Runtime_33972.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_33972/Runtime_33972.csproj
@@ -10,11 +10,13 @@
 $(CLRTestBatchPreCommands)
 set COMPlus_TieredCompilation=0
 set COMPlus_JITMinOpts=0
+set COMPlus_EnableHWIntrinsic=1
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 export COMPlus_TieredCompilation=0
 export COMPlus_JITMinOpts=0
+export COMPlus_EnableHWIntrinsic=1
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Runtime_33972 was failing in ARM64 in JitStress because it turns off HWIntrinsic - so I force the test to enable it.