### PR TITLE
JIT: don't forward sub qmarks to LCL_FLD assignments

### DIFF
--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -530,7 +530,12 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
 
         GenTree* const nextRootNodeLHS = nextRootNode->gtGetOp1();
 
-        if (nextRootNodeLHS->OperIs(GT_LCL_VAR))
+        if (!nextRootNodeLHS->OperIs(GT_LCL_VAR))
+        {
+            JITDUMP(" can't fwd sub qmark for LCL_FLD assign\n");
+            return false;
+        }
+        else
         {
             const unsigned   lhsLclNum = nextRootNodeLHS->AsLclVarCommon()->GetLclNum();
             LclVarDsc* const lhsVarDsc = lvaGetDesc(lhsLclNum);


### PR DESCRIPTION
Morph is not quite ready for this yet.

Closes #76509.