### PR TITLE
[wasm-mt] When workers resize the heap, instanceof SharedArrayBuffer may be false

### DIFF
--- a/src/mono/wasm/runtime/shared-array-buffer.ts
+++ b/src/mono/wasm/runtime/shared-array-buffer.ts
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+export function isSharedArrayBuffer(x: unknown): x is SharedArrayBuffer {
+    // N.B. don't use `x instanceof SharedArrayBuffer`.  If the SAB was created by another worker,
+    // and then sent in a message to the current one, then it will be an instance of that worker's SharedArrayBuffer,
+    // not the current globalThis.SharedArrayBuffer
+    return typeof SharedArrayBuffer !== "undefined" && x?.constructor?.name === "SharedArrayBuffer";
+}

--- a/src/mono/wasm/runtime/shared-array-buffer.ts
+++ b/src/mono/wasm/runtime/shared-array-buffer.ts
@@ -5,5 +5,5 @@ export function isSharedArrayBuffer(x: unknown): x is SharedArrayBuffer {
     // N.B. don't use `x instanceof SharedArrayBuffer`.  If the SAB was created by another worker,
     // and then sent in a message to the current one, then it will be an instance of that worker's SharedArrayBuffer,
     // not the current globalThis.SharedArrayBuffer
-    return typeof SharedArrayBuffer !== "undefined" && x?.constructor?.name === "SharedArrayBuffer";
+    return typeof SharedArrayBuffer !== "undefined" && (<any>x)?.constructor?.name === "SharedArrayBuffer";
 }

--- a/src/mono/wasm/runtime/strings.ts
+++ b/src/mono/wasm/runtime/strings.ts
@@ -8,6 +8,7 @@ import cwraps from "./cwraps";
 import { mono_wasm_new_root } from "./roots";
 import { getI32, getU32 } from "./memory";
 import { NativePointer, CharPtr } from "./types/emscripten";
+import { isSharedArrayBuffer } from "./shared-array-buffer";
 
 export class StringDecoder {
 
@@ -80,7 +81,7 @@ export class StringDecoder {
             // N.B. don't use `Module.HEAPU8.buffer instanceof SharedArrayBuffer` if a worker
             // resized the heap, the buffer will be an instance of that worker's SharedArrayBuffer,
             // not the current globalThis.SharedArrayBuffer
-            const subArray = typeof SharedArrayBuffer !== "undefined" && Module.HEAPU8.buffer.constructor.name === 'SharedArrayBuffer'
+            const subArray = isSharedArrayBuffer(Module.HEAPU8.buffer)
                 ? Module.HEAPU8.slice(<any>start, <any>end)
                 : Module.HEAPU8.subarray(<any>start, <any>end);
 

--- a/src/mono/wasm/runtime/strings.ts
+++ b/src/mono/wasm/runtime/strings.ts
@@ -77,7 +77,10 @@ export class StringDecoder {
             // When threading is enabled, TextDecoder does not accept a view of a
             // SharedArrayBuffer, we must make a copy of the array first.
             // See https://github.com/whatwg/encoding/issues/172
-            const subArray = typeof SharedArrayBuffer !== "undefined" && Module.HEAPU8.buffer instanceof SharedArrayBuffer
+            // N.B. don't use `Module.HEAPU8.buffer instanceof SharedArrayBuffer` if a worker
+            // resized the heap, the buffer will be an instance of that worker's SharedArrayBuffer,
+            // not the current globalThis.SharedArrayBuffer
+            const subArray = typeof SharedArrayBuffer !== "undefined" && Module.HEAPU8.buffer.constructor.name === 'SharedArrayBuffer'
                 ? Module.HEAPU8.slice(<any>start, <any>end)
                 : Module.HEAPU8.subarray(<any>start, <any>end);
 

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -8,7 +8,7 @@ import { mono_assert } from "./types";
 import { Module } from "./imports";
 import { setI32 } from "./memory";
 import { VoidPtr } from "./types/emscripten";
-import { isSharedArrayBuffer }  from "./shared-array-buffer.ts"
+import { isSharedArrayBuffer }  from "./shared-array-buffer";
 
 const wasm_ws_pending_send_buffer = Symbol.for("wasm ws_pending_send_buffer");
 const wasm_ws_pending_send_buffer_offset = Symbol.for("wasm ws_pending_send_buffer_offset");

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -8,6 +8,7 @@ import { mono_assert } from "./types";
 import { Module } from "./imports";
 import { setI32 } from "./memory";
 import { VoidPtr } from "./types/emscripten";
+import { isSharedArrayBuffer }  from "./shared-array-buffer.ts"
 
 const wasm_ws_pending_send_buffer = Symbol.for("wasm ws_pending_send_buffer");
 const wasm_ws_pending_send_buffer_offset = Symbol.for("wasm ws_pending_send_buffer_offset");
@@ -342,7 +343,7 @@ function _mono_wasm_web_socket_send_buffering(ws: WebSocketExtension, buffer_vie
             }
 
             // See https://github.com/whatwg/encoding/issues/172
-            const bytes = typeof SharedArrayBuffer !== "undefined" && buffer.constructor.name === 'SharedArrayBuffer'
+            const bytes = isSharedArrayBuffer(buffer)
                 ? (<any>buffer).slice(0, offset)
                 : buffer.subarray(0, offset);
             return _text_decoder_utf8.decode(bytes);

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -342,7 +342,7 @@ function _mono_wasm_web_socket_send_buffering(ws: WebSocketExtension, buffer_vie
             }
 
             // See https://github.com/whatwg/encoding/issues/172
-            const bytes = typeof SharedArrayBuffer !== "undefined" && buffer instanceof SharedArrayBuffer
+            const bytes = typeof SharedArrayBuffer !== "undefined" && buffer.constructor.name === 'SharedArrayBuffer'
                 ? (<any>buffer).slice(0, offset)
                 : buffer.subarray(0, offset);
             return _text_decoder_utf8.decode(bytes);


### PR DESCRIPTION
Using `Module.HEAPU8.buffer instanceof SharedArrayBuffer` to check if the runtime memory is a SharedArrayBuffer may fail (the instanceof returns false) if the heap is resized by a Web Worker.  In that case, the buffer is an instance of that worker's SharedArrayBuffer, not the current thread's SharedArrayBuffer.

Fixes errors like this:

```
Uncaught TypeError: Failed to execute 'decode' on 'TextDecoder': The provided ArrayBufferView value must not be shared.
    at Er.decode (dotnet.js:formatted:1711:44)
    at Er.copy_root (dotnet.js:formatted:1701:49)
    at jr (dotnet.js:formatted:1731:19)
    at jo (dotnet.js:formatted:2504:20)
    at i.resolve (dotnet.js:formatted:2454:23)
    at Object.To (dotnet.js:formatted:2492:36)
    at _mono_wasm_marshal_promise (dotnet.js:formatted:13226:80)
    at dotnet.wasm:0x2267c
    at dotnet.wasm:0x21b3e
    at dotnet.wasm:0x131c1
```