### PR TITLE
[NativeAOT] fix debug assert on large number of virtual methods

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_ARM64/ARM64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_ARM64/ARM64Emitter.cs
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis.ARM64
 
         public void EmitLDR(Register regDst, Register regSrc, int offset)
         {
-            Debug.Assert(offset >= -255 && offset <= 4095);
+            Debug.Assert(offset >= -255 && offset <= 32760);
             if (offset >= 0)
             {
                 Debug.Assert(offset % 8 == 0);

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_ARM64/ARM64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_ARM64/ARM64Emitter.cs
@@ -63,8 +63,7 @@ namespace ILCompiler.DependencyAnalysis.ARM64
 
         public void EmitLDR(Register regDst, Register regSrc, int offset)
         {
-            Debug.Assert(offset >= -255 && offset <= 32760);
-            if (offset >= 0)
+            if (offset >= 0 && offset <= 32760)
             {
                 Debug.Assert(offset % 8 == 0);
 
@@ -72,11 +71,15 @@ namespace ILCompiler.DependencyAnalysis.ARM64
 
                 Builder.EmitUInt((uint)(0b11_1110_0_1_0_1_000000000000_00000_00000u | ((uint)offset << 10) | ((uint)regSrc << 5) | (uint)regDst));
             }
-            else
+            else if (offset >= -255 && offset < 0)
             {
                 uint o = (uint)offset & 0x1FF;
 
                 Builder.EmitUInt((uint)(0b11_1110_0_0_010_000000000_1_1_00000_00000u | (o << 12) | ((uint)regSrc << 5) | (uint)regDst));
+            }
+            else
+            {
+                throw new NotImplementedException();
             }
         }
 


### PR DESCRIPTION
According to the ARM docs for this op code:

https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDR--immediate---Load-Register--immediate--?lang=en

> For the 64-bit variant: is the optional positive immediate byte offset, a multiple of 8 in the range 0 to 32760, defaulting to 0 and encoded in the "imm12" field as <pimm>/8.

I have [a program](https://github.com/AustinWise/ilc-crash) that reproduces the problem. It is just a class with 1000 virtual properties and a RD.xml file to root them all. The actual program I was trying to compile when I encountered the problem was Microsoft.macos.dll. There are some classes with a large number of virtual methods in that assembly.