### PR TITLE
JIT: Preference locals away from PUTARG_REG killed registers

### DIFF
--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1842,7 +1842,7 @@ private:
     // These methods return the number of sources.
     int BuildNode(GenTree* tree);
 
-    void UpdatePreferenceOfDyingLocal(Interval* interval);
+    void UpdatePreferencesOfDyingLocal(Interval* interval);
     void getTgtPrefOperands(GenTree* tree, GenTree* op1, GenTree* op2, bool* prefOp1, bool* prefOp2);
     bool supportsSpecialPutArg();
 

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1586,6 +1586,25 @@ private:
     PhasedVar<regMaskTP> availableFloatRegs;
     PhasedVar<regMaskTP> availableDoubleRegs;
 
+    // Register mask of argument registers currently occupied because we saw a
+    // PUTARG_REG node. Tracked between the PUTARG_REG and its corresponding
+    // CALL node and used to preference locals away from these (occupied)
+    // registers that will otherwise force a spill.
+    regMaskTP placedArgRegs;
+
+    struct PlacedLocal
+    {
+        unsigned  VarIndex;
+        regMaskTP RegMask;
+    };
+
+    // Locals that are currently placed in registers via PUTARG_REG. These
+    // locals are available due to the special PUTARG treatment, and we keep
+    // track of them between the PUTARG_REG and CALL to ensure we do not
+    // unpreference them.
+    PlacedLocal placedArgLocals[MAX_REG_ARG + MAX_FLOAT_REG_ARG];
+    size_t      numPlacedArgLocals;
+
     // The set of all register candidates. Note that this may be a subset of tracked vars.
     VARSET_TP registerCandidateVars;
     // Current set of live register candidate vars, used during building of RefPositions to determine
@@ -1823,6 +1842,7 @@ private:
     // These methods return the number of sources.
     int BuildNode(GenTree* tree);
 
+    void PreferenceDyingLocal(Interval* interval);
     void getTgtPrefOperands(GenTree* tree, GenTree* op1, GenTree* op2, bool* prefOp1, bool* prefOp2);
     bool supportsSpecialPutArg();
 

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1588,8 +1588,8 @@ private:
 
     // Register mask of argument registers currently occupied because we saw a
     // PUTARG_REG node. Tracked between the PUTARG_REG and its corresponding
-    // CALL node and used to preference locals away from these (occupied)
-    // registers that will otherwise force a spill.
+    // CALL node and is used to avoid preferring these registers for locals
+    // which would otherwise force a spill.
     regMaskTP placedArgRegs;
 
     struct PlacedLocal
@@ -1600,8 +1600,8 @@ private:
 
     // Locals that are currently placed in registers via PUTARG_REG. These
     // locals are available due to the special PUTARG treatment, and we keep
-    // track of them between the PUTARG_REG and CALL to ensure we do not
-    // unpreference them.
+    // track of them between the PUTARG_REG and CALL to ensure we keep the
+    // register they are placed in in the preference set.
     PlacedLocal placedArgLocals[REG_COUNT];
     size_t      numPlacedArgLocals;
 
@@ -1842,7 +1842,7 @@ private:
     // These methods return the number of sources.
     int BuildNode(GenTree* tree);
 
-    void PreferenceDyingLocal(Interval* interval);
+    void UpdatePreferenceOfDyingLocal(Interval* interval);
     void getTgtPrefOperands(GenTree* tree, GenTree* op1, GenTree* op2, bool* prefOp1, bool* prefOp2);
     bool supportsSpecialPutArg();
 

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1595,14 +1595,14 @@ private:
     struct PlacedLocal
     {
         unsigned  VarIndex;
-        regMaskTP RegMask;
+        regNumber Reg;
     };
 
     // Locals that are currently placed in registers via PUTARG_REG. These
     // locals are available due to the special PUTARG treatment, and we keep
     // track of them between the PUTARG_REG and CALL to ensure we do not
     // unpreference them.
-    PlacedLocal placedArgLocals[MAX_REG_ARG + MAX_FLOAT_REG_ARG];
+    PlacedLocal placedArgLocals[REG_COUNT];
     size_t      numPlacedArgLocals;
 
     // The set of all register candidates. Note that this may be a subset of tracked vars.

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -384,6 +384,10 @@ int LinearScan::BuildCall(GenTreeCall* call)
     // Now generate defs and kills.
     regMaskTP killMask = getKillSetForCall(call);
     BuildDefsWithKills(call, dstCount, dstCandidates, killMask);
