### PR TITLE
Remove .dll from Interop.Libraries.HostPolicy for consistency with other runtime libraries

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -44,7 +44,7 @@ internal static partial class Interop
         internal const string CompressionNative = "System.IO.Compression.Native";
         internal const string GlobalizationNative = "System.Globalization.Native";
         internal const string MsQuic = "msquic.dll";
-        internal const string HostPolicy = "hostpolicy.dll";
+        internal const string HostPolicy = "hostpolicy";
         internal const string Ucrtbase = "ucrtbase.dll";
         internal const string Xolehlp = "xolehlp.dll";
     }

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -65,16 +65,16 @@
 //
 // We cannot maintain the same (compat) invariant for linux and thus, we will fallback to using lowest RID-Platform.
 #if defined(TARGET_WINDOWS)
-#define LIB_PREFIX
-#define MAKE_LIBNAME(NAME) (_X(NAME) _X(".dll"))
+#define LIB_PREFIX ""
+#define LIB_FILE_EXT ".dll"
 #define FALLBACK_HOST_RID _X("win10")
 #elif defined(TARGET_OSX)
-#define LIB_PREFIX _X("lib")
-#define MAKE_LIBNAME(NAME) (LIB_PREFIX _X(NAME) _X(".dylib"))
+#define LIB_PREFIX "lib"
+#define LIB_FILE_EXT ".dylib"
 #define FALLBACK_HOST_RID _X("osx.10.12")
 #else
-#define LIB_PREFIX _X("lib")
-#define MAKE_LIBNAME(NAME) (LIB_PREFIX _X(NAME) _X(".so"))
+#define LIB_PREFIX "lib"
+#define LIB_FILE_EXT ".so"
 #if defined(TARGET_FREEBSD)
 #define FALLBACK_HOST_RID _X("freebsd")
 #elif defined(TARGET_ILLUMOS)
@@ -90,15 +90,16 @@
 #endif
 #endif
 
-#define LIBCORECLR_FILENAME (LIB_PREFIX _X("coreclr"))
-#define LIBCORECLR_NAME MAKE_LIBNAME("coreclr")
+#define _STRINGIFY(s) _X(s)
+
+#define LIB_NAME(NAME) LIB_PREFIX NAME
+#define LIB_FILE_NAME(NAME) LIB_PREFIX NAME LIB_FILE_EXT
+#define LIB_FILE_NAME_X(NAME) _STRINGIFY(LIB_FILE_NAME(NAME))
 
 #define CORELIB_NAME _X("System.Private.CoreLib.dll")
-
-#define LIBHOSTPOLICY_FILENAME (LIB_PREFIX _X("hostpolicy"))
-#define LIBHOSTPOLICY_NAME MAKE_LIBNAME("hostpolicy")
-
-#define LIBFXR_NAME MAKE_LIBNAME("hostfxr")
+#define LIBCORECLR_NAME LIB_FILE_NAME_X("coreclr")
+#define LIBFXR_NAME LIB_FILE_NAME_X("hostfxr")
+#define LIBHOSTPOLICY_NAME LIB_FILE_NAME_X("hostpolicy")
 
 #if !defined(PATH_MAX) && !defined(_WIN32)
 #define PATH_MAX    4096

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -8,7 +8,6 @@
 #include "trace.h"
 #include <type_traits>
 
-#define _STRINGIFY(s) _X(s)
 #if defined(_WIN32)
 #define DOTNET_CORE_INSTALL_PREREQUISITES_URL _X("https://go.microsoft.com/fwlink/?linkid=798306")
 #elif defined(TARGET_OSX)

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -53,56 +53,58 @@ namespace
 
     // pinvoke_override:
     // Check if given function belongs to one of statically linked libraries and return a pointer if found.
