### PR TITLE
[wasm] EmccExportedRuntimeMethod MSBuild item

### DIFF
--- a/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
+++ b/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
@@ -5,10 +5,11 @@
     <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
     <PublishTrimmed>true</PublishTrimmed>
     <!-- add OpenGL emulation -->
-    <EmccExtraExportedRuntimeMethods>'GL'</EmccExtraExportedRuntimeMethods>
     <EmccExtraLDFlags> -s USE_CLOSURE_COMPILER=1 -s LEGACY_GL_EMULATION=1 -lGL -lSDL</EmccExtraLDFlags>
   </PropertyGroup>
   <ItemGroup>
+    <!-- add export GL object from Module -->
+    <EmccExportedRuntimeMethod Include="GL" />
     <NativeFileReference Include="fibonacci.c" />
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
   </ItemGroup>

--- a/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
+++ b/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
@@ -4,6 +4,9 @@
     <_SampleProject>Wasm.Advanced.Sample.csproj</_SampleProject>
     <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
     <PublishTrimmed>true</PublishTrimmed>
+    <!-- add OpenGL emulation -->
+    <EmccExtraExportedRuntimeMethods>'GL'</EmccExtraExportedRuntimeMethods>
+    <EmccExtraLDFlags> -s USE_CLOSURE_COMPILER=1 -s LEGACY_GL_EMULATION=1 -lGL -lSDL</EmccExtraLDFlags>
   </PropertyGroup>
   <ItemGroup>
     <NativeFileReference Include="fibonacci.c" />

--- a/src/mono/sample/wasm/browser-advanced/main.js
+++ b/src/mono/sample/wasm/browser-advanced/main.js
@@ -8,7 +8,7 @@ function add(a, b) {
 }
 
 try {
-    const { runtimeBuildInfo, setModuleImports, getAssemblyExports, runMain, getConfig } = await dotnet
+    const { runtimeBuildInfo, setModuleImports, getAssemblyExports, runMain, getConfig, Module } = await dotnet
         .withElementOnExit()
         // 'withModuleConfig' is internal lower level API 
         // here we show how emscripten could be further configured
@@ -49,6 +49,9 @@ try {
     const config = getConfig();
     const exports = await getAssemblyExports(config.mainAssemblyName);
     const meaning = exports.Sample.Test.TestMeaning();
+    if (typeof Module.GL !== "object") {
+        exit(-10, "Can't find GL");
+    }
     console.debug(`meaning: ${meaning}`);
     if (!exports.Sample.Test.IsPrime(meaning)) {
         document.getElementById("out").innerHTML = `${meaning} as computed on dotnet ver ${runtimeBuildInfo.productVersion}`;

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -369,52 +369,13 @@
   </Target>
 
   <Target Name="_WasmWriteRspFilesForLinking" DependsOnTargets="_CheckEmccIsExpectedVersion">
-    <!-- keep in sync with src\mono\wasm\wasm.proj -->
-    <ItemGroup>
-      <EmccExportedRuntimeMethod Include="FS" />
-      <EmccExportedRuntimeMethod Include="print" />
-      <EmccExportedRuntimeMethod Include="ccall" />
-      <EmccExportedRuntimeMethod Include="cwrap" />
-      <EmccExportedRuntimeMethod Include="setValue" />
-      <EmccExportedRuntimeMethod Include="getValue" />
-      <EmccExportedRuntimeMethod Include="UTF8ToString" />
-      <EmccExportedRuntimeMethod Include="UTF8ArrayToString" />
-      <EmccExportedRuntimeMethod Include="FS_createPath" />
-      <EmccExportedRuntimeMethod Include="FS_createDataFile" />
-      <EmccExportedRuntimeMethod Include="removeRunDependency" />
-      <EmccExportedRuntimeMethod Include="addRunDependency" />
-      <EmccExportedRuntimeMethod Include="FS_readFile" />
-
-      <EmccExportedFunction Include="_malloc" />
-      <EmccExportedFunction Include="_memalign" />
-      <EmccExportedFunction Include="_htons" />
-      <EmccExportedFunction Include="_ntohs" />
-    </ItemGroup>
-    <!-- after 3.0 -->
-    <ItemGroup Condition="$([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))">
-      <EmccExportedFunction Include="_memset" />
-    </ItemGroup>
-    <!-- before 3.1.7 see https://github.com/dotnet/runtime/issues/64724 -->
-    <ItemGroup Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))">
-      <EmccExportedFunction Include="__get_daylight" />
-      <EmccExportedFunction Include="__get_timezone" />
-      <EmccExportedFunction Include="__get_tzname" />
-      <EmccExportedFunction Include="g_free" />
-    </ItemGroup>
-    <!-- after 3.1.7 -->
-    <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))">
-      <EmccExportedFunction Include="stackSave"  />
-      <EmccExportedFunction Include="stackRestore" />
-      <EmccExportedFunction Include="stackAlloc" />
-      <EmccExportedFunction Include="_free" />
-    </ItemGroup>
     <PropertyGroup>
