### PR TITLE
Cleaner way of specifying environment variables for tests

### DIFF
--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -439,7 +439,8 @@ $(CLRTestBashPostCommands)
     </PropertyGroup>
     <PropertyGroup>
       <BashEnvironmentVariables>
-@(CLRTestBashEnvironmentVariable -> '%(Identity)', '%0a')
+@(CLRTestBashEnvironmentVariable -> export %(Identity)=%(Value)', '%0a')
+@(CLRTestEnvironmentVariable -> export %(Identity)=%(Value)', '%0a')
       </BashEnvironmentVariables>
     </PropertyGroup>
 
@@ -537,15 +538,15 @@ if [ -n "$__TestEnv" ]%3B then
     source $__TestEnv
 fi
 
-$(BashEnvironmentVariables)
 $(BashCLRTestEnvironmentCompatibilityCheck)
 $(BashCLRTestArgPrep)
 $(BashCLRTestExitCodePrep)
 $(IlasmRoundTripBashScript)
 $(SuperPMICollectionBashScript)
-# Allow precommands to override the ExePath
+# Allow test environment variables or precommands to override the ExePath
 ExePath=$(InputAssemblyName)
 export TestExclusionListPath=$CORE_ROOT/TestExclusionList.txt
+$(BashEnvironmentVariables)
 # PreCommands
 $(BashCLRTestPreCommands)
 # Launch

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -439,8 +439,8 @@ $(CLRTestBashPostCommands)
     </PropertyGroup>
     <PropertyGroup>
       <BashEnvironmentVariables>
-@(CLRTestBashEnvironmentVariable -> export %(Identity)=%(Value)', '%0a')
-@(CLRTestEnvironmentVariable -> export %(Identity)=%(Value)', '%0a')
+@(CLRTestBashEnvironmentVariable -> 'export %(Identity)=%(Value)', '%0a')
+@(CLRTestEnvironmentVariable -> 'export %(Identity)=%(Value)', '%0a')
       </BashEnvironmentVariables>
     </PropertyGroup>
 

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -348,7 +348,8 @@ $(CLRTestBatchPostCommands)
     </PropertyGroup>
     <PropertyGroup>
       <BatchEnvironmentVariables>
-@(CLRTestBatchEnvironmentVariable -> '%(Identity)', '%0d%0a')
+@(CLRTestBatchEnvironmentVariable -> 'set %(Identity)=%(Value)', '%0d%0a')
+@(CLRTestEnvironmentVariable -> 'set %(Identity)=%(Value)', '%0d%0a')
       </BatchEnvironmentVariables>
     </PropertyGroup>
 
@@ -434,18 +435,18 @@ IF NOT "%__TestEnv%"=="" (
     )
 )
 
-REM Environment Variables
-$(BatchEnvironmentVariables)
-
 $(BatchCLRTestEnvironmentCompatibilityCheck)
 
 $(IlasmRoundTripBatchScript)
 
 $(SuperPMICollectionBatchScript)
 
-REM Allow precommands to override the ExePath
+REM Allow test environment variables or precommands to override the ExePath
 set ExePath=$(InputAssemblyName)
 set TestExclusionListPath=%CORE_ROOT%\TestExclusionList.txt
+
+REM Environment Variables
+$(BatchEnvironmentVariables)
 
 REM Precommands
 $(CLRTestBatchPreCommands)

--- a/src/tests/Common/CLRTest.MockHosting.targets
+++ b/src/tests/Common/CLRTest.MockHosting.targets
@@ -10,8 +10,8 @@ This file contains the logic for correctly hooking up a mock hostpolicy to a tes
   <ItemGroup>
     <CMakeProjectReference Include="$(MSBuildThisFileDirectory)hostpolicymock/CMakeLists.txt" />
     <!-- %28 decodes to '('. It's needed to keep MSBuild from trying to parse $(pwd) as an MSBuild property -->
-    <CLRTestBashEnvironmentVariable Include="export MOCK_HOSTPOLICY=$%28pwd)/libhostpolicy" />
+    <CLRTestBashEnvironmentVariable Include="MOCK_HOSTPOLICY" Value="$%28pwd)/libhostpolicy" />
     <!-- %25 decodes to '%'. It's needed to keep %cd itself from being decoded since we want '%cd%' directly in the script. -->
-    <CLRTestBatchEnvironmentVariable Include="set MOCK_HOSTPOLICY=%25cd%\hostpolicy.dll" />
+    <CLRTestBatchEnvironmentVariable Include="MOCK_HOSTPOLICY" Value="%25cd%\hostpolicy.dll" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
+++ b/src/tests/Interop/DllImportAttribute/DllImportPath/DllImportPathTest.csproj
@@ -8,7 +8,7 @@
     <Compile Include="DllImportPathTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <CLRTestBashEnvironmentVariable Include="export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$%28pwd)/Subdirectory" />
+    <CLRTestBashEnvironmentVariable Include="LD_LIBRARY_PATH" Value="$LD_LIBRARY_PATH:$%28pwd)/Subdirectory" />
   </ItemGroup>
   <PropertyGroup>
     <PathEnvSetupCommands><![CDATA[

--- a/src/tests/JIT/Directed/IL/Tailcall/ExplicitTailCallNoSO.ilproj
+++ b/src/tests/JIT/Directed/IL/Tailcall/ExplicitTailCallNoSO.ilproj
@@ -9,17 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExplicitTailCallNoSO.il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJit" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJit=1
-set COMPlus_TC_QuickJitForLoops=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJit=1
-export COMPlus_TC_QuickJitForLoops=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Directed/LoopAlignment/LoopsToProcess.csproj
+++ b/src/tests/JIT/Directed/LoopAlignment/LoopsToProcess.csproj
@@ -6,17 +6,9 @@
   <PropertyGroup>
     <Optimize>True</Optimize>
   </PropertyGroup>
-   <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitAggressiveInlining=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitAggressiveInlining=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="LoopsToProcess.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitAggressiveInlining" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/coverage/flowgraph/gcpoll.csproj
+++ b/src/tests/JIT/Directed/coverage/flowgraph/gcpoll.csproj
@@ -6,19 +6,10 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-   <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitDoAssertionProp=0
-set COMPlus_JitNoCSE=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitDoAssertionProp=0
-export COMPlus_JitNoCSE=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitDoAssertionProp" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JitNoCSE" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/tailcall/more_tailcalls.ilproj
+++ b/src/tests/JIT/Directed/tailcall/more_tailcalls.ilproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressModeNamesNot" Value="STRESS_UNSAFE_BUFFER_CHECKS" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressModeNamesNot=STRESS_UNSAFE_BUFFER_CHECKS
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressModeNamesNot=STRESS_UNSAFE_BUFFER_CHECKS
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Directed/tailcall/tailcall.ilproj
+++ b/src/tests/JIT/Directed/tailcall/tailcall.ilproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressModeNamesNot" Value="STRESS_UNSAFE_BUFFER_CHECKS" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressModeNamesNot=STRESS_UNSAFE_BUFFER_CHECKS
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressModeNamesNot=STRESS_UNSAFE_BUFFER_CHECKS
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
@@ -10,15 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_DoubleArrayToLargeObjectHeap" Value="0x64" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_DoubleArrayToLargeObjectHeap=0x64
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_DoubleArrayToLargeObjectHeap=0x64
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
@@ -10,15 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_DoubleArrayToLargeObjectHeap" Value="0x64" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_DoubleArrayToLargeObjectHeap=0x64
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_DoubleArrayToLargeObjectHeap=0x64
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
@@ -10,15 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_DoubleArrayToLargeObjectHeap" Value="0x64" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_DoubleArrayToLargeObjectHeap=0x64
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_DoubleArrayToLargeObjectHeap=0x64
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
@@ -10,15 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_DoubleArrayToLargeObjectHeap" Value="0x64" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_DoubleArrayToLargeObjectHeap=0x64
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_DoubleArrayToLargeObjectHeap=0x64
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/PGO/ProfileCastClassAndIsInst/ProfileCastClassAndIsInst.csproj
+++ b/src/tests/JIT/PGO/ProfileCastClassAndIsInst/ProfileCastClassAndIsInst.csproj
@@ -2,22 +2,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_TieredCompilation=1
-      set DOTNET_TieredPGO=1
-      set DOTNET_JitProfileCasts=1
-      set DOTNET_JitConsumeProfileForCasts=1
-      ]]></CLRTestBatchPreCommands>
-          <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_TieredCompilation=1
-      export DOTNET_TieredPGO=1
-      export DOTNET_JitProfileCasts=1
-      export DOTNET_JitConsumeProfileForCasts=1
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitProfileCasts" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitConsumeProfileForCasts" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/PGO/ProfileCastClassAndIsInst/ProfileCastClassAndIsInst_random1.csproj
+++ b/src/tests/JIT/PGO/ProfileCastClassAndIsInst/ProfileCastClassAndIsInst_random1.csproj
@@ -2,24 +2,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_TieredCompilation=1
-      set DOTNET_TieredPGO=1
-      set DOTNET_JitProfileCasts=1
-      set DOTNET_JitConsumeProfileForCasts=1
-      set DOTNET_JitRandomGuardedDevirtualization=1
-      ]]></CLRTestBatchPreCommands>
-          <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_TieredCompilation=1
-      export DOTNET_TieredPGO=1
-      export DOTNET_JitProfileCasts=1
-      export DOTNET_JitConsumeProfileForCasts=1
-      export DOTNET_JitRandomGuardedDevirtualization=1
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProfileCastClassAndIsInst.cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitProfileCasts" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitConsumeProfileForCasts" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitRandomGuardedDevirtualization" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/PGO/ProfileCastClassAndIsInst/ProfileCastClassAndIsInst_random2.csproj
+++ b/src/tests/JIT/PGO/ProfileCastClassAndIsInst/ProfileCastClassAndIsInst_random2.csproj
@@ -2,24 +2,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_TieredCompilation=1
-      set DOTNET_TieredPGO=1
-      set DOTNET_JitProfileCasts=1
-      set DOTNET_JitConsumeProfileForCasts=1
-      set DOTNET_JitRandomGuardedDevirtualization=2
-      ]]></CLRTestBatchPreCommands>
-          <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_TieredCompilation=1
-      export DOTNET_TieredPGO=1
-      export DOTNET_JitProfileCasts=1
-      export DOTNET_JitConsumeProfileForCasts=1
-      export DOTNET_JitRandomGuardedDevirtualization=2
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProfileCastClassAndIsInst.cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitProfileCasts" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitConsumeProfileForCasts" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitRandomGuardedDevirtualization" Value="2" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/PGO/ProfileCastClassAndIsInst/ProfileCastClassAndIsInst_random3.csproj
+++ b/src/tests/JIT/PGO/ProfileCastClassAndIsInst/ProfileCastClassAndIsInst_random3.csproj
@@ -2,24 +2,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_TieredCompilation=1
-      set DOTNET_TieredPGO=1
-      set DOTNET_JitProfileCasts=1
-      set DOTNET_JitConsumeProfileForCasts=1
-      set DOTNET_JitRandomGuardedDevirtualization=3
-      ]]></CLRTestBatchPreCommands>
-          <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_TieredCompilation=1
-      export DOTNET_TieredPGO=1
-      export DOTNET_JitProfileCasts=1
-      export DOTNET_JitConsumeProfileForCasts=1
-      export DOTNET_JitRandomGuardedDevirtualization=3
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProfileCastClassAndIsInst.cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitProfileCasts" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitConsumeProfileForCasts" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitRandomGuardedDevirtualization" Value="3" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_278372/DevDiv_278372.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_278372/DevDiv_278372.ilproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressRegs" Value="0x200" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressRegs=0x200
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressRegs=0x200
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_280120/DevDiv_280120.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_280120/DevDiv_280120.csproj
@@ -9,15 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitDoSsa" Value="0" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitDoSsa=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitDoSsa=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_362706/DevDiv_362706.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_362706/DevDiv_362706.ilproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressRegs" Value="0x200" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressRegs=0x200
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressRegs=0x200
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_367099/DevDiv_367099.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_367099/DevDiv_367099.ilproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressRegs" Value="0x200" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressRegs=0x200
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressRegs=0x200
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_370233/DevDiv_370233.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_370233/DevDiv_370233.ilproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressRegs" Value="0x200" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressRegs=0x200
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressRegs=0x200
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_377155/DevDiv_377155.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_377155/DevDiv_377155.ilproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressRegs" Value="0x200" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressRegs=0x200
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressRegs=0x200
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_736188/DevDiv_736188.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_736188/DevDiv_736188.csproj
@@ -6,17 +6,9 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressRegs=0x204
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressRegs=0x204
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressRegs" Value="0x204" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_11408/GitHub_11408.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_11408/GitHub_11408.csproj
@@ -9,15 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TailcallStress" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TailcallStress=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TailcallStress=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13910/GitHub_13910.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13910/GitHub_13910.csproj
@@ -8,16 +8,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressModeNames" Value="STRESS_NULL_OBJECT_CHECK, STRESS_MAKE_CSE" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Set JitStreess variables, Linux requires them to be properly capitalized. -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressModeNames=STRESS_NULL_OBJECT_CHECK, STRESS_MAKE_CSE
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressModeNames=STRESS_NULL_OBJECT_CHECK, STRESS_MAKE_CSE
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13910/GitHub_13910.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13910/GitHub_13910.csproj
@@ -11,7 +11,4 @@
 
     <CLRTestEnvironmentVariable Include="COMPlus_JitStressModeNames" Value="STRESS_NULL_OBJECT_CHECK, STRESS_MAKE_CSE" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Set JitStreess variables, Linux requires them to be properly capitalized. -->
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18362/GitHub_18362.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18362/GitHub_18362.csproj
@@ -9,15 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TailcallStress" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TailcallStress=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TailcallStress=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18884/GitHub_18884.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18884/GitHub_18884.csproj
@@ -9,15 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TailcallStress" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TailcallStress=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TailcallStress=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199_Target_32Bit.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199_Target_32Bit.csproj
@@ -7,16 +7,10 @@
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '32'">true</CLRTestTargetUnsupported>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_GcStressOnDirectCalls=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_GcStressOnDirectCalls=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GitHub_23199.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_GcStressOnDirectCalls" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199_Target_64Bit.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199_Target_64Bit.csproj
@@ -6,16 +6,10 @@
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_GcStressOnDirectCalls=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_GcStressOnDirectCalls=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GitHub_23199.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_GcStressOnDirectCalls" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.csproj
@@ -8,16 +8,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressModeNames" Value="STRESS_RANDOM_INLINE STRESS_DBL_ALN" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Set JitStreess variables, Linux requires them to be properly capitalized. -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitStressModeNames=STRESS_RANDOM_INLINE STRESS_DBL_ALN
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitStressModeNames=STRESS_RANDOM_INLINE STRESS_DBL_ALN
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.csproj
@@ -11,7 +11,4 @@
 
     <CLRTestEnvironmentVariable Include="COMPlus_JitStressModeNames" Value="STRESS_RANDOM_INLINE STRESS_DBL_ALN" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Set JitStreess variables, Linux requires them to be properly capitalized. -->
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_65690/GitHub_65690.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_65690/GitHub_65690.csproj
@@ -7,21 +7,11 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-    <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitDoValueNumber=0
-set COMPlus_JitStressRegs=3
-set COMPlus_TieredCompilation=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitDoValueNumber=0
-export COMPlus_JitStressRegs=3
-export COMPlus_TieredCompilation=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitDoValueNumber" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressRegs" Value="3" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="0" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_65988/GitHub_65988.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_65988/GitHub_65988.csproj
@@ -7,25 +7,13 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-    <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_EnableSSE2=0
-set COMPlus_OSR_HitLimit=1
-set COMPlus_TC_OnStackReplacement=1
-set COMPlus_TC_OnStackReplacement_InitialCounter=1
-set COMPlus_TC_QuickJitForLoops=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_EnableSSE2=0
-export COMPlus_OSR_HitLimit=1
-export COMPlus_TC_OnStackReplacement=1
-export COMPlus_TC_OnStackReplacement_InitialCounter=1
-export COMPlus_TC_QuickJitForLoops=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_EnableSSE2" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_OSR_HitLimit" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement_InitialCounter" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_33972/Runtime_33972.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_33972/Runtime_33972.csproj
@@ -6,22 +6,14 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=0
-set COMPlus_JITMinOpts=0
-set COMPlus_EnableHWIntrinsic=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=0
-export COMPlus_JITMinOpts=0
-export COMPlus_EnableHWIntrinsic=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs">
       <HasDisasmCheck>true</HasDisasmCheck>
     </Compile>
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JITMinOpts" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_EnableHWIntrinsic" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34937/Runtime_34937.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34937/Runtime_34937.csproj
@@ -6,21 +6,14 @@
     <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=0
