### PR TITLE
Detect specifical character in EnumConverter.cs

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -230,6 +230,9 @@
   </data>
   <data name="InvalidCharacterWithinString" xml:space="preserve">
     <value>'{0}' is invalid within a JSON string. The string should be correctly escaped.</value>
+  </data>
+  <data name="InvalidEnumTypeWithSpecialChar" xml:space="preserve">
+    <value>'{0}' is an invalid enum type which contains special character.</value>
   </data>
   <data name="InvalidEndOfJsonNonPrimitive" xml:space="preserve">
     <value>'{0}' is an invalid token type for the end of the JSON payload. Expected either 'EndArray' or 'EndObject'.</value>

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -232,7 +232,7 @@
     <value>'{0}' is invalid within a JSON string. The string should be correctly escaped.</value>
   </data>
   <data name="InvalidEnumTypeWithSpecialChar" xml:space="preserve">
-    <value>'{0}' is an invalid enum type which contains special character.</value>
+    <value>Enum type '{0}' uses unsupported identifer name '{1}'.</value>
   </data>
   <data name="InvalidEndOfJsonNonPrimitive" xml:space="preserve">
     <value>'{0}' is an invalid token type for the end of the JSON payload. Expected either 'EndArray' or 'EndObject'.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -529,8 +529,8 @@ namespace System.Text.Json.Serialization.Converters
 #if NET7_0_OR_GREATER
                     if (!char.IsAsciiLetterOrDigit(cha) && cha != '_')
 #else