-        <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>
-        <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
-        <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
-        <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
-        <_EmccExportedRuntimeMethods>&quot;[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]&quot;</_EmccExportedRuntimeMethods>
-        <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
+      <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>
+      <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
+      <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
+      <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
+      <_EmccExportedRuntimeMethods>&quot;[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]&quot;</_EmccExportedRuntimeMethods>
+      <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
     </PropertyGroup>
     <ItemGroup>
       <!-- order matters -->
@@ -501,6 +462,8 @@
     <ReadEmccProps JsonFilePath="$(_WasmRuntimePackSrcDir)emcc-props.json">
       <Output TaskParameter="EmccProperties" ItemName="_EmccPropItems" />
       <Output TaskParameter="WasmOptConfigurationFlags" ItemName= "_WasmOptConfigurationFlagsItems" />
+      <Output TaskParameter="EmccExportedFunctions" ItemName= "EmccExportedFunction" />
+      <Output TaskParameter="EmccExportedRuntimeMethods" ItemName= "EmccExportedRuntimeMethod" />
     </ReadEmccProps>
 
     <CreateProperty Value="%(_EmccPropItems.Value)">
@@ -687,6 +650,8 @@
     <ParameterGroup>
       <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
       <WasmOptConfigurationFlags ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <EmccExportedFunctions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <EmccExportedRuntimeMethods ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
     </ParameterGroup>
   </UsingTask>
 </Project>

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -413,8 +413,7 @@
         <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
         <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
         <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
-        <_EmccExportedRuntimeMethodsEsc>@(EmccExportedRuntimeMethod -> '%(Identity)', '%27,%27')</_EmccExportedRuntimeMethodsEsc>
-        <_EmccExportedRuntimeMethods>&quot;['$([MSBuild]::Unescape($(EmccExportedRuntimeMethodsEsc)))']&quot;</_EmccExportedRuntimeMethods>
+        <_EmccExportedRuntimeMethods>&quot;[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]&quot;</_EmccExportedRuntimeMethods>
         <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
     </PropertyGroup>
     <ItemGroup>

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -368,13 +368,53 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_WasmWriteRspFilesForLinking">
-	<PropertyGroup>
-      <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>
-      <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
-      <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
-      <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
-	</PropertyGroup>
+  <Target Name="_WasmWriteRspFilesForLinking"
+      DependsOnTargets="_CheckEmccIsExpectedVersion">
+    <!-- keep in sync with src\mono\wasm\wasm.proj -->
+    <ItemGroup>
+      <EmccExportedFunction Include="_malloc" />
+      <EmccExportedFunction Include="_memalign" />
+      <EmccExportedFunction Include="_htons" />
+      <EmccExportedFunction Include="_ntohs" />
+
+      <!-- after 3.0 -->
+      <EmccExportedFunction Include="_memset" Condition="$([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))"/>
+
+      <!-- before 3.1.7 see https://github.com/dotnet/runtime/issues/64724 -->
+      <EmccExportedFunction Include="__get_daylight" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
+      <EmccExportedFunction Include="__get_timezone" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
+      <EmccExportedFunction Include="__get_tzname" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
+      <EmccExportedFunction Include="g_free" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))" />
+
+      <!-- after 3.1.7 -->
+      <EmccExportedFunction Include="stackSave" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
+      <EmccExportedFunction Include="stackRestore" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
+      <EmccExportedFunction Include="stackAlloc" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
+      <EmccExportedFunction Include="_free" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))"/>
+
+      <EmccExportedRuntimeMethod Include="FS" />
+      <EmccExportedRuntimeMethod Include="print" />
+      <EmccExportedRuntimeMethod Include="ccall" />
+      <EmccExportedRuntimeMethod Include="cwrap" />
+      <EmccExportedRuntimeMethod Include="setValue" />
+      <EmccExportedRuntimeMethod Include="getValue" />
+      <EmccExportedRuntimeMethod Include="UTF8ToString" />
+      <EmccExportedRuntimeMethod Include="UTF8ArrayToString" />
+      <EmccExportedRuntimeMethod Include="FS_createPath" />
+      <EmccExportedRuntimeMethod Include="FS_createDataFile" />
+      <EmccExportedRuntimeMethod Include="removeRunDependency" />
+      <EmccExportedRuntimeMethod Include="addRunDependency" />
+      <EmccExportedRuntimeMethod Include="FS_readFile" />
+    </ItemGroup>
+    <PropertyGroup>
+        <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>
+        <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
+        <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
+        <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
+        <EmccExportedRuntimeMethodsEsc>@(EmccExportedRuntimeMethod -> '%(Identity)', '%27,%27')</EmccExportedRuntimeMethodsEsc>
+        <EmccExportedRuntimeMethods>&quot;['$([MSBuild]::Unescape($(EmccExportedRuntimeMethodsEsc)))']&quot;</EmccExportedRuntimeMethods>
+        <EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</EmccExportedFunctions>
+    </PropertyGroup>
     <ItemGroup>
       <!-- order matters -->
       <_WasmNativeFileForLinking Include="%(_BitcodeFile.ObjectFile)" />
