### PR TITLE
enable regions for AoT

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -52,7 +52,7 @@ inline void FATAL_GC_ERROR()
 // This means any empty regions can be freely used for any generation. For
 // Server GC we will balance regions between heaps.
 // For now disable regions for StandAlone GC, NativeAOT and MacOS builds
-#if defined (HOST_64BIT) && !defined (BUILD_AS_STANDALONE) && !defined(__APPLE__) && !defined(FEATURE_NATIVEAOT)
+#if defined (HOST_64BIT) && !defined (BUILD_AS_STANDALONE) && !defined(__APPLE__)
 #define USE_REGIONS
 #endif //HOST_64BIT && BUILD_AS_STANDALONE
 
@@ -3142,7 +3142,7 @@ protected:
     bool is_in_condemned_gc (uint8_t* o);
     // requires checking if o is in the heap range first.
     PER_HEAP_ISOLATED
-    bool is_in_condemned (uint8_t* o);
+    bool is_in_bookkeeping_range (uint8_t* o);
     PER_HEAP_ISOLATED
     bool should_check_brick_for_reloc (uint8_t* o);
 #endif //USE_REGIONS


### PR DESCRIPTION
this fixes the last issue standing in the way of enabling regions for AoT. AoT could conservatively report addresses that land in the GC heap range but not in range that bookkeeping covers. so these need to filtered out. 