### PR TITLE
[PERF] Fix Linux arm64 AOT ROOTFS_DIR missing (Less Impactful)

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -99,37 +99,37 @@ extends:
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-      # # build coreclr and libraries
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      #     buildConfig: release
-      #     platforms:
-      #     - Linux_arm64
-      #     - windows_arm64
-      #     jobParameters:
-      #       testGroup: perf
+      # build coreclr and libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+          buildConfig: release
+          platforms:
+          - Linux_arm64
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
 
-      # # build mono on wasm
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: release
-      #     runtimeFlavor: mono
-      #     platforms:
-      #     - Browser_wasm
-      #     jobParameters:
-      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      #       nameSuffix: wasm
-      #       isOfficialBuild: false
-      #       extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-      #       extraStepsParameters:
-      #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-      #         includeRootFolder: true
-      #         displayName: Browser Wasm Artifacts
-      #         artifactName: BrowserWasm
-      #         archiveType: zip
-      #         archiveExtension: .zip
+      # build mono on wasm
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Browser_wasm
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: wasm
+            isOfficialBuild: false
+            extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+            extraStepsParameters:
+              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+              includeRootFolder: true
+              displayName: Browser Wasm Artifacts
+              artifactName: BrowserWasm
+              archiveType: zip
+              archiveExtension: .zip
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -157,75 +157,75 @@ extends:
               archiveType: tar
               tarCompression: gz
 
-    #   # run mono aot microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-    #       buildConfig: release
-    #       runtimeFlavor: aot
-    #       platforms:
-    #       - Linux_arm64
-    #       container: ubuntu-18.04-cross-arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         runtimeType: mono
-    #         codeGenType: 'AOT'
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro_mono
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfampere'
-    #         timeoutInMinutes: 500 
+      # run mono aot microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+          buildConfig: release
+          runtimeFlavor: aot
+          platforms:
+          - Linux_arm64
+          container: ubuntu-18.04-cross-arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: mono
+            codeGenType: 'AOT'
+            projectFile: microbenchmarks.proj
+            runKind: micro_mono
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfampere'
+            timeoutInMinutes: 500 
 
-    # # run coreclr Linux arm64 ampere microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - Linux_arm64
-    #       container: ubuntu-18.04-cross-arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfampere'
-    #         timeoutInMinutes: 500 
+    # run coreclr Linux arm64 ampere microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - Linux_arm64
+          container: ubuntu-18.04-cross-arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfampere'
+            timeoutInMinutes: 500 
 
-    # # run coreclr Windows arm64 microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - windows_arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfsurf' 
+    # run coreclr Windows arm64 microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfsurf' 
 
-    # # run coreclr Windows arm64 ampere microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - windows_arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfampere' 
+    # run coreclr Windows arm64 ampere microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfampere' 
 
     # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
     # # run coreclr linux crossgen perf job

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -140,6 +140,8 @@ extends:
           runtimeVariant: 'llvmaot'
           platforms:
           - Linux_arm64
+          env:
+            ROOTFS_DIR: /crossrootfs/arm64
           jobParameters:
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
             nameSuffix: AOT

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -99,37 +99,37 @@ extends:
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-      # build coreclr and libraries
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-          buildConfig: release
-          platforms:
-          - Linux_arm64
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
+      # # build coreclr and libraries
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - Linux_arm64
+      #     - windows_arm64
+      #     jobParameters:
+      #       testGroup: perf
 
-      # build mono on wasm
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          runtimeFlavor: mono
-          platforms:
-          - Browser_wasm
-          jobParameters:
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-            nameSuffix: wasm
-            isOfficialBuild: false
-            extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-            extraStepsParameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Browser Wasm Artifacts
-              artifactName: BrowserWasm
-              archiveType: zip
-              archiveExtension: .zip
+      # # build mono on wasm
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - Browser_wasm
+      #     jobParameters:
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #       nameSuffix: wasm
+      #       isOfficialBuild: false
+      #       extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+      #       extraStepsParameters:
+      #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+      #         includeRootFolder: true
+      #         displayName: Browser Wasm Artifacts
+      #         artifactName: BrowserWasm
+      #         archiveType: zip
+      #         archiveExtension: .zip
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -156,75 +156,75 @@ extends:
               archiveType: tar
               tarCompression: gz
 