-    const void* STDMETHODCALLTYPE pinvoke_override(const char* libraryName, const char* entrypointName)
+    const void* STDMETHODCALLTYPE pinvoke_override(const char* library_name, const char* entry_point_name)
     {
+        // This function is only called with the library name specified for a p/invoke, not any variations.
+        // It must handle exact matches to the names specified. See Interop.Libraries.cs for each platform.
 #if defined(_WIN32)
-        const char* hostPolicyLib = "hostpolicy.dll";
+        const char* hostpolicy_lib_name = "hostpolicy";
 
-        if (strcmp(libraryName, "System.IO.Compression.Native") == 0)
+        if (strcmp(library_name, "System.IO.Compression.Native") == 0)
         {
-            return CompressionResolveDllImport(entrypointName);
+            return CompressionResolveDllImport(entry_point_name);
         }
 #else
-        const char* hostPolicyLib = "libhostpolicy";
+        const char* hostpolicy_lib_name = "libhostpolicy";
 
-        if (strcmp(libraryName, "libSystem.IO.Compression.Native") == 0)
+        if (strcmp(library_name, "libSystem.IO.Compression.Native") == 0)
         {
-            return CompressionResolveDllImport(entrypointName);
+            return CompressionResolveDllImport(entry_point_name);
         }
 
-        if (strcmp(libraryName, "libSystem.Net.Security.Native") == 0)
+        if (strcmp(library_name, "libSystem.Net.Security.Native") == 0)
         {
-            return SecurityResolveDllImport(entrypointName);
+            return SecurityResolveDllImport(entry_point_name);
         }
 
-        if (strcmp(libraryName, "libSystem.Native") == 0)
+        if (strcmp(library_name, "libSystem.Native") == 0)
         {
-            return SystemResolveDllImport(entrypointName);
+            return SystemResolveDllImport(entry_point_name);
         }
 
-        if (strcmp(libraryName, "libSystem.Security.Cryptography.Native.OpenSsl") == 0)
+        if (strcmp(library_name, "libSystem.Security.Cryptography.Native.OpenSsl") == 0)
         {
-            return CryptoResolveDllImport(entrypointName);
+            return CryptoResolveDllImport(entry_point_name);
         }
 #endif
         // there are two PInvokes in the hostpolicy itself, redirect them here.
-        if (strcmp(libraryName, hostPolicyLib) == 0)
+        if (strcmp(library_name, hostpolicy_lib_name) == 0)
         {
-            if (strcmp(entrypointName, "corehost_resolve_component_dependencies") == 0)
+            if (strcmp(entry_point_name, "corehost_resolve_component_dependencies") == 0)
             {
                 return (void*)corehost_resolve_component_dependencies;
             }
 
-            if (strcmp(entrypointName, "corehost_set_error_writer") == 0)
+            if (strcmp(entry_point_name, "corehost_set_error_writer") == 0)
             {
                 return (void*)corehost_set_error_writer;
             }
         }
 
 #if defined(TARGET_OSX)
-        if (strcmp(libraryName, "libSystem.Security.Cryptography.Native.Apple") == 0)
+        if (strcmp(library_name, "libSystem.Security.Cryptography.Native.Apple") == 0)
         {
-            return CryptoAppleResolveDllImport(entrypointName);
+            return CryptoAppleResolveDllImport(entry_point_name);
         }
 #endif
 

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -57,38 +57,30 @@ namespace
     {
         // This function is only called with the library name specified for a p/invoke, not any variations.
         // It must handle exact matches to the names specified. See Interop.Libraries.cs for each platform.
-#if defined(_WIN32)
-        const char* hostpolicy_lib_name = "hostpolicy";
-
-        if (strcmp(library_name, "System.IO.Compression.Native") == 0)
-        {
-            return CompressionResolveDllImport(entry_point_name);
-        }
-#else
-        const char* hostpolicy_lib_name = "libhostpolicy";
-
-        if (strcmp(library_name, "libSystem.IO.Compression.Native") == 0)
-        {
-            return CompressionResolveDllImport(entry_point_name);
-        }
-
-        if (strcmp(library_name, "libSystem.Net.Security.Native") == 0)
+#if !defined(_WIN32)
+        if (strcmp(library_name, LIB_NAME("System.Net.Security.Native")) == 0)
         {
             return SecurityResolveDllImport(entry_point_name);
         }
 
-        if (strcmp(library_name, "libSystem.Native") == 0)
+        if (strcmp(library_name, LIB_NAME("System.Native")) == 0)
         {
             return SystemResolveDllImport(entry_point_name);
         }
 
-        if (strcmp(library_name, "libSystem.Security.Cryptography.Native.OpenSsl") == 0)
+        if (strcmp(library_name, LIB_NAME("System.Security.Cryptography.Native.OpenSsl")) == 0)
         {
             return CryptoResolveDllImport(entry_point_name);
         }
 #endif
+
+        if (strcmp(library_name, LIB_NAME("System.IO.Compression.Native")) == 0)
+        {
+            return CompressionResolveDllImport(entry_point_name);
+        }
+
         // there are two PInvokes in the hostpolicy itself, redirect them here.
-        if (strcmp(library_name, hostpolicy_lib_name) == 0)
+        if (strcmp(library_name, LIB_NAME("hostpolicy")) == 0)
         {
             if (strcmp(entry_point_name, "corehost_resolve_component_dependencies") == 0)
             {

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -94,7 +94,7 @@ namespace
         }
 
 #if defined(TARGET_OSX)
-        if (strcmp(library_name, "libSystem.Security.Cryptography.Native.Apple") == 0)
+        if (strcmp(library_name, LIB_NAME("System.Security.Cryptography.Native.Apple")) == 0)
         {
             return CryptoAppleResolveDllImport(entry_point_name);
         }

--- a/src/native/corehost/test/nativehost/nativehost.cpp
+++ b/src/native/corehost/test/nativehost/nativehost.cpp
@@ -72,7 +72,7 @@ int main(const int argc, const pal::char_t *argv[])
             }
 
             nethost_path = get_directory(nethost_path);
-            nethost_path.append(MAKE_LIBNAME("nethost"));
+            nethost_path.append(LIB_FILE_NAME_X("nethost"));
 
             pal::dll_t nethost;
             if (!pal::load_library(&nethost_path, &nethost))


### PR DESCRIPTION
`Interop.Libraries.HostPolicy` is only used for the library name in p/invokes.

Resolves #60080