@@ -401,9 +441,8 @@
       <_EmccLinkStepArgs Include="-o &quot;$(_WasmIntermediateOutputPath)dotnet.js&quot;" />
       <_WasmLinkDependencies Include="$(_EmccLinkRsp)" />
 
-      <!-- sync EXPORTED_RUNTIME_METHODS with src\mono\wasm\wasm.proj -->
-      <_EmccLinkStepArgs Condition="'$(EmccExtraExportedRuntimeMethods)' != ''" 
-                         Include="-s EXPORTED_RUNTIME_METHODS=&quot;[$(EmccExtraExportedRuntimeMethods),'FS','print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency', 'FS_readFile']&quot;"  />
+      <_EmccLinkStepArgs Include="-s EXPORTED_RUNTIME_METHODS=$(EmccExportedRuntimeMethods)" />
+      <_EmccLinkStepArgs Include="-s EXPORTED_FUNCTIONS=$(EmccExportedFunctions)" />
 
       <_EmccLinkStepArgs Include="$(EmccExtraLDFlags)" />
     </ItemGroup>
@@ -499,6 +538,8 @@
     </ItemGroup>
     <PropertyGroup>
       <ActualEmccVersionRaw>%(_ReversedVersionLines.Identity)</ActualEmccVersionRaw>
+      <_EmccVersionRegexPattern>^ *emcc \([^\)]+\) *([0-9\.]+).*\(([^\)]+)\)$</_EmccVersionRegexPattern>
+      <_EmccVersion>$([System.Text.RegularExpressions.Regex]::Match($(ActualEmccVersionRaw), $(_EmccVersionRegexPattern)).Groups[1].Value)</_EmccVersion>
       <_VersionMismatchMessage>Emscripten version mismatch. The runtime pack in $(MicrosoftNetCoreAppRuntimePackDir) expects '$(RuntimeEmccVersionRaw)', but emcc being used has version '$(ActualEmccVersionRaw)'. This might cause build failures.</_VersionMismatchMessage>
     </PropertyGroup>
 

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -462,8 +462,8 @@
     <ReadEmccProps JsonFilePath="$(_WasmRuntimePackSrcDir)emcc-props.json">
       <Output TaskParameter="EmccProperties" ItemName="_EmccPropItems" />
       <Output TaskParameter="WasmOptConfigurationFlags" ItemName= "_WasmOptConfigurationFlagsItems" />
-      <Output TaskParameter="EmccExportedFunctions" ItemName= "EmccExportedFunction" />
-      <Output TaskParameter="EmccExportedRuntimeMethods" ItemName= "EmccExportedRuntimeMethod" />
+      <Output TaskParameter="EmccDefaultExportedFunctions" ItemName= "EmccExportedFunction" />
+      <Output TaskParameter="EmccDefaultExportedRuntimeMethods" ItemName= "EmccExportedRuntimeMethod" />
     </ReadEmccProps>
 
     <CreateProperty Value="%(_EmccPropItems.Value)">
@@ -648,8 +648,8 @@
     <ParameterGroup>
       <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
       <WasmOptConfigurationFlags ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
-      <EmccExportedFunctions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
-      <EmccExportedRuntimeMethods ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <EmccDefaultExportedFunctions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <EmccDefaultExportedRuntimeMethods ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
     </ParameterGroup>
   </UsingTask>
 </Project>

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -502,8 +502,6 @@
     </ItemGroup>
     <PropertyGroup>
       <ActualEmccVersionRaw>%(_ReversedVersionLines.Identity)</ActualEmccVersionRaw>