-set COMPlus_JITMinOpts=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=0
-export COMPlus_JITMinOpts=0
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs">
       <HasDisasmCheck>true</HasDisasmCheck>
     </Compile>
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JITMinOpts" Value="0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_39424/Runtime_39424.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_39424/Runtime_39424.ilproj
@@ -7,12 +7,10 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <PropertyGroup>
-  <!-- Disable CSE to protect fragile `OBJ(ADDR(LCL_FIELD)` constructions. -->
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
 
+    <!-- Disable CSE to protect fragile `OBJ(ADDR(LCL_FIELD)` constructions. -->
     <CLRTestEnvironmentVariable Include="COMPlus_JitNoCSE" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_39424/Runtime_39424.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_39424/Runtime_39424.ilproj
@@ -9,16 +9,10 @@
   </PropertyGroup>
   <PropertyGroup>
   <!-- Disable CSE to protect fragile `OBJ(ADDR(LCL_FIELD)` constructions. -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitNoCSE=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitNoCSE=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitNoCSE" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_52864/Runtime_52864.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_52864/Runtime_52864.csproj
@@ -7,19 +7,10 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredPGO=1
-set COMPlus_TC_QuickJitForLoops=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredPGO=1
-export COMPlus_TC_QuickJitForLoops=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_53549/Runtime_53549.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_53549/Runtime_53549.csproj
@@ -6,19 +6,10 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredPGO=1
-set COMPlus_TC_QuickJitForLoops=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredPGO=1
-export COMPlus_TC_QuickJitForLoops=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_53549/Runtime_53549_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_53549/Runtime_53549_1.csproj
@@ -6,19 +6,10 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredPGO=1
-set COMPlus_TC_QuickJitForLoops=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredPGO=1
-export COMPlus_TC_QuickJitForLoops=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55107/Runtime_55107.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55107/Runtime_55107.csproj
@@ -6,17 +6,9 @@
     <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitDoRedundantBranchOpts=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitDoRedundantBranchOpts=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitDoRedundantBranchOpts" Value="0" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55131/Runtime_55131.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55131/Runtime_55131.csproj
