### PR TITLE
[tvOS] Disable crashing test

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
@@ -893,6 +893,7 @@ namespace System.Numerics.Tests
         [InlineData(0, 120, 4215344322)]
         [InlineData(0, byte.MaxValue, 2910671697)]
         [InlineData(123, byte.MaxValue, 1164749927)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76830", TestPlatforms.tvOS)]
         public static void BitOps_Crc32C_byte(uint crc, byte data, uint expected)
         {
             uint obtained = BitOperations.Crc32C(crc, data);

--- a/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
@@ -905,6 +905,7 @@ namespace System.Numerics.Tests
         [InlineData(0, 120, 575477567)]
         [InlineData(0, ushort.MaxValue, 245266386)]
         [InlineData(123, ushort.MaxValue, 406112372)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76830", TestPlatforms.tvOS)]
         public static void BitOps_Crc32C_ushort(uint crc, ushort data, uint expected)
         {
             uint obtained = BitOperations.Crc32C(crc, data);
@@ -916,6 +917,7 @@ namespace System.Numerics.Tests
         [InlineData(0, 120, 1671666103)]
         [InlineData(0, uint.MaxValue, 3080238136)]
         [InlineData(123, uint.MaxValue, 3055133878)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76830", TestPlatforms.tvOS)]
         public static void BitOps_Crc32C_uint(uint crc, uint data, uint expected)
         {
             uint obtained = BitOperations.Crc32C(crc, data);
@@ -927,6 +929,7 @@ namespace System.Numerics.Tests
         [InlineData(0, 120, 3511526341)]
         [InlineData(0, ulong.MaxValue, 3293575501)]
         [InlineData(123, ulong.MaxValue, 3460750817)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76830", TestPlatforms.tvOS)]
         public static void BitOps_Crc32C_ulong(uint crc, ulong data, uint expected)
         {
             uint obtained = BitOperations.Crc32C(crc, data);


### PR DESCRIPTION
This PR aims to disable `BitOps_Crc32C_byte` on tvOS, which frequently crashes on runtime-extra-platforms