### PR TITLE
[LinuxBionic] Disable failing ProcessStartInfo tests on CI

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -278,6 +278,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76140", TestPlatforms.LinuxBionic)]
         public void EnvironmentGetEnvironmentVariablesIsCaseSensitive()
         {
             var caseSensitiveEnvVars = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -301,6 +302,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76140", TestPlatforms.LinuxBionic)]
         public void ProcessStartInfoEnvironmentDoesNotThrowForCaseSensitiveDuplicates()
         {
             var caseSensitiveEnvVars = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -325,6 +327,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76140", TestPlatforms.LinuxBionic)]
         public void ProcessStartInfoEnvironmentVariablesDoesNotThrowForCaseSensitiveDuplicates()
         {
             var caseSensitiveEnvVars = new Dictionary<string, string>(StringComparer.Ordinal)


### PR DESCRIPTION
A few ProcessStartInfo tests sometimes fail for strange reasons. Disabling until we can look further.

Addresses https://github.com/dotnet/runtime/issues/76140