### PR TITLE
Add support for using sccache on Unix

### DIFF
--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -166,7 +166,7 @@ if [[ "$__TargetArch" != "$__HostArch" ]]; then
 fi
 
 if [[ "$USE_SCCACHE" == "true" ]]; then
-    __CMakeArgs="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+    __CMakeArgs="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache $__CMakeArgs"
 fi
 
 eval "$__RepoRootDir/eng/native/version/copy_version_files.sh"

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -165,6 +165,10 @@ if [[ "$__TargetArch" != "$__HostArch" ]]; then
     __CMakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__TargetArch $__CMakeArgs"
 fi
 
+if [[ "$USE_SCCACHE" == "true" ]]; then
+    __CMakeArgs="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+fi
+
 eval "$__RepoRootDir/eng/native/version/copy_version_files.sh"
 
 build_native "$__TargetOS" "$__HostArch" "$__ProjectRoot" "$__IntermediatesDir" "$__CMakeTarget" "$__CMakeArgs" "CoreCLR component"


### PR DESCRIPTION
sccache (https://github.com/mozilla/sccache) is a compiler caching tool that supports local or remote storage. It's useful in /runtime for caching the results of the C++ components of the build.

This PR adds support for dotnet/runtime by recognizing a $USE_SCCACHE=true environment variable, which then instructs CMake to look for a the sccache binary in the PATH.

This support is still experimental in dotnet/runtime and only on Linux/Mac. It's not confirmed that caching is completely safe for the build.