### PR TITLE
CI: Fix triggers for pipeline changes

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -21,20 +21,12 @@ parameters:
         src/tests/Common/wasm-test-runner/*
     ]
     _wasm_pipelines: [
-        eng/pipelines/*wasm*
-        eng/pipelines/common/templates/*wasm*
-        eng/pipelines/common/templates/runtime/wasm*
-        eng/pipelines/coreclr/*wasm*
+        eng/pipelines/**/*wasm*
     ]
     # src/workloads is only used in runtime-official builds
     # where evaluate-paths is not used
     _always_exclude: [
         eng/pipelines/common/evaluate-default-paths.yml
-        eng/pipelines/coreclr/*
-        eng/pipelines/installer/*
-        eng/pipelines/libraries/*
-        eng/pipelines/mono/*
-        eng/pipelines/runtime*
         src/workloads/*
     ]
 
@@ -60,6 +52,9 @@ jobs:
       - src/libraries/*
       - src/native/libs/*
       - src/tests/*
+      - eng/pipelines/installer/*
+      - eng/pipelines/mono/*
+      - eng/pipelines/libraries/*
       - ${{ parameters._const_paths._wasm_pipelines }}
       - ${{ parameters._const_paths._always_exclude }}
 
@@ -85,6 +80,9 @@ jobs:
       - src/libraries/*
       - src/native/libs/*
       - src/tests/*
+      - eng/pipelines/installer/*
+      - eng/pipelines/coreclr/*
+      - eng/pipelines/libraries/*
 
     - subset: libraries
       exclude:
@@ -99,6 +97,9 @@ jobs:
       - src/coreclr/*
       - src/tests/*
       - src/native/eventpipe/*
+      - eng/pipelines/coreclr/*
+      - eng/pipelines/mono/*
+      - eng/pipelines/installer/*
       - ${{ parameters._const_paths._wasm_pipelines }}
       - ${{ parameters._const_paths._always_exclude }}
 
@@ -127,6 +128,9 @@ jobs:
       - src/libraries/*
       - src/tests/*
       - src/native/eventpipe/*
+      - eng/pipelines/coreclr/*
+      - eng/pipelines/mono/*
+      - eng/pipelines/libraries/*
       - ${{ parameters._const_paths._wasm_pipelines }}
       - ${{ parameters._const_paths._always_exclude }}
 
@@ -237,6 +241,7 @@ jobs:
     # anything other than mono, or wasm specific paths
     - subset: non_mono_and_wasm
       exclude:
+      - eng/pipelines/mono/*
       - ${{ parameters._const_paths._wasm_specific_only }}
       - ${{ parameters._const_paths._wasm_pipelines }}
       - ${{ parameters._const_paths._always_exclude }}

--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -182,6 +182,7 @@ jobs:
       - src/mono/wasm/templates/*
       - src/mono/wasm/Wasm.Build.Tests/*
       - src/tasks/*
+      - ${{ parameters._const_paths._wasm_pipelines }}
 
     - subset: wasmdebuggertests
       include:
@@ -191,6 +192,7 @@ jobs:
       - src/mono/mono/*
       - src/mono/wasm/debugger/*
       - src/mono/wasm/runtime/*
+      - ${{ parameters._const_paths._wasm_pipelines }}
 
     - subset: any_other_than_wasm_wbt_dbg
       exclude:
@@ -207,6 +209,7 @@ jobs:
     - subset: wasm
       include:
       - ${{ parameters._const_paths._wasm_specific_only }}
+      - ${{ parameters._const_paths._wasm_pipelines }}
       # other paths that should also trigger wasm jobs
       - src/mono/*
 


### PR DESCRIPTION
Revert to the earlier triggers which excluded coreclr, installer, or
mono ymls, for the relevant subsets. For example:

```yml
    subset: coreclr
    exclude:
      - eng/pipelines/installer/*
      - eng/pipelines/mono/*
      - eng/pipelines/libraries/*
```

Prompted by #76057 (comment)