### PR TITLE
Use more spans in `System.Reflection.Metadata` et. al.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/AbstractMemoryBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/AbstractMemoryBlock.cs
@@ -34,7 +34,7 @@ namespace System.Reflection.Internal
         /// </remarks>
         public virtual unsafe ImmutableArray<byte> GetContentUnchecked(int start, int length)
         {
-            var result = BlobUtilities.ReadImmutableBytes(Pointer + start, length);
+            var result = new ReadOnlySpan<byte>(Pointer + start, length).ToImmutableArray();
             GC.KeepAlive(this);
             return result;
         }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
@@ -122,7 +122,7 @@ namespace System.Reflection.Internal
         }
 
         /// <exception cref="IOException">IO error while mapping memory or not enough memory to create the mapping.</exception>
-        private unsafe bool TryCreateMemoryMappedFileBlock(long start, int size, [NotNullWhen(true)]out MemoryMappedFileBlock? block)
+        private unsafe bool TryCreateMemoryMappedFileBlock(long start, int size, [NotNullWhen(true)] out MemoryMappedFileBlock? block)
         {
             if (_lazyMemoryMap == null)
             {
@@ -142,7 +142,8 @@ namespace System.Reflection.Internal
                                 access: MemoryMappedFileAccess.Read,
                                 inheritability: HandleInheritability.None,
                                 leaveOpen: true);
-                    } catch (UnauthorizedAccessException e)
+                    }
+                    catch (UnauthorizedAccessException e)
                     {
                         throw new IOException(e.Message, e);
                     }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
@@ -34,50 +34,20 @@ namespace System.Reflection
             buffer[start] = value;
         }
 
