### PR TITLE
Fix loading app-local ICU

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -14,7 +14,7 @@ namespace System
         // do it in a way that failures don't cascade.
         //
 
-        private static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         public static bool IsOpenSUSE => IsDistroAndVersion("opensuse");
         public static bool IsUbuntu => IsDistroAndVersion("ubuntu");
         public static bool IsDebian => IsDistroAndVersion("debian");

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TestRuntime>true</TestRuntime>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="IcuAppLocal.cs" />
@@ -9,6 +10,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
+
+    <!--
+      We define this switch dynamically during the runtime using RemoteExecutor.
+      The reason is, if we enable ICU app-local here, this test will compile and run
+      on all supported OSs even the ICU NuGet package not have native bits support such OSs.
+      Note, it doesn't matter if we have test case conditioned to not run on such OSs, because
+      the test has to start running first before filtering the test cases and teh globalization
+      code will run at that time and will fail fast at that time.
+
+      <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
+    -->
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.Tests.csproj
@@ -16,8 +16,8 @@
       The reason is, if we enable ICU app-local here, this test will compile and run
       on all supported OSs even the ICU NuGet package not have native bits support such OSs.
       Note, it doesn't matter if we have test case conditioned to not run on such OSs, because
-      the test has to start running first before filtering the test cases and teh globalization
-      code will run at that time and will fail fast at that time.
+      the test has to start running first before filtering the test cases and the globalization
+      code will run and fail fast at that time.
 
       <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
     -->

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TestRuntime>true</TestRuntime>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="IcuAppLocal.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.DotNet.RemoteExecutor;
+using System.Diagnostics;
 using System.Reflection;
 using Xunit;
 
@@ -13,23 +15,36 @@ namespace System.Globalization.Tests
                                                          PlatformDetection.IsNotOSX &&
                                                          PlatformDetection.IsNotMobile &&
                                                          !PlatformDetection.IsAlpine &&
-                                                         !PlatformDetection.IsLinuxBionic;
+                                                         !PlatformDetection.IsLinuxBionic &&
+                                                         RemoteExecutor.IsSupported;
 
         [ConditionalFact(nameof(SupportIcuPackageDownload))]