@@ -6,15 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitEnableFinallyCloning" Value="0" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_JitEnableFinallyCloning=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_JitEnableFinallyCloning=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55253/Runtime_55253.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55253/Runtime_55253.csproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TailcallStress" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_TailcallStress=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_TailcallStress=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953.csproj
@@ -6,17 +6,9 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-   <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitOptRepeat=*
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitOptRepeat=*
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitOptRepeat" Value="*" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58827/Runtime_58827.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58827/Runtime_58827.csproj
@@ -4,20 +4,12 @@
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <!-- This test requires PGO -->
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_TieredCompilation=1
-      set DOTNET_TC_QuickJitForLoops=1
-      set DOTNET_TieredPGO=1
-      ]]></CLRTestBatchPreCommands>
-          <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_TieredCompilation=1
-      export DOTNET_TC_QuickJitForLoops=1
-      export DOTNET_TieredPGO=1
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58827/Runtime_58827.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58827/Runtime_58827.csproj
@@ -3,11 +3,11 @@
     <OutputType>Exe</OutputType>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <!-- This test requires PGO -->
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
 
+    <!-- This test requires PGO -->
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_TC_QuickJitForLoops" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62108/Runtime_62108.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62108/Runtime_62108.csproj
@@ -2,16 +2,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set COMPlus_JitOptRepeat=LeafMethod6
-      ]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export COMPlus_JitOptRepeat=LeafMethod6
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitOptRepeat" Value="LeafMethod6" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62524/Runtime_62524.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62524/Runtime_62524.csproj
@@ -2,18 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_JitNoStructPromotion=1
-      set DOTNET_JitNoCSE=1
-      ]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_JitNoStructPromotion=1
-      export DOTNET_JitNoCSE=1
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoStructPromotion" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoCSE" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_63942/Runtime_63942.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_63942/Runtime_63942.csproj
@@ -2,20 +2,12 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_EnableHWIntrinsic=0
-set COMPlus_JITInlineDepth=0
-set COMPlus_TieredCompilation=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_EnableHWIntrinsic=0
-export COMPlus_JITInlineDepth=0
-export COMPlus_TieredCompilation=0
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_EnableHWIntrinsic" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JITInlineDepth" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="0" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64208/Runtime_64208.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64208/Runtime_64208.csproj
@@ -2,16 +2,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_JitAggressiveInlining=1
-      ]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_JitAggressiveInlining=1
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitAggressiveInlining" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64700/Runtime_64700.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64700/Runtime_64700.csproj
@@ -2,16 +2,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_JitOptRepeat=ProblemWithCopyProp
-      ]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_JitOptRepeat=ProblemWithCopyProp
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitOptRepeat" Value="ProblemWithCopyProp" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_65694/Runtime_65694_2.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_65694/Runtime_65694_2.csproj
@@ -2,16 +2,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-      $(CLRTestBatchPreCommands)
-      set DOTNET_JitNoStructPromotion=1
-      ]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-      $(BashCLRTestPreCommands)
-      export DOTNET_JitNoStructPromotion=1
-      ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoStructPromotion" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_69612/Runtime_69612.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_69612/Runtime_69612.csproj
@@ -6,21 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TieredPGO=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TieredPGO=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <!-- Force-enable CSE of constants -->
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
 
