### PR TITLE
Fold full-width SIMD-typed indirections

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1657,38 +1657,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     goto DONE_ASSERTION;
                 }
 
-                //
-                //  Copy Assertions
-                //
-                case GT_OBJ:
-                case GT_BLK:
-                {
-                    // TODO-ADDR: delete once local morph folds SIMD-typed indirections.
-                    //
-                    GenTree* const addr = op2->AsIndir()->Addr();
-
-                    if (addr->OperIs(GT_ADDR))
-                    {
-                        GenTree* const base = addr->AsOp()->gtOp1;
-
-                        if (base->OperIs(GT_LCL_VAR) && varTypeIsStruct(base))
-                        {
-                            ClassLayout* const varLayout = base->GetLayout(this);
-                            ClassLayout* const objLayout = op2->GetLayout(this);
-                            if (ClassLayout::AreCompatible(varLayout, objLayout))
-                            {
-                                op2 = base;
-                                goto IS_COPY;
-                            }
-                        }
-                    }
-
-                    goto DONE_ASSERTION;
-                }
-
                 case GT_LCL_VAR:
                 {
-                IS_COPY:
                     //
                     // Must either be an OAK_EQUAL or an OAK_NOT_EQUAL assertion
                     //

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5756,7 +5756,6 @@ private:
     GenTree* fgMorphMultiOp(GenTreeMultiOp* multiOp);
     GenTree* fgMorphConst(GenTree* tree);
 
-    GenTreeLclVar* fgMorphTryFoldObjAsLclVar(GenTreeObj* obj, bool destroyNodes = true);
     GenTreeOp* fgMorphCommutative(GenTreeOp* tree);
     GenTree* fgMorphCastedBitwiseOp(GenTreeOp* tree);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8473,18 +8473,6 @@ private:
         return (intrinsicId == SIMDIntrinsicEqual);
     }
 
-    // Returns base JIT type of a TYP_SIMD local.
-    // Returns CORINFO_TYPE_UNDEF if the local is not TYP_SIMD.
-    CorInfoType getBaseJitTypeOfSIMDLocal(GenTree* tree)
-    {
-        if (isSIMDTypeLocal(tree))
-        {
-            return lvaGetDesc(tree->AsLclVarCommon())->GetSimdBaseJitType();
-        }
-
-        return CORINFO_TYPE_UNDEF;
-    }
-
     bool isNumericsNamespace(const char* ns)
     {
         return strcmp(ns, "System.Numerics") == 0;

--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -630,25 +630,6 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
         }
     }
 
-    // Optimization:
-    //
-    // If we are about to substitute GT_OBJ, see if we can simplify it first.
-    // Not doing so can lead to regressions...
-    //
-    // Hold off on doing this for call args for now (per issue #51569).
-    // Hold off on OBJ(GT_LCL_ADDR).
-    //
-    if (fwdSubNode->OperIs(GT_OBJ) && !fsv.IsCallArg() && fwdSubNode->gtGetOp1()->OperIs(GT_ADDR))
-    {
-        const bool     destroyNodes = false;
-        GenTree* const optTree      = fgMorphTryFoldObjAsLclVar(fwdSubNode->AsObj(), destroyNodes);
-        if (optTree != nullptr)
-        {
-            JITDUMP(" [folding OBJ(ADDR(LCL...))]");
-            fwdSubNode = optTree;
-        }
-    }
-
     // Quirks:
     //
     // Don't substitute nodes "AddFinalArgsAndDetermineABIInfo" doesn't handle into struct args.

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4381,8 +4381,6 @@ public:
     // argument type, but when a struct is passed as a scalar type, this is
     // that type. Note that if a struct is passed by reference, this will still
     // be the struct type.
-    // TODO-ARGS: Reconsider whether we need this, it does not make much sense
-    // to have this instead of using just the type of the arg node.
     var_types ArgType : 5;
     // True when the argument fills a register slot skipped due to alignment
     // requirements of previous arguments.

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -991,13 +991,6 @@ private:
 
         LclVarDsc* varDsc = m_compiler->lvaGetDesc(val.LclNum());
 
