### PR TITLE
[release/7.0] Fix regression in `JsonIgnoreAttribute` handling of unsupported property types

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -737,7 +737,6 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     if (!_isConfigured)
                     {
-                        // Ensure SourceGen had a chance to add properties
                         LateAddProperties();
                         _properties = new(this);
                         return;
@@ -882,12 +881,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
             else
             {
-                // Resolver didn't modify properties
-
-                // Source gen currently when initializes properties
-                // also assigns JsonPropertyInfo's JsonTypeInfo which causes SO if there are any
-                // cycles in the object graph. For that reason properties cannot be added immediately.
-                // This is a no-op for ReflectionJsonTypeInfo
+                // Resolver didn't modify any properties, create the property cache from scratch.
                 LateAddProperties();
                 PropertyCache ??= CreatePropertyCache(capacity: 0);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -23,11 +23,6 @@ namespace System.Text.Json.Serialization.Metadata
             PopulatePolymorphismMetadata();
             MapInterfaceTypesToCallbacks();
 
-            if (PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object)
-            {
-                AddPropertiesAndParametersUsingReflection();
-            }
-
             Func<object>? createObject = Options.MemberAccessorStrategy.CreateConstructor(typeof(T));
             SetCreateObjectIfCompatible(createObject);
             CreateObjectForExtensionDataProperty = createObject;
@@ -37,11 +32,17 @@ namespace System.Text.Json.Serialization.Metadata
             converter.ConfigureJsonTypeInfoUsingReflection(this, options);
         }
 
-        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
-        private void AddPropertiesAndParametersUsingReflection()
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:RequiresUnreferencedCode",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        internal override void LateAddProperties()
         {
-            Debug.Assert(PropertyInfoForTypeInfo.ConverterStrategy == ConverterStrategy.Object);
+            Debug.Assert(!IsConfigured);
+            Debug.Assert(PropertyCache is null);
+
+            if (Kind != JsonTypeInfoKind.Object)
+            {
+                return;
+            }
 
             const BindingFlags BindingFlags =
                 BindingFlags.Instance |


### PR DESCRIPTION
Backport of #76828 to release/7.0

## Customer Impact

We received a [couple of](https://github.com/dotnet/runtime/issues/76807) [customer reports](https://github.com/dotnet/runtime/issues/76794) that `JsonIgnoreAttribute` handling when applied to unsupported property types has regressed in .NET 7. Even though there are workarounds for the issue, these are generally unintuitive to users and require code modifications, which might inhibit migration of existing applications to .NET 7.

## Testing

Added regression testing for the identified scenarios.

## Risk

Low. Makes a minor change in product code so that a lazy loading mechanism already employed in source generated metadata is also applied to reflection derived metadata.