-      <_EmccVersionRegexPattern>^ *emcc \([^\)]+\) *([0-9\.]+).*\(([^\)]+)\)$</_EmccVersionRegexPattern>
-      <_EmccVersion>$([System.Text.RegularExpressions.Regex]::Match($(ActualEmccVersionRaw), $(_EmccVersionRegexPattern)).Groups[1].Value)</_EmccVersion>
       <_VersionMismatchMessage>Emscripten version mismatch. The runtime pack in $(MicrosoftNetCoreAppRuntimePackDir) expects '$(RuntimeEmccVersionRaw)', but emcc being used has version '$(ActualEmccVersionRaw)'. This might cause build failures.</_VersionMismatchMessage>
     </PropertyGroup>
 

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -372,26 +372,6 @@
       DependsOnTargets="_CheckEmccIsExpectedVersion">
     <!-- keep in sync with src\mono\wasm\wasm.proj -->
     <ItemGroup>
-      <EmccExportedFunction Include="_malloc" />
-      <EmccExportedFunction Include="_memalign" />
-      <EmccExportedFunction Include="_htons" />
-      <EmccExportedFunction Include="_ntohs" />
-
-      <!-- after 3.0 -->
-      <EmccExportedFunction Include="_memset" Condition="$([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))"/>
-
-      <!-- before 3.1.7 see https://github.com/dotnet/runtime/issues/64724 -->
-      <EmccExportedFunction Include="__get_daylight" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
-      <EmccExportedFunction Include="__get_timezone" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
-      <EmccExportedFunction Include="__get_tzname" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
-      <EmccExportedFunction Include="g_free" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))" />
-
-      <!-- after 3.1.7 -->
-      <EmccExportedFunction Include="stackSave" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
-      <EmccExportedFunction Include="stackRestore" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
-      <EmccExportedFunction Include="stackAlloc" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
-      <EmccExportedFunction Include="_free" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))"/>
-
       <EmccExportedRuntimeMethod Include="FS" />
       <EmccExportedRuntimeMethod Include="print" />
       <EmccExportedRuntimeMethod Include="ccall" />
@@ -405,15 +385,38 @@
       <EmccExportedRuntimeMethod Include="removeRunDependency" />
       <EmccExportedRuntimeMethod Include="addRunDependency" />
       <EmccExportedRuntimeMethod Include="FS_readFile" />
+
+      <EmccExportedFunction Include="_malloc" />
+      <EmccExportedFunction Include="_memalign" />
+      <EmccExportedFunction Include="_htons" />
+      <EmccExportedFunction Include="_ntohs" />
+    </ItemGroup>
+    <!-- after 3.0 -->
+    <ItemGroup Condition="$([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))">
+      <EmccExportedFunction Include="_memset" />
+    </ItemGroup>
+    <!-- before 3.1.7 see https://github.com/dotnet/runtime/issues/64724 -->
+    <ItemGroup Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))">
+      <EmccExportedFunction Include="__get_daylight" />
+      <EmccExportedFunction Include="__get_timezone" />
+      <EmccExportedFunction Include="__get_tzname" />
+      <EmccExportedFunction Include="g_free" />
+    </ItemGroup>
+    <!-- after 3.1.7 -->
+    <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))">
+      <EmccExportedFunction Include="stackSave"  />
+      <EmccExportedFunction Include="stackRestore" />
+      <EmccExportedFunction Include="stackAlloc" />
+      <EmccExportedFunction Include="_free" />
     </ItemGroup>
     <PropertyGroup>
         <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>
         <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
         <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
         <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
-        <EmccExportedRuntimeMethodsEsc>@(EmccExportedRuntimeMethod -> '%(Identity)', '%27,%27')</EmccExportedRuntimeMethodsEsc>
-        <EmccExportedRuntimeMethods>&quot;['$([MSBuild]::Unescape($(EmccExportedRuntimeMethodsEsc)))']&quot;</EmccExportedRuntimeMethods>
-        <EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</EmccExportedFunctions>
+        <_EmccExportedRuntimeMethodsEsc>@(EmccExportedRuntimeMethod -> '%(Identity)', '%27,%27')</_EmccExportedRuntimeMethodsEsc>
+        <_EmccExportedRuntimeMethods>&quot;['$([MSBuild]::Unescape($(EmccExportedRuntimeMethodsEsc)))']&quot;</_EmccExportedRuntimeMethods>
+        <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
     </PropertyGroup>
     <ItemGroup>
       <!-- order matters -->
@@ -441,8 +444,8 @@
       <_EmccLinkStepArgs Include="-o &quot;$(_WasmIntermediateOutputPath)dotnet.js&quot;" />
       <_WasmLinkDependencies Include="$(_EmccLinkRsp)" />
 
