### PR TITLE
Rewrite the shared JsonSerializerOptions cache implementation.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
@@ -23,9 +23,6 @@ namespace System.Text.Json
                 options.Key.ClearCaches();
             }
 
-            // Flush the shared caching contexts
-            JsonSerializerOptions.TrackedCachingContexts.Clear();
-
             // Flush the dynamic method cache
             ReflectionEmitCachingMemberAccessor.Clear();
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -257,7 +257,6 @@ namespace System.Text.Json.Serialization.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/66232", TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [MemberData(nameof(GetJsonSerializerOptions))]
         public static void JsonSerializerOptions_ReuseConverterCaches()
         {
             // This test uses reflection to:
@@ -269,7 +268,7 @@ namespace System.Text.Json.Serialization.Tests
             RemoteExecutor.Invoke(static () =>
             {
                 Func<JsonSerializerOptions, JsonSerializerOptions?> getCacheOptions = CreateCacheOptionsAccessor();
-                IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
+                Func<JsonSerializerOptions, JsonSerializerOptions, bool> equalityComparer = CreateEqualityComparerAccessor();
 
                 foreach (var args in GetJsonSerializerOptions())
                 {
@@ -280,8 +279,7 @@ namespace System.Text.Json.Serialization.Tests
 
                     JsonSerializerOptions originalCacheOptions = getCacheOptions(options);
                     Assert.NotNull(originalCacheOptions);
-                    Assert.True(equalityComparer.Equals(options, originalCacheOptions));
-                    Assert.Equal(equalityComparer.GetHashCode(options), equalityComparer.GetHashCode(originalCacheOptions));
+                    Assert.True(equalityComparer(options, originalCacheOptions));
 
                     for (int i = 0; i < 5; i++)
                     {
@@ -290,8 +288,7 @@ namespace System.Text.Json.Serialization.Tests
 
                         JsonSerializer.Serialize(42, options2);
 
-                        Assert.True(equalityComparer.Equals(options2, originalCacheOptions));
-                        Assert.Equal(equalityComparer.GetHashCode(options2), equalityComparer.GetHashCode(originalCacheOptions));
+                        Assert.True(equalityComparer(options2, originalCacheOptions));
                         Assert.Same(originalCacheOptions, getCacheOptions(options2));
                     }
                 }
@@ -327,7 +324,7 @@ namespace System.Text.Json.Serialization.Tests
             // - All public setters in JsonSerializerOptions
             //
             // If either of them changes, this test will need to be kept in sync.
-            IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
+            Func<JsonSerializerOptions, JsonSerializerOptions, bool> equalityComparer = CreateEqualityComparerAccessor();
 
             (PropertyInfo prop, object value)[] propertySettersAndValues = GetPropertiesWithSettersAndNonDefaultValues().ToArray();
 
@@ -337,19 +334,16 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Fail($"{nameof(GetPropertiesWithSettersAndNonDefaultValues)} missing property declaration for {prop.Name}, please update the method.");
             }
 
-            Assert.True(equalityComparer.Equals(JsonSerializerOptions.Default, JsonSerializerOptions.Default));
-            Assert.Equal(equalityComparer.GetHashCode(JsonSerializerOptions.Default), equalityComparer.GetHashCode(JsonSerializerOptions.Default));
+            Assert.True(equalityComparer(JsonSerializerOptions.Default, JsonSerializerOptions.Default));
 
             foreach ((PropertyInfo prop, object? value) in propertySettersAndValues)
             {
                 var options = new JsonSerializerOptions();
                 prop.SetValue(options, value);
 
-                Assert.True(equalityComparer.Equals(options, options));
-                Assert.Equal(equalityComparer.GetHashCode(options), equalityComparer.GetHashCode(options));
+                Assert.True(equalityComparer(options, options));
 
-                Assert.False(equalityComparer.Equals(JsonSerializerOptions.Default, options));
-                Assert.NotEqual(equalityComparer.GetHashCode(JsonSerializerOptions.Default), equalityComparer.GetHashCode(options));
+                Assert.False(equalityComparer(JsonSerializerOptions.Default, options));
             }
 
             static IEnumerable<(PropertyInfo, object)> GetPropertiesWithSettersAndNonDefaultValues()
@@ -395,16 +389,14 @@ namespace System.Text.Json.Serialization.Tests
             //
             // If either of them changes, this test will need to be kept in sync.
 
-            IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
+            Func<JsonSerializerOptions, JsonSerializerOptions, bool> equalityComparer = CreateEqualityComparerAccessor();
             var options1 = new JsonSerializerOptions { WriteIndented = true };
             var options2 = new JsonSerializerOptions { WriteIndented = true };
 
-            Assert.True(equalityComparer.Equals(options1, options2));
-            Assert.Equal(equalityComparer.GetHashCode(options1), equalityComparer.GetHashCode(options2));
+            Assert.True(equalityComparer(options1, options2));
 
             _ = new MyJsonContext(options1); // Associate copy with a JsonSerializerContext
-            Assert.False(equalityComparer.Equals(options1, options2));
-            Assert.NotEqual(equalityComparer.GetHashCode(options1), equalityComparer.GetHashCode(options2));
+            Assert.False(equalityComparer(options1, options2));
         }
 
         private class MyJsonContext : JsonSerializerContext
@@ -416,11 +408,14 @@ namespace System.Text.Json.Serialization.Tests
             protected override JsonSerializerOptions? GeneratedSerializerOptions => Options;
         }
 
