### PR TITLE
Add specific formatting string for SSA numbers

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4364,7 +4364,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         if (verbose)
         {
             printf("\nVN relop based copy assertion prop in " FMT_BB ":\n", compCurBB->bbNum);
-            printf("Assertion index=#%02u: V%02d.%02d %s V%02d.%02d\n", index, op1->AsLclVar()->GetLclNum(),
+            printf("Assertion index=#%02u: V%02d." FMT_SSA " %s V%02d." FMT_SSA "\n", index, op1->AsLclVar()->GetLclNum(),
                    op1->AsLclVar()->GetSsaNum(), (curAssertion->assertionKind == OAK_EQUAL) ? "==" : "!=",
                    op2->AsLclVar()->GetLclNum(), op2->AsLclVar()->GetSsaNum());
             gtDispTree(tree, nullptr, nullptr, true);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4364,9 +4364,10 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         if (verbose)
         {
             printf("\nVN relop based copy assertion prop in " FMT_BB ":\n", compCurBB->bbNum);
-            printf("Assertion index=#%02u: V%02d." FMT_SSA " %s V%02d." FMT_SSA "\n", index, op1->AsLclVar()->GetLclNum(),
-                   op1->AsLclVar()->GetSsaNum(), (curAssertion->assertionKind == OAK_EQUAL) ? "==" : "!=",
-                   op2->AsLclVar()->GetLclNum(), op2->AsLclVar()->GetSsaNum());
+            printf("Assertion index=#%02u: V%02d." FMT_SSA " %s V%02d." FMT_SSA "\n", index,
+                   op1->AsLclVar()->GetLclNum(), op1->AsLclVar()->GetSsaNum(),
+                   (curAssertion->assertionKind == OAK_EQUAL) ? "==" : "!=", op2->AsLclVar()->GetLclNum(),
+                   op2->AsLclVar()->GetSsaNum());
             gtDispTree(tree, nullptr, nullptr, true);
         }
 #endif

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11361,11 +11361,13 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                 if (tree->gtFlags & GTF_VAR_USEASG)
                 {
                     assert(tree->gtFlags & GTF_VAR_DEF);
-                    printf("ud:" FMT_SSA "->" FMT_SSA, tree->AsLclVarCommon()->GetSsaNum(), GetSsaNumForLocalVarDef(tree));
+                    printf("ud:" FMT_SSA "->" FMT_SSA, tree->AsLclVarCommon()->GetSsaNum(),
+                           GetSsaNumForLocalVarDef(tree));
                 }
                 else
                 {
-                    printf("%s:" FMT_SSA, (tree->gtFlags & GTF_VAR_DEF) ? "d" : "u", tree->AsLclVarCommon()->GetSsaNum());
+                    printf("%s:" FMT_SSA, (tree->gtFlags & GTF_VAR_DEF) ? "d" : "u",
+                           tree->AsLclVarCommon()->GetSsaNum());
                 }
             }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11361,11 +11361,11 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                 if (tree->gtFlags & GTF_VAR_USEASG)
                 {
                     assert(tree->gtFlags & GTF_VAR_DEF);
-                    printf("ud:%d->%d", tree->AsLclVarCommon()->GetSsaNum(), GetSsaNumForLocalVarDef(tree));
+                    printf("ud:" FMT_SSA "->" FMT_SSA, tree->AsLclVarCommon()->GetSsaNum(), GetSsaNumForLocalVarDef(tree));
                 }
                 else
                 {
-                    printf("%s:%d", (tree->gtFlags & GTF_VAR_DEF) ? "d" : "u", tree->AsLclVarCommon()->GetSsaNum());
+                    printf("%s:" FMT_SSA, (tree->gtFlags & GTF_VAR_DEF) ? "d" : "u", tree->AsLclVarCommon()->GetSsaNum());
                 }
             }
 

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1145,7 +1145,7 @@ bool Compiler::optJumpThreadPhi(BasicBlock* block, GenTree* tree, ValueNum treeN
         const unsigned lclNum    = unsigned(phiDefFuncApp.m_args[0]);
         const unsigned ssaDefNum = unsigned(phiDefFuncApp.m_args[1]);
         const ValueNum phiVN     = ValueNum(phiDefFuncApp.m_args[2]);
-        JITDUMP("... JT-PHI [interestingVN] in " FMT_BB " relop %s operand VN is PhiDef for V%02u:%u " FMT_VN "\n",
+        JITDUMP("... JT-PHI [interestingVN] in " FMT_BB " relop %s operand VN is PhiDef for V%02u:" FMT_SSA " " FMT_VN "\n",
                 block->bbNum, i == 0 ? "first" : "second", lclNum, ssaDefNum, phiVN);
         if (!foundPhiDef)
         {

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1145,7 +1145,8 @@ bool Compiler::optJumpThreadPhi(BasicBlock* block, GenTree* tree, ValueNum treeN
         const unsigned lclNum    = unsigned(phiDefFuncApp.m_args[0]);
         const unsigned ssaDefNum = unsigned(phiDefFuncApp.m_args[1]);
         const ValueNum phiVN     = ValueNum(phiDefFuncApp.m_args[2]);
-        JITDUMP("... JT-PHI [interestingVN] in " FMT_BB " relop %s operand VN is PhiDef for V%02u:" FMT_SSA " " FMT_VN "\n",
+        JITDUMP("... JT-PHI [interestingVN] in " FMT_BB " relop %s operand VN is PhiDef for V%02u:" FMT_SSA " " FMT_VN
+                "\n",
                 block->bbNum, i == 0 ? "first" : "second", lclNum, ssaDefNum, phiVN);
         if (!foundPhiDef)
         {

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -589,7 +589,7 @@ void SsaBuilder::AddPhiArg(
     }
 #endif // DEBUG
 
-    DBG_SSA_JITDUMP("Added PHI arg u:%d for V%02u from " FMT_BB " in " FMT_BB ".\n", ssaNum, lclNum, pred->bbNum,
+    DBG_SSA_JITDUMP("Added PHI arg u:" FMT_SSA " for V%02u from " FMT_BB " in " FMT_BB ".\n", ssaNum, lclNum, pred->bbNum,
                     block->bbNum);
 }
 
@@ -894,7 +894,7 @@ void SsaBuilder::AddDefToHandlerPhis(BasicBlock* block, unsigned lclNum, unsigne
     EHblkDsc* tryBlk = m_pCompiler->ehGetBlockExnFlowDsc(block);
     if (tryBlk != nullptr)
     {
-        DBG_SSA_JITDUMP("Definition of local V%02u/d:%d in block " FMT_BB
+        DBG_SSA_JITDUMP("Definition of local V%02u/d:" FMT_SSA " in block " FMT_BB
                         " has exn handler; adding as phi arg to handlers.\n",
                         lclNum, ssaNum, block->bbNum);
         while (true)
@@ -955,7 +955,7 @@ void SsaBuilder::AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* bl
         }
 
         // Otherwise...
-        DBG_SSA_JITDUMP("Definition of %s/d:%d in block " FMT_BB " has exn handler; adding as phi arg to handlers.\n",
+        DBG_SSA_JITDUMP("Definition of %s/d:" FMT_SSA " in block " FMT_BB " has exn handler; adding as phi arg to handlers.\n",
                         memoryKindNames[memoryKind], ssaNum, block->bbNum);
         EHblkDsc* tryBlk = m_pCompiler->ehGetBlockExnFlowDsc(block);
         while (true)
@@ -999,7 +999,7 @@ void SsaBuilder::AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* bl
                     handlerMemoryPhi = new (m_pCompiler) BasicBlock::MemoryPhiArg(ssaNum, handlerMemoryPhi);
                 }
 
-                DBG_SSA_JITDUMP("   Added phi arg u:%d for %s to phi defn in handler block " FMT_BB ".\n", ssaNum,
+                DBG_SSA_JITDUMP("   Added phi arg u:" FMT_SSA " for %s to phi defn in handler block " FMT_BB ".\n", ssaNum,
                                 memoryKindNames[memoryKind], memoryKind, handler->bbNum);
 
                 if ((memoryKind == ByrefExposed) && m_pCompiler->byrefStatesMatchGcHeapStates)
@@ -1046,7 +1046,7 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block)
                 unsigned ssaNum = m_pCompiler->lvMemoryPerSsaData.AllocSsaNum(m_allocator);
                 m_renameStack.PushMemory(memoryKind, block, ssaNum);
 
-                DBG_SSA_JITDUMP("Ssa # for %s phi on entry to " FMT_BB " is %d.\n", memoryKindNames[memoryKind],
+                DBG_SSA_JITDUMP("Ssa # for %s phi on entry to " FMT_BB " is " FMT_SSA ".\n", memoryKindNames[memoryKind],
                                 block->bbNum, ssaNum);
 
                 block->bbMemorySsaNumIn[memoryKind] = ssaNum;
@@ -1108,7 +1108,7 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block)
             }
         }
 
-        DBG_SSA_JITDUMP("Ssa # for %s on entry to " FMT_BB " is %d; on exit is %d.\n", memoryKindNames[memoryKind],
+        DBG_SSA_JITDUMP("Ssa # for %s on entry to " FMT_BB " is " FMT_SSA "; on exit is " FMT_SSA ".\n", memoryKindNames[memoryKind],
                         block->bbNum, block->bbMemorySsaNumIn[memoryKind], block->bbMemorySsaNumOut[memoryKind]);
     }
 }
@@ -1203,7 +1203,7 @@ void SsaBuilder::AddPhiArgsToSuccessors(BasicBlock* block)
                         succMemoryPhi = new (m_pCompiler) BasicBlock::MemoryPhiArg(ssaNum, succMemoryPhi);
                     }
                 }
-                DBG_SSA_JITDUMP("  Added phi arg for %s u:%d from " FMT_BB " in " FMT_BB ".\n",
+                DBG_SSA_JITDUMP("  Added phi arg for %s u:" FMT_SSA " from " FMT_BB " in " FMT_BB ".\n",
                                 memoryKindNames[memoryKind], block->bbMemorySsaNumOut[memoryKind], block->bbNum,
                                 succ->bbNum);
             }
@@ -1334,7 +1334,7 @@ void SsaBuilder::AddPhiArgsToSuccessors(BasicBlock* block)
                             handlerMemoryPhi = new (m_pCompiler)
                                 BasicBlock::MemoryPhiArg(block->bbMemorySsaNumOut[memoryKind], handlerMemoryPhi);
                         }
-                        DBG_SSA_JITDUMP("  Added phi arg for %s u:%d from " FMT_BB " in " FMT_BB ".\n",
+                        DBG_SSA_JITDUMP("  Added phi arg for %s u:" FMT_SSA " from " FMT_BB " in " FMT_BB ".\n",
                                         memoryKindNames[memoryKind], block->bbMemorySsaNumOut[memoryKind], block->bbNum,
                                         handlerStart->bbNum);
                     }
@@ -1737,7 +1737,7 @@ void Compiler::JitTestCheckSSA()
             {
                 printf("  Node: ");
                 printTreeID(lcl);
-                printf(", SSA name = <%d, %d> -- SSA name class %d.\n", lcl->GetLclNum(), lcl->GetSsaNum(),
+                printf(", SSA name = <V%02u, " FMT_SSA "> -- SSA name class %d.\n", lcl->GetLclNum(), lcl->GetSsaNum(),
                        tlAndN.m_num);
             }
             SSAName ssaNm;
@@ -1756,10 +1756,10 @@ void Compiler::JitTestCheckSSA()
                 {
                     printf("Node: ");
                     printTreeID(lcl);
-                    printf(", SSA name = <%d, %d> was declared in SSA name class %d,\n", lcl->GetLclNum(),
+                    printf(", SSA name = <V%02u, " FMT_SSA "> was declared in SSA name class %d,\n", lcl->GetLclNum(),
                            lcl->GetSsaNum(), tlAndN.m_num);
                     printf(
-                        "but this SSA name <%d,%d> has already been associated with a different SSA name class: %d.\n",
+                        "but this SSA name <V%02u, " FMT_SSA "> has already been associated with a different SSA name class: %d.\n",
                         ssaNm.m_lvNum, ssaNm.m_ssaNum, num2);
                     unreached();
                 }
@@ -1768,7 +1768,7 @@ void Compiler::JitTestCheckSSA()
                 {
                     printf("Node: ");
                     printTreeID(lcl);
-                    printf(", SSA name = <%d, %d> was declared in SSA name class %d,\n", lcl->GetLclNum(),
+                    printf(", SSA name = <V%02u, " FMT_SSA "> was declared in SSA name class %d,\n", lcl->GetLclNum(),
                            lcl->GetSsaNum(), tlAndN.m_num);
                     printf("but that name class was previously bound to a different SSA name: <%d,%d>.\n",
                            ssaNm.m_lvNum, ssaNm.m_ssaNum);
@@ -1785,7 +1785,7 @@ void Compiler::JitTestCheckSSA()
                 {
                     printf("Node: ");
                     printTreeID(lcl);
-                    printf(", SSA name = <%d, %d> was declared in SSA name class %d,\n", lcl->GetLclNum(),
+                    printf(", SSA name = <V%02u, " FMT_SSA "> was declared in SSA name class %d,\n", lcl->GetLclNum(),
                            lcl->GetSsaNum(), tlAndN.m_num);
                     printf("but this SSA name has already been associated with a different name class: %d.\n", num);
                     unreached();

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -589,8 +589,8 @@ void SsaBuilder::AddPhiArg(
     }
 #endif // DEBUG
 
-    DBG_SSA_JITDUMP("Added PHI arg u:" FMT_SSA " for V%02u from " FMT_BB " in " FMT_BB ".\n", ssaNum, lclNum, pred->bbNum,
-                    block->bbNum);
+    DBG_SSA_JITDUMP("Added PHI arg u:" FMT_SSA " for V%02u from " FMT_BB " in " FMT_BB ".\n", ssaNum, lclNum,
+                    pred->bbNum, block->bbNum);
 }
 
 /**
@@ -955,7 +955,8 @@ void SsaBuilder::AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* bl
         }
 
         // Otherwise...
-        DBG_SSA_JITDUMP("Definition of %s/d:" FMT_SSA " in block " FMT_BB " has exn handler; adding as phi arg to handlers.\n",
+        DBG_SSA_JITDUMP("Definition of %s/d:" FMT_SSA " in block " FMT_BB
+                        " has exn handler; adding as phi arg to handlers.\n",
                         memoryKindNames[memoryKind], ssaNum, block->bbNum);
         EHblkDsc* tryBlk = m_pCompiler->ehGetBlockExnFlowDsc(block);
         while (true)
@@ -999,8 +1000,8 @@ void SsaBuilder::AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* bl
                     handlerMemoryPhi = new (m_pCompiler) BasicBlock::MemoryPhiArg(ssaNum, handlerMemoryPhi);
                 }
 
-                DBG_SSA_JITDUMP("   Added phi arg u:" FMT_SSA " for %s to phi defn in handler block " FMT_BB ".\n", ssaNum,
-                                memoryKindNames[memoryKind], memoryKind, handler->bbNum);
+                DBG_SSA_JITDUMP("   Added phi arg u:" FMT_SSA " for %s to phi defn in handler block " FMT_BB ".\n",
+                                ssaNum, memoryKindNames[memoryKind], memoryKind, handler->bbNum);
 
                 if ((memoryKind == ByrefExposed) && m_pCompiler->byrefStatesMatchGcHeapStates)
                 {
@@ -1046,8 +1047,8 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block)
                 unsigned ssaNum = m_pCompiler->lvMemoryPerSsaData.AllocSsaNum(m_allocator);
                 m_renameStack.PushMemory(memoryKind, block, ssaNum);
 
-                DBG_SSA_JITDUMP("Ssa # for %s phi on entry to " FMT_BB " is " FMT_SSA ".\n", memoryKindNames[memoryKind],
-                                block->bbNum, ssaNum);
+                DBG_SSA_JITDUMP("Ssa # for %s phi on entry to " FMT_BB " is " FMT_SSA ".\n",
+                                memoryKindNames[memoryKind], block->bbNum, ssaNum);
 
                 block->bbMemorySsaNumIn[memoryKind] = ssaNum;
             }
@@ -1108,8 +1109,9 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block)
             }
         }
 
-        DBG_SSA_JITDUMP("Ssa # for %s on entry to " FMT_BB " is " FMT_SSA "; on exit is " FMT_SSA ".\n", memoryKindNames[memoryKind],
-                        block->bbNum, block->bbMemorySsaNumIn[memoryKind], block->bbMemorySsaNumOut[memoryKind]);
+        DBG_SSA_JITDUMP("Ssa # for %s on entry to " FMT_BB " is " FMT_SSA "; on exit is " FMT_SSA ".\n",
+                        memoryKindNames[memoryKind], block->bbNum, block->bbMemorySsaNumIn[memoryKind],
+                        block->bbMemorySsaNumOut[memoryKind]);
     }
 }
 
@@ -1758,9 +1760,9 @@ void Compiler::JitTestCheckSSA()
                     printTreeID(lcl);
                     printf(", SSA name = <V%02u, " FMT_SSA "> was declared in SSA name class %d,\n", lcl->GetLclNum(),
                            lcl->GetSsaNum(), tlAndN.m_num);
-                    printf(
-                        "but this SSA name <V%02u, " FMT_SSA "> has already been associated with a different SSA name class: %d.\n",
-                        ssaNm.m_lvNum, ssaNm.m_ssaNum, num2);
+                    printf("but this SSA name <V%02u, " FMT_SSA
+                           "> has already been associated with a different SSA name class: %d.\n",
+                           ssaNm.m_lvNum, ssaNm.m_ssaNum, num2);
                     unreached();
                 }
                 // And the current node must be of the specified SSA family.

--- a/src/coreclr/jit/ssaconfig.h
+++ b/src/coreclr/jit/ssaconfig.h
@@ -24,3 +24,7 @@ static const int FIRST_SSA_NUM = 1;
 static const int RESERVED_SSA_NUM = 0;
 
 } // end of namespace SsaConfig
+
+// We use the following format when printing an SSA number.
+// This define is used with string concatenation to put this in printf format strings  (Note that %u means unsigned int)
+#define FMT_SSA "ssa%u"

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4879,8 +4879,8 @@ void Compiler::fgValueNumberLocalStore(GenTree*             storeNode,
 
         varDsc->GetPerSsaData(lclDefSsaNum)->m_vnPair = newLclValue;
 
-        JITDUMP("Tree [%06u] assigned VN to local var V%02u/" FMT_SSA ": ", dspTreeID(storeNode), lclDefNode->GetLclNum(),
-                lclDefSsaNum);
+        JITDUMP("Tree [%06u] assigned VN to local var V%02u/" FMT_SSA ": ", dspTreeID(storeNode),
+                lclDefNode->GetLclNum(), lclDefSsaNum);
         JITDUMPEXEC(vnpPrint(newLclValue, 1));
         JITDUMP("\n");
     }
@@ -7687,7 +7687,8 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 #ifdef DEBUG
         if (verbose)
         {
-            printf("SSA PHI definition: set VN of local V%02u/" FMT_SSA " to ", newSsaDef->GetLclNum(), newSsaDef->GetSsaNum());
+            printf("SSA PHI definition: set VN of local V%02u/" FMT_SSA " to ", newSsaDef->GetLclNum(),
+                   newSsaDef->GetSsaNum());
             vnpPrint(newSsaDefVNP, 1);
             printf(" %s.\n", sameVNP.BothDefined() ? "(all same)" : "");
         }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4879,7 +4879,7 @@ void Compiler::fgValueNumberLocalStore(GenTree*             storeNode,
 
         varDsc->GetPerSsaData(lclDefSsaNum)->m_vnPair = newLclValue;
 
-        JITDUMP("Tree [%06u] assigned VN to local var V%02u/%d: ", dspTreeID(storeNode), lclDefNode->GetLclNum(),
+        JITDUMP("Tree [%06u] assigned VN to local var V%02u/" FMT_SSA ": ", dspTreeID(storeNode), lclDefNode->GetLclNum(),
                 lclDefSsaNum);
         JITDUMPEXEC(vnpPrint(newLclValue, 1));
         JITDUMP("\n");
@@ -7687,7 +7687,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 #ifdef DEBUG
         if (verbose)
         {
-            printf("SSA PHI definition: set VN of local %d/%d to ", newSsaDef->GetLclNum(), newSsaDef->GetSsaNum());
+            printf("SSA PHI definition: set VN of local V%02u/" FMT_SSA " to ", newSsaDef->GetLclNum(), newSsaDef->GetSsaNum());
             vnpPrint(newSsaDefVNP, 1);
             printf(" %s.\n", sameVNP.BothDefined() ? "(all same)" : "");
         }
@@ -7732,7 +7732,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
                 // But OSR might leave around "dead" try entry blocks...
                 assert((phiArgs->m_nextArg != nullptr) || opts.IsOSR());
                 ValueNum phiAppVN = vnStore->VNForIntCon(phiArgs->GetSsaNum());
-                JITDUMP("  Building phi application: $%x = SSA# %d.\n", phiAppVN, phiArgs->GetSsaNum());
+                JITDUMP("  Building phi application: $%x = " FMT_SSA ".\n", phiAppVN, phiArgs->GetSsaNum());
                 bool     allSame = true;
                 ValueNum sameVN  = GetMemoryPerSsaData(phiArgs->GetSsaNum())->m_vnPair.GetLiberal();
                 if (sameVN == ValueNumStore::NoVN)
@@ -7752,7 +7752,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 #endif
                     unsigned phiArgSSANum   = phiArgs->GetSsaNum();
                     ValueNum phiArgSSANumVN = vnStore->VNForIntCon(phiArgSSANum);
-                    JITDUMP("  Building phi application: $%x = SSA# %d.\n", phiArgSSANumVN, phiArgSSANum);
+                    JITDUMP("  Building phi application: $%x = " FMT_SSA ".\n", phiArgSSANumVN, phiArgSSANum);
                     phiAppVN = vnStore->VNForFuncNoFolding(TYP_HEAP, VNF_Phi, phiArgSSANumVN, phiAppVN);
                     JITDUMP("  Building phi application: $%x = phi($%x, $%x).\n", phiAppVN, phiArgSSANumVN,
                             oldPhiAppVN);
@@ -7779,7 +7779,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 #ifdef DEBUG
         if (verbose)
         {
-            printf("The SSA definition for %s (#%d) at start of " FMT_BB " is ", memoryKindNames[memoryKind],
+            printf("The SSA definition for %s (" FMT_SSA ") at start of " FMT_BB " is ", memoryKindNames[memoryKind],
                    blk->bbMemorySsaNumIn[memoryKind], blk->bbNum);
             vnPrint(fgCurMemoryVN[memoryKind], 1);
             printf("\n");
@@ -8431,7 +8431,7 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
 
             fieldVarSsaDsc->m_vnPair.SetBoth(newUniqueVN);
 
-            JITDUMP("Tree [%06u] assigned VN to the only field V%02u/%u of promoted struct V%02u: new uniq ",
+            JITDUMP("Tree [%06u] assigned VN to the only field V%02u/" FMT_SSA " of promoted struct V%02u: new uniq ",
                     dspTreeID(tree), lhsVarDsc->lvFieldLclStart, lclVarTree->GetSsaNum(), lhsLclNum);
             JITDUMPEXEC(vnPrint(newUniqueVN, 1));
             JITDUMP("\n");


### PR DESCRIPTION
Format all SSA numbers with the new `FMT_SSA` string.

Currently, this is defined as `ssa%u`, which makes it easy to identify a string as an SSA number, as well as making it easy to search for this string throughout the JitDump.

Examples:
```
N001 [000371]   LCL_VAR   V01 loc0         u:ssa41 (last use) => $12b {ADD($42, $12a)}
N004 [000369]   LCL_VAR   V01 loc0         d:ssa42 => $VN.Void
Tree [000368] assigned VN to local var V01/ssa42: $12c {ADD($42, $12b)}
SSA PHI definition: set VN of local V08/ssa3 to $146 {PhiDef($8, $3, $101)} .
SSA PHI definition: set VN of local V01/ssa46 to $147 {PhiDef($1, $2e, $10d)} .
The SSA definition for ByrefExposed (ssa1) at start of BB23 is $c0 {InitVal($41)}
The SSA definition for GcHeap (ssa1) at start of BB23 is $c0 {InitVal($41)}
```
