### PR TITLE
[release/7.0][PERF][MAUI] Update Maui build Mac vmimage to macos-12

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -416,7 +416,7 @@ jobs:
         nameSuffix: MACiOSAndroidMauiNet7
         isOfficialBuild: false
         pool:
-          vmImage: 'macos-11'
+          vmImage: 'macos-12'
         extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps-net7.yml
         extraStepsParameters:
           rootFolder: '$(Build.SourcesDirectory)/artifacts/'
@@ -440,7 +440,7 @@ jobs:
         nameSuffix: MACiOSAndroidMauiNet6
         isOfficialBuild: false
         pool:
-          vmImage: 'macos-11'
+          vmImage: 'macos-12'
         extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps-net6.yml
         extraStepsParameters:
           rootFolder: '$(Build.SourcesDirectory)/artifacts/'


### PR DESCRIPTION
Backport of: https://github.com/dotnet/runtime/pull/76945 and only makes changes to perf testing yml. Updates the Maui builds to use vmImage mac-12 instead of mac-11 in order to gain access to XCode 14 when building.

## Customer Impact

None, this only impacts the performance infra.

## Testing

Tested on the main version of the change: https://dev.azure.com/dnceng/internal/_build/results?buildId=2018712&view=results

## Risk

Low
The only impact from this will be for the performance infra.
