### PR TITLE
Robustify speech recognition test

### DIFF
--- a/src/libraries/System.Speech/tests/SynthesizeRecognizeTests.cs
+++ b/src/libraries/System.Speech/tests/SynthesizeRecognizeTests.cs
@@ -101,7 +101,7 @@ namespace SampleSynthesisTests
                                     diagnostics.AppendLine($"Alternatives included '{phrase.Text}'' with confidence {phrase.Confidence}");
                                 }
                                 diagnostics.Append($"Elapsed {sw.Elapsed}");
-                                Assert.Fail($"Recognition of '{input}' was expected to produce a string starting with '{output}', but failed");
+                                Assert.Fail($"Recognition of '{input}' was expected to produce a string containing '{output}', but failed");
                             }
                         };
 

--- a/src/libraries/System.Speech/tests/SynthesizeRecognizeTests.cs
+++ b/src/libraries/System.Speech/tests/SynthesizeRecognizeTests.cs
@@ -98,7 +98,7 @@ namespace SampleSynthesisTests
                             {
                                 foreach (RecognizedPhrase phrase in args.Result.Alternates)
                                 {
-                                    diagnostics.AppendLine($"Alternatives included '{phrase.Text}'' with confidence {phrase.Confidence}");
+                                    diagnostics.AppendLine($"Alternatives included '{phrase.Text}' with confidence {phrase.Confidence}");
                                 }
                                 diagnostics.Append($"Elapsed {sw.Elapsed}");
                                 Assert.Fail($"Recognition of '{input}' was expected to produce a string containing '{output}', but failed");
@@ -130,7 +130,7 @@ namespace SampleSynthesisTests
 
                             foreach (RecognizedPhrase phrase in result.Alternates)
                             {
-                                diagnostics.AppendLine($"Alternatives included '{phrase.Text}'' with confidence {phrase.Confidence}");
+                                diagnostics.AppendLine($"Alternatives included '{phrase.Text}' with confidence {phrase.Confidence}");
                             }
 
                             Assert.True(result.Confidence > 0.1); // strings we use are normally > 0.8


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/76626 (?) 

I can't reproduce the failure despite looping the tests for some time while keeping the machine busy doing builds. So I really have no theory why it failed.

1. Change the test words to a couple found by trial and error to be recognized with particularly high confidence level. Used two so we can see if both fail or just one.
2. Add diagnostic logging that is output if the tests fail.
3. Increase a couple of relevant timeouts from defaults.

Also added an error case test with silence.  (Was not able to find an input string that it would refuse to recognize. It always just had low confidence. White noise does lead to failure, but I don't have a quick way to make that in a test.)