-      <_EmccLinkStepArgs Include="-s EXPORTED_RUNTIME_METHODS=$(EmccExportedRuntimeMethods)" />
-      <_EmccLinkStepArgs Include="-s EXPORTED_FUNCTIONS=$(EmccExportedFunctions)" />
+      <_EmccLinkStepArgs Include="-s EXPORTED_RUNTIME_METHODS=$(_EmccExportedRuntimeMethods)" />
+      <_EmccLinkStepArgs Include="-s EXPORTED_FUNCTIONS=$(_EmccExportedFunctions)" />
 
       <_EmccLinkStepArgs Include="$(EmccExtraLDFlags)" />
     </ItemGroup>

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -401,6 +401,10 @@
       <_EmccLinkStepArgs Include="-o &quot;$(_WasmIntermediateOutputPath)dotnet.js&quot;" />
       <_WasmLinkDependencies Include="$(_EmccLinkRsp)" />
 
+      <!-- sync EXPORTED_RUNTIME_METHODS with src\mono\wasm\wasm.proj -->
+      <_EmccLinkStepArgs Condition="'$(EmccExtraExportedRuntimeMethods)' != ''" 
+                         Include="-s EXPORTED_RUNTIME_METHODS=&quot;[$(EmccExtraExportedRuntimeMethods),'FS','print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency', 'FS_readFile']&quot;"  />
+
       <_EmccLinkStepArgs Include="$(EmccExtraLDFlags)" />
     </ItemGroup>
 

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -368,8 +368,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_WasmWriteRspFilesForLinking"
-      DependsOnTargets="_CheckEmccIsExpectedVersion">
+  <Target Name="_WasmWriteRspFilesForLinking" DependsOnTargets="_CheckEmccIsExpectedVersion">
     <!-- keep in sync with src\mono\wasm\wasm.proj -->
     <ItemGroup>
       <EmccExportedRuntimeMethod Include="FS" />

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -51,6 +51,7 @@
       - $(EmccFlags)                        - Emcc flags used for both compiling native files, and linking
       - $(EmccExtraLDFlags)                 - Extra emcc flags for linking
       - $(EmccExtraCFlags)                  - Extra emcc flags for compiling native files
+      - $(EmccExtraExportedRuntimeMethods)  - Extra methods for emcc flag EXPORTED_RUNTIME_METHODS
       - $(EmccInitialHeapSize)              - Initial heap size specified with `emcc`. Default value: 536870912
                                               Corresponds to `INITIAL_MEMORY` arg for emcc.
                                               (previously named EmccTotalMemory, which is still kept as an alias)

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -83,7 +83,7 @@
                                     <WasmExtraConfig Include="string_val" Value="&quot;abc&quot;" />
                                     <WasmExtraConfig Include="string_with_json" Value="&quot;{ &quot;abc&quot;: 4 }&quot;" />
       - @(EmccExportedRuntimeMethod) - Extra method for emcc flag EXPORTED_RUNTIME_METHODS
-      - @(EmccExportedFunction)      - Extra method for emcc flag EXPORTED_FUNCTIONS
+      - @(EmccExportedFunction)      - Extra function for emcc flag EXPORTED_FUNCTIONS
   -->
 
   <PropertyGroup>

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -51,7 +51,6 @@
       - $(EmccFlags)                        - Emcc flags used for both compiling native files, and linking
       - $(EmccExtraLDFlags)                 - Extra emcc flags for linking
       - $(EmccExtraCFlags)                  - Extra emcc flags for compiling native files
-      - $(EmccExtraExportedRuntimeMethods)  - Extra methods for emcc flag EXPORTED_RUNTIME_METHODS
       - $(EmccInitialHeapSize)              - Initial heap size specified with `emcc`. Default value: 536870912
                                               Corresponds to `INITIAL_MEMORY` arg for emcc.
                                               (previously named EmccTotalMemory, which is still kept as an alias)
@@ -83,6 +82,8 @@
                                     <WasmExtraConfig Include="json" Value="{ &quot;abc&quot;: 4 }" />
                                     <WasmExtraConfig Include="string_val" Value="&quot;abc&quot;" />
                                     <WasmExtraConfig Include="string_with_json" Value="&quot;{ &quot;abc&quot;: 4 }&quot;" />
+      - @(EmccExportedRuntimeMethod) - Extra method for emcc flag EXPORTED_RUNTIME_METHODS
+      - @(EmccExportedFunction)      - Extra method for emcc flag EXPORTED_FUNCTIONS
   -->
 
   <PropertyGroup>

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -110,26 +110,6 @@
 
     <!-- keep in sync with src\mono\wasm\build\WasmApp.Native.targets -->
     <ItemGroup>
