### PR TITLE
Use IndexOfAny{Except}InRange in RegexCompiler / source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -3068,7 +3068,7 @@ namespace System.Text.RegularExpressions.Generator
                         (literal.String is not null ||
                          literal.SetChars is not null ||
                          literal.Range.LowInclusive == literal.Range.HighInclusive ||
-                         (literal.Range.LowInclusive <= node.Ch && node.Ch <= literal.Range.HighInclusive)))
+                         (literal.Range.LowInclusive <= node.Ch && node.Ch <= literal.Range.HighInclusive))) // for ranges, only allow when the range overlaps with the target, since there's no accelerated way to search for the union
                     {
                         // e.g. "<[^>]*?>"
 
@@ -3149,7 +3149,7 @@ namespace System.Text.RegularExpressions.Generator
                                 _ => $"{indexOfAnyName}({Literal(literal2.SetChars)});",
                             } :
                             literal2.Range.LowInclusive == literal2.Range.HighInclusive ? $"{indexOfName}({Literal(literal2.Range.LowInclusive)});" :
-                            $"{indexOfAnyName}({Literal(literal2.Range.LowInclusive)}, {Literal(literal2.Range.HighInclusive)});");
+                            $"{indexOfAnyName}InRange({Literal(literal2.Range.LowInclusive)}, {Literal(literal2.Range.HighInclusive)});");
 
                         using (EmitBlock(writer, $"if ({startingPos} < 0)"))
                         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -3413,7 +3413,7 @@ namespace System.Text.RegularExpressions
                     (literal.String is not null ||
                      literal.SetChars is not null ||
                      literal.Range.LowInclusive == literal.Range.HighInclusive ||
-                     (literal.Range.LowInclusive <= node.Ch && node.Ch <= literal.Range.HighInclusive)))
+                     (literal.Range.LowInclusive <= node.Ch && node.Ch <= literal.Range.HighInclusive))) // for ranges, only allow when the range overlaps with the target, since there's no accelerated way to search for the union
                 {
                     // e.g. "<[^>]*?>"
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -336,14 +336,26 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"b.*?", "abc", lineOption, 1, 2, true, "b");
                 yield return (@".*?", "abc", lineOption, 2, 1, true, "");
 
+                yield return (@"a.*?[b\n]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
+                yield return (@"a.*?[b\n]", "xyza12345c6789", lineOption, 0, 14, false, "");
+
                 yield return (@"a.*?[bc]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
                 yield return (@"a.*?[bc]", "xyza12345c6789", lineOption, 0, 14, true, "a12345c");
                 yield return (@"a.*?[bc]", "xyza12345d6789", lineOption, 0, 14, false, "");
+
+                yield return (@"a.*?[bc\n]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
+                yield return (@"a.*?[bc\n]", "xyza12345c6789", lineOption, 0, 14, true, "a12345c");
+                yield return (@"a.*?[bc\n]", "xyza12345d6789", lineOption, 0, 14, false, "");
 
                 yield return (@"a.*?[bcd]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
                 yield return (@"a.*?[bcd]", "xyza12345c6789", lineOption, 0, 14, true, "a12345c");
                 yield return (@"a.*?[bcd]", "xyza12345d6789", lineOption, 0, 14, true, "a12345d");
                 yield return (@"a.*?[bcd]", "xyza12345e6789", lineOption, 0, 14, false, "");
+
+                yield return (@"a.*?[bcd\n]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
+                yield return (@"a.*?[bcd\n]", "xyza12345c6789", lineOption, 0, 14, true, "a12345c");
+                yield return (@"a.*?[bcd\n]", "xyza12345d6789", lineOption, 0, 14, true, "a12345d");
+                yield return (@"a.*?[bcd\n]", "xyza12345e6789", lineOption, 0, 14, false, "");
 
                 yield return (@"a.*?[bcde]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
                 yield return (@"a.*?[bcde]", "xyza12345c6789", lineOption, 0, 14, true, "a12345c");
@@ -351,12 +363,25 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"a.*?[bcde]", "xyza12345e6789", lineOption, 0, 14, true, "a12345e");
                 yield return (@"a.*?[bcde]", "xyza12345f6789", lineOption, 0, 14, false, "");
 
+                yield return (@"a.*?[bcde\n]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
+                yield return (@"a.*?[bcde\n]", "xyza12345c6789", lineOption, 0, 14, true, "a12345c");
+                yield return (@"a.*?[bcde\n]", "xyza12345d6789", lineOption, 0, 14, true, "a12345d");
+                yield return (@"a.*?[bcde\n]", "xyza12345e6789", lineOption, 0, 14, true, "a12345e");
+                yield return (@"a.*?[bcde\n]", "xyza12345f6789", lineOption, 0, 14, false, "");
+
                 yield return (@"a.*?[bcdef]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
                 yield return (@"a.*?[bcdef]", "xyza12345c6789", lineOption, 0, 14, true, "a12345c");
                 yield return (@"a.*?[bcdef]", "xyza12345d6789", lineOption, 0, 14, true, "a12345d");
                 yield return (@"a.*?[bcdef]", "xyza12345e6789", lineOption, 0, 14, true, "a12345e");
                 yield return (@"a.*?[bcdef]", "xyza12345f6789", lineOption, 0, 14, true, "a12345f");
                 yield return (@"a.*?[bcdef]", "xyza12345g6789", lineOption, 0, 14, false, "");
+
+                yield return (@"a[^b]*?[bcdef]", "xyza12345b6789", lineOption, 0, 14, true, "a12345b");
+                yield return (@"a[^c]*?[bcdef]", "xyza12345c6789", lineOption, 0, 14, true, "a12345c");
+                yield return (@"a[^b]*?[bcdef]", "xyza12345d6789", lineOption, 0, 14, true, "a12345d");
+                yield return (@"a[^c]*?[bcdef]", "xyza12345e6789", lineOption, 0, 14, true, "a12345e");
+                yield return (@"a[^b]*?[bcdef]", "xyza12345f6789", lineOption, 0, 14, true, "a12345f");
+                yield return (@"a[^c]*?[bcdef]", "xyza12345g6789", lineOption, 0, 14, false, "");
             }
 
             // Nested loops


### PR DESCRIPTION
Depends on https://github.com/dotnet/runtime/pull/76803.

This augments our existing use of IndexOf, IndexOfAny, and IndexOfAnyExcept to also support IndexOfAnyInRange and IndexOfAnyExceptInRange.  That means, for example, we can now efficiently find the start of a pattern like `[0-9]{5}`, via a vectorized search, whereas previously it'd require iterating character by character in a scalar loop.

As part of this, I changed some tuples to instead be named structs.  They were becoming unwieldy, and we expect we'll be adding even more here as additional IndexOf variants become available.