### PR TITLE
[wasm] benchmark simple app without JSExport

### DIFF
--- a/src/mono/sample/wasm/browser-bench/AppStart.cs
+++ b/src/mono/sample/wasm/browser-bench/AppStart.cs
@@ -22,6 +22,7 @@ namespace Sample
             measurements = new Measurement[] {
                 new PageShow(),
                 new ReachManaged(),
+                new SimpleReachManaged(),
             };
         }
 
@@ -54,12 +55,26 @@ namespace Sample
             }
         }
 
+        class SimpleReachManaged : BenchTask.Measurement
+        {
+            public override string Name => "Simple reach managed";
+            public override int InitialSamples => 3;
+            public override bool HasRunStepAsync => true;
+
+            public override async Task RunStepAsync()
+            {
+                await MainApp.SimpleReachedManaged();
+            }
+        }
+
         public partial class MainApp
         {
             [JSImport("globalThis.mainApp.PageShow")]
             public static partial Task PageShow();
             [JSImport("globalThis.mainApp.FrameReachedManaged")]
             public static partial Task FrameReachedManaged();
+            [JSImport("globalThis.mainApp.SimpleReachedManaged")]
+            public static partial Task SimpleReachedManaged();
         }
 
         public partial class FrameApp

--- a/src/mono/sample/wasm/browser-bench/SimpleApp/AppStart.cs
+++ b/src/mono/sample/wasm/browser-bench/SimpleApp/AppStart.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.JavaScript;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Sample
+{
+    public partial class FrameApp
+    {
+        [JSImport("globalThis.frameApp.ReachedCallback")]
+        public static partial Task ReachedCallback();
+
+        public static void Main()
+        {
+            ReachedCallback();
+        }
+    }
+}

--- a/src/mono/sample/wasm/browser-bench/SimpleApp/Wasm.Browser.Bench.SimpleApp.csproj
+++ b/src/mono/sample/wasm/browser-bench/SimpleApp/Wasm.Browser.Bench.SimpleApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <!-- don't need to run this on helix -->
+    <WasmCopyAppZipToHelixTestDir>false</WasmCopyAppZipToHelixTestDir>
+    <WasmMainJSPath>simple-main.js</WasmMainJSPath>
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+
+  <Target Name="RunSample" />
+
+</Project>

--- a/src/mono/sample/wasm/browser-bench/SimpleApp/appstart-simple.html
+++ b/src/mono/sample/wasm/browser-bench/SimpleApp/appstart-simple.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--  Licensed to the .NET Foundation under one or more agreements. -->
+<!-- The .NET Foundation licenses this file to you under the MIT license. -->
+<html>
+
+<head>
+  <title>App task</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type="module" src="./simple-main.js"></script>
+  <script type='module' src="./dotnet.js"></script>
+  <link rel="preload" href="./mono-config.json" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./dotnet.wasm" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./icudt.dat" as="fetch" crossorigin="anonymous">
+  <link rel="prefetch" href="./managed/System.Private.CoreLib.dll" as="fetch" crossorigin="anonymous">
+</head>
+
+<body>
+  <h3 id="header">Wasm Browser Sample - App task simple</h3>
+  <span id="out"></span>
+</body>
+
+</html>

--- a/src/mono/sample/wasm/browser-bench/SimpleApp/simple-main.js
+++ b/src/mono/sample/wasm/browser-bench/SimpleApp/simple-main.js
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+"use strict";
+
+import { dotnet, exit } from './dotnet.js'
+
+class FrameApp {
+    reachedCallback() {
+        if (window.parent != window) {
+            window.parent.resolveAppStartEvent("reached");
+        }
+    }
+}
+
+let mute = false;
+try {
+    globalThis.frameApp = new FrameApp();
+    globalThis.frameApp.ReachedCallback = globalThis.frameApp.reachedCallback.bind(globalThis.frameApp);
+    if (window.parent != window) {
+        window.addEventListener("pageshow", event => { window.parent.resolveAppStartEvent("pageshow"); })
+    }
+
+    window.muteErrors = () => {
+        mute = true;
+    }
+
+    const runtime = await dotnet
+        .withModuleConfig({
+            printErr: () => undefined,
+            print: () => undefined,
+            onConfigLoaded: (config) => {
+                // we are sharing the same mono-config.json with Main application
+                // we don't want to load all of it, including it's [JSExport]s
+                config.assets = config.assets.filter(a => a.name !== "Wasm.Browser.Bench.Sample.dll")
+
+                if (window.parent != window) {
+                    window.parent.resolveAppStartEvent("onConfigLoaded");
+                }
+                // config.diagnosticTracing = true;
+            }
+        })
+        .create();
+
+    if (window.parent != window) {
+        window.parent.resolveAppStartEvent("onDotnetReady");
+    }
+    await runtime.runMain("Wasm.Browser.Bench.SimpleApp.dll", []);
+}
+catch (err) {
+    if (!mute) {
+        console.error(`WASM ERROR ${err}`);
+    }
+    exit(1, err);
+}

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <!-- don't need to run this on helix -->
@@ -7,13 +7,27 @@
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Console\**" />
+    <Compile Remove="SimpleApp\**" />
+    <EmbeddedResource Remove="Console\**" />
+    <EmbeddedResource Remove="SimpleApp\**" />
+    <None Remove="Console\**" />
+    <None Remove="SimpleApp\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <WasmExtraFilesToDeploy Include="index.html" />
     <WasmExtraFilesToDeploy Include="appstart-frame.html" />
     <WasmExtraFilesToDeploy Include="frame-main.js" />
