### PR TITLE
AOT Runtime.Base: Change AttributeTargets and AttributeUsageAttribute to public

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/AttributeTargets.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/AttributeTargets.cs
@@ -6,7 +6,7 @@ namespace System
     // Enum used to indicate all the elements of the
     // VOS it is valid to attach this element to.
 
-    internal enum AttributeTargets
+    public enum AttributeTargets
     {
         Assembly = 0x0001,
         Module = 0x0002,

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/AttributeUsageAttribute.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/AttributeUsageAttribute.cs
@@ -14,7 +14,7 @@ namespace System
 {
     /* By default, attributes are inherited and multiple attributes are not allowed */
     [AttributeUsage(AttributeTargets.Class, Inherited = true)]
-    internal sealed class AttributeUsageAttribute : Attribute
+    public sealed class AttributeUsageAttribute : Attribute
     {
         //Constructors
         public AttributeUsageAttribute(AttributeTargets validOn)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.Assets/ILCompiler.Compiler.Tests.Assets.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.Assets/ILCompiler.Compiler.Tests.Assets.csproj
@@ -8,7 +8,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <!-- Don't add references to the netstandard platform since this is a core assembly -->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <Features>noRefSafetyRulesAttribute=true</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.csproj
@@ -14,7 +14,6 @@
     <Platforms>x86;x64</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Features>noRefSafetyRulesAttribute=true</Features>
   </PropertyGroup>
 
   <ItemGroup>    


### PR DESCRIPTION
`AttributeTargets` and `AttributeUsageAttribute` must be `public` to allow the C# compiler to emit `[module: RefSafetyRules]` successfully.

See https://github.com/dotnet/runtime/pull/76459#discussion_r986055690.