### PR TITLE
Fixed a typo in a variable name

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -453,17 +453,17 @@ namespace System.Collections.Generic
         {
             Debug.Assert(_items.Length < capacity);
 
-            int newcapacity = _items.Length == 0 ? DefaultCapacity : 2 * _items.Length;
+            int newCapacity = _items.Length == 0 ? DefaultCapacity : 2 * _items.Length;
 
             // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
             // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-            if ((uint)newcapacity > Array.MaxLength) newcapacity = Array.MaxLength;
+            if ((uint)newCapacity > Array.MaxLength) newCapacity = Array.MaxLength;
 
             // If the computed capacity is still less than specified, set to the original argument.
             // Capacities exceeding Array.MaxLength will be surfaced as OutOfMemoryException by Array.Resize.
-            if (newcapacity < capacity) newcapacity = capacity;
+            if (newCapacity < capacity) newCapacity = capacity;
 
-            Capacity = newcapacity;
+            Capacity = newCapacity;
         }
 
         public bool Exists(Predicate<T> match)


### PR DESCRIPTION
# Description

Fixed a casing issue in a variable name.

# Customer Impact

Nothing for customers.

# Regression

No regression.

# Testing

Not needed.

# Risk

No risks.