### PR TITLE
Update Unix dependencies installation script

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
+
+set -e
 
 # This is a simple script primarily used for CI to install necessary dependencies
 #
@@ -13,24 +15,26 @@
 #
 # ./install-native-dependencies.sh <OS>
 
-if [ "$1" = "Linux" ]; then
-    sudo apt update
-    if [ "$?" != "0" ]; then
-       exit 1;
-    fi
-    sudo apt install cmake llvm-3.9 clang-3.9 lldb-3.9 liblldb-3.9-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev libkrb5-dev libnuma-dev build-essential
-    if [ "$?" != "0" ]; then
-        exit 1;
-    fi
-elif [[ "$1" == "MacCatalyst" || "$1" == "OSX" || "$1" == "tvOS" || "$1" == "iOS" ]]; then
-    engdir=$(dirname "${BASH_SOURCE[0]}")
+os="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
 
-    echo "Installed xcode version: `xcode-select -p`"
+if [ -e /etc/os-release ]; then
+    . /etc/os-release
+fi
+
+if [ "$os" = "linux" ] && { [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; }; then
+    apt update
+
+    apt install -y build-essential gettext locales cmake llvm clang lldb liblldb-dev libunwind8-dev libicu-dev liblttng-ust-dev \
+        libssl-dev libkrb5-dev libnuma-dev
+
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+elif [ "$os" = "maccatalyst" ] || [ "$os" = "osx" ] || [ "$os" = "macos" ] || [ "$os" = "tvos" ] || [ "$os" = "ios" ]; then
+    echo "Installed xcode version: $(xcode-select -p)"
 
     if [ "$3" = "azDO" ]; then
         # workaround for old osx images on hosted agents
         # piped in case we get an agent without these values installed
-        if ! brew_output="$(brew uninstall openssl@1.0.2t 2>&1 >/dev/null)"; then
+        if ! brew uninstall openssl@1.0.2t >/dev/null 2>&1; then
             echo "didn't uninstall openssl@1.0.2t"
         else
             echo "successfully uninstalled openssl@1.0.2t"
@@ -38,12 +42,8 @@ elif [[ "$1" == "MacCatalyst" || "$1" == "OSX" || "$1" == "tvOS" || "$1" == "iOS
     fi
 
     brew update --preinstall
-    brew bundle --no-upgrade --no-lock --file "${engdir}/Brewfile"
-    if [ "$?" != "0" ]; then
-        exit 1;
-    fi
+    brew bundle --no-upgrade --no-lock --file "$(dirname "$0")/Brewfile"
 else
-    echo "Must pass \"Linux\", \"tvOS\", \"iOS\" or \"OSX\" as first argument."
+    echo "Must pass 'Linux', 'macOS', 'maccatalyst', 'iOS' or 'tvOS' as first argument."
     exit 1
 fi
-

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -4,14 +4,7 @@ set -e
 
 # This is a simple script primarily used for CI to install necessary dependencies
 #
-# For CI typical usage is
-#
-# ./install-native-dependencies.sh <OS> <arch> azDO
-#
-# For developer use it is not recommended to include the azDO final argument as that
-# makes installation and configuration setting only required for azDO
-#
-# So simple developer usage would currently be
+# Usage:
 #
 # ./install-native-dependencies.sh <OS>
 
@@ -30,16 +23,6 @@ if [ "$os" = "linux" ] && { [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; }
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 elif [ "$os" = "maccatalyst" ] || [ "$os" = "osx" ] || [ "$os" = "macos" ] || [ "$os" = "tvos" ] || [ "$os" = "ios" ]; then
     echo "Installed xcode version: $(xcode-select -p)"
-
-    if [ "$3" = "azDO" ]; then
-        # workaround for old osx images on hosted agents
-        # piped in case we get an agent without these values installed
-        if ! brew uninstall openssl@1.0.2t >/dev/null 2>&1; then
-            echo "didn't uninstall openssl@1.0.2t"
-        else
-            echo "successfully uninstalled openssl@1.0.2t"
-        fi
-    fi
 
     brew update --preinstall
     brew bundle --no-upgrade --no-lock --file "$(dirname "$0")/Brewfile"

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -25,7 +25,7 @@ if [ "$os" = "linux" ] && { [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; }
     apt update
 
     apt install -y build-essential gettext locales cmake llvm clang lldb liblldb-dev libunwind8-dev libicu-dev liblttng-ust-dev \
-        libssl-dev libkrb5-dev libnuma-dev
+        libssl-dev libkrb5-dev libnuma-dev libz-dev
 
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 elif [ "$os" = "maccatalyst" ] || [ "$os" = "osx" ] || [ "$os" = "macos" ] || [ "$os" = "tvos" ] || [ "$os" = "ios" ]; then

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -25,7 +25,7 @@ if [ "$os" = "linux" ] && { [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; }
     apt update
 
     apt install -y build-essential gettext locales cmake llvm clang lldb liblldb-dev libunwind8-dev libicu-dev liblttng-ust-dev \
-        libssl-dev libkrb5-dev libnuma-dev libz-dev
+        libssl-dev libkrb5-dev libnuma-dev zlib1g-dev
 
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 elif [ "$os" = "maccatalyst" ] || [ "$os" = "osx" ] || [ "$os" = "macos" ] || [ "$os" = "tvos" ] || [ "$os" = "ios" ]; then

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -147,7 +147,7 @@ jobs:
             name: ${{ parameters.platform }}
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS', 'MacCatalyst') }}:
-      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }} ${{ parameters.archType }} azDO
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
         displayName: Install Build Dependencies
 
       - script: |

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -111,7 +111,7 @@ jobs:
 
     # Install test build dependencies
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
-      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup) ${{ parameters.archType }} azDO
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies
 
     # Build core/libraries dependencies of test build

--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -85,7 +85,7 @@ jobs:
     # and FreeBSD builds use a build agent with dependencies
     # preinstalled, so we only need this step for OSX and Windows.
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
-      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup) ${{ parameters.archType }} azDO
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies (OSX)
 
     # Install internal tools on official builds

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -159,7 +159,7 @@ jobs:
     # and FreeBSD builds use a build agent with dependencies
     # preinstalled, so we only need this step for OSX and Windows.
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
-      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup) ${{ parameters.archType }} azDO
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies
 
     # Install internal tools on official builds

--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -310,7 +310,7 @@ jobs:
             cleanUnpackFolder: false
 
       - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
-        - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }} ${{ parameters.archType }} azDO
+        - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
           displayName: Install Build Dependencies
 
         - script: |

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -86,7 +86,7 @@ jobs:
           - template: /eng/pipelines/common/restore-internal-tools.yml
 
         - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
