### PR TITLE
Check for non-valid compare chains (#76566)

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2696,7 +2696,7 @@ void CodeGen::genCodeForBinary(GenTreeOp* tree)
         return;
     }
 
-    if (tree->OperIs(GT_AND) && op2->isContainedCompareChainSegment())
+    if (tree->isContainedCompareChainSegment(op2))
     {
         GenCondition cond;
         bool         chain = false;

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2696,7 +2696,7 @@ void CodeGen::genCodeForBinary(GenTreeOp* tree)
         return;
     }
 
-    if (tree->OperIs(GT_AND) && op2->isContainedAndNotIntOrIImmed())
+    if (tree->OperIs(GT_AND) && op2->isContainedCompareChainSegment())
     {
         GenCondition cond;
         bool         chain = false;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -910,10 +910,10 @@ public:
         return isContained() && IsCnsIntOrI() && !isUsedFromSpillTemp();
     }
 
-    // Node is contained, but it isn't contained due to being a containable int.
-    bool isContainedCompareChainSegment() const
+    // Node and its child in isolation form a contained compare chain.
+    bool isContainedCompareChainSegment(GenTree* child) const
     {
-        return isContained() && !isContainedIntOrIImmed();
+        return (OperIs(GT_AND) && child->isContained() && (child->OperIs(GT_AND) || child->OperIsCmpCompare()));
     }
 
     bool isContainedFltOrDblImmed() const

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -911,7 +911,7 @@ public:
     }
 
     // Node is contained, but it isn't contained due to being a containable int.