+    <!-- Force-enable CSE of constants -->
     <CLRTestEnvironmentVariable Include="DOTNET_JitConstCSE" Value="3" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.csproj
@@ -3,16 +3,10 @@
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
     <!-- Force-enable CSE of constants -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_JitConstCSE=3
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_JitConstCSE=3
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitConstCSE" Value="3" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71118/Runtime_71118.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71118/Runtime_71118.csproj
@@ -2,18 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_JitStressModeNamesOnly=1
-set DOTNET_JitStressModeNames=STRESS_NULL_OBJECT_CHECK
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_JitStressModeNamesOnly=1
-export DOTNET_JitStressModeNames=STRESS_NULL_OBJECT_CHECK
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNamesOnly" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_NULL_OBJECT_CHECK" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71611/Runtime_71611.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71611/Runtime_71611.csproj
@@ -5,17 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TieredPGO=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TieredPGO=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_71831/Runtime_71831.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_71831/Runtime_71831.csproj
@@ -3,16 +3,10 @@
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_JitNoStructPromotion=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_JitNoStructPromotion=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoStructPromotion" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72363/Runtime_72363.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72363/Runtime_72363.csproj
@@ -5,17 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TieredPGO=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TieredPGO=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72506/Runtime_72506.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72506/Runtime_72506.csproj
@@ -5,15 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_EnableAVX2" Value="0" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_EnableAVX2=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_EnableAVX2=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72775/Runtime_72775.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72775/Runtime_72775.csproj
@@ -5,17 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TieredPGO=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TieredPGO=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
@@ -3,16 +3,10 @@
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_JitNoStructPromotion=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_JitNoStructPromotion=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_JitNoStructPromotion" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72926/Runtime_72926.csproj
@@ -7,6 +7,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
 