-        if (varTypeIsSIMD(varDsc))
-        {
-            // TODO-ADDR: skip SIMD variables for now, fgMorphFieldAssignToSimdSetElement and
-            // others need to be updated to recognize LCL_FLDs.
-            return IndirTransform::None;
-        }
-
         if (indir->TypeGet() != TYP_STRUCT)
         {
             if (varDsc->lvPromoted)
@@ -1010,6 +1003,14 @@ private:
             if (indir->TypeGet() == varDsc->TypeGet())
             {
                 return IndirTransform::LclVar;
+            }
+
+            if (varTypeIsSIMD(varDsc))
+            {
+                // TODO-ADDR: skip SIMD variables for now, fgMorphFieldAssignToSimdSetElement and
+                // fgMorphFieldToSimdGetElement need to be updated to recognize LCL_FLDs or moved
+                // here.
+                return IndirTransform::None;
             }
 
             // Bool and ubyte are the same type.

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -72,8 +72,8 @@ void Rationalizer::RewriteIndir(LIR::Use& use)
 // Arguments:
 //    use - A use of a GT_IND node of SIMD type
 //
-// TODO-1stClassStructs: These should be eliminated earlier, once we can handle
-// lclVars in all the places that used to have GT_OBJ.
+// TODO-ADDR: delete this once block morphing stops taking addresses of locals
+// under COMMAs.
 //
 void Rationalizer::RewriteSIMDIndir(LIR::Use& use)
 {

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -56,27 +56,14 @@ void Rationalizer::RewriteIndir(LIR::Use& use)
     // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
     indir->gtFlags &= ~GTF_IND_ASG_LHS;
 
-    if (indir->OperIs(GT_IND))
+    if (varTypeIsSIMD(indir))
     {
-        if (varTypeIsSIMD(indir))
-        {
-            RewriteSIMDIndir(use);
-        }
-    }
-    else if (indir->OperIs(GT_OBJ))
-    {
-        assert((indir->TypeGet() == TYP_STRUCT) || !use.User()->OperIsInitBlkOp());
-        if (varTypeIsSIMD(indir->TypeGet()))
+        if (indir->OperIs(GT_BLK, GT_OBJ))
         {
             indir->SetOper(GT_IND);
-            RewriteSIMDIndir(use);
         }
-    }
-    else
-    {
-        assert(indir->OperIs(GT_BLK));
-        // We should only see GT_BLK for TYP_STRUCT or for InitBlocks.
-        assert((indir->TypeGet() == TYP_STRUCT) || use.User()->OperIsInitBlkOp());
+
+        RewriteSIMDIndir(use);
     }
 }
 
@@ -413,45 +400,18 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
 
     genTreeOps locationOp = location->OperGet();
 
-    if (assignment->OperIsBlkOp())
+    if (varTypeIsSIMD(location) && assignment->OperIsInitBlkOp())
     {
-#ifdef FEATURE_SIMD
-        if (varTypeIsSIMD(location) && assignment->OperIsInitBlkOp())
-        {
-            if (location->OperIs(GT_LCL_VAR))
-            {
-                var_types simdType = location->TypeGet();
-                GenTree*  initVal  = assignment->AsOp()->gtOp2;
+        var_types simdType = location->TypeGet();
+        GenTree*  initVal  = assignment->AsOp()->gtOp2;
+        GenTree*  zeroCon  = comp->gtNewZeroConNode(simdType);
+        noway_assert(initVal->IsIntegralConst(0)); // All SIMD InitBlks are zero inits.
 
-                CorInfoType simdBaseJitType = comp->getBaseJitTypeOfSIMDLocal(location);
-                if (simdBaseJitType == CORINFO_TYPE_UNDEF)
-                {
-                    // Lie about the type if we don't know/have it.
-                    simdBaseJitType = CORINFO_TYPE_FLOAT;
-                }
+        assignment->gtOp2 = zeroCon;
+        value             = zeroCon;
 
-                if (initVal->IsIntegralConst(0))
-                {
-                    GenTree* zeroCon = comp->gtNewZeroConNode(simdType);
-
-                    assignment->gtOp2 = zeroCon;
-                    value             = zeroCon;
-
-                    BlockRange().InsertAfter(initVal, zeroCon);
-                    BlockRange().Remove(initVal);
-                }
-                else
-                {
-                    GenTreeSIMD* simdTree = comp->gtNewSIMDNode(simdType, initVal, SIMDIntrinsicInit, simdBaseJitType,
-                                                                genTypeSize(simdType));
-                    assignment->gtOp2 = simdTree;
-                    value             = simdTree;
-
-                    BlockRange().InsertAfter(initVal, simdTree);
-                }
-            }
-        }
-#endif // FEATURE_SIMD
+        BlockRange().InsertAfter(initVal, zeroCon);
+        BlockRange().Remove(initVal);
     }
 
     switch (locationOp)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8250,13 +8250,28 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
     // Is the type being stored different from the type computed by the rhs?
     if (rhs->TypeGet() != lhs->TypeGet())
     {
-        if (rhs->TypeGet() == TYP_REF)
+        if (tree->OperIsInitBlkOp())
+        {
+            ValueNum initObjVN;
+            if (rhs->IsIntegralConst(0))
+            {
+                initObjVN = lhs->TypeIs(TYP_STRUCT) ? vnStore->VNForZeroObj(lhs->GetLayout(this))
+                                                    : vnStore->VNZeroForType(lhs->TypeGet());
+            }
+            else
+            {
+                initObjVN = vnStore->VNForExpr(compCurBB, lhs->TypeGet());
+            }
+
+            rhsVNPair.SetBoth(initObjVN);
+        }
+        else if (rhs->TypeGet() == TYP_REF)
         {
             // If we have an unsafe IL assignment of a TYP_REF to a non-ref (typically a TYP_BYREF)
             // then don't propagate this ValueNumber to the lhs, instead create a new unique VN.
             rhsVNPair.SetBoth(vnStore->VNForExpr(compCurBB, lhs->TypeGet()));
         }
-        else if (lhs->OperGet() != GT_BLK)
+        else
         {
             // This means that there is an implicit cast on the rhs value
             // We will add a cast function to reflect the possible narrowing of the rhs value


### PR DESCRIPTION
I. e. `OBJ/IND<simd>(ADDR(LCL_VAR<simd>))`.

Some positive (in nature) [diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=44369&view=ms.vss-build-web.run-extensions-tab), with a TP win as well.