### PR TITLE
Remove reliance on deactivated A64 queue

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -170,25 +170,7 @@ jobs:
         projectFile: microbenchmarks.proj
         runKind: micro_mono
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        timeoutInMinutes: 500 
-
-# run coreclr Linux arm64 microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_arm64
-      container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfa64'
+        logicalmachine: 'perfampere'
         timeoutInMinutes: 500 
 
 # run coreclr Linux arm64 ampere microbenchmarks perf job


### PR DESCRIPTION
The PerfA64 machines were retired and decommissioned on 9/28. So this removes the regular run that was targeting that queue, and moves the mono AOT run to the new machines. @SamMonoRT @naricc 