### PR TITLE
[JIT] ARM64 - Do not allow move and shifting with MSL on 16-bit vectors

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -3041,7 +3041,9 @@ emitter::code_t emitter::emitInsCode(instruction ins, insFormat fmt)
             {
                 canEncode = true;
             }
-            if (allow_MSL)
+
+            // MSL is only supported for 32-bit.
+            if (allow_MSL && size == EA_4BYTE)
             {
                 if ((bySh == 1) && (immCheck == 0xFF))
                 {

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -3043,7 +3043,7 @@ emitter::code_t emitter::emitInsCode(instruction ins, insFormat fmt)
             }
 
             // MSL is only supported for 32-bit.
-            if (allow_MSL && size == EA_4BYTE)
+            if (allow_MSL && (size == EA_4BYTE))
             {
                 if ((bySh == 1) && (immCheck == 0xFF))
                 {


### PR DESCRIPTION
**Decription**

Should resolve: https://github.com/dotnet/runtime/issues/76880

We were allowing the `movi` instruction in conjunction with `MSL` to be emitted on 16-bit vectors which is not supported; it is only supported for 32-bit vectors. See https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/MOVI--Move-Immediate--vector--?lang=en

**Acceptance Criteria**
- [x] JIT Stress run passes