### PR TITLE
Double the size of new frozen segments

### DIFF
--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -4,8 +4,8 @@
 #include "common.h"
 #include "frozenobjectheap.h"
 
-// Size to reserve for a frozen segment
-#define FOH_SEGMENT_SIZE (4 * 1024 * 1024)
+// Default size to reserve for a frozen segment
+#define FOH_SEGMENT_DEFAULT_SIZE (4 * 1024 * 1024)
 // Size to commit on demand in that reserved space
 #define FOH_COMMIT_SIZE (64 * 1024)
 
@@ -36,8 +36,6 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
 
     _ASSERT(type != nullptr);
     _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
-    _ASSERT(FOH_SEGMENT_SIZE > FOH_COMMIT_SIZE);
-    _ASSERT(FOH_SEGMENT_SIZE % FOH_COMMIT_SIZE == 0);
 
     // NOTE: objectSize is expected be the full size including header
     _ASSERT(objectSize >= MIN_OBJECT_SIZE);
@@ -52,7 +50,7 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
     if (m_CurrentSegment == nullptr)
     {
         // Create the first segment on first allocation
-        m_CurrentSegment = new FrozenObjectSegment();
+        m_CurrentSegment = new FrozenObjectSegment(FOH_SEGMENT_DEFAULT_SIZE);
         m_FrozenSegments.Append(m_CurrentSegment);
         _ASSERT(m_CurrentSegment != nullptr);
     }
@@ -63,7 +61,8 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
     // to create a new one
     if (obj == nullptr)
     {
-        m_CurrentSegment = new FrozenObjectSegment();
+        // Double the reserved size to reduce the number of frozen segments in apps with lots of frozen objects
+        m_CurrentSegment = new FrozenObjectSegment(m_CurrentSegment->GetSize() * 2);
         m_FrozenSegments.Append(m_CurrentSegment);
 
         // Try again
@@ -77,17 +76,33 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
 }
 
 
-FrozenObjectSegment::FrozenObjectSegment():
+FrozenObjectSegment::FrozenObjectSegment(size_t size) :
     m_pStart(nullptr),
     m_pCurrent(nullptr),
     m_SizeCommitted(0),
