### PR TITLE
Make sure that CoreLib ref and src build matches

### DIFF
--- a/eng/references.targets
+++ b/eng/references.targets
@@ -14,21 +14,6 @@
     </ProjectReference>
   </ItemDefinitionGroup>
 
-  <ItemGroup Condition="'@(ProjectReference)' != ''">
-    <_coreLibProjectReference Include="@(ProjectReference->WithMetadataValue('Identity', '$(CoreLibProject)'))" />
-    <ProjectReference Update="@(_coreLibProjectReference)"
-                      Private="false">
-      <SetConfiguration Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
-                                   '$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</SetConfiguration>
-      <SetConfiguration Condition="'$(RuntimeFlavor)' == 'Mono' and
-                                   '$(Configuration)' != '$(MonoConfiguration)'">Configuration=$(MonoConfiguration)</SetConfiguration>
-    </ProjectReference>
-    <!-- If a CoreLib ProjectReference is present, make all P2P assets non transitive. -->
-    <ProjectReference Update="@(ProjectReference->WithMetadataValue('PrivateAssets', ''))"
-                      PrivateAssets="all"
-                      Condition="'$(IsSourceProject)' == 'true' and '@(_coreLibProjectReference)' != ''" />
-  </ItemGroup>
-
   <!-- Filter out transitive P2Ps which should be excluded. -->
   <Target Name="FilterTransitiveProjectReferences"
           AfterTargets="IncludeTransitiveProjectReferences"

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -57,6 +57,22 @@
   <!-- intentionally empty since we no longer need a target -->
   <Target Name="ResolveMatchingContract" />
 
+  <!-- Make configuration and private attributes on the CoreLib ProjectReference consistent between src/libraries and src/"runtime" references. -->
+  <ItemGroup Condition="'@(ProjectReference)' != ''">
+    <_coreLibProjectReference Include="@(ProjectReference->WithMetadataValue('Filename', 'System.Private.CoreLib'))" />
+    <ProjectReference Update="@(_coreLibProjectReference)"
+                      Private="false">
+      <SetConfiguration Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
+                                   '$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</SetConfiguration>
+      <SetConfiguration Condition="'$(RuntimeFlavor)' == 'Mono' and
+                                   '$(Configuration)' != '$(MonoConfiguration)'">Configuration=$(MonoConfiguration)</SetConfiguration>
+    </ProjectReference>
+    <!-- If a CoreLib ProjectReference is present, make all P2P assets non transitive. -->
+    <ProjectReference Update="@(ProjectReference->WithMetadataValue('PrivateAssets', ''))"
+                      PrivateAssets="all"
+                      Condition="'$(IsSourceProject)' == 'true' and '@(_coreLibProjectReference)' != ''" />
+  </ItemGroup>
+
   <!-- Allow P2Ps that target a source project to build against the corresponding ref project. -->
   <Target Name="AnnotateTargetPathWithTargetPlatformMonikerWithReferenceAssembly"
           Condition="'$(HasMatchingContract)' == 'true'"


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75897

This change fixes src/CoreLib referencing ref/CoreLib with a different set of global properties. When building the runtime and libraries in Release mode, the build (at least inside VS) complains that the ref/CoreLib assembly (in Debug configuration) is missing.

Undefined behavior: When src/CoreLib is built in Checked configuration, should ref/CoreLib then also be built in Checked mode?