### PR TITLE
Ensure we cleanup the marshalling for elements of collections (stateful and stateless)

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -324,22 +324,22 @@ namespace Microsoft.Interop
                         IdentifierName("Length")),
                         StubCodeContext.Stage.Cleanup);
 
-            if (!contentsCleanupStatements.IsKind(SyntaxKind.EmptyStatement))
+            if (contentsCleanupStatements.IsKind(SyntaxKind.EmptyStatement))
             {
-                return Block(
-                    LocalDeclarationStatement(VariableDeclaration(
-                    GenericName(
-                        Identifier(TypeNames.System_Span),
-                        TypeArgumentList(SingletonSeparatedList(_unmanagedElementType))),
-                    SingletonSeparatedList(
-                        VariableDeclarator(
-                            Identifier(nativeSpanIdentifier))
-                        .WithInitializer(EqualsValueClause(
-                            GetUnmanagedValuesDestination(info, context)))))),
-                    contentsCleanupStatements);
+                return EmptyStatement();
             }
 
-            return EmptyStatement();
+            return Block(
+                LocalDeclarationStatement(VariableDeclaration(
+                GenericName(
+                    Identifier(TypeNames.System_Span),
+                    TypeArgumentList(SingletonSeparatedList(_unmanagedElementType))),
+                SingletonSeparatedList(
+                    VariableDeclarator(
+                        Identifier(nativeSpanIdentifier))
+                    .WithInitializer(EqualsValueClause(
+                        GetUnmanagedValuesDestination(info, context)))))),
+                contentsCleanupStatements);
         }
 
         protected StatementSyntax GenerateContentsMarshallingStatement(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -315,6 +315,33 @@ namespace Microsoft.Interop
                     StubCodeContext.Stage.Unmarshal));
         }
 
+        protected StatementSyntax GenerateElementCleanupStatement(TypePositionInfo info, StubCodeContext context)
+        {
+            string nativeSpanIdentifier = MarshallerHelpers.GetNativeSpanIdentifier(info, context);
+            StatementSyntax contentsCleanupStatements = GenerateContentsMarshallingStatement(info, context,
+                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName(MarshallerHelpers.GetNativeSpanIdentifier(info, context)),
+                        IdentifierName("Length")),
+                        StubCodeContext.Stage.Cleanup);
+
+            if (!contentsCleanupStatements.IsKind(SyntaxKind.EmptyStatement))
+            {
+                return Block(
+                    LocalDeclarationStatement(VariableDeclaration(
+                    GenericName(
+                        Identifier(TypeNames.System_Span),
+                        TypeArgumentList(SingletonSeparatedList(_unmanagedElementType))),
+                    SingletonSeparatedList(
+                        VariableDeclarator(
+                            Identifier(nativeSpanIdentifier))
+                        .WithInitializer(EqualsValueClause(
+                            GetUnmanagedValuesDestination(info, context)))))),
+                    contentsCleanupStatements);
+            }
+
+            return EmptyStatement();
+        }
+
         protected StatementSyntax GenerateContentsMarshallingStatement(
             TypePositionInfo info,
             StubCodeContext context,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -300,5 +300,37 @@ namespace Microsoft.Interop
                 }
             }
         }
+
+        public static StatementSyntax SkipInitOrDefaultInit(TypePositionInfo info, StubCodeContext context)
+        {
+            (TargetFramework fmk, _) = context.GetTargetFramework();
+            if (info.ManagedType is not PointerTypeInfo
+                && info.ManagedType is not ValueTypeInfo { IsByRefLike: true }
+                && fmk is TargetFramework.Net)
+            {
+                // Use the Unsafe.SkipInit<T> API when available and
+                // managed type is usable as a generic parameter.
+                return ExpressionStatement(
+                    InvocationExpression(
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            ParseName(TypeNames.System_Runtime_CompilerServices_Unsafe),
+                            IdentifierName("SkipInit")))
+                    .WithArgumentList(
+                        ArgumentList(SingletonSeparatedList(
+                            Argument(IdentifierName(info.InstanceIdentifier))
+                            .WithRefOrOutKeyword(Token(SyntaxKind.OutKeyword))))));
+            }
+            else
+            {
+                // Assign out params to default
+                return ExpressionStatement(
+                    AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName(info.InstanceIdentifier),
+                        LiteralExpression(
+                            SyntaxKind.DefaultLiteralExpression,
+                            Token(SyntaxKind.DefaultKeyword))));
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
@@ -447,7 +447,28 @@ namespace Microsoft.Interop
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
-        public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateCleanupStatements(info, context);
+        public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
+        {
+            StatementSyntax elementCleanup = GenerateElementCleanupStatement(info, context);
+
+            if (!elementCleanup.IsKind(SyntaxKind.EmptyStatement))
+            {
+                yield return elementCleanup;
+            }
+
+            if (!_shape.HasFlag(MarshallerShape.Free))
+                yield break;
+
+
+            string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
+            // <marshaller>.Free();
+            yield return ExpressionStatement(
+                InvocationExpression(
+                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName(marshaller),
+                        IdentifierName(ShapeMemberNames.Free)),
+                    ArgumentList()));
+        }
         public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateGuaranteedUnmarshalStatements(info, context);
 
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
@@ -459,7 +459,6 @@ namespace Microsoft.Interop
             if (!_shape.HasFlag(MarshallerShape.Free))
                 yield break;
 
