### PR TITLE
Add --versiononly argument to R2RDump utility

### DIFF
--- a/src/coreclr/tools/r2rdump/Dumper.cs
+++ b/src/coreclr/tools/r2rdump/Dumper.cs
@@ -56,6 +56,7 @@ namespace R2RDump
         public abstract void WriteSubDivider();
         public abstract void SkipLine();
         public abstract void DumpHeader(bool dumpSections);
+        public abstract void DumpVersion();
         public abstract void DumpSection(ReadyToRunSection section);
         public abstract void DumpEntryPoints();
         public abstract void DumpAllMethods();

--- a/src/coreclr/tools/r2rdump/R2RDumpRootCommand.cs
+++ b/src/coreclr/tools/r2rdump/R2RDumpRootCommand.cs
@@ -18,6 +18,8 @@ namespace R2RDump
             new(new[] { "--raw" }, "Dump the raw bytes of each section or runtime function");
         public Option<bool> Header { get; } =
             new(new[] { "--header" }, "Dump R2R header");
+        public Option<bool> VersionOnly { get; } =
+            new(new[] { "--versiononly" }, "Dump R2R version only");
         public Option<bool> Disasm { get; } =
             new(new[] { "--disasm", "-d" }, "Show disassembly of methods or runtime functions");
         public Option<bool> Naked { get; } =
@@ -86,6 +88,7 @@ namespace R2RDump
             AddOption(Out);
             AddOption(Raw);
             AddOption(Header);
+            AddOption(VersionOnly);
             AddOption(Disasm);
             AddOption(Naked);
             AddOption(HideOffsets);

--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -57,6 +57,12 @@ namespace R2RDump
             _writer.WriteLine();
         }
 
+        public override void DumpVersion()
+        {
+            ReadyToRunHeader header = _r2r.ReadyToRunHeader;
+            _writer.WriteLine($"[R2R {header.MajorVersion}.{header.MinorVersion}, {_r2r.OperatingSystem}-{_r2r.Architecture}] {_r2r.Filename}");
+        }
+
         /// <summary>
         /// Dumps the R2RHeader and all the sections in the header
         /// </summary>


### PR DESCRIPTION
This PR introduces `--versiononly` command for `R2RDump` utility to print only R2R version (and RID) of the given input, e.g.:

```
R2RDump -i *.dll --versiononly
```
```
C:\test\publish\clretwrc.dll
C:\test\publish\clrgc.dll
C:\test\publish\clrjit.dll
C:\test\publish\coreclr.dll
[R2R 8.0, Windows-X64] C:\test\publish\hhh.dll
C:\test\publish\hostfxr.dll
C:\test\publish\hostpolicy.dll
[R2R 8.0, Windows-X64] C:\test\publish\Microsoft.CSharp.dll
C:\test\publish\Microsoft.DiaSymReader.Native.amd64.dll
[R2R 8.0, Windows-X64] C:\test\publish\Microsoft.VisualBasic.Core.dll
C:\test\publish\Microsoft.VisualBasic.dll
C:\test\publish\Microsoft.Win32.Primitives.dll
[R2R 8.0, Windows-X64] C:\test\publish\Microsoft.Win32.Registry.dll
C:\test\publish\mscordaccore.dll
C:\test\publish\mscordaccore_amd64_amd64_7.0.22.42610.dll
C:\test\publish\mscordbi.dll
C:\test\publish\mscorlib.dll
C:\test\publish\mscorrc.dll
C:\test\publish\msquic.dll
C:\test\publish\netstandard.dll
C:\test\publish\System.AppContext.dll
C:\test\publish\System.Buffers.dll
[R2R 8.0, Windows-X64] C:\test\publish\System.Collections.Concurrent.dll
[R2R 8.0, Windows-X64] C:\test\publish\System.Collections.dll
[R2R 8.0, Windows-X64] C:\test\publish\System.Collections.Immutable.dll
[R2R 8.0, Windows-X64] C:\test\publish\System.Collections.NonGeneric.dll
[R2R 8.0, Windows-X64] C:\test\publish\System.Collections.Specialized.dll
[R2R 8.0, Windows-X64] C:\test\publish\System.ComponentModel.Annotations.dll
...
```
also it ignores invalid images (only for `--versiononly` command) while currently it throws a BadImageException.