### PR TITLE
[NativeAOT/crossgen2] Increase osx-x64 CPU baseline from SSE2 to AVX

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -80,7 +80,15 @@ namespace ILCompiler
             // The runtime expects certain baselines that the codegen can assume as well.
             if ((targetArchitecture == TargetArchitecture.X86) || (targetArchitecture == TargetArchitecture.X64))
             {
-                instructionSetSupportBuilder.AddSupportedInstructionSet("sse2"); // Lower baselines included by implication
+                if (targetOS == TargetOS.OSX)
+                {
+                    // The oldest hardware that is still supported by Apple as of macOS 10.15 is Intel Core i5-3330S.
+                    instructionSetSupportBuilder.AddSupportedInstructionSet("avx");
+                }
+                else
+                {
+                    instructionSetSupportBuilder.AddSupportedInstructionSet("sse2"); // Lower baselines included by implication
+                }
             }
             else if (targetArchitecture == TargetArchitecture.ARM64)
             {

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -66,7 +66,15 @@ namespace ILCompiler
             // Ready to run images are built with certain instruction set baselines
             if ((_targetArchitecture == TargetArchitecture.X86) || (_targetArchitecture == TargetArchitecture.X64))
             {
-                instructionSetSupportBuilder.AddSupportedInstructionSet("sse2"); // Lower baselines included by implication
+                if (_targetOS == TargetOS.OSX)
+                {
+                    // The oldest hardware that is still supported by Apple as of macOS 10.15 is Intel Core i5-3330S.
+                    instructionSetSupportBuilder.AddSupportedInstructionSet("avx");
+                }
+                else
+                {
+                    instructionSetSupportBuilder.AddSupportedInstructionSet("sse2"); // Lower baselines included by implication
+                }
             }
             else if (_targetArchitecture == TargetArchitecture.ARM64)
             {


### PR DESCRIPTION
Oldest supported HW as of macOS 10.15 is iMac (2012) with Intel Core i5-3330S CPU. Once the requirement is bumped to macOS 11 the oldest supported HW will be iMac (2014) with Intel Core i5-4260U and we can bump to AVX2.