### PR TITLE
Update Arm64 cross build container

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -40,7 +40,7 @@ extends:
           jobTemplate: /eng/pipelines/mono/templates/build-job.yml
           runtimeFlavor: mono
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           platforms:
           - Linux_arm64
 
@@ -49,7 +49,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           platforms:
           - Linux_arm64
           jobParameters:
@@ -61,7 +61,7 @@ extends:
           jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
           buildConfig: release
           runtimeFlavor: mono
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           platforms:
           - Linux_arm64
           jobParameters:
@@ -81,7 +81,7 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
           runtimeFlavor: mono
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           platforms:
           - Browser_wasm
           jobParameters:
@@ -104,7 +104,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           platforms:
           - Linux_arm64
           - windows_arm64
@@ -116,7 +116,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           runtimeFlavor: mono
           platforms:
           - Browser_wasm
@@ -137,7 +137,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           runtimeFlavor: mono
           runtimeVariant: 'llvmaot'
           platforms:
@@ -164,7 +164,7 @@ extends:
           runtimeFlavor: aot
           platforms:
           - Linux_arm64
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           jobParameters:
             testGroup: perf
             liveLibrariesBuildConfig: Release
@@ -184,7 +184,7 @@ extends:
           runtimeFlavor: coreclr
           platforms:
           - Linux_arm64
-          container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
+          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
           jobParameters:
             testGroup: perf
             liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -40,7 +40,7 @@ extends:
           jobTemplate: /eng/pipelines/mono/templates/build-job.yml
           runtimeFlavor: mono
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           platforms:
           - Linux_arm64
 
@@ -49,7 +49,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           platforms:
           - Linux_arm64
           jobParameters:
@@ -61,7 +61,7 @@ extends:
           jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
           buildConfig: release
           runtimeFlavor: mono
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           platforms:
           - Linux_arm64
           jobParameters:
@@ -81,7 +81,7 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
           runtimeFlavor: mono
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           platforms:
           - Browser_wasm
           jobParameters:
@@ -104,7 +104,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           platforms:
           - Linux_arm64
           - windows_arm64
@@ -116,7 +116,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           runtimeFlavor: mono
           platforms:
           - Browser_wasm
@@ -137,7 +137,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           runtimeFlavor: mono
           runtimeVariant: 'llvmaot'
           platforms:
@@ -164,7 +164,7 @@ extends:
           runtimeFlavor: aot
           platforms:
           - Linux_arm64
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           jobParameters:
             testGroup: perf
             liveLibrariesBuildConfig: Release
@@ -184,7 +184,7 @@ extends:
           runtimeFlavor: coreclr
           platforms:
           - Linux_arm64
-          container: ubuntu-18.04-cross-arm64-20221004183302-3fc5553
+          container: ubuntu-18.04-cross-arm64
           jobParameters:
             testGroup: perf
             liveLibrariesBuildConfig: Release


### PR DESCRIPTION
Updating to the latest container for cross build. This should resolve the build issues we are seeing in our Arm64 runs.