-    <CLRTestEnvironmentVariable Include="COMPlus_JitNoStructPromotion" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoStructPromotion" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_73628/Runtime_73628.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_73628/Runtime_73628.csproj
@@ -6,17 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoStructPromotion" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitDoAssertionProp" Value="0" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_JitNoStructPromotion=1
-set DOTNET_JitDoAssertionProp=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_JitNoStructPromotion=1
-export DOTNET_JitDoAssertionProp=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_74774/Runtime_74774.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_74774/Runtime_74774.csproj
@@ -2,16 +2,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_JitNoStructPromotion=2
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_JitNoStructPromotion=2
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoStructPromotion" Value="2" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/Cloning/Runtime_70802.csproj
+++ b/src/tests/JIT/opt/Cloning/Runtime_70802.csproj
@@ -5,15 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredPGO=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredPGO=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/Devirtualization/GDV_GenericInterface.csproj
+++ b/src/tests/JIT/opt/Devirtualization/GDV_GenericInterface.csproj
@@ -3,18 +3,11 @@
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
     <!-- This test requires tiered compilation and PGO -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_TieredCompilation=1
-set DOTNET_TieredPGO=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_TieredCompilation=1
-export DOTNET_TieredPGO=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GDV_GenericInterface.cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/Devirtualization/GDV_GenericInterface.csproj
+++ b/src/tests/JIT/opt/Devirtualization/GDV_GenericInterface.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
-    <!-- This test requires tiered compilation and PGO -->
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GDV_GenericInterface.cs" />
 
