### PR TITLE
Use hashcodes when looking up the JsonSerializerOptions global cache.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -285,6 +285,7 @@ namespace System.Text.Json
                     CompareLists(left._converters, right._converters);
 
                 static bool CompareLists<TValue>(ConfigurationList<TValue> left, ConfigurationList<TValue> right)
+                    where TValue : class?
                 {
                     int n;
                     if ((n = left.Count) != right.Count)
@@ -294,10 +295,7 @@ namespace System.Text.Json
 
                     for (int i = 0; i < n; i++)
                     {
-                        TValue? leftElem = left[i];
-                        TValue? rightElem = right[i];
-                        bool areEqual = leftElem is null ? rightElem is null : leftElem.Equals(rightElem);
-                        if (!areEqual)
+                        if (left[i] != right[i])
                         {
                             return false;
                         }
@@ -311,35 +309,49 @@ namespace System.Text.Json
             {
                 HashCode hc = default;
 
-                hc.Add(options._dictionaryKeyPolicy);
-                hc.Add(options._jsonPropertyNamingPolicy);
-                hc.Add(options._readCommentHandling);
-                hc.Add(options._referenceHandler);
-                hc.Add(options._encoder);
-                hc.Add(options._defaultIgnoreCondition);
-                hc.Add(options._numberHandling);
-                hc.Add(options._unknownTypeHandling);
-                hc.Add(options._defaultBufferSize);
-                hc.Add(options._maxDepth);
-                hc.Add(options._allowTrailingCommas);
-                hc.Add(options._ignoreNullValues);
-                hc.Add(options._ignoreReadOnlyProperties);
-                hc.Add(options._ignoreReadonlyFields);
-                hc.Add(options._includeFields);
-                hc.Add(options._propertyNameCaseInsensitive);
-                hc.Add(options._writeIndented);
-                hc.Add(options._typeInfoResolver);
-                GetHashCode(ref hc, options._converters);
+                AddHashCode(ref hc, options._dictionaryKeyPolicy);
+                AddHashCode(ref hc, options._jsonPropertyNamingPolicy);
+                AddHashCode(ref hc, options._readCommentHandling);
+                AddHashCode(ref hc, options._referenceHandler);
+                AddHashCode(ref hc, options._encoder);
+                AddHashCode(ref hc, options._defaultIgnoreCondition);
+                AddHashCode(ref hc, options._numberHandling);
+                AddHashCode(ref hc, options._unknownTypeHandling);
+                AddHashCode(ref hc, options._defaultBufferSize);
+                AddHashCode(ref hc, options._maxDepth);
+                AddHashCode(ref hc, options._allowTrailingCommas);
+                AddHashCode(ref hc, options._ignoreNullValues);
+                AddHashCode(ref hc, options._ignoreReadOnlyProperties);
+                AddHashCode(ref hc, options._ignoreReadonlyFields);
+                AddHashCode(ref hc, options._includeFields);
+                AddHashCode(ref hc, options._propertyNameCaseInsensitive);
+                AddHashCode(ref hc, options._writeIndented);
+                AddHashCode(ref hc, options._typeInfoResolver);
+                AddListHashCode(ref hc, options._converters);
 
-                static void GetHashCode<TValue>(ref HashCode hc, ConfigurationList<TValue> list)
+                return hc.ToHashCode();
+
+                static void AddListHashCode<TValue>(ref HashCode hc, ConfigurationList<TValue> list)
                 {
-                    for (int i = 0; i < list.Count; i++)
+                    int n = list.Count;
+                    for (int i = 0; i < n; i++)
                     {
-                        hc.Add(list[i]);
+                        AddHashCode(ref hc, list[i]);
                     }
                 }
 
-                return hc.ToHashCode();
+                static void AddHashCode<TValue>(ref HashCode hc, TValue? value)
+                {
+                    if (typeof(TValue).IsValueType)
+                    {
+                        hc.Add(value);
+                    }
+                    else
+                    {
+                        Debug.Assert(!typeof(TValue).IsSealed, "Sealed reference types like string should not use this method.");
+                        hc.Add(RuntimeHelpers.GetHashCode(value));
+                    }
+                }
             }
 
 #if !NETCOREAPP

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -142,12 +142,14 @@ namespace System.Text.Json
         {
             private readonly ConcurrentDictionary<Type, JsonTypeInfo?> _jsonTypeInfoCache = new();
 
-            public CachingContext(JsonSerializerOptions options)
+            public CachingContext(JsonSerializerOptions options, int hashCode)
             {
                 Options = options;
+                HashCode = hashCode;
             }
 
             public JsonSerializerOptions Options { get; }
+            public int HashCode { get; }
             // Property only accessed by reflection in testing -- do not remove.
             // If changing please ensure that src/ILLink.Descriptors.LibraryBuild.xml is up-to-date.
             public int Count => _jsonTypeInfoCache.Count;
@@ -164,37 +166,39 @@ namespace System.Text.Json
         /// <summary>
         /// Defines a cache of CachingContexts; instead of using a ConditionalWeakTable which can be slow to traverse
         /// this approach uses a fixed-size array of weak references of <see cref="CachingContext"/> that can be looked up lock-free.
-        /// Relevant caching contexts are looked up by linear traversal using the equality comparison defined by
-        /// <see cref="AreEquivalentOptions(JsonSerializerOptions, JsonSerializerOptions)"/>.
+        /// Relevant caching contexts are looked up by linear traversal using the equality comparison defined by <see cref="EqualityComparer"/>.
         /// </summary>
         internal static class TrackedCachingContexts
         {
             private const int MaxTrackedContexts = 64;
             private static readonly WeakReference<CachingContext>?[] s_trackedContexts = new WeakReference<CachingContext>[MaxTrackedContexts];
+            private static readonly EqualityComparer s_optionsComparer = new();
 
             public static CachingContext GetOrCreate(JsonSerializerOptions options)
             {
                 Debug.Assert(options.IsReadOnly, "Cannot create caching contexts for mutable JsonSerializerOptions instances");
                 Debug.Assert(options._typeInfoResolver != null);
 
-                if (TryGetContext(options, out int firstUnpopulatedIndex, out CachingContext? result))
+                int hashCode = s_optionsComparer.GetHashCode(options);
+
+                if (TryGetContext(options, hashCode, out int firstUnpopulatedIndex, out CachingContext? result))
                 {
                     return result;
                 }
                 else if (firstUnpopulatedIndex < 0)
                 {
                     // Cache is full; return a fresh instance.
-                    return new CachingContext(options);
+                    return new CachingContext(options, hashCode);
                 }
 
                 lock (s_trackedContexts)
                 {
-                    if (TryGetContext(options, out firstUnpopulatedIndex, out result))
+                    if (TryGetContext(options, hashCode, out firstUnpopulatedIndex, out result))
                     {
                         return result;
                     }
 
-                    var ctx = new CachingContext(options);
+                    var ctx = new CachingContext(options, hashCode);
 
                     if (firstUnpopulatedIndex >= 0)
                     {
@@ -218,6 +222,7 @@ namespace System.Text.Json
 
             private static bool TryGetContext(
                 JsonSerializerOptions options,
+                int hashCode,
                 out int firstUnpopulatedIndex,
                 [NotNullWhen(true)] out CachingContext? result)
             {
@@ -235,7 +240,7 @@ namespace System.Text.Json
                             firstUnpopulatedIndex = i;
                         }
                     }
-                    else if (AreEquivalentOptions(options, ctx.Options))
+                    else if (hashCode == ctx.HashCode && s_optionsComparer.Equals(options, ctx.Options))
                     {
                         result = ctx;
                         return true;
@@ -252,52 +257,102 @@ namespace System.Text.Json
         /// If two instances are equivalent, they should generate identical metadata caches;
         /// the converse however does not necessarily hold.
         /// </summary>
-        private static bool AreEquivalentOptions(JsonSerializerOptions left, JsonSerializerOptions right)
+        private sealed class EqualityComparer : IEqualityComparer<JsonSerializerOptions>
         {
-            Debug.Assert(left != null && right != null);
-
-            return
-                left._dictionaryKeyPolicy == right._dictionaryKeyPolicy &&
-                left._jsonPropertyNamingPolicy == right._jsonPropertyNamingPolicy &&
-                left._readCommentHandling == right._readCommentHandling &&
-                left._referenceHandler == right._referenceHandler &&
-                left._encoder == right._encoder &&
-                left._defaultIgnoreCondition == right._defaultIgnoreCondition &&
-                left._numberHandling == right._numberHandling &&
-                left._unknownTypeHandling == right._unknownTypeHandling &&
-                left._defaultBufferSize == right._defaultBufferSize &&
-                left._maxDepth == right._maxDepth &&
-                left._allowTrailingCommas == right._allowTrailingCommas &&
-                left._ignoreNullValues == right._ignoreNullValues &&
-                left._ignoreReadOnlyProperties == right._ignoreReadOnlyProperties &&
-                left._ignoreReadonlyFields == right._ignoreReadonlyFields &&
-                left._includeFields == right._includeFields &&
-                left._propertyNameCaseInsensitive == right._propertyNameCaseInsensitive &&
-                left._writeIndented == right._writeIndented &&
-                left._typeInfoResolver == right._typeInfoResolver &&
-                CompareLists(left._converters, right._converters);
-
-            static bool CompareLists<TValue>(ConfigurationList<TValue> left, ConfigurationList<TValue> right)
+            public bool Equals(JsonSerializerOptions? left, JsonSerializerOptions? right)
             {
-                int n;
-                if ((n = left.Count) != right.Count)
-                {
-                    return false;
-                }
+                Debug.Assert(left != null && right != null);
 
-                for (int i = 0; i < n; i++)
+                return
+                    left._dictionaryKeyPolicy == right._dictionaryKeyPolicy &&
+                    left._jsonPropertyNamingPolicy == right._jsonPropertyNamingPolicy &&
+                    left._readCommentHandling == right._readCommentHandling &&
+                    left._referenceHandler == right._referenceHandler &&
+                    left._encoder == right._encoder &&
+                    left._defaultIgnoreCondition == right._defaultIgnoreCondition &&
+                    left._numberHandling == right._numberHandling &&
+                    left._unknownTypeHandling == right._unknownTypeHandling &&
+                    left._defaultBufferSize == right._defaultBufferSize &&
+                    left._maxDepth == right._maxDepth &&
+                    left._allowTrailingCommas == right._allowTrailingCommas &&
+                    left._ignoreNullValues == right._ignoreNullValues &&
+                    left._ignoreReadOnlyProperties == right._ignoreReadOnlyProperties &&
+                    left._ignoreReadonlyFields == right._ignoreReadonlyFields &&
+                    left._includeFields == right._includeFields &&
+                    left._propertyNameCaseInsensitive == right._propertyNameCaseInsensitive &&
+                    left._writeIndented == right._writeIndented &&
+                    left._typeInfoResolver == right._typeInfoResolver &&
+                    CompareLists(left._converters, right._converters);
+
+                static bool CompareLists<TValue>(ConfigurationList<TValue> left, ConfigurationList<TValue> right)
                 {
-                    TValue? leftElem = left[i];
-                    TValue? rightElem = right[i];
-                    bool areEqual = leftElem is null ? rightElem is null : leftElem.Equals(rightElem);
-                    if (!areEqual)
+                    int n;
+                    if ((n = left.Count) != right.Count)
                     {
                         return false;
                     }
+
+                    for (int i = 0; i < n; i++)
+                    {
+                        TValue? leftElem = left[i];
+                        TValue? rightElem = right[i];
+                        bool areEqual = leftElem is null ? rightElem is null : leftElem.Equals(rightElem);
+                        if (!areEqual)
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            public int GetHashCode(JsonSerializerOptions options)
+            {
+                HashCode hc = default;
+
+                hc.Add(options._dictionaryKeyPolicy);
+                hc.Add(options._jsonPropertyNamingPolicy);
+                hc.Add(options._readCommentHandling);
+                hc.Add(options._referenceHandler);
+                hc.Add(options._encoder);
+                hc.Add(options._defaultIgnoreCondition);
+                hc.Add(options._numberHandling);
+                hc.Add(options._unknownTypeHandling);
+                hc.Add(options._defaultBufferSize);
+                hc.Add(options._maxDepth);
+                hc.Add(options._allowTrailingCommas);
+                hc.Add(options._ignoreNullValues);
+                hc.Add(options._ignoreReadOnlyProperties);
+                hc.Add(options._ignoreReadonlyFields);
+                hc.Add(options._includeFields);
+                hc.Add(options._propertyNameCaseInsensitive);
+                hc.Add(options._writeIndented);
+                hc.Add(options._typeInfoResolver);
+                GetHashCode(ref hc, options._converters);
+
+                static void GetHashCode<TValue>(ref HashCode hc, ConfigurationList<TValue> list)
+                {
+                    for (int i = 0; i < list.Count; i++)
+                    {
+                        hc.Add(list[i]);
+                    }
                 }
 
-                return true;
+                return hc.ToHashCode();
             }
+
+#if !NETCOREAPP
+            /// <summary>
+            /// Polyfill for System.HashCode.
+            /// </summary>
+            private struct HashCode
+            {
+                private int _hashCode;
+                public void Add<T>(T? value) => _hashCode = (_hashCode, value).GetHashCode();
+                public int ToHashCode() => _hashCode;
+            }
+#endif
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -257,6 +257,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/66232", TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [MemberData(nameof(GetJsonSerializerOptions))]
         public static void JsonSerializerOptions_ReuseConverterCaches()
         {
             // This test uses reflection to:
@@ -268,7 +269,7 @@ namespace System.Text.Json.Serialization.Tests
             RemoteExecutor.Invoke(static () =>
             {
                 Func<JsonSerializerOptions, JsonSerializerOptions?> getCacheOptions = CreateCacheOptionsAccessor();
-                Func<JsonSerializerOptions, JsonSerializerOptions, bool> equalityComparer = CreateEqualityComparerAccessor();
+                IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
 
                 foreach (var args in GetJsonSerializerOptions())
                 {
@@ -279,7 +280,8 @@ namespace System.Text.Json.Serialization.Tests
 
                     JsonSerializerOptions originalCacheOptions = getCacheOptions(options);
                     Assert.NotNull(originalCacheOptions);
-                    Assert.True(equalityComparer(options, originalCacheOptions));
+                    Assert.True(equalityComparer.Equals(options, originalCacheOptions));
+                    Assert.Equal(equalityComparer.GetHashCode(options), equalityComparer.GetHashCode(originalCacheOptions));
 
                     for (int i = 0; i < 5; i++)
                     {
@@ -288,7 +290,8 @@ namespace System.Text.Json.Serialization.Tests
 
                         JsonSerializer.Serialize(42, options2);
 
-                        Assert.True(equalityComparer(options2, originalCacheOptions));
+                        Assert.True(equalityComparer.Equals(options2, originalCacheOptions));
+                        Assert.Equal(equalityComparer.GetHashCode(options2), equalityComparer.GetHashCode(originalCacheOptions));
                         Assert.Same(originalCacheOptions, getCacheOptions(options2));
                     }
                 }
@@ -324,7 +327,7 @@ namespace System.Text.Json.Serialization.Tests
             // - All public setters in JsonSerializerOptions
             //
             // If either of them changes, this test will need to be kept in sync.
-            Func<JsonSerializerOptions, JsonSerializerOptions, bool> equalityComparer = CreateEqualityComparerAccessor();
+            IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
 
             (PropertyInfo prop, object value)[] propertySettersAndValues = GetPropertiesWithSettersAndNonDefaultValues().ToArray();
 
@@ -334,16 +337,19 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Fail($"{nameof(GetPropertiesWithSettersAndNonDefaultValues)} missing property declaration for {prop.Name}, please update the method.");
             }
 
-            Assert.True(equalityComparer(JsonSerializerOptions.Default, JsonSerializerOptions.Default));
+            Assert.True(equalityComparer.Equals(JsonSerializerOptions.Default, JsonSerializerOptions.Default));
+            Assert.Equal(equalityComparer.GetHashCode(JsonSerializerOptions.Default), equalityComparer.GetHashCode(JsonSerializerOptions.Default));
 
             foreach ((PropertyInfo prop, object? value) in propertySettersAndValues)
             {
                 var options = new JsonSerializerOptions();
                 prop.SetValue(options, value);
 
-                Assert.True(equalityComparer(options, options));
+                Assert.True(equalityComparer.Equals(options, options));
+                Assert.Equal(equalityComparer.GetHashCode(options), equalityComparer.GetHashCode(options));
 
-                Assert.False(equalityComparer(JsonSerializerOptions.Default, options));
+                Assert.False(equalityComparer.Equals(JsonSerializerOptions.Default, options));
+                Assert.NotEqual(equalityComparer.GetHashCode(JsonSerializerOptions.Default), equalityComparer.GetHashCode(options));
             }
 
             static IEnumerable<(PropertyInfo, object)> GetPropertiesWithSettersAndNonDefaultValues()
@@ -389,14 +395,16 @@ namespace System.Text.Json.Serialization.Tests
             //
             // If either of them changes, this test will need to be kept in sync.
 
-            Func<JsonSerializerOptions, JsonSerializerOptions, bool> equalityComparer = CreateEqualityComparerAccessor();
+            IEqualityComparer<JsonSerializerOptions> equalityComparer = CreateEqualityComparerAccessor();
             var options1 = new JsonSerializerOptions { WriteIndented = true };
             var options2 = new JsonSerializerOptions { WriteIndented = true };
 
-            Assert.True(equalityComparer(options1, options2));
+            Assert.True(equalityComparer.Equals(options1, options2));
+            Assert.Equal(equalityComparer.GetHashCode(options1), equalityComparer.GetHashCode(options2));
 
             _ = new MyJsonContext(options1); // Associate copy with a JsonSerializerContext
-            Assert.False(equalityComparer(options1, options2));
+            Assert.False(equalityComparer.Equals(options1, options2));
+            Assert.NotEqual(equalityComparer.GetHashCode(options1), equalityComparer.GetHashCode(options2));
         }
 
         private class MyJsonContext : JsonSerializerContext
@@ -408,10 +416,11 @@ namespace System.Text.Json.Serialization.Tests
             protected override JsonSerializerOptions? GeneratedSerializerOptions => Options;
         }
 
-        public static Func<JsonSerializerOptions, JsonSerializerOptions, bool> CreateEqualityComparerAccessor()
+        public static IEqualityComparer<JsonSerializerOptions> CreateEqualityComparerAccessor()
         {
-            MethodInfo equalityComparerMethod = typeof(JsonSerializerOptions).GetMethod("AreEquivalentOptions", BindingFlags.NonPublic | BindingFlags.Static);
-            return (Func<JsonSerializerOptions, JsonSerializerOptions, bool>)Delegate.CreateDelegate(typeof(Func<JsonSerializerOptions, JsonSerializerOptions, bool>), equalityComparerMethod);
+            Type equalityComparerType = typeof(JsonSerializerOptions).GetNestedType("EqualityComparer", BindingFlags.NonPublic);
+            Assert.NotNull(equalityComparerType);
+            return (IEqualityComparer<JsonSerializerOptions>)Activator.CreateInstance(equalityComparerType, nonPublic: true);
         }
 
         public static IEnumerable<object[]> WriteSuccessCases


### PR DESCRIPTION
Following up on #76607 this PR adds hashcode comparison when looking up the cache. This should minimize the number of full-blown equality comparisons when traversing a saturated cache.