### PR TITLE
Target only net7.0 during source-build - Port of #75168 to main

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,6 +53,7 @@
     <NetCoreAppCurrentBrandName>.NET $(NetCoreAppCurrentVersion)</NetCoreAppCurrentBrandName>
     <NetCoreAppCurrent>net$(NetCoreAppCurrentVersion)</NetCoreAppCurrent>
     <NetCoreAppMinimum>net6.0</NetCoreAppMinimum>
+    <NetCoreAppMinimum Condition="'$(DotNetBuildFromSource)' == 'true'">$(NetCoreAppCurrent)</NetCoreAppMinimum>
 
     <NetCoreAppToolCurrentVersion>7.0</NetCoreAppToolCurrentVersion>
     <NetCoreAppToolCurrent>net$(NetCoreAppToolCurrentVersion)</NetCoreAppToolCurrent>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -48,6 +48,7 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:BuildDebPackage=false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnableNgenOptimization=false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:AdditionalRuntimeIdentifierParent=$(BaseOS)</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:EnablePackageValidation=false</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/src/libraries/System.Text.RegularExpressions/tools/GenerateRegexCasingTable.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tools/GenerateRegexCasingTable.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
       <OutputType>Exe</OutputType>
       <TargetFramework>net7.0</TargetFramework>
+      <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+      <LangVersion>latest</LangVersion>
       <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/libraries/System.Text.RegularExpressions/tools/GenerateRegexCasingTable.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tools/GenerateRegexCasingTable.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
       <OutputType>Exe</OutputType>
       <TargetFramework>net7.0</TargetFramework>
-      <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
-      <LangVersion>latest</LangVersion>
       <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Port of #75168 to main.  These changes are also needed to support building main in source build.

* Target net7.0 in additional projects

* Update compatibility suppressions

* Only target net7.0 for source-build

* Disable package validation for source-build

* Revert compatibility suppression changes

* Use NetCoreAppCurrent instead of hardcoding net7.0

* Revert mono Apple TFM change

* Remove unnecessary LangVersion