-        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "ICU package doesn't support these platforms.")]
         public void TestIcuAppLocal()
         {
-            Type? interopGlobalization = Type.GetType("Interop+Globalization, System.Private.CoreLib");
-            Assert.NotNull(interopGlobalization);
+            // We define this switch dynamically during the runtime using RemoteExecutor.
+            // The reason is, if we enable ICU app-local here, this test will compile and run
+            // on all supported OSs even the ICU NuGet package not have native bits support such OSs.
+            // Note, it doesn't matter if we have test case conditioned to not run on such OSs, because
+            // the test has to start running first before filtering the test cases and the globalization
+            // code will run at that time and will fail fast at that time.
 
-            MethodInfo? methodInfo = interopGlobalization.GetMethod("GetICUVersion", BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.NotNull(methodInfo);
+            ProcessStartInfo psi = new ProcessStartInfo() { UseShellExecute = false };
+            psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU", "68.2.0.9");
 
-            // Assert the ICU version 0x44020009 is 68.2.0.9
-            Assert.Equal(0x44020009, (int)methodInfo.Invoke(null, null));
+            RemoteExecutor.Invoke(() =>
+            {
+                Type? interopGlobalization = Type.GetType("Interop+Globalization, System.Private.CoreLib");
+                Assert.NotNull(interopGlobalization);
 
-            // Now call globalization API to ensure the binding working without any problem.
-            Assert.Equal(-1, CultureInfo.GetCultureInfo("en-US").CompareInfo.Compare("sample\u0000", "Sample\u0000", CompareOptions.IgnoreSymbols));
+                MethodInfo? methodInfo = interopGlobalization.GetMethod("GetICUVersion", BindingFlags.NonPublic | BindingFlags.Static);
+                Assert.NotNull(methodInfo);
+
+                // Assert the ICU version 0x44020009 is 68.2.0.9
+                Assert.Equal(0x44020009, (int)methodInfo.Invoke(null, null));
+
+                // Now call globalization API to ensure the binding working without any problem.
+                Assert.Equal(-1, CultureInfo.GetCultureInfo("en-US").CompareInfo.Compare("sample\u0000", "Sample\u0000", CompareOptions.IgnoreSymbols));
+            }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
     }
 }

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -16,6 +16,7 @@ namespace System.Globalization.Tests
                                                          !PlatformDetection.IsLinuxBionic;
 
         [ConditionalFact(nameof(SupportIcuPackageDownload))]
+        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "ICU package doesn't support these platforms.")]
         public void TestIcuAppLocal()
         {
             Type? interopGlobalization = Type.GetType("Interop+Globalization, System.Private.CoreLib");

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -9,8 +9,13 @@ namespace System.Globalization.Tests
     public class IcuAppLocalTests
     {
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
+        private static bool SupportIcuPackageDownload => PlatformDetection.Is64BitProcess &&
+                                                         PlatformDetection.IsNotOSX &&
+                                                         PlatformDetection.IsNotMobile &&
+                                                         !PlatformDetection.IsAlpine &&
+                                                         !PlatformDetection.IsLinuxBionic;
+
+        [ConditionalFact(nameof(SupportIcuPackageDownload))]
         public void TestIcuAppLocal()
         {
             Type? interopGlobalization = Type.GetType("Interop+Globalization, System.Private.CoreLib");

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -8,9 +8,9 @@ namespace System.Globalization.Tests
 {
     public class IcuAppLocalTests
     {
-        private static bool SupportIcuLocals => PlatformDetection.IsNotMobile && !PlatformDetection.Is32BitProcess;
 
-        [ConditionalFact(nameof(SupportIcuLocals))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
         public void TestIcuAppLocal()
         {
             Type? interopGlobalization = Type.GetType("Interop+Globalization, System.Private.CoreLib");

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -26,7 +26,7 @@ namespace System.Globalization.Tests
             // the test has to start running first before filtering the test cases and the globalization
             // code will run and fail fast at that time.
 
-            ProcessStartInfo psi = new ProcessStartInfo() { UseShellExecute = false };
+            ProcessStartInfo psi = new ProcessStartInfo();
             psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU", "68.2.0.9");
 
             RemoteExecutor.Invoke(() =>

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.Globalization.Tests
+{
+    public class IcuAppLocalTests
+    {
+        private static bool SupportIcuLocals => PlatformDetection.IsNotMobile && !PlatformDetection.Is32BitProcess;
+
+        [ConditionalFact(nameof(SupportIcuLocals))]
+        public void TestIcuAppLocal()
+        {
+            Type? interopGlobalization = Type.GetType("Interop+Globalization, System.Private.CoreLib");
+            Assert.NotNull(interopGlobalization);
+
+            MethodInfo? methodInfo = interopGlobalization.GetMethod("GetICUVersion", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(methodInfo);
+
+            // Assert the ICU version 0x44020009 is 68.2.0.9
+            Assert.Equal(0x44020009, (int)methodInfo.Invoke(null, null));
+
+            // Now call globalization API to ensure the binding working without any problem.
+            Assert.Equal(-1, CultureInfo.GetCultureInfo("en-US").CompareInfo.Compare("sample\u0000", "Sample\u0000", CompareOptions.IgnoreSymbols));
+        }
+    }
+}

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -10,15 +10,13 @@ namespace System.Globalization.Tests
 {
     public class IcuAppLocalTests
     {
+        private static bool SupportsIcuPackageDownload => RemoteExecutor.IsSupported &&
+                                                          ((PlatformDetection.IsWindows && !PlatformDetection.IsArmProcess) ||
+                                                           (PlatformDetection.IsLinux && (PlatformDetection.IsX64Process || PlatformDetection.IsArm64Process) &&
+                                                           !PlatformDetection.IsAlpine && !PlatformDetection.IsLinuxBionic));
 
-        private static bool SupportIcuPackageDownload => PlatformDetection.Is64BitProcess &&
-                                                         PlatformDetection.IsNotOSX &&
-                                                         PlatformDetection.IsNotMobile &&
-                                                         !PlatformDetection.IsAlpine &&
-                                                         !PlatformDetection.IsLinuxBionic &&
-                                                         RemoteExecutor.IsSupported;
 
-        [ConditionalFact(nameof(SupportIcuPackageDownload))]
+        [ConditionalFact(nameof(SupportsIcuPackageDownload))]
         public void TestIcuAppLocal()
         {
             // We define this switch dynamically during the runtime using RemoteExecutor.
@@ -26,7 +24,7 @@ namespace System.Globalization.Tests
             // on all supported OSs even the ICU NuGet package not have native bits support such OSs.
             // Note, it doesn't matter if we have test case conditioned to not run on such OSs, because
             // the test has to start running first before filtering the test cases and the globalization
-            // code will run at that time and will fail fast at that time.
+            // code will run and fail fast at that time.
 
             ProcessStartInfo psi = new ProcessStartInfo() { UseShellExecute = false };
             psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU", "68.2.0.9");

--- a/src/native/libs/System.Globalization.Native/pal_icushim.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim.c
@@ -539,6 +539,7 @@ void GlobalizationNative_InitICUFunctions(void* icuuc, void* icuin, const char* 
     ValidateICUDataCanLoad();
 
     InitializeVariableMaxAndTopPointers(symbolVersion);
+    InitializeUColClonePointers(symbolVersion);
 }
 
 #undef PER_FUNCTION_BLOCK


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/77045

Awhile ago we had a change https://github.com/dotnet/runtime/pull/68847 to fix the build breaks because of obsoleted ICU APIs. The fix was changing static binding to the API during the compile time to be a runtime binding. This change work fine except we missed to do some pointer initialization when having [app-local ICU ](https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#app-local-icu). 