### PR TITLE
Fixes issue when monitoring a process launched via the same command line

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -60,7 +60,9 @@ namespace System.Diagnostics.Metrics
             public const EventKeywords InstrumentPublishing = (EventKeywords)0x4;
         }
 
-        private Lazy<CommandHandler> _handler = new Lazy<CommandHandler>();
+        private CommandHandler _handler = new CommandHandler();
+
+        private MetricsEventSource(){}
 
         /// <summary>
         /// Used to send ad-hoc diagnostics to humans.
@@ -184,7 +186,7 @@ namespace System.Diagnostics.Metrics
         {
             lock (this)
             {
-                _handler.Value.OnEventCommand(command, this);
+                _handler.OnEventCommand(command, this);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/diagnostics/issues/3366. A NullReferenceException was being thrown and caught because the CommandHandler in MetricsEventSource was being referenced before being initialized. Now custom metrics are displayed when trying to monitor a process in the same command line. Here is example output for a simple application with a custom meter that displays random values:

- Running ```  dotnet-counters monitor --counters System.Runtime,demo_meter -- countersbug.exe ``` will now output:
  
  ```
  Press p to pause, r to resume, q to quit.
      Status: Running
  
  [System.Runtime]
      % Time in GC since last GC (%)                                 0
      Allocation Rate (B / 1 sec)                               16,072
      CPU Usage (%)                                                  0
      Exception Count (Count / 1 sec)                                0
      GC Committed Bytes (MB)                                        0
      GC Fragmentation (%)                                           0
      GC Heap Size (MB)                                              0.462
      Gen 0 GC Count (Count / 1 sec)                                 0
      Gen 0 Size (B)                                                 0
      Gen 1 GC Count (Count / 1 sec)                                 0
      Gen 1 Size (B)                                                 0
      Gen 2 GC Count (Count / 1 sec)                                 0
      Gen 2 Size (B)                                                 0
      IL Bytes Jitted (B)                                       47,239
      LOH Size (B)                                                   0
      Monitor Lock Contention Count (Count / 1 sec)                  0
      Number of Active Timers                                        0
      Number of Assemblies Loaded                                   13
      Number of Methods Jitted                                     438
      POH (Pinned Object Heap) Size (B)                              0
      ThreadPool Completed Work Item Count (Count / 1 sec)           0
      ThreadPool Queue Length                                        0
      ThreadPool Thread Count                                        0
      Time spent in JIT (ms / 1 sec)                                10.01
      Working Set (MB)                                              25.793
  [demo_meter]
      random (Count / 1 sec)
          instance=app                                            -793.95
  ```

- Running ```  dotnet-counters monitor --counters demo_meter -- countersbug.exe ``` will now output:
  ```
  Press p to pause, r to resume, q to quit.
      Status: Running
  
  [demo_meter]
      random (Count / 1 sec)
          instance=app                                 799.513
  ```