### PR TITLE
[hot_reload] Add instance fields

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
@@ -32,5 +32,11 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         }
 
         public string GetStringProp => string.Empty;
+
+        public event EventHandler<double> ExistingEvent;
+
+        public void FireEvents() {
+            ExistingEvent(this, 123.0);
+        }
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class AddInstanceField
+    {
+        public AddInstanceField () {
+        }
+
+        public string GetStringField => _stringField;
+        public double GetDoubleField => _doubleField;
+
+        private string _stringField;
+        private double _doubleField;
+
+        public void TestMethod () {
+            _stringField = "abcd";
+            _doubleField = 3.14159;
+        }
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
@@ -16,10 +16,15 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         private string _stringField;
         private double _doubleField;
 
+        private int[] _intArrayFieldWithInit = new[] { 2, 4, 6, 8, 10, 12 };
+
         public void TestMethod () {
             _stringField = "abcd";
             _doubleField = 3.14159;
         }
+
+        public int GetIntArrayLength() => _intArrayFieldWithInit?.Length ?? -1;
+        public int GetIntArrayElt(int i) => _intArrayFieldWithInit[i];
 
         public void IncRefDouble (ref double d)
         {

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
@@ -31,5 +31,6 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             d += 1.0;
         }
 
+        public string GetStringProp => string.Empty;
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
@@ -21,5 +21,10 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             _doubleField = 3.14159;
         }
 
+        public void IncRefDouble (ref double d)
+        {
+            d += 1.0;
+        }
+
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField.cs
@@ -35,8 +35,17 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
 
         public event EventHandler<double> ExistingEvent;
 
-        public void FireEvents() {
+        public double Accumulator;
+
+        private void AccumHandler (object sender, double value) => Accumulator += value;
+
+        public double FireEvents() {
+            Accumulator = 0.0;
+            ExistingEvent += AccumHandler;
             ExistingEvent(this, 123.0);
+            ExistingEvent -= AccumHandler;
+
+            return Accumulator;
         }
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
@@ -8,12 +8,20 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
     public class AddInstanceField
     {
         public AddInstanceField () {
-            _doubleField2 = -5.5e12;
+            _doubleField2 = 5.5;
             _stringField2 = "New Initial Value";
             NewStructField = new NewStruct {
-                D = -1984.0,
+                D = -1985.0,
                 O = new int[2] { 15, 17 },
             };
+            // a little bit ldflda testing
+            IncRefDouble (ref NewStructField.D);
+            IncRefDouble (ref _doubleField2);
+        }
+
+        public void IncRefDouble (ref double d)
+        {
+            d += 1.0;
         }
 
         public string GetStringField => _stringField2;

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
@@ -10,6 +10,10 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         public AddInstanceField () {
             _doubleField2 = -5.5e12;
             _stringField2 = "New Initial Value";
+            NewStructField = new NewStruct {
+                D = -1984.0,
+                O = new int[2] { 15, 17 },
+            };
         }
 
         public string GetStringField => _stringField2;
@@ -27,5 +31,12 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             _doubleField2 = 0.707106;
         }
 
+        public struct NewStruct
+        {
+            public double D;
+            public object O;
+        }
+
+        public NewStruct NewStructField;
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
@@ -17,6 +17,8 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             // a little bit ldflda testing
             IncRefDouble (ref NewStructField.D);
             IncRefDouble (ref _doubleField2);
+
+            AddedStringAutoProp = "abcd";
         }
 
         public void IncRefDouble (ref double d)
@@ -40,6 +42,7 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             _stringField2 = "4567";
             _doubleField = 2.71828;
             _doubleField2 = 0.707106;
+            AddedStringAutoProp = AddedStringAutoProp + "Test";
         }
 
         public int GetIntArrayLength() => _intArrayFieldWithInit2?.Length ?? -1;
@@ -52,5 +55,11 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         }
 
         public NewStruct NewStructField;
+
+        public string GetStringProp => AddedStringAutoProp;
+
+        public string AddedStringAutoProp { get; set; }
+
+
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
@@ -68,9 +68,21 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         public event EventHandler<double> ExistingEvent;
         public event EventHandler<double> AddedEvent;
 
-        public void FireEvents() {
+        public double Accumulator;
+
+        private void AccumHandler (object sender, double value) => Accumulator += value;
+
+        public double FireEvents() {
+            Accumulator = 0.0;
+            ExistingEvent += AccumHandler;
             ExistingEvent(this, 123.0);
+            ExistingEvent -= AccumHandler;
+
+            AddedEvent += AccumHandler;
             AddedEvent(this, 123.0);
+            AddedEvent -= AccumHandler;
+
+            return Accumulator;
         }
 
     }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
@@ -32,12 +32,18 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
         private double _doubleField;
         private double _doubleField2;
 
+        private int[] _intArrayFieldWithInit = new[] { 2, 4, 6, 8, 10, 12 };
+        private int[] _intArrayFieldWithInit2 = new[] { 1, 3, 5, 7, 9, 11 };
+
         public void TestMethod () {
             _stringField = "spqr";
             _stringField2 = "4567";
             _doubleField = 2.71828;
             _doubleField2 = 0.707106;
         }
+
+        public int GetIntArrayLength() => _intArrayFieldWithInit2?.Length ?? -1;
+        public int GetIntArrayElt(int i) => _intArrayFieldWithInit2[i];
 
         public struct NewStruct
         {

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
@@ -19,6 +19,11 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
             IncRefDouble (ref _doubleField2);
 
             AddedStringAutoProp = "abcd";
+
+            AddedEvent += MyHandler;
+
+            void MyHandler (object sender, double data) {
+            }
         }
 
         public void IncRefDouble (ref double d)
@@ -60,6 +65,13 @@ namespace System.Reflection.Metadata.ApplyUpdate.Test
 
         public string AddedStringAutoProp { get; set; }
 
+        public event EventHandler<double> ExistingEvent;
+        public event EventHandler<double> AddedEvent;
+
+        public void FireEvents() {
+            ExistingEvent(this, 123.0);
+            AddedEvent(this, 123.0);
+        }
 
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/AddInstanceField_v1.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class AddInstanceField
+    {
+        public AddInstanceField () {
+            _doubleField2 = -5.5e12;
+            _stringField2 = "New Initial Value";
+        }
+
+        public string GetStringField => _stringField2;
+        public double GetDoubleField => _doubleField2;
+
+        private string _stringField;
+        private string _stringField2;
+        private double _doubleField;
+        private double _doubleField2;
+
+        public void TestMethod () {
+            _stringField = "spqr";
+            _stringField2 = "4567";
+            _doubleField = 2.71828;
+            _doubleField2 = 0.707106;
+        }
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AddInstanceField.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "AddInstanceField.cs", "update": "AddInstanceField_v1.cs"},
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -331,10 +331,15 @@ namespace System.Reflection.Metadata
                 Assert.Equal ("4567", x1.GetStringField);
                 Assert.Equal (0.707106, x1.GetDoubleField);
 
+                Assert.Equal (-1, x1.GetIntArrayLength ()); // new field on existing object is initially null
+
                 var x2 = new System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField();
 
                 Assert.Equal ("New Initial Value", x2.GetStringField);
                 Assert.Equal (6.5, x2.GetDoubleField);
+
+                Assert.Equal (6, x2.GetIntArrayLength());
+                Assert.Equal (7, x2.GetIntArrayElt (3));
                 
                 // now check that reflection can get/set the new fields
                 var fi = x2.GetType().GetField("NewStructField");

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -391,6 +391,11 @@ namespace System.Reflection.Metadata
 
                 Assert.True ((addedPropToken & 0x00ffffff) < 64);
 
+
+                var eventInfo = x2.GetType().GetEvent("AddedEvent", BindingFlags.Public | BindingFlags.Instance);
+
+                Assert.NotNull (eventInfo);
+
             });
         }
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -380,6 +380,16 @@ namespace System.Reflection.Metadata
 
                 Assert.Equal("abcdTest", x2.GetStringProp);
 
+                var addedPropToken = propInfo.MetadataToken;
+
+                Assert.True (addedPropToken > 0);
+
+                // we don't know exactly what token Roslyn will assign to the added property, but
+                // since the AddInstanceField.dll assembly is relatively small, assume that the
+                // total number of properties in the updated generation is less than 64 and the
+                // token is in that range.  If more code is added, revise this test.
+
+                Assert.True ((addedPropToken & 0x00ffffff) < 64);
 
             });
         }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -308,6 +308,7 @@ namespace System.Reflection.Metadata
             });
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76702", TestRuntimes.CoreCLR)]
         [ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
         public static void TestAddInstanceField()
         {

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -369,6 +369,18 @@ namespace System.Reflection.Metadata
                 Assert.Equal (32768.2, x2.GetDoubleField);
                 Assert.Equal ((object)32768.2, fi.GetValueDirect (tr));
 
+                Assert.Equal("abcd", x2.GetStringProp);
+
+                var propInfo = x2.GetType().GetProperty("AddedStringAutoProp", BindingFlags.Public | BindingFlags.Instance);
+
+                Assert.NotNull(propInfo);
+                Assert.Equal("abcd", propInfo.GetMethod.Invoke (x2, new object[] {}));
+
+                x2.TestMethod();
+
+                Assert.Equal("abcdTest", x2.GetStringProp);
+
+
             });
         }
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -344,18 +344,19 @@ namespace System.Reflection.Metadata
 
                 Assert.NotNull(x2);
 
-                var fid = fi.GetType().GetField("D");
-
+                var fid = fi.FieldType.GetField("D");
                 Assert.NotNull(fid);
-
-
                 Assert.Equal(-1984.0, fid.GetValue(s));
-
                 var tr = TypedReference.MakeTypedReference (x2, new FieldInfo[] {fi});
-
                 fid.SetValueDirect(tr, (object)34567.0);
-
                 Assert.Equal (34567.0, fid.GetValueDirect (tr));
+
+                fi = x2.GetType().GetField("_doubleField2", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                Assert.NotNull(fi);
+
+                fi.SetValue(x2, 65535.01);
+                Assert.Equal(65535.01, x2.GetDoubleField);
 
             });
         }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -309,6 +309,36 @@ namespace System.Reflection.Metadata
         }
 
         [ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
+        public static void TestAddInstanceField()
+        {
+            // Test that adding a new instance field to an existing class is supported
+            ApplyUpdateUtil.TestCase(static () =>
+            {
+                var assm = typeof(System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField).Assembly;
+
+                var x1 = new System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField();
+
+                x1.TestMethod();
+
+                Assert.Equal ("abcd", x1.GetStringField);
+                Assert.Equal (3.14159, x1.GetDoubleField);
+
+                ApplyUpdateUtil.ApplyUpdate(assm);
+
+                x1.TestMethod();
+
+                Assert.Equal ("4567", x1.GetStringField);
+                Assert.Equal (0.707106, x1.GetDoubleField);
+
+                var x2 = new System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField();
+
+                Assert.Equal ("New Initial Value", x2.GetStringField);
+                Assert.Equal (-5.5e12, x2.GetDoubleField);
+                
+            });
+        }
+
+        [ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
         public static void TestAddNestedClass()
         {
             // Test that adding a new nested class to an existing class is supported

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -333,7 +333,7 @@ namespace System.Reflection.Metadata
                 var x2 = new System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField();
 
                 Assert.Equal ("New Initial Value", x2.GetStringField);
-                Assert.Equal (-5.5e12, x2.GetDoubleField);
+                Assert.Equal (6.5, x2.GetDoubleField);
                 
                 // now check that reflection can get/set the new fields
                 var fi = x2.GetType().GetField("NewStructField");

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -335,6 +335,28 @@ namespace System.Reflection.Metadata
                 Assert.Equal ("New Initial Value", x2.GetStringField);
                 Assert.Equal (-5.5e12, x2.GetDoubleField);
                 
+                // now check that reflection can get/set the new fields
+                var fi = x2.GetType().GetField("NewStructField");
+
+                Assert.NotNull(fi);
+
+                var s = fi.GetValue (x2);
+
+                Assert.NotNull(x2);
+
+                var fid = fi.GetType().GetField("D");
+
+                Assert.NotNull(fid);
+
+
+                Assert.Equal(-1984.0, fid.GetValue(s));
+
+                var tr = TypedReference.MakeTypedReference (x2, new FieldInfo[] {fi});
+
+                fid.SetValueDirect(tr, (object)34567.0);
+
+                Assert.Equal (34567.0, fid.GetValueDirect (tr));
+
             });
         }
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -400,6 +400,18 @@ namespace System.Reflection.Metadata
 
                 Assert.NotNull (eventInfo);
 