-        public static void WriteUInt16(this byte[] buffer, int start, ushort value)
-        {
-            if (!BitConverter.IsLittleEndian)
-            {
-                value = BinaryPrimitives.ReverseEndianness(value);
-            }
-            Unsafe.WriteUnaligned(ref buffer[start], value);
-        }
+        public static void WriteUInt16(this byte[] buffer, int start, ushort value) =>
+            Unsafe.WriteUnaligned(ref buffer[start], !BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
 
-        public static void WriteUInt16BE(this byte[] buffer, int start, ushort value)
-        {
-            if (BitConverter.IsLittleEndian)
-            {
-                value = BinaryPrimitives.ReverseEndianness(value);
-            }
-            Unsafe.WriteUnaligned(ref buffer[start], value);
-        }
+        public static void WriteUInt16BE(this byte[] buffer, int start, ushort value) =>
+            Unsafe.WriteUnaligned(ref buffer[start], BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
 
-        public static void WriteUInt32BE(this byte[] buffer, int start, uint value)
-        {
-            if (BitConverter.IsLittleEndian)
-            {
-                value = BinaryPrimitives.ReverseEndianness(value);
-            }
-            Unsafe.WriteUnaligned(ref buffer[start], value);
-        }
+        public static void WriteUInt32BE(this byte[] buffer, int start, uint value) =>
+            Unsafe.WriteUnaligned(ref buffer[start], BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
 
-        public static void WriteUInt32(this byte[] buffer, int start, uint value)
-        {
-            if (!BitConverter.IsLittleEndian)
-            {
-                value = BinaryPrimitives.ReverseEndianness(value);
-            }
-            Unsafe.WriteUnaligned(ref buffer[start], value);
-        }
+        public static void WriteUInt32(this byte[] buffer, int start, uint value) =>
+            Unsafe.WriteUnaligned(ref buffer[start], !BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
 
-        public static void WriteUInt64(this byte[] buffer, int start, ulong value)
-        {
-            if (!BitConverter.IsLittleEndian)
-            {
-                value = BinaryPrimitives.ReverseEndianness(value);
-            }
-            Unsafe.WriteUnaligned(ref buffer[start], value);
-        }
+        public static void WriteUInt64(this byte[] buffer, int start, ulong value) =>
+            Unsafe.WriteUnaligned(ref buffer[start], !BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
 
         public const int SizeOfSerializedDecimal = sizeof(byte) + 3 * sizeof(uint);
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers.Binary;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Internal;
 using System.Runtime.CompilerServices;
@@ -11,16 +10,6 @@ namespace System.Reflection
 {
     internal static unsafe class BlobUtilities
     {
-        public static byte[] ReadBytes(byte* buffer, int byteCount)
-        {
-            return new ReadOnlySpan<byte>(buffer, byteCount).ToArray();
-        }
-
-        public static ImmutableArray<byte> ReadImmutableBytes(byte* buffer, int byteCount)
-        {
-            return ImmutableArray.Create(new ReadOnlySpan<byte>(buffer, byteCount));
-        }
-
         public static void WriteBytes(this byte[] buffer, int start, byte value, int byteCount)
         {
             Debug.Assert(buffer.Length > 0);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
@@ -5,6 +5,7 @@ using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Reflection.Internal;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Reflection
 {
@@ -19,20 +20,12 @@ namespace System.Reflection
 
         public static void WriteDouble(this byte[] buffer, int start, double value)
         {
-#if NETCOREAPP
-            BinaryPrimitives.WriteDoubleLittleEndian(buffer.AsSpan(start), value);
-#else
             WriteUInt64(buffer, start, *(ulong*)&value);
-#endif
         }
 
         public static void WriteSingle(this byte[] buffer, int start, float value)
         {
-#if NETCOREAPP
-            BinaryPrimitives.WriteSingleLittleEndian(buffer.AsSpan(start), value);
-#else
             WriteUInt32(buffer, start, *(uint*)&value);
-#endif
         }
 
         public static void WriteByte(this byte[] buffer, int start, byte value)
@@ -43,27 +36,47 @@ namespace System.Reflection
 
         public static void WriteUInt16(this byte[] buffer, int start, ushort value)
         {
-            BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(start), value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = BinaryPrimitives.ReverseEndianness(value);
+            }
+            Unsafe.WriteUnaligned(ref buffer[start], value);
         }
 
         public static void WriteUInt16BE(this byte[] buffer, int start, ushort value)
         {
-            BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(start), value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = BinaryPrimitives.ReverseEndianness(value);
+            }
+            Unsafe.WriteUnaligned(ref buffer[start], value);
         }
 
         public static void WriteUInt32BE(this byte[] buffer, int start, uint value)
         {
-            BinaryPrimitives.WriteUInt32BigEndian(buffer.AsSpan(start), value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = BinaryPrimitives.ReverseEndianness(value);
+            }
+            Unsafe.WriteUnaligned(ref buffer[start], value);
         }
 
         public static void WriteUInt32(this byte[] buffer, int start, uint value)
         {
-            BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(start), value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = BinaryPrimitives.ReverseEndianness(value);
+            }
+            Unsafe.WriteUnaligned(ref buffer[start], value);
         }
 
         public static void WriteUInt64(this byte[] buffer, int start, ulong value)
         {
-            BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(start), value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = BinaryPrimitives.ReverseEndianness(value);
+            }
+            Unsafe.WriteUnaligned(ref buffer[start], value);
         }
 
         public const int SizeOfSerializedDecimal = sizeof(byte) + 3 * sizeof(uint);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableByteArrayInterop.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableByteArrayInterop.cs
@@ -49,9 +49,9 @@ namespace System.Reflection.Internal
         /// whose underlying backing field is modified.
         /// </remarks>
         /// <returns>An immutable array.</returns>
-        internal static ImmutableArray<byte> DangerousCreateFromUnderlyingArray([DisallowNull] ref byte[]? array)
+        internal static ImmutableArray<byte> DangerousCreateFromUnderlyingArray(ref byte[]? array)
         {
-            byte[] givenArray = array;
+            byte[] givenArray = array!;
             array = null;
 
             return Unsafe.As<byte[], ImmutableArray<byte>>(ref givenArray);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableByteArrayInterop.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableByteArrayInterop.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Reflection.Internal
 {
@@ -22,16 +23,10 @@ namespace System.Reflection.Internal
     ///
     /// This implementation is scoped to byte arrays as that is all that the metadata reader needs.
     ///
-    /// Also, since we don't have access to immutable collection internals, we use a trick involving
-    /// overlapping a <see cref="ImmutableArray{Byte}"/> with an array reference. While
-    /// unverifiable, it is valid. See ECMA-335, section II.10.7 Controlling instance layout:
+    /// Also, since we don't have access to immutable collection internals, we use
+    /// <see cref="Unsafe.As{TFrom, TTo}(ref TFrom)"/>.
     ///
-    /// "It is possible to overlap fields in this way, though offsets occupied by an object reference
-    /// shall not overlap with offsets occupied by a built-in value type or a part of
-    /// another object reference. While one object reference can completely overlap another, this is
-    /// unverifiable."
-    ///
-    /// Furthermore, the fact that <see cref="ImmutableArray{Byte}"/> backed by a single byte array
+    /// The fact that <see cref="ImmutableArray{Byte}"/> is backed by a single byte array
     /// field is something inherent to the design of ImmutableArray in order to get its performance
     /// characteristics and therefore something we (Microsoft) are comfortable defining as a contract that
     /// can be depended upon as below.
@@ -54,14 +49,12 @@ namespace System.Reflection.Internal
         /// whose underlying backing field is modified.
         /// </remarks>
         /// <returns>An immutable array.</returns>
-        internal static ImmutableArray<byte> DangerousCreateFromUnderlyingArray(ref byte[]? array)
+        internal static ImmutableArray<byte> DangerousCreateFromUnderlyingArray([DisallowNull] ref byte[]? array)
         {
-            byte[] givenArray = array!;
+            byte[] givenArray = array;
             array = null;
 
-            ByteArrayUnion union = default;
-            union.UnderlyingArray = givenArray;
-            return union.ImmutableArray;
+            return Unsafe.As<byte[], ImmutableArray<byte>>(ref givenArray);
         }
 
         /// <summary>
@@ -81,19 +74,7 @@ namespace System.Reflection.Internal
         /// <returns>The underlying array, or null if <see cref="ImmutableArray{T}.IsDefault"/> is true.</returns>
         internal static byte[]? DangerousGetUnderlyingArray(ImmutableArray<byte> array)
         {
-            ByteArrayUnion union = default;
-            union.ImmutableArray = array;
-            return union.UnderlyingArray;
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        private struct ByteArrayUnion
-        {
-            [FieldOffset(0)]
-            internal byte[]? UnderlyingArray;
-
-            [FieldOffset(0)]
-            internal ImmutableArray<byte> ImmutableArray;
+            return Unsafe.As<ImmutableArray<byte>, byte[]>(ref array);
         }
     }
 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
@@ -512,7 +512,7 @@ namespace System.Reflection.Internal
         internal byte[] PeekBytes(int offset, int byteCount)
         {
             CheckBounds(offset, byteCount);
-            return BlobUtilities.ReadBytes(Pointer + offset, byteCount);
+            return new ReadOnlySpan<byte>(Pointer + offset, byteCount).ToArray();
         }
 
         internal int IndexOf(byte b, int start)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/MemoryBlock.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -126,11 +127,8 @@ namespace System.Reflection.Internal
         {
             CheckBounds(offset, sizeof(uint));
 
-            unchecked
-            {
-                byte* ptr = Pointer + offset;
-                return (uint)(ptr[0] | (ptr[1] << 8) | (ptr[2] << 16) | (ptr[3] << 24));
-            }
+            uint result = Unsafe.ReadUnaligned<uint>(Pointer + offset);
+            return BitConverter.IsLittleEndian ? result : BinaryPrimitives.ReverseEndianness(result);
         }
 
         /// <summary>
@@ -187,11 +185,8 @@ namespace System.Reflection.Internal
         {
             CheckBounds(offset, sizeof(ushort));
 
-            unchecked
-            {
-                byte* ptr = Pointer + offset;
-                return (ushort)(ptr[0] | (ptr[1] << 8));
-            }
+            ushort result = Unsafe.ReadUnaligned<ushort>(Pointer + offset);
+            return BitConverter.IsLittleEndian ? result : BinaryPrimitives.ReverseEndianness(result);
         }
 
         // When reference has tag bits.
@@ -250,7 +245,7 @@ namespace System.Reflection.Internal
             byte* ptr = Pointer + offset;
             if (BitConverter.IsLittleEndian)
             {
-                return *(Guid*)ptr;
+                return Unsafe.ReadUnaligned<Guid>(ptr);
             }
             else
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -656,11 +656,6 @@ namespace System.Reflection.Metadata
 
         private void WriteBytesUnchecked(ReadOnlySpan<byte> buffer)
         {
-            if (buffer.IsEmpty)
-            {
-                return;
-            }
-
             int bytesToCurrent = Math.Min(FreeBytes, buffer.Length);
 
             buffer.Slice(0, bytesToCurrent).CopyTo(_buffer.AsSpan(Length));

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -344,7 +344,7 @@ namespace System.Reflection.Metadata
 
             foreach (var chunk in GetChunks())
             {
-                destination.WriteBytes(chunk._buffer, 0, chunk.Length);
+                destination.WriteBytes(chunk._buffer.AsSpan(0, chunk.Length));
             }
         }
 
@@ -359,7 +359,7 @@ namespace System.Reflection.Metadata
 
             foreach (var chunk in GetChunks())
             {
-                destination.WriteBytes(chunk._buffer.AsSpan());
+                destination.WriteBytes(chunk._buffer.AsSpan(0, chunk.Length));
             }
         }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Reflection.Internal;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace System.Reflection.Metadata
 {
@@ -360,7 +359,7 @@ namespace System.Reflection.Metadata
 
             foreach (var chunk in GetChunks())
             {
-                destination.WriteBytes(chunk._buffer, 0, chunk.Length);
+                destination.WriteBytes(chunk._buffer.AsSpan());
             }
         }
 
@@ -652,24 +651,29 @@ namespace System.Reflection.Metadata
                 Throw.InvalidOperationBuilderAlreadyLinked();
             }
 
-            WriteBytesUnchecked(buffer, byteCount);
+            WriteBytesUnchecked(new ReadOnlySpan<byte>(buffer, byteCount));
         }
 
-        private unsafe void WriteBytesUnchecked(byte* buffer, int byteCount)
+        private void WriteBytesUnchecked(ReadOnlySpan<byte> buffer)
         {
-            int bytesToCurrent = Math.Min(FreeBytes, byteCount);
+            if (buffer.IsEmpty)
+            {
+                return;
+            }
 
-            Marshal.Copy((IntPtr)buffer, _buffer, Length, bytesToCurrent);
+            int bytesToCurrent = Math.Min(FreeBytes, buffer.Length);
+
+            buffer.Slice(0, bytesToCurrent).CopyTo(_buffer.AsSpan(Length));
 
             AddLength(bytesToCurrent);
 
-            int remaining = byteCount - bytesToCurrent;
-            if (remaining > 0)
+            ReadOnlySpan<byte> remaining = buffer.Slice(bytesToCurrent);
+            if (!remaining.IsEmpty)
             {
-                Expand(remaining);
+                Expand(remaining.Length);
 
-                Marshal.Copy((IntPtr)(buffer + bytesToCurrent), _buffer, 0, remaining);
-                AddLength(remaining);
+                remaining.CopyTo(_buffer);
+                AddLength(remaining.Length);
             }
         }
 
@@ -725,7 +729,12 @@ namespace System.Reflection.Metadata
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
         public void WriteBytes(ImmutableArray<byte> buffer)
         {
-            WriteBytes(buffer, 0, buffer.IsDefault ? 0 : buffer.Length);
+            if (buffer.IsDefault)
+            {
+                Throw.ArgumentNull(nameof(buffer));
+            }
+
+            WriteBytes(buffer.AsSpan());
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
@@ -733,20 +742,32 @@ namespace System.Reflection.Metadata
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
         public void WriteBytes(ImmutableArray<byte> buffer, int start, int byteCount)
         {
-            WriteBytes(ImmutableByteArrayInterop.DangerousGetUnderlyingArray(buffer)!, start, byteCount);
+            if (buffer.IsDefault)
+            {
+                Throw.ArgumentNull(nameof(buffer));
+            }
+
+            BlobUtilities.ValidateRange(buffer.Length, start, byteCount, nameof(byteCount));
+
+            WriteBytes(buffer.AsSpan(start, byteCount));
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
         public void WriteBytes(byte[] buffer)
         {
-            WriteBytes(buffer, 0, buffer?.Length ?? 0);
+            if (buffer is null)
+            {
+                Throw.ArgumentNull(nameof(buffer));
+            }
+
+            WriteBytes(buffer.AsSpan());
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Range specified by <paramref name="start"/> and <paramref name="byteCount"/> falls outside of the bounds of the <paramref name="buffer"/>.</exception>
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
-        public unsafe void WriteBytes(byte[] buffer, int start, int byteCount)
+        public void WriteBytes(byte[] buffer, int start, int byteCount)
         {
             if (buffer is null)
             {
@@ -755,21 +776,17 @@ namespace System.Reflection.Metadata
 
             BlobUtilities.ValidateRange(buffer.Length, start, byteCount, nameof(byteCount));
 
+            WriteBytes(buffer.AsSpan(start, byteCount));
+        }
+
+        private void WriteBytes(ReadOnlySpan<byte> buffer)
+        {
             if (!IsHead)
             {
                 Throw.InvalidOperationBuilderAlreadyLinked();
             }
 
-            // an empty array has no element pointer:
-            if (buffer.Length == 0)
-            {
-                return;
-            }
-
-            fixed (byte* ptr = &buffer[0])
-            {
-                WriteBytesUnchecked(ptr + start, byteCount);
-            }
+            WriteBytesUnchecked(buffer);
         }
 
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
@@ -929,7 +946,7 @@ namespace System.Reflection.Metadata
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
-        public unsafe void WriteUTF16(char[] value)
+        public void WriteUTF16(char[] value)
         {
             if (value is null)
             {
@@ -941,25 +958,7 @@ namespace System.Reflection.Metadata
                 Throw.InvalidOperationBuilderAlreadyLinked();
             }
 
-            if (value.Length == 0)
-            {
-                return;
-            }
-
-            if (BitConverter.IsLittleEndian)
-            {
-                fixed (char* ptr = &value[0])
-                {
-                    WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
-                }
-            }
-            else
-            {
-                for (int i = 0; i < value.Length; i++)
-                {
-                    WriteUInt16((ushort)value[i]);
-                }
-            }
+            WriteUTF16(value.AsSpan());
         }
 
         /// <summary>
@@ -967,7 +966,7 @@ namespace System.Reflection.Metadata
         /// </summary>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
-        public unsafe void WriteUTF16(string value)
+        public void WriteUTF16(string value)
         {
             if (value is null)
             {
@@ -979,18 +978,25 @@ namespace System.Reflection.Metadata
                 Throw.InvalidOperationBuilderAlreadyLinked();
             }
 
+            WriteUTF16(value.AsSpan());
+        }
+
+        private void WriteUTF16(ReadOnlySpan<char> value)
+        {
+            if (!IsHead)
+            {
+                Throw.InvalidOperationBuilderAlreadyLinked();
+            }
+
             if (BitConverter.IsLittleEndian)
             {
-                fixed (char* ptr = value)
-                {
-                    WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
-                }
+                WriteBytesUnchecked(MemoryMarshal.AsBytes(value));
             }
             else
             {
-                for (int i = 0; i < value.Length; i++)
+                foreach (char c in value)
                 {
-                    WriteUInt16((ushort)value[i]);
+                    WriteUInt16(c);
                 }
             }
         }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobContentId.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobContentId.cs
@@ -12,13 +12,16 @@ namespace System.Reflection.Metadata
     {
         private const int Size = BlobUtilities.SizeOfGuid + sizeof(uint);
 
-        public Guid Guid { get; }
-        public uint Stamp { get; }
+        private readonly Guid _guid;
+        private readonly uint _stamp;
+
+        public Guid Guid => _guid;
+        public uint Stamp => _stamp;
 
         public BlobContentId(Guid guid, uint stamp)
         {
-            Guid = guid;
-            Stamp = stamp;
+            _guid = guid;
+            _stamp = stamp;
         }
 
         public BlobContentId(ImmutableArray<byte> id)
@@ -28,7 +31,7 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(id));
             }
 
-            (Guid, Stamp) = Initialize(id.AsSpan());
+            Initialize(id.AsSpan(), out _guid, out _stamp);
         }
 
         public BlobContentId(byte[] id)
@@ -38,10 +41,10 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(id));
             }
 
-            (Guid, Stamp) = Initialize(id);
+            Initialize(id, out _guid, out _stamp);
         }
 
-        private static unsafe (Guid guid, uint stamp) Initialize(ReadOnlySpan<byte> id)
+        private static unsafe void Initialize(ReadOnlySpan<byte> id, out Guid guid, out uint stamp)
         {
             if (id.Length != Size)
             {
@@ -51,10 +54,8 @@ namespace System.Reflection.Metadata
             fixed (byte* ptr = &id[0])
             {
                 var reader = new BlobReader(ptr, id.Length);
-                Guid guid = reader.ReadGuid();
-                uint stamp = reader.ReadUInt32();
-
-                return (guid, stamp);
+                guid = reader.ReadGuid();
+                stamp = reader.ReadUInt32();
             }
         }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -217,7 +217,7 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(buffer));
             }
 
-            WriteBytes(buffer);
+            WriteBytes(buffer.AsSpan());
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 namespace System.Reflection.Metadata
 {
     // TODO: argument checking
-    public unsafe struct BlobWriter
+    public struct BlobWriter
     {
         // writable slice:
         private readonly byte[] _buffer;
@@ -88,9 +88,7 @@ namespace System.Reflection.Metadata
         {
             BlobUtilities.ValidateRange(Length, start, byteCount, nameof(byteCount));
 
-            var result = new byte[byteCount];
-            Array.Copy(_buffer, _start + start, result, 0, byteCount);
-            return result;
+            return _buffer.AsSpan(_start + start, byteCount).ToArray();
         }
 
         public ImmutableArray<byte> ToImmutableArray()
@@ -101,8 +99,9 @@ namespace System.Reflection.Metadata
         /// <exception cref="ArgumentOutOfRangeException">Range specified by <paramref name="start"/> and <paramref name="byteCount"/> falls outside of the bounds of the buffer content.</exception>
         public ImmutableArray<byte> ToImmutableArray(int start, int byteCount)
         {
-            byte[]? array = ToArray(start, byteCount);
-            return ImmutableByteArrayInterop.DangerousCreateFromUnderlyingArray(ref array);
+            BlobUtilities.ValidateRange(Length, start, byteCount, nameof(byteCount));
+
+            return ImmutableArray.Create(_buffer.AsSpan(_start + start, byteCount));
         }
 
         private int Advance(int value)
@@ -128,14 +127,7 @@ namespace System.Reflection.Metadata
             }
 
             int start = Advance(byteCount);
-            fixed (byte* buffer = _buffer)
-            {
-                byte* ptr = buffer + start;
-                for (int i = 0; i < byteCount; i++)
-                {
-                    ptr[i] = value;
-                }
-            }
+            _buffer.AsSpan(start, byteCount).Fill(value);
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
@@ -152,13 +144,13 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentOutOfRange(nameof(byteCount));
             }
 
-            WriteBytesUnchecked(buffer, byteCount);
+            WriteBytesUnchecked(new ReadOnlySpan<byte>(buffer, byteCount));
         }
 
-        private unsafe void WriteBytesUnchecked(byte* buffer, int byteCount)
+        private void WriteBytesUnchecked(ReadOnlySpan<byte> buffer)
         {
-            int start = Advance(byteCount);
-            Marshal.Copy((IntPtr)buffer, _buffer, start, byteCount);
+            int start = Advance(buffer.Length);
+            buffer.CopyTo(_buffer.AsSpan(start));
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
@@ -195,25 +187,42 @@ namespace System.Reflection.Metadata
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
         public void WriteBytes(ImmutableArray<byte> buffer)
         {
-            WriteBytes(buffer, 0, buffer.IsDefault ? 0 : buffer.Length);
+            if (buffer.IsDefault)
+            {
+                Throw.ArgumentNull(nameof(buffer));
+            }
+
+            WriteBytesUnchecked(buffer.AsSpan());
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Range specified by <paramref name="start"/> and <paramref name="byteCount"/> falls outside of the bounds of the <paramref name="buffer"/>.</exception>
         public void WriteBytes(ImmutableArray<byte> buffer, int start, int byteCount)
         {
-            WriteBytes(ImmutableByteArrayInterop.DangerousGetUnderlyingArray(buffer)!, start, byteCount);
+            if (buffer.IsDefault)
+            {
+                Throw.ArgumentNull(nameof(buffer));
+            }
+
+            BlobUtilities.ValidateRange(buffer.Length, start, byteCount, nameof(byteCount));
+
+            WriteBytesUnchecked(buffer.AsSpan(start, byteCount));
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
-        public unsafe void WriteBytes(byte[] buffer)
+        public void WriteBytes(byte[] buffer)
         {
-            WriteBytes(buffer, 0, buffer?.Length ?? 0);
+            if (buffer is null)
+            {
+                Throw.ArgumentNull(nameof(buffer));
+            }
+
+            WriteBytesUnchecked(buffer);
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Range specified by <paramref name="start"/> and <paramref name="byteCount"/> falls outside of the bounds of the <paramref name="buffer"/>.</exception>
-        public unsafe void WriteBytes(byte[] buffer, int start, int byteCount)
+        public void WriteBytes(byte[] buffer, int start, int byteCount)
         {
             if (buffer is null)
             {
@@ -222,16 +231,7 @@ namespace System.Reflection.Metadata
 
             BlobUtilities.ValidateRange(buffer.Length, start, byteCount, nameof(byteCount));
 
-            // an empty array has no element pointer:
-            if (buffer.Length == 0)
-            {
-                return;
-            }
-
-            fixed (byte* ptr = &buffer[0])
-            {
-                WriteBytes(ptr + start, byteCount);
-            }
+            WriteBytesUnchecked(buffer.AsSpan(start, byteCount));
         }
 
         public void PadTo(int offset)
@@ -376,25 +376,7 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(value));
             }
 
-            if (value.Length == 0)
-            {
-                return;
-            }
-
-            if (BitConverter.IsLittleEndian)
-            {
-                fixed (char* ptr = &value[0])
-                {
-                    WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
-                }
-            }
-            else
-            {
-                for (int i = 0; i < value.Length; i++)
-                {
-                    WriteUInt16((ushort)value[i]);
-                }
-            }
+            WriteUTF16(value.AsSpan());
         }
 
         /// <summary>
@@ -408,18 +390,20 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(value));
             }
 
+            WriteUTF16(value.AsSpan());
+        }
+
+        private void WriteUTF16(ReadOnlySpan<char> value)
+        {
             if (BitConverter.IsLittleEndian)
             {
-                fixed (char* ptr = value)
-                {
-                    WriteBytesUnchecked((byte*)ptr, value.Length * sizeof(char));
-                }
+                WriteBytesUnchecked(MemoryMarshal.AsBytes(value));
             }
             else
             {
-                for (int i = 0; i < value.Length; i++)
+                foreach (char c in value)
                 {
-                    WriteUInt16((ushort)value[i]);
+                    WriteUInt16(c);
                 }
             }
         }
