### PR TITLE
Add GenTreeID in allocating registers table

### DIFF
--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -6,6 +6,8 @@
 #define _JIT_H_
 /*****************************************************************************/
 
+//#undef _DEBUG
+//#undef DEBUG
 //
 // clr.sln only defines _DEBUG
 // The jit uses DEBUG rather than _DEBUG
@@ -16,6 +18,7 @@
 #define DEBUG 1
 #endif
 #endif
+
 
 // Clang-format messes with the indentation of comments if they directly precede an
 // ifdef. This macro allows us to anchor the comments to the regular flow of code.

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -6,8 +6,6 @@
 #define _JIT_H_
 /*****************************************************************************/
 
-//#undef _DEBUG
-//#undef DEBUG
 //
 // clr.sln only defines _DEBUG
 // The jit uses DEBUG rather than _DEBUG
@@ -18,7 +16,6 @@
 #define DEBUG 1
 #endif
 #endif
-
 
 // Clang-format messes with the indentation of comments if they directly precede an
 // ifdef. This macro allows us to anchor the comments to the regular flow of code.

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -5294,21 +5294,6 @@ void LinearScan::allocateRegisters()
                 {
                     regNumber copyReg        = assignCopyReg(currentRefPosition);
                     lastAllocatedRefPosition = currentRefPosition;
-                    bool unassign            = false;
-                    if (currentInterval->isWriteThru)
-                    {
-                        if (currentRefPosition->refType == RefTypeDef)
-                        {
-                            currentRefPosition->writeThru = true;
-                        }
-                        if (!currentRefPosition->lastUse)
-                        {
-                            if (currentRefPosition->spillAfter)
-                            {
-                                unassign = true;
-                            }
-                        }
-                    }
                     regMaskTP copyRegMask     = getRegMask(copyReg, currentInterval->registerType);
                     regMaskTP assignedRegMask = getRegMask(assignedRegister, currentInterval->registerType);
                     regsInUseThisLocation |= copyRegMask | assignedRegMask;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -3928,7 +3928,10 @@ regNumber LinearScan::findAnotherHalfRegNum(regNumber regNum)
 //    None
 //
 // Return Value:
-//    True only if previous interval of regRec can be restored
+//    True if:
+//      1. previous interval of regRec is different than `assignedInterval`
+//      2. previous interval's assigned interval is still `regRec`.
+//      3. previous interval still have more refpositions.
 //
 bool LinearScan::canRestorePreviousInterval(RegRecord* regRec, Interval* assignedInterval)
 {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -5292,8 +5292,8 @@ void LinearScan::allocateRegisters()
                 // It's already in a register, but not one we need.
                 if (!RefTypeIsDef(currentRefPosition->refType))
                 {
-                    regNumber copyReg        = assignCopyReg(currentRefPosition);
-                    lastAllocatedRefPosition = currentRefPosition;
+                    regNumber copyReg         = assignCopyReg(currentRefPosition);
+                    lastAllocatedRefPosition  = currentRefPosition;
                     regMaskTP copyRegMask     = getRegMask(copyReg, currentInterval->registerType);
                     regMaskTP assignedRegMask = getRegMask(assignedRegister, currentInterval->registerType);
                     regsInUseThisLocation |= copyRegMask | assignedRegMask;
@@ -10040,7 +10040,8 @@ void LinearScan::dumpRegRecordHeader()
     // BBnn printed left-justified in the NAME Typeld and allocationInfo space.
     int bbNumWidth = (int)log10((double)compiler->fgBBNumMax) + 1;
     // In the unlikely event that BB numbers overflow the space, we'll simply omit the predBB
-    int predBBNumDumpSpace = regTableIndent - locationAndRPNumWidth - bbNumWidth - treeIdWidth - 9 /* 'BB' + ' PredBB' */;
+    int predBBNumDumpSpace =
+        regTableIndent - locationAndRPNumWidth - bbNumWidth - treeIdWidth - 9 /* 'BB' + ' PredBB' */;
     if (predBBNumDumpSpace < bbNumWidth)
     {
         sprintf_s(bbRefPosFormat, MAX_LEGEND_FORMAT_CHARS, "BB%%-%dd", shortRefPositionDumpWidth - 2);
@@ -10281,7 +10282,7 @@ void LinearScan::dumpRefPositionShort(RefPosition* refPosition, BasicBlock* curr
     {
         dumpEmptyTreeID();
     }
-    
+
     printf(shortRefPositionFormat, refPosition->nodeLocation, refPosition->rpNum);
     if (refPosition->isIntervalRef())
     {

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -2314,7 +2314,10 @@ public:
     GenTree* buildNode;
 #endif // DEBUG
 
-    RefPosition(unsigned int bbNum, LsraLocation nodeLocation, GenTree* treeNode, RefType refType DEBUG_ARG(GenTree* buildNode))
+    RefPosition(unsigned int bbNum,
+                LsraLocation nodeLocation,
+                GenTree*     treeNode,
+                RefType refType DEBUG_ARG(GenTree* buildNode))
         : referent(nullptr)
         , nextRefPosition(nullptr)
         , treeNode(treeNode)

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1396,7 +1396,7 @@ private:
     char             shortRefPositionFormat[MAX_FORMAT_CHARS];
     char             emptyRefPositionFormat[MAX_FORMAT_CHARS];
     char             indentFormat[MAX_FORMAT_CHARS];
-    static const int MAX_LEGEND_FORMAT_CHARS = 25;
+    static const int MAX_LEGEND_FORMAT_CHARS = 34;
     char             bbRefPosFormat[MAX_LEGEND_FORMAT_CHARS];
     char             legendFormat[MAX_LEGEND_FORMAT_CHARS];
 
@@ -1422,6 +1422,8 @@ private:
     void dumpRefPositionShort(RefPosition* refPosition, BasicBlock* currentBlock);
     // Print the number of spaces occupied by a dumpRefPositionShort()
     void dumpEmptyRefPosition();
+    // Print the number of spaces occupied by tree ID.
+    void dumpEmptyTreeID();
     // A dump of Referent, in exactly regColumnWidth characters
     void dumpIntervalName(Interval* interval);
 
@@ -1562,6 +1564,12 @@ private:
     LsraLocation curBBStartLocation;
     // True if the method contains any critical edges.
     bool hasCriticalEdges;
+
+#ifdef DEBUG
+    // Tracks the GenTree* for which intervals are being
+    // built. Use for displaying in allocation table.
+    GenTree* currBuildNode;
+#endif
 
     // True if there are any register candidate lclVars available for allocation.
     bool enregisterLocalVars;
@@ -2300,9 +2308,13 @@ public:
     // The unique RefPosition number, equal to its index in the
     // refPositions list. Only used for debugging dumps.
     unsigned rpNum;
+
+    // Tracks the GenTree* for which this refposition was built.
+    // Use for displaying in allocation table.
+    GenTree* buildNode;
 #endif // DEBUG
 
-    RefPosition(unsigned int bbNum, LsraLocation nodeLocation, GenTree* treeNode, RefType refType)
+    RefPosition(unsigned int bbNum, LsraLocation nodeLocation, GenTree* treeNode, RefType refType DEBUG_ARG(GenTree* buildNode))
         : referent(nullptr)
         , nextRefPosition(nullptr)
         , treeNode(treeNode)
@@ -2326,6 +2338,7 @@ public:
 #ifdef DEBUG
         , minRegCandidateCount(1)
         , rpNum(0)
+        , buildNode(buildNode)
 #endif
     {
     }

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1589,7 +1589,7 @@ private:
     // The set of all register candidates. Note that this may be a subset of tracked vars.
     VARSET_TP registerCandidateVars;
     // Current set of live register candidate vars, used during building of RefPositions to determine
-    // whether to preference to callee-save.
+    // whether to give preference to callee-save.
     VARSET_TP currentLiveVars;
     // Set of variables that may require resolution across an edge.
     // This is first constructed during interval building, to contain all the lclVars that are live at BB edges.

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2327,7 +2327,6 @@ void LinearScan::buildIntervals()
                     {
                         // If we are using locations from a predecessor, we should never require DummyDefs.
                         assert(!predBlockIsAllocated);
-
                         JITDUMP("Creating dummy definitions\n");
                         VarSetOps::Iter iter(compiler, newLiveIn);
                         unsigned        varIndex = 0;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -177,10 +177,14 @@ Interval* LinearScan::newInterval(RegisterType theRegisterType)
 //
 RefPosition* LinearScan::newRefPositionRaw(LsraLocation nodeLocation, GenTree* treeNode, RefType refType)
 {
-    refPositions.emplace_back(curBBNum, nodeLocation, treeNode, refType);
+    refPositions.emplace_back(curBBNum, nodeLocation, treeNode, refType DEBUG_ARG(currBuildNode));
     RefPosition* newRP = &refPositions.back();
 #ifdef DEBUG
-    newRP->rpNum = static_cast<unsigned>(refPositions.size() - 1);
+    // Reset currBuildNode so we do not set it for subsequent refpositions belonging
+    // to the same treeNode and hence, avoid printing it for every refposition inside
+    // the allocation table.
+    currBuildNode = nullptr;
+    newRP->rpNum  = static_cast<unsigned>(refPositions.size() - 1);
 #endif // DEBUG
     return newRP;
 }
@@ -1749,6 +1753,7 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, LsraLocation currentLoc
     // the last RefPosition prior to those created for this node.
     RefPositionIterator refPositionMark = refPositions.backPosition();
     int                 oldDefListCount = defList.Count();
+    currBuildNode                       = tree;
 #endif // DEBUG
 
     int consume = BuildNode(tree);


### PR DESCRIPTION
While debugging LSRA issues, there is often a need to find out the GenTree node that was responsible to create the refpositions. So I added an column that includes the `GenTreeID` for which we were building the refpositions that are seen in the table. We end up creating more than 1 refpositions for a given `GenTree*`. To make sure that the table is not verbose where we print same GenTreeID for multiple refpositions that got created, I just print it once, and the remaining refpositions can be linked back to the last GenTreeID. To track it, I added `currBuildNode` in `LinearScan` and `buildNode` at Refposition level.

Here is the sample output:

```
──────────────────────────────────────────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┤
TreeID   LocRP# Name Type  Action    Reg  │r0  │r1  │r2  │r3  │r4  │r5  │f0  │f1  │f2  │f16 │f17 │
──────────────────────────────────────────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┤
                                          │    │    │    │    │    │    │V0 a│V0 a│V1 a│    │    │
          0.#0  V0   Parm   Keep     f0   │    │    │    │    │    │    │V0 a│V0 a│V1 a│    │    │
──────────────────────────────────────────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┤
TreeID   LocRP# Name Type  Action    Reg  │r0  │r1  │r2  │r3  │r4  │r5  │f0  │f1  │f2  │f3  │f16 │f17 │
──────────────────────────────────────────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┼────┤
          0.#1  V1   Parm   Keep     f2   │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│    │    │
          1.#2  BB1 PredBB0               │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│    │    │
[000002]  9.#3  V0   Use    Keep     f0   │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│    │    │
          9.#4  V0   Use    Keep     f0   │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│    │    │
         10.#5  I2   Def    FREE (A) f16  │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│I2 a│I2 a│
[000005] 15.#6  V1   Use    Keep     f2   │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│I2 a│I2 a│
         15.#7  V1   Use    Keep     f2   │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│I2 a│I2 a│
         16.#8  I3   Def    Spill    f16  │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│    │    │
                            SPILL(A) f16  │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│I3 a│I3 a│
[000006] 17.#9  I2   Use *  ReLod    NA   │    │    │    │    │    │    │V0 a│V0 a│V1 a│V1 a│I3 a│I3 a│
                            Spill    f2   │    │    │    │    │    │    │V0 a│V0 a│    │    │I3 a│I3 a│
                            FNREF(A) f2   │    │    │    │    │    │    │V0 a│V0 a│I2 a│I2 a│I3 a│I3 a│
         17.#10 I3   Use *  Keep     f16  │    │    │    │    │    │    │V0 a│V0 a│I2 a│I2 a│I3 a│I3 a│
```

I have also included a commit that removes the dead code.