### PR TITLE
[mono][ppc64le] Fix wrong implementation of OP_CHECK_THIS 

### DIFF
--- a/src/mono/mono/mini/mini-ppc.c
+++ b/src/mono/mono/mini/mini-ppc.c
@@ -3837,7 +3837,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 		case OP_CHECK_THIS:
 			/* ensure ins->sreg1 is not NULL */
-			ppc_ldptr (code, ppc_r0, 0, ins->sreg1);
+			ppc_lbz (code, ppc_r0, 0, ins->sreg1);
 			break;
 		case OP_ARGLIST: {
 			long cookie_offset = cfg->sig_cookie + cfg->stack_usage;


### PR DESCRIPTION
In OP_CHECK_THIS access single byte only instead of double word.
This fixes crashes observed in runtime-portable/runtime during source build with rc1 on ppc64le. All these crashes were  segmentation faults in SpanHelpers.IndexOfValueType.

Similar issue has been observed on s390 platform as well. Issue was opened [here ](https://github.com/dotnet/runtime/issues/76915) and fixed by https://github.com/dotnet/runtime/pull/76916