### PR TITLE
Revert "Backport: work around GitHub .patch URL issue"

### DIFF
--- a/eng/actions/backport/index.js
+++ b/eng/actions/backport/index.js
@@ -67,9 +67,7 @@ async function run() {
     } catch { }
 
     // download and apply patch
-    let patch_url = github.context.payload.issue.pull_request.patch_url;
-    patch_url = patch_url.replace("runtime", "RUNTIME");
-    await exec.exec(`curl -sSL "${patch_url}" --output changes.patch`);
+    await exec.exec(`curl -sSL "${github.context.payload.issue.pull_request.patch_url}" --output changes.patch`);
 
     const git_am_command = "git am --3way --ignore-whitespace --keep-non-patch changes.patch";
     let git_am_output = `$ ${git_am_command}\n\n`;


### PR DESCRIPTION
Reverts dotnet/runtime#74452

GitHub Support just got back to me that the issue was fixed, reverting that workaround.