### PR TITLE
Remove container specification

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -104,7 +104,6 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64
           platforms:
           - Linux_arm64
           - windows_arm64
@@ -116,7 +115,6 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64
           runtimeFlavor: mono
           platforms:
           - Browser_wasm


### PR DESCRIPTION
This removes the direct use of a container as the work done here, https://github.com/dotnet/runtime/pull/75473, makes it automatic.