### PR TITLE
[PERF] Update perf_slow scheduled micro_mono run queue

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -69,7 +69,7 @@ jobs:
         projectFile: microbenchmarks.proj
         runKind: micro_mono
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfa64'
+        logicalmachine: 'perfampere'
         timeoutInMinutes: 500 
 
   # build mono on wasm


### PR DESCRIPTION
Change mono interpreter perf_slow runs to use perfampere logicalmachine as the a64 machines have been deprecated.