### PR TITLE
JIT: Avoid internal register allocation when possible for PUTARG_SPLIT

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1246,9 +1246,9 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
                 allocatedValueReg = treeNode->ExtractTempReg();
             }
 
-            // Pick a register to store intermediate values in for to-stack
+            // Pick a register to store intermediate values in for the to-stack
             // copy. It must not conflict with addrReg. We try to prefer an
-            // argument register since those acn always use thumb encoding.
+            // argument register since those can always use thumb encoding.
             valueReg = treeNode->GetRegNumByIdx(0);
             if (valueReg == addrReg)
             {

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1329,7 +1329,8 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             structOffset += moveSize;
         }
 
-        // Place registers, ensuring we place 'valueRegIndex' last.
+        // Place registers starting from firstRegToPlace. It should ensure we
+        // place addrReg last (if we place it at all).
         structOffset         = static_cast<unsigned>(firstRegToPlace) * TARGET_POINTER_SIZE;
         unsigned curRegIndex = firstRegToPlace;
 

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1211,7 +1211,7 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
         // in a register and that register is the unique target register we are
         // placing. LSRA will always allocate an internal register when there
         // is just one target register to handle this situation.
-
+        //
         int          firstRegToPlace;
         regNumber    valueReg     = REG_NA;
         unsigned     srcLclNum    = BAD_VAR_NUM;
@@ -1265,6 +1265,13 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
 
             // Find first register to place. If we are placing addrReg, then
             // make sure we place it last to avoid clobbering its value.
+            //
+            // The loop below will start at firstRegToPlace and place
+            // treeNode->gtNumRegs registers in order, with wraparound. For
+            // example, if the registers to place are r0, r1, r2=addrReg, r3
+            // then we will set firstRegToPlace = 3 (r3) and the loop below
+            // will place r3, r0, r1, r2. The last placement will clobber
+            // addrReg.
             firstRegToPlace = 0;
             for (unsigned i = 0; i < treeNode->gtNumRegs; i++)
             {

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1205,7 +1205,15 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
         var_types targetType = source->TypeGet();
         assert(source->isContained() && varTypeIsStruct(targetType));
 
-        regNumber    baseReg      = treeNode->ExtractTempReg();
+        // We need a register to store intermediate values that we are loading
+        // from the source into. We can usually use one of the target registers
+        // that will be overridden anyway. The exception is when the source is
+        // in a register and that register is the unique target register we are
+        // placing. LSRA will always allocate an internal register when there
+        // is just one target register to handle this situation.
+
+        int          firstRegToPlace;
+        regNumber    valueReg     = REG_NA;
         unsigned     srcLclNum    = BAD_VAR_NUM;
         unsigned     srcLclOffset = 0;
         regNumber    addrReg      = REG_NA;
@@ -1221,6 +1229,10 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
 
             // This struct must live on the stack frame.
             assert(varDsc->lvOnFrame && !varDsc->lvRegister);
+
+            // No possible conflicts, just use the first register as the value register.
+            firstRegToPlace = 0;
+            valueReg        = treeNode->GetRegNumByIdx(0);
         }
         else // we must have a GT_OBJ
         {
@@ -1228,10 +1240,40 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             addrReg  = genConsumeReg(source->AsObj()->Addr());
             addrType = source->AsObj()->Addr()->TypeGet();
 
-            // If addrReg equal to baseReg, we use the last target register as alternative baseReg.
-            // Because the candidate mask for the internal baseReg does not include any of the target register,
-            // we can ensure that baseReg, addrReg, and the last target register are not all same.
-            assert(baseReg != addrReg);
+            regNumber allocatedValueReg = REG_NA;
+            if (treeNode->gtNumRegs == 1)
+            {
+                allocatedValueReg = treeNode->ExtractTempReg();
+            }
+
+            // Pick a register to store intermediate values in for to-stack
+            // copy. It must not conflict with addrReg. We try to prefer an
+            // argument register since those acn always use thumb encoding.
+            valueReg = treeNode->GetRegNumByIdx(0);
+            if (valueReg == addrReg)
+            {
+                if (treeNode->gtNumRegs == 1)
+                {
+                    valueReg = allocatedValueReg;
+                }
+                else
+                {
+                    // Prefer argument register that can always use thumb encoding.
+                    valueReg = treeNode->GetRegNumByIdx(1);
+                }
+            }
+
+            // Find first register to place. If we are placing addrReg, then
+            // make sure we place it last to avoid clobbering its value.
+            firstRegToPlace = 0;
+            for (unsigned i = 0; i < treeNode->gtNumRegs; i++)
+            {
+                if (treeNode->GetRegNumByIdx(i) == addrReg)
+                {
+                    firstRegToPlace = i + 1;
+                    break;
+                }
+            }
         }
 
         // Put on stack first
