### PR TITLE
Improve perf of Enumerable.Order{Descending} for primitives

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderBy.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderBy.cs
@@ -43,8 +43,8 @@ namespace System.Linq
         /// If comparer is <see langword="null"/>, the default comparer <see cref="Comparer{T}.Default"/> is used to compare elements.
         /// </remarks>
         public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source, IComparer<T>? comparer) =>
-            TypeIsImplicitlyStable<T>() ?
-                new OrderedImplicitlyStableEnumerable<T>(source, comparer, descending: false) :
+            TypeIsImplicitlyStable<T>() && (comparer is null || comparer == Comparer<T>.Default) ?
+                new OrderedImplicitlyStableEnumerable<T>(source, descending: false) :
                 OrderBy(source, EnumerableSorter<T>.IdentityFunc, comparer);
 
         public static IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
@@ -88,8 +88,8 @@ namespace System.Linq
         /// If comparer is <see langword="null"/>, the default comparer <see cref="Comparer{T}.Default"/> is used to compare elements.
         /// </remarks>
         public static IOrderedEnumerable<T> OrderDescending<T>(this IEnumerable<T> source, IComparer<T>? comparer) =>
-            TypeIsImplicitlyStable<T>()?
-                new OrderedImplicitlyStableEnumerable<T>(source, comparer, descending: true) :
+            TypeIsImplicitlyStable<T>() && (comparer is null || comparer == Comparer<T>.Default) ?
+                new OrderedImplicitlyStableEnumerable<T>(source, descending: true) :
                 OrderByDescending(source, EnumerableSorter<T>.IdentityFunc, comparer);
 
         public static IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>

--- a/src/libraries/System.Linq/src/System/Linq/OrderBy.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderBy.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System.Linq
 {
@@ -23,7 +24,7 @@ namespace System.Linq
         /// This method compares elements by using the default comparer <see cref="Comparer{T}.Default"/>.
         /// </remarks>
         public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source) =>
-            OrderBy(source, EnumerableSorter<T>.IdentityFunc);
+            Order(source, comparer: null);
 
         /// <summary>
         /// Sorts the elements of a sequence in ascending order.
@@ -42,7 +43,9 @@ namespace System.Linq
         /// If comparer is <see langword="null"/>, the default comparer <see cref="Comparer{T}.Default"/> is used to compare elements.
         /// </remarks>
         public static IOrderedEnumerable<T> Order<T>(this IEnumerable<T> source, IComparer<T>? comparer) =>
-            OrderBy(source, EnumerableSorter<T>.IdentityFunc, comparer);
+            TypeIsImplicitlyStable<T>() ?
+                new OrderedImplicitlyStableEnumerable<T>(source, comparer, descending: false) :
+                OrderBy(source, EnumerableSorter<T>.IdentityFunc, comparer);
 
         public static IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
             => new OrderedEnumerable<TSource, TKey>(source, keySelector, null, false, null);
@@ -66,7 +69,7 @@ namespace System.Linq
         /// This method compares elements by using the default comparer <see cref="Comparer{T}.Default"/>.
         /// </remarks>
         public static IOrderedEnumerable<T> OrderDescending<T>(this IEnumerable<T> source) =>
-            OrderByDescending(source, EnumerableSorter<T>.IdentityFunc);
+            OrderDescending(source, comparer: null);
 
         /// <summary>
         /// Sorts the elements of a sequence in descending order.
@@ -85,7 +88,9 @@ namespace System.Linq
         /// If comparer is <see langword="null"/>, the default comparer <see cref="Comparer{T}.Default"/> is used to compare elements.
         /// </remarks>
         public static IOrderedEnumerable<T> OrderDescending<T>(this IEnumerable<T> source, IComparer<T>? comparer) =>
-            OrderByDescending(source, EnumerableSorter<T>.IdentityFunc, comparer);
+            TypeIsImplicitlyStable<T>()?
+                new OrderedImplicitlyStableEnumerable<T>(source, comparer, descending: true) :
+                OrderByDescending(source, EnumerableSorter<T>.IdentityFunc, comparer);
 
         public static IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
             new OrderedEnumerable<TSource, TKey>(source, keySelector, null, true, null);
