### PR TITLE
Do not produce full-width local field stores for normalize-on-store locals

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1012,14 +1012,6 @@ private:
                 return IndirTransform::LclVar;
             }
 
-            // Locals are not enregistered when optimizations are disabled; there is no point
-            // in spending time finding LCL_VAR-equivalent trees for them. TODO-ADDR: move
-            // this check earlier.
-            if (m_compiler->opts.OptimizationDisabled())
-            {
-                return IndirTransform::LclFld;
-            }
-
             // Bool and ubyte are the same type.
             if ((indir->TypeIs(TYP_BOOL) && (varDsc->TypeGet() == TYP_UBYTE)) ||
                 (indir->TypeIs(TYP_UBYTE) && (varDsc->TypeGet() == TYP_BOOL)))
@@ -1033,6 +1025,11 @@ private:
             {
                 assert(varTypeIsSmall(indir));
                 return IndirTransform::LclVar;
+            }
+
+            if (m_compiler->opts.OptimizationDisabled())
+            {
+                return IndirTransform::LclFld;
             }
 
             // Turn this into a bitcast if we can.


### PR DESCRIPTION
A full-width local field store may leave the upper bits of the 4-byte stack location denormalized.

Fixes #76546.

Going with the "shallow" fix (no asserts, etc) in the interest of unblocking the CI.

We're expecting TP losses, negating some of the wins from #76155.