### PR TITLE
Revert "[wasm] Run System.Runtime tests in a deterministic order to w…

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -16,12 +16,6 @@
     <WithoutCategories Condition="'$(EnableAdditionalTimezoneChecks)' != 'true'">$(WithoutCategories);AdditionalTimezoneChecks</WithoutCategories>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
-    <!-- Workaround for https://github.com/dotnet/runtime/issues/74302 -->
-    <XUnitUseRandomizedTestOrderer>true</XUnitUseRandomizedTestOrderer>
-    <WasmXHarnessMonoArgs>--setenv=XUNIT_RANDOM_ORDER_SEED=1</WasmXHarnessMonoArgs>
-  </PropertyGroup>
-
   <ItemGroup>
     <RdXmlFile Include="default.rd.xml" />
   </ItemGroup>


### PR DESCRIPTION
…ork around https://github.com/dotnet/runtime/issues/74302. (#76287)"

This reverts commit 68593dd718390853b4c74dc1d79906390aaf1589.

https://github.com/dotnet/runtime/issues/74302 should be fixed now by a07188777ffa92adc8a00ca974bd1c63156d19f1.