+                var addedEventToken = eventInfo.MetadataToken;
+
+                Assert.True (addedEventToken > 0);
+
+                // we don't know exactly what token Roslyn will assign to the added event, but
+                // since the AddInstanceField.dll assembly is relatively small, assume that the
+                // total number of events in the updated generation is less than 4 and the
+                // token is in that range.  If more code is added, revise this test.
+
+                Assert.True ((addedEventToken & 0x00ffffff) < 4);
+                
+
             });
         }
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -364,6 +364,11 @@ namespace System.Reflection.Metadata
                 fi.SetValue(x2, 65535.01);
                 Assert.Equal(65535.01, x2.GetDoubleField);
 
+                tr = __makeref(x2);
+                fi.SetValueDirect (tr, 32768.2);
+                Assert.Equal (32768.2, x2.GetDoubleField);
+                Assert.Equal ((object)32768.2, fi.GetValueDirect (tr));
+
             });
         }
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -392,6 +392,10 @@ namespace System.Reflection.Metadata
                 Assert.True ((addedPropToken & 0x00ffffff) < 64);
 
 
+                var accumResult = x2.FireEvents();
+
+                Assert.Equal (246.0, accumResult);
+
                 var eventInfo = x2.GetType().GetEvent("AddedEvent", BindingFlags.Public | BindingFlags.Instance);
 
                 Assert.NotNull (eventInfo);

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -58,6 +58,7 @@
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis\System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddStaticField\System.Reflection.Metadata.ApplyUpdate.Test.AddStaticField.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField\System.Reflection.Metadata.ApplyUpdate.Test.AddInstanceField.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass\System.Reflection.Metadata.ApplyUpdate.Test.AddNestedClass.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddStaticLambda\System.Reflection.Metadata.ApplyUpdate.Test.AddStaticLambda.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.StaticLambdaRegression\System.Reflection.Metadata.ApplyUpdate.Test.StaticLambdaRegression.csproj" />

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -644,5 +644,9 @@
 
 		<!-- FIXME: only if  feature="System.Reflection.Metadata.MetadataUpdater.IsSupported" featurevalue="true" -->
 		<type fullname="Mono.HotReload.FieldStore" preserve="fields" />
+                <type fullname="Mono.HotReload.InstanceFieldTable">
+                    <!-- hot_reload.c -->
+                    <method name="GetInstanceFieldFieldStore" />
+                </type>
 	</assembly>
 </linker>

--- a/src/mono/System.Private.CoreLib/src/Mono/HotReload.cs
+++ b/src/mono/System.Private.CoreLib/src/Mono/HotReload.cs
@@ -10,8 +10,8 @@ using System.Runtime.InteropServices;
 namespace Mono.HotReload;
 
 // TODO: this is just a sketch, instance field additions aren't supported by Mono yet until  https://github.com/dotnet/runtime/issues/63643 is fixed
-#if false
-internal class InstanceFieldTable
+#if true
+internal sealed class InstanceFieldTable
 {
     // Q: Does CoreCLR EnC allow adding fields to a valuetype?
     // A: No, see EEClass::AddField - if the type has layout or is a valuetype, you can't add fields to it.
@@ -35,8 +35,8 @@ internal class InstanceFieldTable
     //   we want to create some storage space that has the same lifetime as the instance object.
 
     // // TODO: should the linker keep this if Hot Reload stuff is enabled?  Hot Reload is predicated on the linker not rewriting user modules, but maybe trimming SPC is ok?
-    internal static FieldStore GetInstanceFieldFieldStore(object inst, RuntimeTypeHandle type, uint fielddef_token)
-        => _singleton.GetOrCreateInstanceFields(inst).LookupOrAdd(type, fielddef_token);
+    internal static FieldStore GetInstanceFieldFieldStore(object inst, IntPtr type, uint fielddef_token)
+        => _singleton.GetOrCreateInstanceFields(inst).LookupOrAdd(new RuntimeTypeHandle (type), fielddef_token);
 
     private static InstanceFieldTable _singleton = new();
 
@@ -50,7 +50,7 @@ internal class InstanceFieldTable
     private InstanceFields GetOrCreateInstanceFields(object key)
         => _table.GetOrCreateValue(key);
 
-    private class InstanceFields
+    private sealed class InstanceFields
     {
         private Dictionary<uint, FieldStore> _fields;
         private object _lock;

--- a/src/mono/System.Private.CoreLib/src/Mono/HotReload.cs
+++ b/src/mono/System.Private.CoreLib/src/Mono/HotReload.cs
@@ -10,8 +10,6 @@ using System.Runtime.InteropServices;
 
 namespace Mono.HotReload;
 
-// TODO: this is just a sketch, instance field additions aren't supported by Mono yet until  https://github.com/dotnet/runtime/issues/63643 is fixed
-#if true
 internal sealed class InstanceFieldTable
 {
     // Q: Does CoreCLR EnC allow adding fields to a valuetype?
@@ -82,7 +80,6 @@ internal sealed class InstanceFieldTable
     }
 
 }
-#endif
 
 // This is similar to System.Diagnostics.EditAndContinueHelper in CoreCLR, except instead of
 // having the allocation logic in native (see EditAndContinueModule::ResolveOrAllocateField,

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -9825,8 +9825,6 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			if (!found)
 				goto invalid_fieldid;
 get_field_value:
-			/* TODO: metadata-update: implement support for added fields */
-			g_assert (!m_field_is_from_update (f));
 			if (f->type->attrs & FIELD_ATTRIBUTE_STATIC) {
 				guint8 *val;
 				MonoVTable *vtable;
@@ -9849,7 +9847,17 @@ get_field_value:
 				buffer_add_value (buf, f->type, val, obj->vtable->domain);
 				g_free (val);
 			} else {
-				void *field_value = (guint8*)obj + m_field_get_offset (f);
+				void *field_value = NULL;
+				if (G_UNLIKELY (m_field_is_from_update (f))) {
+					uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (f));
+					field_value = mono_metadata_update_added_field_ldflda (obj, f->type, token, error);
+					if (!is_ok (error)) {
+						mono_error_cleanup (error);
+						goto invalid_object;
+					}
+				} else {
+					field_value = (guint8*)obj + m_field_get_offset (f);
+				}
 
 				buffer_add_value (buf, f->type, field_value, obj->vtable->domain);
 			}
@@ -9874,9 +9882,6 @@ get_field_value:
 			if (!found)
 				goto invalid_fieldid;
 
-			/* TODO: metadata-update: implement support for added fields. */
-			g_assert (!m_field_is_from_update (f));
-
 			if (f->type->attrs & FIELD_ATTRIBUTE_STATIC) {
 				guint8 *val;
 				MonoVTable *vtable;
@@ -9900,7 +9905,18 @@ get_field_value:
 				mono_field_static_set_value_internal (vtable, f, val);
 				g_free (val);
 			} else {
-				err = decode_value (f->type, obj->vtable->domain, (guint8*)obj + m_field_get_offset (f), p, &p, end, TRUE);
+				void *dest = NULL;
+				if (G_UNLIKELY (m_field_is_from_update (f))) {
+					uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (f));
+					dest = mono_metadata_update_added_field_ldflda (obj, f->type, token, error);
+					if (!is_ok (error)) {
+						mono_error_cleanup (error);
+						goto invalid_fieldid;
+					}
+				} else {
+					dest = (guint8*)obj + m_field_get_offset (f);
+				}
+				err = decode_value (f->type, obj->vtable->domain, dest, p, &p, end, TRUE);
 				if (err != ERR_NONE)
 					goto exit;
 			}

--- a/src/mono/mono/component/hot_reload-internals.h
+++ b/src/mono/mono/component/hot_reload-internals.h
@@ -82,7 +82,7 @@ typedef struct _MonoClassMetadataUpdateProperty {
 
 typedef struct _MonoClassMetadataUpdateEvent {
 	MonoEvent evt;
-	uint32_t generatino; /* when this event was added */
+	uint32_t generation; /* when this event was added */
 	uint32_t token; /* the Event table token where this event was defined. */
 } MonoClassMetadataUpdateEvent;
 

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -116,6 +116,9 @@ hot_reload_stub_get_method_params (MonoImage *base_image, uint32_t methoddef_tok
 static gpointer
 hot_reload_stub_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
 
+static MonoProperty *
+hot_reload_stub_added_properties_iter (MonoClass *klass, gpointer *iter);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -151,6 +154,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_get_capabilities,
 	&hot_reload_stub_get_method_params,
 	&hot_reload_stub_added_field_ldflda,
+	&hot_reload_stub_added_properties_iter,
 };
 
 static bool
@@ -362,6 +366,13 @@ hot_reload_stub_added_field_ldflda (MonoObject *instance, MonoType *field_type, 
 {
 	return NULL;
 }
+
+static MonoProperty *
+hot_reload_stub_added_properties_iter (MonoClass *klass, gpointer *iter)
+{
+	return NULL;
+}
+
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentHotReload *

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -119,6 +119,9 @@ hot_reload_stub_added_field_ldflda (MonoObject *instance, MonoType *field_type, 
 static MonoProperty *
 hot_reload_stub_added_properties_iter (MonoClass *klass, gpointer *iter);
 
+static uint32_t
+hot_reload_stub_get_property_idx (MonoProperty *prop);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -155,6 +158,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_get_method_params,
 	&hot_reload_stub_added_field_ldflda,
 	&hot_reload_stub_added_properties_iter,
+	&hot_reload_stub_get_property_idx,
 };
 
 static bool
@@ -371,6 +375,12 @@ static MonoProperty *
 hot_reload_stub_added_properties_iter (MonoClass *klass, gpointer *iter)
 {
 	return NULL;
+}
+
+static uint32_t
+hot_reload_stub_get_property_idx (MonoProperty *prop)
+{
+	return 0;
 }
 
 

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -113,6 +113,9 @@ hot_reload_get_capabilities (void);
 static uint32_t
 hot_reload_stub_get_method_params (MonoImage *base_image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
 
+static gpointer
+hot_reload_stub_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -147,6 +150,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_get_num_methods_added,
 	&hot_reload_get_capabilities,
 	&hot_reload_stub_get_method_params,
+	&hot_reload_stub_added_field_ldflda,
 };
 
 static bool
@@ -353,9 +357,16 @@ hot_reload_stub_get_method_params (MonoImage *base_image, uint32_t methoddef_tok
 	return 0;
 }
 
+static gpointer
+hot_reload_stub_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error)
+{
+	return NULL;
+}
+
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentHotReload *
 mono_component_hot_reload_init (void)
 {
 	return component_hot_reload_stub_init ();
 }
+

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -125,6 +125,9 @@ hot_reload_stub_get_property_idx (MonoProperty *prop);
 static MonoEvent *
 hot_reload_stub_added_events_iter (MonoClass *klass, gpointer *iter);
 
+static uint32_t
+hot_reload_stub_get_event_idx (MonoEvent *evt);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -163,6 +166,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_added_properties_iter,
 	&hot_reload_stub_get_property_idx,
 	&hot_reload_stub_added_events_iter,
+	&hot_reload_stub_get_event_idx,
 };
 
 static bool