-      <EmccExportedFunction Include="_malloc" />
-      <EmccExportedFunction Include="_memalign" />
-      <EmccExportedFunction Include="_htons" />
-      <EmccExportedFunction Include="_ntohs" />
-
-      <!-- after 3.0 -->
-      <EmccExportedFunction Include="_memset" Condition="$([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))"/>
-
-      <!-- before 3.1.7 see https://github.com/dotnet/runtime/issues/64724 -->
-      <EmccExportedFunction Include="__get_daylight" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
-      <EmccExportedFunction Include="__get_timezone" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
-      <EmccExportedFunction Include="__get_tzname" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
-      <EmccExportedFunction Include="g_free" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))" />
-
-      <!-- after 3.1.7 -->
-      <EmccExportedFunction Include="stackSave" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
-      <EmccExportedFunction Include="stackRestore" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
-      <EmccExportedFunction Include="stackAlloc" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
-      <EmccExportedFunction Include="_free" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))"/>
-
       <EmccExportedRuntimeMethod Include="FS" />
       <EmccExportedRuntimeMethod Include="print" />
       <EmccExportedRuntimeMethod Include="ccall" />
@@ -143,11 +123,34 @@
       <EmccExportedRuntimeMethod Include="removeRunDependency" />
       <EmccExportedRuntimeMethod Include="addRunDependency" />
       <EmccExportedRuntimeMethod Include="FS_readFile" />
+
+      <EmccExportedFunction Include="_malloc" />
+      <EmccExportedFunction Include="_memalign" />
+      <EmccExportedFunction Include="_htons" />
+      <EmccExportedFunction Include="_ntohs" />
+    </ItemGroup>
+    <!-- after 3.0 -->
+    <ItemGroup Condition="$([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))">
+      <EmccExportedFunction Include="_memset" />
+    </ItemGroup>
+    <!-- before 3.1.7 see https://github.com/dotnet/runtime/issues/64724 -->
+    <ItemGroup Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))">
+      <EmccExportedFunction Include="__get_daylight" />
+      <EmccExportedFunction Include="__get_timezone" />
+      <EmccExportedFunction Include="__get_tzname" />
+      <EmccExportedFunction Include="g_free" />
+    </ItemGroup>
+    <!-- after 3.1.7 -->
+    <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))">
+      <EmccExportedFunction Include="stackSave"  />
+      <EmccExportedFunction Include="stackRestore" />
+      <EmccExportedFunction Include="stackAlloc" />
+      <EmccExportedFunction Include="_free" />
     </ItemGroup>
     <PropertyGroup>
-      <EmccExportedRuntimeMethodsEsc>@(EmccExportedRuntimeMethod -> '%(Identity)', '%27,%27')</EmccExportedRuntimeMethodsEsc>
-      <EmccExportedRuntimeMethods>&quot;['$([MSBuild]::Unescape($(EmccExportedRuntimeMethodsEsc)))']&quot;</EmccExportedRuntimeMethods>
-      <EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</EmccExportedFunctions>
+      <_EmccExportedRuntimeMethodsEsc>@(EmccExportedRuntimeMethod -> '%(Identity)', '%27,%27')</_EmccExportedRuntimeMethodsEsc>
+      <_EmccExportedRuntimeMethods>&quot;['$([MSBuild]::Unescape($(EmccExportedRuntimeMethodsEsc)))']&quot;</_EmccExportedRuntimeMethods>
+      <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
     </PropertyGroup>
     <ItemGroup>
       <_EmccCommonFlags Condition="'$(WasmEnableSIMD)' == 'true'" Include="-msimd128" />
@@ -158,8 +161,8 @@
       <_EmccLinkFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
       <_EmccLinkFlags Include="-s NO_EXIT_RUNTIME=1" />
       <_EmccLinkFlags Include="-s FORCE_FILESYSTEM=1" />
-      <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=$(EmccExportedRuntimeMethods)" />
-      <_EmccLinkFlags Include="-s EXPORTED_FUNCTIONS=$(EmccExportedFunctions)" />
+      <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=$(_EmccExportedRuntimeMethods)" />
+      <_EmccLinkFlags Include="-s EXPORTED_FUNCTIONS=$(_EmccExportedFunctions)" />
       <_EmccLinkFlags Include="--source-map-base http://example.com" />
       <_EmccLinkFlags Include="-s STRICT_JS=1" />
       <_EmccLinkFlags Include="-s EXPORT_NAME=&quot;'createDotnetRuntime'&quot;" />

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -108,17 +108,47 @@
     <Error Text="Failed to parse emcc version, and hash from the full version string: '$(_EmccVersionRaw)'"
            Condition="'$(_EmccVersion)' == '' or '$(_EmccVersionHash)' == ''" />
 
