### PR TITLE
Fix reading TestEnv.txt in BionicRunnerTemplate.sh

### DIFF
--- a/eng/testing/BionicRunnerTemplate.sh
+++ b/eng/testing/BionicRunnerTemplate.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-. TestEnv.txt
 
 EXECUTION_DIR="$(realpath "$(dirname "$0")")"
+. "$EXECUTION_DIR/TestEnv.txt"
+
 RUNTIME_PATH="$2"
 TEST_SCRIPT="$(basename "$ASSEMBLY_NAME" .dll).sh"
 if [[ -z "$HELIX_WORKITEM_UPLOAD_ROOT" ]]; then


### PR DESCRIPTION
It was assuming the script is run from the same dir as the .txt file but that is not always the case.