### PR TITLE
[wasm][debugger] Remove non-deterministic signals from debugger tests.

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -505,8 +505,7 @@ namespace DebuggerTests
                 expression = "window.setTimeout(function() { " + func_name + "(); }, 1);"
             });
             await cli.SendCommand("Runtime.evaluate", run_method, token);
-            insp.NotifyOfNonWasmIsLoading(true);
-            await insp.WaitFor(Inspector.NON_WASM_PAGE_READY);
+            await WaitForEventAsync("Runtime.executionContextCreated");
 
             run_method = JObject.FromObject(new
             {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -505,7 +505,8 @@ namespace DebuggerTests
                 expression = "window.setTimeout(function() { " + func_name + "(); }, 1);"
             });
             await cli.SendCommand("Runtime.evaluate", run_method, token);
-            await Task.Delay(1000, token);
+            insp.NotifyOfNonWasmIsLoading(true);
+            await insp.WaitFor(Inspector.NON_WASM_PAGE_READY);
 
             run_method = JObject.FromObject(new
             {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1451,17 +1451,17 @@ namespace DebuggerTests
             return await WaitFor(Inspector.PAUSE);
         }
 
-        public async Task<JObject> WaitForBreakpointResolvedEvent()
+        public Task<JObject> WaitForBreakpointResolvedEvent() => WaitForEventAsync("Debugger.breakpointResolved");
+
+        public async Task<JObject> WaitForEventAsync(string eventName)
         {
             try
             {
-                var res = await insp.WaitForEvent("Debugger.breakpointResolved");
-                _testOutput.WriteLine ($"breakpoint resolved to {res}");
-                return res;
+                return await insp.WaitForEvent(eventName);
             }
             catch (TaskCanceledException)
             {
-                throw new XunitException($"Timed out waiting for Debugger.breakpointResolved event");
+                throw new XunitException($"Timed out waiting for {eventName} event");
             }
         }
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
@@ -238,7 +238,7 @@ namespace DebuggerTests
                                     {
                                         ignoreCache = true
                                     }));
-            Thread.Sleep(1000);
+            await insp.WaitFor(Inspector.APP_READY);
 
             var eval_expr = "window.setTimeout(function() { invoke_static_method (" +
                 $"'{entry_method_name}'" +
@@ -281,7 +281,7 @@ namespace DebuggerTests
                                     }), "Page.reload",null, 0, 0, null);
             Thread.Sleep(1000);
 
-            // Hit resume to skip 
+            // Hit resume to skip
             int count = 0;
             while(true)
             {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
@@ -275,7 +275,6 @@ namespace DebuggerTests
             await SetPauseOnException("all");
 
             await SendCommand("Page.enable", null);
-            // this is waiting for Debugger.paused, so we don't need to use Thread.Sleep after it
             var pause_location = await SendCommandAndCheck(JObject.FromObject(new
                                     {
                                         ignoreCache = true

--- a/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/ExceptionTests.cs
@@ -275,11 +275,11 @@ namespace DebuggerTests
             await SetPauseOnException("all");
 
             await SendCommand("Page.enable", null);
+            // this is waiting for Debugger.paused, so we don't need to use Thread.Sleep after it
             var pause_location = await SendCommandAndCheck(JObject.FromObject(new
                                     {
                                         ignoreCache = true
-                                    }), "Page.reload",null, 0, 0, null);
-            Thread.Sleep(1000);
+                                    }), "Page.reload", null, 0, 0, null);
 
             // Hit resume to skip
             int count = 0;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
@@ -29,18 +29,15 @@ namespace DebuggerTests
 
         public const string PAUSE = "pause";
         public const string APP_READY = "app-ready";
-        public const string NON_WASM_PAGE_READY = "non-wasm-page-ready";
         public CancellationToken Token { get; }
         public InspectorClient Client { get; }
         public DebuggerProxyBase? Proxy { get; }
         public bool DetectAndFailOnAssertions { get; set; } = true;
-        public void NotifyOfNonWasmIsLoading(bool value) => _nonWasmIsLoading = value;
 
         private CancellationTokenSource _cancellationTokenSource;
         private Exception? _isFailingWithException;
         private bool _gotRuntimeReady = false;
         private bool _gotAppReady = false;
-        private bool _nonWasmIsLoading = false;
 
         protected static Lazy<ILoggerFactory> s_loggerFactory = new(() =>
             LoggerFactory.Create(builder =>
@@ -202,13 +199,6 @@ namespace DebuggerTests
             bool fail = false;
             switch (method)
             {
-                case "Runtime.executionContextCreated":
-                    if (_nonWasmIsLoading)
-                    {
-                        _nonWasmIsLoading = false;
-                        NotifyOf(NON_WASM_PAGE_READY, args);
-                    }
-                    break;
                 case "Debugger.paused":
                     NotifyOf(PAUSE, args);
                     break;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Inspector.cs
@@ -29,15 +29,18 @@ namespace DebuggerTests
 
         public const string PAUSE = "pause";
         public const string APP_READY = "app-ready";
+        public const string NON_WASM_PAGE_READY = "non-wasm-page-ready";
         public CancellationToken Token { get; }
         public InspectorClient Client { get; }
         public DebuggerProxyBase? Proxy { get; }
         public bool DetectAndFailOnAssertions { get; set; } = true;
+        public void NotifyOfNonWasmIsLoading(bool value) => _nonWasmIsLoading = value;
 
         private CancellationTokenSource _cancellationTokenSource;
         private Exception? _isFailingWithException;
         private bool _gotRuntimeReady = false;
         private bool _gotAppReady = false;
+        private bool _nonWasmIsLoading = false;
 
         protected static Lazy<ILoggerFactory> s_loggerFactory = new(() =>
             LoggerFactory.Create(builder =>
@@ -199,6 +202,13 @@ namespace DebuggerTests
             bool fail = false;
             switch (method)
             {
+                case "Runtime.executionContextCreated":
+                    if (_nonWasmIsLoading)
+                    {
+                        _nonWasmIsLoading = false;
+                        NotifyOf(NON_WASM_PAGE_READY, args);
+                    }
+                    break;
                 case "Debugger.paused":
                     NotifyOf(PAUSE, args);
                     break;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75392.
Removes `Task.Delay` and `Thread.Sleep` from debugger tests.

- `ExceptionTestUncaughtWithReload` - using `App_Ready` is enough.
- `CreateGoodBreakpointAndHitGoToNonWasmPageComeBackAndHitAgain`: we are going to non-wasm page, so there's no runtime from which we could get info about being ready. Also, we cannot rely on any message passed from browser to notify the inspector in all cases because it would send notification for wasm as well. That's why we introduce a new mechanism of informing Inspector that tests are waiting for non-wasm loading and only then we can notify about runtime context being created.
- `ExceptionTestAllWithReload` had a Sleep that was in fact useless as `SendCommandAndCheck` waits for `Inspector.PAUSE` evant by default anyway.
