### PR TITLE
[wasm][debugger] Fix debugger behavior when the type has ToString method overridden

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
@@ -272,7 +272,8 @@ internal sealed class JObjectValueCreator
             foreach (var typeId in typeIds)
             {
                 var typeInfo = await _sdbAgent.GetTypeInfo(typeId, token);
-                if (typeInfo != null && typeInfo.Name != "object")
+                if (typeInfo == null || typeInfo.Name == "object")
+                    continue;
                 {
                     MethodInfo methodInfo = typeInfo.Info.Methods.FirstOrDefault(m => m.Name == "ToString");
                     if (methodInfo != null)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
@@ -300,9 +300,12 @@ internal sealed class JObjectValueCreator
             if (methodInfo != null)
             {
                 int[] methodIds = await _sdbAgent.GetMethodIdsByName(type_id[0], "ToString", token);
-                var toString = await _sdbAgent.InvokeMethod(objectId, methodIds[0], isValueType: false, token);
-                if (toString["value"]?["value"] != null)
-                    description = toString["value"]?["value"].Value<string>();
+                if (methodIds.Length > 0)
+                {
+                    var toString = await _sdbAgent.InvokeMethod(objectId, methodIds[0], isValueType: false, token);
+                    if (toString["value"]?["value"] != null)
+                        description = toString["value"]?["value"].Value<string>();
+                }
             }
         }
         return Create<object>(value: null, type: "object", description: description, className: className, objectId: $"dotnet:object:{objectId}");

--- a/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
@@ -279,8 +279,9 @@ internal sealed class JObjectValueCreator
         var description = className.ToString();
 
         if (debuggerDisplayAttribute != null)
+        {
             description = debuggerDisplayAttribute;
-
+        }
         else if (await _sdbAgent.IsDelegate(objectId, token))
         {
             if (typeIdFromAttribute != -1)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
@@ -293,6 +293,18 @@ internal sealed class JObjectValueCreator
                 return Create(value: className, type: "symbol", description: className);
             }
         }
+        var typeInfo = await _sdbAgent.GetTypeInfo(type_id[0], token);
+        if (typeInfo != null && typeInfo.Name != "object")
+        {
+            MethodInfo methodInfo = typeInfo.Info.Methods.FirstOrDefault(m => m.Name == "ToString");
+            if (methodInfo != null)
+            {
+                int[] methodIds = await _sdbAgent.GetMethodIdsByName(type_id[0], "ToString", token);
+                var toString = await _sdbAgent.InvokeMethod(objectId, methodIds[0], isValueType: false, token);
+                if (toString["value"]?["value"] != null)
+                    description = toString["value"]?["value"].Value<string>();
+            }
+        }
         return Create<object>(value: null, type: "object", description: description, className: className, objectId: $"dotnet:object:{objectId}");
     }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
@@ -297,7 +297,7 @@ internal sealed class JObjectValueCreator
         }
         else
         {
-            var toString = await _sdbAgent.InvokeToStringAsync(typeIds, false, false, objectId, BindingFlags.DeclaredOnly, token);
+            var toString = await _sdbAgent.InvokeToStringAsync(typeIds, isValueType: false, isEnum: false, objectId, BindingFlags.DeclaredOnly, token);
             if (toString != null)
                 description = toString;
         }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Net.WebSockets;
 using BrowserDebugProxy;
 using System.Globalization;
+using System.Reflection;
 
 namespace Microsoft.WebAssembly.Diagnostics
 {
@@ -458,7 +459,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                                     return await ExpressionEvaluator.EvaluateSimpleExpression(this, eaFormatted, elementAccessStr, variableDefinitions, logger, token);
                                 }
                                 var typeIds = await context.SdbAgent.GetTypeIdsForObject(objectId.Value, true, token);
-                                int[] methodIds = await context.SdbAgent.GetMethodIdsByName(typeIds[0], "ToArray", token);
+                                int[] methodIds = await context.SdbAgent.GetMethodIdsByName(typeIds[0], "ToArray", BindingFlags.Default, token);
                                 // ToArray should not have an overload, but if user defined it, take the default one: without params
                                 if (methodIds == null)
                                     throw new InvalidOperationException($"Type '{rootObject?["className"]?.Value<string>()}' cannot be indexed.");
@@ -560,7 +561,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 {
                     typeIds = await context.SdbAgent.GetTypeIdsForObject(objectId.Value, true, token);
                 }