+    <WasmExtraFilesToDeploy Include="SimpleApp/appstart-simple.html" />
+    <WasmExtraFilesToDeploy Include="SimpleApp/simple-main.js" />
     <WasmExtraFilesToDeploy Include="style.css" />
     <Compile Remove="Console/Console.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="SimpleApp\Wasm.Browser.Bench.SimpleApp.csproj" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -22,5 +36,9 @@
   </PropertyGroup>
 
   <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
+
+  <ItemGroup>
+    <None Remove="C:\Dev\runtime\src\mono\sample\wasm\browser-bench\Console\Console.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -23,11 +23,10 @@
     <WasmExtraFilesToDeploy Include="SimpleApp/appstart-simple.html" />
     <WasmExtraFilesToDeploy Include="SimpleApp/simple-main.js" />
     <WasmExtraFilesToDeploy Include="style.css" />
-    <Compile Remove="Console/Console.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="SimpleApp\Wasm.Browser.Bench.SimpleApp.csproj" />
+    <ProjectReference Include="SimpleApp\Wasm.Browser.Bench.SimpleApp.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -36,9 +35,5 @@
   </PropertyGroup>
 
   <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
-
-  <ItemGroup>
-    <None Remove="C:\Dev\runtime\src\mono\sample\wasm\browser-bench\Console\Console.cs" />
-  </ItemGroup>
 
 </Project>

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.sln
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31625.145
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wasm.Browser.Bench.Sample", "Wasm.Browser.Bench.Sample.csproj", "{3C87C8E2-2D72-495A-8BB5-B9A503603121}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wasm.Browser.Bench.SimpleApp", "SimpleApp\Wasm.Browser.Bench.SimpleApp.csproj", "{2FB4221B-EEDC-4F5A-8D92-45CC0C8D6A94}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{3C87C8E2-2D72-495A-8BB5-B9A503603121}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C87C8E2-2D72-495A-8BB5-B9A503603121}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C87C8E2-2D72-495A-8BB5-B9A503603121}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FB4221B-EEDC-4F5A-8D92-45CC0C8D6A94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FB4221B-EEDC-4F5A-8D92-45CC0C8D6A94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FB4221B-EEDC-4F5A-8D92-45CC0C8D6A94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FB4221B-EEDC-4F5A-8D92-45CC0C8D6A94}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -119,7 +119,7 @@ class MainApp {
 
     async pageShow() {
         try {
-            await this.waitFor('pageshow');
+            await this.waitFor('pageshow', 'appstart-frame.html');
         } finally {
             this.removeFrame();
         }
@@ -127,18 +127,26 @@ class MainApp {
 
     async frameReachedManaged() {
         try {
-            await this.waitFor('reached');
+            await this.waitFor('reached', 'appstart-frame.html');
         } finally {
             this.removeFrame();
         }
     }
 
-    async waitFor(eventName) {
+    async simpleReachedManaged() {
+        try {
+            await this.waitFor('reached', 'appstart-simple.html');
+        } finally {
+            this.removeFrame();
+        }
+    }
+
+    async waitFor(eventName, src) {
         try {
             let promise;
             let promiseResolve;
             this._frame = document.createElement('iframe');
-            this._frame.src = 'appstart-frame.html';
+            this._frame.src = src;
 
             promise = new Promise(resolve => { promiseResolve = resolve; })
             window.resolveAppStartEvent = function (event) {
@@ -163,6 +171,7 @@ class MainApp {
 try {
     globalThis.mainApp = new MainApp();
     globalThis.mainApp.FrameReachedManaged = globalThis.mainApp.frameReachedManaged.bind(globalThis.mainApp);
+    globalThis.mainApp.SimpleReachedManaged = globalThis.mainApp.simpleReachedManaged.bind(globalThis.mainApp);
     globalThis.mainApp.PageShow = globalThis.mainApp.pageShow.bind(globalThis.mainApp);
 
     const runtime = await dotnet

--- a/src/mono/sample/wasm/simple-server/Program.cs
+++ b/src/mono/sample/wasm/simple-server/Program.cs
@@ -166,6 +166,11 @@ namespace HttpServer
 
                 context.Response.ContentLength64 = buffer.Length;
                 context.Response.AppendHeader("cache-control", "public, max-age=31536000");
+
+                // make sure we can load with threads and more precise performance.now()
+                context.Response.AppendHeader("Cross-Origin-Opener-Policy", "same-origin");
+                context.Response.AppendHeader("Cross-Origin-Embedder-Policy", "require-corp");
+
                 var stream = context.Response.OutputStream;
                 try
                 {


### PR DESCRIPTION
The new benchmark `SimpleReachManaged` is comparable to `ReachManaged` but it doesn't contain any `JSExport`

Contributes to https://github.com/dotnet/runtime/issues/75598