### PR TITLE
Avoid runtime "atomic write" check in ConcurrentDictionary for shared generics

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -555,7 +555,7 @@ namespace System.Collections.Concurrent
                         {
                             if (valueComparer.Equals(node._value, comparisonValue))
                             {
-                                if (!typeof(TValue).IsValueType || ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic)
+                                if (IsValueWriteAtomic)
                                 {
                                     node._value = newValue;
                                 }
@@ -894,7 +894,7 @@ namespace System.Collections.Concurrent
                             // be written atomically, since lock-free reads may be happening concurrently.
                             if (updateIfExists)
                             {
-                                if (!typeof(TValue).IsValueType || ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic)
+                                if (IsValueWriteAtomic)
                                 {
                                     node._value = value;
                                 }
@@ -2124,6 +2124,15 @@ namespace System.Collections.Concurrent
             {
                 ReleaseLocks(0, locksAcquired);
             }
+        }
+
+        /// <summary>Determine whether writing a value is atomic.</summary>
+        private static bool IsValueWriteAtomic
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            // Do the reference type check up front here since JIT is unable to
+            // inline across the different shared generic dictionary.
+            get => !typeof(TValue).IsValueType || ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic;
         }
 
         /// <summary>

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -555,7 +555,7 @@ namespace System.Collections.Concurrent
                         {
                             if (valueComparer.Equals(node._value, comparisonValue))
                             {
-                                if (ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic())
+                                if (!typeof(TValue).IsValueType || ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic)
                                 {
                                     node._value = newValue;
                                 }
@@ -894,7 +894,7 @@ namespace System.Collections.Concurrent
                             // be written atomically, since lock-free reads may be happening concurrently.
                             if (updateIfExists)
                             {
-                                if (ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic())
+                                if (!typeof(TValue).IsValueType || ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic)
                                 {
                                     node._value = value;
                                 }
@@ -2233,7 +2233,7 @@ namespace System.Collections.Concurrent
     internal static class ConcurrentDictionaryTypeProps<T>
     {
         /// <summary>Whether T's type can be written atomically (i.e., with no danger of torn reads).</summary>
-        private static readonly bool s_isTypeWriteAtomic = IsWriteAtomicPrivate();
+        internal static readonly bool IsWriteAtomic = IsWriteAtomicPrivate();
 
         private static bool IsWriteAtomicPrivate()
         {
@@ -2269,11 +2269,6 @@ namespace System.Collections.Concurrent
                     return false;
             }
         }
-
-        /// <summary>Determines whether type T can be written atomically.</summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsWriteAtomic()
-            => !typeof(T).IsValueType || s_isTypeWriteAtomic;
     }
 
     internal sealed class IDictionaryDebugView<TKey, TValue> where TKey : notnull

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -71,10 +71,12 @@ namespace System.Collections.Concurrent
                 case TypeCode.UInt16:
                 case TypeCode.UInt32:
                     return true;
+
                 case TypeCode.Double:
                 case TypeCode.Int64:
                 case TypeCode.UInt64:
                     return IntPtr.Size == 8;
+
                 default:
                     return false;
             }
@@ -92,22 +94,22 @@ namespace System.Collections.Concurrent
                 typeof(TValue) == typeof(IntPtr) ||
                 typeof(TValue) == typeof(UIntPtr) ||
                 typeof(TValue) == typeof(bool) ||
-                typeof(TValue) == typeof(byte) ||
-                typeof(TValue) == typeof(char) ||
+                typeof(TValue) == typeof(sbyte) ||
                 typeof(TValue) == typeof(short) ||
                 typeof(TValue) == typeof(int) ||
-                typeof(TValue) == typeof(sbyte) ||
-                typeof(TValue) == typeof(float) ||
+                typeof(TValue) == typeof(byte) ||
                 typeof(TValue) == typeof(ushort) ||
-                typeof(TValue) == typeof(uint))
+                typeof(TValue) == typeof(uint) ||
+                typeof(TValue) == typeof(char) ||
+                typeof(TValue) == typeof(float))
             {
                 return true;
             }
 
             if (IntPtr.Size == 8 &&
-                (typeof(TValue) == typeof(double) ||
-                 typeof(TValue) == typeof(long) ||
-                 typeof(TValue) == typeof(ulong)))
+                (typeof(TValue) == typeof(long) ||
+                 typeof(TValue) == typeof(ulong) ||
+                 typeof(TValue) == typeof(double)))
             {
                 return true;
             }

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -555,7 +555,11 @@ namespace System.Collections.Concurrent
                         {
                             if (valueComparer.Equals(node._value, comparisonValue))
                             {
-                                if (IsValueWriteAtomic)
+                                // Do the reference type check up front to handle many cases of shared generics.
+                                // If TValue is a value type then the field's value here can be baked in. Otherwise,
+                                // for the remaining shared generic cases the field access here would disqualify inlining,
+                                // so the following check cannot be factored out of TryAddInternal/TryUpdateInternal.
+                                if (!typeof(TValue).IsValueType || ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic)
                                 {
                                     node._value = newValue;
                                 }
@@ -894,7 +898,11 @@ namespace System.Collections.Concurrent
                             // be written atomically, since lock-free reads may be happening concurrently.
                             if (updateIfExists)
                             {
-                                if (IsValueWriteAtomic)
+                                // Do the reference type check up front to handle many cases of shared generics.
+                                // If TValue is a value type then the field's value here can be baked in. Otherwise,
+                                // for the remaining shared generic cases the field access here would disqualify inlining,
+                                // so the following check cannot be factored out of TryAddInternal/TryUpdateInternal.
+                                if (!typeof(TValue).IsValueType || ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic)
                                 {
                                     node._value = value;
                                 }
@@ -2124,15 +2132,6 @@ namespace System.Collections.Concurrent
             {
                 ReleaseLocks(0, locksAcquired);
             }
-        }
-
-        /// <summary>Determine whether writing a value is atomic.</summary>
-        private static bool IsValueWriteAtomic
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            // Do the reference type check up front here since JIT is unable to
-            // inline across the different shared generic dictionary.
-            get => !typeof(TValue).IsValueType || ConcurrentDictionaryTypeProps<TValue>.IsWriteAtomic;
         }
 
         /// <summary>


### PR DESCRIPTION
ConcurrentDictionary caches an s_isValueWriteAtomic in a static readonly, but this trick does not work for shared generics. Instead add an eager check for the reference types and extract the static readonly field so that its value can be baked in even if the key is System.__Canon.

```csharp
        [Benchmark]
        public int BenchIntString()
        {
            ConcurrentDictionary<int, string> cd = new();
            for (int i = 0; i < 1000000; i++)
                cd[0] = "";

            return cd.Count;
        }

        [Benchmark]
        public int BenchStringInt()
        {
            ConcurrentDictionary<string, int> cd = new();
            for (int i = 0; i < 1000000; i++)
                cd[""] = i;

            return cd.Count;
        }

        [Benchmark]
        public int BenchStringString()
        {
            ConcurrentDictionary<string, string> cd = new();
            for (int i = 0; i < 1000000; i++)
                cd[""] = "";

            return cd.Count;
        }

        [Benchmark]
        public int BenchStringDayOfWeek()
        {
            ConcurrentDictionary<string, DayOfWeek> cd = new();
            for (int i = 0; i < 1000000; i++)
                cd[""] = DayOfWeek.Friday;

            return cd.Count;
        }

        [Benchmark]
        public int BenchStringGuid()
        {
            ConcurrentDictionary<string, Guid> cd = new();
            Guid g = Guid.NewGuid();
            for (int i = 0; i < 1000000; i++)
                cd[""] = g;

            return cd.Count;
        }

        [Benchmark]
        public int BenchIntInt()
        {
            ConcurrentDictionary<int, int> cd = new();
            for (int i = 0; i < 1000000; i++)
                cd[0] = i;

            return cd.Count;
        }

        [Benchmark]
        public int BenchGuidInt()
        {
            ConcurrentDictionary<Guid, int> cd = new();
            Guid g = Guid.NewGuid();
            for (int i = 0; i < 1000000; i++)
                cd[g] = i;

            return cd.Count;
        }

```

|               Method |        Job |         Toolchain |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |
|--------------------- |----------- |------------------ |---------:|---------:|---------:|---------:|------:|--------:|
|       BenchIntString | Job-WELKHT | \main\corerun.exe | 20.97 ms | 0.325 ms | 0.304 ms | 20.96 ms |  1.00 |    0.00 |
|       BenchIntString | Job-XNZJCP |   \pr\corerun.exe | 18.96 ms | 0.372 ms | 0.365 ms | 18.96 ms |  0.90 |    0.03 |
|                      |            |                   |          |          |          |          |       |         |
|       BenchStringInt | Job-WELKHT | \main\corerun.exe | 23.22 ms | 0.051 ms | 0.061 ms | 23.22 ms |  1.00 |    0.00 |
|       BenchStringInt | Job-XNZJCP |   \pr\corerun.exe | 20.06 ms | 0.159 ms | 0.124 ms | 20.10 ms |  0.86 |    0.01 |
|                      |            |                   |          |          |          |          |       |         |
|    BenchStringString | Job-WELKHT | \main\corerun.exe | 24.90 ms | 0.465 ms | 0.652 ms | 24.91 ms |  1.00 |    0.00 |
|    BenchStringString | Job-XNZJCP |   \pr\corerun.exe | 22.80 ms | 0.454 ms | 1.196 ms | 22.79 ms |  0.91 |    0.05 |
|                      |            |                   |          |          |          |          |       |         |
| BenchStringDayOfWeek | Job-WELKHT | \main\corerun.exe | 23.25 ms | 0.098 ms | 0.092 ms | 23.23 ms |  1.00 |    0.00 |
| BenchStringDayOfWeek | Job-XNZJCP |   \pr\corerun.exe | 20.17 ms | 0.289 ms | 0.256 ms | 20.08 ms |  0.87 |    0.01 |
|                      |            |                   |          |          |          |          |       |         |
|      BenchStringGuid | Job-WELKHT | \main\corerun.exe | 30.43 ms | 0.242 ms | 0.227 ms | 30.42 ms |  1.00 |    0.00 |
|      BenchStringGuid | Job-XNZJCP |   \pr\corerun.exe | 27.28 ms | 0.248 ms | 0.232 ms | 27.26 ms |  0.90 |    0.01 |
|                      |            |                   |          |          |          |          |       |         |
|          BenchIntInt | Job-WELKHT | \main\corerun.exe | 16.37 ms | 0.050 ms | 0.044 ms | 16.37 ms |  1.00 |    0.00 |
|          BenchIntInt | Job-XNZJCP |   \pr\corerun.exe | 16.29 ms | 0.029 ms | 0.024 ms | 16.29 ms |  1.00 |    0.00 |
|                      |            |                   |          |          |          |          |       |         |
|         BenchGuidInt | Job-WELKHT | \main\corerun.exe | 20.17 ms | 0.395 ms | 0.439 ms | 19.87 ms |  1.00 |    0.00 |
|         BenchGuidInt | Job-XNZJCP |   \pr\corerun.exe | 20.35 ms | 0.362 ms | 0.321 ms | 20.53 ms |  1.02 |    0.03 |

(The `BenchGuidInt` one swings, I can get between 0.95-1.05 ratio by running them more times).