-    bool isContainedAndNotIntOrIImmed() const
+    bool isContainedCompareChainSegment() const
     {
         return isContained() && !isContainedIntOrIImmed();
     }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2753,7 +2753,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 #ifdef TARGET_ARM64
     // Do not optimise further if op1 has a contained chain.
     if (op1->OperIs(GT_AND) &&
-        (op1->gtGetOp1()->isContainedAndNotIntOrIImmed() || op1->gtGetOp2()->isContainedAndNotIntOrIImmed()))
+        (op1->gtGetOp1()->isContainedCompareChainSegment() || op1->gtGetOp2()->isContainedCompareChainSegment()))
     {
         return cmp;
     }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2753,7 +2753,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 #ifdef TARGET_ARM64
     // Do not optimise further if op1 has a contained chain.
     if (op1->OperIs(GT_AND) &&
-        (op1->gtGetOp1()->isContainedCompareChainSegment() || op1->gtGetOp2()->isContainedCompareChainSegment()))
+        (op1->isContainedCompareChainSegment(op1->gtGetOp1()) || op1->isContainedCompareChainSegment(op1->gtGetOp2())))
     {
         return cmp;
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2255,15 +2255,14 @@ bool Lowering::IsValidCompareChain(GenTree* child, GenTree* parent)
 {
     assert(parent->OperIs(GT_AND) || parent->OperIs(GT_SELECT));
 
-    if (child->isContainedAndNotIntOrIImmed())
+    if (child->OperIs(GT_AND) || child->OperIsCmpCompare())
     {
-        // Already have a chain.
-        assert(child->OperIs(GT_AND) || child->OperIsCmpCompare());
-        return true;
-    }
-    else
-    {
-        if (child->OperIs(GT_AND))
+        if (child->isContainedCompareChainSegment())
+        {
+            // Already have a chain.
+            return true;
+        }
+        else if (child->OperIs(GT_AND))
         {
             // Count both sides.
             return IsValidCompareChain(child->AsOp()->gtGetOp2(), child) &&
@@ -2299,7 +2298,7 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
     assert(parent->OperIs(GT_AND) || parent->OperIs(GT_SELECT));
     *startOfChain = nullptr; // Nothing found yet.
 
-    if (child->isContainedAndNotIntOrIImmed())
+    if (child->isContainedCompareChainSegment())
     {
         // Already have a chain.
         return true;
@@ -2310,7 +2309,7 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
         if (child->OperIs(GT_AND))
         {
             // If Op2 is not contained, then try to contain it.
-            if (!child->AsOp()->gtGetOp2()->isContainedAndNotIntOrIImmed())
+            if (!child->AsOp()->gtGetOp2()->isContainedCompareChainSegment())
             {
                 if (!ContainCheckCompareChain(child->gtGetOp2(), child, startOfChain))
                 {
@@ -2320,7 +2319,7 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
             }
 
             // If Op1 is not contained, then try to contain it.
-            if (!child->AsOp()->gtGetOp1()->isContainedAndNotIntOrIImmed())
+            if (!child->AsOp()->gtGetOp1()->isContainedCompareChainSegment())
             {
                 if (!ContainCheckCompareChain(child->gtGetOp1(), child, startOfChain))
                 {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2255,25 +2255,21 @@ bool Lowering::IsValidCompareChain(GenTree* child, GenTree* parent)
 {
     assert(parent->OperIs(GT_AND) || parent->OperIs(GT_SELECT));
 
-    if (child->OperIs(GT_AND) || child->OperIsCmpCompare())
+    if (parent->isContainedCompareChainSegment(child))
     {
-        if (child->isContainedCompareChainSegment())
-        {
-            // Already have a chain.
-            return true;
-        }
-        else if (child->OperIs(GT_AND))
-        {
-            // Count both sides.
-            return IsValidCompareChain(child->AsOp()->gtGetOp2(), child) &&
-                   IsValidCompareChain(child->AsOp()->gtGetOp1(), child);
-        }
-        else if (child->OperIsCmpCompare() && varTypeIsIntegral(child->gtGetOp1()) &&
-                 varTypeIsIntegral(child->gtGetOp2()))
-        {
-            // Can the child compare be contained.
-            return IsSafeToContainMem(parent, child);
-        }
+        // Already have a chain.
+        return true;
+    }
+    else if (child->OperIs(GT_AND))
+    {
+        // Count both sides.
+        return IsValidCompareChain(child->AsOp()->gtGetOp2(), child) &&
+               IsValidCompareChain(child->AsOp()->gtGetOp1(), child);
+    }
+    else if (child->OperIsCmpCompare() && varTypeIsIntegral(child->gtGetOp1()) && varTypeIsIntegral(child->gtGetOp2()))
+    {
+        // Can the child compare be contained.
+        return IsSafeToContainMem(parent, child);
     }
 
     return false;
@@ -2298,9 +2294,9 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
     assert(parent->OperIs(GT_AND) || parent->OperIs(GT_SELECT));
     *startOfChain = nullptr; // Nothing found yet.
 
-    if (child->isContainedCompareChainSegment())
+    if (parent->isContainedCompareChainSegment(child))
     {
-        // Already have a chain.
+        // Already have a contained chain.
         return true;
     }
     // Can the child be contained.
@@ -2309,7 +2305,7 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
         if (child->OperIs(GT_AND))
         {
             // If Op2 is not contained, then try to contain it.
-            if (!child->AsOp()->gtGetOp2()->isContainedCompareChainSegment())
+            if (!child->isContainedCompareChainSegment(child->AsOp()->gtGetOp2()))
             {
                 if (!ContainCheckCompareChain(child->gtGetOp2(), child, startOfChain))
                 {
@@ -2319,7 +2315,7 @@ bool Lowering::ContainCheckCompareChain(GenTree* child, GenTree* parent, GenTree
             }
 
             // If Op1 is not contained, then try to contain it.
-            if (!child->AsOp()->gtGetOp1()->isContainedCompareChainSegment())
+            if (!child->isContainedCompareChainSegment(child->AsOp()->gtGetOp1()))
             {
                 if (!ContainCheckCompareChain(child->gtGetOp1(), child, startOfChain))
                 {


### PR DESCRIPTION
Small change to not fall over when finding contained nodes that aren't a valid compare chain.