### PR TITLE
[release/6.0] [wasm][debugger] Avoid exception when calling WhenAny with a null parameter

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsProxy.cs
@@ -61,6 +61,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 WebSocketReceiveResult result = await socket.ReceiveAsync(new ArraySegment<byte>(buff), token);
                 if (result.MessageType == WebSocketMessageType.Close)
                 {
+                    Log("error", $"DevToolsProxy: Client initiated close: {result.CloseStatus.Value} - {result.CloseStatusDescription}");
                     client_initiated_close.TrySetResult();
                     return null;
                 }
@@ -257,7 +258,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     {
                         while (!x.IsCancellationRequested)
                         {
-                            Task task = await Task.WhenAny(pending_ops.ToArray());
+                            Task task = await Task.WhenAny(pending_ops.Where(i => i != null).ToArray());
 
                             if (client_initiated_close.Task.IsCompleted)
                             {


### PR DESCRIPTION
Looks like this is the exception:
`fail: Microsoft.WebAssembly.Diagnostics.DevToolsProxy[0] DevToolsProxy::Run: Exception System.ArgumentException: The tasks argument included a null value. (Parameter 'tasks') at System.Threading.Tasks.Task.WhenAny(Task[] tasks) at Microsoft.WebAssembly.Diagnostics.DevToolsProxy.Run(Uri browserUri, WebSocket ideSocket)`

Trying to force it locally I cannot reproduce. But I'm trying to avoid the exception and adding extra log to help us to detect what is going on.

fixes #68402 