-        public static IEqualityComparer<JsonSerializerOptions> CreateEqualityComparerAccessor()
+        public static Func<JsonSerializerOptions, JsonSerializerOptions, bool> CreateEqualityComparerAccessor()
         {
             Type equalityComparerType = typeof(JsonSerializerOptions).GetNestedType("EqualityComparer", BindingFlags.NonPublic);
             Assert.NotNull(equalityComparerType);
-            return (IEqualityComparer<JsonSerializerOptions>)Activator.CreateInstance(equalityComparerType, nonPublic: true);
+            MethodInfo equalityComparerMethod = equalityComparerType.GetMethod("Equals", new[] { typeof(JsonSerializerOptions), typeof(JsonSerializerOptions) });
+            Assert.NotNull(equalityComparerMethod);
+
+            return (Func<JsonSerializerOptions, JsonSerializerOptions, bool>)Delegate.CreateDelegate(typeof(Func<JsonSerializerOptions, JsonSerializerOptions, bool>), equalityComparerMethod);
         }
 
         public static IEnumerable<object[]> WriteSuccessCases

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -410,11 +410,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public static Func<JsonSerializerOptions, JsonSerializerOptions, bool> CreateEqualityComparerAccessor()
         {
-            Type equalityComparerType = typeof(JsonSerializerOptions).GetNestedType("EqualityComparer", BindingFlags.NonPublic);
-            Assert.NotNull(equalityComparerType);
-            MethodInfo equalityComparerMethod = equalityComparerType.GetMethod("Equals", new[] { typeof(JsonSerializerOptions), typeof(JsonSerializerOptions) });
-            Assert.NotNull(equalityComparerMethod);
-
+            MethodInfo equalityComparerMethod = typeof(JsonSerializerOptions).GetMethod("AreEquivalentOptions", BindingFlags.NonPublic | BindingFlags.Static);
             return (Func<JsonSerializerOptions, JsonSerializerOptions, bool>)Delegate.CreateDelegate(typeof(Func<JsonSerializerOptions, JsonSerializerOptions, bool>), equalityComparerMethod);
         }
 


### PR DESCRIPTION
Rewrites the shared `JsonSerializerOptions.CachingContext` implementation so that matching instances are looked up using lock-free linear search over an array of `WeakReference<CachingContext>` instances. This achieves a couple of things:

1. Fixes #76548, in which user-defined converters referencing a large amount memory could end up being rooted in the global cache in scenaria where serialization operations are not performed frequently.
2. Improves performance compared to the existing `ConcurrentDictionary` approach:

|                   Method |        Job |                                                                                                          Branch |        Mean |       Error |      StdDev |      Median |         Min |         Max | Ratio | MannWhitney(3%) | RatioSD |  Gen 0 |  Gen 1 |  Gen 2 | Allocated | Alloc Ratio |
|------------------------- |----------- |------------------------------------------------------------------------------------------------------------------- |------------:|------------:|------------:|------------:|------------:|------------:|------:|---------------- |--------:|-------:|-------:|-------:|----------:|------------:|
|                          |            |                                                                                                                    |             |             |             |             |             |             |       |                 |         |        |        |        |           |             |
|        NewDefaultOptions | Job-CLWPWY |          main |    998.3 ns |    47.26 ns |    54.43 ns |  1,010.4 ns |    885.2 ns |  1,087.4 ns |  1.00 |            Base |    0.00 | 0.0408 | 0.0041 | 0.0041 |     461 B |        1.00 |
|        NewDefaultOptions | Job-AKKANL | PR |    901.2 ns |    46.17 ns |    53.17 ns |    894.7 ns |    832.5 ns |  1,001.2 ns |  0.91 |          Faster |    0.08 | 0.0398 | 0.0040 | 0.0040 |     461 B |        1.00 |
|                          |            |                                                                                                                    |             |             |             |             |             |             |       |                 |         |        |        |        |           |             |
|     NewCustomizedOptions | Job-CLWPWY |          main |  1,079.3 ns |    52.27 ns |    55.93 ns |  1,077.0 ns |    990.1 ns |  1,211.8 ns |  1.00 |            Base |    0.00 | 0.0435 | 0.0040 | 0.0040 |     485 B |        1.00 |
|     NewCustomizedOptions | Job-AKKANL | PR |  1,027.9 ns |    45.85 ns |    52.80 ns |  1,032.2 ns |    938.0 ns |  1,102.2 ns |  0.95 |            Same |    0.07 | 0.0427 | 0.0039 | 0.0039 |     487 B |        1.00 |
|                          |            |                                                                                                                    |             |             |             |             |             |             |       |                 |         |        |        |        |           |             |
|       NewCustomConverter | Job-CLWPWY |          main | 21,462.8 ns | 1,790.02 ns | 1,915.31 ns | 20,926.3 ns | 18,933.0 ns | 25,316.8 ns |  1.00 |            Base |    0.00 | 0.7659 | 0.0766 |      - |    8027 B |        1.00 |
|       NewCustomConverter | Job-AKKANL | PR | 20,540.2 ns |   848.39 ns |   977.01 ns | 20,651.8 ns | 19,212.5 ns | 22,677.2 ns |  0.95 |            Same |    0.09 | 0.7716 | 0.0772 |      - |    8005 B |        1.00 |
|                          |            |                                                                                                                    |             |             |             |             |             |             |       |                 |         |        |        |        |           |             |
| NewCachedCustomConverter | Job-CLWPWY |          main |  1,228.5 ns |    89.28 ns |    99.23 ns |  1,204.1 ns |  1,067.9 ns |  1,422.1 ns |  1.00 |            Base |    0.00 | 0.0502 | 0.0046 | 0.0046 |     545 B |        1.00 |
| NewCachedCustomConverter | Job-AKKANL | PR |  1,089.1 ns |    43.82 ns |    50.47 ns |  1,105.0 ns |    982.9 ns |  1,159.6 ns |  0.89 |          Faster |    0.08 | 0.0509 | 0.0039 | 0.0039 |     545 B |        1.00 |