### PR TITLE
JIT: A small CQ improvement for Equals/StartsWith unrolling

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -175,6 +175,21 @@ bool IntegralRange::Contains(int64_t value) const
             }
             break;
 
+        case GT_CNS_INT:
+            if (node->IsIntegralConst(0))
+            {
+                return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::Zero};
+            }
+            if (node->IsIntegralConst(1))
+            {
+                return {SymbolicIntegerValue::One, SymbolicIntegerValue::One};
+            }
+            break;
+
+        case GT_QMARK:
+            return Union(ForNode(node->AsQmark()->ThenNode(), compiler),
+                         ForNode(node->AsQmark()->ElseNode(), compiler));
+
         case GT_CAST:
             return ForCastOutput(node->AsCast());
 
@@ -428,6 +443,12 @@ bool IntegralRange::Contains(int64_t value) const
     }
 
     return {lowerBound, upperBound};
+}
+
+/* static */ IntegralRange IntegralRange::Union(IntegralRange range1, IntegralRange range2)
+{
+    return IntegralRange(min(range1.GetLowerBound(), range2.GetLowerBound()),
+                         max(range1.GetUpperBound(), range2.GetUpperBound()));
 }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -176,13 +176,9 @@ bool IntegralRange::Contains(int64_t value) const
             break;
 
         case GT_CNS_INT:
-            if (node->IsIntegralConst(0))
+            if (node->IsIntegralConst(0) || node->IsIntegralConst(1))
             {
-                return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::Zero};
-            }
-            if (node->IsIntegralConst(1))
-            {
-                return {SymbolicIntegerValue::One, SymbolicIntegerValue::One};
+                return {SymbolicIntegerValue::Zero, SymbolicIntegerValue::One};
             }
             break;
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1268,6 +1268,7 @@ public:
     static IntegralRange ForNode(GenTree* node, Compiler* compiler);
     static IntegralRange ForCastInput(GenTreeCast* cast);
     static IntegralRange ForCastOutput(GenTreeCast* cast);
+    static IntegralRange Union(IntegralRange range1, IntegralRange range2);
 
 #ifdef DEBUG
     static void Print(IntegralRange range);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5712,6 +5712,16 @@ struct GenTreeQmark : public GenTreeOp
         assert((colon != nullptr) && colon->OperIs(GT_COLON));
     }
 