@@ -132,6 +137,17 @@ namespace System.Linq
 
             return source.CreateOrderedEnumerable(keySelector, comparer, true);
         }
+
+        /// <summary>Gets whether the results of an unstable sort will be observably the same as a stable sort.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TypeIsImplicitlyStable<T>() =>
+            typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) ||
+            typeof(T) == typeof(int) || typeof(T) == typeof(uint) ||
+            typeof(T) == typeof(short) || typeof(T) == typeof(ushort) ||
+            typeof(T) == typeof(long) || typeof(T) == typeof(ulong) ||
+            typeof(T) == typeof(Int128) || typeof(T) == typeof(UInt128) ||
+            typeof(T) == typeof(nint) || typeof(T) == typeof(nuint) ||
+            typeof(T) == typeof(bool) || typeof(T) == typeof(char);
     }
 
     public interface IOrderedEnumerable<out TElement> : IEnumerable<TElement>

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -3,13 +3,13 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace System.Linq
 {
     internal abstract partial class OrderedEnumerable<TElement> : IPartition<TElement>
     {
-        public TElement[] ToArray()
+        public virtual TElement[] ToArray()
         {
             Buffer<TElement> buffer = new Buffer<TElement>(_source);
 
@@ -29,7 +29,7 @@ namespace System.Linq
             return array;
         }
 
-        public List<TElement> ToList()
+        public virtual List<TElement> ToList()
         {
             Buffer<TElement> buffer = new Buffer<TElement>(_source);
             int count = buffer._count;
@@ -245,6 +245,23 @@ namespace System.Linq
             }
 
             return value;
+        }
+    }
+
+    internal sealed partial class OrderedImplicitlyStableEnumerable<TElement> : OrderedEnumerable<TElement>
+    {
+        public override TElement[] ToArray()
+        {
+            TElement[] array = _source.ToArray();
+            Sort(array, _comparer, _descending);
+            return array;
+        }
+
+        public override List<TElement> ToList()
+        {
+            List<TElement> list = _source.ToList();
+            Sort(CollectionsMarshal.AsSpan(list), _comparer, _descending);
+            return list;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -253,14 +253,14 @@ namespace System.Linq
         public override TElement[] ToArray()
         {
             TElement[] array = _source.ToArray();
-            Sort(array, _comparer, _descending);
+            Sort(array, _descending);
             return array;
         }
 
         public override List<TElement> ToList()
         {
             List<TElement> list = _source.ToList();
-            Sort(CollectionsMarshal.AsSpan(list), _comparer, _descending);
+            Sort(CollectionsMarshal.AsSpan(list), _descending);
             return list;
         }
     }

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -18,7 +18,7 @@ namespace System.Linq
         private int[] SortedMap(Buffer<TElement> buffer, int minIdx, int maxIdx) =>
             GetEnumerableSorter().Sort(buffer._items, buffer._count, minIdx, maxIdx);
 
-        public IEnumerator<TElement> GetEnumerator()
+        public virtual IEnumerator<TElement> GetEnumerator()
         {
             Buffer<TElement> buffer = new Buffer<TElement>(_source);
             if (buffer._count > 0)
@@ -62,9 +62,7 @@ namespace System.Linq
 
         internal abstract EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next);
 
-        private CachingComparer<TElement> GetComparer() => GetComparer(null);
-
-        internal abstract CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer);
+        internal abstract CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer = null);
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -156,6 +154,64 @@ namespace System.Linq
                 ? new CachingComparer<TElement, TKey>(_keySelector, _comparer, _descending)
                 : new CachingComparerWithChild<TElement, TKey>(_keySelector, _comparer, _descending, childComparer);
             return _parent != null ? _parent.GetComparer(cmp) : cmp;
