### PR TITLE
API Debt - Microsoft.Extensions.DependencyInjection

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
@@ -72,15 +72,30 @@ namespace Microsoft.Extensions.DependencyInjection
             ServiceType = serviceType;
         }
 
+        /// <summary>
+        /// The <see cref="ServiceLifetime"/> of the service.
+        /// </summary>
         public ServiceLifetime Lifetime { get; }
 
+        /// <summary>
+        /// The <see cref="Type"/> of the service.
+        /// </summary>
         public Type ServiceType { get; }
 
+        /// <summary>
+        /// The <see cref="Type"/> implementing the service.
+        /// </summary>
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? ImplementationType { get; }
 
+        /// <summary>
+        /// The instance implementing the service.
+        /// </summary>
         public object? ImplementationInstance { get; }
 
+        /// <summary>
+        /// A factory used for creating service instances.
+        /// </summary>
         public Func<IServiceProvider, object>? ImplementationFactory { get; }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
@@ -73,28 +73,28 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// The <see cref="ServiceLifetime"/> of the service.
+        /// Gets the <see cref="ServiceLifetime"/> of the service.
         /// </summary>
         public ServiceLifetime Lifetime { get; }
 
         /// <summary>
-        /// The <see cref="Type"/> of the service.
+        /// Gets the <see cref="Type"/> of the service.
         /// </summary>
         public Type ServiceType { get; }
 
         /// <summary>
-        /// The <see cref="Type"/> implementing the service.
+        /// Gets the <see cref="Type"/> that implements the service.
         /// </summary>
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? ImplementationType { get; }
 
         /// <summary>
-        /// The instance implementing the service.
+        /// Gets the instance that implements the service.
         /// </summary>
         public object? ImplementationInstance { get; }
 
         /// <summary>
-        /// A factory used for creating service instances.
+        /// Gets the factory used for creating service instances.
         /// </summary>
         public Func<IServiceProvider, object>? ImplementationFactory { get; }
 

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/ServiceCollectionHostedServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/ServiceCollectionHostedServiceExtensions.cs
@@ -8,6 +8,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Extension methods for adding hosted services to an <see cref="IServiceCollection" />.
+    /// </summary>
     public static class ServiceCollectionHostedServiceExtensions
     {
         /// <summary>


### PR DESCRIPTION
## Summary
Resolves some of the missing triple slash as described in #43871. A separate PR will be opened in the API docs repo to resolve missing namespace descriptions and parameterless constructors.

### Inheritdoc Issues
The following were flagged as missing, but were present as inheritdoc summaries:
 - M:Microsoft.Extensions.DependencyInjection.DefaultServiceProviderFactory.CreateBuilder
 - M:Microsoft.Extensions.DependencyInjection.DefaultServiceProviderFactory.CreateServiceProvider
 - M:Microsoft.Extensions.DependencyInjection.ServiceCollection.Contains
 - M:Microsoft.Extensions.DependencyInjection.ServiceCollection.CopyTo
 - M:Microsoft.Extensions.DependencyInjection.ServiceCollection.IndexOf
 - M:Microsoft.Extensions.DependencyInjection.ServiceCollection.Insert
 - M:Microsoft.Extensions.DependencyInjection.ServiceCollection.Remove
 - M:Microsoft.Extensions.DependencyInjection.ServiceCollection.RemoveAt(System.Int32)
 - M:Microsoft.Extensions.DependencyInjection.ServiceDescriptor.ToString

### Obsoletes
 - P:Microsoft.Extensions.DependencyInjection.ServiceCollection.Item(System.Int32)

### Namespace Note
It appears that `Microsoft.Extensions.DependencyInjection.Extensions` has been renamed to `Microsoft.Extensions.DependencyInjection.Abstractions`. Regardless, `Microsoft.Extensions.DependencyInjection.Extensions` is obsolete and `Microsoft.Extensions.DependencyInjection.Abstractions` needs a summary that will be included in the upcoming PR in the API docs repo.