### PR TITLE
Vectorize  {Last}IndexOfAny{Except} for ASCII needles

### DIFF
--- a/src/libraries/System.Memory/tests/Span/IndexOfAnyExcept.T.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAnyExcept.T.cs
@@ -53,6 +53,48 @@ namespace System.SpanTests
                     break;
             }
         }
+
+        [Fact]
+        public static void TestIndexOfAnyExcept_RandomInputs_Char()
+        {
+            IndexOfAnyCharTestHelper.TestRandomInputs(
+                expected: IndexOfAnyExceptReferenceImpl,
+                actual: (searchSpace, values) => searchSpace.IndexOfAnyExcept(values));
+
+            static int IndexOfAnyExceptReferenceImpl(ReadOnlySpan<char> searchSpace, ReadOnlySpan<char> values)
+            {
+                for (int i = 0; i < searchSpace.Length; i++)
+                {
+                    if (!values.Contains(searchSpace[i]))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+        }
+
+        [Fact]
+        public static void TestLastIndexOfAnyExcept_RandomInputs_Char()
+        {
+            IndexOfAnyCharTestHelper.TestRandomInputs(
+                expected: LastIndexOfAnyExceptReferenceImpl,
+                actual: (searchSpace, values) => searchSpace.LastIndexOfAnyExcept(values));
+
+            static int LastIndexOfAnyExceptReferenceImpl(ReadOnlySpan<char> searchSpace, ReadOnlySpan<char> values)
+            {
+                for (int i = searchSpace.Length - 1; i >= 0; i--)
+                {
+                    if (!values.Contains(searchSpace[i]))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+        }
     }
 
     public record SimpleRecord(int Value);

--- a/src/libraries/System.Memory/tests/Span/IndexOfAnyExcept.T.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAnyExcept.T.cs
@@ -55,6 +55,7 @@ namespace System.SpanTests
         }
 
         [Fact]
+        [OuterLoop("Takes about a second to execute")]
         public static void TestIndexOfAnyExcept_RandomInputs_Char()
         {
             IndexOfAnyCharTestHelper.TestRandomInputs(
@@ -76,6 +77,7 @@ namespace System.SpanTests
         }
 
         [Fact]
+        [OuterLoop("Takes about a second to execute")]
         public static void TestLastIndexOfAnyExcept_RandomInputs_Char()
         {
             IndexOfAnyCharTestHelper.TestRandomInputs(

--- a/src/libraries/System.Memory/tests/Span/LastIndexOfAny.T.cs
+++ b/src/libraries/System.Memory/tests/Span/LastIndexOfAny.T.cs
@@ -951,5 +951,26 @@ namespace System.SpanTests
                 }
             }
         }
+
+        [Fact]
+        public static void TestLastIndexOfAny_RandomInputs_Char()
+        {
+            IndexOfAnyCharTestHelper.TestRandomInputs(
+                expected: LastIndexOfAnyReferenceImpl,
+                actual: (searchSpace, values) => searchSpace.LastIndexOfAny(values));
+
+            static int LastIndexOfAnyReferenceImpl(ReadOnlySpan<char> searchSpace, ReadOnlySpan<char> values)
+            {
+                for (int i = searchSpace.Length - 1; i >= 0; i--)
+                {
+                    if (values.Contains(searchSpace[i]))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
+            }
+        }
     }
 }

--- a/src/libraries/System.Memory/tests/Span/LastIndexOfAny.T.cs
+++ b/src/libraries/System.Memory/tests/Span/LastIndexOfAny.T.cs
@@ -953,6 +953,7 @@ namespace System.SpanTests
         }
 
         [Fact]