@@ -391,6 +395,12 @@ MonoEvent *
 hot_reload_stub_added_events_iter (MonoClass *klass, gpointer *iter)
 {
 	return NULL;
+}
+
+static uint32_t
+hot_reload_stub_get_event_idx (MonoEvent *evt)
+{
+	return 0;
 }
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -122,6 +122,9 @@ hot_reload_stub_added_properties_iter (MonoClass *klass, gpointer *iter);
 static uint32_t
 hot_reload_stub_get_property_idx (MonoProperty *prop);
 
+static MonoEvent *
+hot_reload_stub_added_events_iter (MonoClass *klass, gpointer *iter);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -159,6 +162,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_added_field_ldflda,
 	&hot_reload_stub_added_properties_iter,
 	&hot_reload_stub_get_property_idx,
+	&hot_reload_stub_added_events_iter,
 };
 
 static bool
@@ -383,6 +387,11 @@ hot_reload_stub_get_property_idx (MonoProperty *prop)
 	return 0;
 }
 
+MonoEvent *
+hot_reload_stub_added_events_iter (MonoClass *klass, gpointer *iter)
+{
+	return NULL;
+}
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentHotReload *
@@ -390,4 +399,5 @@ mono_component_hot_reload_init (void)
 {
 	return component_hot_reload_stub_init ();
 }
+
 

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -187,7 +187,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_get_num_methods_added,
 	&hot_reload_get_capabilities,
 	&hot_reload_get_method_params,
-        &hot_reload_added_field_ldflda,
+	&hot_reload_added_field_ldflda,
 };
 
 MonoComponentHotReload *
@@ -3257,21 +3257,21 @@ hot_reload_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint3
 	}
 	g_assert (get_instance_store);
 
-        gpointer args[3];
+	gpointer args[3];
 
-        args[0] = instance;
-        args[1] = &field_type;
-        args[2] = &fielddef_token;
+	args[0] = instance;
+	args[1] = &field_type;
+	args[2] = &fielddef_token;
 
-        MonoHotReloadFieldStoreObject *field_store;
-        field_store = (MonoHotReloadFieldStoreObject*) mono_runtime_invoke_checked (get_instance_store, NULL, args, error);
-        gpointer result = NULL;
-        /* If it's a value type, return a ptr to the beginning of the
-         * boxed data in FieldStore:_loc. If it's a reference type,
-         * return the address of FieldStore:_loc itself. */
-        if (!mono_type_is_reference (field_type))
-                result = mono_object_unbox_internal (field_store->_loc);
-        else
-                result = (gpointer)&field_store->_loc;
-        return result;
+	MonoHotReloadFieldStoreObject *field_store;
+	field_store = (MonoHotReloadFieldStoreObject*) mono_runtime_invoke_checked (get_instance_store, NULL, args, error);
+	gpointer result = NULL;
+	/* If it's a value type, return a ptr to the beginning of the
+	 * boxed data in FieldStore:_loc. If it's a reference type,
+	 * return the address of FieldStore:_loc itself. */
+	if (!mono_type_is_reference (field_type))
+		result = mono_object_unbox_internal (field_store->_loc);
+	else
+		result = (gpointer)&field_store->_loc;
+	return result;
 }

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -153,6 +153,10 @@ hot_reload_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint3
 static MonoProperty *
 hot_reload_added_properties_iter (MonoClass *klass, gpointer *iter);
 
+static uint32_t
+hot_reload_get_property_idx (MonoProperty *prop);
+
+
 static MonoClassMetadataUpdateField *
 metadata_update_field_setup_basic_info (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, DeltaInfo *delta_info, MonoClass *parent_klass, uint32_t fielddef_token, uint32_t field_flags);
 
@@ -201,6 +205,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_get_method_params,
 	&hot_reload_added_field_ldflda,
 	&hot_reload_added_properties_iter,
+	&hot_reload_get_property_idx,
 };
 
 MonoComponentHotReload *
@@ -3448,4 +3453,12 @@ hot_reload_added_properties_iter (MonoClass *klass, gpointer *iter)
 	idx++;
 	*iter = GUINT_TO_POINTER (idx);
 	return &prop->prop;
+}
+
+uint32_t
+hot_reload_get_property_idx (MonoProperty *prop)
+{
+	g_assert (m_property_is_from_update (prop));
+	MonoClassMetadataUpdateProperty *prop_info = (MonoClassMetadataUpdateProperty *)prop;
+	return mono_metadata_token_index (prop_info->token);
 }

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -159,6 +159,9 @@ hot_reload_get_property_idx (MonoProperty *prop);
 MonoEvent *
 hot_reload_added_events_iter (MonoClass *klass, gpointer *iter);
 
+static uint32_t
+hot_reload_get_event_idx (MonoEvent *evt);
+
 static MonoClassMetadataUpdateField *
 metadata_update_field_setup_basic_info (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, DeltaInfo *delta_info, MonoClass *parent_klass, uint32_t fielddef_token, uint32_t field_flags);
 
@@ -215,6 +218,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_added_properties_iter,
 	&hot_reload_get_property_idx,
 	&hot_reload_added_events_iter,
+	&hot_reload_get_event_idx,
 };
 
 MonoComponentHotReload *
@@ -3559,6 +3563,14 @@ hot_reload_get_property_idx (MonoProperty *prop)
 	g_assert (m_property_is_from_update (prop));
 	MonoClassMetadataUpdateProperty *prop_info = (MonoClassMetadataUpdateProperty *)prop;
 	return mono_metadata_token_index (prop_info->token);
