### PR TITLE
Change type of _version in List<T> from int to long

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -24,7 +24,7 @@ namespace System.Collections.Generic
 
         internal T[] _items; // Do not rename (binary serialization)
         internal int _size; // Do not rename (binary serialization)
-        internal int _version; // Do not rename (binary serialization)
+        internal long _version; // Do not rename (binary serialization)
 
 #pragma warning disable CA1825 // avoid the extra generic instantiation for Array.Empty<T>()
         private static readonly T[] s_emptyArray = new T[0];
@@ -606,7 +606,7 @@ namespace System.Collections.Generic
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.action);
             }
 
-            int version = _version;
+            long version = _version;
 
             for (int i = 0; i < _size; i++)
             {
@@ -1148,7 +1148,7 @@ namespace System.Collections.Generic
         {
             private readonly List<T> _list;
             private int _index;
-            private readonly int _version;
+            private readonly long _version;
             private T? _current;
 
             internal Enumerator(List<T> list)


### PR DESCRIPTION
`List<T>` uses _version field to check is list changed while iteration. But this way has an exception.

When I call List<T>::Add or other methods which changes itself, the _version field increase. And if the _version met `int.MaxValue`, it ignore overflow. The bug is from this.

```cs
var list = new List<long>();

list.Add(1);
list.Add(2);
list.ForEach(x =>
{
    Console.WriteLine(x);
    if (x != 1) return;
    list.Add(3);
    list.Add(4);
    for (long a = 0; a < (long)int.MaxValue / 2; a++)
    {
        list.Add(1);
        list.Add(2);
        list.RemoveAt(5);
        list.RemoveAt(4);
    }
    list.Add(5);
    list.Add(6);
});

```
In this code, this is trying to edit the list while iteration. So excepted operation is throwing an error. But, this code works fine. So, I changed type of _version to long.


Excepted:
```
1
Unhandled exception. System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.ForEach(Action`1 action)
   at Program.<Main>$(String[] args) in Path:line 5
```

Result:
```
1
2
3
4
5
6
```