+        }
+    }
+
+    /// <summary>An ordered enumerable used by Order/OrderDescending for Ts that are bitwise indistinguishable for any considered equal.</summary>
+    internal sealed partial class OrderedImplicitlyStableEnumerable<TElement> : OrderedEnumerable<TElement>
+    {
+        private readonly IComparer<TElement> _comparer;
+        private readonly bool _descending;
+
+        public OrderedImplicitlyStableEnumerable(IEnumerable<TElement> source, IComparer<TElement>? comparer, bool descending) : base(source)
+        {
+            Debug.Assert(Enumerable.TypeIsImplicitlyStable<TElement>());
+
+            if (source is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            _comparer = comparer ?? Comparer<TElement>.Default;
+            _descending = descending;
+        }
+
+        internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer) =>
+            childComparer == null ?
+                new CachingComparer<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, _comparer, _descending) :
+                new CachingComparerWithChild<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, _comparer, _descending, childComparer);
+
+        internal override EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next) =>
+            new EnumerableSorter<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, _comparer, _descending, next);
+
+        public override IEnumerator<TElement> GetEnumerator()
+        {
+            var buffer = new Buffer<TElement>(_source);
+            if (buffer._count > 0)
+            {
+                Sort(buffer._items.AsSpan(0, buffer._count), _comparer, _descending);
+                for (int i = 0; i < buffer._count; i++)
+                {
+                    yield return buffer._items[i];
+                }
+            }
+        }
+
+        private static void Sort(Span<TElement> span, IComparer<TElement> comparer, bool descending)
+        {
+            if (!descending)
+            {
+                span.Sort(comparer);
+            }
+            else if (comparer == Comparer<TElement>.Default)
+            {
+                span.Sort(static (a, b) => Comparer<TElement>.Default.Compare(b, a));
+            }
+            else
+            {
+                IComparer<TElement> capturedComparer = comparer;
+                span.Sort((a, b) => capturedComparer.Compare(b, a));
+            }
         }
     }
 

--- a/src/libraries/System.Linq/tests/OrderDescendingTests.cs
+++ b/src/libraries/System.Linq/tests/OrderDescendingTests.cs
@@ -104,6 +104,48 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void OrderedDescendingToArray()
+        {
+            var source = new[]
+            {
+                5, 9, 6, 7, 8, 5, 20
+            };
+            var expected = new[]
+            {
+                20, 9, 8, 7, 6, 5, 5
+            };
+
+            Assert.Equal(expected, source.OrderDescending().ToArray());
+        }
+
+        [Fact]
+        public void EmptyOrderedDescendingToArray()
+        {
+            Assert.Empty(Enumerable.Empty<int>().OrderDescending().ToArray());
+        }
+
+        [Fact]
+        public void OrderedDescendingToList()
+        {
+            var source = new[]
+            {
+                5, 9, 6, 7, 8, 5, 20
+            };
+            var expected = new[]
+            {
+                20, 9, 8, 7, 6, 5, 5
+            };
+
+            Assert.Equal(expected, source.OrderDescending().ToList());
+        }
+
+        [Fact]
+        public void EmptyOrderedDescendingToList()
+        {
+            Assert.Empty(Enumerable.Empty<int>().OrderDescending().ToList());
+        }
+
+        [Fact]
         public void SameKeysVerifySortStable()
         {
             var source = new[]

--- a/src/libraries/System.Linq/tests/OrderTests.cs
+++ b/src/libraries/System.Linq/tests/OrderTests.cs
@@ -485,5 +485,13 @@ namespace System.Linq.Tests
                 }
             }
         }
+
+        [Fact]
+        public void StableSort_CustomComparerAlwaysReturns0()
+        {
+            byte[] values = new byte[] { 0x45, 0x7D, 0x4B, 0x61, 0x27 };
+            byte[] newValues = values.Order(Comparer<byte>.Create((a, b) => 0)).ToArray();
+            AssertExtensions.SequenceEqual(values, newValues);
+        }
     }
 }


### PR DESCRIPTION
For non-floating point primitive types, stable sorts are indistinguishable from unstable sorts.  They could be distinguishable if there are custom keys associated with each item, but Order{Descending} doesn't have separate keys from the elements themselves.  As such, we can avoid all of the overhead associated with the int[] map Order{Descending}By creates as part of implementing the stable sort, avoid always specifying a comparer, etc.  This PR does so for Order{Descending}(comparer) followed by ToArray, ToList, and foreach/GetEnumerator.

