### PR TITLE
[wasm] WBT.WithDllImportInAssembly - don't use RandomFileName in `id`

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
@@ -182,7 +182,7 @@ namespace Wasm.Build.Tests
         public void WithDllImportInMainAssembly(string config)
         {
             // Based on https://github.com/dotnet/runtime/issues/59255
-            string id = $"blz_dllimp_{config}_{Path.GetRandomFileName()}";
+            string id = $"blz_dllimp_{config}";
             string projectFile = CreateProjectWithNativeReference(id);
             string nativeSource = @"
                 #include <stdio.h>


### PR DESCRIPTION
.. because it gets used as the namespace in the C# source file.

Fixes https://github.com/dotnet/runtime/issues/76617 .