### PR TITLE
Ensure reflection property metadata is instantiated lazily

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -731,7 +731,6 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     if (!_isConfigured)
                     {
-                        // Ensure SourceGen had a chance to add properties
                         LateAddProperties();
                         _properties = new(this);
                         return;
@@ -876,12 +875,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
             else
             {
-                // Resolver didn't modify properties
-
-                // Source gen currently when initializes properties
-                // also assigns JsonPropertyInfo's JsonTypeInfo which causes SO if there are any
-                // cycles in the object graph. For that reason properties cannot be added immediately.
-                // This is a no-op for ReflectionJsonTypeInfo
+                // Resolver didn't modify any properties, create the property cache from scratch.
                 LateAddProperties();
                 PropertyCache ??= CreatePropertyCache(capacity: 0);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -23,11 +23,6 @@ namespace System.Text.Json.Serialization.Metadata
             PopulatePolymorphismMetadata();
             MapInterfaceTypesToCallbacks();
 
-            if (converter.ConverterStrategy == ConverterStrategy.Object)
-            {
-                AddPropertiesAndParametersUsingReflection();
-            }
-
             Func<object>? createObject = JsonSerializerOptions.MemberAccessorStrategy.CreateConstructor(typeof(T));
             SetCreateObjectIfCompatible(createObject);
             CreateObjectForExtensionDataProperty = createObject;
@@ -37,11 +32,17 @@ namespace System.Text.Json.Serialization.Metadata
             converter.ConfigureJsonTypeInfoUsingReflection(this, options);
         }
 
-        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private void AddPropertiesAndParametersUsingReflection()
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:RequiresUnreferencedCode",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        internal override void LateAddProperties()
         {
-            Debug.Assert(Converter.ConverterStrategy == ConverterStrategy.Object);
+            Debug.Assert(!IsConfigured);
+            Debug.Assert(PropertyCache is null);
+
+            if (Kind != JsonTypeInfoKind.Object)
+            {
+                return;
+            }
 
             const BindingFlags BindingFlags =
                 BindingFlags.Instance |


### PR DESCRIPTION
Updates the reflection-based JsonTypeInfo implementation so that the property metadata resolution logic is done lazily via the pre-existing `LateAddProperties` method used by the source-gen metadata implementation instead of the constructor. This ensures that any pre-existing errors related to property misconfiguration/unsupported properties occurs at configuration time rather than at construction time.

Fixes #76807.