### PR TITLE
Trim trailing SP and HTAB for header value on HTTP/1.1

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1208,7 +1208,7 @@ namespace System.Net.Http
             {
                 int spIdx = value.Length - 1;
 
-                if ((uint)spIdx >= (uint)value.Length || value[spIdx] != ' ' || value[spIdx] != '\t')
+                if ((uint)spIdx >= (uint)value.Length || !(value[spIdx] is (byte)' ' or (byte)'\t'))
                 {
                     // hot path
                     break;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1203,12 +1203,12 @@ namespace System.Net.Http
                 value = value.Slice(1);
             }
 
-            // Skip trailing whitespace for value.
+            // Skip trailing OWS for value.
             while (true)
             {
                 int spIdx = value.Length - 1;
 
-                if ((uint)spIdx >= (uint)value.Length || value[spIdx] != ' ')
+                if ((uint)spIdx >= (uint)value.Length || value[spIdx] != ' ' || value[spIdx] != '\t')
                 {
                     // hot path
                     break;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -19,7 +19,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -19,6 +19,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
@@ -3680,8 +3681,16 @@ namespace System.Net.Http.Functional.Tests
     {
         public SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http11(ITestOutputHelper output) : base(output) { }
 
-        [Fact]
-        public async Task ResponseHeaders_ExtraWhitespace_Trimmed()
+        [Theory]
+        [InlineData("foo ", "bar ")]
+        [InlineData("foo", " bar")]
+        [InlineData("foo", "bar\t")]
+        [InlineData("foo", "\tbar")]
+        [InlineData("foo ", " bar ")]
+        [InlineData("foo", "\tbar\t")]
+        [InlineData("foo", "\t bar \t")]
+        [InlineData("foo  ", " \t bar  \r\n ")]
+        public async Task ResponseHeaders_ExtraWhitespace_Trimmed(string name, string value)
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
@@ -3689,12 +3698,12 @@ namespace System.Net.Http.Functional.Tests
 
                 using HttpResponseMessage response = await client.GetAsync(uri);
 
-                Assert.True(response.Headers.NonValidated.TryGetValues("foo", out HeaderStringValues value));
-                Assert.Equal("bar", Assert.Single(value));
+                Assert.True(response.Headers.NonValidated.TryGetValues("foo", out HeaderStringValues values));
+                Assert.Equal("bar", Assert.Single(values));
             },
             async server =>
             {
-                await server.HandleRequestAsync(headers: new[] { new HttpHeaderData("foo  ", " \t bar  \r\n ") });
+                await server.HandleRequestAsync(headers: new[] { new HttpHeaderData(name, value) });
             });
         }
     }


### PR DESCRIPTION
Trim trailing SP and HTAB for header value on HTTP/1.1

Fixes #77001

Please review
Thank you in advance