### PR TITLE
Fix loop canonicalization for call-finally case

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_76346/Runtime_76346.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_76346/Runtime_76346.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    public static int Main()
+    {
+        int i = 0;
+
+        try
+        {
+            Console.WriteLine("Running... {0}", i);
+        }
+        finally
+        {
+            // Don't want this to be cloned, so add more EH
+            Console.WriteLine("In finally1");
+            try
+            {
+                Console.WriteLine("try2... {0}", i);
+            }
+            finally
+            {
+                Console.WriteLine("finally2... {0}", i);
+            }
+        }
+        do
+        {
+            do
+            {
+                ++i;
+            } while (i % 19 != 0);
+        } while (i < 40);
+
+        return (i == 57) ? 100 : 101;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_76346/Runtime_76346.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_76346/Runtime_76346.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If a call-finally is followed by a loop body that requires canonicalization, we hit an assert that the `head` block preceding the loop must be a fall-through block. This was true in all cases except if the preceding block was the BBJ_ALWAYS of a BBJ_CALLFINALLY/BBJ_ALWAYS pair.

To fix this, add a new canonicalization. If this case occurs, simply insert a new fall-through block above the loop top and redirect the BBJ_ALWAYS to that new block.

Fixes #76346