### PR TITLE
[wasm] Pass --web-server-use-cop for threading samples

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -12,6 +12,7 @@ parameters:
         src/libraries/sendtohelix-wasm.targets
         src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/*
         src/mono/nuget/Microsoft.NET.Runtime.wasm.Sample.Mono/*
+        src/mono/sample/wasm/*
         src/mono/wasi/*
         src/mono/wasm/*
         src/tasks/WasmAppBuilder/*

--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -7,6 +7,7 @@
     <RunScriptInputName Condition="'$(TargetOS)' == 'Browser' and '$(OS)' == 'Windows_NT'">WasmRunnerTemplate.cmd</RunScriptInputName>
 
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(WasmAppDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
+    <WasmXHarnessArgs Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true' or '$(MonoWasmBuildVariant)' == 'perftrace' or '$(MonoWasmBuildVariant)' == 'multithread'">$(WasmXHarnessArgs) --web-server-use-cop</WasmXHarnessArgs>
   </PropertyGroup>
 
   <Target Name="BuildSampleInTree"


### PR DESCRIPTION
This will fix:
`[03:51:52] fail: [out of order message from the browser]: http://127.0.0.1:34655/dotnet.js 13:13768 Uncaught ReferenceError: SharedArrayBuffer is not defined`

Fixes https://github.com/dotnet/runtime/issues/76331 .