### PR TITLE
Fix ILLink running in incremental builds

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -3,8 +3,6 @@
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>
     <PrepareResourcesDependsOn>_EmbedILLinkXmls;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">$(TargetsTriggeredByCompilation);ILLinkTrimAssembly</TargetsTriggeredByCompilation>
-    <!-- ApiCompat's assembly validation should use the trimmed assemblies as an input, so we make sure that ILLink runs first. -->
-    <ApiCompatValidateAssembliesDependsOn Condition="'$(IsCrossTargetingBuild)' != 'true'">$(ApiCompatValidateAssembliesDependsOn);ILLinkTrimAssembly</ApiCompatValidateAssembliesDependsOn>
   </PropertyGroup>
   
   <!-- Flow the IsTrimmable property down to consuming projects, in order for oob.proj


### PR DESCRIPTION
Now that the new APICompat runs after all the compilation targets, this depends on in illink.targets isn't necessary anymore and fixes the incremental build issue.

Regressed with https://github.com/dotnet/runtime/commit/960e4d723c27a5407dc691d06e546bc455a9c4a5 as the new APICompat doesn't run as post compiler target anymore but instead, as part of the `PrepareForRun` target. That caused the ILLink dependent target to always run, even if the compiler didn't run and the inputs/outputs didn't change.

cc @smasher164 