### PR TITLE
Fix insertion of alignment after BBJ_CALLFINALLY/BBJ_ALWAYS

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -823,7 +823,12 @@ void CodeGen::genCodeForBBlist()
             // compJitAlignLoopBoundary.
             // For adaptive alignment, alignment instruction will always be of 15 bytes for xarch
             // and 16 bytes for arm64.
+
             assert(ShouldAlignLoops());
+            assert(!block->isBBCallAlwaysPairTail());
+#if FEATURE_EH_CALLFINALLY_THUNKS
+            assert(block->bbJumpKind != BBJ_CALLFINALLY);
+#endif // FEATURE_EH_CALLFINALLY_THUNKS
 
             GetEmitter()->emitLoopAlignment(DEBUG_ARG1(block->bbJumpKind == BBJ_ALWAYS));
         }


### PR DESCRIPTION
The Runtime_76346 test exposed a case where, in the case of STRESS_EMITTER, we were inserting breakpoint instructions instead of NOPs for loop alignment when the alignment followed an unconditional branch. However, it wasn't considering the case of a BBJ_CALLFINALLY/BBJ_ALWAYS pair immediately followed by a loop head.

This pointed out that alignment instructions should never be inserted in that BBJ_ALWAYS block, since that block shouldn't contain any code. Inserting the alignment NOPs affected the reported range of the EH cloned finally region in the FEATURE_EH_CALLFINALLY_THUNKS case.

In these special cases, we simply give up on trying to align the loop.

Fixes #76910

[No diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=50941&view=ms.vss-build-web.run-extensions-tab)