-                int[] methodIds = await context.SdbAgent.GetMethodIdsByName(typeIds[0], methodName, token);
+                int[] methodIds = await context.SdbAgent.GetMethodIdsByName(typeIds[0], methodName, BindingFlags.Default, token);
                 if (methodIds == null)
                 {
                     //try to search on System.Linq.Enumerable
@@ -666,7 +667,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                 }
 
-                int[] newMethodIds = await context.SdbAgent.GetMethodIdsByName(linqTypeId, methodName, token);
+                int[] newMethodIds = await context.SdbAgent.GetMethodIdsByName(linqTypeId, methodName, BindingFlags.Default, token);
                 if (newMethodIds == null)
                     return 0;
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -787,7 +787,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         private DebugStore store;
         private SessionId sessionId;
 
-        private readonly ILogger logger;
+        internal readonly ILogger logger;
         private static readonly Regex regexForAsyncLocals = new (@"\<([^)]*)\>", RegexOptions.Singleline);
         private static readonly Regex regexForAsyncMethodName = new (@"\<([^>]*)\>([d][_][_])([0-9]*)", RegexOptions.Compiled);
         private static readonly Regex regexForGenericArgs = new (@"[`][0-9]+", RegexOptions.Compiled);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -1846,9 +1846,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 foreach (var typeId in typeIds)
                 {
                     var typeInfo = await GetTypeInfo(typeId, token);
-                    if (typeInfo == null)
-                        continue;
-                    if (typeInfo.Name == "object")
+                    if (typeInfo == null || typeInfo.Name == "object")
                         continue;
                     Microsoft.WebAssembly.Diagnostics.MethodInfo methodInfo = typeInfo.Info.Methods.FirstOrDefault(m => m.Name == "ToString");
                     if (isEnum != true && methodInfo == null)
@@ -1865,7 +1863,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                         return retMethod["value"]?["value"].Value<string>();
                     }
                 }
-                return null;
             }
             catch (Exception e)
             {
@@ -1873,8 +1870,6 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
             return null;
         }
-
-
 
         public async Task<int> GetPropertyMethodIdByName(int typeId, string propertyName, CancellationToken token)
         {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -1737,7 +1737,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             return retDebuggerCmdReader.ReadInt32();
         }
 
-        public async Task<int[]> GetMethodIdsByName(int type_id, string method_name, CancellationToken token)
+        public async Task<int[]> GetMethodIdsByName(int type_id, string method_name, BindingFlags extraFlags, CancellationToken token)
         {
             if (type_id <= 0)
                 throw new DebuggerAgentException($"Invalid type_id {type_id} (method_name: {method_name}");
@@ -1745,7 +1745,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             using var commandParamsWriter = new MonoBinaryWriter();
             commandParamsWriter.Write((int)type_id);
             commandParamsWriter.Write(method_name);
-            commandParamsWriter.Write((int)(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static));
+            commandParamsWriter.Write((int)(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | extraFlags));
             commandParamsWriter.Write((int)1); //case sensitive
             using var retDebuggerCmdReader = await SendDebuggerAgentCommand(CmdType.GetMethodsByNameFlags, commandParamsWriter, token);
             var nMethods = retDebuggerCmdReader.ReadInt32();
@@ -2169,7 +2169,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                             break;
                         cAttrTypeId = genericTypeId;
                     }
-                    int[] methodIds = await GetMethodIdsByName(cAttrTypeId, ".ctor", token);
+                    int[] methodIds = await GetMethodIdsByName(cAttrTypeId, ".ctor", BindingFlags.Default, token);
                     if (methodIds != null)
                         methodId = methodIds[0];
                     break;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -1839,7 +1839,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 : throw new ArgumentException($"Cannot invoke method with id {methodId} on {dotnetObjectId}", nameof(dotnetObjectId));
         }
 
-        public async Task<string> InvokeToStringAsync(List<int> typeIds, bool isValueType, bool isEnum, int objectId, BindingFlags extraFlags, CancellationToken token)
+        public async Task<string> InvokeToStringAsync(IEnumerable<int> typeIds, bool isValueType, bool isEnum, int objectId, BindingFlags extraFlags, CancellationToken token)
         {
             try
             {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
@@ -111,6 +111,7 @@ namespace BrowserDebugProxy
                 return fieldValue;
             }
         }
