### PR TITLE
Change StringValues implicit cast behavior to string[] to not return null

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringValues.cs
@@ -78,9 +78,9 @@ namespace Microsoft.Extensions.Primitives
         /// Defines an implicit conversion of a given <see cref="StringValues"/> to a string array.
         /// </summary>
         /// <param name="value">A <see cref="StringValues"/> to implicitly convert.</param>
-        public static implicit operator string?[]? (StringValues value)
+        public static implicit operator string?[] (StringValues value)
         {
-            return value.GetArrayValue();
+            return value.ToArray();
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringValuesTests.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringValuesTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.Primitives
         [MemberData(nameof(DefaultOrNullStringValues))]
         public void DefaultOrNull_ExpectedValues(StringValues stringValues)
         {
-            Assert.Null((string[])stringValues);
+            Assert.Equal(Array.Empty<string>(), (string[])stringValues);
         }
 
         [Theory]
@@ -210,7 +210,7 @@ namespace Microsoft.Extensions.Primitives
             StringValues stringValues = nullString;
             Assert.Empty(stringValues);
             Assert.Null((string)stringValues);
-            Assert.Null((string[])stringValues);
+            Assert.Equal(Array.Empty<string>(), (string[])stringValues);
 
             string aString = "abc";
             stringValues = aString;
@@ -259,7 +259,7 @@ namespace Microsoft.Extensions.Primitives
             StringValues stringValues = nullStringArray;
             Assert.Empty(stringValues);
             Assert.Null((string)stringValues);
-            Assert.Null((string[])stringValues);
+            Assert.Equal(Array.Empty<string>(), (string[])stringValues);
 
             string aString = "abc";
             string[] aStringArray = new[] { aString };


### PR DESCRIPTION
Changed StringValues implicit cast to string[] logic as discussed in https://github.com/dotnet/aspnetcore/issues/44509.
The StringValues implicit cast to string[] will return empty array instead of null, after the change.