### PR TITLE
Cleanup file descriptions baked into Windows unmanaged .dlls

### DIFF
--- a/src/coreclr/debug/createdump/createdump.rc
+++ b/src/coreclr/debug/createdump/createdump.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Crash Dump Generator\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime Crash Dump Generator"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/dlls/clretwrc/clretwrc.rc
+++ b/src/coreclr/dlls/clretwrc/clretwrc.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime resources\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime resources"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/dlls/mscordac/Native.rc
+++ b/src/coreclr/dlls/mscordac/Native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET External Data Access Support\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime External Data Access Support"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/dlls/mscordbi/Native.rc
+++ b/src/coreclr/dlls/mscordbi/Native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Debugging Services\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime Debugging Services"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/dlls/mscoree/Native.rc
+++ b/src/coreclr/dlls/mscoree/Native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/dlls/mscorrc/mscorrc.rc
+++ b/src/coreclr/dlls/mscorrc/mscorrc.rc
@@ -13,7 +13,7 @@
 #include <winresrc.h>
 
 #ifndef FX_VER_FILEDESCRIPTION_STR
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime resources\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime resources"
 #endif
 
 #include <fxver.h>

--- a/src/coreclr/gc/windows/Native.rc
+++ b/src/coreclr/gc/windows/Native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Standalone GC\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime Standalone GC"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/hosts/corerun/native.rc
+++ b/src/coreclr/hosts/corerun/native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft CoreCLR EXE launcher\0"
+#define FX_VER_FILEDESCRIPTION_STR "CoreCLR test host"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/ilasm/Native.rc
+++ b/src/coreclr/ilasm/Native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Framework IL assembler\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET IL Assembler"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/ildasm/dasm.rc
+++ b/src/coreclr/ildasm/dasm.rc
@@ -15,7 +15,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 #endif // !TARGET_UNIX
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Framework IL disassembler\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET IL Disassembler"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/jit/Native.rc
+++ b/src/coreclr/jit/Native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Just-In-Time Compiler\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime Just-In-Time Compiler"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/tools/aot/jitinterface/Native.rc
+++ b/src/coreclr/tools/aot/jitinterface/Native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Just-In-Time Compiler Type System Interface\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Runtime Just-In-Time Compiler Type System Interface"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/coreclr/tools/metainfo/Native.rc
+++ b/src/coreclr/tools/metainfo/Native.rc
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#define FX_VER_FILEDESCRIPTION_STR "Microsoft Common Language Runtime Metadata Info\0"
+#define FX_VER_FILEDESCRIPTION_STR ".NET Metadata Info"
 
 #include <fxver.h>
 #include <fxver.rc>

--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -109,11 +109,11 @@ else ()
     set(NATIVECOMPRESSION_SOURCES ${ZLIB_SOURCES} ${NATIVECOMPRESSION_SOURCES})
 
     if (GEN_SHARED_LIB)
+        add_definitions(-DVER_FILEDESCRIPTION_STR="System.IO.Compression.Native")
         add_library(System.IO.Compression.Native
             SHARED
             ${NATIVECOMPRESSION_SOURCES}
             System.IO.Compression.Native.def
-            # This will add versioning to the library
             ${VERSION_FILE_RC_PATH}
         )
     endif ()

--- a/src/native/libs/System.IO.Compression.Native/Native.rc
+++ b/src/native/libs/System.IO.Compression.Native/Native.rc
@@ -1,4 +1,0 @@
-#define FX_VER_FILEDESCRIPTION_STR "Native data compression routines\0"
-
-#include <fxver.h>
-#include <fxver.rc>


### PR DESCRIPTION
Delete Microsoft and .NET Framework from the descriptions