+    <!-- This test requires tiered compilation and PGO -->
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
   </ItemGroup>

--- a/src/tests/JIT/opt/Devirtualization/GitHub_50492.csproj
+++ b/src/tests/JIT/opt/Devirtualization/GitHub_50492.csproj
@@ -5,18 +5,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- This test requires tiered compilation and PGO -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_TieredCompilation=1
-set DOTNET_TieredPGO=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_TieredCompilation=1
-export DOTNET_TieredPGO=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GitHub_50492.cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/Devirtualization/GitHub_50492.csproj
+++ b/src/tests/JIT/opt/Devirtualization/GitHub_50492.csproj
@@ -3,12 +3,10 @@
     <OutputType>Exe</OutputType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- This test requires tiered compilation and PGO -->
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="GitHub_50492.cs" />
 
+    <!-- This test requires tiered compilation and PGO -->
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
   </ItemGroup>

--- a/src/tests/JIT/opt/Devirtualization/structreturningstruct.csproj
+++ b/src/tests/JIT/opt/Devirtualization/structreturningstruct.csproj
@@ -8,20 +8,12 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- This test requires tiered compilation and PGO -->
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_TieredCompilation=1
-set DOTNET_TieredPGO=1
-set DOTNET_TC_QuickJitForLoops=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_TieredCompilation=1
-export DOTNET_TieredPGO=1
-export DOTNET_TC_QuickJitForLoops=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="structreturningstruct.cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TC_QuickJitForLoops" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/opt/Devirtualization/structreturningstruct.csproj
+++ b/src/tests/JIT/opt/Devirtualization/structreturningstruct.csproj
@@ -6,12 +6,10 @@
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- This test requires tiered compilation and PGO -->
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="structreturningstruct.cs" />
 
+    <!-- This test requires tiered compilation and PGO -->
     <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_TC_QuickJitForLoops" Value="1" />