+
+    // No args are placed in registers anymore.
+    placedArgRegs      = RBM_NONE;
+    numPlacedArgLocals = 0;
     return srcCount;
 }
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2965,12 +2965,12 @@ void LinearScan::UpdatePreferencesOfDyingLocal(Interval* interval)
     assert(!VarSetOps::IsMember(compiler, currentLiveVars, interval->getVarIndex(compiler)));
 
     // If we see a use of a local between placing a register and a call then we
-    // want to update that local's preferences to exclude that register.
-    // Picking that register is otherwise going to force a spill.
+    // want to update that local's preferences to exclude the "placed" register.
+    // Picking the "placed" register is otherwise going to force a spill.
     //
     // We only need to do this on liveness updates because if the local is live
     // _after_ the call, then we are going to prefer callee-saved registers for
-    // it anyway, so there is no need to look at such local uses.
+    // such local anyway, so there is no need to look at such local uses.
     //
     if (placedArgRegs == RBM_NONE)
     {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2986,7 +2986,7 @@ void LinearScan::PreferenceDyingLocal(Interval* interval)
     // Find registers that are occupied with other values.
     regMaskTP unpref   = placedArgRegs;
     unsigned  varIndex = interval->getVarIndex(compiler);
-    for (int i = 0; i < numPlacedArgLocals; i++)
+    for (size_t i = 0; i < numPlacedArgLocals; i++)
     {
         if (placedArgLocals[i].VarIndex == varIndex)
         {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2992,7 +2992,7 @@ void LinearScan::PreferenceDyingLocal(Interval* interval)
         {
             // This local's value is going to be available in this register so
             // keep it in the preferences.
-            unpref &= ~placedArgLocals[i].RegMask;
+            unpref &= ~genRegMask(placedArgLocals[i].Reg);
         }
     }
 
@@ -3979,12 +3979,12 @@ int LinearScan::BuildPutArgReg(GenTreeUnOp* node)
     placedArgRegs |= argMask;
 
     // If this is a passthrough tracked local then record it so that we can
-    // ensure we do not unpreference if we see a future use (see OnLocalDying).
+    // ensure we do not unpreference if we see a future use (see PreferenceDyingLocal).
     if (isSpecialPutArg)
     {
         assert(numPlacedArgLocals < ArrLen(placedArgLocals));
         placedArgLocals[numPlacedArgLocals].VarIndex = use->getInterval()->getVarIndex(compiler);
-        placedArgLocals[numPlacedArgLocals].RegMask  = argMask;
+        placedArgLocals[numPlacedArgLocals].Reg      = argReg;
         numPlacedArgLocals++;
     }
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3918,15 +3918,16 @@ int LinearScan::BuildPutArgReg(GenTreeUnOp* node)
         }
     }
 
+    // Preference locals that are still live out of this register.
+    // If they are used before the call and we allocate it to this register
+    // it would force a spill.
+    // If they are used after the call, then the preference set is anyway
+    // going to become the callee-saved registers when we see the call
+    // which in the common case does not conflict with the argument
+    // registers.
     if (enregisterLocalVars)
     {
-        // Preference locals that are still live out of this register.
-        // If they are used before the call and we allocate it to this register it would force a spill.
-        // If they are used after the call, then the preference set is anyway
-        // going to become the callee-saved registers when we see the call which
-        // in the common case does not conflict with the argument registers.
-
-        // Note that if 'op1' is a local we should not unpreference it from the
+        // If 'op1' is a local we should not unpreference it from the
         // register since PUTARG_REG is pass through. We know how to use the
         // value out of this register between the PUTARG_REG and the call when
         // "special putarg" is supported.
@@ -3950,7 +3951,7 @@ int LinearScan::BuildPutArgReg(GenTreeUnOp* node)
             }
 
             Interval* interval = getIntervalForLocalVar(varIndex);
-            // Spilling a write-thru register is free so avoid preferencing it
+            // Spilling a write-thru local is free so avoid preferencing it
             // away from these registers.
             if (interval->isWriteThru)
             {

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1238,6 +1238,10 @@ int LinearScan::BuildCall(GenTreeCall* call)
     // Now generate defs and kills.
     regMaskTP killMask = getKillSetForCall(call);
     BuildDefsWithKills(call, dstCount, dstCandidates, killMask);
+
+    // No args are placed in registers anymore.
+    placedArgRegs      = RBM_NONE;
+    numPlacedArgLocals = 0;
     return srcCount;
 }
 


### PR DESCRIPTION
If we see uses of locals between `PUTARG_REG` and the corresponding `CALL` node, then preference those intervals to not be allocated into the already placed register. Doing so will otherwise force a spill.

To do this effectively we only need to look at dying locals. If the local is not dying between the `PUTARG_REG` and `CALL` then it either does not have a use after the `PUTARG_REG`, or it has a use after the `CALL` and will be callee-saved register preferenced anyway.