### PR TITLE
[build] Enable CodeQL with TSA

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Runtime\\Reliability\\Docs",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
+    "repositoryName":"Runtime",
+    "codebaseName": "Runtime"
+}

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -2,9 +2,9 @@
     "instanceUrl": "https://devdiv.visualstudio.com/",
     "template": "TFSDEVDIV",
     "projectName": "DEVDIV",
-    "areaPath": "DevDiv\\NET Runtime\\Reliability\\Docs",
+    "areaPath": "DevDiv\\NET Libraries",
     "iterationPath": "DevDiv",
     "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
-    "repositoryName":"Runtime",
+    "repositoryName": "Runtime",
     "codebaseName": "Runtime"
 }

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -120,9 +120,6 @@ jobs:
         continueOnError: ${{ parameters.continueOnError }}
         condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
 
-  - task: CodeQL3000Init@0
-    displayName: CodeQL Initialize
-
   - ${{ if and(eq(parameters.runAsPublic, 'false'), eq(variables['System.TeamProject'], 'internal')) }}:
     - task: NuGetAuthenticate@0
 
@@ -230,6 +227,3 @@ jobs:
         PackageVersion: ${{ parameters.packageVersion}}
         BuildDropPath: ${{ parameters.buildDropPath }}
         IgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
-
-  - task: CodeQL3000Finalize@0
-    displayName: CodeQL Finalize

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -120,6 +120,9 @@ jobs:
         continueOnError: ${{ parameters.continueOnError }}
         condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
 
+  - task: CodeQL3000Init@0
+    displayName: CodeQL Initialize
+
   - ${{ if and(eq(parameters.runAsPublic, 'false'), eq(variables['System.TeamProject'], 'internal')) }}:
     - task: NuGetAuthenticate@0
 
@@ -228,3 +231,5 @@ jobs:
         BuildDropPath: ${{ parameters.buildDropPath }}
         IgnoreDirectories: ${{ parameters.componentGovernanceIgnoreDirectories }}
 
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL Finalize

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -163,20 +163,22 @@ jobs:
         inputs:
           filePath: $(Build.SourcesDirectory)/eng/pipelines/mono/update-machine-certs.ps1
 
-    - ${{ if eq(parameters.isManualCodeQLBuild, true) }}:
-      - task: CodeQL3000Init@0
-        displayName: Initialize CodeQL (manually-injected)
 
     # Build
     - ${{ if eq(parameters.isSourceBuild, false) }}:
+      - ${{ if eq(parameters.isManualCodeQLBuild, true) }}:
+        - task: CodeQL3000Init@0
+          displayName: Initialize CodeQL (manually-injected)
+
       - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
         displayName: Build product
         ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
           continueOnError: ${{ parameters.shouldContinueOnError }}
 
-    - ${{ if eq(parameters.isManualCodeQLBuild, true) }}:
-      - task: CodeQL3000Finalize@0
-        displayName: Finalize CodeQL (manually-injected)
+      - ${{ if eq(parameters.isManualCodeQLBuild, true) }}:
+        - task: CodeQL3000Finalize@0
+          displayName: Finalize CodeQL (manually-injected)
+    #endif isSourceBuild
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS', 'Android') }}:
       - script: |

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -32,6 +32,7 @@ parameters:
   enableRichCodeNavigation: false
   richCodeNavigationLanguage: 'csharp'
   richCodeNavigationEnvironment: 'production'
+  isManualCodeQLBuild: false
 
 jobs:
 - template: /eng/common/templates/job/job.yml
@@ -162,12 +163,20 @@ jobs:
         inputs:
           filePath: $(Build.SourcesDirectory)/eng/pipelines/mono/update-machine-certs.ps1
 
+    - ${{ if eq(parameters.isManualCodeQLBuild, true) }}:
+      - task: CodeQL3000Init@0
+        displayName: Initialize CodeQL (manually-injected)
+
     # Build
     - ${{ if eq(parameters.isSourceBuild, false) }}:
       - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
         displayName: Build product
         ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
           continueOnError: ${{ parameters.shouldContinueOnError }}
+
+    - ${{ if eq(parameters.isManualCodeQLBuild, true) }}:
+      - task: CodeQL3000Finalize@0
+        displayName: Finalize CodeQL (manually-injected)
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS', 'Android') }}:
       - script: |

--- a/eng/pipelines/common/internal-variables.yml
+++ b/eng/pipelines/common/internal-variables.yml
@@ -1,0 +1,8 @@
+parameters:
+  teamName: ''
+
+variables:
+  - name: TeamName
+    value: ${{ parameters.teamName }}
+  - name: PostBuildSign
+    value: true