--- a/src/tests/JIT/opt/GuardedDevirtualization/enumerablecloning.csproj
+++ b/src/tests/JIT/opt/GuardedDevirtualization/enumerablecloning.csproj
@@ -6,17 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TieredPGO=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TieredPGO=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/GuardedDevirtualization/typetestcloning.csproj
+++ b/src/tests/JIT/opt/GuardedDevirtualization/typetestcloning.csproj
@@ -6,17 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TieredPGO=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TieredPGO=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/Runtime_69032.csproj
+++ b/src/tests/JIT/opt/OSR/Runtime_69032.csproj
@@ -6,21 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredPGO" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TieredPGO=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TieredPGO=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/addressexposedlocal.csproj
+++ b/src/tests/JIT/opt/OSR/addressexposedlocal.csproj
@@ -7,19 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/doublestackalloc.csproj
+++ b/src/tests/JIT/opt/OSR/doublestackalloc.csproj
@@ -7,19 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/example.csproj
+++ b/src/tests/JIT/opt/OSR/example.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/genericmethodpatchpoint.csproj
+++ b/src/tests/JIT/opt/OSR/genericmethodpatchpoint.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/handlerloop.csproj
+++ b/src/tests/JIT/opt/OSR/handlerloop.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/innerloop.csproj
+++ b/src/tests/JIT/opt/OSR/innerloop.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/integersumloop.csproj
+++ b/src/tests/JIT/opt/OSR/integersumloop.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/invalidpromotion.csproj
+++ b/src/tests/JIT/opt/OSR/invalidpromotion.csproj
@@ -6,25 +6,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_OSR_HitLimit" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement_InitialCounter" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-set COMPlus_OSR_HitLimit=1
-set COMPlus_TC_OnStackReplacement=1
-set COMPlus_TC_OnStackReplacement_InitialCounter=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-export COMPlus_OSR_HitLimit=1
-export COMPlus_TC_OnStackReplacement=1
-export COMPlus_TC_OnStackReplacement_InitialCounter=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/largefuncletframe.csproj
+++ b/src/tests/JIT/opt/OSR/largefuncletframe.csproj
@@ -7,25 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_OSR_HitLimit" Value="2" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JitRandomOnStackReplacement" Value="15" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStress" Value="2" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-set COMPlus_OSR_HitLimit=2
-set COMPlus_JitRandomOnStackReplacement=15
-set COMPlus_JitStress=2
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-export COMPlus_OSR_HitLimit=2
-export COMPlus_JitRandomOnStackReplacement=15
-export COMPlus_JitStress=2
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/livelocaladdress.csproj
+++ b/src/tests/JIT/opt/OSR/livelocaladdress.csproj
@@ -7,19 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/livelocalstackalloc.csproj
+++ b/src/tests/JIT/opt/OSR/livelocalstackalloc.csproj
@@ -7,19 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/mainloop.csproj
+++ b/src/tests/JIT/opt/OSR/mainloop.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/mainloop2.csproj
+++ b/src/tests/JIT/opt/OSR/mainloop2.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/mainlooptry.csproj
+++ b/src/tests/JIT/opt/OSR/mainlooptry.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/mainlooptry2.csproj
+++ b/src/tests/JIT/opt/OSR/mainlooptry2.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/mainlooptry3.csproj
+++ b/src/tests/JIT/opt/OSR/mainlooptry3.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/mainlooptry4.csproj
+++ b/src/tests/JIT/opt/OSR/mainlooptry4.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/memoryargument.csproj
+++ b/src/tests/JIT/opt/OSR/memoryargument.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/nesteddoloops.csproj
+++ b/src/tests/JIT/opt/OSR/nesteddoloops.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/originalstackalloc.csproj
+++ b/src/tests/JIT/opt/OSR/originalstackalloc.csproj
@@ -7,19 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/osrcontainstry.csproj
+++ b/src/tests/JIT/opt/OSR/osrcontainstry.csproj
@@ -7,19 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/pinnedlocal.csproj
+++ b/src/tests/JIT/opt/OSR/pinnedlocal.csproj
@@ -7,15 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_GCStress" Value="3" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_GCStress=3
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_GCStress=3
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/promoted.csproj
+++ b/src/tests/JIT/opt/OSR/promoted.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/shortenregisteredlocal.csproj
+++ b/src/tests/JIT/opt/OSR/shortenregisteredlocal.csproj
@@ -6,23 +6,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement_InitialCounter" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_OSR_HitLimit" Value="2" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-set COMPlus_TC_OnStackReplacement_InitialCounter=1
-set COMPlus_OSR_HitLimit=2
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-export COMPlus_TC_OnStackReplacement_InitialCounter=1
-export COMPlus_OSR_HitLimit=2
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/synchronized.csproj
+++ b/src/tests/JIT/opt/OSR/synchronized.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/tailpgo.csproj
+++ b/src/tests/JIT/opt/OSR/tailpgo.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/tailpgo2.csproj
+++ b/src/tests/JIT/opt/OSR/tailpgo2.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/tailrecurse.csproj
+++ b/src/tests/JIT/opt/OSR/tailrecurse.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/tailrecursetry.csproj
+++ b/src/tests/JIT/opt/OSR/tailrecursetry.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/tailrecursetry2.csproj
+++ b/src/tests/JIT/opt/OSR/tailrecursetry2.csproj
@@ -7,19 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/twoosrmethods.csproj
+++ b/src/tests/JIT/opt/OSR/twoosrmethods.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/OSR/twoosrmethods1.csproj
+++ b/src/tests/JIT/opt/OSR/twoosrmethods1.csproj
@@ -6,19 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_OnStackReplacement" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=1
-set COMPlus_TC_QuickJitForLoops=1
-set COMPlus_TC_OnStackReplacement=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=1
-export COMPlus_TC_QuickJitForLoops=1
-export COMPlus_TC_OnStackReplacement=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -8,28 +8,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_ProfApi_RejitOnAttach" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JITMinOpts" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JitNoForceFallback" Value="1" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JitDebuggable" Value="0" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JitStressModeNamesNot" Value="STRESS_RANDOM_INLINE,STRESS_MIN_OPTS" />
+    <CLRTestEnvironmentVariable Include="COMPlus_JitObjectStackAllocation" Value="1" />
   </ItemGroup>
   <PropertyGroup>
     <CrossGen2TestExtraArguments>--codegenopt JitObjectStackAllocation=1</CrossGen2TestExtraArguments>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TieredCompilation=0
-set COMPlus_ProfApi_RejitOnAttach=0
-set COMPlus_JITMinOpts=0
-set COMPlus_JitNoForceFallback=1
-set COMPlus_JitDebuggable=0
-set COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE,STRESS_MIN_OPTS
-set COMPlus_JitObjectStackAllocation=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TieredCompilation=0
-export COMPlus_ProfApi_RejitOnAttach=0
-export COMPlus_JITMinOpts=0
-export COMPlus_JitNoForceFallback=1
-export COMPlus_JitDebuggable=0
-export COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE,STRESS_MIN_OPTS
-export COMPlus_JitObjectStackAllocation=1
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>