+
         public async Task<string> ToString(MonoSDBHelper sdbAgent, CancellationToken token)
         {
             var typeInfo = await sdbAgent.GetTypeInfo(TypeId, token);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
@@ -117,7 +117,7 @@ namespace BrowserDebugProxy
             string description = className;
             if (ShouldAutoInvokeToString(className) || IsEnum)
             {
-                var toString = await sdbAgent.InvokeToStringAsync(new int[]{ TypeId }, true, IsEnum, Id.Value, IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
+                var toString = await sdbAgent.InvokeToStringAsync(new int[]{ TypeId }, isValueType: true, IsEnum, Id.Value, IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
                 if (toString == null)
                     sdbAgent.logger.LogDebug($"Error while evaluating ToString method on typeId = {TypeId}");
                 else
@@ -134,7 +134,7 @@ namespace BrowserDebugProxy
                 }
                 else
                 {
-                    var toString = await sdbAgent.InvokeToStringAsync(new int[]{ TypeId }, true, IsEnum, Id.Value, IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
+                    var toString = await sdbAgent.InvokeToStringAsync(new int[]{ TypeId }, isValueType: true, IsEnum, Id.Value, IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
                     if (toString != null)
                         description = toString;
                 }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace BrowserDebugProxy
 {
@@ -123,8 +124,15 @@ namespace BrowserDebugProxy
             int[] methodIds = await sdbAgent.GetMethodIdsByName(TypeId, "ToString", token);
             if (methodIds == null)
                 return null;
-            var retMethod = await sdbAgent.InvokeMethod(Buffer, methodIds[0], token, "methodRet");
-            return retMethod["value"]?["value"].Value<string>();
+            try {
+                var retMethod = await sdbAgent.InvokeMethod(Buffer, methodIds[0], token, "methodRet");
+                return retMethod["value"]?["value"].Value<string>();
+            }
+            catch (Exception e)
+            {
+                sdbAgent.logger.LogDebug($"Error while evaluating ToString method: {e}");
+            }
+            return null;
         }
 
         public async Task<JObject> ToJObject(MonoSDBHelper sdbAgent, bool forDebuggerDisplayAttribute, CancellationToken token)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
@@ -112,7 +112,7 @@ namespace BrowserDebugProxy
             }
         }
 
-        public async Task<string> ToString(MonoSDBHelper sdbAgent, CancellationToken token)
+        public async Task<string> InvokeToStringAsync(MonoSDBHelper sdbAgent, CancellationToken token)
         {
             var typeInfo = await sdbAgent.GetTypeInfo(TypeId, token);
             if (typeInfo == null)
@@ -122,12 +122,18 @@ namespace BrowserDebugProxy
             Microsoft.WebAssembly.Diagnostics.MethodInfo methodInfo = typeInfo.Info.Methods.FirstOrDefault(m => m.Name == "ToString");
             if (!IsEnum && methodInfo == null)
                 return null;
-            int[] methodIds = await sdbAgent.GetMethodIdsByName(TypeId, "ToString", token);
+            int[] methodIds = await sdbAgent.GetMethodIdsByName(TypeId, "ToString", IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
             if (methodIds == null)
                 return null;
             try {
-                var retMethod = await sdbAgent.InvokeMethod(Buffer, methodIds[0], token, "methodRet");
-                return retMethod["value"]?["value"].Value<string>();
+                foreach (var methodId in methodIds)
+                {
+                    var methodInfoFromRuntime = await sdbAgent.GetMethodInfo(methodId, token);
+                    if (methodInfoFromRuntime.Info.GetParametersInfo().Length > 0)
+                        continue;
+                    var retMethod = await sdbAgent.InvokeMethod(Buffer, methodId, token, "methodRet");
+                    return retMethod["value"]?["value"].Value<string>();
+                }
             }
             catch (Exception e)
             {
@@ -141,10 +147,11 @@ namespace BrowserDebugProxy
             string description = className;
             if (ShouldAutoInvokeToString(className) || IsEnum)
             {
-                var toString = await ToString(sdbAgent, token);
+                var toString = await InvokeToStringAsync(sdbAgent, token);
                 if (toString == null)
-                    throw new InternalErrorException($"Cannot find method 'ToString' on typeId = {TypeId}");
-                description = toString;
+                    sdbAgent.logger.LogDebug($"Error while evaluating ToString method on typeId = {TypeId}");
+                else
+                    description = toString;
                 if (className.Equals("System.Guid"))
                     description = description.ToUpperInvariant(); //to keep the old behavior
             }
@@ -155,7 +162,7 @@ namespace BrowserDebugProxy
                     description = displayString;
                 else
                 {
-                    var toString = await ToString(sdbAgent, token);
+                    var toString = await InvokeToStringAsync(sdbAgent, token);
                     if (toString != null)
                         description = toString;
                 }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ValueTypeClass.cs
@@ -117,7 +117,7 @@ namespace BrowserDebugProxy
             string description = className;
             if (ShouldAutoInvokeToString(className) || IsEnum)
             {
-                var toString = await sdbAgent.InvokeToStringAsync(new List<int>(){TypeId}, true, IsEnum, Id.Value, IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
+                var toString = await sdbAgent.InvokeToStringAsync(new int[]{ TypeId }, true, IsEnum, Id.Value, IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
                 if (toString == null)
                     sdbAgent.logger.LogDebug($"Error while evaluating ToString method on typeId = {TypeId}");
                 else
@@ -129,10 +129,12 @@ namespace BrowserDebugProxy
             {
                 string displayString = await sdbAgent.GetValueFromDebuggerDisplayAttribute(Id, TypeId, token);
                 if (displayString != null)
+                {
                     description = displayString;
+                }
                 else
                 {
-                    var toString = await sdbAgent.InvokeToStringAsync(new List<int>(){TypeId}, true, IsEnum, Id.Value, IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
+                    var toString = await sdbAgent.InvokeToStringAsync(new int[]{ TypeId }, true, IsEnum, Id.Value, IsEnum ? BindingFlags.Default : BindingFlags.DeclaredOnly, token);
                     if (toString != null)
                         description = toString;
                 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -106,5 +106,24 @@ namespace DebuggerTests
                 Assert.True(task.Result);
             }
         }
+        
+        [ConditionalFact(nameof(RunningOnChrome))]
+        public async Task InspectObjectOfTypeWithToStringOverwritten()
+        {
+            var expression = $"{{ invoke_static_method('[debugger-test] ToStringOverwritten:Run'); }}";
+
+            await EvaluateAndCheck(
+                "window.setTimeout(function() {" + expression + "; }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 1384, 8,
+                "ToStringOverwritten.Run",
+                wait_for_event_fn: async (pause_location) =>
+                {
+                    var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+                    await EvaluateOnCallFrameAndCheck(id,
+                        ("a", TObject("ToStringOverwritten", description:"hithays"))
+                    );
+                }
+            );
+        }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -108,19 +108,22 @@ namespace DebuggerTests
         }
         
         [ConditionalFact(nameof(RunningOnChrome))]
-        public async Task InspectObjectOfTypeWithToStringOverwritten()
+        public async Task InspectObjectOfTypeWithToStringOverriden()
         {
-            var expression = $"{{ invoke_static_method('[debugger-test] ToStringOverwritten:Run'); }}";
+            var expression = $"{{ invoke_static_method('[debugger-test] ToStringOverriden:Run'); }}";
 
             await EvaluateAndCheck(
                 "window.setTimeout(function() {" + expression + "; }, 1);",
-                "dotnet://debugger-test.dll/debugger-test.cs", 1384, 8,
-                "ToStringOverwritten.Run",
+                "dotnet://debugger-test.dll/debugger-test.cs", 1412, 8,
+                "ToStringOverriden.Run",
                 wait_for_event_fn: async (pause_location) =>
                 {
                     var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
                     await EvaluateOnCallFrameAndCheck(id,
-                        ("a", TObject("ToStringOverwritten", description:"hello"))
+                        ("a", TObject("ToStringOverriden", description:"helloToStringOverriden")),
+                        ("b", TObject("ToStringOverriden.ToStringOverridenB", description:"helloToStringOverridenA")),
+                        ("c", TObject("ToStringOverriden.ToStringOverridenD", description:"helloToStringOverridenD")),
+                        ("d", TObject("ToStringOverriden.ToStringOverridenE", description:"helloToStringOverridenE"))
                     );
                 }
             );

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -114,7 +114,7 @@ namespace DebuggerTests
 
             await EvaluateAndCheck(
                 "window.setTimeout(function() {" + expression + "; }, 1);",
-                "dotnet://debugger-test.dll/debugger-test.cs", 1412, 8,
+                "dotnet://debugger-test.dll/debugger-test.cs", 1474, 8,
                 "ToStringOverriden.Run",
                 wait_for_event_fn: async (pause_location) =>
                 {
@@ -123,7 +123,14 @@ namespace DebuggerTests
                         ("a", TObject("ToStringOverriden", description:"helloToStringOverriden")),
                         ("b", TObject("ToStringOverriden.ToStringOverridenB", description:"helloToStringOverridenA")),
                         ("c", TObject("ToStringOverriden.ToStringOverridenD", description:"helloToStringOverridenD")),
-                        ("d", TObject("ToStringOverriden.ToStringOverridenE", description:"helloToStringOverridenE"))
+                        ("d", TObject("ToStringOverriden.ToStringOverridenE", description:"helloToStringOverridenE")),
+                        ("e", TObject("ToStringOverriden.ToStringOverridenB", description:"helloToStringOverridenA")),
+                        ("f", TObject("ToStringOverriden.ToStringOverridenB", description:"helloToStringOverridenA")),
+                        ("g", TObject("ToStringOverriden.ToStringOverridenG", description:"helloToStringOverridenG")),
+                        ("h", TObject("ToStringOverriden.ToStringOverridenH", description:"helloToStringOverridenH")),
+                        ("i", TObject("ToStringOverriden.ToStringOverridenI", description:"ToStringOverriden.ToStringOverridenI")),
+                        ("j", TObject("ToStringOverriden.ToStringOverridenJ", description:"helloToStringOverridenJ")),
+                        ("k", TObject("ToStringOverriden.ToStringOverridenK", description:"ToStringOverriden.ToStringOverridenK"))
                     );
                 }
             );

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -114,7 +114,7 @@ namespace DebuggerTests
 
             await EvaluateAndCheck(
                 "window.setTimeout(function() {" + expression + "; }, 1);",
-                "dotnet://debugger-test.dll/debugger-test.cs", 1474, 8,
+                "dotnet://debugger-test.dll/debugger-test.cs", 1505, 8,
                 "ToStringOverriden.Run",
                 wait_for_event_fn: async (pause_location) =>
                 {
@@ -130,7 +130,10 @@ namespace DebuggerTests
                         ("h", TObject("ToStringOverriden.ToStringOverridenH", description:"helloToStringOverridenH")),
                         ("i", TObject("ToStringOverriden.ToStringOverridenI", description:"ToStringOverriden.ToStringOverridenI")),
                         ("j", TObject("ToStringOverriden.ToStringOverridenJ", description:"helloToStringOverridenJ")),
-                        ("k", TObject("ToStringOverriden.ToStringOverridenK", description:"ToStringOverriden.ToStringOverridenK"))
+                        ("k", TObject("ToStringOverriden.ToStringOverridenK", description:"ToStringOverriden.ToStringOverridenK")),
+                        ("l", TObject("ToStringOverriden.ToStringOverridenL", description:"helloToStringOverridenL")),
+                        ("m", TObject("ToStringOverriden.ToStringOverridenM", description:"ToStringOverridenM { }")),
+                        ("n", TObject("ToStringOverriden.ToStringOverridenN", description:"helloToStringOverridenN"))
                     );
                 }
             );

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -120,7 +120,7 @@ namespace DebuggerTests
                 {
                     var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
                     await EvaluateOnCallFrameAndCheck(id,
-                        ("a", TObject("ToStringOverwritten", description:"hithays"))
+                        ("a", TObject("ToStringOverwritten", description:"hello"))
                     );
                 }
             );

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -713,7 +713,7 @@ namespace DebuggerTests
 
                  await CheckProps(frame_locals, new
                  {
-                     mi = TObject("System.Reflection.RuntimeMethodInfo"), //this is what is returned when debugging desktop apps using VS
+                     mi = TObject("System.Reflection.RuntimeMethodInfo", description: "Void SimpleStaticMethod(System.DateTime, System.String)"), //this is what is returned when debugging desktop apps using VS
                      dt = TDateTime(new DateTime(4210, 3, 4, 5, 6, 7)),
                      i = TNumber(4),
                      strings = TArray("string[]", "string[1]"),

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1373,15 +1373,43 @@ public class ReadOnlySpanTest
     }
 }
 
-public class ToStringOverwritten
+public class ToStringOverriden
 {
+    class ToStringOverridenA {
+        public override string ToString()
+        {
+            return "helloToStringOverridenA";
+        }
+    }
+    class ToStringOverridenB: ToStringOverridenA {}
+
+    class ToStringOverridenC {}
+    class ToStringOverridenD: ToStringOverridenC
+    {
+        public override string ToString()
+        {
+            return "helloToStringOverridenD";
+        }
+    }
+
+    struct ToStringOverridenE 
+    {
+        public override string ToString()
+        {
+            return "helloToStringOverridenE";
+        }
+    }
+
     public override string ToString()
     {
-        return "hello";
+        return "helloToStringOverriden";
     }
     public static void Run()
     {
-        var a = new ToStringOverwritten();
+        var a = new ToStringOverriden();
+        var b = new ToStringOverridenB();
+        var c = new ToStringOverridenD();
+        var d = new ToStringOverridenE();
         System.Diagnostics.Debugger.Break();
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1377,7 +1377,7 @@ public class ToStringOverwritten
 {
     public override string ToString()
     {
-        return "hithays";
+        return "hello";
     }
     public static void Run()
     {

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1392,7 +1392,7 @@ public class ToStringOverriden
         }
     }
 
-    struct ToStringOverridenE 
+    struct ToStringOverridenE
     {
         public override string ToString()
         {

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1455,6 +1455,34 @@ public class ToStringOverriden
         }
     }
 
+    record ToStringOverridenL
+    {
+        public override string ToString()
+        {
+            return "helloToStringOverridenL";
+        }
+    }
+
+    record ToStringOverridenM
+    {
+        public string ToString(bool withParms = true)
+        {
+            return "helloToStringOverridenMWrong";
+        }
+    }
+
+    record ToStringOverridenN
+    {
+        public override string ToString()
+        {
+            return "helloToStringOverridenN";
+        }
+        public string ToString(bool withParms = true)
+        {
+            return "helloToStringOverridenNWrong";
+        }
+    }
+
     public override string ToString()
     {
         return "helloToStringOverriden";
@@ -1472,6 +1500,9 @@ public class ToStringOverriden
         var i = new ToStringOverridenI();
         var j = new ToStringOverridenJ();
         var k = new ToStringOverridenK();
+        var l = new ToStringOverridenL();
+        var m = new ToStringOverridenM();
+        var n = new ToStringOverridenN();
         System.Diagnostics.Debugger.Break();
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1400,6 +1400,61 @@ public class ToStringOverriden
         }
     }
 
+    class ToStringOverridenF
+    {
+        public override string ToString()
+        {
+            return "helloToStringOverridenF";
+        }
+    }
+    class ToStringOverridenG: ToStringOverridenF
+    {
+        public override string ToString()
+        {
+            return "helloToStringOverridenG";
+        }
+    }
+
+    class ToStringOverridenH
+    {
+        public override string ToString()
+        {
+            return "helloToStringOverridenH";
+        }
+        public string ToString(bool withParms = true)
+        {
+            return "helloToStringOverridenHWrong";
+        }
+    }
+
+    class ToStringOverridenI
+    {
+        public string ToString(bool withParms = true)
+        {
+            return "helloToStringOverridenIWrong";
+        }
+    }
+
+    struct ToStringOverridenJ
+    {
+        public override string ToString()
+        {
+            return "helloToStringOverridenJ";
+        }
+        public string ToString(bool withParms = true)
+        {
+            return "helloToStringOverridenJWrong";
+        }
+    }
+
+    struct ToStringOverridenK
+    {
+        public string ToString(bool withParms = true)
+        {
+            return "helloToStringOverridenKWrong";
+        }
+    }
+
     public override string ToString()
     {
         return "helloToStringOverriden";
@@ -1410,6 +1465,13 @@ public class ToStringOverriden
         var b = new ToStringOverridenB();
         var c = new ToStringOverridenD();
         var d = new ToStringOverridenE();
+        ToStringOverridenA e = new ToStringOverridenB();
+        object f = new ToStringOverridenB();
+        var g = new ToStringOverridenG();
+        var h = new ToStringOverridenH();
+        var i = new ToStringOverridenI();
+        var j = new ToStringOverridenJ();
+        var k = new ToStringOverridenK();
         System.Diagnostics.Debugger.Break();
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1372,3 +1372,16 @@ public class ReadOnlySpanTest
         System.Diagnostics.Debugger.Break();
     }
 }
+
+public class ToStringOverwritten
+{
+    public override string ToString()
+    {
+        return "hithays";
+    }
+    public static void Run()
+    {
+        var a = new ToStringOverwritten();
+        System.Diagnostics.Debugger.Break();
+    }
+}


### PR DESCRIPTION
The description of an object that has ToString implemented should bethe result of the ToString and not the type name.

Fixes #76748 

Using this PR:
![image](https://user-images.githubusercontent.com/4503299/194716463-281603dc-6ae4-4d05-ba63-28c0d639318c.png)