-      # run mono aot microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-          buildConfig: release
-          runtimeFlavor: aot
-          platforms:
-          - Linux_arm64
-          container: ubuntu-18.04-cross-arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            runtimeType: mono
-            codeGenType: 'AOT'
-            projectFile: microbenchmarks.proj
-            runKind: micro_mono
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfampere'
-            timeoutInMinutes: 500 
+    #   # run mono aot microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+    #       buildConfig: release
+    #       runtimeFlavor: aot
+    #       platforms:
+    #       - Linux_arm64
+    #       container: ubuntu-18.04-cross-arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         runtimeType: mono
+    #         codeGenType: 'AOT'
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro_mono
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfampere'
+    #         timeoutInMinutes: 500 
 
-    # run coreclr Linux arm64 ampere microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - Linux_arm64
-          container: ubuntu-18.04-cross-arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfampere'
-            timeoutInMinutes: 500 
+    # # run coreclr Linux arm64 ampere microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - Linux_arm64
+    #       container: ubuntu-18.04-cross-arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfampere'
+    #         timeoutInMinutes: 500 
 
-    # run coreclr Windows arm64 microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfsurf' 
+    # # run coreclr Windows arm64 microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - windows_arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfsurf' 
 
-    # run coreclr Windows arm64 ampere microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfampere' 
+    # # run coreclr Windows arm64 ampere microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - windows_arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfampere' 
 
     # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
     # # run coreclr linux crossgen perf job

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -138,14 +138,14 @@ extends:
           container: ubuntu-18.04-cross-arm64
           runtimeFlavor: mono
           runtimeVariant: 'llvmaot'
+          variables:
+            - name: ROOTFS_DIR
+              value: /crossrootfs/arm64
           platforms:
           - Linux_arm64
           jobParameters:
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
             nameSuffix: AOT
-            variables:
-              - name: ROOTFS_DIR
-                value: /crossrootfs/arm64
             isOfficialBuild: false
             extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
             extraStepsParameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -143,7 +143,7 @@ extends:
           jobParameters:
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
             nameSuffix: AOT
-            env:
+            variables:
               ROOTFS_DIR: /crossrootfs/arm64
             isOfficialBuild: false
             extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -50,6 +50,9 @@ extends:
           jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
           buildConfig: release
           container: ubuntu-18.04-cross-arm64
+          variables:
+            - name: ROOTFS_DIR
+              value: /crossrootfs/arm64
           platforms:
           - Linux_arm64
           jobParameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -144,7 +144,8 @@ extends:
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
             nameSuffix: AOT
             variables:
-              ROOTFS_DIR: /crossrootfs/arm64
+              - name: ROOTFS_DIR
+                value: /crossrootfs/arm64
             isOfficialBuild: false
             extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
             extraStepsParameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -102,37 +102,37 @@ extends:
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-      # # build coreclr and libraries
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      #     buildConfig: release
-      #     platforms:
-      #     - Linux_arm64
-      #     - windows_arm64
-      #     jobParameters:
-      #       testGroup: perf
+      # build coreclr and libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+          buildConfig: release
+          platforms:
+          - Linux_arm64
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
 
