### PR TITLE
[JIT] Cleanup, share more code between x86 and x64 in `genAllocLclFrame`

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -2191,7 +2191,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
             GetEmitter()->emitIns_R(INS_push, EA_PTRSIZE, REG_SECRET_STUB_PARAM);
             spOffset += REGSIZE_BYTES;
         }
-#else // !TARGET_X86
+#else  // !TARGET_X86
         static_assert_no_msg((RBM_STACK_PROBE_HELPER_ARG & (RBM_SECRET_STUB_PARAM | RBM_DEFAULT_HELPER_CALL_TARGET)) ==
                              RBM_NONE);
 #endif // !TARGET_X86


### PR DESCRIPTION
**Description**
I'm in the process of getting familiar with our xarch codegen/emitter. Am trying to wrap my head around the differences between x86 and x64 for stack pointers - noticed that the two could share a little bit more logic in `genAllocLclFrame`.

This change is purely cleanup and should produce zero diffs.

**Acceptance Criteria**
- [x] [No Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=40870&view=ms.vss-build-web.run-extensions-tab)