```C#
[Params(10, 1_000, 1_000_000)]
public int Size { get; set; }

[Params(false, true)]
public bool CustomComparer { get; set; }

private IEnumerable<int> _source;
private IComparer<int> _comparer;

[GlobalSetup]
public void Setup()
{
    _source = Enumerable.Range(0, Size).Reverse();
    _comparer = CustomComparer ? Comparer<int>.Create((a, b) => a.CompareTo(b)) : null;
}

[Benchmark]
public int[] OrderToArray() => _source.Order(_comparer).ToArray();

[Benchmark]
public List<int> OrderToList() => _source.Order(_comparer).ToList();

[Benchmark]
public int[] OrderDescendingToArray() => _source.OrderDescending(_comparer).ToArray();

[Benchmark]
public List<int> OrderDescendingToList() => _source.OrderDescending(_comparer).ToList();
```

|                 Method |         Toolchain |    Size | CustomComparer |              Mean | Ratio |  Allocated | Alloc Ratio |
|----------------------- |------------------ |-------- |--------------- |------------------:|------:|-----------:|------------:|
|           OrderToArray | \main\corerun.exe |      10 |          False |         278.17 ns |  1.00 |      368 B |        1.00 |
|           OrderToArray |   \pr\corerun.exe |      10 |          False |          92.35 ns |  0.33 |      104 B |        0.28 |
|                        |                   |         |                |                   |       |            |             |
|            OrderToList | \main\corerun.exe |      10 |          False |         319.36 ns |  1.00 |      400 B |        1.00 |
|            OrderToList |   \pr\corerun.exe |      10 |          False |         111.68 ns |  0.35 |      136 B |        0.34 |
|                        |                   |         |                |                   |       |            |             |
| OrderDescendingToArray | \main\corerun.exe |      10 |          False |         141.88 ns |  1.00 |      368 B |        1.00 |
| OrderDescendingToArray |   \pr\corerun.exe |      10 |          False |          78.19 ns |  0.55 |      104 B |        0.28 |
|                        |                   |         |                |                   |       |            |             |
|  OrderDescendingToList | \main\corerun.exe |      10 |          False |         153.89 ns |  1.00 |      400 B |        1.00 |
|  OrderDescendingToList |   \pr\corerun.exe |      10 |          False |         102.72 ns |  0.67 |      136 B |        0.34 |
|                        |                   |         |                |                   |       |            |             |
|           OrderToArray | \main\corerun.exe |      10 |           True |         420.89 ns |  1.00 |      368 B |        1.00 |
|           OrderToArray |   \pr\corerun.exe |      10 |           True |         292.21 ns |  0.69 |      168 B |        0.46 |
|                        |                   |         |                |                   |       |            |             |
|            OrderToList | \main\corerun.exe |      10 |           True |         438.26 ns |  1.00 |      400 B |        1.00 |
|            OrderToList |   \pr\corerun.exe |      10 |           True |         298.27 ns |  0.68 |      200 B |        0.50 |
|                        |                   |         |                |                   |       |            |             |
| OrderDescendingToArray | \main\corerun.exe |      10 |           True |         175.02 ns |  1.00 |      368 B |        1.00 |
| OrderDescendingToArray |   \pr\corerun.exe |      10 |           True |         114.31 ns |  0.68 |      192 B |        0.52 |
|                        |                   |         |                |                   |       |            |             |
|  OrderDescendingToList | \main\corerun.exe |      10 |           True |         192.11 ns |  1.00 |      400 B |        1.00 |
|  OrderDescendingToList |   \pr\corerun.exe |      10 |           True |         132.25 ns |  0.69 |      224 B |        0.56 |
|                        |                   |         |                |                   |       |            |             |
|           OrderToArray | \main\corerun.exe |    1000 |          False |      37,076.72 ns |  1.00 |    12248 B |        1.00 |
|           OrderToArray |   \pr\corerun.exe |    1000 |          False |       8,460.32 ns |  0.21 |     4064 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
|            OrderToList | \main\corerun.exe |    1000 |          False |      39,205.11 ns |  1.00 |    12280 B |        1.00 |
|            OrderToList |   \pr\corerun.exe |    1000 |          False |       9,620.57 ns |  0.25 |     4096 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
| OrderDescendingToArray | \main\corerun.exe |    1000 |          False |      22,122.96 ns |  1.00 |    12248 B |        1.00 |
| OrderDescendingToArray |   \pr\corerun.exe |    1000 |          False |      21,061.94 ns |  0.95 |     4064 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
|  OrderDescendingToList | \main\corerun.exe |    1000 |          False |      25,929.92 ns |  1.00 |    12280 B |        1.00 |
|  OrderDescendingToList |   \pr\corerun.exe |    1000 |          False |      21,786.70 ns |  0.84 |     4096 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
|           OrderToArray | \main\corerun.exe |    1000 |           True |      78,531.66 ns |  1.00 |    12248 B |        1.00 |
|           OrderToArray |   \pr\corerun.exe |    1000 |           True |      46,769.75 ns |  0.59 |     4128 B |        0.34 |
|                        |                   |         |                |                   |       |            |             |
|            OrderToList | \main\corerun.exe |    1000 |           True |      78,907.46 ns |  1.00 |    12280 B |        1.00 |
|            OrderToList |   \pr\corerun.exe |    1000 |           True |      48,665.61 ns |  0.62 |     4160 B |        0.34 |
|                        |                   |         |                |                   |       |            |             |
| OrderDescendingToArray | \main\corerun.exe |    1000 |           True |      48,244.70 ns |  1.00 |    12248 B |        1.00 |
| OrderDescendingToArray |   \pr\corerun.exe |    1000 |           True |      35,226.95 ns |  0.73 |     4152 B |        0.34 |
|                        |                   |         |                |                   |       |            |             |
|  OrderDescendingToList | \main\corerun.exe |    1000 |           True |      47,008.31 ns |  1.00 |    12280 B |        1.00 |
|  OrderDescendingToList |   \pr\corerun.exe |    1000 |           True |      35,854.03 ns |  0.76 |     4184 B |        0.34 |
|                        |                   |         |                |                   |       |            |             |
|           OrderToArray | \main\corerun.exe | 1000000 |          False | 106,464,660.88 ns |  1.00 | 12000356 B |        1.00 |
|           OrderToArray |   \pr\corerun.exe | 1000000 |          False |  17,732,985.94 ns |  0.17 |  4000094 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
|            OrderToList | \main\corerun.exe | 1000000 |          False |  85,958,815.56 ns |  1.00 | 12000388 B |        1.00 |
|            OrderToList |   \pr\corerun.exe | 1000000 |          False |  18,666,339.84 ns |  0.22 |  4000126 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
| OrderDescendingToArray | \main\corerun.exe | 1000000 |          False |  54,612,728.42 ns |  1.00 | 12000661 B |        1.00 |
| OrderDescendingToArray |   \pr\corerun.exe | 1000000 |          False |  48,403,715.76 ns |  0.88 |  4000095 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
|  OrderDescendingToList | \main\corerun.exe | 1000000 |          False |  64,468,350.83 ns |  1.00 | 12000361 B |        1.00 |
|  OrderDescendingToList |   \pr\corerun.exe | 1000000 |          False |  48,894,085.31 ns |  0.76 |  4000127 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
|           OrderToArray | \main\corerun.exe | 1000000 |           True | 192,562,314.29 ns |  1.00 | 12000360 B |        1.00 |
|           OrderToArray |   \pr\corerun.exe | 1000000 |           True | 114,808,988.57 ns |  0.60 |  4000195 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
|            OrderToList | \main\corerun.exe | 1000000 |           True | 194,070,950.00 ns |  1.00 | 12000392 B |        1.00 |
|            OrderToList |   \pr\corerun.exe | 1000000 |           True | 120,640,043.40 ns |  0.62 |  4000227 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
| OrderDescendingToArray | \main\corerun.exe | 1000000 |           True | 114,865,036.00 ns |  1.00 | 12001080 B |        1.00 |
| OrderDescendingToArray |   \pr\corerun.exe | 1000000 |           True |  81,669,459.18 ns |  0.71 |  4000200 B |        0.33 |
|                        |                   |         |                |                   |       |            |             |
|  OrderDescendingToList | \main\corerun.exe | 1000000 |           True | 110,513,381.48 ns |  1.00 | 12000410 B |        1.00 |
|  OrderDescendingToList |   \pr\corerun.exe | 1000000 |           True |  88,667,991.07 ns |  0.80 |  4000240 B |        0.33 |