### PR TITLE
JIT: Slightly relax "const vector propagation" heuristics

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3301,6 +3301,10 @@ bool Compiler::optIsProfitableToSubstitute(GenTreeLclVarCommon* lcl, BasicBlock*
             GenTreeLclVarCommon* currlcl = lcl;
             for (size_t i = 0; i < 4; i++)
             {
+                if (currlcl->GetSsaNum() == SsaConfig::RESERVED_SSA_NUM)
+                {
+                    return true;
+                }
                 LclSsaVarDsc* def = lvaGetDesc(currlcl)->GetPerSsaData(currlcl->GetSsaNum());
                 if (def == nullptr)
                 {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3313,10 +3313,11 @@ bool Compiler::optIsProfitableToSubstitute(GenTreeLclVarCommon* lcl, BasicBlock*
                 GenTreeOp* asgNode = def->GetAssignment();
                 if (asgNode != nullptr)
                 {
-                    GenTree* val = asgNode->gtGetOp2();
-                    if (val->IsLocal())
+                    GenTree* lhs = asgNode->gtGetOp1();
+                    GenTree* rhs = asgNode->gtGetOp2();
+                    if (rhs->IsLocal() && lhs->IsLocal() && lhs->AsLclVarCommon()->GetLclNum() == currlcl->GetLclNum())
                     {
-                        currlcl = val->AsLclVarCommon();
+                        currlcl = rhs->AsLclVarCommon();
                         continue;
                     }
                 }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3302,6 +3302,10 @@ bool Compiler::optIsProfitableToSubstitute(GenTreeLclVarCommon* lcl, BasicBlock*
             for (size_t i = 0; i < 4; i++)
             {
                 LclSsaVarDsc* def = lvaGetDesc(currlcl)->GetPerSsaData(currlcl->GetSsaNum());
+                if (def == nullptr)
+                {
+                    return true;
+                }
                 if (isBlockWeightDifferenceTooBig(this, def->GetBlock(), lclBlock))
                 {
                     return false;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3275,7 +3275,7 @@ bool Compiler::optIsProfitableToSubstitute(GenTreeLclVarCommon* lcl, BasicBlock*
 
     gtPrepareCost(value);
 
-    if ((value->GetCostEx() > 1) && (value->GetCostSz() > 1))
+    if ((value->GetCostEx() > 2) && (value->GetCostSz() > 1))
     {
         // Try to find the block this constant was originally defined in
         if (lcl->HasSsaName())
@@ -3289,7 +3289,7 @@ bool Compiler::optIsProfitableToSubstitute(GenTreeLclVarCommon* lcl, BasicBlock*
                 const weight_t defBlockWeight = defBlock->getBBWeight(this);
                 const weight_t lclblockWeight = lclBlock->getBBWeight(this);
 
-                if ((defBlockWeight > 0) && ((lclblockWeight / defBlockWeight) >= BB_LOOP_WEIGHT_SCALE))
+                if ((defBlockWeight > 0) && ((lclblockWeight / defBlockWeight) >= 4))
                 {
                     JITDUMP("Constant propagation inside loop " FMT_BB " is not profitable\n", lclBlock->bbNum);
                     return false;

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -207,6 +207,7 @@ def main(main_args):
         os.path.join(script_dir, "superpmi.py"),
         "asmdiffs",
         "--no_progress",
+        "-metrics", "PerfScore",
         "-core_root", core_root_dir,
         "-target_os", platform_name,
         "-target_arch", arch_name,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/76781

By changing too conservative heuristic I introduced in https://github.com/dotnet/runtime/pull/70378, also changed SPMI to print PerfScore (will revert before merge)

Snippet from https://github.com/dotnet/runtime/issues/76781
```csharp
static void Foo(ref byte src, nuint length, ref byte dest)
{
    nuint idx = 0;
    Vector128<byte> mask = Vector128.Create((byte)0x7F);
    if (length >= (uint)Vector128<byte>.Count)
    {
        nuint vecEnd = length - (uint)Vector128<byte>.Count;
        do
        {
            Vector128<byte> vec = Vector128.LoadUnsafe(ref src, idx);
            vec &= mask;
            vec.StoreUnsafe(ref dest, idx);
            idx += (uint)Vector128<byte>.Count;
        } while (idx <= vecEnd);
    }
}
```

```diff
; Method Program:Foo(byref,ulong,byref)
G_M5292_IG01:              
       C5F877               vzeroupper 
G_M5292_IG02:              
       33C0                 xor      eax, eax
+      C4E179100532000000   vmovupd  xmm0, xmmword ptr [reloc @RWD00]
       4883FA10             cmp      rdx, 16
       7223                 jb       SHORT G_M5292_IG05
G_M5292_IG03:              
       4883C2F0             add      rdx, -16
-      90                   align    [1 bytes for IG04]
+      0F1F840000000000     align    [8 bytes for IG04]
G_M5292_IG04:              
-      C5FA6F0401           vmovdqu  xmm0, xmmword ptr [rcx+rax]
-      C5F9DB0513000000     vpand    xmm0, xmm0, xmmword ptr [reloc @RWD00]
-      C4C17A7F0400         vmovdqu  xmmword ptr [r8+rax], xmm0
+      C5F9DB0C01           vpand    xmm1, xmm0, xmmword ptr [rcx+rax]
+      C4C17A7F0C00         vmovdqu  xmmword ptr [r8+rax], xmm1
       4883C010             add      rax, 16
       483BC2               cmp      rax, rdx
       76E4                 jbe      SHORT G_M5292_IG04
G_M5292_IG05:              
       C3                   ret      
RWD00  	dq	7F7F7F7F7F7F7F7Fh, 7F7F7F7F7F7F7F7Fh
-; Total bytes of code: 45
+; Total bytes of code: 53  ;; but better overall perfscore!
```