### PR TITLE
Fixing repro command line arguments

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -793,7 +793,7 @@ namespace ILCompiler
             if (method == null)
                 throw new CommandLineException(string.Format(SR.MethodNotFoundOnType, singleMethodName, singleMethodTypeName));
 
-            if (method.HasInstantiation != (singleMethodGenericArgs != null) ||
+            if (method.HasInstantiation != (singleMethodGenericArgs.Length != 0) ||
                 (method.HasInstantiation && (method.Instantiation.Length != singleMethodGenericArgs.Length)))
             {
                 throw new CommandLineException(

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -793,8 +793,7 @@ namespace ILCompiler
             if (method == null)
                 throw new CommandLineException(string.Format(SR.MethodNotFoundOnType, singleMethodName, singleMethodTypeName));
 
-            if (method.HasInstantiation != (singleMethodGenericArgs.Length != 0) ||
-                (method.HasInstantiation && (method.Instantiation.Length != singleMethodGenericArgs.Length)))
+            if (method.Instantiation.Length != singleMethodGenericArgs.Length)
             {
                 throw new CommandLineException(
                     string.Format(SR.GenericArgCountMismatch, method.Instantiation.Length, singleMethodName, singleMethodTypeName));


### PR DESCRIPTION
We are unable to jit only one method. The reason is variable singleMethodGenericArgs is now an empty array and never null.

Repruducing steps:
1) Build the repo from main branch.
2) Write any piece of code as example.
3) Jit that code with --print-repro-instructions added on command line arguments.
4) Using the given --singlemethodtypename --singlemethodname --singlemethodindex on the output console as command line arguments will give you an exception on the line this PR is changing.