### PR TITLE
Fix for pipelines broken in #75473

### DIFF
--- a/eng/pipelines/runtime-android.yml
+++ b/eng/pipelines/runtime-android.yml
@@ -7,10 +7,12 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-
-- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-    isAndroidOnlyBuild: ${{ variables.isAndroidOnlyBuild }}
-    isRollingBuild: ${{ variables.isRollingBuild }}
+    jobs:
+    - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+      parameters:
+        isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+        isAndroidOnlyBuild: ${{ variables.isAndroidOnlyBuild }}
+        isRollingBuild: ${{ variables.isRollingBuild }}

--- a/eng/pipelines/runtime-androidemulator.yml
+++ b/eng/pipelines/runtime-androidemulator.yml
@@ -8,10 +8,12 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-
-- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-    isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
-    isRollingBuild: ${{ variables.isRollingBuild }}
+    jobs:
+    - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+      parameters:
+        isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+        isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
+        isRollingBuild: ${{ variables.isRollingBuild }}

--- a/eng/pipelines/runtime-ioslike.yml
+++ b/eng/pipelines/runtime-ioslike.yml
@@ -7,10 +7,12 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-
-- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-    isiOSLikeOnlyBuild: ${{ variables.isiOSLikeOnlyBuild }}
-    isRollingBuild: ${{ variables.isRollingBuild }}
+    jobs:
+    - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+      parameters:
+        isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+        isiOSLikeOnlyBuild: ${{ variables.isiOSLikeOnlyBuild }}
+        isRollingBuild: ${{ variables.isRollingBuild }}

--- a/eng/pipelines/runtime-ioslikesimulator.yml
+++ b/eng/pipelines/runtime-ioslikesimulator.yml
@@ -8,10 +8,12 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-
-- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-    isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
-    isRollingBuild: ${{ variables.isRollingBuild }}
+    jobs:
+    - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+      parameters:
+        isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+        isiOSLikeSimulatorOnlyBuild: ${{ variables.isiOSLikeSimulatorOnlyBuild }}
+        isRollingBuild: ${{ variables.isRollingBuild }}

--- a/eng/pipelines/runtime-linuxbionic.yml
+++ b/eng/pipelines/runtime-linuxbionic.yml
@@ -7,10 +7,12 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-
-- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-linuxbionic.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-    isLinuxBionicOnlyBuild: ${{ variables.isLinuxBionicOnlyBuild }}
-    isRollingBuild: ${{ variables.isRollingBuild }}
+    jobs:
+    - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-linuxbionic.yml
+      parameters:
+        isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+        isLinuxBionicOnlyBuild: ${{ variables.isLinuxBionicOnlyBuild }}
+        isRollingBuild: ${{ variables.isRollingBuild }}

--- a/eng/pipelines/runtime-maccatalyst.yml
+++ b/eng/pipelines/runtime-maccatalyst.yml
@@ -7,10 +7,12 @@ trigger: none
 variables:
   - template: /eng/pipelines/common/variables.yml
 
-jobs:
-
-- template: /eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
   parameters:
-    isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
-    isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
-    isRollingBuild: ${{ variables.isRollingBuild }}
+    jobs:
+    - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+      parameters:
+        isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+        isMacCatalystOnlyBuild: ${{ variables.isMacCatalystOnlyBuild }}
+        isRollingBuild: ${{ variables.isRollingBuild }}


### PR DESCRIPTION
Gotta use the new template syntax in runtime-android etc, to avoid `A container resource with name Linux_bionic could not be found. The container resource does not exist. If you intended to specify an image, use NAME:TAG or NAME@DIGEST. For example, ubuntu:latest`