### PR TITLE
Devirtualize EqualityComparer for reference types

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3621,7 +3621,7 @@ protected:
                             CORINFO_CALL_INFO* callInfo,
                             IL_OFFSET          rawILOffset);
 
-    CORINFO_CLASS_HANDLE impGetSpecialIntrinsicExactReturnType(CORINFO_METHOD_HANDLE specialIntrinsicHandle);
+    CORINFO_CLASS_HANDLE impGetSpecialIntrinsicExactReturnType(GenTreeCall* call);
 
     bool impMethodInfo_hasRetBuffArg(CORINFO_METHOD_INFO* methInfo, CorInfoCallConvExtension callConv);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17529,7 +17529,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
                     break;
                 }
 
-                CORINFO_CLASS_HANDLE specialObjClass = impGetSpecialIntrinsicExactReturnType(call->gtCallMethHnd);
+                CORINFO_CLASS_HANDLE specialObjClass = impGetSpecialIntrinsicExactReturnType(call);
                 if (specialObjClass != nullptr)
                 {
                     objClass    = specialObjClass;


### PR DESCRIPTION
I noticed that we give up on reference types for `EqualityComparer.Default<T>`/`Comparer.Default<T>`, e.g.:
```csharp
static bool Foo(string s1, string s2) => 
    EqualityComparer<string>.Default.Equals(s1, s2);
```
used to emit:
```asm
; Method ConsoleApp5.Program:Foo(System.String,System.String):bool
G_M38758_IG01:
       sub      rsp, 40
       mov      r8, rcx
       mov      rax, rdx
G_M38758_IG02:
       mov      rcx, 0xD1FFAB1E      ; const ptr
       mov      rcx, gword ptr [rcx]
       mov      rdx, r8
       mov      r8, rax
       call     [System.Collections.Generic.GenericEqualityComparer`1[System.__Canon]
:Equals(System.__Canon,System.__Canon):bool:this]
       nop      
G_M38758_IG03:
       add      rsp, 40
       ret      
; Total bytes of code: 41
```
New codegen:
```asm
; Method ConsoleApp5.Program:Foo(System.String,System.String):bool
G_M38758_IG01:
       sub      rsp, 40
G_M38758_IG02:
       test     rcx, rcx
       je       SHORT G_M38758_IG08
G_M38758_IG03:
       test     rdx, rdx
       je       SHORT G_M38758_IG07
G_M38758_IG04:
       mov      r11, 0xD1FFAB1E      ; code for System.IEquatable`1[__Canon][System.__Canon]:Equals
       call     [r11]System.IEquatable`1[System.__Canon]:Equals(System.__Canon):bool:this
G_M38758_IG05:
       nop      
G_M38758_IG06:
       add      rsp, 40
       ret      
G_M38758_IG07:
       xor      eax, eax
       jmp      SHORT G_M38758_IG05
G_M38758_IG08:
       test     rdx, rdx
       jne      SHORT G_M38758_IG09
       mov      eax, 1
       jmp      SHORT G_M38758_IG05
G_M38758_IG09:
       xor      eax, eax
       jmp      SHORT G_M38758_IG05
; Total bytes of code: 53
```
So now `GenericEqaulityCompare<string>.get_Default().Equals(string,string)` is inlined. Although, it still contains a runtime lookup 🤔 - it seems that inliner doesn't propagate the known generic context here.