### PR TITLE
DateTime: Use Optimised Equals Implementation in object.Equals()

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1170,11 +1170,7 @@ namespace System
         //
         public override bool Equals([NotNullWhen(true)] object? value)
         {
-            if (value is DateTime time)
-            {
-                return this == time;
-            }
-            return false;
+            return value is DateTime dt && this == dt;
         }
 
         public bool Equals(DateTime value)

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1170,9 +1170,9 @@ namespace System
         //
         public override bool Equals([NotNullWhen(true)] object? value)
         {
-            if (value is DateTime)
+            if (value is DateTime time)
             {
-                return Ticks == ((DateTime)value).Ticks;
+                return this == time;
             }
             return false;
         }


### PR DESCRIPTION
* This picks up from #59857 , adding the new equals implementation to the `object.Equals()` method, since previously the old implementation was still intact there.  

Codegen Diff: https://www.diffchecker.com/O0mRKfb6 (-21 bytes)

----

Setup:  

```
BenchmarkDotNet=v0.13.1.1847-nightly, OS=Windows 10 (10.0.19044.2075/21H2/November2021Update)
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.100-rtm.22480.6
  [Host]     : .NET 7.0.0 (7.0.22.47809), X64 RyuJIT AVX2
```

Before:  

`py scripts\benchmarks_ci.py -f net7.0 --bdn-arguments="--artifacts "C:\results\latest_sdk"" --filter System.Tests.Perf_DateTime.Equals*`

```ini
Job-NDINMX : .NET 7.0.0 (7.0.22.47809), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250.0000 ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

|       Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Code Size | Allocated |
|------------- |---------:|----------:|----------:|---------:|---------:|---------:|----------:|----------:|
| ObjectEquals | 1.392 ns | 0.0169 ns | 0.0150 ns | 1.389 ns | 1.365 ns | 1.420 ns |     210 B |         - |
```

After:  

`py scripts\benchmarks_ci.py -f net7.0 --bdn-arguments="--artifacts "C:\results\dev" -d" --filter System.Tests.Perf_DateTime.ObjectEquals* --corerun "C:\Users\sewer\Desktop\Projects\runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\8.0.0\corerun.exe"`

```ini
Job-YQMWEN : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  Toolchain=CoreRun  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

|       Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Code Size | Allocated |
|------------- |----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|
| ObjectEquals | 0.6923 ns | 0.0073 ns | 0.0061 ns | 0.6915 ns | 0.6826 ns | 0.7062 ns |     189 B |         - |
```

----

Benchmark:  https://github.com/Sewer56/performance/commit/2a762e3d10d533b2aa7c0a26d6222bba918fb822
dotnet/performance: https://github.com/dotnet/performance/pull/2626