-                    if ((uint)((cha | 0x20) - 'a') > 'z' - 'a' && 
-                     (uint)(char - '0') > '9' - '0' && 
+                    if ((uint)((cha | 0x20) - 'a') > 'z' - 'a' &&
+                     (uint)(cha - '0') > '9' - '0' &&
                      cha != '_')
 #endif
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -18,8 +18,6 @@ namespace System.Text.Json.Serialization.Converters
         // Odd type codes are conveniently signed types (for enum backing types).
         private static readonly bool s_isSignedEnum = ((int)s_enumTypeCode % 2) == 1;
 
-        private static readonly char[] s_specialChars = { ',' };
-
         private static readonly bool s_containsSpecialChar = ContainsSpecialChar();
 
         private const string ValueSeparator = ", ";
@@ -521,16 +519,22 @@ namespace System.Text.Json.Serialization.Converters
 #if NETCOREAPP
             string[] names = Enum.GetNames<T>();
 #else
-            string[] names = Enum.GetNames(TypeToConvert);
+            string[] names = Enum.GetNames(typeof(T));
 #endif
 
             foreach (string name in names)
             {
-                foreach (char specialChar in s_specialChars)
+                foreach (char cha in name)
                 {
-                    if (name.Contains(specialChar))
+#if NET7_0_OR_GREATER
+                    if (!char.IsAsciiLetterOrDigit(cha) && cha != '_')
+#else
+                    if ((uint)((cha | 0x20) - 'a') > 'z' - 'a' && 
+                     (uint)(char - '0') > '9' - '0' && 
+                     cha != '_')
+#endif
                     {
-                        return true;
+                        return false;
                     }
                 }
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -17,10 +17,10 @@ namespace System.Text.Json.Serialization.Converters
 
         private static readonly char[] s_specialChars = new[] { ',', ' ' };
 
+        private static readonly bool s_containsSpecialChar = ContainsSpecialChar();
+
         // Odd type codes are conveniently signed types (for enum backing types).
         private static readonly bool s_isSignedEnum = ((int)s_enumTypeCode % 2) == 1;
-
-        private static readonly bool s_containsSpecialChar = ContainsSpecialChar();
 
         private const string ValueSeparator = ", ";
 
@@ -532,16 +532,9 @@ namespace System.Text.Json.Serialization.Converters
 
             foreach (string name in names)
             {
-                foreach (char cha in s_specialChars)
+                if (name.IndexOfAny(s_specialChars) != -1)
                 {
-#if NETCOREAPP2_1_OR_GREATER
-                    if (name.Contains(cha))
-#else
-                    if (name.IndexOf(cha) != -1)
-#endif
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -56,6 +56,12 @@ namespace System.Text.Json.Serialization.Converters
 
         public EnumConverter(EnumConverterOptions converterOptions, JsonNamingPolicy? namingPolicy, JsonSerializerOptions serializerOptions)
         {
+            // If enum contains special char, make it failed to serialize or deserialize.
+            if (s_containsSpecialChar)
+            {
+                ThrowHelper.ThrowJsonException();
+            }
+
             _converterOptions = converterOptions;
             _namingPolicy = namingPolicy;
             _nameCacheForWriting = new ConcurrentDictionary<ulong, JsonEncodedText>();
@@ -112,12 +118,6 @@ namespace System.Text.Json.Serialization.Converters
 #endif
                 {
                     return value;
-                }
-
-                // If enum contains special char, fail before passing bogus tokens into the naming policy.
-                if (s_containsSpecialChar)
-                {
-                    ThrowHelper.ThrowJsonException();
                 }
 
 #if NETCOREAPP
@@ -196,12 +196,6 @@ namespace System.Text.Json.Serialization.Converters
             // If strings are allowed, attempt to write it out as a string value
             if (_converterOptions.HasFlag(EnumConverterOptions.AllowStrings))
             {
-                // If enum contains special char, fail instead of write wrong json string.
-                if (s_containsSpecialChar)
-                {
-                    ThrowHelper.ThrowJsonException();
-                }
-
                 ulong key = ConvertToUInt64(value);
 
                 if (_nameCacheForWriting.TryGetValue(key, out JsonEncodedText formatted))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -117,7 +117,6 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     return value;
                 }
-
 #if NETCOREAPP
                 return ReadEnumUsingNamingPolicy(reader.GetString());
 #else

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Converters
             // If enum contains special char, make it failed to serialize or deserialize.
             if (s_containsSpecialChar)
             {
-                ThrowHelper.ThrowJsonException();
+                ThrowHelper.ThrowInvalidOperationException_InvalidEnumTypeWithSpecialChar(typeof(T));
             }
 
             _converterOptions = converterOptions;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -812,6 +812,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        public static void ThrowInvalidOperationException_InvalidEnumTypeWithSpecialChar(Type enumType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.InvalidEnumTypeWithSpecialChar, enumType.Name));
+        }
+
+        [DoesNotReturn]
         public static void ThrowJsonException_UnrecognizedTypeDiscriminator(object typeDiscriminator)
         {
             ThrowJsonException(SR.Format(SR.Polymorphism_UnrecognizedTypeDiscriminator, typeDiscriminator));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -812,9 +812,9 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowInvalidOperationException_InvalidEnumTypeWithSpecialChar(Type enumType)
+        public static void ThrowInvalidOperationException_InvalidEnumTypeWithSpecialChar(Type enumType, string enumName)
         {
-            throw new InvalidOperationException(SR.Format(SR.InvalidEnumTypeWithSpecialChar, enumType.Name));
+            throw new InvalidOperationException(SR.Format(SR.InvalidEnumTypeWithSpecialChar, enumType.Name, enumName));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -1,0 +1,18 @@
+﻿module System.Text.Json.Tests.FSharp.EnumTests
+
+open System
+open System.Text.Json
+open Xunit
+
+[<Flags>]
+type MyEnum =
+  | ``There's a comma, in my name`` = 1
+  | ``There's a comma, even here`` = 2
+
+let enum = (MyEnum.``There's a comma, in my name`` ||| MyEnum.``There's a comma, even here``).ToString()
+
+[<Fact>]
+let ``Throw Exception If Enum Contains Comma`` () =
+    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<MyEnum>(enum) |> ignore)
+
+

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -5,14 +5,23 @@ open System.Text.Json
 open Xunit
 
 [<Flags>]
-type MyEnum =
+type BadEnum =
   | ``There's a comma, in my name`` = 1
   | ``There's a comma, even here`` = 2
 
-let enum = (MyEnum.``There's a comma, in my name`` ||| MyEnum.``There's a comma, even here``).ToString()
+let badEnum = (BadEnum.``There's a comma, in my name`` ||| BadEnum.``There's a comma, even here``).ToString()
+
+[<Flags>]
+type GoodEnum =
+  | ``Thereisnocommainmyname_1`` = 1
+  | ``Thereisnocommaevenhere_2`` = 2
+
+let goodEnum = (GoodEnum.``Thereisnocommainmyname_1`` ||| GoodEnum.``Thereisnocommaevenhere_2``).ToString()
 
 [<Fact>]
-let ``Throw Exception If Enum Contains Comma`` () =
-    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<MyEnum>(enum) |> ignore)
+let ``Throw Exception If Enum Contains Special Char`` () =
+    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnum) |> ignore)
 
-
+[<Fact>]
+let ``Successful deserialize normal enum`` () =
+    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<BadEnum>(goodEnum) |> ignore)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -13,7 +13,7 @@ type BadEnum =
   | ``ThisisagoodEnumValue`` = 4
 
 let badEnum = BadEnum.``There's a comma, in my name`` ||| BadEnum.``There's a comma, even here``