+    <!-- keep in sync with src\mono\wasm\build\WasmApp.Native.targets -->
+    <ItemGroup>
+      <EmccExportedFunction Include="_malloc" />
+      <EmccExportedFunction Include="_memalign" />
+      <EmccExportedFunction Include="_htons" />
+      <EmccExportedFunction Include="_ntohs" />
+
+      <!-- after 3.0 -->
+      <EmccExportedFunction Include="_memset" Condition="$([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))"/>
+
+      <!-- before 3.1.7 see https://github.com/dotnet/runtime/issues/64724 -->
+      <EmccExportedFunction Include="__get_daylight" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
+      <EmccExportedFunction Include="__get_timezone" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
+      <EmccExportedFunction Include="__get_tzname" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))"/>
+      <EmccExportedFunction Include="g_free" Condition="$([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.1.7'))" />
+
+      <!-- after 3.1.7 -->
+      <EmccExportedFunction Include="stackSave" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
+      <EmccExportedFunction Include="stackRestore" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
+      <EmccExportedFunction Include="stackAlloc" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))" />
+      <EmccExportedFunction Include="_free" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))"/>
+
+      <EmccExportedRuntimeMethod Include="FS" />
+      <EmccExportedRuntimeMethod Include="print" />
+      <EmccExportedRuntimeMethod Include="ccall" />
+      <EmccExportedRuntimeMethod Include="cwrap" />
+      <EmccExportedRuntimeMethod Include="setValue" />
+      <EmccExportedRuntimeMethod Include="getValue" />
+      <EmccExportedRuntimeMethod Include="UTF8ToString" />
+      <EmccExportedRuntimeMethod Include="UTF8ArrayToString" />
+      <EmccExportedRuntimeMethod Include="FS_createPath" />
+      <EmccExportedRuntimeMethod Include="FS_createDataFile" />
+      <EmccExportedRuntimeMethod Include="removeRunDependency" />
+      <EmccExportedRuntimeMethod Include="addRunDependency" />
+      <EmccExportedRuntimeMethod Include="FS_readFile" />
+    </ItemGroup>
     <PropertyGroup>
-      <_DefaultExportedFunctions Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_EmccVersion)', '3.1.7'))"
-                                >_malloc,stackSave,stackRestore,stackAlloc,_memalign,_memset,_htons,_ntohs,_free</_DefaultExportedFunctions>
-
-      <!-- _htons,_ntohs,__get_daylight,__get_timezone,__get_tzname are exported temporarily, until the issue is fixed in emscripten, https://github.com/dotnet/runtime/issues/64724  -->
-      <_DefaultExportedFunctions Condition="'$(_DefaultExportedFunctions)' == '' and $([MSBuild]::VersionGreaterThan('$(_EmccVersion)', '3.0'))"
-                                >g_free,_malloc,_memalign,_memset,_htons,_ntohs,__get_daylight,__get_timezone,__get_tzname</_DefaultExportedFunctions>
-      <_DefaultExportedFunctions Condition="'$(_DefaultExportedFunctions)' == '' and $([MSBuild]::VersionLessThan('$(_EmccVersion)', '3.0'))"
-                                >g_free,_malloc,_htons,_ntohs,__get_daylight,__get_timezone,__get_tzname,_memalign</_DefaultExportedFunctions>
+      <EmccExportedRuntimeMethodsEsc>@(EmccExportedRuntimeMethod -> '%(Identity)', '%27,%27')</EmccExportedRuntimeMethodsEsc>
+      <EmccExportedRuntimeMethods>&quot;['$([MSBuild]::Unescape($(EmccExportedRuntimeMethodsEsc)))']&quot;</EmccExportedRuntimeMethods>
+      <EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</EmccExportedFunctions>
     </PropertyGroup>
-
     <ItemGroup>
       <_EmccCommonFlags Condition="'$(WasmEnableSIMD)' == 'true'" Include="-msimd128" />
       <_EmccCommonFlags Condition="'$(MonoWasmThreads)' == 'true'" Include="-s USE_PTHREADS=1" />
@@ -128,9 +158,8 @@
       <_EmccLinkFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
       <_EmccLinkFlags Include="-s NO_EXIT_RUNTIME=1" />
       <_EmccLinkFlags Include="-s FORCE_FILESYSTEM=1" />
