### PR TITLE
[mono][s390x] Fix wrong implementation of OP_CHECK_THIS

### DIFF
--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -3594,8 +3594,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_CHECK_THIS: {
 			/* ensure ins->sreg1 is not NULL */
-			s390_lg   (code, s390_r0, 0, ins->sreg1, 0);
-			s390_ltgr (code, s390_r0, s390_r0);
+			s390_llgc (code, s390_r0, 0, ins->sreg1, 0);
 		}
 			break;
 		case OP_ARGLIST: {


### PR DESCRIPTION
* Only access a single byte in memory for OP_CHECK_THIS

* Remove unnecessary ltgr instruction

* Fixes https://github.com/dotnet/runtime/issues/76915