@@ -480,7 +464,7 @@ namespace System.Reflection.Metadata
             WriteUTF8(value, 0, value.Length, allowUnpairedSurrogates, prependSize: false);
         }
 
-        private void WriteUTF8(string str, int start, int length, bool allowUnpairedSurrogates, bool prependSize)
+        private unsafe void WriteUTF8(string str, int start, int length, bool allowUnpairedSurrogates, bool prependSize)
         {
             fixed (char* strPtr = str)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -144,10 +144,10 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentOutOfRange(nameof(byteCount));
             }
 
-            WriteBytesUnchecked(new ReadOnlySpan<byte>(buffer, byteCount));
+            WriteBytes(new ReadOnlySpan<byte>(buffer, byteCount));
         }
 
-        private void WriteBytesUnchecked(ReadOnlySpan<byte> buffer)
+        internal void WriteBytes(ReadOnlySpan<byte> buffer)
         {
             int start = Advance(buffer.Length);
             buffer.CopyTo(_buffer.AsSpan(start));
@@ -192,7 +192,7 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(buffer));
             }
 
-            WriteBytesUnchecked(buffer.AsSpan());
+            WriteBytes(buffer.AsSpan());
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
@@ -206,7 +206,7 @@ namespace System.Reflection.Metadata
 
             BlobUtilities.ValidateRange(buffer.Length, start, byteCount, nameof(byteCount));
 
