### PR TITLE
[release/6.0] Delete dangling thread session states

### DIFF
--- a/src/native/eventpipe/ep-buffer-manager.c
+++ b/src/native/eventpipe/ep-buffer-manager.c
@@ -791,6 +791,7 @@ buffer_manager_try_convert_buffer_to_read_only (
 	EventPipeThread *thread = ep_buffer_get_writer_thread (new_read_buffer);
 	EP_SPIN_LOCK_ENTER (ep_thread_get_rt_lock_ref (thread), section1);
 		EventPipeThreadSessionState *thread_session_state = ep_thread_get_session_state (thread, buffer_manager->session);
+		EP_ASSERT(thread_session_state != NULL);
 		if (ep_thread_session_state_get_write_buffer (thread_session_state) == new_read_buffer) {
 			ep_thread_session_state_set_write_buffer (thread_session_state, NULL);
 			EP_ASSERT (ep_buffer_get_volatile_state (new_read_buffer) == EP_BUFFER_STATE_READ_ONLY);
@@ -1091,6 +1092,7 @@ ep_buffer_manager_suspend_write_event (
 		EventPipeThread *thread = ep_rt_thread_array_iterator_value (&thread_array_iterator);
 		EP_SPIN_LOCK_ENTER (ep_thread_get_rt_lock_ref (thread), section2)
 			EventPipeThreadSessionState *thread_session_state = ep_thread_get_session_state (thread, buffer_manager->session);
+			EP_ASSERT(thread_session_state != NULL);
 			ep_thread_session_state_set_write_buffer (thread_session_state, NULL);
 		EP_SPIN_LOCK_EXIT (ep_thread_get_rt_lock_ref (thread), section2)
 		ep_rt_thread_array_iterator_next (&thread_array_iterator);

--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -233,7 +233,7 @@ ep_session_remove_dangling_session_states (EventPipeSession *session)
 	while (!ep_rt_thread_array_iterator_end (&threads, &threads_iterator)) {
 		EventPipeThread *thread = ep_rt_thread_array_iterator_value (&threads_iterator);
 		if (thread) {
-			EP_SPIN_LOCK_ENTER (&thread->rt_lock, section1);
+			EP_SPIN_LOCK_ENTER (ep_thread_get_rt_lock_ref (thread), section1);
 				EventPipeThreadSessionState *session_state = ep_thread_get_session_state(thread, session);
 				if (session_state) {
 					// If a buffer tries to write event(s) but never gets a buffer because the maximum total buffer size

--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -216,6 +216,47 @@ ep_on_error:
 }
 
 void
+ep_session_remove_dangling_session_states (EventPipeSession *session)
+{
+	ep_return_void_if_nok (session != NULL);
+
+	EP_RT_DECLARE_LOCAL_THREAD_ARRAY (threads);
+	ep_rt_thread_array_init (&threads);
+
+	ep_thread_get_threads (&threads);
+
+	ep_rt_thread_array_iterator_t threads_iterator = ep_rt_thread_array_iterator_begin (&threads);
+	while (!ep_rt_thread_array_iterator_end (&threads, &threads_iterator)) {
+		EventPipeThread *thread = ep_rt_thread_array_iterator_value (&threads_iterator);
+		if (thread) {
+			EP_SPIN_LOCK_ENTER (&thread->rt_lock, section1);
+				EventPipeThreadSessionState *session_state = ep_thread_get_session_state(thread, session);
+				if (session_state) {
+					// If a buffer tries to write event(s) but never gets a buffer because the maximum total buffer size
+					// has been exceeded, we can leak the EventPipeThreadSessionState* and crash later trying to access 
+					// the session from the thread session state. Whenever we terminate a session we check to make sure
+					// we haven't leaked any thread session states.
+					ep_thread_delete_session_state(thread, session);
+				}
+			EP_SPIN_LOCK_EXIT (&thread->rt_lock, section1);
+
+			// ep_thread_get_threads calls ep_thread_addref for every entry, need to release it here
+			ep_thread_release (thread);
+		}
+
+		ep_rt_thread_array_iterator_next (&threads_iterator);
+	}
+
+	ep_rt_thread_array_fini (&threads);
+
+ep_on_exit:
+	return;
+
+ep_on_error:
+	ep_exit_error_handler ();
+}
+
+void
 ep_session_free (EventPipeSession *session)
 {
 	ep_return_void_if_nok (session != NULL);
@@ -228,6 +269,8 @@ ep_session_free (EventPipeSession *session)
 
 	ep_buffer_manager_free (session->buffer_manager);
 	ep_file_free (session->file);
+
+	ep_session_remove_dangling_session_states (session);
 
 	ep_rt_object_free (session);
 }

--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -26,6 +26,10 @@ static
 void
 session_create_streaming_thread (EventPipeSession *session);
 
+static
+void
+ep_session_remove_dangling_session_states (EventPipeSession *session);
+
 /*
  * EventPipeSession.
  */

--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -242,7 +242,7 @@ ep_session_remove_dangling_session_states (EventPipeSession *session)
 					// we haven't leaked any thread session states.
 					ep_thread_delete_session_state(thread, session);
 				}
-			EP_SPIN_LOCK_EXIT (&thread->rt_lock, section1);
+			EP_SPIN_LOCK_EXIT (ep_thread_get_rt_lock_ref (thread), section1);
 
 			// ep_thread_get_threads calls ep_thread_addref for every entry, need to release it here
 			ep_thread_release (thread);

--- a/src/native/eventpipe/ep-thread.c
+++ b/src/native/eventpipe/ep-thread.c
@@ -247,7 +247,6 @@ ep_thread_get_session_state (
 
 	ep_thread_requires_lock_held (thread);
 
-	EP_ASSERT (thread->session_state [ep_session_get_index (session)] != NULL);
 	return thread->session_state [ep_session_get_index (session)];
 }
 


### PR DESCRIPTION
As described in #76430, we have a partner team running in to a previously unknown EventPipe issue. We can leak EventPipeThreadSessionState* under certain circumstances, leading to a fatal CLR error and crashing the process.

This fix is a targeted fix for 6.0 where we do a simple loop over the existing threads and manually delete any dangling session states when we delete the session object. The fix for 8.0 will be more of a refactoring to make sure EventPipeThreadSessionStates are owned in a logically consistent manner.

### Customer Impact
Customers that have many threads and short lived sessions are vulnerable to this issue and there is no workaround. They will experience random crashes.

### Risk
Low, it is a targeted fix that is easy to reason about

### Testing
Manual testing by our team, and pending partner validation