+}
+
+uint32_t
+hot_reload_get_event_idx (MonoEvent *evt)
+{
+	g_assert (m_event_is_from_update (evt));
+	MonoClassMetadataUpdateEvent *event_info = (MonoClassMetadataUpdateEvent *)evt;
+	return mono_metadata_token_index (event_info->token);
 }
 
 

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -3238,7 +3238,7 @@ hot_reload_get_method_params (MonoImage *base_image, uint32_t methoddef_token, u
 static const char *
 hot_reload_get_capabilities (void)
 {
-	return "Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes";
+	return "Baseline AddMethodToExistingType AddStaticFieldToExistingType NewTypeDefinition ChangeCustomAttributes AddInstanceFieldToExistingType";
 }
 
 static GENERATE_GET_CLASS_WITH_CACHE_DECL (hot_reload_instance_field_table);

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -34,7 +34,7 @@
 
 #include <mono/utils/mono-compiler.h>
 
-#undef ALLOW_INSTANCE_FIELD_ADD
+#define ALLOW_INSTANCE_FIELD_ADD
 
 typedef struct _BaselineInfo BaselineInfo;
 typedef struct _DeltaInfo DeltaInfo;

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -3253,7 +3253,7 @@ hot_reload_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint3
 	static MonoMethod *get_instance_store = NULL;
 	if (G_UNLIKELY (get_instance_store == NULL)) {
 		MonoClass *table_class = mono_class_get_hot_reload_instance_field_table_class ();
-		get_instance_store = mono_class_get_method_from_name_checked (table_class, "GetInstanceFieldStore", 3, 0, error);
+		get_instance_store = mono_class_get_method_from_name_checked (table_class, "GetInstanceFieldFieldStore", 3, 0, error);
 		mono_error_assert_ok (error);
 	}
 	g_assert (get_instance_store);

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -34,8 +34,6 @@
 
 #include <mono/utils/mono-compiler.h>
 
-#define ALLOW_INSTANCE_FIELD_ADD
-
 typedef struct _BaselineInfo BaselineInfo;
 typedef struct _DeltaInfo DeltaInfo;
 
@@ -2235,15 +2233,6 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 
 				uint32_t mapped_token = hot_reload_relative_delta_index (image_dmeta, delta_info, log_token);
 				uint32_t field_flags = mono_metadata_decode_row_col (&image_dmeta->tables [MONO_TABLE_FIELD], mapped_token - 1, MONO_FIELD_FLAGS);
-
-#ifndef ALLOW_INSTANCE_FIELD_ADD
-				if ((field_flags & FIELD_ATTRIBUTE_STATIC) == 0) {
-					/* TODO: implement instance (and literal?) fields */
-					mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_METADATA_UPDATE, "Adding non-static fields isn't implemented yet (token 0x%08x, class %s.%s)", log_token, m_class_get_name_space (add_member_klass), m_class_get_name (add_member_klass));
-					mono_error_set_not_implemented (error, "Adding non-static fields isn't implemented yet (token 0x%08x, class %s.%s)", log_token, m_class_get_name_space (add_member_klass), m_class_get_name (add_member_klass));
-					return FALSE;
-				}
-#endif
 
 				add_field_to_baseline (base_info, delta_info, add_member_klass, log_token);
 

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -49,6 +49,7 @@ typedef struct _MonoComponentHotReload {
 	uint32_t (*get_num_methods_added) (MonoClass *klass);
 	const char* (*get_capabilities) (void);
 	uint32_t (*get_method_params) (MonoImage *base_image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
+        gpointer (*added_field_ldflda) (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -50,6 +50,7 @@ typedef struct _MonoComponentHotReload {
 	const char* (*get_capabilities) (void);
 	uint32_t (*get_method_params) (MonoImage *base_image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
 	gpointer (*added_field_ldflda) (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
+	MonoProperty* (*added_properties_iter) (MonoClass *klass, gpointer *iter);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -52,6 +52,7 @@ typedef struct _MonoComponentHotReload {
 	gpointer (*added_field_ldflda) (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
 	MonoProperty* (*added_properties_iter) (MonoClass *klass, gpointer *iter);
 	uint32_t (*get_property_idx) (MonoProperty *prop);
+	MonoEvent* (*added_events_iter) (MonoClass *klass, gpointer *iter);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -49,7 +49,7 @@ typedef struct _MonoComponentHotReload {
 	uint32_t (*get_num_methods_added) (MonoClass *klass);
 	const char* (*get_capabilities) (void);
 	uint32_t (*get_method_params) (MonoImage *base_image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
-        gpointer (*added_field_ldflda) (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
+	gpointer (*added_field_ldflda) (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -53,6 +53,7 @@ typedef struct _MonoComponentHotReload {
 	MonoProperty* (*added_properties_iter) (MonoClass *klass, gpointer *iter);
 	uint32_t (*get_property_idx) (MonoProperty *prop);
 	MonoEvent* (*added_events_iter) (MonoClass *klass, gpointer *iter);
+	uint32_t (*get_event_idx) (MonoEvent *evt);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -51,6 +51,7 @@ typedef struct _MonoComponentHotReload {
 	uint32_t (*get_method_params) (MonoImage *base_image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
 	gpointer (*added_field_ldflda) (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
 	MonoProperty* (*added_properties_iter) (MonoClass *klass, gpointer *iter);
+	uint32_t (*get_property_idx) (MonoProperty *prop);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -2273,6 +2273,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 				int idx = first_field_idx + i;
 				guint32 offset;
 				mono_metadata_field_info (klass->image, idx, &offset, NULL, NULL);
+                                /* metadata-update: updates to explicit layout classes are not allowed. */
 				field_offsets [i] = offset + MONO_ABI_SIZEOF (MonoObject);
 			}
 			ftype = mono_type_get_underlying_type (field->type);

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -3587,6 +3587,11 @@ mono_class_setup_properties (MonoClass *klass)
 		first = ginfo->first;
 		count = ginfo->count;
 	} else {
+                /*
+                 * metadata-update: note this is only adding properties from the base image. new
+                 * properties added to an existing class won't be here since they're not in the
+                 * contiguous rows [first,last].
+                 */
 		first = mono_metadata_properties_from_typedef (klass->image, mono_metadata_token_index (klass->type_token) - 1, &last);
 		g_assert ((last - first) >= 0);
 		count = last - first;

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1350,7 +1350,7 @@ MONO_COMPONENT_API
 void
 mono_class_set_nested_classes_property (MonoClass *klass, GList *value);
 
-MonoClassPropertyInfo*
+MONO_COMPONENT_API MonoClassPropertyInfo*
 mono_class_get_property_info (MonoClass *klass);
 
 void

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1356,7 +1356,7 @@ mono_class_get_property_info (MonoClass *klass);
 void
 mono_class_set_property_info (MonoClass *klass, MonoClassPropertyInfo *info);
 
-MonoClassEventInfo*
+MONO_COMPONENT_API MonoClassEventInfo*
 mono_class_get_event_info (MonoClass *klass);
 
 void

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -6605,13 +6605,13 @@ static guint32
 mono_field_resolve_flags (MonoClassField *field)
 {
 	if (G_UNLIKELY (m_field_is_from_update (field))) {
-                /* metadata-update: Just resolve the whole field, for simplicity. */
-                ERROR_DECL (error);
-                mono_field_resolve_type (field, error);
-                mono_error_assert_ok (error);
-                g_assert (field->type);
-                return field->type->attrs;
-        }
+		/* metadata-update: Just resolve the whole field, for simplicity. */
+		ERROR_DECL (error);
+		mono_field_resolve_type (field, error);
+		mono_error_assert_ok (error);
+		g_assert (field->type);
+		return field->type->attrs;
+	}
 
 	MonoClass *klass = m_field_get_parent (field);
 	MonoImage *image = m_class_get_image (klass);

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2539,6 +2539,7 @@ mono_class_get_field_token (MonoClassField *field)
 static int
 mono_field_get_index (MonoClassField *field)
 {
+	/* metadata-update: the callers of this method need changes to support updates */
 	g_assert (!m_field_is_from_update (field));
 	int index = GPTRDIFF_TO_INT (field - m_class_get_fields (m_field_get_parent (field)));
 	g_assert (index >= 0 && GINT_TO_UINT32(index) < mono_class_get_field_count (m_field_get_parent (field)));
@@ -2568,6 +2569,9 @@ mono_class_get_field_default_value (MonoClassField *field, MonoTypeEnum *def_typ
 
 		mono_class_set_field_def_values (klass, def_values);
 	}
+
+	/* TODO: metadata-update - added literal fields */
+	g_assert (!m_field_is_from_update (field));
 
 	field_index = mono_field_get_index (field);
 
@@ -5547,7 +5551,7 @@ mono_field_get_rva (MonoClassField *field, int swizzle)
 
 	g_assert (field->type->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA);
 
-	/* TODO: metadata-update: make this work. */
+	/* metadata-update: TODO support added static fields with initializers. */
 	g_assert (!m_field_is_from_update (field));
 
 	def_values = mono_class_get_field_def_values_with_swizzle (klass, swizzle);

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -5554,7 +5554,7 @@ mono_field_get_rva (MonoClassField *field, int swizzle)
 
 	g_assert (field->type->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA);
 
-	/* metadata-update: TODO support added static fields with initializers. */
+	/* metadata-update: added static fields with initializers don't seem to get here */
 	g_assert (!m_field_is_from_update (field));
 
 	def_values = mono_class_get_field_def_values_with_swizzle (klass, swizzle);

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -5217,7 +5217,6 @@ mono_class_get_methods (MonoClass* klass, gpointer *iter)
 MonoProperty*
 mono_class_get_properties (MonoClass* klass, gpointer *iter)
 {
-	MonoProperty* property;
 	if (!iter)
 		return NULL;
 	if (!*iter) {

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2637,6 +2637,8 @@ mono_class_get_property_default_value (MonoProperty *property, MonoTypeEnum *def
 		}
 		return NULL;
 	}
+	/* TODO: metadata-update: if property is from update, get the token directly. */
+	g_assert (!m_property_is_from_update (property));
 	cindex = mono_metadata_get_constant_index (klass_image, mono_class_get_property_token (property), 0);
 	if (!cindex)
 		return NULL;

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2637,7 +2637,7 @@ mono_class_get_property_default_value (MonoProperty *property, MonoTypeEnum *def
 		}
 		return NULL;
 	}
-	/* TODO: metadata-update: if property is from update, get the token directly. */
+	/* metadata-update: Roslyn doesn't emit HasDefault on added properties. */
 	g_assert (!m_property_is_from_update (property));
 	cindex = mono_metadata_get_constant_index (klass_image, mono_class_get_property_token (property), 0);
 	if (!cindex)
@@ -2699,6 +2699,14 @@ guint32
 mono_class_get_property_token (MonoProperty *prop)
 {
 	MonoClass *klass = prop->parent;
+
+	if (G_UNLIKELY (m_class_get_image (klass)->has_updates)) {
+		if (G_UNLIKELY (m_property_is_from_update (prop))) {
+			uint32_t idx = mono_metadata_update_get_property_idx (prop);
+			return mono_metadata_make_token (MONO_TABLE_PROPERTY, idx);
+		}
+	}
+
 	while (klass) {
 		MonoProperty* p;
 		int i = 0;

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2510,6 +2510,13 @@ mono_class_get_field_token (MonoClassField *field)
 
 	mono_class_setup_fields (klass);
 
+	if (G_UNLIKELY (m_class_get_image (klass)->has_updates)) {
+		if (G_UNLIKELY (m_field_is_from_update (field))) {
+			uint32_t idx = mono_metadata_update_get_field_idx (field);
+			return mono_metadata_make_token (MONO_TABLE_FIELD, idx);
+		}
+	}
+
 	while (klass) {
 		MonoClassField *klass_fields = m_class_get_fields (klass);
 		if (!klass_fields)
@@ -2524,10 +2531,6 @@ mono_class_get_field_token (MonoClassField *field)
 					idx = mono_metadata_translate_token_index (m_class_get_image (klass), MONO_TABLE_FIELD, idx);
 				return mono_metadata_make_token (MONO_TABLE_FIELD, idx);
 			}
-		}
-		if (G_UNLIKELY (m_class_get_image (klass)->has_updates)) {
-			/* TODO: metadata-update: check if the field was added. */
-			g_assert_not_reached ();
 		}
 		klass = m_class_get_parent (klass);
 	}

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2656,11 +2656,17 @@ mono_class_get_event_token (MonoEvent *event)
 {
 	MonoClass *klass = event->parent;
 
+	if (G_UNLIKELY (m_class_get_image (klass)->has_updates)) {
+		if (G_UNLIKELY (m_event_is_from_update (event))) {
+			uint32_t idx = mono_metadata_update_get_event_idx (event);
+			return mono_metadata_make_token (MONO_TABLE_EVENT, idx);
+		}
+	}
+
 	while (klass) {
 		MonoClassEventInfo *info = mono_class_get_event_info (klass);
 		if (info) {
 			for (guint32 i = 0; i < info->count; ++i) {
-				/* TODO: metadata-update: get tokens for added props, too */
 				g_assert (!m_event_is_from_update (&info->events[i]));
 				if (&info->events [i] == event)
 					return mono_metadata_make_token (MONO_TABLE_EVENT, info->first + i + 1);

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -186,6 +186,8 @@ find_property_index (MonoClass *klass, MonoProperty *property)
 static guint32
 find_event_index (MonoClass *klass, MonoEvent *event)
 {
+        if (G_UNLIKELY (m_event_is_from_update (event)))
+                return mono_metadata_update_get_event_idx (event);
 	MonoClassEventInfo *info = mono_class_get_event_info (klass);
 
 	for (guint32 i = 0; i < info->count; ++i) {

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -2890,6 +2890,8 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 		}
 	} else {
 		/* FIXME: metadata-update */
+                if (G_UNLIKELY (image->has_updates))
+                        g_warning ("[WeakAttribute] ignored on fields added by hot reload in '%s'", image->name);
 
 		/* Memberref pointing to a typeref */
 		tdef = &image->tables [MONO_TABLE_MEMBERREF];

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -169,6 +169,8 @@ find_field_index (MonoClass *klass, MonoClassField *field) {
 static guint32
 find_property_index (MonoClass *klass, MonoProperty *property)
 {
+        if (G_UNLIKELY (m_property_is_from_update (property)))
+                return mono_metadata_update_get_property_idx (property);
 	MonoClassPropertyInfo *info = mono_class_get_property_info (klass);
 
 	for (guint32 i = 0; i < info->count; ++i) {

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -169,8 +169,8 @@ find_field_index (MonoClass *klass, MonoClassField *field) {
 static guint32
 find_property_index (MonoClass *klass, MonoProperty *property)
 {
-        if (G_UNLIKELY (m_property_is_from_update (property)))
-                return mono_metadata_update_get_property_idx (property);
+	if (G_UNLIKELY (m_property_is_from_update (property)))
+		return mono_metadata_update_get_property_idx (property);
 	MonoClassPropertyInfo *info = mono_class_get_property_info (klass);
 
 	for (guint32 i = 0; i < info->count; ++i) {
@@ -186,8 +186,8 @@ find_property_index (MonoClass *klass, MonoProperty *property)
 static guint32
 find_event_index (MonoClass *klass, MonoEvent *event)
 {
-        if (G_UNLIKELY (m_event_is_from_update (event)))
-                return mono_metadata_update_get_event_idx (event);
+	if (G_UNLIKELY (m_event_is_from_update (event)))
+		return mono_metadata_update_get_event_idx (event);
 	MonoClassEventInfo *info = mono_class_get_event_info (klass);
 
 	for (guint32 i = 0; i < info->count; ++i) {
@@ -364,7 +364,7 @@ handle_enum:
 			type = mono_class_enum_basetype_internal (t->data.klass)->type;
 			goto handle_enum;
 		} else {
-			MonoClass *k =  t->data.klass;
+			MonoClass *k =	t->data.klass;
 
 			if (mono_is_corlib_image (m_class_get_image (k)) && strcmp (m_class_get_name_space (k), "System") == 0 && strcmp (m_class_get_name (k), "DateTime") == 0){
 				guint64 *val = (guint64 *)g_malloc (sizeof (guint64));
@@ -704,7 +704,7 @@ handle_enum:
 			type = mono_class_enum_basetype_internal (t->data.klass)->type;
 			goto handle_enum;
 		} else {
-			MonoClass *k =  t->data.klass;
+			MonoClass *k =	t->data.klass;
 
 			if (mono_is_corlib_image (m_class_get_image (k)) && strcmp (m_class_get_name_space (k), "System") == 0 && strcmp (m_class_get_name (k), "DateTime") == 0){
 				guint64 *val = (guint64 *)g_malloc (sizeof (guint64));
@@ -2589,7 +2589,7 @@ mono_reflection_get_custom_attrs_data_checked (MonoObjectHandle obj, MonoError *
 		if (!cinfo->cached)
 			mono_custom_attrs_free (cinfo);
 		goto_if_nok (error, leave);
-	} else  {
+	} else	{
 		MonoClass *cattr_data = try_get_cattr_data_class (error);
 		goto_if_nok (error, return_null);
 
@@ -2894,8 +2894,8 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 		}
 	} else {
 		/* FIXME: metadata-update */
-                if (G_UNLIKELY (image->has_updates))
-                        g_warning ("[WeakAttribute] ignored on fields added by hot reload in '%s'", image->name);
+		if (G_UNLIKELY (image->has_updates))
+			g_warning ("[WeakAttribute] ignored on fields added by hot reload in '%s'", image->name);
 
 		/* Memberref pointing to a typeref */
 		tdef = &image->tables [MONO_TABLE_MEMBERREF];

--- a/src/mono/mono/metadata/handle.h
+++ b/src/mono/mono/metadata/handle.h
@@ -487,28 +487,6 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 
 #define mono_handle_domain(handle) MONO_HANDLE_DOMAIN ((handle))
 
-/* Given an object and a MonoClassField, return the value (must be non-object)
- * of the field.  It's the caller's responsibility to check that the object is
- * of the correct class. */
-#define MONO_HANDLE_GET_FIELD_VAL(HANDLE,TYPE,FIELD) (*(TYPE *)(mono_handle_unsafe_field_addr (MONO_HANDLE_CAST (MonoObject, (HANDLE)), (FIELD))))
-#define MONO_HANDLE_GET_FIELD_BOOL(handle, type, field) (MONO_BOOL (MONO_HANDLE_GET_FIELD_VAL ((handle), type, (field))))
-
-#define MONO_HANDLE_NEW_GET_FIELD(HANDLE,TYPE,FIELD) MONO_HANDLE_NEW (TYPE, MONO_HANDLE_SUPPRESS (*(TYPE**)(mono_handle_unsafe_field_addr (MONO_HANDLE_CAST (MonoObject, MONO_HANDLE_UNSUPPRESS (HANDLE)), (FIELD)))))
-
-#define MONO_HANDLE_SET_FIELD_VAL(HANDLE,TYPE,FIELD,VAL) do {		\
-		MonoObjectHandle __obj = (HANDLE);			\
-		MonoClassField *__field = (FIELD);			\
-		TYPE __value = (VAL);					\
-		*(TYPE*)(mono_handle_unsafe_field_addr (__obj, __field)) = __value; \
-	} while (0)
-
-#define MONO_HANDLE_SET_FIELD_REF(HANDLE,FIELD,VALH) do {		\
-		MonoObjectHandle __obj = MONO_HANDLE_CAST (MonoObject, (HANDLE)); \
-		MonoClassField *__field = (FIELD);			\
-		MonoObjectHandle __value = MONO_HANDLE_CAST (MonoObject, (VALH)); \
-		MONO_HANDLE_SUPPRESS (mono_gc_wbarrier_generic_store_internal (mono_handle_unsafe_field_addr (__obj, __field), MONO_HANDLE_RAW (__value))); \
-	} while (0)
-
 #define MONO_HANDLE_GET_CLASS(handle) (MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoObject, (handle)), vtable)->klass)
 
 /* Baked typed handles we all want */
@@ -601,15 +579,6 @@ mono_handle_assign_raw (MonoObjectHandleOut dest, void *src)
 	g_assert (dest.__raw);
 	MONO_HANDLE_SUPPRESS (*dest.__raw = (MonoObject*)src);
 	return dest;
-}
-
-/* It is unsafe to call this function directly - it does not pin the handle!  Use MONO_HANDLE_GET_FIELD_VAL(). */
-static inline gpointer
-mono_handle_unsafe_field_addr (MonoObjectHandle h, MonoClassField *field)
-{
-	/* TODO: metadata-update: fix all callers */
-	g_assert (!m_field_is_from_update (field));
-	return MONO_HANDLE_SUPPRESS (((gchar *)MONO_HANDLE_RAW (h)) + field->offset);
 }
 
 /* Matches ObjectHandleOnStack in managed code */

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6301,8 +6301,8 @@ ves_icall_System_TypedReference_InternalMakeTypedReference (MonoTypedRef *res, M
 
 	(void)mono_handle_class (target);
 
-        /* if relative, offset is from the start of target. Otherwise offset is actually an address */
-        gboolean relative = TRUE;
+	/* if relative, offset is from the start of target. Otherwise offset is actually an address */
+	gboolean relative = TRUE;
 	intptr_t offset = 0;
 	for (guint i = 0; i < mono_array_handle_length (fields); ++i) {
 		MonoClassField *f;
@@ -6311,33 +6311,33 @@ ves_icall_System_TypedReference_InternalMakeTypedReference (MonoTypedRef *res, M
 		g_assert (f);
 
 		if (i == 0) {
-                        if (G_LIKELY (!m_field_is_from_update (f)))
-                                offset = m_field_get_offset (f);
-                        else {
-                                /* The first field was added by a metadata-update to an exsiting type.
-                                 * Since it's store outside the object, offset is an absolute address
-                                 */
-                                relative = FALSE;
-                                ERROR_DECL (error);
-                                uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (f));
-                                offset = (intptr_t) mono_metadata_update_added_field_ldflda (MONO_HANDLE_RAW (target), f->type, token, error);
-                                mono_error_assert_ok (error);
-                        }
+			if (G_LIKELY (!m_field_is_from_update (f)))
+				offset = m_field_get_offset (f);
+			else {
+				/* The first field was added by a metadata-update to an exsiting type.
+				 * Since it's store outside the object, offset is an absolute address
+				 */
+				relative = FALSE;
+				ERROR_DECL (error);
+				uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (f));
+				offset = (intptr_t) mono_metadata_update_added_field_ldflda (MONO_HANDLE_RAW (target), f->type, token, error);
+				mono_error_assert_ok (error);
+			}
 		} else {
-                        /* metadata-update: the first field might be added, the rest are inside structs */
-                        g_assert (!m_field_is_from_update (f));
+			/* metadata-update: the first field might be added, the rest are inside structs */
+			g_assert (!m_field_is_from_update (f));
 			offset += m_field_get_offset (f) - sizeof (MonoObject);
-                }
+		}
 		(void)mono_class_from_mono_type_internal (f->type);
 		ftype = f->type;
 	}
 
 	res->type = ftype;
 	res->klass = mono_class_from_mono_type_internal (ftype);
-        if (G_LIKELY (relative))
-                res->value = (guint8*)MONO_HANDLE_RAW (target) + offset;
-        else
-                res->value = (guint8*)offset;
+	if (G_LIKELY (relative))
+		res->value = (guint8*)MONO_HANDLE_RAW (target) + offset;
+	else
+		res->value = (guint8*)offset;
 }
 
 void

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6519,6 +6519,9 @@ ves_icall_property_info_get_default_value (MonoReflectionPropertyHandle property
 		return NULL_HANDLE;
 	}
 
+	/* metadata-update: looks like Roslyn doesn't set the HasDefault attribute for updates */
+	g_assert (!m_property_is_from_update (prop));
+
 	def_value = mono_class_get_property_default_value (prop, &def_type);
 
 	mono_type_from_blob_type (&blob_type, def_type, type);

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2027,7 +2027,7 @@ ves_icall_RuntimeFieldInfo_GetFieldOffset (MonoReflectionFieldHandle field, Mono
 	MonoClassField *class_field = MONO_HANDLE_GETVAL (field, field);
 	mono_class_setup_fields (m_field_get_parent (class_field));
 
-	/* TODO: metadata-update: figure out what CoreCLR does in this situation. */
+	/* metadata-update: mono only calls this for ExplicitLayout types */
 	g_assert (!m_field_is_from_update (class_field));
 
 	return m_field_get_offset (class_field) - MONO_ABI_SIZEOF (MonoObject);

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6318,7 +6318,6 @@ ves_icall_System_TypedReference_InternalMakeTypedReference (MonoTypedRef *res, M
 				 * Since it's store outside the object, offset is an absolute address
 				 */
 				relative = FALSE;
-				ERROR_DECL (error);
 				uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (f));
 				offset = (intptr_t) mono_metadata_update_added_field_ldflda (MONO_HANDLE_RAW (target), f->type, token, error);
 				mono_error_assert_ok (error);

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -255,3 +255,9 @@ mono_metadata_update_get_property_idx (MonoProperty *prop)
 {
         return mono_component_hot_reload()->get_property_idx (prop);
 }
+
+MonoEvent *
+mono_metadata_update_added_events_iter (MonoClass *klass, gpointer *iter)
+{
+        return mono_component_hot_reload()->added_events_iter (klass, iter);
+}

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -249,3 +249,9 @@ mono_metadata_update_added_properties_iter (MonoClass *klass, gpointer *iter)
 {
 	return mono_component_hot_reload()->added_properties_iter (klass, iter);
 }
+
+uint32_t
+mono_metadata_update_get_property_idx (MonoProperty *prop)
+{
+        return mono_component_hot_reload()->get_property_idx (prop);
+}

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -242,3 +242,10 @@ mono_metadata_update_added_field_ldflda (MonoObject *instance, MonoType *field_t
 {
 	return mono_component_hot_reload()->added_field_ldflda (instance, field_type, fielddef_token, error);
 }
+
+
+MonoProperty *
+mono_metadata_update_added_properties_iter (MonoClass *klass, gpointer *iter)
+{
+	return mono_component_hot_reload()->added_properties_iter (klass, iter);
+}

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -236,3 +236,9 @@ mono_metadata_update_get_method_params (MonoImage *image, uint32_t methoddef_tok
 {
 	return mono_component_hot_reload()->get_method_params (image, methoddef_token, out_param_count_opt);
 }
+
+gpointer
+mono_metadata_update_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error)
+{
+	return mono_component_hot_reload()->added_field_ldflda (instance, field_type, fielddef_token, error);
+}

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -261,3 +261,9 @@ mono_metadata_update_added_events_iter (MonoClass *klass, gpointer *iter)
 {
         return mono_component_hot_reload()->added_events_iter (klass, iter);
 }
+
+uint32_t
+mono_metadata_update_get_event_idx (MonoEvent *evt)
+{
+        return mono_component_hot_reload()->get_event_idx (evt);
+}

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -109,4 +109,8 @@ mono_metadata_update_get_property_idx (MonoProperty *prop);
 MonoEvent *
 mono_metadata_update_added_events_iter (MonoClass *klass, gpointer *iter);
 
+uint32_t
+mono_metadata_update_get_event_idx (MonoEvent *event);
+
+
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -103,4 +103,7 @@ mono_metadata_update_added_field_ldflda (MonoObject *instance, MonoType *field_t
 MonoProperty *
 mono_metadata_update_added_properties_iter (MonoClass *klass, gpointer *iter);
 
+uint32_t
+mono_metadata_update_get_property_idx (MonoProperty *prop);
+
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -96,4 +96,8 @@ mono_metadata_update_get_num_methods_added (MonoClass *klass);
 
 uint32_t
 mono_metadata_update_get_method_params (MonoImage *image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
+
+gpointer
+mono_metadata_update_ldflda (MonoObject *instance, MonoType *field_type, guint32 fielddef_token, MonoError *error);
+
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -98,6 +98,6 @@ uint32_t
 mono_metadata_update_get_method_params (MonoImage *image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
 
 gpointer
-mono_metadata_update_ldflda (MonoObject *instance, MonoType *field_type, guint32 fielddef_token, MonoError *error);
+mono_metadata_update_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
 
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -64,7 +64,7 @@ mono_metadata_update_metadata_linear_search (MonoImage *base_image, MonoTableInf
 MonoMethod*
 mono_metadata_update_find_method_by_name (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 
-uint32_t
+MONO_COMPONENT_API uint32_t
 mono_metadata_update_get_field_idx (MonoClassField *field);
 
 MonoClassField *
@@ -97,7 +97,7 @@ mono_metadata_update_get_num_methods_added (MonoClass *klass);
 uint32_t
 mono_metadata_update_get_method_params (MonoImage *image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
 
-gpointer
+MONO_COMPONENT_API gpointer
 mono_metadata_update_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
 
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -106,4 +106,7 @@ mono_metadata_update_added_properties_iter (MonoClass *klass, gpointer *iter);
 uint32_t
 mono_metadata_update_get_property_idx (MonoProperty *prop);
 
+MonoEvent *
+mono_metadata_update_added_events_iter (MonoClass *klass, gpointer *iter);
+
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -100,4 +100,7 @@ mono_metadata_update_get_method_params (MonoImage *image, uint32_t methoddef_tok
 MONO_COMPONENT_API gpointer
 mono_metadata_update_added_field_ldflda (MonoObject *instance, MonoType *field_type, uint32_t fielddef_token, MonoError *error);
 
+MonoProperty *
+mono_metadata_update_added_properties_iter (MonoClass *klass, gpointer *iter);
+
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6192,7 +6192,7 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 		loc.col_idx = MONO_FIELD_LAYOUT_FIELD;
 		loc.t = tdef;
 
-		/* FIXME: metadata-update */
+		/* metadata-update: explicit layout not supported, just return -1 */
 
 		if (tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator)) {
 			*offset = mono_metadata_decode_row_col (tdef, loc.result, MONO_FIELD_LAYOUT_OFFSET);
@@ -6206,7 +6206,14 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 		loc.col_idx = MONO_FIELD_RVA_FIELD;
 		loc.t = tdef;
 
-		if (tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator)) {
+                gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator);
+
+                if (G_UNLIKELY (meta->has_updates)) {
+                        if (!found)
+                                found = (mono_metadata_update_metadata_linear_search (meta, tdef, &loc, table_locator) != NULL);
+                }
+
+		if (found) {
 			/*
 			 * LAMESPEC: There is no signature, no nothing, just the raw data.
 			 */

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6440,10 +6440,16 @@ mono_metadata_properties_from_typedef (MonoImage *meta, guint32 index, guint *en
 	}
 
 	start = mono_metadata_decode_row_col (tdef, loc.result, MONO_PROPERTY_MAP_PROPERTY_LIST);
-	if (loc.result + 1 < mono_metadata_table_num_rows (meta, MONO_TABLE_PROPERTYMAP)) {
+        /*
+         * metadata-update: note this next line needs block needs to look at the number of rows in
+         * PropertyMap and Property of the base image.  Updates will add rows for new properties,
+         * but they won't be contiguous.  if we set end to the number of rows in the updated
+         * Property table, the range will include properties from some other class
+         */
+	if (loc.result + 1 < table_info_get_rows (&meta->tables [MONO_TABLE_PROPERTYMAP])) {
 		end = mono_metadata_decode_row_col (tdef, loc.result + 1, MONO_PROPERTY_MAP_PROPERTY_LIST) - 1;
 	} else {
-		end = mono_metadata_table_num_rows (meta, MONO_TABLE_PROPERTY);
+		end = table_info_get_rows (&meta->tables [MONO_TABLE_PROPERTY]);
 	}
 
 	*end_idx = GUINT32_TO_UINT(end);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6327,6 +6327,12 @@ mono_metadata_events_from_typedef (MonoImage *meta, guint32 index, guint *end_id
 	}
 
 	start = mono_metadata_decode_row_col (tdef, loc.result, MONO_EVENT_MAP_EVENTLIST);
+        /*
+         * metadata-update: note this next line needs block needs to look at the number of rows in
+         * EventMap and Event of the base image.  Updates will add rows for new properties,
+         * but they won't be contiguous.  if we set end to the number of rows in the updated
+         * Property table, the range will include properties from some other class
+         */
 	if (loc.result + 1 < table_info_get_rows (tdef)) {
 		end = mono_metadata_decode_row_col (tdef, loc.result + 1, MONO_EVENT_MAP_EVENTLIST) - 1;
 	} else {

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6180,7 +6180,7 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 				       MonoMarshalSpec **marshal_spec, gboolean alloc_from_image)
 {
 	MonoTableInfo *tdef;
-	locator_t loc;
+	locator_t loc = {0,};
 
 	loc.idx = index + 1;
 	if (meta->uncompressed_metadata)
@@ -6946,7 +6946,7 @@ handle_enum:
 const char*
 mono_metadata_get_marshal_info (MonoImage *meta, guint32 idx, gboolean is_field)
 {
-	locator_t loc;
+	locator_t loc = {0,};
 	MonoTableInfo *tdef  = &meta->tables [MONO_TABLE_FIELDMARSHAL];
 
 	loc.t = tdef;

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -2932,10 +2932,14 @@ mono_field_get_value_internal (MonoObject *obj, MonoClassField *field, void *val
 
 	g_return_if_fail (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC));
 
-	/* TODO: metadata-update: implement me */
-	g_assert (!m_field_is_from_update (field));
-
-	src = (char*)obj + m_field_get_offset (field);
+	if (G_UNLIKELY (m_field_is_from_update (field))) {
+                ERROR_DECL (error);
+                uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (field));
+                src = mono_metadata_update_added_field_ldflda (obj, field->type, token, error);
+                mono_error_assert_ok (error);
+        } else {
+                src = (char*)obj + m_field_get_offset (field);
+        }
 	mono_copy_value (field->type, value, src, TRUE);
 }
 

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -2773,13 +2773,13 @@ mono_field_set_value_internal (MonoObject *obj, MonoClassField *field, void *val
 	if ((field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 		return;
 
-        if (G_UNLIKELY (m_field_is_from_update (field))) {
-                ERROR_DECL (error);
-                uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (field));
-                dest = mono_metadata_update_added_field_ldflda (obj, field->type, token, error);
-                mono_error_assert_ok (error);
-        } else
-                dest = (char*)obj + m_field_get_offset (field);
+	if (G_UNLIKELY (m_field_is_from_update (field))) {
+		ERROR_DECL (error);
+		uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (field));
+		dest = mono_metadata_update_added_field_ldflda (obj, field->type, token, error);
+		mono_error_assert_ok (error);
+	} else
+		dest = (char*)obj + m_field_get_offset (field);
 
 	mono_copy_value (field->type, dest, value, value && field->type->type == MONO_TYPE_PTR);
 }
@@ -2937,13 +2937,13 @@ mono_field_get_value_internal (MonoObject *obj, MonoClassField *field, void *val
 	g_return_if_fail (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC));
 
 	if (G_UNLIKELY (m_field_is_from_update (field))) {
-                ERROR_DECL (error);
-                uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (field));
-                src = mono_metadata_update_added_field_ldflda (obj, field->type, token, error);
-                mono_error_assert_ok (error);
-        } else {
-                src = (char*)obj + m_field_get_offset (field);
-        }
+		ERROR_DECL (error);
+		uint32_t token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (field));
+		src = mono_metadata_update_added_field_ldflda (obj, field->type, token, error);
+		mono_error_assert_ok (error);
+	} else {
+		src = (char*)obj + m_field_get_offset (field);
+	}
 	mono_copy_value (field->type, value, src, TRUE);
 }
 

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -7823,6 +7823,7 @@ mono_class_value_size (MonoClass *klass, guint32 *align)
 gpointer
 mono_vtype_get_field_addr (gpointer vtype, MonoClassField *field)
 {
+        /* metadata-update: no added fields in valuetypes */
 	g_assert (!m_field_is_from_update (field));
 	return ((char*)vtype) + m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject);
 }

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -2502,7 +2502,9 @@ mono_reflection_get_token_checked (MonoObjectHandle obj, MonoError *error)
 	} else if (strcmp (klass_name, "RuntimePropertyInfo") == 0) {
 		MonoReflectionPropertyHandle p = MONO_HANDLE_CAST (MonoReflectionProperty, obj);
 
-		token = mono_class_get_property_token (MONO_HANDLE_GETVAL (p, property));
+		MonoProperty *prop = MONO_HANDLE_GETVAL (p, property);
+		g_assert (!m_property_is_from_update (prop)); // TODO: metadata-update: get the token directly
+		token = mono_class_get_property_token (prop);
 	} else if (strcmp (klass_name, "RuntimeEventInfo") == 0) {
 		MonoReflectionMonoEventHandle p = MONO_HANDLE_CAST (MonoReflectionMonoEvent, obj);
 

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -2503,7 +2503,6 @@ mono_reflection_get_token_checked (MonoObjectHandle obj, MonoError *error)
 		MonoReflectionPropertyHandle p = MONO_HANDLE_CAST (MonoReflectionProperty, obj);
 
 		MonoProperty *prop = MONO_HANDLE_GETVAL (p, property);
-		g_assert (!m_property_is_from_update (prop)); // TODO: metadata-update: get the token directly
 		token = mono_class_get_property_token (prop);
 	} else if (strcmp (klass_name, "RuntimeEventInfo") == 0) {
 		MonoReflectionMonoEventHandle p = MONO_HANDLE_CAST (MonoReflectionMonoEvent, obj);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3011,6 +3011,7 @@ mono_get_field_token (MonoClassField *field)
 	MonoClass *klass = m_field_get_parent (field);
 	int i;
 
+	/* metadata-update: there are no updates during AOT */
 	g_assert (!m_field_is_from_update (field));
 	int fcount = mono_class_get_field_count (klass);
 	MonoClassField *klass_fields = m_class_get_fields (klass);

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7507,10 +7507,13 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_METADATA_UPDATE_LDFLDA) {
 			gpointer *dest = LOCAL_VAR (ip [1], gpointer);
 			MonoObject *inst = LOCAL_VAR (ip [2], MonoObject*);
-			MonoType *field_type = frame->imethod->data_items [ip [3]]; // correct offset?
-			MonoType *fielddef_token = frame->imethod->data_items [ip [4]]; // offset?
+			MonoType *field_type = frame->imethod->data_items [ip [3]];
+			uint32_t fielddef_token = GPOINTER_TO_UINT32 (frame->imethod->data_items [ip [4]]);
 			// FIXME: can we emit a call directly instead of a runtime-invoke?
-			*dest = mono_metadata_update_ldflda (inst, field_type, fielddef_token, error); // FIXME write barrier
+			gpointer field_addr = mono_metadata_update_added_field_ldflda (inst, field_type, fielddef_token, error);
+			mono_gc_wbarrier_generic_store_internal (dest, field_addr);
+			/* FIXME: think about pinning the FieldStore and adding a second opcode to
+			 * unpin it */
 			mono_interp_error_cleanup (error);
 			ip += 5;
 			MINT_IN_BREAK;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7504,7 +7504,17 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			ip += 3;
 			MINT_IN_BREAK;
 		}
-
+		MINT_IN_CASE(MINT_METADATA_UPDATE_LDFLDA) {
+			gpointer *dest = LOCAL_VAR (ip [1], gpointer);
+			MonoObject *inst = LOCAL_VAR (ip [2], MonoObject*);
+			MonoType *field_type = frame->imethod->data_items [ip [3]]; // correct offset?
+			MonoType *fielddef_token = frame->imethod->data_items [ip [4]]; // offset?
+			// FIXME: can we emit a call directly instead of a runtime-invoke?
+			*dest = mono_metadata_update_ldflda (inst, field_type, fielddef_token, error); // FIXME write barrier
+			mono_interp_error_cleanup (error);
+			ip += 5;
+			MINT_IN_BREAK;
+		}
 #ifdef HOST_BROWSER
 		MINT_IN_CASE(MINT_TIER_NOP_JITERPRETER) {
 			ip += 3;
@@ -7611,7 +7621,6 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MINT_IN_BREAK;
 		}
 #endif
-
 #if !USE_COMPUTED_GOTO
 		default:
 			interp_error_xsx ("Unimplemented opcode: %04x %s at 0x%x\n", *ip, mono_interp_opname (*ip), GPTRDIFF_TO_INT (ip - frame->imethod->code));

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7505,15 +7505,15 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_METADATA_UPDATE_LDFLDA) {
-			gpointer *dest = LOCAL_VAR (ip [1], gpointer);
+			gpointer *dest = (gpointer*)(locals + ip [1]);
 			MonoObject *inst = LOCAL_VAR (ip [2], MonoObject*);
 			MonoType *field_type = frame->imethod->data_items [ip [3]];
 			uint32_t fielddef_token = GPOINTER_TO_UINT32 (frame->imethod->data_items [ip [4]]);
 			// FIXME: can we emit a call directly instead of a runtime-invoke?
 			gpointer field_addr = mono_metadata_update_added_field_ldflda (inst, field_type, fielddef_token, error);
-			mono_gc_wbarrier_generic_store_internal (dest, field_addr);
 			/* FIXME: think about pinning the FieldStore and adding a second opcode to
 			 * unpin it */
+			mono_gc_wbarrier_generic_store_internal (dest, field_addr);
 			mono_interp_error_cleanup (error);
 			ip += 5;
 			MINT_IN_BREAK;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7505,7 +7505,6 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_METADATA_UPDATE_LDFLDA) {
-			gpointer *dest = (gpointer*)(locals + ip [1]);
 			MonoObject *inst = LOCAL_VAR (ip [2], MonoObject*);
 			MonoType *field_type = frame->imethod->data_items [ip [3]];
 			uint32_t fielddef_token = GPOINTER_TO_UINT32 (frame->imethod->data_items [ip [4]]);
@@ -7513,7 +7512,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gpointer field_addr = mono_metadata_update_added_field_ldflda (inst, field_type, fielddef_token, error);
 			/* FIXME: think about pinning the FieldStore and adding a second opcode to
 			 * unpin it */
-			mono_gc_wbarrier_generic_store_internal (dest, field_addr);
+			LOCAL_VAR (ip [1], gpointer) = field_addr;
 			mono_interp_error_cleanup (error);
 			ip += 5;
 			MINT_IN_BREAK;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7623,6 +7623,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MINT_IN_BREAK;
 		}
 #endif
+
 #if !USE_COMPUTED_GOTO
 		default:
 			interp_error_xsx ("Unimplemented opcode: %04x %s at 0x%x\n", *ip, mono_interp_opname (*ip), GPTRDIFF_TO_INT (ip - frame->imethod->code));

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -806,5 +806,3 @@ OPDEF(MINT_METADATA_UPDATE_LDFLDA, "metadata_update.ldflda", 5, 1, 1, MintOpTwoS
 OPDEF(MINT_TIER_PREPARE_JITERPRETER, "tier_prepare_jiterpreter", 3, 0, 0, MintOpInt)
 OPDEF(MINT_TIER_NOP_JITERPRETER, "tier_nop_jiterpreter", 3, 0, 0, MintOpInt)
 OPDEF(MINT_TIER_ENTER_JITERPRETER, "tier_enter_jiterpreter", 3, 0, 0, MintOpInt)
-
-

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -800,7 +800,11 @@ OPDEF(MINT_INTRINS_64ORDINAL_IGNORE_CASE_ASCII, "intrins_64ordinal_ignore_case_a
 OPDEF(MINT_INTRINS_U32_TO_DECSTR, "intrins_u32_to_decstr", 5, 1, 1, MintOpTwoShorts)
 OPDEF(MINT_INTRINS_WIDEN_ASCII_TO_UTF16, "intrins_widen_ascii_to_utf16", 5, 1, 3, MintOpNoArgs)
 
+OPDEF(MINT_METADATA_UPDATE_LDFLDA, "metadata_update.ldflda", 5, 1, 1, MintOpTwoShorts)
+
 // TODO: Make this wasm only
 OPDEF(MINT_TIER_PREPARE_JITERPRETER, "tier_prepare_jiterpreter", 3, 0, 0, MintOpInt)
 OPDEF(MINT_TIER_NOP_JITERPRETER, "tier_nop_jiterpreter", 3, 0, 0, MintOpInt)
 OPDEF(MINT_TIER_ENTER_JITERPRETER, "tier_enter_jiterpreter", 3, 0, 0, MintOpInt)
+
+

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6076,7 +6076,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					if (G_UNLIKELY (m_field_is_from_update (field))) {
 						/* metadata-update: can't add byref fields */
 						g_assert (!m_type_is_byref (ftype));
-						MonoClass *field_class = mono_class_from_mono_type_internal (ftype);
 						interp_emit_metadata_update_ldflda (td, field, error);
 						goto_if_nok (error, exit);
 						td->ip += 5;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -1935,16 +1935,6 @@ interp_emit_metadata_update_ldflda (TransformData *td, MonoClassField *field, Mo
 	field_type = m_class_get_byval_arg (field_klass);
 	guint32 field_token = mono_metadata_make_token (MONO_TABLE_FIELD, mono_metadata_update_get_field_idx (field));
 
-#if 0
-	// FIXME: this should go in interp.c
-	static MonoMethod *get_instance_store = NULL;
-	if (G_UNLIKELY (get_instance_store == NULL)) {
-		MonoClass *table_class = mono_class_get_hot_reload_instance_field_table_class ();
-		get_instance_store = mono_class_get_method_from_name_checked (table_class, "GetInstanceFieldStore", 3, 0, error);
-		mono_error_assert_ok (error);
-	}
-	g_assert (get_instance_store);
-#endif
 	interp_add_ins (td, MINT_METADATA_UPDATE_LDFLDA);
 	td->sp--;
 	interp_ins_set_sreg (td->last_ins, td->sp [0].local);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6124,7 +6124,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					interp_emit_sfld_access (td, field, field_klass, mt, TRUE, error);
 					goto_if_nok (error, exit);
 				} else if (td->sp [-1].type == STACK_TYPE_VT) {
-					/* TODO: metadata-update: implement me */
+					/* metadata-update: can't add fields to structs */
 					g_assert (!m_field_is_from_update (field));
 					int size = 0;
 					/* First we pop the vt object from the stack. Then we push the field */
@@ -6153,7 +6153,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					if (G_UNLIKELY (m_field_is_from_update (field))) {
 						g_assert (!m_type_is_byref (field->type));
 						MonoClass *field_class = mono_class_from_mono_type_internal (field->type);
-						MonoType *local_type = m_class_get_byval_arg (field_class);
 						interp_emit_metadata_update_ldflda (td, field, error);
 						goto_if_nok (error, exit);
 						interp_add_ins (td, interp_get_ldind_for_mt (mt));

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6072,7 +6072,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					interp_emit_ldsflda (td, field, error);
 					goto_if_nok (error, exit);
 				} else {
-					/* TODO: metadata-update: implement me. If it's an added field, emit a call to the helper method instead of MINT_LDFLDA_UNSAFE */
 					if (G_UNLIKELY (m_field_is_from_update (field))) {
 						/* metadata-update: can't add byref fields */
 						g_assert (!m_type_is_byref (ftype));

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6229,7 +6229,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 						td->ip += 5;
 						break;
 					}
-						
 					int opcode = MINT_STFLD_I1 + mt - MINT_TYPE_I1;
 #ifdef NO_UNALIGNED_ACCESS
 					if ((mt == MINT_TYPE_I8 || mt == MINT_TYPE_R8) && field->offset % SIZEOF_VOID_P != 0)

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -391,6 +391,7 @@ collect_field_info_nested (MonoClass *klass, GArray *fields_array, int offset, g
 		while ((field = mono_class_get_fields_internal (klass, &iter))) {
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
+			/* metadata-update: we're in the JIT here, right? updates aren't supported */
 			g_assert (!m_field_is_from_update (field));
 			if (MONO_TYPE_ISSTRUCT (field->type)) {
 				collect_field_info_nested (mono_class_from_mono_type_internal (field->type), fields_array, m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject), pinvoke, unicode);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -844,7 +844,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             var assemblyName = await context.SdbAgent.GetAssemblyNameFromModule(moduleId, token);
             DebugStore store = await LoadStore(sessionId, true, token);
             AssemblyInfo asm = store.GetAssemblyByName(assemblyName);
-            var methods = DebugStore.EnC(asm, meta_buf, pdb_buf);
+            var methods = DebugStore.EnC(context.SdbAgent, asm, meta_buf, pdb_buf);
             foreach (var method in methods)
             {
                 await ResetBreakpoint(sessionId, store, method, token);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -833,6 +833,10 @@ namespace Microsoft.WebAssembly.Diagnostics
             ClearCache();
         }
 
+        public void ResetTypes() {
+            this.types = new ();
+        }
+
         public async Task<AssemblyInfo> GetAssemblyInfo(int assemblyId, CancellationToken token)
         {
             if (assemblies.TryGetValue(assemblyId, out AssemblyInfo asm))

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -583,7 +583,13 @@ namespace DebuggerTests
                                        locals_fn: async (locals) => {
                                            //var c_props1 = await GetObjectOnFrame (locals, "c");
                                            _testOutput.WriteLine ("aleksey cprops1 ---- {0}", locals);
-                                           await CheckProps (locals, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields+C"), "c", num_fields: 1);
+                                           //await CheckProps (locals, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields+C"), "c", num_fields: 1);
+                                           await CheckObject(locals, "c", "ApplyUpdateReferencedAssembly.AddInstanceFields.C");
+                                           var c = await GetObjectOnLocals(locals, "c");
+                                           // TODO: get the field "Field1" from "c" and check its value
+                                           await CheckProps (c, new {
+                                                           Field1 = TNumber(123),
+                                                   }, "c", num_fields: 1);
                                        });
 #if false
             await SendCommandAndCheck (JObject.FromObject(new { }), "Debugger.resume", script_loc: null, line: -1, column: -1, function_name: null,

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -573,15 +573,19 @@ namespace DebuggerTests
             var pause_location = await LoadAssemblyAndTestHotReload(asm_file, pdb_file, asm_file_hot_reload, "AddInstanceFields", "StaticMethod1",
                                                                     expectBpResolvedEvent: false, sourcesToWait: new string [] { "MethodBody2.cs" });
             var frame = pause_location["callFrames"][0];
-            var c_props = await GetObjectOnFrame (frame, "c");
+            var locals = await GetProperties(frame["callFrameId"].Value<string>());
+            await CheckObject(locals, "c", "ApplyUpdateReferencedAssembly.AddInstanceFields.C");
+            //var c_props = await GetObjectOnFrame (frame, "c");
+            //_testOutput.WriteLine ("aleksey cprops ---- {0}", c_props.ToString());
+            //await CheckProps (c_props, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields.C"), "c", num_fields: 0);
             _testOutput.WriteLine ("aleksey 234");
-#if false
-            await CheckProps (c_props, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields+C"), "c", num_fields: 0);
             await SendCommandAndCheck (JObject.FromObject(new { }), "Debugger.resume", script_loc: null, line: -1, column: -1, function_name: null,
                                        locals_fn: async (locals) => {
-                                           var c_props1 = await GetObjectOnFrame (locals, "c");
-                                           await CheckProps (c_props1, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields+C"), "c1", num_fields: 1);
+                                           //var c_props1 = await GetObjectOnFrame (locals, "c");
+                                           _testOutput.WriteLine ("aleksey cprops1 ---- {0}", locals);
+                                           await CheckProps (locals, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields+C"), "c", num_fields: 1);
                                        });
+#if false
             await SendCommandAndCheck (JObject.FromObject(new { }), "Debugger.resume", script_loc: null, line: -1, column: -1, function_name: null,
                                        locals_fn: async (locals) => {
                                            var c_props2 = await GetObjectOnFrame (locals, "c");

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -561,5 +561,33 @@ namespace DebuggerTests
             CheckLocation("dotnet://ApplyUpdateReferencedAssembly2.dll/MethodBody2.cs", 12, 12, scripts, pause_location["callFrames"]?[0]["location"]);
             await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", $"dotnet://ApplyUpdateReferencedAssembly2.dll/MethodBody2.cs", 18, 12, "ApplyUpdateReferencedAssembly.AddMethod.StaticMethod2");
         }
+
+        [ConditionalFact(nameof(RunningOnChrome))]
+        public async Task DebugHotReload_NewInstanceFields()
+        {
+            string asm_name = "ApplyUpdateReferencedAssembly3";
+            string asm_file = Path.Combine (DebuggerTestAppPath, asm_name + ".dll");
+            string pdb_file = Path.Combine (DebuggerTestAppPath, asm_name + ".pdb");
+            string asm_file_hot_reload = Path.Combine (DebuggerTestAppPath, "..", "wasm", asm_name+ ".dll");
+            _testOutput.WriteLine ("aleksey 123");
+            var pause_location = await LoadAssemblyAndTestHotReload(asm_file, pdb_file, asm_file_hot_reload, "AddInstanceFields", "StaticMethod1",
+                                                                    expectBpResolvedEvent: false, sourcesToWait: new string [] { "MethodBody2.cs" });
+            var frame = pause_location["callFrames"][0];
+            var c_props = await GetObjectOnFrame (frame, "c");
+            _testOutput.WriteLine ("aleksey 234");
+#if false
+            await CheckProps (c_props, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields+C"), "c", num_fields: 0);
+            await SendCommandAndCheck (JObject.FromObject(new { }), "Debugger.resume", script_loc: null, line: -1, column: -1, function_name: null,
+                                       locals_fn: async (locals) => {
+                                           var c_props1 = await GetObjectOnFrame (locals, "c");
+                                           await CheckProps (c_props1, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields+C"), "c1", num_fields: 1);
+                                       });
+            await SendCommandAndCheck (JObject.FromObject(new { }), "Debugger.resume", script_loc: null, line: -1, column: -1, function_name: null,
+                                       locals_fn: async (locals) => {
+                                           var c_props2 = await GetObjectOnFrame (locals, "c");
+                                           await CheckProps (c_props2, TObject("ApplyUpdateReferencedAssembly.AddInstanceFields+C"), "c2", num_fields: 2);
+                                       });
+#endif
+        }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -577,7 +577,6 @@ namespace DebuggerTests
             await SendCommandAndCheck (JObject.FromObject(new { }), "Debugger.resume", script_loc: null, line: -1, column: -1, function_name: null,
                                        locals_fn: async (locals) => {
                                            await CheckObject(locals, "c", "ApplyUpdateReferencedAssembly.AddInstanceFields.C");
-#if true
                                            var c = await GetObjectOnLocals(locals, "c");
                                            await CheckProps (c, new {
                                                            Field1 = TNumber(123),
@@ -589,14 +588,11 @@ namespace DebuggerTests
                                            await CheckProps (c, new {
                                                            Field1 = TNumber("456.5", isDecimal: true),
                                                    }, "c", num_fields: 1);
-#endif
                                        });
             await SendCommandAndCheck (JObject.FromObject(new { }), "Debugger.resume", script_loc: null, line: -1, column: -1, function_name: null,
                                        locals_fn: async (locals) => {
-                                           _testOutput.WriteLine ("aleksey cprops1 ---- {0}", locals);
                                            await CheckObject(locals, "c", "ApplyUpdateReferencedAssembly.AddInstanceFields.C");
                                            var c = await GetObjectOnLocals(locals, "c");
-                                           _testOutput.WriteLine ("aleksey cprops1 ---- {0}", c);
                                            await CheckProps (c, new {
                                                            Field1 = TNumber(123),
                                                            Field2 = TString("spqr"),

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/ApplyUpdateReferencedAssembly3.csproj
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/ApplyUpdateReferencedAssembly3.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="EnableAggressiveTrimming;PublishTrimmed">
+  <PropertyGroup>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+    <OutputType>library</OutputType>
+    <IsTestProject>false</IsTestProject>
+    <IsTestSupportProject>true</IsTestSupportProject>
+    <!-- to call AsssemblyExtensions.ApplyUpdate we need Optimize=false, EmitDebugInformation=true in all configurations -->
+    <Optimize>false</Optimize>
+    <EmitDebugInformation>true</EmitDebugInformation>
+    <!-- hot reload is not compatible with trimming -->
+    <EnableAggressiveTrimming>false</EnableAggressiveTrimming>
+    <PublishTrimmed>false</PublishTrimmed>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EmbedAllSources>true</EmbedAllSources>
+
+    <!-- FIXME: issue -->
+    <DisableSourceLink>true</DisableSourceLink>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="MethodBody2.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- This package from https://github.com/dotnet/hotreload-utils provides
+         targets that read the json delta script and generates deltas based on the baseline assembly and the modified sources.
+
+         Projects must define the DeltaScript property that specifies the (relative) path to the json script.
+         Deltas will be emitted next to the output assembly.  Deltas will be copied when the current
+         project is referenced from other other projects.
+    -->
+    <PackageReference Include="Microsoft.DotNet.HotReload.Utils.Generator.BuildTool" Version="$(MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion)" />
+  </ItemGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/MethodBody2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/MethodBody2.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class AddInstanceFields {
+        public static string StaticMethod1 () {
+            C c = new();
+            Debugger.Break();
+            return "OLD STRING";
+        }
+
+        public class C {
+            public C()
+            {
+            }
+        }
+
+    }
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/MethodBody2_v1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/MethodBody2_v1.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class AddInstanceFields {
+        public static string StaticMethod1 () {
+            C c = new();
+            Debugger.Break();
+            return "OLD STRING";
+        }
+
+        public class C {
+            public C()
+            {
+                Field1 = 123.0;
+            }
+            public double Field1;
+        }
+    }
+
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/MethodBody2_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/MethodBody2_v2.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System;
+//keep the same line number for class in the original file and the updates ones
+namespace ApplyUpdateReferencedAssembly
+{
+    public class AddInstanceFields {
+        public static string StaticMethod1 () {
+            C c = new();
+            Debugger.Break();
+            return "OLD STRING";
+        }
+
+        public class C {
+            public C()
+            {
+                Field1 = 123.0;
+                Field2 = "abcd";
+            }
+            public double Field1;
+            public string Field2;
+        }
+    }
+        
+}

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/MethodBody2_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/MethodBody2_v2.cs
@@ -9,6 +9,7 @@ namespace ApplyUpdateReferencedAssembly
     public class AddInstanceFields {
         public static string StaticMethod1 () {
             C c = new();
+            c.Field2 = "spqr";
             Debugger.Break();
             return "OLD STRING";
         }

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/deltascript.json
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly3/deltascript.json
@@ -1,0 +1,7 @@
+{
+    "changes": [
+        {"document": "MethodBody2.cs", "update": "MethodBody2_v1.cs"},
+        {"document": "MethodBody2.cs", "update": "MethodBody2_v2.cs"}
+    ]
+}
+

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -21,6 +21,7 @@
     <!-- We want to bundle these assemblies, so build them first -->
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly2\ApplyUpdateReferencedAssembly2.csproj" />
+    <ProjectReference Include="..\ApplyUpdateReferencedAssembly3\ApplyUpdateReferencedAssembly3.csproj" />
     <ProjectReference Include="..\ApplyUpdateReferencedAssemblyChineseCharInPathㄨ\ApplyUpdateReferencedAssemblyChineseCharInPathㄨ.csproj" />
     <ProjectReference Include="..\debugger-test-special-char-in-path-#@\debugger-test-special-char-in-path.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\debugger-test-chinese-char-in-path-ㄨ\debugger-test-chinese-char-in-path-ㄨ.csproj" ReferenceOutputAssembly="false" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/63643

Remaining work:
- [x] get/set fields in the debugger
- [x] Add instance properties
- [x] verify `ves_icall_property_info_get_default_value`works with added props
- [x] Add instance events (need added skeletons)
- [x] `mono_class_get_field_token`
- [x] `mono_class_get_event_token`
- [x] `mono_class_get_property_token`
- [x] `mono_field_get_rva`
- [x] `init_weak_fields_inner`
- [x] `ves_icall_RuntimeFieldInfo_GetFieldOffset`
- [x] `ves_icall_System_RuntimeFieldHandle_GetValueDirect`/`SetValueDirect`
- [x] audit callers of `mono_handle_unsafe_field_addr`
- [x] `mono_metadata_field_info_full`
- [x] `mono_metadata_get_marshal_info`, possibly