-            WriteBytesUnchecked(buffer.AsSpan(start, byteCount));
+            WriteBytes(buffer.AsSpan(start, byteCount));
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
@@ -217,7 +217,7 @@ namespace System.Reflection.Metadata
                 Throw.ArgumentNull(nameof(buffer));
             }
 
-            WriteBytesUnchecked(buffer);
+            WriteBytes(buffer);
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
@@ -231,7 +231,7 @@ namespace System.Reflection.Metadata
 
             BlobUtilities.ValidateRange(buffer.Length, start, byteCount, nameof(byteCount));
 
-            WriteBytesUnchecked(buffer.AsSpan(start, byteCount));
+            WriteBytes(buffer.AsSpan(start, byteCount));
         }
 
         public void PadTo(int offset)
@@ -397,7 +397,7 @@ namespace System.Reflection.Metadata
         {
             if (BitConverter.IsLittleEndian)
             {
-                WriteBytesUnchecked(MemoryMarshal.AsBytes(value));
+                WriteBytes(MemoryMarshal.AsBytes(value));
             }
             else
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -97,7 +97,7 @@ namespace System.Reflection.Metadata
             }
             catch (InvalidOperationException ex)
             {
-                throw new BadImageFormatException(ex.Message);
+                throw new BadImageFormatException(ex.Message, assemblyFile, ex);
             }
         }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.EmbeddedPortablePdb.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.EmbeddedPortablePdb.cs
