### PR TITLE
[ilasm] Lazily allocate memory in Indx256

### DIFF
--- a/src/tests/JIT/jit64/opt/cse/HugeField1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/HugeField1.csproj
@@ -3,8 +3,6 @@
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- https://github.com/dotnet/runtime/issues/73139 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/jit64/opt/cse/HugeField2.csproj
+++ b/src/tests/JIT/jit64/opt/cse/HugeField2.csproj
@@ -3,8 +3,6 @@
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- ilasm round-trip test failure, see https://github.com/dotnet/runtime/issues/38529 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/jit64/opt/cse/hugeexpr1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/hugeexpr1.csproj
@@ -3,8 +3,6 @@
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- ilasm round-trip testing test failure: https://github.com/dotnet/runtime/issues/38515 -->
-    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>


### PR DESCRIPTION
Indx256 is a trie (or prefix tree) used to map labels to instructions.  It is very space-intensive because it allocates 256-element arrays for child nodes.  This is a localized fix to lazily allocate the child arrays and to split them into two 128-element arrays to handle common cases such as ildasm's output (IL_<hex>).  A more aggressive change to a different data structure would save much more memory but should probably include an analysis of why a trie was originally used.

Fixes #38515, #38529, #43818, and #73139.  I don't think hugeExpr1 (#38515) is going to get picked up by our current testing since the ilasmroundtrip run doesn't turn off tiered compilation, but I did check its behavior on x86 locally.