### PR TITLE
Include bitcasts in an assert

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1191,7 +1191,7 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
     {
         assert(src->OperIs(GT_LCL_VAR, GT_LCL_FLD, GT_FIELD, GT_IND, GT_OBJ, GT_CALL, GT_MKREFANY, GT_RET_EXPR,
                            GT_COMMA, GT_CNS_VEC) ||
-               ((src->TypeGet() != TYP_STRUCT) && src->OperIsSIMD()));
+               ((src->TypeGet() != TYP_STRUCT) && (src->OperIsSIMD() || src->OperIs(GT_BITCAST))));
     }
 #endif // DEBUG
 


### PR DESCRIPTION
They can be of `TYP_SIMD8`.

Fixes #76550. FYI @tannergooding 