### PR TITLE
Base64.Decode: fixed latent bug for non-ASCII inputs

### DIFF
--- a/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -286,7 +286,7 @@ namespace System.Buffers.Text.Tests
 
             Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
             Assert.Equal(expectedConsumed, consumed);
-            Assert.Equal(expectedWritten, decodedByteCount); // expectedWritten == decodedBytes.Length
+            Assert.Equal(expectedWritten, decodedByteCount);
         }
 
         [Theory]

--- a/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -273,12 +273,12 @@ namespace System.Buffers.Text.Tests
         }
 
         [Theory]
-        [InlineData("ìz/T", 0, 0)]                                              // scalar code-path
-        [InlineData("z/Ta123ì", 4, 3)]
-        [InlineData("ìz/TpH7sqEkerqMweH1uSw==", 0, 0)]                          // Vector128 code-path
-        [InlineData("z/TpH7sqEkerqMweH1uSwì==", 20, 15)]
-        [InlineData("ìz/TpH7sqEkerqMweH1uSw1a5ebaAF9xa8B0ze1wet4epo==", 0, 0)]  // Vector256 / AVX code-path
-        [InlineData("z/TpH7sqEkerqMweH1uSw1a5ebaAF9xa8B0ze1wet4epoì==", 44, 33)]
+        [InlineData("\u00ecz/T", 0, 0)]                                              // scalar code-path
+        [InlineData("z/Ta123\u00ec", 4, 3)]
+        [InlineData("\u00ecz/TpH7sqEkerqMweH1uSw==", 0, 0)]                          // Vector128 code-path
+        [InlineData("z/TpH7sqEkerqMweH1uSw\u00ec==", 20, 15)]
+        [InlineData("\u00ecz/TpH7sqEkerqMweH1uSw1a5ebaAF9xa8B0ze1wet4epo==", 0, 0)]  // Vector256 / AVX code-path
+        [InlineData("z/TpH7sqEkerqMweH1uSw1a5ebaAF9xa8B0ze1wet4epo\u00ec==", 44, 33)]
         public void BasicDecodingNonAsciiInputInvalid(string inputString, int expectedConsumed, int expectedWritten)
         {
             Span<byte> source = Encoding.UTF8.GetBytes(inputString);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs
@@ -592,8 +592,9 @@ namespace System.Buffers.Text
 
                 // lookup
                 Vector128<byte> hiNibbles = Vector128.ShiftRightLogical(str.AsInt32(), 4).AsByte() & mask2F;
+                Vector128<byte> loNibbles = str & mask2F;
                 Vector128<byte> hi = SimdShuffle(lutHi, hiNibbles, mask8F);
-                Vector128<byte> lo = SimdShuffle(lutLo, str, mask8F);
+                Vector128<byte> lo = SimdShuffle(lutLo, loNibbles, mask8F);
 
                 // Check for invalid input: if any "and" values from lo and hi are not zero,
                 // fall back on bytewise code to do error checking and reporting:


### PR DESCRIPTION
Repro:
```c#
string base64      = "ìz/TpH7sqEkerqMweH1uSw==";    // first char is not ASCII
byte[] base64Bytes = Encoding.UTF8.GetBytes(base64);
Span<byte> data    = stackalloc byte[128];

OperationStatus status = Base64_.DecodeFromUtf8(base64Bytes, data, out int consumed, out int written);
```
Here the `ì` isn't recognized as being not part of the base64-alphabet, so wrong data is decoded. Ultimately the check https://github.com/dotnet/runtime/blob/f33d77841d936570a94af2a4c567da7c6d3f7045/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs#L200 fails as the length doesn't match (base64-len is 24, base64Bytes-len is 25).
So status reports `InvalidData` correctly, but consumed (24) and written (17) are wrong, as they should be 0 each.

This latent bug got introduced by https://github.com/dotnet/runtime/pull/70654, and unfortunately there was a test-hole that didn't catch this.
https://github.com/dotnet/runtime/pull/70654#discussion_r895762249 talks about the shuffle mask -- here the highest bit of the mask-byte is set so after the shuffle the bits of that vector-element are set to `0`, thus https://github.com/dotnet/runtime/blob/f33d77841d936570a94af2a4c567da7c6d3f7045/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs#L598-L601 doesn't detect the non-ASCII / non-base64 char.

By masking with `0xF` we clear the highest bit -- actually we mask by `0x2F` as that constant is used somewhere else and for shuffling (besides the highest bit) only the lower-nibble of the mask-byte is relevant.