-let badEnumJsonStr = @$"""{badEnum.ToString()}"""
+let badEnumJsonStr = $"\"{badEnum}\""
 
 let badEnumWithGoodValue = BadEnum.ThisisagoodEnumValue
 let badEnumWithGoodValueJsonStr = @$"""{badEnumWithGoodValue.ToString()}"""

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -2,6 +2,7 @@
 
 open System
 open System.Text.Json
+open System.Text.Json.Serialization
 open Xunit
 
 [<Flags>]
@@ -18,10 +19,16 @@ type GoodEnum =
 
 let goodEnum = (GoodEnum.``Thereisnocommainmyname_1`` ||| GoodEnum.``Thereisnocommaevenhere_2``).ToString()
 
+
+let options = new JsonSerializerOptions()
+options.Converters.Add(new JsonStringEnumConverter())
+
 [<Fact>]
 let ``Throw Exception If Enum Contains Special Char`` () =
-    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnum) |> ignore)
+    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<BadEnum>(@$"""{badEnum}""", options) |> ignore)
 
 [<Fact>]
 let ``Successful deserialize normal enum`` () =
-    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<BadEnum>(goodEnum) |> ignore)
+    let actual = JsonSerializer.Deserialize<GoodEnum>(@$"""{goodEnum}""", options)
+    Assert.Equal(GoodEnum.Thereisnocommainmyname_1 ||| GoodEnum.Thereisnocommaevenhere_2, actual)
+

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -1,6 +1,7 @@
 ﻿module System.Text.Json.Tests.FSharp.EnumTests
 
 open System
+open System.Reflection
 open System.Text.Json
 open System.Text.Json.Serialization
 open Xunit
@@ -14,15 +15,15 @@ type BadEnum =
 let badEnum = BadEnum.``There's a comma, in my name`` ||| BadEnum.``There's a comma, even here``
 let badEnumJsonStr = @$"""{badEnum.ToString()}"""
 
-let badEnumWithGoodValue = BadEnum.``ThisisagoodEnumValue``
+let badEnumWithGoodValue = BadEnum.ThisisagoodEnumValue
 let badEnumWithGoodValueJsonStr = @$"""{badEnumWithGoodValue.ToString()}"""
 
 [<Flags>]
 type GoodEnum =
-  | ``Thereisnocommainmyname_1`` = 1
-  | ``Thereisnocommaevenhere_2`` = 2
+  | Thereisnocommainmyname_1 = 1
+  | Thereisnocommaevenhere_2 = 2
 