+    GenTree* ThenNode()
+    {
+        return gtOp2->AsColon()->ThenNode();
+    }
+
+    GenTree* ElseNode()
+    {
+        return gtOp2->AsColon()->ElseNode();
+    }
+
 #if DEBUGGABLE_GENTREE
     GenTreeQmark() : GenTreeOp()
     {

--- a/src/coreclr/jit/importer_vectorization.cpp
+++ b/src/coreclr/jit/importer_vectorization.cpp
@@ -526,7 +526,7 @@ GenTree* Compiler::impExpandHalfConstEquals(GenTreeLclVar*   data,
         GenTreeColon* lenCheckColon = gtNewColonNode(TYP_INT, indirCmp, gtNewFalse());
 
         // For StartsWith we use GT_GE, e.g.: `x.Length >= 10`
-        lenCheckNode = gtNewQmarkNode(TYP_INT, gtNewOperNode(cmpOp, TYP_INT, lengthFld, elementsCount), lenCheckColon);
+        lenCheckNode = gtNewQmarkNode(TYP_BOOL, gtNewOperNode(cmpOp, TYP_INT, lengthFld, elementsCount), lenCheckColon);
     }
 
     GenTree* rootQmark;
@@ -534,7 +534,7 @@ GenTree* Compiler::impExpandHalfConstEquals(GenTreeLclVar*   data,
     {
         // varData == nullptr
         GenTreeColon* nullCheckColon = gtNewColonNode(TYP_INT, lenCheckNode, gtNewFalse());
-        rootQmark = gtNewQmarkNode(TYP_INT, gtNewOperNode(GT_NE, TYP_INT, data, gtNewNull()), nullCheckColon);
+        rootQmark = gtNewQmarkNode(TYP_BOOL, gtNewOperNode(GT_NE, TYP_INT, data, gtNewNull()), nullCheckColon);
     }
     else
     {
@@ -722,11 +722,9 @@ GenTree* Compiler::impStringEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO
         if (unrolled->OperIs(GT_QMARK))
         {
             // QMARK nodes cannot reside on the evaluation stack
-            unrolled->ChangeType(TYP_BOOL);
             unsigned rootTmp = lvaGrabTemp(true DEBUGARG("spilling unroll qmark"));
             impAssignTempGen(rootTmp, unrolled);
             unrolled = gtNewLclvNode(rootTmp, TYP_INT);
-            lvaTable[rootTmp].lvType = TYP_BOOL;
         }
 
         JITDUMP("\n... Successfully unrolled to:\n")
@@ -874,11 +872,9 @@ GenTree* Compiler::impSpanEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO* 
         if (unrolled->OperIs(GT_QMARK))
         {
             // QMARK can't be a root node, spill it to a temp
-            unrolled->ChangeType(TYP_BOOL);
             unsigned rootTmp = lvaGrabTemp(true DEBUGARG("spilling unroll qmark"));
             impAssignTempGen(rootTmp, unrolled);
             unrolled = gtNewLclvNode(rootTmp, TYP_INT);
-            lvaTable[rootTmp].lvType = TYP_BOOL;
         }
 
         JITDUMP("... Successfully unrolled to:\n")

--- a/src/coreclr/jit/importer_vectorization.cpp
+++ b/src/coreclr/jit/importer_vectorization.cpp
@@ -526,7 +526,7 @@ GenTree* Compiler::impExpandHalfConstEquals(GenTreeLclVar*   data,
         GenTreeColon* lenCheckColon = gtNewColonNode(TYP_INT, indirCmp, gtNewFalse());
 
         // For StartsWith we use GT_GE, e.g.: `x.Length >= 10`
-        lenCheckNode = gtNewQmarkNode(TYP_BOOL, gtNewOperNode(cmpOp, TYP_INT, lengthFld, elementsCount), lenCheckColon);
+        lenCheckNode = gtNewQmarkNode(TYP_INT, gtNewOperNode(cmpOp, TYP_INT, lengthFld, elementsCount), lenCheckColon);
     }
 
     GenTree* rootQmark;
@@ -534,7 +534,7 @@ GenTree* Compiler::impExpandHalfConstEquals(GenTreeLclVar*   data,
     {
         // varData == nullptr
         GenTreeColon* nullCheckColon = gtNewColonNode(TYP_INT, lenCheckNode, gtNewFalse());
-        rootQmark = gtNewQmarkNode(TYP_BOOL, gtNewOperNode(GT_NE, TYP_INT, data, gtNewNull()), nullCheckColon);
+        rootQmark = gtNewQmarkNode(TYP_INT, gtNewOperNode(GT_NE, TYP_INT, data, gtNewNull()), nullCheckColon);
     }
     else
     {

--- a/src/coreclr/jit/importer_vectorization.cpp
+++ b/src/coreclr/jit/importer_vectorization.cpp
@@ -722,9 +722,11 @@ GenTree* Compiler::impStringEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO
         if (unrolled->OperIs(GT_QMARK))
         {
             // QMARK nodes cannot reside on the evaluation stack
+            unrolled->ChangeType(TYP_BOOL);
             unsigned rootTmp = lvaGrabTemp(true DEBUGARG("spilling unroll qmark"));
             impAssignTempGen(rootTmp, unrolled);
             unrolled = gtNewLclvNode(rootTmp, TYP_INT);
+            lvaTable[rootTmp].lvType = TYP_BOOL;
         }
 
         JITDUMP("\n... Successfully unrolled to:\n")
@@ -872,9 +874,11 @@ GenTree* Compiler::impSpanEqualsOrStartsWith(bool startsWith, CORINFO_SIG_INFO* 
         if (unrolled->OperIs(GT_QMARK))
         {
             // QMARK can't be a root node, spill it to a temp
+            unrolled->ChangeType(TYP_BOOL);
             unsigned rootTmp = lvaGrabTemp(true DEBUGARG("spilling unroll qmark"));
             impAssignTempGen(rootTmp, unrolled);
             unrolled = gtNewLclvNode(rootTmp, TYP_INT);
+            lvaTable[rootTmp].lvType = TYP_BOOL;
         }
 
         JITDUMP("... Successfully unrolled to:\n")


### PR DESCRIPTION
A quick fix for a CQ problem noticed by @stephentoub:
```csharp
static bool IsHttps(string text) => text.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
```
```diff
; Method Program:IsHttps(System.String):bool
 G_M40142_IG01:              
       C5F877               vzeroupper 
 G_M40142_IG02:              
       83790808             cmp      dword ptr [rcx+08H], 8
       7C25                 jl       SHORT G_M40142_IG04
 G_M40142_IG03:              
       C5F910410C           vmovupd  xmm0, xmmword ptr [rcx+0CH]
       C5F9EB052A000000     vpor     xmm0, xmm0, xmmword ptr [reloc @RWD00]
       C5F9EF0532000000     vpxor    xmm0, xmm0, xmmword ptr [reloc @RWD16]
       C4E27917C0           vptest   xmm0, xmm0
       0F94C0               sete     al
       0FB6C0               movzx    rax, al
       EB02                 jmp      SHORT G_M40142_IG05
 G_M40142_IG04:              
       33C0                 xor      eax, eax
 G_M40142_IG05:              
-      0FB6C0               movzx    rax, al
-G_M40142_IG06:              
       C3                   ret      
RWD00  	dq	0020002000200020h, 0000000000000020h
RWD16  	dq	0070007400740068h, 002F002F003A0073h
; Total bytes of code: 49
```
Some [nice diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=36534&view=ms.vss-build-web.run-extensions-tab).