### PR TITLE
[hot_reload] Fix unresolved token when new nested structs are used

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType.cs
@@ -25,6 +25,8 @@ public class ZExistingClass
         public event EventHandler<string> E;
         public void R() { E(this,"123"); }
     }
+
+    public static void ExistingMethod () {}
 }
 
 [AttributeUsage(AttributeTargets.All, AllowMultiple=true, Inherited=false)]

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType/ReflectionAddNewType_v1.cs
@@ -38,6 +38,14 @@ public class ZExistingClass
     public static DateTime NewStaticField;
 
     public static double NewProp { get; set; }
+
+    public static void ExistingMethod ()
+    {
+        // modified
+        NewStaticField2 = new AnotherAddedClass();
+    }
+
+    public static AnotherAddedClass NewStaticField2;
 }
 
 [AttributeUsage(AttributeTargets.All, AllowMultiple=true, Inherited=false)]
@@ -86,4 +94,23 @@ public interface INewInterface : IExistingInterface {
 
 public enum NewEnum {
     Red, Yellow, Green
+}
+
+public class AnotherAddedClass
+{
+    public struct NewNestedStruct
+    {
+        public double D;
+        public object O;
+    }
+
+    public NewNestedStruct S;
+
+    public AnotherAddedClass()
+    {
+        S = new NewNestedStruct {
+            D = 1234.0,
+            O = "1234",
+        };
+    }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -625,6 +625,8 @@ namespace System.Reflection.Metadata
                 var i = (System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.IExistingInterface)o;
 
                 Assert.Equal("123", i.ItfMethod(123));
+
+                System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.ZExistingClass.ExistingMethod ();
             });
         }
     }

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -6604,8 +6604,14 @@ mono_field_resolve_type (MonoClassField *field, MonoError *error)
 static guint32
 mono_field_resolve_flags (MonoClassField *field)
 {
-	/* Fields in metadata updates are pre-resolved, so this method should not be called. */
-	g_assert (!m_field_is_from_update (field));
+	if (G_UNLIKELY (m_field_is_from_update (field))) {
+                /* metadata-update: Just resolve the whole field, for simplicity. */
+                ERROR_DECL (error);
+                mono_field_resolve_type (field, error);
+                mono_error_assert_ok (error);
+                g_assert (field->type);
+                return field->type->attrs;
+        }
 
 	MonoClass *klass = m_field_get_parent (field);
 	MonoImage *image = m_class_get_image (klass);


### PR DESCRIPTION
When a hot reload delta contains a new nested struct that is used as a field in a newly-added class, the metadata delta adds the field of the enclosing class before it adds the fields of the nested struct.  As a result, resolving the token of the field of the enclosing struct too early will make the runtime think that the nested struct has 0 fields and subsequent field lookups will fail.

Example:

Original Code:
```csharp
public class C {
  public void ExistingMethod() { }
```

Delta code:
```csharp
public class C {
  public void ExistingMethod() {
    new AddedClass();
  }
}

public class AddedClass {
  public NestedStruct Field1;
  public AddedClass() {
    Field1 = new NestedStruct { D = 1.0 };
  }
  public struct NestedStruct {
    public double D;
  }
}
```

Expected result:
Applying the hot reload delta succeeds

Actual result:

`System.BadImageFormatException: Could not resolve field token 0x04000014`
