### PR TITLE
Add tests for customizing source-gen contracts

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -254,7 +254,7 @@ namespace System.Text.Json.Serialization.Metadata
             Debug.Assert(!info.CanSerialize);
             Debug.Assert(!info.CanDeserialize);
 
-            info.Name = string.Empty;
+            info.SetNameInternal(string.Empty);
 
             return info;
         }
@@ -363,7 +363,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNameNull(this);
             }
 
-            Name = name;
+            SetNameInternal(name);
         }
 
         private void CacheNameAsUtf8BytesAndEscapedNameSection()
@@ -654,10 +654,24 @@ namespace System.Text.Json.Serialization.Metadata
                 }
 
                 _name = value;
+
+                // This setter should only be called by end users.
+                // Disable fast-path if a user modifies a property name.
+                if (ParentTypeInfo != null)
+                {
+                    ParentTypeInfo.CanUseSerializeHandler = false;
+                }
             }
         }
 
         private string? _name;
+
+        internal void SetNameInternal(string name)
+        {
+            Debug.Assert(name is not null);
+            VerifyMutable();
+            _name = name;
+        }
 
         /// <summary>
         /// Utf8 version of Name.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -189,7 +189,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowInvalidOperationException_SerializerPropertyNameNull(this);
             }
 
-            Name = name;
+            SetNameInternal(name);
             MemberName = propertyInfo.PropertyName;
             MemberType = propertyInfo.IsProperty ? MemberTypes.Property : MemberTypes.Field;
             SrcGen_IsPublic = propertyInfo.IsPublic;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -199,6 +199,9 @@ namespace System.Text.Json.Serialization.Metadata
         ///
         /// It is required that added <see cref="JsonPropertyInfo"/> entries are unique up to <see cref="JsonPropertyInfo.Name"/>,
         /// however this will only be validated on serialization, once the metadata instance gets locked for further modification.
+        ///
+        /// If the <see cref="JsonTypeInfo"/> instance was created with source generation mode
+        /// <see cref="JsonSourceGenerationMode.Serialization"/>, an empty, read-only list will be returned.
         /// </remarks>
         public IList<JsonPropertyInfo> Properties
         {
@@ -271,7 +274,7 @@ namespace System.Text.Json.Serialization.Metadata
         private JsonTypeInfo? _elementTypeInfo;
 
         // Flag indicating that JsonTypeInfo<T>.SerializeHandler is populated and is compatible with the associated Options instance.
-        internal bool CanUseSerializeHandler { get; private protected set; }
+        internal bool CanUseSerializeHandler { get; set; }
 
         // Configure would normally have thrown why initializing properties for source gen but type had SerializeHandler
         // so it is allowed to be used for fast-path serialization but it will throw if used for metadata-based serialization
@@ -713,7 +716,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
 
             JsonPropertyInfo propertyInfo = CreatePropertyUsingReflection(propertyType);
-            propertyInfo.Name = name;
+            propertyInfo.SetNameInternal(name);
 
             return propertyInfo;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/SourceGenJsonTypeInfoOfT.cs
@@ -177,6 +177,7 @@ namespace System.Text.Json.Serialization.Metadata
                     continue;
                 }
 
+                jsonPropertyInfo.EnsureChildOf(this);
                 CacheMember(jsonPropertyInfo, propertyCache, ref ignoredMembers);
             }
 


### PR DESCRIPTION
Attempting to understand/codify behavior expectations when users attempt to modify contracts generated by the source generator.