### PR TITLE
[release/7.0] Ensure source generated metadata properties are read-only. (#76540)

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1015,6 +1015,8 @@ private static {JsonParameterInfoValuesTypeRef}[] {typeGenerationSpec.TypeInfoPr
 
                 return $@"
 
+// Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
+// methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
 private void {serializeMethodName}({Utf8JsonWriterTypeRef} {WriterVarName}, {valueTypeRef} {ValueVarName})
 {{
     {GetEarlyNullCheckSource(emitNullCheck)}
@@ -1090,15 +1092,18 @@ private void {serializeMethodName}({Utf8JsonWriterTypeRef} {WriterVarName}, {val
 /// </summary>
 public {typeInfoPropertyTypeRef} {typeFriendlyName}
 {{
-    get => _{typeFriendlyName} ??= {typeMetadata.CreateTypeInfoMethodName}({OptionsInstanceVariableName});
+    get => _{typeFriendlyName} ??= {typeMetadata.CreateTypeInfoMethodName}({OptionsInstanceVariableName}, makeReadOnly: true);
 }}
 
-// Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-// methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-private {typeInfoPropertyTypeRef} {typeMetadata.CreateTypeInfoMethodName}({JsonSerializerOptionsTypeRef} {OptionsLocalVariableName})
+private {typeInfoPropertyTypeRef} {typeMetadata.CreateTypeInfoMethodName}({JsonSerializerOptionsTypeRef} {OptionsLocalVariableName}, bool makeReadOnly)
 {{
     {typeInfoPropertyTypeRef}? {JsonTypeInfoReturnValueLocalVariableName} = null;
     {WrapWithCheckForCustomConverter(metadataInitSource, typeCompilableName)}
+
+    if (makeReadOnly)
+    {{
+        {JsonMetadataServicesTypeRef}.MakeReadOnly({JsonTypeInfoReturnValueLocalVariableName});
+    }}
 
     return {JsonTypeInfoReturnValueLocalVariableName};
 }}
@@ -1276,30 +1281,23 @@ public override {JsonTypeInfoTypeRef} GetTypeInfo({TypeTypeRef} type)
                 // Explicit IJsonTypeInfoResolver implementation
                 sb.AppendLine();
                 sb.Append(@$"{JsonTypeInfoTypeRef}? {JsonTypeInfoResolverTypeRef}.GetTypeInfo({TypeTypeRef} type, {JsonSerializerOptionsTypeRef} {OptionsLocalVariableName})
-{{
-    if ({OptionsInstanceVariableName} == {OptionsLocalVariableName})
-    {{
-        return this.GetTypeInfo(type);
-    }}
-    else
-    {{");
+{{");
                 // TODO (https://github.com/dotnet/runtime/issues/52218): Make this Dictionary-lookup-based if root-serializable type count > 64.
                 foreach (TypeGenerationSpec metadata in types)
                 {
                     if (metadata.ClassType != ClassType.TypeUnsupportedBySourceGen)
                     {
                         sb.Append($@"
-        if (type == typeof({metadata.TypeRef}))
-        {{
-            return {metadata.CreateTypeInfoMethodName}({OptionsLocalVariableName});
-        }}
+    if (type == typeof({metadata.TypeRef}))
+    {{
+        return {metadata.CreateTypeInfoMethodName}({OptionsLocalVariableName}, makeReadOnly: false);
+    }}
 ");
                     }
                 }
 
                 sb.Append($@"
-        return null;
-    }}
+    return null;
 }}
 ");
 

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -3,11 +3,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
-using System.Reflection.Metadata;
-using System.Text.Json;
 using System.Text.Json.Reflection;
 using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis;
@@ -28,6 +25,7 @@ namespace System.Text.Json.SourceGeneration
             private const string DefaultOptionsStaticVarName = "s_defaultOptions";
             private const string DefaultContextBackingStaticVarName = "s_defaultContext";
             internal const string GetConverterFromFactoryMethodName = "GetConverterFromFactory";
+            private const string MakeReadOnlyMethodName = "MakeReadOnly";
             private const string InfoVarName = "info";
             private const string PropertyInfoVarName = "propertyInfo";
             internal const string JsonContextVarName = "jsonContext";
@@ -1102,7 +1100,7 @@ private {typeInfoPropertyTypeRef} {typeMetadata.CreateTypeInfoMethodName}({JsonS
 
     if (makeReadOnly)
     {{
-        {JsonMetadataServicesTypeRef}.MakeReadOnly({JsonTypeInfoReturnValueLocalVariableName});
+        {JsonTypeInfoReturnValueLocalVariableName}.{MakeReadOnlyMethodName}();
     }}
 
     return {JsonTypeInfoReturnValueLocalVariableName};

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -1077,6 +1077,7 @@ namespace System.Text.Json.Serialization.Metadata
         public static System.Text.Json.Serialization.JsonConverter<System.Text.Json.Nodes.JsonNode> JsonNodeConverter { get { throw null; } }
         public static System.Text.Json.Serialization.JsonConverter<System.Text.Json.Nodes.JsonObject> JsonObjectConverter { get { throw null; } }
         public static System.Text.Json.Serialization.JsonConverter<System.Text.Json.Nodes.JsonValue> JsonValueConverter { get { throw null; } }
+        public static void MakeReadOnly(System.Text.Json.Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
         public static System.Text.Json.Serialization.JsonConverter<object?> ObjectConverter { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public static System.Text.Json.Serialization.JsonConverter<sbyte> SByteConverter { get { throw null; } }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -1077,7 +1077,6 @@ namespace System.Text.Json.Serialization.Metadata
         public static System.Text.Json.Serialization.JsonConverter<System.Text.Json.Nodes.JsonNode> JsonNodeConverter { get { throw null; } }
         public static System.Text.Json.Serialization.JsonConverter<System.Text.Json.Nodes.JsonObject> JsonObjectConverter { get { throw null; } }
         public static System.Text.Json.Serialization.JsonConverter<System.Text.Json.Nodes.JsonValue> JsonValueConverter { get { throw null; } }
-        public static void MakeReadOnly(System.Text.Json.Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
         public static System.Text.Json.Serialization.JsonConverter<object?> ObjectConverter { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public static System.Text.Json.Serialization.JsonConverter<sbyte> SByteConverter { get { throw null; } }
@@ -1191,7 +1190,9 @@ namespace System.Text.Json.Serialization.Metadata
         internal JsonTypeInfo() { }
         public System.Text.Json.Serialization.JsonConverter Converter { get { throw null; } }
         public System.Func<object>? CreateObject { get { throw null; } set { } }
+        public bool IsReadOnly { get { throw null; } }
         public System.Text.Json.Serialization.Metadata.JsonTypeInfoKind Kind { get { throw null; } }
+        public void MakeReadOnly() { throw null; }
         public System.Text.Json.Serialization.JsonNumberHandling? NumberHandling { get { throw null; } set { } }
         public System.Action<object>? OnDeserialized { get { throw null; } set { } }
         public System.Action<object>? OnDeserializing { get { throw null; } set { } }

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -247,10 +247,10 @@
     <value>Cannot add callbacks to the 'Modifiers' property after the resolver has been used for the first time.</value>
   </data>
   <data name="TypeInfoImmutable" xml:space="preserve">
-    <value>JsonTypeInfo cannot be changed after first usage.</value>
+    <value>This JsonTypeInfo instance is marked read-only or has already been used in serialization or deserialization.</value>
   </data>
   <data name="PropertyInfoImmutable" xml:space="preserve">
-    <value>JsonPropertyInfo cannot be changed after first usage.</value>
+    <value>This JsonTypeInfo instance is marked read-only or has already been used in serialization or deserialization.</value>
   </data>
   <data name="MaxDepthMustBePositive" xml:space="preserve">
     <value>Max depth must be positive.</value>
@@ -337,7 +337,7 @@
     <value>The JSON object contains a trailing comma at the end which is not supported in this mode. Change the reader options.</value>
   </data>
   <data name="SerializerOptionsImmutable" xml:space="preserve">
-    <value>Serializer options cannot be changed once serialization or deserialization has occurred.</value>
+    <value>This JsonSerializerOptions instance is read-only or has already been used in serialization or deserialization.</value>
   </data>
   <data name="StreamNotWritable" xml:space="preserve">
     <value>Stream is not writable.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
@@ -94,20 +94,5 @@ namespace System.Text.Json.Serialization.Metadata
             JsonTypeInfo<T> info = new SourceGenJsonTypeInfo<T>(converter, options);
             return info;
         }
-
-        /// <summary>
-        /// Marks the provided <see cref="JsonTypeInfo"/> instance as locked for further modification.
-        /// </summary>
-        /// <param name="jsonTypeInfo">The metadata instance to lock for modification.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="jsonTypeInfo"/> is null.</exception>
-        public static void MakeReadOnly(JsonTypeInfo jsonTypeInfo)
-        {
-            if (jsonTypeInfo is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(jsonTypeInfo));
-            }
-
-            jsonTypeInfo.IsReadOnly = true;
-        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
@@ -94,5 +94,20 @@ namespace System.Text.Json.Serialization.Metadata
             JsonTypeInfo<T> info = new SourceGenJsonTypeInfo<T>(converter, options);
             return info;
         }
+
+        /// <summary>
+        /// Marks the provided <see cref="JsonTypeInfo"/> instance as locked for further modification.
+        /// </summary>
+        /// <param name="jsonTypeInfo">The metadata instance to lock for modification.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="jsonTypeInfo"/> is null.</exception>
+        public static void MakeReadOnly(JsonTypeInfo jsonTypeInfo)
+        {
+            if (jsonTypeInfo is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(jsonTypeInfo));
+            }
+
+            jsonTypeInfo.IsReadOnly = true;
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -268,7 +268,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         private protected void VerifyMutable()
         {
-            if (_isConfigured)
+            if (ParentTypeInfo?.IsReadOnly == true)
             {
                 ThrowHelper.ThrowInvalidOperationException_PropertyInfoImmutable();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -256,6 +256,23 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
+        /// <summary>
+        /// Specifies whether the current instance has been locked for modification.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="JsonTypeInfo"/> instance can be locked either if
+        /// it has been passed to one of the <see cref="JsonSerializer"/> methods,
+        /// has been associated with a <see cref="JsonSerializerContext"/> instance,
+        /// or a user explicitly called the <see cref="MakeReadOnly"/> method on the instance.
+        /// </remarks>
+        public bool IsReadOnly { get; private set; }
+
+        /// <summary>
+        /// Locks the current instance for further modification.
+        /// </summary>
+        /// <remarks>This method is idempotent.</remarks>
+        public void MakeReadOnly() => IsReadOnly = true;
+
         private protected JsonPolymorphismOptions? _polymorphismOptions;
 
         internal object? CreateObjectWithArgs { get; set; }
@@ -493,8 +510,6 @@ namespace System.Text.Json.Serialization.Metadata
         private ExceptionDispatchInfo? _cachedConfigureError;
 
         internal bool IsConfigured => _isConfigured;
-
-        internal bool IsReadOnly { get; set; }
 
         internal void EnsureConfigured()
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -482,7 +482,7 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal void VerifyMutable()
         {
-            if (_isConfigured)
+            if (IsReadOnly)
             {
                 ThrowHelper.ThrowInvalidOperationException_TypeInfoImmutable();
             }
@@ -493,6 +493,8 @@ namespace System.Text.Json.Serialization.Metadata
         private ExceptionDispatchInfo? _cachedConfigureError;
 
         internal bool IsConfigured => _isConfigured;
+
+        internal bool IsReadOnly { get; set; }
 
         internal void EnsureConfigured()
         {
@@ -516,6 +518,7 @@ namespace System.Text.Json.Serialization.Metadata
                     {
                         Configure();
 
+                        IsReadOnly = true;
                         _isConfigured = true;
                     }
                     catch (Exception e)
@@ -699,6 +702,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <returns>A blank <see cref="JsonPropertyInfo"/> instance.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> or <paramref name="name"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="propertyType"/> cannot be used for serialization.</exception>
+        /// <exception cref="InvalidOperationException">The <see cref="JsonTypeInfo"/> instance has been locked for further modification.</exception>
         [RequiresUnreferencedCode(MetadataFactoryRequiresUnreferencedCode)]
         [RequiresDynamicCode(MetadataFactoryRequiresUnreferencedCode)]
         public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name)
@@ -718,6 +722,7 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowArgumentException_CannotSerializeInvalidType(nameof(propertyType), propertyType, Type, name);
             }
 
+            VerifyMutable();
             JsonPropertyInfo propertyInfo = CreatePropertyUsingReflection(propertyType);
             propertyInfo.Name = name;
 
@@ -753,6 +758,8 @@ namespace System.Text.Json.Serialization.Metadata
         {
             Debug.Assert(jsonPropertyInfo.MemberName != null, "MemberName can be null in custom JsonPropertyInfo instances and should never be passed in this method");
             string memberName = jsonPropertyInfo.MemberName;
+
+            jsonPropertyInfo.EnsureChildOf(this);
 
             if (jsonPropertyInfo.IsExtensionData)
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -26,6 +26,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             JsonTypeInfo<Person> typeInfo = PersonJsonContext.Default.Person;
 
+            Assert.True(typeInfo.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => typeInfo.CreateObject = null);
             Assert.Throws<InvalidOperationException>(() => typeInfo.OnDeserializing = obj => { });
             Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Clear());
@@ -42,6 +43,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             JsonTypeInfo<Person> typeInfo = (JsonTypeInfo<Person>)PersonJsonContext.Default.GetTypeInfo(typeof(Person));
 
+            Assert.True(typeInfo.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => typeInfo.CreateObject = null);
             Assert.Throws<InvalidOperationException>(() => typeInfo.OnDeserializing = obj => { });
             Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Clear());
@@ -60,9 +62,11 @@ namespace System.Text.Json.SourceGeneration.Tests
             JsonTypeInfo<Person> typeInfo = (JsonTypeInfo<Person>)resolver.GetTypeInfo(typeof(Person), PersonJsonContext.Default.Options);
 
             Assert.NotSame(typeInfo, PersonJsonContext.Default.Person);
+            Assert.False(typeInfo.IsReadOnly);
 
             JsonTypeInfo<Person> typeInfo2 = (JsonTypeInfo<Person>)resolver.GetTypeInfo(typeof(Person), PersonJsonContext.Default.Options);
             Assert.NotSame(typeInfo, typeInfo2);
+            Assert.False(typeInfo.IsReadOnly);
 
             typeInfo.CreateObject = null;
             typeInfo.OnDeserializing = obj => { };

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -22,6 +22,66 @@ namespace System.Text.Json.SourceGeneration.Tests
         }
 
         [Fact]
+        public static void PropertyMetadataIsImmutable()
+        {
+            JsonTypeInfo<Person> typeInfo = PersonJsonContext.Default.Person;
+
+            Assert.Throws<InvalidOperationException>(() => typeInfo.CreateObject = null);
+            Assert.Throws<InvalidOperationException>(() => typeInfo.OnDeserializing = obj => { });
+            Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Clear());
+
+            JsonPropertyInfo propertyInfo = typeInfo.Properties[0];
+            Assert.Throws<InvalidOperationException>(() => propertyInfo.Name = "differentName");
+            Assert.Throws<InvalidOperationException>(() => propertyInfo.NumberHandling = JsonNumberHandling.AllowReadingFromString);
+            Assert.Throws<InvalidOperationException>(() => propertyInfo.IsRequired = true);
+            Assert.Throws<InvalidOperationException>(() => propertyInfo.Order = -1);
+        }
+
+        [Fact]
+        public static void JsonSerializerContext_GetTypeInfo_MetadataIsImmutable()
+        {
+            JsonTypeInfo<Person> typeInfo = (JsonTypeInfo<Person>)PersonJsonContext.Default.GetTypeInfo(typeof(Person));
+
+            Assert.Throws<InvalidOperationException>(() => typeInfo.CreateObject = null);
+            Assert.Throws<InvalidOperationException>(() => typeInfo.OnDeserializing = obj => { });
+            Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Clear());
+
+            JsonPropertyInfo propertyInfo = typeInfo.Properties[0];
+            Assert.Throws<InvalidOperationException>(() => propertyInfo.Name = "differentName");
+            Assert.Throws<InvalidOperationException>(() => propertyInfo.NumberHandling = JsonNumberHandling.AllowReadingFromString);
+            Assert.Throws<InvalidOperationException>(() => propertyInfo.IsRequired = true);
+            Assert.Throws<InvalidOperationException>(() => propertyInfo.Order = -1);
+        }
+
+        [Fact]
+        public static void IJsonTypeInfoResolver_GetTypeInfo_MetadataIsMutable()
+        {
+            IJsonTypeInfoResolver resolver = PersonJsonContext.Default;
+            JsonTypeInfo<Person> typeInfo = (JsonTypeInfo<Person>)resolver.GetTypeInfo(typeof(Person), PersonJsonContext.Default.Options);
+
+            Assert.NotSame(typeInfo, PersonJsonContext.Default.Person);
+
+            JsonTypeInfo<Person> typeInfo2 = (JsonTypeInfo<Person>)resolver.GetTypeInfo(typeof(Person), PersonJsonContext.Default.Options);
+            Assert.NotSame(typeInfo, typeInfo2);
+
+            typeInfo.CreateObject = null;
+            typeInfo.OnDeserializing = obj => { };
+
+            JsonPropertyInfo propertyInfo = typeInfo.Properties[0];
+            propertyInfo.Name = "differentName";
+            propertyInfo.NumberHandling = JsonNumberHandling.AllowReadingFromString;
+            propertyInfo.IsRequired = true;
+            propertyInfo.Order = -1;
+
+            typeInfo.Properties.Clear();
+            Assert.Equal(0, typeInfo.Properties.Count);
+
+            // Changes should not impact other metadata instances
+            Assert.Equal(2, typeInfo2.Properties.Count);
+            Assert.Equal(2, PersonJsonContext.Default.Person.Properties.Count);
+        }
+
+        [Fact]
         public static void VariousGenericsAreSupported()
         {
             AssertGenericContext(GenericContext<int>.Default);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -400,16 +400,22 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(typeof(T), typeInfo.Type);
             Assert.True(typeInfo.Converter.CanConvert(typeof(T)));
 
-            JsonPropertyInfo prop = typeInfo.CreateJsonPropertyInfo(typeof(string), "foo");
             Assert.True(typeInfo.Properties.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => untyped.CreateObject = untyped.CreateObject);
             Assert.Throws<InvalidOperationException>(() => typeInfo.CreateObject = typeInfo.CreateObject);
             Assert.Throws<InvalidOperationException>(() => typeInfo.NumberHandling = typeInfo.NumberHandling);
+            Assert.Throws<InvalidOperationException>(() => typeInfo.CreateJsonPropertyInfo(typeof(string), "foo"));
             Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Clear());
-            Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Add(prop));
-            Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Insert(0, prop));
             Assert.Throws<InvalidOperationException>(() => typeInfo.PolymorphismOptions = null);
             Assert.Throws<InvalidOperationException>(() => typeInfo.PolymorphismOptions = new());
+
+            if (typeInfo.Properties.Count > 0)
+            {
+                JsonPropertyInfo prop = typeInfo.Properties[0];
+                Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Add(prop));
+                Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.Insert(0, prop));
+                Assert.Throws<InvalidOperationException>(() => typeInfo.Properties.RemoveAt(0));
+            }
 
             if (typeInfo.PolymorphismOptions is JsonPolymorphismOptions jpo)
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -36,6 +36,7 @@ namespace System.Text.Json.Serialization.Tests
 
             JsonTypeInfo ti = r.GetTypeInfo(type, o);
 
+            Assert.False(ti.IsReadOnly);
             Assert.Same(o, ti.Options);
             Assert.NotNull(ti.Properties);
 
@@ -400,7 +401,9 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(typeof(T), typeInfo.Type);
             Assert.True(typeInfo.Converter.CanConvert(typeof(T)));
 
+            Assert.True(typeInfo.IsReadOnly);
             Assert.True(typeInfo.Properties.IsReadOnly);
+            Assert.Throws<InvalidOperationException>(() => typeInfo.CreateJsonPropertyInfo(typeof(string), "foo"));
             Assert.Throws<InvalidOperationException>(() => untyped.CreateObject = untyped.CreateObject);
             Assert.Throws<InvalidOperationException>(() => typeInfo.CreateObject = typeInfo.CreateObject);
             Assert.Throws<InvalidOperationException>(() => typeInfo.NumberHandling = typeInfo.NumberHandling);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -994,9 +994,11 @@ namespace System.Text.Json.Serialization.Tests
             options.TypeInfoResolver = new DefaultJsonTypeInfoResolver();
             JsonTypeInfo typeInfo = options.GetTypeInfo(type);
             Assert.Equal(type, typeInfo.Type);
+            Assert.False(typeInfo.IsReadOnly);
 
             JsonTypeInfo typeInfo2 = options.GetTypeInfo(type);
             Assert.Equal(type, typeInfo2.Type);
+            Assert.False(typeInfo2.IsReadOnly);
 
             Assert.NotSame(typeInfo, typeInfo2);
 
@@ -1015,6 +1017,7 @@ namespace System.Text.Json.Serialization.Tests
 
             JsonTypeInfo typeInfo = options.GetTypeInfo(type);
             Assert.Equal(type, typeInfo.Type);
+            Assert.True(typeInfo.IsReadOnly);
 
             JsonTypeInfo typeInfo2 = options.GetTypeInfo(type);
             Assert.Same(typeInfo, typeInfo2);
@@ -1026,6 +1029,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
             JsonTypeInfo<TestClassForEncoding> jti = (JsonTypeInfo<TestClassForEncoding>)options.GetTypeInfo(typeof(TestClassForEncoding));
 
+            Assert.False(jti.IsReadOnly);
             Assert.Equal(1, jti.Properties.Count);
             jti.Properties.Clear();
 
@@ -1034,11 +1038,13 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("{}", json);
 
             // Using JsonTypeInfo will lock JsonSerializerOptions
+            Assert.True(jti.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => options.IncludeFields = false);
 
             // Getting JsonTypeInfo now should return a fresh immutable instance
             JsonTypeInfo<TestClassForEncoding> jti2 = (JsonTypeInfo<TestClassForEncoding>)options.GetTypeInfo(typeof(TestClassForEncoding));
             Assert.NotSame(jti, jti2);
+            Assert.True(jti2.IsReadOnly);
             Assert.Equal(1, jti2.Properties.Count);
             Assert.Throws<InvalidOperationException>(() => jti2.Properties.Clear());
 


### PR DESCRIPTION
Backport of #76540 to release/7.0

## Customer Impact

The inclusion of the [contract customization](https://github.com/dotnet/runtime/issues/63686) feature exposes a number of APIs that makes it possible for users to modify aspects of the pre-existing `JsonTypeInfo` contract metadata model. However, it seems that we neglected to freeze modifications for instances instantiated and cached by the source generator:
```C#
JsonTypeInfo<MyPoco> metadata = MyContext.Default.MyPoco;

// Can modify metadata on the static `Default` context instance.
metadata.CreateObject = null;
metadata.Properties.Clear();

[JsonSerializable(typeof(MyPoco))]
public partial class MyContext : JsonSerializerContext { }

public class MyPoco 
{ 
    public int Id { get; set; }
}
```
At first glance this problem might be considered benign, however it has the potential to create a couple of issues:

1. The source generator is aggressively caching metadata instances for performance, so this is effectively introducing global mutable state. Changes in one component can cause unforeseen changes in an unrelated context:

    ```C#
    // Mutate the result of a GetTypeInfo call
    JsonTypeInfo metadata = MySerializerContext.Default.GetTypeInfo(typeof(MyClass));
    metadata.Properties.Clear();

    // Change leaks to the static property:
    Console.WriteLine(MySerializerContext.Default.MyClass.Properties.Count); // 0
    ```
    or might be the cause of races when multiple threads are independently attempting to modify contracts:

    ```C#
    Parallel.For(0, 100, i =>
    {
         // Simulates multiple threads attempting to independently modify metadata:
         JsonTypeInfo typeInfo = MySerializerContext.Default.GetTypeInfo(typeof(MyPoco));
         typeInfo.Properties[0].Name = typeInfo.Properties[0].Name + ".suffix";
    });

    // Changes on `GetTypeInfo` results mutate the static instance
    // Id.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix.suffix
    Console.WriteLine(MySerializerContext.Default.MyPoco.Properties[0].Name);
     ```

2. Direct mutation of source gen metadata breaks the fast-path invalidation logic:

    ```C#
    MyContext.Default.MyPoco.Properties[0].Name = "alternative_name";

    // Modification ignored because the serializer still calls into the fast path that cannot be modified.
    JsonSerializer.Serialize(new MyPoco { Id = 42 }, MyContext.Default.MyPoco); // { "Id" : 42 }
    ```


## Testing

Added testing validating that cached source generated metadata is read-only.

## Risk

Moderate. Even though the fix is fairly straightforward, it necessitates the introduction of a new public method that can be used by the source generator for locking the metadata it is producing. Adding new APIs at such a late stage carries inherent risks, but we've explored the options thoroughly and landed on an API that should also help customers discover that the metadata can be locked and understand when that occurs.

```c#
public partial class JsonTypeInfo
{
    public void MakeReadOnly();
    public bool IsReadOnly { get; }
}
```

While we don't expect user code will directly invoke either of these APIs, their presence is beneficial. When the metadata is locked, mutation members throw exceptions, and customers can anticipate that possibility by seeing `IsReadOnly` and inspecting its value and when it changes. There is a possibility user code will begin referencing `MakeReadOnly` in scenarios we don't anticipate, and/or that we'll want to introduce scoped or validated read-only states in the future. If those scenarios arise, it's possible the shape introduced here won't be ideal. But we have mitigation approaches if needed.