--- a/src/tests/Loader/NativeLibs/FromNativePaths.csproj
+++ b/src/tests/Loader/NativeLibs/FromNativePaths.csproj
@@ -14,8 +14,8 @@
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
-    <CLRTestBashEnvironmentVariable Include="export CORE_LIBRARIES=$CORE_LIBRARIES:$%28pwd)/Subdirectory" />
-    <CLRTestBatchEnvironmentVariable Include="set CORE_LIBRARIES=$CORE_LIBRARIES%3B%25cd%\\Subdirectory" />
+    <CLRTestBashEnvironmentVariable Include="CORE_LIBRARIES" Value="$CORE_LIBRARIES:$%28pwd)/Subdirectory" />
+    <CLRTestBatchEnvironmentVariable Include="CORE_LIBRARIES" Value="$CORE_LIBRARIES%3B%25cd%\\Subdirectory" />
   </ItemGroup>
   <PropertyGroup>
     <PathEnvSetupCommands><![CDATA[

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff.csproj
@@ -6,15 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicTest.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="0" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJitForLoops=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJitForLoops=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOff_R2r.csproj
@@ -9,15 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicTest.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="0" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJitForLoops=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJitForLoops=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn.csproj
@@ -6,15 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicTest.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJitForLoops=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJitForLoops=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitForLoopsOn_R2r.csproj
@@ -9,15 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicTest.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJitForLoops" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJitForLoops=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJitForLoops=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOff.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOff.csproj
@@ -6,15 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicTest.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJit" Value="0" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJit=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJit=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOff_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOff_R2r.csproj
@@ -9,15 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicTest.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJit" Value="0" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJit=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJit=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOn.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOn.csproj
@@ -6,15 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicTest.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJit" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJit=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJit=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTest_QuickJitOn_R2r.csproj
@@ -9,15 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicTest.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_TC_QuickJit" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_TC_QuickJit=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_TC_QuickJit=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/TieredCompilation/McjRecorderTimeoutBeforeStop.csproj
+++ b/src/tests/baseservices/TieredCompilation/McjRecorderTimeoutBeforeStop.csproj
@@ -6,15 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="McjRecorderTimeoutBeforeStop.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_MultiCoreJitProfileWriteDelay" Value="1" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_MultiCoreJitProfileWriteDelay=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_MultiCoreJitProfileWriteDelay=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/threading/DeadThreads/DeadThreads.csproj
+++ b/src/tests/baseservices/threading/DeadThreads/DeadThreads.csproj
@@ -4,17 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_Thread_DeadThreadCountThresholdForGCTrigger" Value="8" />
+    <CLRTestEnvironmentVariable Include="COMPlus_Thread_DeadThreadGCTriggerPeriodMilliseconds" Value="3e8" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_Thread_DeadThreadCountThresholdForGCTrigger=8
-set COMPlus_Thread_DeadThreadGCTriggerPeriodMilliseconds=3e8
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_Thread_DeadThreadCountThresholdForGCTrigger=8
-export COMPlus_Thread_DeadThreadGCTriggerPeriodMilliseconds=3e8
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>

--- a/src/tests/baseservices/threading/regressions/269336/objmonhelper.csproj
+++ b/src/tests/baseservices/threading/regressions/269336/objmonhelper.csproj
@@ -4,17 +4,9 @@
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_FastGCStress=1
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_FastGCStress=1
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="objmonhelper.cs" />
+
+    <CLRTestEnvironmentVariable Include="COMPlus_FastGCStress" Value="1" />
   </ItemGroup>
 </Project>

--- a/src/tests/readytorun/DynamicMethodGCStress/DynamicMethodGCStress.csproj
+++ b/src/tests/readytorun/DynamicMethodGCStress/DynamicMethodGCStress.csproj
@@ -11,15 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_GCStress" Value="3" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set COMPlus_GCStress=3
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_GCStress=3
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Existing ways of specifying environment variables:
- [3 times] CLRTestBashEnvironmentVariable is a list of `export var=value` strings
- [2 times] CLRTestBatchEnvironmentVariable is a list of `set var=value` strings
- [~100 times] BashCLRTestPreCommands and CLRTestBatchPreCommands are set to include `export`/`set` strings for the same variables

This changes CLRTestBashEnvironmentVariable and CLRTestBatchEnvironmentVariable to be a list of Identity/Value pairs and adds a new list CLRTestEnvironmentVariable in the same format.  These are automatically expanded to the necessary `export`/`set` strings as appropriate.

A few details of note:
- "Real" changes are in CLRTest.Execute.Bash/Batch.targets.  This moves the environment variables section of the generated cmd/sh files down to the precommands area.  This is only a change for the 5 existing uses, which look ok.
- If a test has a more complicated precommands list, it may not be appropriate to extract the variables.  For example, src\tests\readytorun\tests\mainv1.csproj includes them in setlocal/endlocal because they are for crossgen2 in the precommands, not the test itself.  This change only updates otherwise blank precommands lists.