### PR TITLE
JIT: Ensure no overflow in ContainBlockStoreAddress

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -688,12 +688,12 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
     {
         return;
     }
-#else
+#else // !TARGET_ARM
     if ((ClrSafeInt<int>(offset) + ClrSafeInt<int>(size)).IsOverflow())
     {
         return;
     }
-#endif // TARGET_ARM
+#endif // !TARGET_ARM
 
     if (!IsSafeToContainMem(blkNode, addr))
     {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -688,6 +688,11 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
     {
         return;
     }
+#else
+    if ((ClrSafeInt<int>(offset) + ClrSafeInt<int>(size)).IsOverflow())
+    {
+        return;
+    }
 #endif // TARGET_ARM
 
     if (!IsSafeToContainMem(blkNode, addr))


### PR DESCRIPTION
The offset here can be a "base" address due to various JIT transformations so we should ensure the range [offset, offset+size) does not overflow.

Fix #76506