-let goodEnum = GoodEnum.``Thereisnocommainmyname_1`` ||| GoodEnum.``Thereisnocommaevenhere_2``
+let goodEnum = GoodEnum.Thereisnocommainmyname_1 ||| GoodEnum.Thereisnocommaevenhere_2
 let goodEnumJsonStr = @$"""{goodEnum.ToString()}"""
 
 let options = new JsonSerializerOptions()
@@ -30,11 +31,11 @@ options.Converters.Add(new JsonStringEnumConverter())
 
 [<Fact>]
 let ``Deserialize With Exception If Enum Contains Special Char`` () =
-    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumJsonStr, options) |> ignore)
+    Assert.Throws<TargetInvocationException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumJsonStr, options) |> ignore)
 
 [<Fact>]
 let ``Serialize With Exception If Enum Contains Special Char`` () =
-    Assert.Throws<JsonException>(fun () ->  JsonSerializer.Serialize(badEnum, options) |> ignore)
+    Assert.Throws<TargetInvocationException>(fun () ->  JsonSerializer.Serialize(badEnum, options) |> ignore)
 
 [<Fact>]
 let ``Successful Deserialize Normal Enum`` () =
@@ -42,10 +43,9 @@ let ``Successful Deserialize Normal Enum`` () =
     Assert.Equal(GoodEnum.Thereisnocommainmyname_1 ||| GoodEnum.Thereisnocommaevenhere_2, actual)
 
 [<Fact>]
-let ``Success Deserialize Good Value Of Bad Enum Type`` () =
-    let jsonStr = JsonSerializer.Deserialize<BadEnum>(badEnumWithGoodValueJsonStr, options)
-    Assert.Equal(BadEnum.ThisisagoodEnumValue, jsonStr)
+let ``Fail Deserialize Good Value Of Bad Enum Type`` () =
+    Assert.Throws<TargetInvocationException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumWithGoodValueJsonStr, options) |> ignore)
 
 [<Fact>]
 let ``Fail Serialize Good Value Of Bad Enum Type`` () =
-    Assert.Throws<JsonException>(fun () ->  JsonSerializer.Serialize(badEnumWithGoodValue, options) |> ignore)
+    Assert.Throws<TargetInvocationException>(fun () ->  JsonSerializer.Serialize(badEnumWithGoodValue, options) |> ignore)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -24,7 +24,7 @@ type GoodEnum =
   | Thereisnocommaevenhere_2 = 2
 
 let goodEnum = GoodEnum.Thereisnocommainmyname_1 ||| GoodEnum.Thereisnocommaevenhere_2
-let goodEnumJsonStr = @$"""{goodEnum.ToString()}"""
+let goodEnumJsonStr = $"\"{goodEnum}\""
 
 let options = new JsonSerializerOptions()
 options.Converters.Add(new JsonStringEnumConverter())

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -16,7 +16,7 @@ let badEnum = BadEnum.``There's a comma, in my name`` ||| BadEnum.``There's a co
 let badEnumJsonStr = $"\"{badEnum}\""
 
 let badEnumWithGoodValue = BadEnum.ThisisagoodEnumValue
-let badEnumWithGoodValueJsonStr = @$"""{badEnumWithGoodValue.ToString()}"""
+let badEnumWithGoodValueJsonStr = $"\"{badEnumWithGoodValue}\""
 
 [<Flags>]
 type GoodEnum =

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -33,14 +33,14 @@ options.Converters.Add(new JsonStringEnumConverter())
 let ``Deserialize With Exception If Enum Contains Special Char`` () =
     let ex = Assert.Throws<TargetInvocationException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumJsonStr, options) |> ignore)
     Assert.Equal(typeof<InvalidOperationException>, ex.InnerException.GetType())
