### PR TITLE
API Debt - Microsoft.Extensions.Hosting

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Extensions.Hosting
         /// Triggered when the application host is ready to start the service.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+        /// <returns>A <see cref="Task"/>.</returns>
         public virtual Task StartAsync(CancellationToken cancellationToken)
         {
             // Create linked token to allow cancelling executing task from provided token
@@ -58,6 +59,7 @@ namespace Microsoft.Extensions.Hosting
         /// Triggered when the application host is performing a graceful shutdown.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
+        /// <returns>A <see cref="Task"/>.</returns>
         public virtual async Task StopAsync(CancellationToken cancellationToken)
         {
             // Stop called without start

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Hosting
         /// Triggered when the application host is ready to start the service.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
-        /// <returns>A <see cref="Task"/>.</returns>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous Start operation.</returns>
         public virtual Task StartAsync(CancellationToken cancellationToken)
         {
             // Create linked token to allow cancelling executing task from provided token
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.Hosting
         /// Triggered when the application host is performing a graceful shutdown.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
-        /// <returns>A <see cref="Task"/>.</returns>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous Stop operation.</returns>
         public virtual async Task StopAsync(CancellationToken cancellationToken)
         {
             // Stop called without start

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/Environments.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/Environments.cs
@@ -8,8 +8,17 @@ namespace Microsoft.Extensions.Hosting
     /// </summary>
     public static class Environments
     {
+        /// <summary>
+        /// The development environment can enable features that shouldn't be exposed in production. Because of the performance cost, scope validation and dependency validation only happens in development.
+        /// </summary>
         public static readonly string Development = "Development";
+        /// <summary>
+        /// The staging environment can be used to validate app changes before changing the environment to production.
+        /// </summary>
         public static readonly string Staging = "Staging";
+        /// <summary>
+        /// The production environment should be configured to maximize security, performance, and application robustness.
+        /// </summary>
         public static readonly string Production = "Production";
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/Environments.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/Environments.cs
@@ -9,16 +9,19 @@ namespace Microsoft.Extensions.Hosting
     public static class Environments
     {
         /// <summary>
-        /// The development environment can enable features that shouldn't be exposed in production. Because of the performance cost, scope validation and dependency validation only happens in development.
+        /// Specifies the Development environment.
         /// </summary>
+        /// <remarks>The development environment can enable features that shouldn't be exposed in production. Because of the performance cost, scope validation and dependency validation only happens in development.</remarks>
         public static readonly string Development = "Development";
         /// <summary>
-        /// The staging environment can be used to validate app changes before changing the environment to production.
+        /// Specifies the Staging environment.
         /// </summary>
+        /// <remarks>The staging environment can be used to validate app changes before changing the environment to production.</remarks>
         public static readonly string Staging = "Staging";
         /// <summary>
-        /// The production environment should be configured to maximize security, performance, and application robustness.
+        /// Specifies the Production environment.
         /// </summary>
+        /// <remarks>The production environment should be configured to maximize security, performance, and application robustness.</remarks>
         public static readonly string Production = "Production";
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostBuilderContext.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostBuilderContext.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Extensions.Hosting
     /// </summary>
     public class HostBuilderContext
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="HostBuilderContext"/>.
+        /// </summary>
+        /// <param name="properties">A non-null <see cref="IDictionary{TKey, TValue}"/> for sharing state between components during the host building process.</param>
         public HostBuilderContext(IDictionary<object, object> properties)
         {
             ThrowHelper.ThrowIfNull(properties);

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostBuilderExtensions.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// Provides extension methods for the <see cref="IHostBuilder"/> from the hosting abstractions package.
+    /// </summary>
     public static class HostingAbstractionsHostBuilderExtensions
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -8,6 +8,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// Provides extension methods for the <see cref="IHost"/> from the hosting abstractions package.
+    /// </summary>
     public static class HostingAbstractionsHostExtensions
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostBuilder.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Extensions.Hosting
         /// Overrides the factory used to create the service provider.
         /// </summary>
         /// <typeparam name="TContainerBuilder">The type of builder.</typeparam>
+        /// <param name="factory">The factory to register.</param>
         /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
         IHostBuilder UseServiceProviderFactory<TContainerBuilder>(Func<HostBuilderContext, IServiceProviderFactory<TContainerBuilder>> factory) where TContainerBuilder : notnull;
 

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostLifetime.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Extensions.Hosting
 {
     /// <summary>
-    /// An interface for tracking host lifetime.
+    /// Tracks host lifetime.
     /// </summary>
     public interface IHostLifetime
     {

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostLifetime.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// An interface for tracking host lifetime.
+    /// </summary>
     public interface IHostLifetime
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostedService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostedService.cs
@@ -15,12 +15,14 @@ namespace Microsoft.Extensions.Hosting
         /// Triggered when the application host is ready to start the service.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+        /// <returns>A <see cref="Task"/>.</returns>
         Task StartAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
+        /// <returns>A <see cref="Task"/>.</returns>
         Task StopAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostedService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostedService.cs
@@ -15,14 +15,14 @@ namespace Microsoft.Extensions.Hosting
         /// Triggered when the application host is ready to start the service.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
-        /// <returns>A <see cref="Task"/>.</returns>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous Start operation.</returns>
         Task StartAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Triggered when the application host is performing a graceful shutdown.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
-        /// <returns>A <see cref="Task"/>.</returns>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous Stop operation.</returns>
         Task StopAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/ISystemdNotifier.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/ISystemdNotifier.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
         /// <summary>
         /// Sends a notification to systemd.
         /// </summary>
+        /// <param name="state">The <see cref="ServiceState"/> to notify.</param>
         void Notify(ServiceState state);
         /// <summary>
         /// Returns whether systemd is configured to receive service notifications.

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/ServiceState.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/ServiceState.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
         /// <summary>
         /// Create custom ServiceState.
         /// </summary>
+        /// <param name="state">A <see cref="string"/> representation of service state.</param>
         public ServiceState(string state)
         {
             ThrowHelper.ThrowIfNull(state);
@@ -36,6 +37,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
         /// <summary>
         /// String representation of service state.
         /// </summary>
+        /// <returns>The <see cref="string"/> representation of the service state.</returns>
         public override string ToString()
             => _data == null ? string.Empty : Encoding.UTF8.GetString(_data);
 

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdLifetime.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Extensions.Hosting.Systemd
         private CancellationTokenRegistration _applicationStoppingRegistration;
 
         /// <summary>
-        /// Instantiates a <see cref="SystemdLifetime"/> object.
+        /// Initializes a new <see cref="SystemdLifetime"/> instance.
         /// </summary>
-        /// <param name="environment">Contains information about the host.</param>
+        /// <param name="environment">Information about the host.</param>
         /// <param name="applicationLifetime">The <see cref="IHostApplicationLifetime"/> that tracks the service lifetime.</param>
         /// <param name="systemdNotifier">The <see cref="ISystemdNotifier"/> to notify Systemd about service status.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdLifetime.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
         /// Instantiates a <see cref="SystemdLifetime"/> object.
         /// </summary>
         /// <param name="environment">Contains information about the host.</param>
-        /// <param name="applicationLifetime">The <see cref="IHostLifetime"/> that tracks the service lifetime.</param>
+        /// <param name="applicationLifetime">The <see cref="IHostApplicationLifetime"/> that tracks the service lifetime.</param>
         /// <param name="systemdNotifier">The <see cref="ISystemdNotifier"/> to notify Systemd about service status.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>
         public SystemdLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ISystemdNotifier systemdNotifier, ILoggerFactory loggerFactory)

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdLifetime.cs
@@ -9,6 +9,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Hosting.Systemd
 {
+    /// <summary>
+    /// Provides notification messages for application started and stopping, and configures console logging to the systemd format.
+    /// </summary>
     [UnsupportedOSPlatform("android")]
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
@@ -19,6 +22,13 @@ namespace Microsoft.Extensions.Hosting.Systemd
         private CancellationTokenRegistration _applicationStartedRegistration;
         private CancellationTokenRegistration _applicationStoppingRegistration;
 
+        /// <summary>
+        /// Instantiates a <see cref="SystemdLifetime"/> object.
+        /// </summary>
+        /// <param name="environment">Contains information about the host.</param>
+        /// <param name="applicationLifetime">The <see cref="IHostLifetime"/> that tracks the service lifetime.</param>
+        /// <param name="systemdNotifier">The <see cref="ISystemdNotifier"/> to notify Systemd about service status.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>
         public SystemdLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ISystemdNotifier systemdNotifier, ILoggerFactory loggerFactory)
         {
             ThrowHelper.ThrowIfNull(environment);

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdNotifier.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdNotifier.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Extensions.Hosting.Systemd
 
         private readonly string? _socketPath;
 
+        /// <summary>
+        /// Instantiates a new <see cref="SystemdNotifier"/> and sets the notify socket path.
+        /// </summary>
         public SystemdNotifier() :
             this(GetNotifySocketPath())
         { }

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
 
         // Called by base.Run when the service is ready to start.
         /// <summary>
-        /// Raises the Start event when the servuce is ready to start.
+        /// Raises the Start event when the service is ready to start.
         /// </summary>
         /// <param name="args">The command line arguments passed to the service.</param>
         protected override void OnStart(string[] args)

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -11,6 +11,9 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Hosting.WindowsServices
 {
+    /// <summary>
+    /// Listens for shutdown signal and tracks the status of the Windows service.
+    /// </summary>
     [SupportedOSPlatform("windows")]
     public class WindowsServiceLifetime : ServiceBase, IHostLifetime
     {
@@ -18,11 +21,26 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         private readonly ManualResetEventSlim _delayStop = new ManualResetEventSlim();
         private readonly HostOptions _hostOptions;
 
+        /// <summary>
+        /// Instantiates a <see cref="WindowsServiceLifetime"/> object.
+        /// </summary>
+        /// <param name="environment">Contains information about the host.</param>
+        /// <param name="applicationLifetime">The <see cref="IHostLifetime"/> that tracks the service lifetime.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>
+        /// <param name="optionsAccessor">The <see cref="IOptions{HostOptions}"/> containing options for the service.</param>
         public WindowsServiceLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor)
             : this(environment, applicationLifetime, loggerFactory, optionsAccessor, Options.Options.Create(new WindowsServiceLifetimeOptions()))
         {
         }
 
+        /// <summary>
+        /// Instantiates a <see cref="WindowsServiceLifetime"/> object.
+        /// </summary>
+        /// <param name="environment">Contains information about the host.</param>
+        /// <param name="applicationLifetime">The <see cref="IHostLifetime"/> that tracks the service lifetime.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>
+        /// <param name="optionsAccessor">The <see cref="IOptions{HostOptions}"/> containing options for the service.</param>
+        /// <param name="windowsServiceOptionsAccessor">Contains the Windows service options and is used to find the service name.</param>
         public WindowsServiceLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor, IOptions<WindowsServiceLifetimeOptions> windowsServiceOptionsAccessor)
         {
             ThrowHelper.ThrowIfNull(environment);
@@ -84,15 +102,20 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             return Task.CompletedTask;
         }
 
-        // Called by base.Run when the service is ready to start.
+        /// <summary>
+        /// Called by base.Run when the service is ready to start.
+        /// </summary>
+        /// <param name="args">The command line arguments passed to the service.</param>
         protected override void OnStart(string[] args)
         {
             _delayStart.TrySetResult(null);
             base.OnStart(args);
         }
 
-        // Called by base.Stop. This may be called multiple times by service Stop, ApplicationStopping, and StopAsync.
-        // That's OK because StopApplication uses a CancellationTokenSource and prevents any recursion.
+        /// <summary>
+        /// Called by base.Stop to stop the <see cref="WindowsServiceLifetime"/>.
+        /// </summary>
+        /// <remarks>This may be called multiple times by service Stop, ApplicationStopping, and StopAsync. That's OK because StopApplication uses a CancellationTokenSource and prevents any recursion.</remarks>
         protected override void OnStop()
         {
             ApplicationLifetime.StopApplication();
@@ -101,6 +124,9 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             base.OnStop();
         }
 
+        /// <summary>
+        /// Called when the service starts shutdown.
+        /// </summary>
         protected override void OnShutdown()
         {
             ApplicationLifetime.StopApplication();
@@ -109,6 +135,10 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             base.OnShutdown();
         }
 
+        /// <summary>
+        /// Disposes the <see cref="WindowsServiceLifetime"/>.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> is invoked from <see cref="IDisposable.Dispose"/>.</param>
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         private readonly HostOptions _hostOptions;
 
         /// <summary>
-        /// Instantiates a <see cref="WindowsServiceLifetime"/> object.
+        /// Initializes a new <see cref="WindowsServiceLifetime"/> instance.
         /// </summary>
-        /// <param name="environment">Contains information about the host.</param>
+        /// <param name="environment">Information about the host.</param>
         /// <param name="applicationLifetime">The <see cref="IHostLifetime"/> that tracks the service lifetime.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>
         /// <param name="optionsAccessor">The <see cref="IOptions{HostOptions}"/> containing options for the service.</param>
@@ -34,13 +34,13 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         }
 
         /// <summary>
-        /// Instantiates a <see cref="WindowsServiceLifetime"/> object.
+        /// Initializes a new instance of the <see cref="WindowsServiceLifetime"/> class.
         /// </summary>
-        /// <param name="environment">Contains information about the host.</param>
+        /// <param name="environment">Information about the host.</param>
         /// <param name="applicationLifetime">The <see cref="IHostLifetime"/> that tracks the service lifetime.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>
         /// <param name="optionsAccessor">The <see cref="IOptions{HostOptions}"/> containing options for the service.</param>
-        /// <param name="windowsServiceOptionsAccessor">Contains the Windows service options and is used to find the service name.</param>
+        /// <param name="windowsServiceOptionsAccessor">The Windows service options used to find the service name.</param>
         public WindowsServiceLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor, IOptions<WindowsServiceLifetimeOptions> windowsServiceOptionsAccessor)
         {
             ThrowHelper.ThrowIfNull(environment);
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         /// <summary>
         /// Called by base.Stop to stop the <see cref="WindowsServiceLifetime"/>.
         /// </summary>
-        /// <remarks>This may be called multiple times by service Stop, ApplicationStopping, and StopAsync. That's OK because StopApplication uses a CancellationTokenSource and prevents any recursion.</remarks>
+        /// <remarks>This might be called multiple times by service Stop, ApplicationStopping, and StopAsync. That's okay because StopApplication uses a CancellationTokenSource and prevents any recursion.</remarks>
         protected override void OnStop()
         {
             ApplicationLifetime.StopApplication();
@@ -138,7 +138,8 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         /// <summary>
         /// Releases the resources used by the <see cref="WindowsServiceLifetime"/>.
         /// </summary>
-        /// <param name="disposing"><c>true</c> is invoked from <see cref="IDisposable.Dispose"/>.</param>
+        /// <param name="disposing">
+               <see langword="true /> only when called from <see cref="IDisposable.Dispose"/>; otherwise, <see langword="false" />.</param>
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         }
 
         /// <summary>
-        /// Called when the service starts shutdown.
+        /// Executes when the service starts shutdown.
         /// </summary>
         protected override void OnShutdown()
         {
@@ -136,7 +136,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         }
 
         /// <summary>
-        /// Disposes the <see cref="WindowsServiceLifetime"/>.
+        /// Releases the resources used by the <see cref="WindowsServiceLifetime"/>.
         /// </summary>
         /// <param name="disposing"><c>true</c> is invoked from <see cref="IDisposable.Dispose"/>.</param>
         protected override void Dispose(bool disposing)

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         /// Initializes a new <see cref="WindowsServiceLifetime"/> instance.
         /// </summary>
         /// <param name="environment">Information about the host.</param>
-        /// <param name="applicationLifetime">The <see cref="IHostLifetime"/> that tracks the service lifetime.</param>
+        /// <param name="applicationLifetime">The <see cref="IHostApplicationLifetime"/> that tracks the service lifetime.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>
         /// <param name="optionsAccessor">The <see cref="IOptions{HostOptions}"/> containing options for the service.</param>
         public WindowsServiceLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory, IOptions<HostOptions> optionsAccessor)
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         /// Initializes a new instance of the <see cref="WindowsServiceLifetime"/> class.
         /// </summary>
         /// <param name="environment">Information about the host.</param>
-        /// <param name="applicationLifetime">The <see cref="IHostLifetime"/> that tracks the service lifetime.</param>
+        /// <param name="applicationLifetime">The <see cref="IHostApplicationLifetime"/> that tracks the service lifetime.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> used to instantiate the lifetime logger.</param>
         /// <param name="optionsAccessor">The <see cref="IOptions{HostOptions}"/> containing options for the service.</param>
         /// <param name="windowsServiceOptionsAccessor">The Windows service options used to find the service name.</param>
@@ -103,10 +103,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         }
 
         // Called by base.Run when the service is ready to start.
-        /// <summary>
-        /// Raises the Start event when the service is ready to start.
-        /// </summary>
-        /// <param name="args">The command line arguments passed to the service.</param>
+        /// <inheritdoc />
         protected override void OnStart(string[] args)
         {
             _delayStart.TrySetResult(null);
@@ -126,7 +123,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         }
 
         /// <summary>
-        /// Raise the Shutdown event.
+        /// Raises the Shutdown event.
         /// </summary>
         protected override void OnShutdown()
         {

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceLifetime.cs
@@ -102,8 +102,9 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             return Task.CompletedTask;
         }
 
+        // Called by base.Run when the service is ready to start.
         /// <summary>
-        /// Called by base.Run when the service is ready to start.
+        /// Raises the Start event when the servuce is ready to start.
         /// </summary>
         /// <param name="args">The command line arguments passed to the service.</param>
         protected override void OnStart(string[] args)
@@ -113,7 +114,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         }
 
         /// <summary>
-        /// Called by base.Stop to stop the <see cref="WindowsServiceLifetime"/>.
+        /// Raises the Stop event to stop the <see cref="WindowsServiceLifetime"/>.
         /// </summary>
         /// <remarks>This might be called multiple times by service Stop, ApplicationStopping, and StopAsync. That's okay because StopApplication uses a CancellationTokenSource and prevents any recursion.</remarks>
         protected override void OnStop()
@@ -125,7 +126,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         }
 
         /// <summary>
-        /// Executes when the service starts shutdown.
+        /// Raise the Shutdown event.
         /// </summary>
         protected override void OnShutdown()
         {
@@ -138,8 +139,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
         /// <summary>
         /// Releases the resources used by the <see cref="WindowsServiceLifetime"/>.
         /// </summary>
-        /// <param name="disposing">
-               <see langword="true /> only when called from <see cref="IDisposable.Dispose"/>; otherwise, <see langword="false" />.</param>
+        /// <param name="disposing"><see langword="true" /> only when called from <see cref="IDisposable.Dispose"/>; otherwise, <see langword="false" />.</param>
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/libraries/Microsoft.Extensions.Hosting/src/ConsoleLifetimeOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/ConsoleLifetimeOptions.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// Provides option flags for <see cref="Internal.ConsoleLifetime"/>.
+    /// </summary>
     public class ConsoleLifetimeOptions
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Extensions.Hosting
         private IServiceProvider? _appServices;
         private PhysicalFileProvider? _defaultProvider;
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="HostBuilder"/>.
+        /// </summary>
         [RequiresDynamicCode(Host.RequiresDynamicCodeMessage)]
         public HostBuilder()
         {

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -18,6 +18,9 @@ using Microsoft.Extensions.Logging.EventLog;
 
 namespace Microsoft.Extensions.Hosting
 {
+    /// <summary>
+    /// Provides extension methods for the <see cref="IHostBuilder"/> from the hosting package.
+    /// </summary>
     public static class HostingHostBuilderExtensions
     {
         /// <summary>
@@ -64,7 +67,7 @@ namespace Microsoft.Extensions.Hosting
         /// Specify the <see cref="IServiceProvider"/> to be the default one.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder"/> to configure.</param>
-        /// <param name="configure"></param>
+        /// <param name="configure">The delegate that configures the <see cref="IServiceProvider"/>.</param>
         /// <returns>The <see cref="IHostBuilder"/>.</returns>
         [RequiresDynamicCode(Host.RequiresDynamicCodeMessage)]
         public static IHostBuilder UseDefaultServiceProvider(this IHostBuilder hostBuilder, Action<ServiceProviderOptions> configure)
@@ -161,7 +164,7 @@ namespace Microsoft.Extensions.Hosting
         /// Enables configuring the instantiated dependency container. This can be called multiple times and
         /// the results will be additive.
         /// </summary>
-        /// <typeparam name="TContainerBuilder"></typeparam>
+        /// <typeparam name="TContainerBuilder">The type of builder.</typeparam>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
         /// <param name="configureDelegate">The delegate for configuring the <typeparamref name="TContainerBuilder"/>.</param>
         /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>


### PR DESCRIPTION
### Summary
Fixes #43915 pending additional PR to resolve namespace summary for the following:

- Microsoft.Extensions.Hosting
- Microsoft.Extensions.Hosting.Systemd
- Microsoft.Extensions.Hosting.WindowsServices

as well as writing in descriptions for the following parameterless constructors:

- M:Microsoft.Extensions.Hosting.BackgroundService.#ctor
- M:Microsoft.Extensions.Hosting.ConsoleLifetimeOptions.#ctor
- M:Microsoft.Extensions.Hosting.HostOptions.#ctor

### Obsoletes
The following are obsolete (to my knowledge):

- F:Microsoft.Extensions.Hosting.EnvironmentName.Development
- F:Microsoft.Extensions.Hosting.EnvironmentName.Production
- F:Microsoft.Extensions.Hosting.EnvironmentName.Staging