### PR TITLE
Use property AutoreleasePoolSupport in test

### DIFF
--- a/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.csproj
+++ b/src/tests/Interop/ObjectiveC/AutoReleaseTest/AutoReleaseTest.csproj
@@ -3,10 +3,8 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsiOS)' != 'true' and '$(TargetstvOS)' != 'true'">true</CLRTestTargetUnsupported>
+    <AutoreleasePoolSupport>true</AutoreleasePoolSupport>
   </PropertyGroup>
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Threading.Thread.EnableAutoreleasePool" Value="true" Trim="true" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>


### PR DESCRIPTION
The [SDK also sets the RuntimeHostConfigurationOption item](https://github.com/dotnet/sdk/blob/71c4fb3c8ca7338c82a35f5335229f2b81ade08d/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L512). So setting in this project results in multiple copies of the same item.

This MSBuild property is [documented here](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/threading#autoreleasepool-for-managed-threads).

I'm not sure if this causes a problem with any currently supported configuration of .NET, but it is detectable when compiling this test with NativeAOT. ILC fails because multiple copies of the `--appcontextswitch` flag are passed with the same key.