### PR TITLE
[mono][tests] Update instantiate_info to use mono_class_interface_offset_with_variance for interface offset

### DIFF
--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -2273,7 +2273,8 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 		mono_class_setup_vtable (info->klass);
 		// FIXME: Check type load
 		if (mono_class_is_interface (iface_class)) {
-			ioffset = mono_class_interface_offset (info->klass, iface_class);
+			gboolean variance_used;
+			ioffset = mono_class_interface_offset_with_variance (info->klass, iface_class, &variance_used);
 			g_assert (ioffset != -1);
 		} else {
 			ioffset = 0;

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1469,9 +1469,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/MethodImpl/CovariantReturns/Structs/IncompatibleOverride/**">
             <Issue>Crashes during LLVM AOT compilation.</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_71319/**">
-            <Issue>https://github.com/dotnet/runtime/issues/71910</Issue>
-        </ExcludeList>
 
         <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/General/HwiOp/CompareVectorWithZero/**">
             <Issue>https://github.com/dotnet/runtime/pull/65632#issuecomment-1046294324</Issue>


### PR DESCRIPTION
Fix disabled runtime generic methods test. Update `instantiate_info` to use `mono_class_interface_offset_with_variance` for interface offset in `MONO_RGCTX_INFO_VIRT_METHOD_CODE`.

Related issues:

- https://github.com/dotnet/runtime/issues/71910