--- a/eng/pipelines/runtime-codeql.yml
+++ b/eng/pipelines/runtime-codeql.yml
@@ -44,6 +44,7 @@ extends:
             nameSuffix: AllSubsets_CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             timeoutInMinutes: 360
+            isManualCodeQLBuild: true
 
       #
       # Build Mono runtime packs
@@ -61,3 +62,4 @@ extends:
             nameSuffix: AllSubsets_Mono
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             timeoutInMinutes: 360
+            isManualCodeQLBuild: true

--- a/eng/pipelines/runtime-codeql.yml
+++ b/eng/pipelines/runtime-codeql.yml
@@ -1,0 +1,68 @@
+trigger:
+  none
+
+schedules:
+  - cron: 0 12 * * 1
+    displayName: Weekly Monday CodeQL/Semmle run
+    branches:
+      include:
+      - main
+    always: true
+
+variables:
+- template: /eng/pipelines/common/variables.yml
+# TODO: (Consolidation) Switch away from old signing/validation variables from former Core-Setup. https://github.com/dotnet/runtime/issues/1027
+- name: TeamName
+  value: dotnet-core-acquisition
+- name: PostBuildSign
+  value: true
+- name: Codeql.Enabled
+  value: True
+- name: Codeql.Cadence
+  value: 0
+- name: Codeql.TSAEnabled
+  value: True
+- name: Codeql.BuildIdentifier
+  value: $(System.JobDisplayName)
+- name: Codeql.Language
+  value: cpp,csharp,java,python
+
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
+
+      #
+      # Build CoreCLR runtime packs
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          platforms:
+          - Linux_x64
+          - windows_x64
+          jobParameters:
+            buildArgs: -s clr+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: AllSubsets_CoreCLR
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 360
+
+      #
+      # Build Mono runtime packs
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Linux_x64
+          - windows_x64
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs+mono.mscordbi -c $(_BuildConfig)
+            nameSuffix: AllSubsets_Mono
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 360

--- a/eng/pipelines/runtime-codeql.yml
+++ b/eng/pipelines/runtime-codeql.yml
@@ -10,22 +10,17 @@ schedules:
     always: true
 
 variables:
-- template: /eng/pipelines/common/variables.yml
-# TODO: (Consolidation) Switch away from old signing/validation variables from former Core-Setup. https://github.com/dotnet/runtime/issues/1027
-- name: TeamName
-  value: dotnet-core-acquisition
-- name: PostBuildSign
-  value: true
-- name: Codeql.Enabled
-  value: True
-- name: Codeql.Cadence
-  value: 0
-- name: Codeql.TSAEnabled
-  value: True
-- name: Codeql.BuildIdentifier
-  value: $(System.JobDisplayName)
-- name: Codeql.Language
-  value: cpp,csharp,java,python
+  - template: /eng/pipelines/common/variables.yml
+  - name: Codeql.Enabled
+    value: True
+  - name: Codeql.Cadence
+    value: 0
+  - name: Codeql.TSAEnabled
+    value: True
+  - name: Codeql.BuildIdentifier
+    value: $(System.JobDisplayName)
+  - name: Codeql.Language
+    value: cpp,csharp,java,python
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -24,11 +24,9 @@ pr: none
 
 variables:
 - template: /eng/pipelines/common/variables.yml
-# TODO: (Consolidation) Switch away from old signing/validation variables from former Core-Setup. https://github.com/dotnet/runtime/issues/1027
-- name: TeamName
-  value: dotnet-core-acquisition
-- name: PostBuildSign
-  value: true
+- template: /eng/pipelines/common/internal-variables.yml
+  parameters:
+    teamName: dotnet-core-acquisition
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml


### PR DESCRIPTION
CodeQL is a static analysis tool that is able to scan source code to help detect security vulnerabilities. In Dotnet/Runtime, there already exists auto-injection of CodeQL's init and finalize tasks within official pipelines.

Although we can enable CodeQL within the official pipeline, there are a significant number (close to 100) of jobs contained within https://github.com/dotnet/runtime/blob/main/eng/pipelines/runtime-official.yml numerous of which end up building the same source code. Enabling CodeQL in all of these jobs would be unnecessary and an unreasonable strain on resources. Instead, we aim to enable CodeQL on a subset of jobs that would lead to a high amount of code coverage; as such, having a separate pipeline that targets these minimal subset of jobs makes more sense (compared to opting in/out for each specific job within the pipeline).

This PR  does the following:
Manually inject CodeQL Init and Finalize tasks to wrap around the build.
Enables CodeQL in a separate pipeline with a weekly schedule based on the main branch
Enable TSA with CodeQL
Scans Linux and Windows CoreCLR Runtime Builds
Scans Linux and Windows Mono Runtime Builds