-
             string marshaller = StatefulValueMarshalling.GetMarshallerIdentifier(info, context);
             // <marshaller>.Free();
             yield return ExpressionStatement(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
@@ -376,11 +376,19 @@ namespace Microsoft.Interop
         public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
         {
+            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
             yield return LocalDeclarationStatement(
                 VariableDeclaration(
                     PredefinedType(Token(SyntaxKind.IntKeyword)),
                     SingletonSeparatedList(
-                        VariableDeclarator(MarshallerHelpers.GetNumElementsIdentifier(info, context)))));
+                        VariableDeclarator(numElementsIdentifier))));
+            // Use the numElements local to ensure the compiler doesn't give errors for using an uninitialized variable.
+            // The value will never be used unless it has been initialized, so this is safe.
+            yield return MarshallerHelpers.SkipInitOrDefaultInit(
+                new TypePositionInfo(SpecialTypeInfo.Int32, NoMarshallingInfo.Instance)
+                {
+                    InstanceIdentifier = numElementsIdentifier
+                }, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalCaptureStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
@@ -600,11 +608,19 @@ namespace Microsoft.Interop
 
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
         {
+            string numElementsIdentifier = MarshallerHelpers.GetNumElementsIdentifier(info, context);
             yield return LocalDeclarationStatement(
                 VariableDeclaration(
                     PredefinedType(Token(SyntaxKind.IntKeyword)),
                     SingletonSeparatedList(
-                        VariableDeclarator(MarshallerHelpers.GetNumElementsIdentifier(info, context)))));
+                        VariableDeclarator(numElementsIdentifier))));
+            // Use the numElements local to ensure the compiler doesn't give errors for using an uninitialized variable.
+            // The value will never be used unless it has been initialized, so this is safe.
+            yield return MarshallerHelpers.SkipInitOrDefaultInit(
+                new TypePositionInfo(SpecialTypeInfo.Int32, NoMarshallingInfo.Instance)
+                {
+                    InstanceIdentifier = numElementsIdentifier
+                }, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalCaptureStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
@@ -251,6 +251,10 @@ namespace Microsoft.Interop
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
+            foreach (StatementSyntax statement in _innerMarshaller.GenerateCleanupStatements(info, context))
+            {
+                yield return statement;
+            }
             // <marshallerType>.Free(<nativeIdentifier>);
             yield return ExpressionStatement(
                 InvocationExpression(
@@ -512,7 +516,15 @@ namespace Microsoft.Interop
 
         public TypeSyntax AsNativeType(TypePositionInfo info) => _nativeTypeSyntax;
 
-        public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
+        public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
+        {
+            StatementSyntax elementCleanup = GenerateElementCleanupStatement(info, context);
+
+            if (!elementCleanup.IsKind(SyntaxKind.EmptyStatement))
+            {
+                yield return elementCleanup;
+            }
+        }
 
         public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
@@ -502,7 +502,7 @@ namespace SharedTypes
 
                 _list = managed;
                 // Always allocate at least one byte when the list is zero-length.
-                int spaceToAllocate = Math.Max(managed.Count * sizeof(TUnmanagedElement), 1);
+                int spaceToAllocate = Math.Max(managed.Count, 1);
                 if (spaceToAllocate <= buffer.Length)
                 {
                     _span = buffer[0..spaceToAllocate];

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
@@ -502,14 +502,14 @@ namespace SharedTypes
 
                 _list = managed;
                 // Always allocate at least one byte when the list is zero-length.
-                int spaceToAllocate = Math.Max(managed.Count, 1);
-                if (spaceToAllocate <= buffer.Length)
+                int countToAllocate = Math.Max(managed.Count, 1);
+                if (countToAllocate <= buffer.Length)
                 {
-                    _span = buffer[0..spaceToAllocate];
+                    _span = buffer[0..countToAllocate];
                 }
                 else
                 {
-                    _allocatedMemory = Marshal.AllocCoTaskMem(spaceToAllocate);
+                    _allocatedMemory = Marshal.AllocCoTaskMem(countToAllocate * sizeof(TUnmanagedElement));
                     _span = new Span<TUnmanagedElement>((void*)_allocatedMemory, managed.Count);
                 }
             }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
@@ -196,6 +196,31 @@ namespace SharedTypes
         }
     }
 
+    [CustomMarshaller(typeof(IntWrapper), MarshalMode.Default, typeof(IntWrapperMarshallerWithFreeCounts))]
+    public static unsafe class IntWrapperMarshallerWithFreeCounts
+    {
+        [ThreadStatic]
+        public static int NumCallsToFree = 0;
+
+        public static int* ConvertToUnmanaged(IntWrapper managed)
+        {
+            int* ret = (int*)Marshal.AllocCoTaskMem(sizeof(int));
+            *ret = managed.i;
+            return ret;
+        }
+
+        public static IntWrapper ConvertToManaged(int* unmanaged)
+        {
+            return new IntWrapper { i = *unmanaged };
+        }
+
+        public static void Free(int* unmanaged)
+        {
+            NumCallsToFree++;
+            Marshal.FreeCoTaskMem((IntPtr)unmanaged);
+        }
+    }
+
     [CustomMarshaller(typeof(IntWrapper), MarshalMode.Default, typeof(Marshaller))]
     public static unsafe class IntWrapperMarshallerStateful
     {


### PR DESCRIPTION
We accidentally lost the element marshalling when moving to the released marshaller design. This PR adds it back with matching logic to the previous marshaller design.

Verified manually that we emit the right code for the case in #76584 

Fixes https://github.com/dotnet/runtime/issues/76584

Given the scope of the break that this fixes (memory leaks), I think this is a backport candidate.