### PR TITLE
Add null check before calling Path.GetFullPath

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -184,19 +184,14 @@ namespace ILCompiler
 
         private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding, ModuleData oldModuleData = null, bool throwOnFailureToLoad = true)
         {
-            if (filePath != null)
-            {
-                filePath = Path.GetFullPath(filePath);
-            }
-
             PEReader peReader = null;
-
             MemoryMappedViewAccessor mappedViewAccessor = null;
             PdbSymbolReader pdbReader = null;
             try
             {
                 if (oldModuleData == null)
                 {
+                    filePath = Path.GetFullPath(filePath);
                     peReader = OpenPEFile(filePath, out mappedViewAccessor);
 
 #if !READYTORUN

--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -184,9 +184,13 @@ namespace ILCompiler
 
         private EcmaModule AddModule(string filePath, string expectedSimpleName, bool useForBinding, ModuleData oldModuleData = null, bool throwOnFailureToLoad = true)
         {
-            filePath = Path.GetFullPath(filePath);
+            if (filePath != null)
+            {
+                filePath = Path.GetFullPath(filePath);
+            }
 
             PEReader peReader = null;
+
             MemoryMappedViewAccessor mappedViewAccessor = null;
             PdbSymbolReader pdbReader = null;
             try


### PR DESCRIPTION
filePath can be null when AddModule() is called by InheritOpenModules().

System.ArgumentNullException is occured when crossgen2 run with "--out-near-input --single-file-compilation" options.
To fix this bugs, add null check code in AddModule()

```
root:/usr/share/dotnet/shared/Microsoft.NETCore.App/7.0.0> ./corerun ./crossgen2/crossgen2.dll --jitpath /usr/share/dotnet/shared/Microsoft.NETCore.App/7.0.0/libclrjit.so --targetarch arm64 -r:/usr/share/dotnet/shared/Microsoft.NETCore.App/7.0.0/*.dll --out-near-input --single-file-compilation /home/owner/HelloConsole.dll 
Error: Value cannot be null. (Parameter 'path')
System.ArgumentNullException: Value cannot be null. (Parameter 'path')
   at System.ArgumentNullException.Throw(String paramName)
   at System.ArgumentNullException.ThrowIfNull(Object argument, String paramName)
   at System.ArgumentException.ThrowNullOrEmptyException(String argument, String paramName)
   at System.IO.Path.GetFullPath(String path)
   at ILCompiler.CompilerTypeSystemContext.AddModule(String filePath, String expectedSimpleName, Boolean useForBinding, ModuleData oldModuleData, Boolean throwOnFailureToLoad) in /runtime/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs:line 187
   at ILCompiler.CompilerTypeSystemContext.InheritOpenModules(CompilerTypeSystemContext oldTypeSystemContext) in /runtime/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs:line 266
   at ILCompiler.ReadyToRunCompilerContext..ctor(TargetDetails details, SharedGenericsMode genericsMode, Boolean bubbleIncludesCorelib, CompilerTypeSystemContext oldTypeSystemContext) in /runtime/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs:line 64
   at ILCompiler.Program.Run() in /runtime/src/coreclr/tools/aot/crossgen2/Program.cs:line 265
   at ILCompiler.Crossgen2RootCommand.<>c__DisplayClass181_0.<.ctor>b__0(InvocationContext context) in /runtime/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs:line 287

```