+    m_Size(size),
     m_SegmentHandle(nullptr)
     COMMA_INDEBUG(m_ObjectsCount(0))
 {
-    void* alloc = ClrVirtualAlloc(nullptr, FOH_SEGMENT_SIZE, MEM_RESERVE, PAGE_READWRITE);
+    _ASSERT(m_Size > FOH_COMMIT_SIZE);
+    _ASSERT(m_Size % FOH_COMMIT_SIZE == 0);
+
+    void* alloc = ClrVirtualAlloc(nullptr, m_Size, MEM_RESERVE, PAGE_READWRITE);
     if (alloc == nullptr)
     {
-        ThrowOutOfMemory();
+        // Try again with the default FOH size
+        if (m_Size > FOH_SEGMENT_DEFAULT_SIZE)
+        {
+            m_Size = FOH_SEGMENT_DEFAULT_SIZE;
+            _ASSERT(m_Size > FOH_COMMIT_SIZE);
+            _ASSERT(m_Size % FOH_COMMIT_SIZE == 0);
+            alloc = ClrVirtualAlloc(nullptr, m_Size, MEM_RESERVE, PAGE_READWRITE);
+        }
+
+        if (alloc == nullptr)
+        {
+            ThrowOutOfMemory();
+        }
     }
 
     // Commit a chunk in advance
@@ -107,7 +122,7 @@ FrozenObjectSegment::FrozenObjectSegment():
     si.ibFirstObject = sizeof(ObjHeader);
     si.ibAllocated = si.ibFirstObject;
     si.ibCommit = FOH_COMMIT_SIZE;
-    si.ibReserved = FOH_SEGMENT_SIZE;
+    si.ibReserved = m_Size;
 
     m_SegmentHandle = GCHeapUtilities::GetGCHeap()->RegisterFrozenSegment(&si);
     if (m_SegmentHandle == nullptr)
@@ -125,13 +140,13 @@ FrozenObjectSegment::FrozenObjectSegment():
 
 Object* FrozenObjectSegment::TryAllocateObject(PTR_MethodTable type, size_t objectSize)
 {
-    _ASSERT(m_pStart != nullptr && FOH_SEGMENT_SIZE > 0 && m_SegmentHandle != nullptr); // Expected to be inited
+    _ASSERT(m_pStart != nullptr && m_Size > 0 && m_SegmentHandle != nullptr); // Expected to be inited
     _ASSERT(IS_ALIGNED(m_pCurrent, DATA_ALIGNMENT));
     _ASSERT(objectSize <= FOH_COMMIT_SIZE);
     _ASSERT(m_pCurrent >= m_pStart + sizeof(ObjHeader));
 
     const size_t spaceUsed = (size_t)(m_pCurrent - m_pStart);
-    const size_t spaceLeft = FOH_SEGMENT_SIZE - spaceUsed;
+    const size_t spaceLeft = m_Size - spaceUsed;
 
     _ASSERT(spaceUsed >= sizeof(ObjHeader));
     _ASSERT(spaceLeft >= sizeof(ObjHeader));
@@ -146,7 +161,7 @@ Object* FrozenObjectSegment::TryAllocateObject(PTR_MethodTable type, size_t obje
     if (spaceUsed + objectSize + sizeof(ObjHeader) > m_SizeCommitted)
     {
         // Make sure we don't go out of bounds during this commit
-        _ASSERT(m_SizeCommitted + FOH_COMMIT_SIZE <= FOH_SEGMENT_SIZE);
+        _ASSERT(m_SizeCommitted + FOH_COMMIT_SIZE <= m_Size);
 
         if (ClrVirtualAlloc(m_pStart + m_SizeCommitted, FOH_COMMIT_SIZE, MEM_COMMIT, PAGE_READWRITE) == nullptr)
         {

--- a/src/coreclr/vm/frozenobjectheap.h
+++ b/src/coreclr/vm/frozenobjectheap.h
@@ -38,8 +38,13 @@ private:
 class FrozenObjectSegment
 {
 public:
-    FrozenObjectSegment();
+    FrozenObjectSegment(size_t size);
     Object* TryAllocateObject(PTR_MethodTable type, size_t objectSize);
+
+    size_t GetSize() const
+    {
+        return m_Size;
+    }
 
 private:
     // Start of the reserved memory, the first object starts at "m_pStart + sizeof(ObjHeader)" (its pMT)
@@ -55,6 +60,9 @@ private:
     //
     // m_SizeCommitted <= m_pStart + FOH_SIZE_RESERVED
     size_t m_SizeCommitted;
+
+    // Total memory reserved for the current segment
+    size_t m_Size;
 
     segment_handle m_SegmentHandle;
     INDEBUG(size_t m_ObjectsCount);

--- a/src/coreclr/vm/frozenobjectheap.h
+++ b/src/coreclr/vm/frozenobjectheap.h
@@ -38,7 +38,7 @@ private:
 class FrozenObjectSegment
 {
 public:
-    FrozenObjectSegment(size_t size);
+    FrozenObjectSegment(size_t sizeHint);
     Object* TryAllocateObject(PTR_MethodTable type, size_t objectSize);
 
     size_t GetSize() const


### PR DESCRIPTION
Reduce number of frozen segments in large apps, see https://github.com/dotnet/runtime/issues/76151#issuecomment-1273886204 by doubling size of new segments.

```
Segment0: 4Mb
Segment1: 8Mb
Segment2: 16Mb
Segment3: 4Mb (e.g. it tried to reserve 32Mb but there were not enough memory for that)
Segment4: 8Mb
...
```