-    Assert.Equal("'BadEnum' is an invalid enum type which contains special character.", ex.InnerException.Message)
+    Assert.Equal("Enum type 'BadEnum' uses unsupported identifer name 'There's a comma, in my name'.", ex.InnerException.Message)
 
 
 [<Fact>]
 let ``Serialize With Exception If Enum Contains Special Char`` () =
     let ex = Assert.Throws<TargetInvocationException>(fun () ->  JsonSerializer.Serialize(badEnum, options) |> ignore)
     Assert.Equal(typeof<InvalidOperationException>, ex.InnerException.GetType())
-    Assert.Equal("'BadEnum' is an invalid enum type which contains special character.", ex.InnerException.Message)
+    Assert.Equal("Enum type 'BadEnum' uses unsupported identifer name 'There's a comma, in my name'.", ex.InnerException.Message)
 
 [<Fact>]
 let ``Successful Deserialize Normal Enum`` () =
@@ -51,10 +51,10 @@ let ``Successful Deserialize Normal Enum`` () =
 let ``Fail Deserialize Good Value Of Bad Enum Type`` () =
     let ex = Assert.Throws<TargetInvocationException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumWithGoodValueJsonStr, options) |> ignore)
     Assert.Equal(typeof<InvalidOperationException>, ex.InnerException.GetType())
-    Assert.Equal("'BadEnum' is an invalid enum type which contains special character.", ex.InnerException.Message)
+    Assert.Equal("Enum type 'BadEnum' uses unsupported identifer name 'There's a comma, in my name'.", ex.InnerException.Message)
 
 [<Fact>]
 let ``Fail Serialize Good Value Of Bad Enum Type`` () =
     let ex = Assert.Throws<TargetInvocationException>(fun () ->  JsonSerializer.Serialize(badEnumWithGoodValue, options) |> ignore)
     Assert.Equal(typeof<InvalidOperationException>, ex.InnerException.GetType())
-    Assert.Equal("'BadEnum' is an invalid enum type which contains special character.", ex.InnerException.Message)
+    Assert.Equal("Enum type 'BadEnum' uses unsupported identifer name 'There's a comma, in my name'.", ex.InnerException.Message)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -31,11 +31,16 @@ options.Converters.Add(new JsonStringEnumConverter())
 
 [<Fact>]
 let ``Deserialize With Exception If Enum Contains Special Char`` () =
-    Assert.Throws<TargetInvocationException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumJsonStr, options) |> ignore)
+    let ex = Assert.Throws<TargetInvocationException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumJsonStr, options) |> ignore)
+    Assert.Equal(typeof<InvalidOperationException>, ex.InnerException.GetType())
+    Assert.Equal("'BadEnum' is an invalid enum type which contains special character.", ex.InnerException.Message)
+
 
 [<Fact>]
 let ``Serialize With Exception If Enum Contains Special Char`` () =
-    Assert.Throws<TargetInvocationException>(fun () ->  JsonSerializer.Serialize(badEnum, options) |> ignore)
+    let ex = Assert.Throws<TargetInvocationException>(fun () ->  JsonSerializer.Serialize(badEnum, options) |> ignore)
+    Assert.Equal(typeof<InvalidOperationException>, ex.InnerException.GetType())
+    Assert.Equal("'BadEnum' is an invalid enum type which contains special character.", ex.InnerException.Message)
 
 [<Fact>]
 let ``Successful Deserialize Normal Enum`` () =
@@ -44,8 +49,12 @@ let ``Successful Deserialize Normal Enum`` () =
 
 [<Fact>]
 let ``Fail Deserialize Good Value Of Bad Enum Type`` () =
-    Assert.Throws<TargetInvocationException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumWithGoodValueJsonStr, options) |> ignore)
+    let ex = Assert.Throws<TargetInvocationException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumWithGoodValueJsonStr, options) |> ignore)
+    Assert.Equal(typeof<InvalidOperationException>, ex.InnerException.GetType())
+    Assert.Equal("'BadEnum' is an invalid enum type which contains special character.", ex.InnerException.Message)
 
 [<Fact>]
 let ``Fail Serialize Good Value Of Bad Enum Type`` () =
