### PR TITLE
[mono][tests] Fix FullAOT runtime generic methods test 

### DIFF
--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2001,7 +2001,7 @@ mono_method_get_vtable_slot (MonoMethod *method)
 			g_assert (klass_methods);
 			mcount = mono_class_get_method_count (method->klass);
 			for (i = 0; i < mcount; ++i) {
-				if (klass_methods [i] == method || (klass_methods [i]->name == method->name && klass_methods [i]->slot != -1))
+				if (klass_methods [i] == method)
 					break;
 			}
 			g_assert (i < mcount);

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2004,7 +2004,6 @@ mono_method_get_vtable_slot (MonoMethod *method)
 				if (klass_methods [i] == method || (klass_methods [i]->name == method->name && klass_methods [i]->slot != -1))
 					break;
 			}
-
 			g_assert (i < mcount);
 			g_assert (m_class_get_methods (gklass));
 			method->slot = m_class_get_methods (gklass) [i]->slot;

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2001,9 +2001,10 @@ mono_method_get_vtable_slot (MonoMethod *method)
 			g_assert (klass_methods);
 			mcount = mono_class_get_method_count (method->klass);
 			for (i = 0; i < mcount; ++i) {
-				if (klass_methods [i] == method)
+				if (klass_methods [i] == method || (klass_methods [i]->name == method->name && klass_methods [i]->slot != -1))
 					break;
 			}
+
 			g_assert (i < mcount);
 			g_assert (m_class_get_methods (gklass));
 			method->slot = m_class_get_methods (gklass) [i]->slot;

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -2278,7 +2278,12 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 		} else {
 			ioffset = 0;
 		}
-		slot = mono_method_get_vtable_slot (info->method);
+		
+		if (info->method->is_generic == 0 && mono_class_is_ginst (info->method->klass)) {
+			slot = mono_method_get_vtable_slot (((MonoMethodInflated*)(info->method))->declaring);
+		} else {
+			slot = mono_method_get_vtable_slot (info->method);
+		}
 		g_assert (slot != -1);
 		g_assert (m_class_get_vtable (info->klass));
 		method = m_class_get_vtable (info->klass) [ioffset + slot];
@@ -2328,7 +2333,11 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 		} else {
 			ioffset = 0;
 		}
-		slot = mono_method_get_vtable_slot (info->method);
+		if (info->method->is_generic == 0 && mono_class_is_ginst (info->method->klass)) {
+			slot = mono_method_get_vtable_slot (((MonoMethodInflated*)(info->method))->declaring);
+		} else {
+			slot = mono_method_get_vtable_slot (info->method);
+		}
 		g_assert (slot != -1);
 		g_assert (m_class_get_vtable (info->klass));
 		method = m_class_get_vtable (info->klass) [ioffset + slot];

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3075,10 +3075,6 @@
             <Issue>https://github.com/dotnet/runtime/issues/57352</Issue>
         </ExcludeList>
 
-        <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm/**">
-            <Issue>https://github.com/dotnet/runtime/issues/57512</Issue>
-        </ExcludeList>
-
         <ExcludeList Include="$(XunitTestBinBase)/Interop/DisabledRuntimeMarshalling/DisabledRuntimeMarshalling_Disabled_NativeAssemblyEnabled/**">
             <Issue>This test includes an intentionally-invalid UnmanagedCallersOnly method. Invalid UnmanagedCallersOnly methods cause failures at AOT-time.</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fix disabled FullAOT runtime generic methods test on x64 and arm64. Update `mono_method_get_vtable_slot` method to get vtable slot by address or name for generic methods.

Related issues:

- https://github.com/dotnet/runtime/issues/57512