### PR TITLE
Add basic test for `PrintDocument.Print` using the default print controller

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
@@ -22,13 +22,13 @@ namespace System.Drawing.Printing
         public override void OnStartPrint(PrintDocument document, PrintEventArgs e)
         {
             Debug.Assert(_dc == null && _graphics == null, "PrintController methods called in the wrong order?");
-            Debug.Assert(_modeHandle != null);
 
             base.OnStartPrint(document, e);
             // the win32 methods below SuppressUnmanagedCodeAttributes so assertin on UnmanagedCodePermission is redundant
             if (!document.PrinterSettings.IsValid)
                 throw new InvalidPrinterException(document.PrinterSettings);
 
+            Debug.Assert(_modeHandle != null);
             _dc = document.PrinterSettings.CreateDeviceContext(_modeHandle);
             Interop.Gdi32.DOCINFO info = new Interop.Gdi32.DOCINFO();
             info.lpszDocName = document.DocumentName;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
@@ -28,7 +28,7 @@ namespace System.Drawing.Printing
             if (!document.PrinterSettings.IsValid)
                 throw new InvalidPrinterException(document.PrinterSettings);
 
-            Debug.Assert(_modeHandle != null);
+            Debug.Assert(_modeHandle != null, "_modeHandle should have been set by PrintController.OnStartPrint");
             _dc = document.PrinterSettings.CreateDeviceContext(_modeHandle);
             Interop.Gdi32.DOCINFO info = new Interop.Gdi32.DOCINFO();
             info.lpszDocName = document.DocumentName;

--- a/src/libraries/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -188,16 +188,21 @@ namespace System.Drawing.Printing.Tests
         [ConditionalFact(nameof(CanPrintToPdf))]
         public void Print_DefaultPrintController_Success()
         {
-            string printFilePath = GetTestFilePath();
+            bool endPrintCalled = false;
+            var endPrintHandler = new PrintEventHandler((sender, e) => endPrintCalled = true);
             using (var document = new PrintDocument())
             {
                 document.PrinterSettings.PrinterName = PrintToPdfPrinterName;
-                document.PrinterSettings.PrintFileName = printFilePath;
+                document.PrinterSettings.PrintFileName = GetTestFilePath();
                 document.PrinterSettings.PrintToFile = true;
+                document.EndPrint += endPrintHandler;
                 document.Print();
+                document.EndPrint -= endPrintHandler;
             }
 
-            Assert.True(File.Exists(printFilePath));
+            // File may not have finished saving to disk when Print returns,
+            // so we check for EndPrint being called instead of file existence.
+            Assert.True(endPrintCalled);
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/26428")]


### PR DESCRIPTION
We didn't have any coverage for actually using the default print controller. This adds one basic test (conditional based on what is available on the machine)

Scenario from https://github.com/dotnet/runtime/issues/76538.