-    Assert.Throws<TargetInvocationException>(fun () ->  JsonSerializer.Serialize(badEnumWithGoodValue, options) |> ignore)
+    let ex = Assert.Throws<TargetInvocationException>(fun () ->  JsonSerializer.Serialize(badEnumWithGoodValue, options) |> ignore)
+    Assert.Equal(typeof<InvalidOperationException>, ex.InnerException.GetType())
+    Assert.Equal("'BadEnum' is an invalid enum type which contains special character.", ex.InnerException.Message)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/EnumTests.fs
@@ -9,26 +9,43 @@ open Xunit
 type BadEnum =
   | ``There's a comma, in my name`` = 1
   | ``There's a comma, even here`` = 2
+  | ``ThisisagoodEnumValue`` = 4
 
-let badEnum = (BadEnum.``There's a comma, in my name`` ||| BadEnum.``There's a comma, even here``).ToString()
+let badEnum = BadEnum.``There's a comma, in my name`` ||| BadEnum.``There's a comma, even here``
+let badEnumJsonStr = @$"""{badEnum.ToString()}"""
+
+let badEnumWithGoodValue = BadEnum.``ThisisagoodEnumValue``
+let badEnumWithGoodValueJsonStr = @$"""{badEnumWithGoodValue.ToString()}"""
 
 [<Flags>]
 type GoodEnum =
   | ``Thereisnocommainmyname_1`` = 1
   | ``Thereisnocommaevenhere_2`` = 2
 
-let goodEnum = (GoodEnum.``Thereisnocommainmyname_1`` ||| GoodEnum.``Thereisnocommaevenhere_2``).ToString()
-
+let goodEnum = GoodEnum.``Thereisnocommainmyname_1`` ||| GoodEnum.``Thereisnocommaevenhere_2``
+let goodEnumJsonStr = @$"""{goodEnum.ToString()}"""
 
 let options = new JsonSerializerOptions()
 options.Converters.Add(new JsonStringEnumConverter())
 
 [<Fact>]
-let ``Throw Exception If Enum Contains Special Char`` () =
-    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<BadEnum>(@$"""{badEnum}""", options) |> ignore)
+let ``Deserialize With Exception If Enum Contains Special Char`` () =
+    Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<BadEnum>(badEnumJsonStr, options) |> ignore)
 
 [<Fact>]
-let ``Successful deserialize normal enum`` () =
-    let actual = JsonSerializer.Deserialize<GoodEnum>(@$"""{goodEnum}""", options)
+let ``Serialize With Exception If Enum Contains Special Char`` () =
+    Assert.Throws<JsonException>(fun () ->  JsonSerializer.Serialize(badEnum, options) |> ignore)
+
+[<Fact>]
+let ``Successful Deserialize Normal Enum`` () =
+    let actual = JsonSerializer.Deserialize<GoodEnum>(goodEnumJsonStr, options)
     Assert.Equal(GoodEnum.Thereisnocommainmyname_1 ||| GoodEnum.Thereisnocommaevenhere_2, actual)
 
+[<Fact>]
+let ``Success Deserialize Good Value Of Bad Enum Type`` () =
+    let jsonStr = JsonSerializer.Deserialize<BadEnum>(badEnumWithGoodValueJsonStr, options)
+    Assert.Equal(BadEnum.ThisisagoodEnumValue, jsonStr)
+
+[<Fact>]
+let ``Fail Serialize Good Value Of Bad Enum Type`` () =
+    Assert.Throws<JsonException>(fun () ->  JsonSerializer.Serialize(badEnumWithGoodValue, options) |> ignore)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/System.Text.Json.FSharp.Tests.fsproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/System.Text.Json.FSharp.Tests.fsproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="EnumTests.fs" />
     <Compile Include="Helpers.fs" />
     <Compile Include="OptionTests.fs" />
     <Compile Include="ValueOptionTests.fs" />

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/System.Text.Json.FSharp.Tests.fsproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.FSharp.Tests/System.Text.Json.FSharp.Tests.fsproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="EnumTests.fs" />
     <Compile Include="Helpers.fs" />
