### PR TITLE
Check if interval interferes with the call

### DIFF
--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -153,7 +153,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   </Type>
 
   <Type Name="RefPosition">
-    <DisplayString>[{nodeLocation,d}. #{rpNum,d} - {refType,en}]</DisplayString>
+    <DisplayString>[#{rpNum,d} - {refType,en}]</DisplayString>
     <Expand>
         <Item Name="Referent" Condition="this->isPhysRegRef">(RegRecord*)this-&gt;referent</Item>
         <Item Name="Referent" Condition="!this->isPhysRegRef">(Interval*)this-&gt;referent</Item>

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -153,7 +153,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   </Type>
 
   <Type Name="RefPosition">
-    <DisplayString>[#{rpNum,d} - {refType,en}]</DisplayString>
+    <DisplayString>[{nodeLocation,d}. #{rpNum,d} - {refType,en}]</DisplayString>
     <Expand>
         <Item Name="Referent" Condition="this->isPhysRegRef">(RegRecord*)this-&gt;referent</Item>
         <Item Name="Referent" Condition="!this->isPhysRegRef">(Interval*)this-&gt;referent</Item>

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -624,6 +624,8 @@ LinearScan::LinearScan(Compiler* theCompiler)
     , intervals(theCompiler->getAllocator(CMK_LSRA_Interval))
     , allocationPassComplete(false)
     , refPositions(theCompiler->getAllocator(CMK_LSRA_RefPosition))
+    , callRefPositionLocations(theCompiler->getAllocator(CMK_LSRA))
+    , callKillMasks(theCompiler->getAllocator(CMK_LSRA))
     , listNodePool(theCompiler)
 {
     regSelector  = new (theCompiler, CMK_LSRA) RegisterSelection(this);
@@ -703,6 +705,8 @@ LinearScan::LinearScan(Compiler* theCompiler)
     blockSequenceWorkList = nullptr;
     curBBSeqNum           = 0;
     bbSeqCount            = 0;
+    callRefPositionCount  = 0;
+    recentRefPosition     = nullptr;
 
     // Information about each block, including predecessor blocks used for variable locations at block entry.
     blockInfo = nullptr;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -698,12 +698,13 @@ LinearScan::LinearScan(Compiler* theCompiler)
     // Note that we don't initialize the bbVisitedSet until we do the first traversal
     // This is so that any blocks that are added during the first traversal
     // are accounted for (and we don't have BasicBlockEpoch issues).
-    blockSequencingDone           = false;
-    blockSequence                 = nullptr;
-    blockSequenceWorkList         = nullptr;
-    curBBSeqNum                   = 0;
-    bbSeqCount                    = 0;
-    recentCallRefPositionLocation = 0;
+    blockSequencingDone   = false;
+    blockSequence         = nullptr;
+    blockSequenceWorkList = nullptr;
+    curBBSeqNum           = 0;
+    bbSeqCount            = 0;
+    recentRefPosition     = nullptr;
+    recentKillLocation    = 0;
 
     // Information about each block, including predecessor blocks used for variable locations at block entry.
     blockInfo = nullptr;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -624,8 +624,6 @@ LinearScan::LinearScan(Compiler* theCompiler)
     , intervals(theCompiler->getAllocator(CMK_LSRA_Interval))
     , allocationPassComplete(false)
     , refPositions(theCompiler->getAllocator(CMK_LSRA_RefPosition))
-    , callRefPositionLocations(theCompiler->getAllocator(CMK_LSRA))
-    , callKillMasks(theCompiler->getAllocator(CMK_LSRA))
     , listNodePool(theCompiler)
 {
     regSelector  = new (theCompiler, CMK_LSRA) RegisterSelection(this);
@@ -705,8 +703,6 @@ LinearScan::LinearScan(Compiler* theCompiler)
     blockSequenceWorkList         = nullptr;
     curBBSeqNum                   = 0;
     bbSeqCount                    = 0;
-    callRefPositionCount          = 0;
-    recentRefPosition             = nullptr;
     recentCallRefPositionLocation = 0;
 
     // Information about each block, including predecessor blocks used for variable locations at block entry.

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -700,13 +700,14 @@ LinearScan::LinearScan(Compiler* theCompiler)
     // Note that we don't initialize the bbVisitedSet until we do the first traversal
     // This is so that any blocks that are added during the first traversal
     // are accounted for (and we don't have BasicBlockEpoch issues).
-    blockSequencingDone   = false;
-    blockSequence         = nullptr;
-    blockSequenceWorkList = nullptr;
-    curBBSeqNum           = 0;
-    bbSeqCount            = 0;
-    callRefPositionCount  = 0;
-    recentRefPosition     = nullptr;
+    blockSequencingDone           = false;
+    blockSequence                 = nullptr;
+    blockSequenceWorkList         = nullptr;
+    curBBSeqNum                   = 0;
+    bbSeqCount                    = 0;
+    callRefPositionCount          = 0;
+    recentRefPosition             = nullptr;
+    recentCallRefPositionLocation = 0;
 
     // Information about each block, including predecessor blocks used for variable locations at block entry.
     blockInfo = nullptr;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1582,6 +1582,15 @@ private:
     // Ordered list of RefPositions
     RefPositionList refPositions;
 
+    // Most recent refpostion assigned
+    RefPosition* recentRefPosition;
+
+    // Ordered list of locations where CALL happens
+    jitstd::list<LsraLocation> callRefPositionLocations;
+    // Equivalent list of kill masks for those calls
+    jitstd::list<regMaskTP> callKillMasks;
+    int                     callRefPositionCount;
+
     // Per-block variable location mappings: an array indexed by block number that yields a
     // pointer to an array of regNumber, one per variable.
     VarToRegMap* inVarToRegMaps;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1582,7 +1582,8 @@ private:
     // Ordered list of RefPositions
     RefPositionList refPositions;
 
-    LsraLocation               recentCallRefPositionLocation;
+    RefPosition* recentRefPosition;
+    LsraLocation recentKillLocation;
     // Per-block variable location mappings: an array indexed by block number that yields a
     // pointer to an array of regNumber, one per variable.
     VarToRegMap* inVarToRegMaps;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1582,16 +1582,7 @@ private:
     // Ordered list of RefPositions
     RefPositionList refPositions;
 
-    // Most recent refpostion assigned
-    RefPosition* recentRefPosition;
-
-    // Ordered list of locations where CALL happens
     LsraLocation               recentCallRefPositionLocation;
-    jitstd::list<LsraLocation> callRefPositionLocations;
-    // Equivalent list of kill masks for those calls
-    jitstd::list<regMaskTP> callKillMasks;
-    int                     callRefPositionCount;
-
     // Per-block variable location mappings: an array indexed by block number that yields a
     // pointer to an array of regNumber, one per variable.
     VarToRegMap* inVarToRegMaps;

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1586,6 +1586,7 @@ private:
     RefPosition* recentRefPosition;
 
     // Ordered list of locations where CALL happens
+    LsraLocation               recentCallRefPositionLocation;
     jitstd::list<LsraLocation> callRefPositionLocations;
     // Equivalent list of kill masks for those calls
     jitstd::list<regMaskTP> callKillMasks;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2731,7 +2731,6 @@ void LinearScan::buildIntervals()
 
                             if (newPreferences != RBM_NONE)
                             {
-#ifdef DEBUG
                                 if (VERBOSE)
                                 {
                                     printf("Interval %2u: Update preferences (callee-save) from ",
@@ -2740,7 +2739,6 @@ void LinearScan::buildIntervals()
                                     JITDUMP(", New preference= ");
                                     dumpRegMask(newPreferences);
                                 }
-#endif
                                 interval.updateRegisterPreferences(newPreferences);
 
                                 printf(" to ");

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2669,6 +2669,7 @@ void LinearScan::buildIntervals()
 
                             if (newPreferences != RBM_NONE)
                             {
+#ifdef DEBUG
                                 if (VERBOSE)
                                 {
                                     printf("Interval %2u: Update preferences (callee-save) from ",
@@ -2678,6 +2679,7 @@ void LinearScan::buildIntervals()
                                     dumpRegMask(newPreferences);
                                     printf("\n");
                                 }
+#endif
                                 interval.updateRegisterPreferences(newPreferences);
                             }
                         }


### PR DESCRIPTION
After building intervals, check if any of them interferes with a call. In other words, scan all the intervals and check if there are refpositions that are created before a call and used after the call. If yes, then update such intervals preference to use `callee-save` registers. To accomplish this, I keep track of `LsraLocation` just before adding `RefTypeKill` and also record the killmask. After building intervals, go through all the call locations and see if any of the interval collides and if yes, then set its `preferCalleeSave = true`.

I am assuming a TP cost to do this because we will be doing non-linear search, but hopefully, it will be not as bad, and we do get some good results out of it. I do add various checks to skip iteration if we know that scanning it won't make sense. We cannot do this at the time of building interval, because we do not have information about the future uses of the interval under consideration.

Related conversation: https://github.com/dotnet/runtime/pull/75565#issuecomment-1275032313