-          - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }} ${{ parameters.archType }} azDO
+          - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
             displayName: Install Build Dependencies
 
           - script: |

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -122,7 +122,7 @@ jobs:
     # and FreeBSD builds use a build agent with dependencies
     # preinstalled, so we only need this step for OSX and Windows.
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
-      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup) ${{ parameters.archType }} azDO
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies
 
     - ${{ each monoCrossAOTTargetOS in parameters.monoCrossAOTTargetOS }}:

--- a/eng/pipelines/mono/templates/generate-offsets.yml
+++ b/eng/pipelines/mono/templates/generate-offsets.yml
@@ -57,7 +57,7 @@ jobs:
     # and FreeBSD builds use a build agent with dependencies
     # preinstalled, so we only need this step for OSX and Windows.
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
-      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup) ${{ parameters.archType }} azDO
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies
 
     # Build


### PR DESCRIPTION
* Use version-less llvm toolchain on Debian/Ubuntu (https://github.com/dotnet/runtime/pull/74811).
* Allow case insensitive OS name (`eng/install-native-dependencies.sh macos # or osx`).
* Check if distro is Debian or its derivative (`apt` is a Debian thing).
* Remove `sudo` to make it work with root (e.g. in a docker container); non-root will get a (readable) error from the system, when higher privileges are needed.
* Fix shellcheck errors and lower the dependency to Unix/Bourne shell script (we were using mixed syntax, now it is unified).