### PR TITLE
JIT: disable phi based redundant branch opts

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -657,7 +657,12 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
         // We were unable to determine the relop value via dominance checks.
         // See if we can jump thread via phi disambiguation.
         //
-        return optJumpThreadPhi(block, tree, treeNormVN);
+        // optJumpThreadPhi disabled as it is exposing problems with stale SSA.
+        // See issue #76636 and related.
+        //
+        // return optJumpThreadPhi(block, tree, treeNormVN);
+
+        return false;
     }
 
     // Be conservative if there is an exception effect and we're in an EH region


### PR DESCRIPTION
This is exposing our lack of SSA update and leading downstream opts like CSE and assertion prop to make bad decisions.

Disabling for now until I have time to figure out how to safely enable.

Fixes #76636, #76507

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=42271&view=ms.vss-build-web.run-extensions-tab) show lots of code size increases. Hopefully we can get most of this back.