-      <!-- sync EXPORTED_RUNTIME_METHODS with src\mono\wasm\build\WasmApp.Native.targets -->
-      <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=&quot;['FS','print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency', 'FS_readFile']&quot;"  />
-      <_EmccLinkFlags Include="-s EXPORTED_FUNCTIONS=$(_DefaultExportedFunctions)" Condition="'$(_DefaultExportedFunctions)' != ''" />
+      <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=$(EmccExportedRuntimeMethods)" />
+      <_EmccLinkFlags Include="-s EXPORTED_FUNCTIONS=$(EmccExportedFunctions)" />
       <_EmccLinkFlags Include="--source-map-base http://example.com" />
       <_EmccLinkFlags Include="-s STRICT_JS=1" />
       <_EmccLinkFlags Include="-s EXPORT_NAME=&quot;'createDotnetRuntime'&quot;" />

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -108,7 +108,6 @@
     <Error Text="Failed to parse emcc version, and hash from the full version string: '$(_EmccVersionRaw)'"
            Condition="'$(_EmccVersion)' == '' or '$(_EmccVersionHash)' == ''" />
 
-    <!-- keep in sync with src\mono\wasm\build\WasmApp.Native.targets -->
     <ItemGroup>
       <EmccExportedRuntimeMethod Include="FS" />
       <EmccExportedRuntimeMethod Include="print" />

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -200,8 +200,8 @@
     "WasmOptConfigurationFlags": [
       { "identity": "WasmOptConfigurationFlags", "value": "$(_WasmOptConfigurationFlags)" }
     ],
-    "EmccExportedFunctions": [@(EmccExportedFunction -> '%22%(Identity)%22', ',')],
-    "EmccExportedRuntimeMethods": [@(EmccExportedRuntimeMethod -> '%22%(Identity)%22', ',')]
+    "EmccDefaultExportedFunctions": [@(EmccExportedFunction -> '%22%(Identity)%22', ',')],
+    "EmccDefaultExportedRuntimeMethods": [@(EmccExportedRuntimeMethod -> '%22%(Identity)%22', ',')]
   }
 }
 ]]>

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -148,8 +148,7 @@
       <EmccExportedFunction Include="_free" />
     </ItemGroup>
     <PropertyGroup>
-      <_EmccExportedRuntimeMethodsEsc>@(EmccExportedRuntimeMethod -> '%(Identity)', '%27,%27')</_EmccExportedRuntimeMethodsEsc>
-      <_EmccExportedRuntimeMethods>&quot;['$([MSBuild]::Unescape($(EmccExportedRuntimeMethodsEsc)))']&quot;</_EmccExportedRuntimeMethods>
+      <_EmccExportedRuntimeMethods>&quot;[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]&quot;</_EmccExportedRuntimeMethods>
       <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
     </PropertyGroup>
     <ItemGroup>
@@ -200,7 +199,9 @@
     ],
     "WasmOptConfigurationFlags": [
       { "identity": "WasmOptConfigurationFlags", "value": "$(_WasmOptConfigurationFlags)" }
-    ]
+    ],
+    "EmccExportedFunctions": [@(EmccExportedFunction -> '%22%(Identity)%22', ',')],
+    "EmccExportedRuntimeMethods": [@(EmccExportedRuntimeMethod -> '%22%(Identity)%22', ',')]
   }
 }
 ]]>

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -128,6 +128,7 @@
       <_EmccLinkFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
       <_EmccLinkFlags Include="-s NO_EXIT_RUNTIME=1" />
       <_EmccLinkFlags Include="-s FORCE_FILESYSTEM=1" />
+      <!-- sync EXPORTED_RUNTIME_METHODS with src\mono\wasm\build\WasmApp.Native.targets -->
       <_EmccLinkFlags Include="-s EXPORTED_RUNTIME_METHODS=&quot;['FS','print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency', 'FS_readFile']&quot;"  />
       <_EmccLinkFlags Include="-s EXPORTED_FUNCTIONS=$(_DefaultExportedFunctions)" Condition="'$(_DefaultExportedFunctions)' != ''" />
       <_EmccLinkFlags Include="--source-map-base http://example.com" />


### PR DESCRIPTION
- add ability to extend `EXPORTED_RUNTIME_METHODS` via `EmccExportedRuntimeMethod` MSBuild item
- add ability to extend `EXPORTED_FUNCTIONS` via `EmccExportedFunction` MSBuild item
- add example to advanced sample

Fixes https://github.com/dotnet/runtime/issues/76077