### PR TITLE
Handle GT_IND in optVNConstantPropCurStmt

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -6129,6 +6129,16 @@ Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block, Sta
         case GT_INTRINSIC:
             break;
 
+        case GT_IND:
+        {
+            const ValueNum vn = tree->GetVN(VNK_Conservative);
+            if ((tree->gtFlags & GTF_IND_ASG_LHS) || (vnStore->VNNormalValue(vn) != vn))
+            {
+                return WALK_CONTINUE;
+            }
+        }
+        break;
+
         case GT_JTRUE:
             break;
 

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -207,6 +207,7 @@ def main(main_args):
         os.path.join(script_dir, "superpmi.py"),
         "asmdiffs",
         "--no_progress",
+        "-metrics", "PerfScore",
         "-core_root", core_root_dir,
         "-target_os", platform_name,
         "-target_arch", arch_name,

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -207,7 +207,6 @@ def main(main_args):
         os.path.join(script_dir, "superpmi.py"),
         "asmdiffs",
         "--no_progress",
-        "-metrics", "PerfScore",
         "-core_root", core_root_dir,
         "-target_os", platform_name,
         "-target_arch", arch_name,


### PR DESCRIPTION
As discussed with @SingleAccretion filing a separate PR with this change:

It turns out that there are `GT_IND` nodes with "represents a constant" VNs e.g. known methodtable lookups.
This PR introduces a small size regression (64bit imms are heavy) with a PerfScore improvement. I might disable this for arm64 if size regression will be too bad there.

Example of an improvement:
```diff
-mov      rdx, qword ptr [rdi]
+mov      rdx, 0xD1FFAB1E      ; System.Xml.Xsl.IListEnumerator`1[System.Xml.Xsl.Qil.QilNode]
```
https://www.diffchecker.com/94HXdOJJ
```diff
-; Total bytes of code 212, prolog size 22, PerfScore 104.20
+; Total bytes of code 244, prolog size 22, PerfScore 89.90
```
Bigger size but better PerfScore.