+    <Compile Include="EnumTests.fs" />
     <Compile Include="OptionTests.fs" />
     <Compile Include="ValueOptionTests.fs" />
     <Compile Include="CollectionTests.fs" />


### PR DESCRIPTION

It is possible for enum identifiers to contain commas in [IL](https://sharplab.io/#v2:DYLgZgzgNALiCWwA+B7ADgUwHYAIDKAnhDBgLYCwAUFQNoA8AYsAIYDmEAfALpUwGY4AsgQCiWAK6kcAXio4cSHAAMlAFQAWGAE4YA5BBzMcAYxSlSzKDni5SBHFmakMKmTgCMchcrWad+wxMzCysMADdsHD8XJTcAJi8qYAwYBycMNwAKYTFJADoVDW09AyNTc0trW3tHZ1ckBqFRCVIC32KAsuDK8MjolQBKPNUUPBgtG1ZMgaoAelmcMOZgNOcQHGIJrFY3ACIi/1KgiqsbHDtVjCsDksDykJxe3GjdqiSUnB0IcWBU6Rxcq0AArMLQQDB0HItDiZWoYGaUeb4IgkVoAQS0rEk2BgIgAHsYMGgYPAUFh1gAlDAAR3EGGIGAAJotlnScLobp1jg8zhc4ddolz7j0Is8OjgAO7MAxYFCpMAocRYRl5OYLeSGVKEBmtQHDLQEEFgjAAIQIADl0pkKUqSc5VPwMthJA7MFYqcxGQB5LDAAh4NDMLBKdws4B0qwmlAoZJB6ysWU6ADC0quOCjMYwcZg6i0KAlPoYzEQ4h0VgAqgBJLAwABsABYAGSfek/GAIpEa5halFkPJ61QGo3g6swADMcUB1tt8HtjseLVdaY93t9/sDwdDS3DadHE/ONmrxnDEHgESse7i52YeKPJ7PaYzsdw8ATKGTqcj0efOBzeYLWBFiWZY4EuSYoIyGR8G6OCXs2Xxth26ryN2yI6v2LT6oaoLgjQqiAlw1pZqufoBkGIZhhG6bflmL5vh+4Jfpm2a5vmhbFuGIH4S08Gtr8SEapqaGohh+SDthxp4QRmRjFsOzblRT60fGiYYCmjHUcxuB/mxgEcaWabcZIvHfPxaqCah2oiXqw4YFJLSEbJkyUY+NFxq+qnqfC5ldj26E2ThdlGaQjnjM5CneYiyFCXQYygjA4hoOBkEACQMHglYAPoAAzZe4ACsHB5GlGU5Xl+V5BYNgAALVdMVQ4EmIAADrluCYLNRg8AwBAoKBs1kERMAA1ylgKTNVoM7OAAtGAWYJToY7NRAWjGM1wDwAARlooLwPSzVWX2qgYHiMB5AAUhAZLLTAjI2CAG1jTgcT5T5KF+SJNo1rOGCCCk6gQQAEkGjLJHk1ZhCgADWv3/RBmReptABWGDGKkMCgqwKRWAAaig8CMgAVIThiYtiNbQPgHndgZGyvkxP7wBA4FYJs4ho++Am+cJfZUmAyRo6SWB5H9OYQRD0PaODWCQzDCPI6jqQoMjF41kC4wk5jlMmjYd3bEwbAGDYssYGiMDjAMQA===).

Use reflection to check whethe enum value contains specifical character ( chars except digit, letter and underscore). Fail early, before pass bogus tokens into the naming policy.


closes #73712