### PR TITLE
Test and fix using AesCcm after disposal with OpenSSL

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesCcm.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesCcm.OpenSsl.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography
 {
     public sealed partial class AesCcm
     {
-        private byte[] _key;
+        private byte[]? _key;
 
         public static bool IsSupported { get; } = Interop.OpenSslNoInit.OpenSslIsAvailable;
 
@@ -18,7 +18,9 @@ namespace System.Security.Cryptography
         {
             // OpenSSL does not allow setting nonce length after setting the key
             // we need to store it as bytes instead
-            _key = key.ToArray();
+            // Pin the array on the POH so that the GC doesn't move it around to allow zeroing to be more effective.
+            _key = GC.AllocateArray<byte>(key.Length, pinned: true);
+            key.CopyTo(_key);
         }
 
         private void EncryptCore(
@@ -28,6 +30,8 @@ namespace System.Security.Cryptography
             Span<byte> tag,
             ReadOnlySpan<byte> associatedData = default)
         {
+            CheckDisposed();
+
             using (SafeEvpCipherCtxHandle ctx = Interop.Crypto.EvpCipherCreatePartial(GetCipher(_key.Length * 8)))
             {
                 Interop.Crypto.CheckValidOpenSslHandle(ctx);
@@ -82,6 +86,8 @@ namespace System.Security.Cryptography
             Span<byte> plaintext,
             ReadOnlySpan<byte> associatedData)
         {
+            CheckDisposed();
+
             using (SafeEvpCipherCtxHandle ctx = Interop.Crypto.EvpCipherCreatePartial(GetCipher(_key.Length * 8)))
             {
                 Interop.Crypto.CheckValidOpenSslHandle(ctx);
@@ -134,6 +140,13 @@ namespace System.Security.Cryptography
         public void Dispose()
         {
             CryptographicOperations.ZeroMemory(_key);
+            _key = null;
+        }
+
+        [MemberNotNull(nameof(_key))]
+        private void CheckDisposed()
+        {
+            ObjectDisposedException.ThrowIf(_key is null, this);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/AesCcmTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/AesCcmTests.cs
@@ -376,6 +376,22 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [Fact]
+        public static void UseAfterDispose()
+        {
+            byte[] key = "eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6".HexToByteArray();
+            byte[] nonce = "a544218dadd3c1".HexToByteArray();
+            byte[] plaintext = Array.Empty<byte>();
+            byte[] ciphertext = Array.Empty<byte>();
+            byte[] tag = "469c90bb".HexToByteArray();
+
+            AesCcm aesCcm = new AesCcm(key);
+            aesCcm.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => aesCcm.Encrypt(nonce, plaintext, ciphertext, new byte[tag.Length]));
+            Assert.Throws<ObjectDisposedException>(() => aesCcm.Decrypt(nonce, ciphertext, tag, plaintext));
+        }
+
         public static IEnumerable<object[]> GetValidNonceSizes()
         {
             return GetValidSizes(AesCcm.NonceByteSizes);

--- a/src/libraries/System.Security.Cryptography/tests/AesGcmTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/AesGcmTests.cs
@@ -383,6 +383,22 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [Fact]
+        public static void UseAfterDispose()
+        {
+            byte[] key = new byte[16];
+            byte[] nonce = new byte[12];
+            byte[] plaintext = Array.Empty<byte>();
+            byte[] ciphertext = Array.Empty<byte>();
+            byte[] tag = "58e2fccefa7e3061367f1d57a4e7455a".HexToByteArray();
+
+            AesGcm aesGcm = new AesGcm(key);
+            aesGcm.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => aesGcm.Encrypt(nonce, plaintext, ciphertext, new byte[tag.Length]));
+            Assert.Throws<ObjectDisposedException>(() => aesGcm.Decrypt(nonce, ciphertext, tag, plaintext));
+        }
+
         public static IEnumerable<object[]> GetValidNonceSizes()
         {
             return GetValidSizes(AesGcm.NonceByteSizes);

--- a/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
@@ -316,6 +316,22 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [Fact]
+        public static void UseAfterDispose()
+        {
+            byte[] key = new byte[32];
+            byte[] nonce = new byte[12];
+            byte[] plaintext = Array.Empty<byte>();
+            byte[] ciphertext = Array.Empty<byte>();
+            byte[] tag = "4eb972c9a8fb3a1b382bb4d36f5ffad1".HexToByteArray();
+
+            ChaCha20Poly1305 chaChaPoly = new ChaCha20Poly1305(key);
+            chaChaPoly.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => chaChaPoly.Encrypt(nonce, plaintext, ciphertext, new byte[tag.Length]));
+            Assert.Throws<ObjectDisposedException>(() => chaChaPoly.Decrypt(nonce, ciphertext, tag, plaintext));
+        }
+
         public static IEnumerable<object[]> GetInvalidNonceSizes()
         {
             yield return new object[] { 0 };


### PR DESCRIPTION
This PR makes two changes to `AesCcm` when using OpenSSL:

1. The key is pinned to the POH so the GC doesn't move it around like we do for `ChaCha20Poly1305` on macOS. This will make the zeroing in `Dispose` more useful so GC compaction doesn't leave copies around.
2. Null out the key after disposal and throw an `ObjectDisposedException`. AES-CCM on OpenSSL today will "work" after it has been disposed, but it will just use the zeroed out key. This changes it to throw like the other implementations do, and add a test.