-      # # build mono on wasm
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-      #     buildConfig: release
-      #     runtimeFlavor: mono
-      #     platforms:
-      #     - Browser_wasm
-      #     jobParameters:
-      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-      #       nameSuffix: wasm
-      #       isOfficialBuild: false
-      #       extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-      #       extraStepsParameters:
-      #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-      #         includeRootFolder: true
-      #         displayName: Browser Wasm Artifacts
-      #         artifactName: BrowserWasm
-      #         archiveType: zip
-      #         archiveExtension: .zip
+      # build mono on wasm
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          runtimeFlavor: mono
+          platforms:
+          - Browser_wasm
+          jobParameters:
+            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+            nameSuffix: wasm
+            isOfficialBuild: false
+            extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+            extraStepsParameters:
+              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+              includeRootFolder: true
+              displayName: Browser Wasm Artifacts
+              artifactName: BrowserWasm
+              archiveType: zip
+              archiveExtension: .zip
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -160,89 +160,75 @@ extends:
               archiveType: tar
               tarCompression: gz
 
-            # build coreclr and libraries
+      # run mono aot microbenchmarks perf job
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
-          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
           buildConfig: release
-          container: ubuntu-18.04-cross-arm64
-          variables:
-            - name: ROOTFS_DIR
-              value: /crossrootfs/arm64
+          runtimeFlavor: aot
           platforms:
           - Linux_arm64
+          container: ubuntu-18.04-cross-arm64
           jobParameters:
             testGroup: perf
+            liveLibrariesBuildConfig: Release
+            runtimeType: mono
+            codeGenType: 'AOT'
+            projectFile: microbenchmarks.proj
+            runKind: micro_mono
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfampere'
+            timeoutInMinutes: 500 
 
-    #   # run mono aot microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-    #       buildConfig: release
-    #       runtimeFlavor: aot
-    #       platforms:
-    #       - Linux_arm64
-    #       container: ubuntu-18.04-cross-arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         runtimeType: mono
-    #         codeGenType: 'AOT'
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro_mono
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfampere'
-    #         timeoutInMinutes: 500 
+    # run coreclr Linux arm64 ampere microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - Linux_arm64
+          container: ubuntu-18.04-cross-arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfampere'
+            timeoutInMinutes: 500 
 
-    # # run coreclr Linux arm64 ampere microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - Linux_arm64
-    #       container: ubuntu-18.04-cross-arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfampere'
-    #         timeoutInMinutes: 500 
+    # run coreclr Windows arm64 microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfsurf' 
 
-    # # run coreclr Windows arm64 microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - windows_arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfsurf' 
-
-    # # run coreclr Windows arm64 ampere microbenchmarks perf job
-    #   - template: /eng/pipelines/common/platform-matrix.yml
-    #     parameters:
-    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    #       buildConfig: release
-    #       runtimeFlavor: coreclr
-    #       platforms:
-    #       - windows_arm64
-    #       jobParameters:
-    #         testGroup: perf
-    #         liveLibrariesBuildConfig: Release
-    #         projectFile: microbenchmarks.proj
-    #         runKind: micro
-    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-    #         logicalmachine: 'perfampere' 
+    # run coreclr Windows arm64 ampere microbenchmarks perf job
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+          - windows_arm64
+          jobParameters:
+            testGroup: perf
+            liveLibrariesBuildConfig: Release
+            projectFile: microbenchmarks.proj
+            runKind: micro
+            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+            logicalmachine: 'perfampere' 
 
     # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
     # # run coreclr linux crossgen perf job

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -102,37 +102,37 @@ extends:
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-      # build coreclr and libraries
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-          buildConfig: release
-          platforms:
-          - Linux_arm64
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
+      # # build coreclr and libraries
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      #     buildConfig: release
+      #     platforms:
+      #     - Linux_arm64
+      #     - windows_arm64
+      #     jobParameters:
+      #       testGroup: perf
 
-      # build mono on wasm
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          runtimeFlavor: mono
-          platforms:
-          - Browser_wasm
-          jobParameters:
-            buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-            nameSuffix: wasm
-            isOfficialBuild: false
-            extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-            extraStepsParameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Browser Wasm Artifacts
-              artifactName: BrowserWasm
-              archiveType: zip
-              archiveExtension: .zip
+      # # build mono on wasm
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+      #     buildConfig: release
+      #     runtimeFlavor: mono
+      #     platforms:
+      #     - Browser_wasm
+      #     jobParameters:
+      #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+      #       nameSuffix: wasm
+      #       isOfficialBuild: false
+      #       extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+      #       extraStepsParameters:
+      #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+      #         includeRootFolder: true
+      #         displayName: Browser Wasm Artifacts
+      #         artifactName: BrowserWasm
+      #         archiveType: zip
+      #         archiveExtension: .zip
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -160,75 +160,89 @@ extends:
               archiveType: tar
               tarCompression: gz
 