@@ -1268,19 +1310,18 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             if (srcLclNum != BAD_VAR_NUM)
             {
                 // Load from our local source
-                emit->emitIns_R_S(loadIns, attr, baseReg, srcLclNum, srcLclOffset + structOffset);
+                emit->emitIns_R_S(loadIns, attr, valueReg, srcLclNum, srcLclOffset + structOffset);
             }
             else
             {
-                // check for case of destroying the addrRegister while we still need it
-                assert(baseReg != addrReg);
+                assert(valueReg != addrReg);
 
                 // Load from our address expression source
-                emit->emitIns_R_R_I(loadIns, attr, baseReg, addrReg, structOffset);
+                emit->emitIns_R_R_I(loadIns, attr, valueReg, addrReg, structOffset);
             }
 
             // Emit the instruction to store the register into the outgoing argument area
-            emit->emitIns_S_R(ins_Store(type), attr, baseReg, varNumOut, argOffsetOut);
+            emit->emitIns_S_R(ins_Store(type), attr, valueReg, varNumOut, argOffsetOut);
             argOffsetOut += moveSize;
             assert(argOffsetOut <= argOffsetMax);
 
@@ -1288,13 +1329,20 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             structOffset += moveSize;
         }
 
-        // We set up the registers in order, so that we assign the last target register `baseReg` is no longer in use,
-        // in case we had to reuse the last target register for it.
-        structOffset = 0;
-        for (unsigned idx = 0; idx < treeNode->gtNumRegs; idx++)
+        // Place registers, ensuring we place 'valueRegIndex' last.
+        structOffset         = static_cast<unsigned>(firstRegToPlace) * TARGET_POINTER_SIZE;
+        unsigned curRegIndex = firstRegToPlace;
+
+        for (unsigned regsPlaced = 0; regsPlaced < treeNode->gtNumRegs; regsPlaced++)
         {
-            regNumber targetReg = treeNode->GetRegNumByIdx(idx);
-            var_types type      = treeNode->GetRegType(idx);
+            if (curRegIndex == treeNode->gtNumRegs)
+            {
+                curRegIndex  = 0;
+                structOffset = 0;
+            }
+
+            regNumber targetReg = treeNode->GetRegNumByIdx(curRegIndex);
+            var_types type      = treeNode->GetRegType(curRegIndex);
 
             if (srcLclNum != BAD_VAR_NUM)
             {
@@ -1303,17 +1351,13 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
             }
             else
             {
-                // check for case of destroying the addrRegister while we still need it
-                if (targetReg == addrReg && idx != treeNode->gtNumRegs - 1)
-                {
-                    assert(targetReg != baseReg);
-                    emit->emitIns_Mov(INS_mov, emitActualTypeSize(addrType), baseReg, addrReg, /* canSkip */ false);
-                    addrReg = baseReg;
-                }
+                assert((addrReg != targetReg) || (regsPlaced == treeNode->gtNumRegs - 1));
 
                 // Load from our address expression source
                 emit->emitIns_R_R_I(INS_ldr, emitTypeSize(type), targetReg, addrReg, structOffset);
             }
+
+            curRegIndex++;
             structOffset += TARGET_POINTER_SIZE;
         }
     }

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -554,11 +554,17 @@ int LinearScan::BuildPutArgSplit(GenTreePutArgSplit* argNode)
     {
         assert(src->TypeIs(TYP_STRUCT) && src->isContained());
 
-        // We can use a ldr/str sequence so we need an internal register
-        buildInternalIntRegisterDefForNode(argNode, allRegs(TYP_INT) & ~argMask);
-
         if (src->OperIs(GT_OBJ))
         {
+            // If the PUTARG_SPLIT clobbers only one register we may need an
+            // extra internal register in case there is a conflict between the
+            // source address register and target register.
+            if (argNode->gtNumRegs == 1)
+            {
+                // We can use a ldr/str sequence so we need an internal register
+                buildInternalIntRegisterDefForNode(argNode, allRegs(TYP_INT) & ~argMask);
+            }
+
             // We will generate code that loads from the OBJ's address, which must be in a register.
             srcCount = BuildOperandUses(src->AsObj()->Addr());
         }


### PR DESCRIPTION
We can almost always avoid allocating an internal register, which may be expensive if lr is picked since we cannot use thumb encoding for it.

The only case where we need an internal register is when we have a source that is in a register, and we have a single taget register to place that conflicts with that source register. The to-stack copies then need an intermediate scratch register to avoid clobbering the source register.