### PR TITLE
Fix Interop.Gdi32.StartDoc p/invoke

### DIFF
--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Gdi32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Gdi32.cs
@@ -52,7 +52,7 @@ internal static partial class Interop
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef hDC, DOCINFO lpDocInfo);
+            HandleRef hDC, in DOCINFO lpDocInfo);
 
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial int StartPage(
@@ -179,13 +179,15 @@ internal static partial class Interop
         [NativeMarshalling(typeof(Marshaller))]
 #endif
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        internal sealed class DOCINFO
+        internal struct DOCINFO
         {
             internal int cbSize = 20;
             internal string? lpszDocName;
             internal string? lpszOutput;
             internal string? lpszDatatype;
             internal int fwType;
+
+            public DOCINFO() { }
 
 #if NET7_0_OR_GREATER
             [CustomMarshaller(typeof(DOCINFO), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]


### PR DESCRIPTION
[`StartDoc`](https://learn.microsoft.com/windows/win32/api/wingdi/nf-wingdi-startdocw) takes a pointer to a `DOCINFO` struct. We had `DOCINFO` defined as a class on the managed side such that built-in marshalling would marshal it as a pointer. With the switch to custom marshalling via `NativeMarshalling`, we ended up marshalling the struct that is the native representation rather than a pointer to it.

This switches the `DOCINFO` to a struct and updates the parameter to `StartDoc` to be `in`, such that it should be marshalled as a pointer to the struct by both generated and built-in marshalling.

See https://github.com/dotnet/runtime/issues/76538. This is the fix in main. We will need to backport to 7.0.

cc @ericstj @JeremyKuhne 