-      # run mono aot microbenchmarks perf job
+            # build coreclr and libraries
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+          jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
           buildConfig: release
-          runtimeFlavor: aot
+          container: ubuntu-18.04-cross-arm64
+          variables:
+            - name: ROOTFS_DIR
+              value: /crossrootfs/arm64
           platforms:
           - Linux_arm64
-          container: ubuntu-18.04-cross-arm64
           jobParameters:
             testGroup: perf
-            liveLibrariesBuildConfig: Release
-            runtimeType: mono
-            codeGenType: 'AOT'
-            projectFile: microbenchmarks.proj
-            runKind: micro_mono
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfampere'
-            timeoutInMinutes: 500 
 
-    # run coreclr Linux arm64 ampere microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - Linux_arm64
-          container: ubuntu-18.04-cross-arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfampere'
-            timeoutInMinutes: 500 
+    #   # run mono aot microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+    #       buildConfig: release
+    #       runtimeFlavor: aot
+    #       platforms:
+    #       - Linux_arm64
+    #       container: ubuntu-18.04-cross-arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         runtimeType: mono
+    #         codeGenType: 'AOT'
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro_mono
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfampere'
+    #         timeoutInMinutes: 500 
 
-    # run coreclr Windows arm64 microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfsurf' 
+    # # run coreclr Linux arm64 ampere microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - Linux_arm64
+    #       container: ubuntu-18.04-cross-arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfampere'
+    #         timeoutInMinutes: 500 
 
-    # run coreclr Windows arm64 ampere microbenchmarks perf job
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - windows_arm64
-          jobParameters:
-            testGroup: perf
-            liveLibrariesBuildConfig: Release
-            projectFile: microbenchmarks.proj
-            runKind: micro
-            runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-            logicalmachine: 'perfampere' 
+    # # run coreclr Windows arm64 microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - windows_arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfsurf' 
+
+    # # run coreclr Windows arm64 ampere microbenchmarks perf job
+    #   - template: /eng/pipelines/common/platform-matrix.yml
+    #     parameters:
+    #       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+    #       buildConfig: release
+    #       runtimeFlavor: coreclr
+    #       platforms:
+    #       - windows_arm64
+    #       jobParameters:
+    #         testGroup: perf
+    #         liveLibrariesBuildConfig: Release
+    #         projectFile: microbenchmarks.proj
+    #         runKind: micro
+    #         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+    #         logicalmachine: 'perfampere' 
 
     # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
     # # run coreclr linux crossgen perf job

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -140,11 +140,11 @@ extends:
           runtimeVariant: 'llvmaot'
           platforms:
           - Linux_arm64
-          env:
-            ROOTFS_DIR: /crossrootfs/arm64
           jobParameters:
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
             nameSuffix: AOT
+            env:
+              ROOTFS_DIR: /crossrootfs/arm64
             isOfficialBuild: false
             extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
             extraStepsParameters:


### PR DESCRIPTION
This adds the ROOTFS_DIR variable to the global-build-job for Linux AOT Arm64. This is a less impactful and smaller update to fix the problem than https://github.com/dotnet/runtime/pull/77024 as this does not change global-build-job. Although it may still be worthwhile to check if the crossrootfsDir condition is incorrect and fix it.

Working build with the change: https://dev.azure.com/dnceng/internal/_build/results?buildId=2020245&view=logs&j=29aef6bf-22ff-5269-0c67-e98540f696db&t=d29db927-bdb9-52f6-e00d-5ad3c37b6beb