+        [OuterLoop("Takes about a second to execute")]
         public static void TestLastIndexOfAny_RandomInputs_Char()
         {
             IndexOfAnyCharTestHelper.TestRandomInputs(

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -414,6 +414,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IFormatProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IFormattable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Index.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IndexOfAnyAsciiSearcher.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IndexOutOfRangeException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\InsufficientExecutionStackException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\InsufficientMemoryException.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyAsciiSearcher.cs
@@ -1,0 +1,353 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace System
+{
+    internal static class IndexOfAnyAsciiSearcher
+    {
+        private static bool IsSupported => Ssse3.IsSupported || AdvSimd.Arm64.IsSupported;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool TryComputeBitmap(ReadOnlySpan<char> values, byte* bitmap, out bool needleContainsZero)
+        {
+            byte* bitmapLocal = bitmap;
+
+            foreach (char c in values)
+            {
+                if (c > 127)
+                {
+                    needleContainsZero = false;
+                    return false;
+                }
+
+                int highNibble = c >> 4;
+                int lowNibble = c & 0xF;
+
+                bitmapLocal[(uint)lowNibble] |= (byte)(1 << highNibble);
+            }
+
+            needleContainsZero = (bitmap[0] & 1) != 0;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryIndexOfAny(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index) =>
+            TryIndexOfAny<DontNegate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryIndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index) =>
+            TryIndexOfAny<Negate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryLastIndexOfAny(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index) =>
+            TryLastIndexOfAny<DontNegate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryLastIndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index) =>
+            TryLastIndexOfAny<Negate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool TryIndexOfAny<TNegator>(ref short searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index)
+            where TNegator : struct, INegator
+        {
+            Debug.Assert(searchSpaceLength >= Vector128<short>.Count);
+
+            if (IsSupported)
+            {
+                Vector128<byte> bitmap = default;
+                if (TryComputeBitmap(asciiValues, (byte*)&bitmap, out bool needleContainsZero))
+                {
+                    index = Ssse3.IsSupported && needleContainsZero
+                        ? IndexOfAnyVectorized<TNegator, Ssse3HandleZeroInNeedle>(ref searchSpace, searchSpaceLength, bitmap)
+                        : IndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, bitmap);
+                    return true;
+                }
+            }
+
+            index = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool TryLastIndexOfAny<TNegator>(ref short searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index)
+            where TNegator : struct, INegator
+        {
+            Debug.Assert(searchSpaceLength >= Vector128<short>.Count);
+
+            if (IsSupported)
+            {
+                Vector128<byte> bitmap = default;
+                if (TryComputeBitmap(asciiValues, (byte*)&bitmap, out bool needleContainsZero))
+                {
+                    index = Ssse3.IsSupported && needleContainsZero
+                        ? LastIndexOfAnyVectorized<TNegator, Ssse3HandleZeroInNeedle>(ref searchSpace, searchSpaceLength, bitmap)
+                        : LastIndexOfAnyVectorized<TNegator, Default>(ref searchSpace, searchSpaceLength, bitmap);
+                    return true;
+                }
+            }
+
+            index = default;
+            return false;
+        }
+
+        private static int IndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, Vector128<byte> bitmap)
+            where TNegator : struct, INegator
+            where TOptimizations : struct, IOptimizations
+        {
+            ref short currentSearchSpace = ref searchSpace;
+
+            if (searchSpaceLength > 2 * Vector128<short>.Count)
+            {
+                // Process the input in chunks of 16 characters (2 * Vector128<short>).
+                // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
+                // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                // Let the fallback below handle it instead. This is why the condition is
+                // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - (2 * Vector128<short>.Count));
+
+                do
+                {
+                    Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
+
+                    Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
+                    if (result != Vector128<byte>.Zero)
+                    {
+                        return ComputeFirstIndex<TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                    }
+
+                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 2 * Vector128<short>.Count);
+                }
+                while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref twoVectorsAwayFromEnd));
+            }
+
+            // We have 1-16 characters remaining. Process the first and last vector in the search space.
+            // They may overlap, but we'll handle that in the index calculation if we do get a match.
+            Debug.Assert(searchSpaceLength >= Vector128<short>.Count, "We expect that the input is long enough for us to load a whole vector.");
+            {
+                ref short oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<short>.Count);
+
+                ref short firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd)
+                    ? ref oneVectorAwayFromEnd
+                    : ref currentSearchSpace;
+
+                Vector128<short> source0 = Vector128.LoadUnsafe(ref firstVector);
+                Vector128<short> source1 = Vector128.LoadUnsafe(ref oneVectorAwayFromEnd);
+
+                Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
+                if (result != Vector128<byte>.Zero)
+                {
+                    return ComputeFirstIndexOverlapped<TNegator>(ref searchSpace, ref firstVector, ref oneVectorAwayFromEnd, result);
+                }
+            }
+
+            return -1;
+        }
+
+        private static int LastIndexOfAnyVectorized<TNegator, TOptimizations>(ref short searchSpace, int searchSpaceLength, Vector128<byte> bitmap)
+            where TNegator : struct, INegator
+            where TOptimizations : struct, IOptimizations
+        {
+            ref short currentSearchSpace = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+
+            if (searchSpaceLength > 2 * Vector128<short>.Count)
+            {
+                // Process the input in chunks of 16 characters (2 * Vector128<short>).
+                // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
+                // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                // Let the fallback below handle it instead. This is why the condition is
+                // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                ref short twoVectorsAfterStart = ref Unsafe.Add(ref searchSpace, 2 * Vector128<short>.Count);
+
+                do
+                {
+                    currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, 2 * Vector128<short>.Count);
+
+                    Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
+
+                    Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
+                    if (result != Vector128<byte>.Zero)
+                    {
+                        return ComputeLastIndex<TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                    }
+                }
+                while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref twoVectorsAfterStart));
+            }
+
+            // We have 1-16 characters remaining. Process the first and last vector in the search space.
+            // They may overlap, but we'll handle that in the index calculation if we do get a match.
+            Debug.Assert(searchSpaceLength >= Vector128<short>.Count, "We expect that the input is long enough for us to load a whole vector.");
+            {
+                ref short oneVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<short>.Count);
+
+                ref short secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAfterStart)
+                    ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<short>.Count)
+                    : ref searchSpace;
+
+                Vector128<short> source0 = Vector128.LoadUnsafe(ref searchSpace);
+                Vector128<short> source1 = Vector128.LoadUnsafe(ref secondVector);
+
+                Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
+                if (result != Vector128<byte>.Zero)
+                {
+                    return ComputeLastIndexOverlapped<TNegator>(ref searchSpace, ref secondVector, result);
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<byte> IndexOfAnyLookup<TNegator, TOptimizations>(Vector128<short> source0, Vector128<short> source1, Vector128<byte> bitmapLookup)
+            where TNegator : struct, INegator
+            where TOptimizations : struct, IOptimizations
+        {
+            // Pack two vectors of characters into bytes. While the type is Vector128<short>, these are really UInt16 characters.
+            // X86: Downcast every character using saturation.
+            // - Values <= 32767 result in min(value, 255).
+            // - Values  > 32767 result in 0. Because of this we must do more work to handle needles that contain 0.
+            // ARM64: Take the low byte of each character.
+            // - All values result in (value & 0xFF).
+            Vector128<byte> source = Sse2.IsSupported
+                ? Sse2.PackUnsignedSaturate(source0, source1)
+                : AdvSimd.Arm64.UnzipEven(source0.AsByte(), source1.AsByte());
+
+            // On X86, the Ssse3.Shuffle instruction will already perform an implicit 'AND 0xF' on the indices, so we can skip it.
+            // For values above 127, Ssse3.Shuffle will also set the result to 0. This saves us from explicitly checking whether the input was ascii below.
+            Vector128<byte> lowerNibbles = Ssse3.IsSupported
+                ? source
+                : source & Vector128.Create((byte)0xF);
+
+            Vector128<byte> highNibbles = Vector128.ShiftRightLogical(source.AsInt32(), 4).AsByte() & Vector128.Create((byte)0xF);
+
+            // The bitmapLookup represents a 8x16 table of bits, indicating whether a character is present in the needle.
+            // Lookup the rows via the lower nibble and the column via the higher nibble.
+            Vector128<byte> bitMask = Shuffle(bitmapLookup, lowerNibbles);
+            Vector128<byte> bitPositions = Shuffle(Vector128.Create(0x8040201008040201).AsByte(), highNibbles);
+
+            Vector128<byte> result = bitMask & bitPositions;
+
+            // On ARM64, we ignored the high byte of every character when packing (see above).
+            // The 'result' can therefore contain false positives - e.g. 0x141 would match 0x41 ('A').
+            // On X86, PackUnsignedSaturate resulted in values becoming 0 for inputs above 32767.
+            // Any value above 32767 would therefore match against 0. If 0 is present in the needle, we must clear the false positives.
+            // In both cases, we can correct the result by clearing any bits that matched with a non-ascii source character.
+            if (AdvSimd.Arm64.IsSupported || TOptimizations.NeedleContainsZero)
+            {
+                Vector128<short> ascii0 = Vector128.LessThan(source0.AsUInt16(), Vector128.Create((ushort)128)).AsInt16();
+                Vector128<short> ascii1 = Vector128.LessThan(source1.AsUInt16(), Vector128.Create((ushort)128)).AsInt16();
+                Vector128<byte> ascii = Sse2.IsSupported
+                    ? Sse2.PackSignedSaturate(ascii0, ascii1).AsByte()
+                    : AdvSimd.Arm64.UnzipEven(ascii0.AsByte(), ascii1.AsByte());
+                result &= ascii;
+            }
+
+            return TNegator.NegateIfNeeded(result);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<byte> Shuffle(Vector128<byte> vector, Vector128<byte> indices)
+        {
+            // We're not using Vector128.Shuffle as the caller already accounts for and relies on differences in behavior between platforms.
+            return Ssse3.IsSupported
+                ? Ssse3.Shuffle(vector, indices)
+                : AdvSimd.Arm64.VectorTableLookup(vector, indices);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeFirstIndex<TNegator>(ref short searchSpace, ref short current, Vector128<byte> result)
+            where TNegator : struct, INegator
+        {
+            uint mask = TNegator.ExtractMask(result);
+            int offsetInVector = BitOperations.TrailingZeroCount(mask);
+            return offsetInVector + (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / sizeof(short));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeFirstIndexOverlapped<TNegator>(ref short searchSpace, ref short current0, ref short current1, Vector128<byte> result)
+            where TNegator : struct, INegator
+        {
+            uint mask = TNegator.ExtractMask(result);
+            int offsetInVector = BitOperations.TrailingZeroCount(mask);
+            if (offsetInVector >= Vector128<short>.Count)
+            {
+                // We matched within the second vector
+                current0 = ref current1;
+                offsetInVector -= Vector128<short>.Count;
+            }
+            return offsetInVector + (int)(Unsafe.ByteOffset(ref searchSpace, ref current0) / sizeof(short));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeLastIndex<TNegator>(ref short searchSpace, ref short current, Vector128<byte> result)
+            where TNegator : struct, INegator
+        {
+            uint mask = TNegator.ExtractMask(result) & 0xFFFF;
+            int offsetInVector = 31 - BitOperations.LeadingZeroCount(mask);
+            return offsetInVector + (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / sizeof(char));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int ComputeLastIndexOverlapped<TNegator>(ref short searchSpace, ref short secondVector, Vector128<byte> result)
+            where TNegator : struct, INegator
+        {
+            uint mask = TNegator.ExtractMask(result) & 0xFFFF;
+            int offsetInVector = 31 - BitOperations.LeadingZeroCount(mask);
+            if (offsetInVector < Vector128<short>.Count)
+            {
+                return offsetInVector;
+            }
+
+            // We matched within the second vector
+            return offsetInVector - Vector128<short>.Count + (int)(Unsafe.ByteOffset(ref searchSpace, ref secondVector) / sizeof(char));
+        }
+
+        private interface INegator
+        {
+            static abstract bool NegateIfNeeded(bool result);
+            static abstract Vector128<byte> NegateIfNeeded(Vector128<byte> result);
+            static abstract uint ExtractMask(Vector128<byte> result);
+        }
+
+        private struct DontNegate : INegator
+        {
+            public static bool NegateIfNeeded(bool result) => result;
+            public static Vector128<byte> NegateIfNeeded(Vector128<byte> result) => result;
+            public static uint ExtractMask(Vector128<byte> result) => ~Vector128.Equals(result, Vector128<byte>.Zero).ExtractMostSignificantBits();
+        }
+
+        private struct Negate : INegator
+        {
+            public static bool NegateIfNeeded(bool result) => !result;
+            // This is intentionally testing for equality with 0 instead of "~result".
+            // We want to know if any character didn't match, as that means it should be treated as a match for the -Except method.
+            public static Vector128<byte> NegateIfNeeded(Vector128<byte> result) => Vector128.Equals(result, Vector128<byte>.Zero);
+            public static uint ExtractMask(Vector128<byte> result) => result.ExtractMostSignificantBits();
+        }
+
+        private interface IOptimizations
+        {
+            static abstract bool NeedleContainsZero { get; }
+        }
+
+        private struct Ssse3HandleZeroInNeedle : IOptimizations
+        {
+            public static bool NeedleContainsZero => true;
+        }
+
+        private struct Default : IOptimizations
+        {
+            public static bool NeedleContainsZero => false;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyAsciiSearcher.cs
@@ -17,7 +17,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe bool TryComputeBitmap(ReadOnlySpan<char> values, byte* bitmap, out bool needleContainsZero)
         {
-            byte* bitmapLocal = bitmap;
+            byte* bitmapLocal = bitmap; // https://github.com/dotnet/runtime/issues/9040
 
             foreach (char c in values)
             {
@@ -319,14 +319,14 @@ namespace System
             static abstract uint ExtractMask(Vector128<byte> result);
         }
 
-        private struct DontNegate : INegator
+        private readonly struct DontNegate : INegator
         {
             public static bool NegateIfNeeded(bool result) => result;
             public static Vector128<byte> NegateIfNeeded(Vector128<byte> result) => result;
             public static uint ExtractMask(Vector128<byte> result) => ~Vector128.Equals(result, Vector128<byte>.Zero).ExtractMostSignificantBits();
         }
 
-        private struct Negate : INegator
+        private readonly struct Negate : INegator
         {
             public static bool NegateIfNeeded(bool result) => !result;
             // This is intentionally testing for equality with 0 instead of "~result".
@@ -340,12 +340,12 @@ namespace System
             static abstract bool NeedleContainsZero { get; }
         }
 
-        private struct Ssse3HandleZeroInNeedle : IOptimizations
+        private readonly struct Ssse3HandleZeroInNeedle : IOptimizations
         {
             public static bool NeedleContainsZero => true;
         }
 
-        private struct Default : IOptimizations
+        private readonly struct Default : IOptimizations
         {
             public static bool NeedleContainsZero => false;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -716,6 +716,15 @@ namespace System
                     return IndexOfAnyExcept(span, values[0], values[1], values[2], values[3]);
 
                 default:
+                    if (RuntimeHelpers.IsBitwiseEquatable<T>() && Unsafe.SizeOf<T>() == sizeof(char))
+                    {
+                        return ProbabilisticMap.IndexOfAnyExcept(
+                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                            span.Length,
+                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(values)),
+                            values.Length);
+                    }
+
                     for (int i = 0; i < span.Length; i++)
                     {
                         if (!values.Contains(span[i]))
@@ -960,6 +969,15 @@ namespace System
                     return LastIndexOfAnyExcept(span, values[0], values[1], values[2], values[3]);
 
                 default:
+                    if (RuntimeHelpers.IsBitwiseEquatable<T>() && Unsafe.SizeOf<T>() == sizeof(char))
+                    {
+                        return ProbabilisticMap.LastIndexOfAnyExcept(
+                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                            span.Length,
+                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(values)),
+                            values.Length);
+                    }
+
                     for (int i = span.Length - 1; i >= 0; i--)
                     {
                         if (!values.Contains(span[i]))
@@ -1681,42 +1699,12 @@ namespace System
                                 span.Length);
 
                         default:
-                            return IndexOfAnyProbabilistic(ref Unsafe.As<short, char>(ref spanRef), span.Length, ref Unsafe.As<short, char>(ref valueRef), values.Length);
+                            return ProbabilisticMap.IndexOfAny(ref Unsafe.As<short, char>(ref spanRef), span.Length, ref Unsafe.As<short, char>(ref valueRef), values.Length);
                     }
                 }
             }
 
             return SpanHelpers.IndexOfAny(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(values), values.Length);
-        }
-
-        /// <summary>Searches for the first index of any of the specified values using a <see cref="ProbabilisticMap"/>.</summary>
-        private static unsafe int IndexOfAnyProbabilistic(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
-        {
-            Debug.Assert(searchSpaceLength >= 0);
-            Debug.Assert(valuesLength >= 0);
-
-            ReadOnlySpan<char> valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
-            ProbabilisticMap map = default;
-
-            uint* charMap = (uint*)&map;
-            ProbabilisticMap.Initialize(charMap, valuesSpan);
-
-            ref char cur = ref searchSpace;
-            while (searchSpaceLength != 0)
-            {
-                int ch = cur;
-                if (ProbabilisticMap.IsCharBitSet(charMap, (byte)ch) &&
-                    ProbabilisticMap.IsCharBitSet(charMap, (byte)(ch >> 8)) &&
-                    ProbabilisticMap.SpanContains(valuesSpan, (char)ch))
-                {
-                    return (int)((nint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
-                }
-
-                searchSpaceLength--;
-                cur = ref Unsafe.Add(ref cur, 1);
-            }
-
-            return -1;
         }
 
         /// <summary>
@@ -1791,8 +1779,8 @@ namespace System
         /// </summary>
         /// <param name="span">The span to search.</param>
         /// <param name="values">The set of values to search for.</param>
-        public static int LastIndexOfAny<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>?
-            => LastIndexOfAny((ReadOnlySpan<T>)span, values);
+        public static int LastIndexOfAny<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>? =>
+            LastIndexOfAny((ReadOnlySpan<T>)span, values);
 
         /// <summary>
         /// Searches for the last index of any of the specified values similar to calling LastIndexOf several times with the logical OR operator. If not found, returns -1.
@@ -1950,42 +1938,12 @@ namespace System
 #endif
 
                         default:
-                            return LastIndexOfAnyProbabilistic(ref Unsafe.As<short, char>(ref spanRef), span.Length, ref Unsafe.As<short, char>(ref valueRef), values.Length);
+                            return ProbabilisticMap.LastIndexOfAny(ref Unsafe.As<short, char>(ref spanRef), span.Length, ref Unsafe.As<short, char>(ref valueRef), values.Length);
                     }
                 }
             }
 
             return SpanHelpers.LastIndexOfAny(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(values), values.Length);
-        }
-
-        /// <summary>Searches for the last index of any of the specified values using a <see cref="ProbabilisticMap"/>.</summary>
-        private static unsafe int LastIndexOfAnyProbabilistic(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
-        {
-            Debug.Assert(searchSpaceLength >= 0);
-            Debug.Assert(valuesLength >= 0);
-
-            var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
-            ProbabilisticMap map = default;
-
-            uint* charMap = (uint*)&map;
-            ProbabilisticMap.Initialize(charMap, valuesSpan);
-
-            ref char cur = ref Unsafe.Add(ref searchSpace, searchSpaceLength - 1);
-            while (searchSpaceLength != 0)
-            {
-                int ch = cur;
-                if (ProbabilisticMap.IsCharBitSet(charMap, (byte)ch) &&
-                    ProbabilisticMap.IsCharBitSet(charMap, (byte)(ch >> 8)) &&
-                    ProbabilisticMap.SpanContains(valuesSpan, (char)ch))
-                {
-                    return (int)((nint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
-                }
-
-                searchSpaceLength--;
-                cur = ref Unsafe.Add(ref cur, -1);
-            }
-
-            return -1;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1779,6 +1779,7 @@ namespace System
         /// </summary>
         /// <param name="span">The span to search.</param>
         /// <param name="values">The set of values to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAny<T>(this Span<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>? =>
             LastIndexOfAny((ReadOnlySpan<T>)span, values);
 

--- a/src/libraries/System.Private.CoreLib/src/System/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ProbabilisticMap.cs
@@ -89,19 +89,19 @@ namespace System
         }
 
         public static int IndexOfAny(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength) =>
-            IndexOfAny<DontNegate>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+            IndexOfAny<SpanHelpers.DontNegate<char>>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
 
         public static int IndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength) =>
-            IndexOfAny<Negate>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+            IndexOfAny<SpanHelpers.Negate<char>>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
 
         public static int LastIndexOfAny(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength) =>
-            LastIndexOfAny<DontNegate>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+            LastIndexOfAny<SpanHelpers.DontNegate<char>>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
 
         public static int LastIndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength) =>
-            LastIndexOfAny<Negate>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+            LastIndexOfAny<SpanHelpers.Negate<char>>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
 
         private static int IndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
-            where TNegator : struct, INegator
+            where TNegator : struct, SpanHelpers.INegator<char>
         {
             ReadOnlySpan<char> valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
 
@@ -124,7 +124,7 @@ namespace System
                 return -1;
             }
 
-            if (typeof(TNegator) == typeof(DontNegate)
+            if (typeof(TNegator) == typeof(SpanHelpers.DontNegate<char>)
                 ? IndexOfAnyAsciiSearcher.TryIndexOfAny(ref searchSpace, searchSpaceLength, valuesSpan, out int index)
                 : IndexOfAnyAsciiSearcher.TryIndexOfAnyExcept(ref searchSpace, searchSpaceLength, valuesSpan, out index))
             {
@@ -135,7 +135,7 @@ namespace System
         }
 
         private static int LastIndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
-            where TNegator : struct, INegator
+            where TNegator : struct, SpanHelpers.INegator<char>
         {
             var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
 
@@ -157,7 +157,7 @@ namespace System
                 return -1;
             }
 
-            if (typeof(TNegator) == typeof(DontNegate)
+            if (typeof(TNegator) == typeof(SpanHelpers.DontNegate<char>)
                 ? IndexOfAnyAsciiSearcher.TryLastIndexOfAny(ref searchSpace, searchSpaceLength, valuesSpan, out int index)
                 : IndexOfAnyAsciiSearcher.TryLastIndexOfAnyExcept(ref searchSpace, searchSpaceLength, valuesSpan, out index))
             {
@@ -168,7 +168,7 @@ namespace System
         }
 
         private static unsafe int ProbabilisticIndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
-            where TNegator : struct, INegator
+            where TNegator : struct, SpanHelpers.INegator<char>
         {
             var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
 
@@ -197,7 +197,7 @@ namespace System
         }
 
         private static unsafe int ProbabilisticLastIndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
-            where TNegator : struct, INegator
+            where TNegator : struct, SpanHelpers.INegator<char>
         {
             var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
 
@@ -222,21 +222,6 @@ namespace System
             }
 
             return -1;
-        }
-
-        private interface INegator
-        {
-            static abstract bool NegateIfNeeded(bool result);
-        }
-
-        private struct DontNegate : INegator
-        {
-            public static bool NegateIfNeeded(bool result) => result;
-        }
-
-        private struct Negate : INegator
-        {
-            public static bool NegateIfNeeded(bool result) => !result;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ProbabilisticMap.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 namespace System
 {
@@ -72,23 +73,155 @@ namespace System
         private static unsafe void SetCharBit(uint* charMap, byte value) =>
             charMap[(uint)value & IndexMask] |= 1u << (value >> IndexShift);
 
-        /// <summary>Determines whether <paramref name="searchChar"/> is in <paramref name="span"/>.</summary>
-        /// <remarks>
-        /// <see cref="MemoryExtensions.Contains{T}(ReadOnlySpan{T}, T)"/> could be used, but it's optimized
-        /// for longer spans, whereas typical usage here expects a relatively small number of items in the span.
-        /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool SpanContains(ReadOnlySpan<char> span, char searchChar)
+        public static int IndexOfAny(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength) =>
+            IndexOfAny<DontNegate>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+
+        public static int IndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength) =>
+            IndexOfAny<Negate>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+
+        public static int LastIndexOfAny(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength) =>
+            LastIndexOfAny<DontNegate>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+
+        public static int LastIndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength) =>
+            LastIndexOfAny<Negate>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+
+        private static int IndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
+            where TNegator : struct, INegator
         {
-            for (int i = 0; i < span.Length; i++)
+            ReadOnlySpan<char> valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
+
+            // If the search space is relatively short compared to the needle, do a simple O(n * m) search.
+            if (searchSpaceLength < Vector128<short>.Count || (searchSpaceLength < 20 && searchSpaceLength < (valuesLength >> 1)))
             {
-                if (span[i] == searchChar)
+                ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+                ref char cur = ref searchSpace;
+
+                while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
                 {
-                    return true;
+                    if (TNegator.NegateIfNeeded(valuesSpan.Contains(cur)))
+                    {
+                        return (int)(Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                    }
+
+                    cur = ref Unsafe.Add(ref cur, 1);
+                }
+
+                return -1;
+            }
+
+            if (typeof(TNegator) == typeof(DontNegate)
+                ? IndexOfAnyAsciiSearcher.TryIndexOfAny(ref searchSpace, searchSpaceLength, valuesSpan, out int index)
+                : IndexOfAnyAsciiSearcher.TryIndexOfAnyExcept(ref searchSpace, searchSpaceLength, valuesSpan, out index))
+            {
+                return index;
+            }
+
+            return ProbabilisticIndexOfAny<TNegator>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+        }
+
+        private static int LastIndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
+            where TNegator : struct, INegator
+        {
+            var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
+
+            // If the search space is relatively short compared to the needle, do a simple O(n * m) search.
+            if (searchSpaceLength < Vector128<short>.Count || (searchSpaceLength < 20 && searchSpaceLength < (valuesLength >> 1)))
+            {
+                ref char cur = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+
+                while (!Unsafe.AreSame(ref searchSpace, ref cur))
+                {
+                    cur = ref Unsafe.Subtract(ref cur, 1);
+
+                    if (TNegator.NegateIfNeeded(valuesSpan.Contains(cur)))
+                    {
+                        return (int)(Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                    }
+                }
+
+                return -1;
+            }
+
+            if (typeof(TNegator) == typeof(DontNegate)
+                ? IndexOfAnyAsciiSearcher.TryLastIndexOfAny(ref searchSpace, searchSpaceLength, valuesSpan, out int index)
+                : IndexOfAnyAsciiSearcher.TryLastIndexOfAnyExcept(ref searchSpace, searchSpaceLength, valuesSpan, out index))
+            {
+                return index;
+            }
+
+            return ProbabilisticLastIndexOfAny<TNegator>(ref searchSpace, searchSpaceLength, ref values, valuesLength);
+        }
+
+        private static unsafe int ProbabilisticIndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
+            where TNegator : struct, INegator
+        {
+            var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
+
+            ProbabilisticMap map = default;
+            uint* charMap = (uint*)&map;
+            Initialize(charMap, valuesSpan);
+
+            ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+            ref char cur = ref searchSpace;
+
+            while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
+            {
+                int ch = cur;
+                if (TNegator.NegateIfNeeded(
+                        IsCharBitSet(charMap, (byte)ch) &&
+                        IsCharBitSet(charMap, (byte)(ch >> 8)) &&
+                        valuesSpan.Contains((char)ch)))
+                {
+                    return (int)(Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                }
+
+                cur = ref Unsafe.Add(ref cur, 1);
+            }
+
+            return -1;
+        }
+
+        private static unsafe int ProbabilisticLastIndexOfAny<TNegator>(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
+            where TNegator : struct, INegator
+        {
+            var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
+
+            ProbabilisticMap map = default;
+            uint* charMap = (uint*)&map;
+            Initialize(charMap, valuesSpan);
+
+            ref char cur = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+
+            while (!Unsafe.AreSame(ref searchSpace, ref cur))
+            {
+                cur = ref Unsafe.Subtract(ref cur, 1);
+
+                int ch = cur;
+                if (TNegator.NegateIfNeeded(
+                        IsCharBitSet(charMap, (byte)ch) &&
+                        IsCharBitSet(charMap, (byte)(ch >> 8)) &&
+                        valuesSpan.Contains((char)ch)))
+                {
+                    return (int)(Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
                 }
             }
 
-            return false;
+            return -1;
+        }
+
+        private interface INegator
+        {
+            static abstract bool NegateIfNeeded(bool result);
+        }
+
+        private struct DontNegate : INegator
+        {
+            public static bool NegateIfNeeded(bool result) => result;
+        }
+
+        private struct Negate : INegator
+        {
+            public static bool NegateIfNeeded(bool result) => !result;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -2650,21 +2650,21 @@ namespace System
             return (int)offset + index;
         }
 
-        private interface INegator<T> where T : struct
+        internal interface INegator<T> where T : struct
         {
             static abstract bool NegateIfNeeded(bool equals);
             static abstract Vector128<T> NegateIfNeeded(Vector128<T> equals);
             static abstract Vector256<T> NegateIfNeeded(Vector256<T> equals);
         }
 
-        private readonly struct DontNegate<T> : INegator<T> where T : struct
+        internal readonly struct DontNegate<T> : INegator<T> where T : struct
         {
             public static bool NegateIfNeeded(bool equals) => equals;
             public static Vector128<T> NegateIfNeeded(Vector128<T> equals) => equals;
             public static Vector256<T> NegateIfNeeded(Vector256<T> equals) => equals;
         }
 
-        private readonly struct Negate<T> : INegator<T> where T : struct
+        internal readonly struct Negate<T> : INegator<T> where T : struct
         {
             public static bool NegateIfNeeded(bool equals) => !equals;
             public static Vector128<T> NegateIfNeeded(Vector128<T> equals) => ~equals;


### PR DESCRIPTION
Contributes to #68328 (and contributes the workhorse implementation for an eventual dedicated API)
cc: @gfoidl

This PR adds a vectorized path for `IndexOfAny`-like methods if the input is at least 8 characters long and the needle is only ASCII.
It is used if `Ssse3` or `AdvSimd.Arm64` are supported.

I also unified all `(Last)IndexOfAny(Except)` methods to use the same approach of
```c#
if (HaystackIsShort) return SimpleSearch();
if (NeedleIsAscii) return Vectorized();
return ProbabilisticMap();
```
leading to perf improvements for both short and long inputs.

For inputs with long runs of no matches, the vectorized path has 10 to 140+ times the throughput on realistic inputs.
As the `-Except` methods were previously `O(n * m)`, you can of course see arbitrarily large improvements. 

<details>
<summary><strong>X86 numbers</strong></summary>

These numbers were collected on a Windows Azure VM running on an Intel Xeon 8370C processor.

|               Method | Toolchain | Length |       Needle |         Mean |     Error | Ratio |
|--------------------- |---------- |------- |------------- |-------------:|----------:|------:|
|           IndexOfAny |      main |      1 |       ABCDEF |     9.787 ns | 0.0087 ns |  1.00 |
|           IndexOfAny |        pr |      1 |       ABCDEF |     5.852 ns | 0.0053 ns |  0.60 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |      1 |       ABCDEF |     5.313 ns | 0.0077 ns |  1.00 |
|     IndexOfAnyExcept |        pr |      1 |       ABCDEF |     6.676 ns | 0.0104 ns |  1.26 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |      1 |       ABCDEF |    11.376 ns | 0.0065 ns |  1.00 |
|       LastIndexOfAny |        pr |      1 |       ABCDEF |     5.783 ns | 0.0037 ns |  0.51 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |      1 |       ABCDEF |     5.946 ns | 0.0123 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |      1 |       ABCDEF |     6.030 ns | 0.0324 ns |  1.01 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |      1 | AlphaNumeric |    63.653 ns | 0.0265 ns |  1.00 |
|           IndexOfAny |        pr |      1 | AlphaNumeric |     5.855 ns | 0.0066 ns |  0.09 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |      1 | AlphaNumeric |     6.371 ns | 0.0128 ns |  1.00 |
|     IndexOfAnyExcept |        pr |      1 | AlphaNumeric |     7.619 ns | 0.0104 ns |  1.20 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |      1 | AlphaNumeric |    74.164 ns | 0.0712 ns |  1.00 |
|       LastIndexOfAny |        pr |      1 | AlphaNumeric |     5.558 ns | 0.0011 ns |  0.07 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |      1 | AlphaNumeric |     8.766 ns | 0.2798 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |      1 | AlphaNumeric |     6.859 ns | 0.0018 ns |  0.88 |
|                      |           |        |              |              |           |       |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |      8 |       ABCDEF |     14.12 ns |  0.016 ns |  1.00 |
|           IndexOfAny |        pr |      8 |       ABCDEF |     12.25 ns |  0.006 ns |  0.87 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |      8 |       ABCDEF |     24.38 ns |  0.019 ns |  1.00 |
|     IndexOfAnyExcept |        pr |      8 |       ABCDEF |     14.86 ns |  0.005 ns |  0.61 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |      8 |       ABCDEF |     16.51 ns |  0.008 ns |  1.00 |
|       LastIndexOfAny |        pr |      8 |       ABCDEF |     12.23 ns |  0.006 ns |  0.74 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |      8 |       ABCDEF |     23.42 ns |  0.022 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |      8 |       ABCDEF |     14.93 ns |  0.013 ns |  0.64 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |      8 | AlphaNumeric |     67.53 ns |  0.075 ns |  1.00 |
|           IndexOfAny |        pr |      8 | AlphaNumeric |     34.92 ns |  0.045 ns |  0.52 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |      8 | AlphaNumeric |     27.99 ns |  0.025 ns |  1.00 |
|     IndexOfAnyExcept |        pr |      8 | AlphaNumeric |     31.09 ns |  0.036 ns |  1.11 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |      8 | AlphaNumeric |     79.39 ns |  0.065 ns |  1.00 |
|       LastIndexOfAny |        pr |      8 | AlphaNumeric |     34.32 ns |  0.028 ns |  0.43 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |      8 | AlphaNumeric |     27.67 ns |  0.097 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |      8 | AlphaNumeric |     25.80 ns |  0.014 ns |  0.93 |
|                      |           |        |              |              |           |       |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |     16 |       ABCDEF |     20.15 ns |  0.060 ns |  1.00 |
|           IndexOfAny |        pr |     16 |       ABCDEF |     12.25 ns |  0.007 ns |  0.61 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |     16 |       ABCDEF |     43.59 ns |  0.043 ns |  1.00 |
|     IndexOfAnyExcept |        pr |     16 |       ABCDEF |     14.96 ns |  0.011 ns |  0.34 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |     16 |       ABCDEF |     21.76 ns |  0.012 ns |  1.00 |
|       LastIndexOfAny |        pr |     16 |       ABCDEF |     12.23 ns |  0.006 ns |  0.56 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |     16 |       ABCDEF |     41.38 ns |  0.033 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |     16 |       ABCDEF |     14.92 ns |  0.010 ns |  0.36 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |     16 | AlphaNumeric |     73.53 ns |  0.060 ns |  1.00 |
|           IndexOfAny |        pr |     16 | AlphaNumeric |     67.08 ns |  0.084 ns |  0.91 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |     16 | AlphaNumeric |     49.79 ns |  0.032 ns |  1.00 |
|     IndexOfAnyExcept |        pr |     16 | AlphaNumeric |     54.95 ns |  0.051 ns |  1.10 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |     16 | AlphaNumeric |     84.76 ns |  0.061 ns |  1.00 |
|       LastIndexOfAny |        pr |     16 | AlphaNumeric |     66.56 ns |  0.060 ns |  0.79 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |     16 | AlphaNumeric |     50.64 ns |  0.162 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |     16 | AlphaNumeric |     45.80 ns |  0.062 ns |  0.91 |
|                      |           |        |              |              |           |       |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |     32 |       ABCDEF |     29.04 ns |  0.034 ns |  1.00 |
|           IndexOfAny |        pr |     32 |       ABCDEF |     13.37 ns |  0.009 ns |  0.46 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |     32 |       ABCDEF |     83.02 ns |  0.093 ns |  1.00 |
|     IndexOfAnyExcept |        pr |     32 |       ABCDEF |     15.98 ns |  0.007 ns |  0.19 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |     32 |       ABCDEF |     31.55 ns |  0.022 ns |  1.00 |
|       LastIndexOfAny |        pr |     32 |       ABCDEF |     13.92 ns |  0.050 ns |  0.44 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |     32 |       ABCDEF |     82.09 ns |  0.090 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |     32 |       ABCDEF |     15.77 ns |  0.007 ns |  0.19 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |     32 | AlphaNumeric |     83.50 ns |  0.061 ns |  1.00 |
|           IndexOfAny |        pr |     32 | AlphaNumeric |     65.77 ns |  0.252 ns |  0.79 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |     32 | AlphaNumeric |    106.94 ns |  0.054 ns |  1.00 |
|     IndexOfAnyExcept |        pr |     32 | AlphaNumeric |     66.03 ns |  0.099 ns |  0.62 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |     32 | AlphaNumeric |     94.24 ns |  0.052 ns |  1.00 |
|       LastIndexOfAny |        pr |     32 | AlphaNumeric |     64.81 ns |  0.073 ns |  0.69 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |     32 | AlphaNumeric |    107.73 ns |  0.249 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |     32 | AlphaNumeric |     65.58 ns |  0.034 ns |  0.61 |
|                      |           |        |              |              |           |       |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |     64 |       ABCDEF |     51.95 ns |  0.321 ns |  1.00 |
|           IndexOfAny |        pr |     64 |       ABCDEF |     15.31 ns |  0.009 ns |  0.30 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |     64 |       ABCDEF |    165.25 ns |  0.166 ns |  1.00 |
|     IndexOfAnyExcept |        pr |     64 |       ABCDEF |     17.54 ns |  0.026 ns |  0.11 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |     64 |       ABCDEF |     52.16 ns |  0.039 ns |  1.00 |
|       LastIndexOfAny |        pr |     64 |       ABCDEF |     15.83 ns |  0.020 ns |  0.30 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |     64 |       ABCDEF |    164.63 ns |  0.167 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |     64 |       ABCDEF |     17.01 ns |  0.008 ns |  0.10 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |     64 | AlphaNumeric |    105.16 ns |  0.079 ns |  1.00 |
|           IndexOfAny |        pr |     64 | AlphaNumeric |     67.26 ns |  0.093 ns |  0.64 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |     64 | AlphaNumeric |    208.43 ns |  0.070 ns |  1.00 |
|     IndexOfAnyExcept |        pr |     64 | AlphaNumeric |     68.18 ns |  0.107 ns |  0.33 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |     64 | AlphaNumeric |    115.14 ns |  0.057 ns |  1.00 |
|       LastIndexOfAny |        pr |     64 | AlphaNumeric |     66.35 ns |  0.040 ns |  0.58 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |     64 | AlphaNumeric |    212.70 ns |  0.583 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |     64 | AlphaNumeric |     67.31 ns |  0.059 ns |  0.32 |
|                      |           |        |              |              |           |       |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |    128 |       ABCDEF |     90.31 ns |  0.083 ns |  1.00 |
|           IndexOfAny |        pr |    128 |       ABCDEF |     18.74 ns |  0.008 ns |  0.21 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |    128 |       ABCDEF |    336.07 ns |  0.234 ns |  1.00 |
|     IndexOfAnyExcept |        pr |    128 |       ABCDEF |     20.78 ns |  0.015 ns |  0.06 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |    128 |       ABCDEF |    100.96 ns |  0.050 ns |  1.00 |
|       LastIndexOfAny |        pr |    128 |       ABCDEF |     18.80 ns |  0.024 ns |  0.19 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |    128 |       ABCDEF |    337.61 ns |  0.233 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |    128 |       ABCDEF |     21.00 ns |  0.040 ns |  0.06 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |    128 | AlphaNumeric |    148.35 ns |  0.231 ns |  1.00 |
|           IndexOfAny |        pr |    128 | AlphaNumeric |     70.20 ns |  0.121 ns |  0.47 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |    128 | AlphaNumeric |    425.60 ns |  0.178 ns |  1.00 |
|     IndexOfAnyExcept |        pr |    128 | AlphaNumeric |     71.25 ns |  0.041 ns |  0.17 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |    128 | AlphaNumeric |    165.64 ns |  0.085 ns |  1.00 |
|       LastIndexOfAny |        pr |    128 | AlphaNumeric |     70.08 ns |  0.118 ns |  0.42 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |    128 | AlphaNumeric |    438.12 ns |  1.407 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |    128 | AlphaNumeric |     72.16 ns |  0.126 ns |  0.16 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |    256 |       ABCDEF |    182.60 ns |  0.382 ns |  1.00 |
|           IndexOfAny |        pr |    256 |       ABCDEF |     29.07 ns |  0.026 ns |  0.16 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |    256 |       ABCDEF |    703.61 ns |  0.468 ns |  1.00 |
|     IndexOfAnyExcept |        pr |    256 |       ABCDEF |     32.34 ns |  0.019 ns |  0.05 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |    256 |       ABCDEF |    196.47 ns |  1.878 ns |  1.00 |
|       LastIndexOfAny |        pr |    256 |       ABCDEF |     29.52 ns |  0.063 ns |  0.15 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |    256 |       ABCDEF |    704.98 ns |  0.586 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |    256 |       ABCDEF |     31.83 ns |  0.019 ns |  0.05 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |    256 | AlphaNumeric |    236.97 ns |  0.128 ns |  1.00 |
|           IndexOfAny |        pr |    256 | AlphaNumeric |     81.93 ns |  0.287 ns |  0.35 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |    256 | AlphaNumeric |    878.10 ns |  0.445 ns |  1.00 |
|     IndexOfAnyExcept |        pr |    256 | AlphaNumeric |     82.96 ns |  0.094 ns |  0.09 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |    256 | AlphaNumeric |    247.84 ns |  0.110 ns |  1.00 |
|       LastIndexOfAny |        pr |    256 | AlphaNumeric |     80.38 ns |  0.055 ns |  0.32 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |    256 | AlphaNumeric |    871.79 ns |  0.353 ns |  1.00 |
| LastIndexOfAnyExcept |        pr |    256 | AlphaNumeric |     83.21 ns |  0.096 ns |  0.10 |
|                      |           |        |              |              |           |       |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |  10000 |       ABCDEF |   6,409.6 ns |   4.42 ns |  1.00 |
|           IndexOfAny |        pr |  10000 |       ABCDEF |     651.2 ns |   0.36 ns |  0.10 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |  10000 |       ABCDEF |  71,960.2 ns |  31.30 ns |  1.00 |
|     IndexOfAnyExcept |        pr |  10000 |       ABCDEF |     741.1 ns |   0.36 ns |  0.01 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |  10000 |       ABCDEF |   6,396.7 ns |   2.27 ns |  1.00 |
|       LastIndexOfAny |        pr |  10000 |       ABCDEF |     643.2 ns |   0.36 ns |  0.10 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |  10000 |       ABCDEF |  81,927.2 ns |  23.11 ns | 1.000 |
| LastIndexOfAnyExcept |        pr |  10000 |       ABCDEF |     728.1 ns |   0.26 ns | 0.009 |
|                      |           |        |              |              |           |       |
|           IndexOfAny |      main |  10000 | AlphaNumeric |   6,450.1 ns |   2.54 ns |  1.00 |
|           IndexOfAny |        pr |  10000 | AlphaNumeric |     704.2 ns |   0.41 ns |  0.11 |
|                      |           |        |              |              |           |       |
|     IndexOfAnyExcept |      main |  10000 | AlphaNumeric | 114,854.9 ns |  91.93 ns | 1.000 |
|     IndexOfAnyExcept |        pr |  10000 | AlphaNumeric |     791.0 ns |   0.36 ns | 0.007 |
|                      |           |        |              |              |           |       |
|       LastIndexOfAny |      main |  10000 | AlphaNumeric |   6,613.7 ns |  21.32 ns |  1.00 |
|       LastIndexOfAny |        pr |  10000 | AlphaNumeric |     690.0 ns |   0.08 ns |  0.10 |
|                      |           |        |              |              |           |       |
| LastIndexOfAnyExcept |      main |  10000 | AlphaNumeric | 110,475.7 ns |  74.60 ns | 1.000 |
| LastIndexOfAnyExcept |        pr |  10000 | AlphaNumeric |     774.9 ns |   0.04 ns | 0.007 |

</details>

On X86 we have to do a bit more work if the needle contains a zero:
|     Method | Length |         Needle |     Mean |   Error |
|----------- |------- |--------------- |---------:|--------:|
| IndexOfAny |  10000 |         ABCDEF | 536.8 ns | 0.45 ns |
| IndexOfAny |  10000 | NeedleWithZero | 820.7 ns | 0.74 ns |

Approximate ARM64 numbers:
|            Method | Length | Needle |      Mean |     Error |
|------------------ |------- |------- |----------:|----------:|
|        IndexOfAny |  10000 | ABCDEF |  1.783 µs | 0.0051 µs |
| CurrentIndexOfAny |  10000 | ABCDEF | 10.355 µs | 0.0010 µs |