@@ -83,9 +83,9 @@ namespace System.Reflection.PortableExecutable
             {
                 decompressed = new NativeHeapMemoryBlock(decompressedSize);
             }
-            catch
+            catch (Exception e)
             {
-                throw new BadImageFormatException(SR.DataTooBig);
+                throw new BadImageFormatException(SR.DataTooBig, e);
             }
 
             bool success = false;
@@ -110,7 +110,7 @@ namespace System.Reflection.PortableExecutable
                     }
                     catch (Exception e)
                     {
-                        throw new BadImageFormatException(e.Message, e.InnerException);
+                        throw new BadImageFormatException(e.Message, e);
                     }
 
                     if (actualLength != decompressed.Size)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -718,7 +718,7 @@ namespace System.Reflection.PortableExecutable
             }
             catch (Exception e)
             {
-                throw new ArgumentException(e.Message, nameof(peImagePath));
+                throw new ArgumentException(e.Message, nameof(peImagePath), e);
             }
 
             Exception? errorToReport = null;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Throw.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Throw.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using System.Runtime.CompilerServices;
 
 namespace System.Reflection
 {
@@ -13,294 +12,252 @@ namespace System.Reflection
     internal static class Throw
     {
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidCast()
         {
             throw new InvalidCastException();
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidArgument(string message, string parameterName)
         {
             throw new ArgumentException(message, parameterName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidArgument_OffsetForVirtualHeapHandle()
         {
             throw new ArgumentException(SR.CantGetOffsetForVirtualHeapHandle, "handle");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static Exception InvalidArgument_UnexpectedHandleKind(HandleKind kind)
         {
             throw new ArgumentException(SR.Format(SR.UnexpectedHandleKind, kind));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static Exception InvalidArgument_Handle(string parameterName)
         {
             throw new ArgumentException(SR.InvalidHandle, parameterName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void SignatureNotVarArg()
         {
             throw new InvalidOperationException(SR.SignatureNotVarArg);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ControlFlowBuilderNotAvailable()
         {
             throw new InvalidOperationException(SR.ControlFlowBuilderNotAvailable);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidOperationBuilderAlreadyLinked()
         {
             throw new InvalidOperationException(SR.BuilderAlreadyLinked);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidOperation(string message)
         {
             throw new InvalidOperationException(message);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidOperation_LabelNotMarked(int id)
         {
             throw new InvalidOperationException(SR.Format(SR.LabelNotMarked, id));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void LabelDoesntBelongToBuilder(string parameterName)
         {
             throw new ArgumentException(SR.LabelDoesntBelongToBuilder, parameterName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void HeapHandleRequired()
         {
             throw new ArgumentException(SR.NotMetadataHeapHandle, "handle");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void EntityOrUserStringHandleRequired()
         {
             throw new ArgumentException(SR.NotMetadataTableOrUserStringHandle, "handle");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidToken()
         {
             throw new ArgumentException(SR.InvalidToken, "token");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ArgumentNull(string parameterName)
         {
             throw new ArgumentNullException(parameterName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ArgumentEmptyString(string parameterName)
         {
             throw new ArgumentException(SR.ExpectedNonEmptyString, parameterName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ArgumentEmptyArray(string parameterName)
         {
             throw new ArgumentException(SR.ExpectedNonEmptyArray, parameterName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ValueArgumentNull()
         {
             throw new ArgumentNullException("value");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void BuilderArgumentNull()
         {
             throw new ArgumentNullException("builder");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ArgumentOutOfRange(string parameterName)
         {
             throw new ArgumentOutOfRangeException(parameterName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ArgumentOutOfRange(string parameterName, string message)
         {
             throw new ArgumentOutOfRangeException(parameterName, message);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void BlobTooLarge(string parameterName)
         {
             throw new ArgumentOutOfRangeException(parameterName, SR.BlobTooLarge);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void IndexOutOfRange()
         {
             throw new ArgumentOutOfRangeException("index");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void TableIndexOutOfRange()
         {
             throw new ArgumentOutOfRangeException("tableIndex");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ValueArgumentOutOfRange()
         {
             throw new ArgumentOutOfRangeException("value");
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void OutOfBounds()
         {
             throw new BadImageFormatException(SR.OutOfBoundsRead);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void WriteOutOfBounds()
         {
             throw new InvalidOperationException(SR.OutOfBoundsWrite);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidCodedIndex()
         {
             throw new BadImageFormatException(SR.InvalidCodedIndex);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidHandle()
         {
             throw new BadImageFormatException(SR.InvalidHandle);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidCompressedInteger()
         {
             throw new BadImageFormatException(SR.InvalidCompressedInteger);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidSerializedString()
         {
             throw new BadImageFormatException(SR.InvalidSerializedString);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ImageTooSmall()
         {
             throw new BadImageFormatException(SR.ImageTooSmall);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ImageTooSmallOrContainsInvalidOffsetOrCount()
         {
             throw new BadImageFormatException(SR.ImageTooSmallOrContainsInvalidOffsetOrCount);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ReferenceOverflow()
         {
             throw new BadImageFormatException(SR.RowIdOrHeapOffsetTooLarge);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void TableNotSorted(TableIndex tableIndex)
         {
             throw new BadImageFormatException(SR.Format(SR.MetadataTableNotSorted, tableIndex));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidOperation_TableNotSorted(TableIndex tableIndex)
         {
             throw new InvalidOperationException(SR.Format(SR.MetadataTableNotSorted, tableIndex));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void InvalidOperation_PEImageNotAvailable()
         {
             throw new InvalidOperationException(SR.PEImageNotAvailable);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void TooManySubnamespaces()
         {
             throw new BadImageFormatException(SR.TooManySubnamespaces);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ValueOverflow()
         {
             throw new BadImageFormatException(SR.ValueTooLarge);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void SequencePointValueOutOfRange()
         {
             throw new BadImageFormatException(SR.SequencePointValueOutOfRange);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void HeapSizeLimitExceeded(HeapIndex heap)
         {
             throw new ImageFormatLimitationException(SR.Format(SR.HeapSizeLimitExceeded, heap));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void PEReaderDisposed()
         {
             throw new ObjectDisposedException(nameof(PortableExecutable.PEReader));

--- a/src/libraries/System.Reflection.Metadata/tests/Utilities/StreamExtensionsTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Utilities/StreamExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace System.Reflection.Internal.Tests
                 p--;
             }
 
-            return BlobUtilities.ReadBytes(buffer, (int)(p + 1 - buffer));
+            return new ReadOnlySpan<byte>(buffer, (int)(p + 1 - buffer)).ToArray();
         }
 
         [Fact]


### PR DESCRIPTION
This PR among other things changes the buffer code of `System.Reflection.Metadata` so that it uses spans and framework methods that are more optimized, and reduces pinning and unsafely converting between immutable and mutable arrays.