### PR TITLE
[PERF] Fix Linux arm64 AOT ROOTFS_DIR missing 

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -83,10 +83,10 @@ jobs:
       - name: _crossBuildPropertyArg
         value: /p:CrossBuild=${{ parameters.crossBuild }}
 
-      - ${{ if ne(parameters.jobParameters.crossrootfsDir, '') }}:
+      - ${{ if ne(parameters.crossrootfsDir, '') }}:
         # This is only required for cross builds.
         - name: ROOTFS_DIR
-          value: ${{ parameters.jobParameters.crossrootfsDir }}
+          value: ${{ parameters.crossrootfsDir }}
 
       - name: _cxx11Parameter
         ${{ if and(eq(parameters.osGroup, 'Linux'), eq(parameters.archType, 'arm64')) }}:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -136,13 +136,13 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
           container: ubuntu-18.04-cross-arm64
+          crossrootfsDir: '/crossrootfs/arm64'
           runtimeFlavor: mono
           runtimeVariant: 'llvmaot'
           platforms:
           - Linux_arm64
           jobParameters:
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-            crossrootfsDir: '/crossrootfs/arm64'
             nameSuffix: AOT
             isOfficialBuild: false
             extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -175,55 +175,55 @@ extends:
             logicalmachine: 'perfampere'
             timeoutInMinutes: 500 
 
-    # # run coreclr Linux arm64 ampere microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - Linux_arm64
-    #       container: ubuntu-18.04-cross-arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfampere'
-    #         timeoutInMinutes: 500 
+    # run coreclr Linux arm64 ampere microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - Linux_arm64
+          container: ubuntu-18.04-cross-arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfampere'
+            timeoutInMinutes: 500 
 
-    # # run coreclr Windows arm64 microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - windows_arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfsurf' 
+    # run coreclr Windows arm64 microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfsurf' 
 
-    # # run coreclr Windows arm64 ampere microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - windows_arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfampere' 
+    # run coreclr Windows arm64 ampere microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfampere' 
 
     # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
     # # run coreclr linux crossgen perf job

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -99,37 +99,37 @@ extends:
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-      # build coreclr and libraries
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-          buildConfig: release
-          platforms:
-          - Linux_arm64
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
+      # # build coreclr and libraries
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - Linux_arm64
+      #     - windows_arm64
+      #     jobParameters:
+      #       testGroup: perf
 
-      # build mono on wasm
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          runtimeFlavor: mono
-          platforms:
-          - Browser_wasm
-          jobParameters:
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-            nameSuffix: wasm
-            isOfficialBuild: false
-            extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-            extraStepsParameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Browser Wasm Artifacts
-              artifactName: BrowserWasm
-              archiveType: zip
-              archiveExtension: .zip
+      # # build mono on wasm
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - Browser_wasm
+      #     jobParameters:
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #       nameSuffix: wasm
+      #       isOfficialBuild: false
+      #       extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+      #       extraStepsParameters:
+      #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+      #         includeRootFolder: true
+      #         displayName: Browser Wasm Artifacts
+      #         artifactName: BrowserWasm
+      #         archiveType: zip
+      #         archiveExtension: .zip
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -174,55 +174,55 @@ extends:
             logicalmachine: 'perfampere'
             timeoutInMinutes: 500 
 
-    # run coreclr Linux arm64 ampere microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - Linux_arm64
-          container: ubuntu-18.04-cross-arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfampere'
-            timeoutInMinutes: 500 
+    # # run coreclr Linux arm64 ampere microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - Linux_arm64
+    #       container: ubuntu-18.04-cross-arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfampere'
+    #         timeoutInMinutes: 500 
 
-    # run coreclr Windows arm64 microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfsurf' 
+    # # run coreclr Windows arm64 microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - windows_arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfsurf' 
 
-    # run coreclr Windows arm64 ampere microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfampere' 
+    # # run coreclr Windows arm64 ampere microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - windows_arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfampere' 
 
     # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
     # # run coreclr linux crossgen perf job

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -99,37 +99,37 @@ extends:
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-      # # build coreclr and libraries
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      #     buildConfig: release
-      #     platforms:
-      #     - Linux_arm64
-      #     - windows_arm64
-      #     jobParameters:
-      #       testGroup: perf
+      # build coreclr and libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+          buildConfig: release
+          platforms:
+          - Linux_arm64
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
 
-      # # build mono on wasm
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: release
-      #     runtimeFlavor: mono
-      #     platforms:
-      #     - Browser_wasm
-      #     jobParameters:
-      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      #       nameSuffix: wasm
-      #       isOfficialBuild: false
-      #       extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-      #       extraStepsParameters:
-      #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-      #         includeRootFolder: true
-      #         displayName: Browser Wasm Artifacts
-      #         artifactName: BrowserWasm
-      #         archiveType: zip
-      #         archiveExtension: .zip
+      # build mono on wasm
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Browser_wasm
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: wasm
+            isOfficialBuild: false
+            extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+            extraStepsParameters:
+              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+              includeRootFolder: true
+              displayName: Browser Wasm Artifacts
+              artifactName: BrowserWasm
+              archiveType: zip
+              archiveExtension: .zip
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -136,13 +136,14 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
           container: ubuntu-18.04-cross-arm64
-          crossrootfsDir: '/crossrootfs/arm64'
+          crossrootfsDir: '/crossrootfs/arm64'  
           runtimeFlavor: mono
           runtimeVariant: 'llvmaot'
           platforms:
           - Linux_arm64
           jobParameters:
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+            crossrootfsDir: '/crossrootfs/arm64'  
             nameSuffix: AOT
             isOfficialBuild: false
             extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -142,6 +142,7 @@ extends:
           - Linux_arm64
           jobParameters:
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+            crossrootfsDir: '/crossrootfs/arm64'
             nameSuffix: AOT
             isOfficialBuild: false
             extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -136,7 +136,6 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: release
           container: ubuntu-18.04-cross-arm64
-          crossrootfsDir: '/crossrootfs/arm64'  
           runtimeFlavor: mono
           runtimeVariant: 'llvmaot'
           platforms:


### PR DESCRIPTION
Added crossrootfsDir parameter to AOT job pointing to crossrootfsDir for the arm64 run and removed 'jobParameters.' from the assignment in global-build-job as was not correctly passing the crossrootfsDir parameter. This seems to have been broken by: https://github.com/dotnet/runtime/commit/3c99def0a527de0489fcb2b0dc16f46d1f948a32.

The addition of crossrootfsDir condition was recent in https://github.com/dotnet/runtime/pull/75513, I think that this new format is the correct one given jobParameters is not used as a parameter group elsewhere in the global-build-job.yml.

Run showing the 'Build Linux arm64 release AOT' job running successfully: https://dev.azure.com/dnceng/internal/_build/results?buildId=2020079&view=results.