### PR TITLE
[release/6.0][mono] Fix iOS/tvOS build with Xcode 14

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -719,6 +719,9 @@
 /* Define to 1 if `kp_proc' is a member of `struct kinfo_proc'. */
 #cmakedefine HAVE_STRUCT_KINFO_PROC_KP_PROC 1
 
+/* Define to 1 if `super_class' is a member of `struct objc_super'. */
+#cmakedefine HAVE_OBJC_SUPER_SUPER_CLASS 1
+
 /* Define to 1 if you have the <sys/time.h> header file. */
 #cmakedefine HAVE_SYS_TIME_H 1
 

--- a/src/mono/cmake/configure.cmake
+++ b/src/mono/cmake/configure.cmake
@@ -129,6 +129,10 @@ check_struct_has_member("struct sockaddr_in6" sin6_len "netinet/in.h" HAVE_SOCKA
 check_struct_has_member("struct stat" st_atim "sys/types.h;sys/stat.h;unistd.h" HAVE_STRUCT_STAT_ST_ATIM)
 check_struct_has_member("struct stat" st_atimespec "sys/types.h;sys/stat.h;unistd.h" HAVE_STRUCT_STAT_ST_ATIMESPEC)
 
+if (HOST_DARWIN)
+  check_struct_has_member("struct objc_super" super_class "objc/runtime.h;objc/message.h" HAVE_OBJC_SUPER_SUPER_CLASS)
+endif()
+
 check_type_size("int" SIZEOF_INT)
 check_type_size("void*" SIZEOF_VOID_P)
 check_type_size("long" SIZEOF_LONG)

--- a/src/mono/mono/utils/mono-threads-mach-helper.c
+++ b/src/mono/mono/utils/mono-threads-mach-helper.c
@@ -59,10 +59,10 @@ mono_dead_letter_dealloc (id self, SEL _cmd)
 {
 	struct objc_super super;
 	super.receiver = self;
-#if !defined(__cplusplus) && !__OBJC2__
-	super.class = nsobject;
-#else
+#if defined(__cplusplus) || defined(HAVE_OBJC_SUPER_SUPER_CLASS)
 	super.super_class = nsobject;
+#else
+	super.class = nsobject;
 #endif
 	void (*objc_msgSendSuper_op)(struct objc_super *, SEL) = (void (*)(struct objc_super *, SEL)) objc_msgSendSuper;
 	objc_msgSendSuper_op (&super, dealloc);


### PR DESCRIPTION
Backport of #76433 to release/6.0

## Customer Impact

This impacts our official build, without it we can't build iOS/tvOS with Xcode 14 as soon as it rolls out to AzDO.

## Testing

Local tests with Xcode 14 confirmed it fixes the issue.

## Risk

Low.

IMPORTANT: Is this backport for a servicing release? If so and this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.