### PR TITLE
Update README.md's to use "contribution bar"

### DIFF
--- a/src/libraries/README.md
+++ b/src/libraries/README.md
@@ -4,17 +4,22 @@ This folder contains the source and tests for the .NET Libraries. Different libr
 
 ## Contribution Bar
 
-Some libraries are under more active development than others. Depending on the library's status, expectations for issues and pull requests can vary. Check the library's folder for a `README.md` that declares the contribution bar for that library which consists of Dos and Donts. Regardless of a library's contribution bar, refer to the [DOs and DON'Ts](../../CONTRIBUTING.md#dos-and-donts) and [Suggested Workflow](../../CONTRIBUTING.md#suggested-workflow) in our contribution guidelines before submitting a pull request.
+Some libraries are under more active development than others. Depending on the library's status, expectations for issues and pull requests can vary. Check the library's folder for a `README.md` that declares the contribution bar for that library which consists of  a **Primary bar** and optional **Secondary bars**. Regardless of a library's contribution bar, refer to the [DOs and DON'Ts](../../CONTRIBUTING.md#dos-and-donts) and [Suggested Workflow](../../CONTRIBUTING.md#suggested-workflow) in our contribution guidelines before submitting a pull request.
 
-### Primary bar (each library will specify one)
+### Assumed bars (unless a library says otherwise)
+- **We take security fixes**
+- **We take test changes**
+- **We don't take style-only changes**
 
+### Primary bar
 - **We take new features, new APIs and performance changes**
   - This is the most encompassing category and takes on the most risk 
-    - PRs for both features and fixes will be considered when aligned with current efforts
-  - For new APIs, please follow the [API Review Process](docs/project/api-review-process.md)
+  - PRs for both features and fixes will be considered when aligned with current efforts
+    - For new APIs, please follow the [API Review Process](../../docs/project/api-review-process.md)
+  - PRs for performance gains are welcome. Update [benchmarks](https://github.com/dotnet/performance) as appropriate.
   - Refactoring changes are welcome
 - **We only take fixes to maintain or improve quality**
-  - New features and APIs are **not** normally considered but there are exceptions such as when there are runtime changes or language additions
+  - New features and APIs are **not** normally considered but there are exceptions such as when responding to runtime changes or language additions
   - The library is likely mature and feature-complete
   - PRs for performance are considered if they are lower-risk or high-impact
   - Refactoring changes are considered if there is a clear benefit
@@ -25,14 +30,9 @@ Some libraries are under more active development than others. Depending on the l
   - New features and APIs are **not** considered
   - This may include infrastructure changes and other housekeeping
 
-### Secondary bars (each library may specify one or more)
-- **We take PRs targeting this library for analyzers**
-- **We don't take changes due to new language features**
-
-### Assumed bars (unless specifically negated)
-- **We take security fixes**
-- **We take test changes**
-- **We don't take style-only changes**
+### Secondary bars
+- **We take PRs that target this library for new [source code analyzers](../../docs/project/analyzers.md)**
+- **We don't take refactorting changes due to new language features**
 
 ## Deployment
 

--- a/src/libraries/README.md
+++ b/src/libraries/README.md
@@ -2,22 +2,37 @@
 
 This folder contains the source and tests for the .NET Libraries. Different libraries are owned by different team members; refer to the [Areas](../../docs/area-owners.md#areas) list for lead and owner information.
 
-## Development Statuses
+## Contribution Bar
 
-Some libraries are under more active development than others. Depending on the library's status, expectations for issues and pull requests can vary. Check the library's folder for a `README.md` that declares the status for that library. Regardless of a library's status, refer to the [DOs and DON'Ts](../../CONTRIBUTING.md#dos-and-donts) and [Suggested Workflow](../../CONTRIBUTING.md#suggested-workflow) in our contribution guidelines before submitting a pull request.
+Some libraries are under more active development than others. Depending on the library's status, expectations for issues and pull requests can vary. Check the library's folder for a `README.md` that declares the contribution bar for that library which consists of Dos and Donts. Regardless of a library's contribution bar, refer to the [DOs and DON'Ts](../../CONTRIBUTING.md#dos-and-donts) and [Suggested Workflow](../../CONTRIBUTING.md#suggested-workflow) in our contribution guidelines before submitting a pull request.
 
-- **Active**
-  - Under active development by the team
-  - Issues will be considered for fix or addition to the backlog
-  - PRs for both features and fixes will be considered when aligned with current efforts
-- **Inactive**
-  - Under minimal development; quality is maintained
-  - Issues will be considered for fix or addition to the backlog
-  - PRs for both features and fixes will be considered
-- **Legacy**
-  - Not under development; maintained for compatibility
-  - Issues are likely to be closed without fixes
-  - PRs are unlikely to be accepted
+### Primary bar (each library will specify one)
+
+- **We take new features, new APIs and performance changes**
+  - This is the most encompassing category and takes on the most risk 
+    - PRs for both features and fixes will be considered when aligned with current efforts
+  - For new APIs, please follow the [API Review Process](docs/project/api-review-process.md)
+  - Refactoring changes are welcome
+- **We only take fixes to maintain or improve quality**
+  - New features and APIs are **not** normally considered but there are exceptions such as when there are runtime changes or language additions
+  - The library is likely mature and feature-complete
+  - PRs for performance are considered if they are lower-risk or high-impact
+  - Refactoring changes are considered if there is a clear benefit
+- **We only take lower-risk or high-impact fixes to maintain or improve quality**
+  - New features and APIs are **not** considered
+  - We don't take potentially destabilizing fixes or test changes unless there is a clear need
+- **We only take fixes that unblock critical issues**
+  - New features and APIs are **not** considered
+  - This may include infrastructure changes and other housekeeping
+
+### Secondary bars (each library may specify one or more)
+- **We take PRs targeting this library for analyzers**
+- **We don't take changes due to new language features**
+
+### Assumed bars (unless specifically negated)
+- **We take security fixes**
+- **We take test changes**
+- **We don't take style-only changes**
 
 ## Deployment
 

--- a/src/libraries/README.md
+++ b/src/libraries/README.md
@@ -4,35 +4,34 @@ This folder contains the source and tests for the .NET Libraries. Different libr
 
 ## Contribution Bar
 
-Some libraries are under more active development than others. Depending on the library's status, expectations for issues and pull requests can vary. Check the library's folder for a `README.md` that declares the contribution bar for that library which consists of  a **Primary bar** and optional **Secondary bars**. Regardless of a library's contribution bar, refer to the [DOs and DON'Ts](../../CONTRIBUTING.md#dos-and-donts) and [Suggested Workflow](../../CONTRIBUTING.md#suggested-workflow) in our contribution guidelines before submitting a pull request.
+Some libraries are under more active development than others. Depending on the library's status, expectations for issues and pull requests can vary. Check the library's folder for a `README.md` that declares the contribution bar for that library which consists of a **Primary bar** and optional **Secondary bars**. Regardless of a library's contribution bar, refer to the [DOs and DON'Ts](../../CONTRIBUTING.md#dos-and-donts) and [Suggested Workflow](../../CONTRIBUTING.md#suggested-workflow) in our contribution guidelines before submitting a pull request.
 
 ### Assumed bars (unless a library says otherwise)
-- **We take security fixes**
-- **We take test changes**
-- **We don't take style-only changes**
+- **We consider security fixes**
+- **We consider test coverage changes**
+- **We don't accept style-only changes**
 
 ### Primary bar
-- **We take new features, new APIs and performance changes**
-  - This is the most encompassing category and takes on the most risk 
-  - PRs for both features and fixes will be considered when aligned with current efforts
+- **We consider new features, new APIs and performance changes**
+  - Both features and fixes will be considered when aligned with current efforts
     - For new APIs, please follow the [API Review Process](../../docs/project/api-review-process.md)
-  - PRs for performance gains are welcome. Update [benchmarks](https://github.com/dotnet/performance) as appropriate.
+  - Performance gains are welcome. Update [benchmarks](https://github.com/dotnet/performance) as appropriate
   - Refactoring changes are welcome
-- **We only take fixes to maintain or improve quality**
-  - New features and APIs are **not** normally considered but there are exceptions such as when responding to runtime changes or language additions
-  - The library is likely mature and feature-complete
-  - PRs for performance are considered if they are lower-risk or high-impact
+- **We only consider fixes to maintain or improve quality**
+  - New features and APIs are **not** normally accepted but there are exceptions such as when responding to runtime changes or language additions
+  - The library is likely mature and feature-complete but may be extended occasionally
+  - Performance gains are considered if they are lower-risk or high-impact
   - Refactoring changes are considered if there is a clear benefit
-- **We only take lower-risk or high-impact fixes to maintain or improve quality**
-  - New features and APIs are **not** considered
-  - We don't take potentially destabilizing fixes or test changes unless there is a clear need
-- **We only take fixes that unblock critical issues**
-  - New features and APIs are **not** considered
-  - This may include infrastructure changes and other housekeeping
+- **We only consider lower-risk or high-impact fixes to maintain or improve quality**
+  - New features and APIs are **not** accepted
+  - We don't accept potentially destabilizing fixes or test changes unless there is a clear need
+- **We only consider fixes that unblock critical issues**
+  - New features and APIs are **not** accepted
+  - Infrastructure changes and other non-functional changes are considered
 
 ### Secondary bars
-- **We take PRs that target this library for new [source code analyzers](../../docs/project/analyzers.md)**
-- **We don't take refactorting changes due to new language features**
+- **We consider PRs that target this library for new [source code analyzers](../../docs/project/analyzers.md)**
+- **We don't accept refactoring changes due to new language features**
 
 ## Deployment
 

--- a/src/libraries/System.Reflection.Context/README.md
+++ b/src/libraries/System.Reflection.Context/README.md
@@ -4,7 +4,7 @@ Used by `System.ComponentModel` to support [`CustomReflectionContext`](https://l
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.context.
 
 ## Contribution Bar
-- [x] [We only take fixes that unblock critical issues](../../libraries/README.md#primary-bar)
+- [x] [We only consider fixes that unblock critical issues](../../libraries/README.md#primary-bar)
 
 ## Deployment
 [System.Reflection.Context](https://www.nuget.org/packages/System.Reflection.Context) NuGet package

--- a/src/libraries/System.Reflection.Context/README.md
+++ b/src/libraries/System.Reflection.Context/README.md
@@ -3,8 +3,8 @@ Used by `System.ComponentModel` to support [`CustomReflectionContext`](https://l
 
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.context.
 
-## Contribution Bar: [we only take fixes that unblock critical issues](../../libraries/README.md#contribution-bar)
-
+## Contribution Bar
+- [x] [We only take fixes that unblock critical issues](../../libraries/README.md#primary-bar)
 
 ## Deployment
 [System.Reflection.Context](https://www.nuget.org/packages/System.Reflection.Context) NuGet package

--- a/src/libraries/System.Reflection.Context/README.md
+++ b/src/libraries/System.Reflection.Context/README.md
@@ -3,7 +3,8 @@ Used by `System.ComponentModel` to support [`CustomReflectionContext`](https://l
 
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.context.
 
-## Status: [Legacy](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we only take fixes that unblock critical issues](../../libraries/README.md#contribution-bar)
+
 
 ## Deployment
 [System.Reflection.Context](https://www.nuget.org/packages/System.Reflection.Context) NuGet package

--- a/src/libraries/System.Reflection.DispatchProxy/README.md
+++ b/src/libraries/System.Reflection.DispatchProxy/README.md
@@ -3,7 +3,7 @@ Supports the [`DispatchProxy`](https://learn.microsoft.com/dotnet/api/system.ref
 
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.dispatchproxy.
 
-## Status: [Legacy](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
 Although used for key scenarios by the community, it has remained relatively unchanged. Internally it uses [Emit](../System.Reflection.Emit/README.md) to generate the proxies so it doesn't work on all platforms.
 
 ## Deployment

--- a/src/libraries/System.Reflection.DispatchProxy/README.md
+++ b/src/libraries/System.Reflection.DispatchProxy/README.md
@@ -4,7 +4,7 @@ Supports the [`DispatchProxy`](https://learn.microsoft.com/dotnet/api/system.ref
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.dispatchproxy.
 
 ## Contribution Bar
-- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
+- [x] [We consider new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
 
 Although used for key scenarios by the community, it has remained relatively unchanged. Internally it uses [Emit](../System.Reflection.Emit/README.md) to generate the proxies so it doesn't work on all platforms.
 

--- a/src/libraries/System.Reflection.DispatchProxy/README.md
+++ b/src/libraries/System.Reflection.DispatchProxy/README.md
@@ -3,7 +3,9 @@ Supports the [`DispatchProxy`](https://learn.microsoft.com/dotnet/api/system.ref
 
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.dispatchproxy.
 
-## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
+## Contribution Bar
+- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
+
 Although used for key scenarios by the community, it has remained relatively unchanged. Internally it uses [Emit](../System.Reflection.Emit/README.md) to generate the proxies so it doesn't work on all platforms.
 
 ## Deployment

--- a/src/libraries/System.Reflection.Emit.ILGeneration/README.md
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/README.md
@@ -3,7 +3,8 @@ Contains types used with [`System.Reflection.Emit`](../System.Reflection.Emit/RE
 
 The primary class is [`ILGenerator`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.ilgenerator).
 
-## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
+## Contribution Bar
+- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
 
 See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Emit+label%3A%22help+wanted%22) issues.
 

--- a/src/libraries/System.Reflection.Emit.ILGeneration/README.md
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/README.md
@@ -3,7 +3,9 @@ Contains types used with [`System.Reflection.Emit`](../System.Reflection.Emit/RE
 
 The primary class is [`ILGenerator`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.ilgenerator).
 
-## Status: [Inactive](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
+
+See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Emit+label%3A%22help+wanted%22) issues.
 
 ## Deployment
 [System.Reflection.Emit.ILGeneration](https://www.nuget.org/packages/System.Reflection.Emit.ILGeneration) is included in the shared framework.

--- a/src/libraries/System.Reflection.Emit.ILGeneration/README.md
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/README.md
@@ -4,7 +4,7 @@ Contains types used with [`System.Reflection.Emit`](../System.Reflection.Emit/RE
 The primary class is [`ILGenerator`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.ilgenerator).
 
 ## Contribution Bar
-- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
+- [x] [We consider new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
 
 See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Emit+label%3A%22help+wanted%22) issues.
 

--- a/src/libraries/System.Reflection.Emit.Lightweight/README.md
+++ b/src/libraries/System.Reflection.Emit.Lightweight/README.md
@@ -1,7 +1,8 @@
 # System.Reflection.Emit.Lightweight
 The primary class is [`DynamicMethod`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.DynamicMethod).
 
-## Contribution Bar: [we only take fixes to maintain or improve quality](../../libraries/README.md#contribution-bar)
+## Contribution Bar
+- [x] [We only take fixes to maintain or improve quality](../../libraries/README.md#primary-bar)
 
 ## Deployment
 [System.Reflection.Emit.Lightweight](https://www.nuget.org/packages/System.Reflection.Emit.Lightweight) is included in the shared framework.

--- a/src/libraries/System.Reflection.Emit.Lightweight/README.md
+++ b/src/libraries/System.Reflection.Emit.Lightweight/README.md
@@ -2,7 +2,7 @@
 The primary class is [`DynamicMethod`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.DynamicMethod).
 
 ## Contribution Bar
-- [x] [We only take fixes to maintain or improve quality](../../libraries/README.md#primary-bar)
+- [x] [We only consider fixes to maintain or improve quality](../../libraries/README.md#primary-bar)
 
 ## Deployment
 [System.Reflection.Emit.Lightweight](https://www.nuget.org/packages/System.Reflection.Emit.Lightweight) is included in the shared framework.

--- a/src/libraries/System.Reflection.Emit.Lightweight/README.md
+++ b/src/libraries/System.Reflection.Emit.Lightweight/README.md
@@ -1,7 +1,7 @@
 # System.Reflection.Emit.Lightweight
 The primary class is [`DynamicMethod`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.DynamicMethod).
 
-## Status: [Inactive](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we only take fixes to maintain or improve quality](../../libraries/README.md#contribution-bar)
 
 ## Deployment
 [System.Reflection.Emit.Lightweight](https://www.nuget.org/packages/System.Reflection.Emit.Lightweight) is included in the shared framework.

--- a/src/libraries/System.Reflection.Emit/README.md
+++ b/src/libraries/System.Reflection.Emit/README.md
@@ -5,8 +5,12 @@ Not all platforms and runtimes support IL.Emit.
 
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.emit. The primary class is [`AssemblyBuilder`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.AssemblyBuilder).
 
-## Status: [Inactive](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
 The APIs and functionality are mature, but do get extended occasionally.
+
+See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Emit+label%3A%22help+wanted%22) issues.
+
+The primary new feature under consideration is [AssemblyBuilder.Save()](https://github.com/dotnet/runtime/issues/62956).
 
 ## Deployment
 [System.Reflection.Emit](https://www.nuget.org/packages/System.Reflection.Emit) is included in the shared framework. The package does not need to be installed into any project compatible with .NET Standard 2.1; it only needs to be installed when targeting .NET Standard 2.0.

--- a/src/libraries/System.Reflection.Emit/README.md
+++ b/src/libraries/System.Reflection.Emit/README.md
@@ -6,7 +6,7 @@ Not all platforms and runtimes support IL.Emit.
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.emit. The primary class is [`AssemblyBuilder`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.AssemblyBuilder).
 
 ## Contribution Bar
-- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
+- [x] [We consider new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
 
 See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Emit+label%3A%22help+wanted%22) issues.
 

--- a/src/libraries/System.Reflection.Emit/README.md
+++ b/src/libraries/System.Reflection.Emit/README.md
@@ -5,8 +5,8 @@ Not all platforms and runtimes support IL.Emit.
 
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.emit. The primary class is [`AssemblyBuilder`](https://learn.microsoft.com/dotnet/api/system.reflection.emit.AssemblyBuilder).
 
-## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
-The APIs and functionality are mature, but do get extended occasionally.
+## Contribution Bar
+- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
 
 See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Emit+label%3A%22help+wanted%22) issues.
 

--- a/src/libraries/System.Reflection.Extensions/README.md
+++ b/src/libraries/System.Reflection.Extensions/README.md
@@ -2,7 +2,7 @@
 This supports forwarding types to the runtime including [CustomAttributeExtensions](https://learn.microsoft.com/dotnet/api/system.reflection.CustomAttributeExtensions), [InterfaceMapping](https://learn.microsoft.com/dotnet/api/system.reflection.InterfaceMapping) and [RuntimeReflectionExtensions](https://learn.microsoft.com/dotnet/api/system.reflection.RuntimeReflectionExtensions).
 
 ## Contribution Bar
-- [x] [We only take fixes that unblock critical issues](../../libraries/README.md#primary-bar)
+- [x] [We only consider fixes that unblock critical issues](../../libraries/README.md#primary-bar)
 
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 

--- a/src/libraries/System.Reflection.Extensions/README.md
+++ b/src/libraries/System.Reflection.Extensions/README.md
@@ -1,7 +1,9 @@
 # System.Reflection.Extensions
 This supports forwarding types to the runtime including [CustomAttributeExtensions](https://learn.microsoft.com/dotnet/api/system.reflection.CustomAttributeExtensions), [InterfaceMapping](https://learn.microsoft.com/dotnet/api/system.reflection.InterfaceMapping) and [RuntimeReflectionExtensions](https://learn.microsoft.com/dotnet/api/system.reflection.RuntimeReflectionExtensions).
 
-## Contribution Bar: [we only take fixes that unblock critical issues](../../libraries/README.md#contribution-bar)
+## Contribution Bar
+- [x] [We only take fixes that unblock critical issues](../../libraries/README.md#primary-bar)
+
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 
 ## Deployment

--- a/src/libraries/System.Reflection.Extensions/README.md
+++ b/src/libraries/System.Reflection.Extensions/README.md
@@ -1,7 +1,7 @@
 # System.Reflection.Extensions
 This supports forwarding types to the runtime including [CustomAttributeExtensions](https://learn.microsoft.com/dotnet/api/system.reflection.CustomAttributeExtensions), [InterfaceMapping](https://learn.microsoft.com/dotnet/api/system.reflection.InterfaceMapping) and [RuntimeReflectionExtensions](https://learn.microsoft.com/dotnet/api/system.reflection.RuntimeReflectionExtensions).
 
-## Status: [Legacy](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we only take fixes that unblock critical issues](../../libraries/README.md#contribution-bar)
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 
 ## Deployment

--- a/src/libraries/System.Reflection.Metadata/README.md
+++ b/src/libraries/System.Reflection.Metadata/README.md
@@ -2,8 +2,7 @@
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.metadata.
 
 ## Contribution Bar
-- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
-
+- [x] [We consider new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
 
 See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Metadata+label%3A%22help+wanted%22) issues.
 

--- a/src/libraries/System.Reflection.Metadata/README.md
+++ b/src/libraries/System.Reflection.Metadata/README.md
@@ -1,8 +1,10 @@
 # System.Reflection.Metadata
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.metadata.
 
-## Status: [Inactive](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
 The APIs and functionality are mature, but do get extended occasionally.
+
+See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Metadata+label%3A%22help+wanted%22) issues.
 
 ## Deployment
 [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata) is included in the shared framework.

--- a/src/libraries/System.Reflection.Metadata/README.md
+++ b/src/libraries/System.Reflection.Metadata/README.md
@@ -1,8 +1,9 @@
 # System.Reflection.Metadata
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.metadata.
 
-## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
-The APIs and functionality are mature, but do get extended occasionally.
+## Contribution Bar
+- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
+
 
 See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection.Metadata+label%3A%22help+wanted%22) issues.
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/README.md
+++ b/src/libraries/System.Reflection.MetadataLoadContext/README.md
@@ -3,12 +3,8 @@ This provides a high-level API for inspecting types given raw assembly contents 
 
 This library takes a dependency on `System.Reflection.Metadata` for reading the assembly.
 
-## Status: [Inactive](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we only take fixes to maintain or improve quality](../../libraries/README.md#contribution-bar)
 The APIs and functionality are mature, but do get extended occasionally.
-
-## Source
-
-* [../System.Reflection.MetadataLoadContext](../System.Reflection.MetadataLoadContext)
 
 ## Deployment
 [System.Reflection.MetadataLoadContext](https://www.nuget.org/packages/System.Reflection.MetadataLoadContext) NuGet package.

--- a/src/libraries/System.Reflection.MetadataLoadContext/README.md
+++ b/src/libraries/System.Reflection.MetadataLoadContext/README.md
@@ -3,8 +3,8 @@ This provides a high-level API for inspecting types given raw assembly contents 
 
 This library takes a dependency on `System.Reflection.Metadata` for reading the assembly.
 
-## Contribution Bar: [we only take fixes to maintain or improve quality](../../libraries/README.md#contribution-bar)
-The APIs and functionality are mature, but do get extended occasionally.
+## Contribution Bar
+- [x] [We only take fixes to maintain or improve quality](../../libraries/README.md#primary-bar)
 
 ## Deployment
 [System.Reflection.MetadataLoadContext](https://www.nuget.org/packages/System.Reflection.MetadataLoadContext) NuGet package.

--- a/src/libraries/System.Reflection.MetadataLoadContext/README.md
+++ b/src/libraries/System.Reflection.MetadataLoadContext/README.md
@@ -4,7 +4,7 @@ This provides a high-level API for inspecting types given raw assembly contents 
 This library takes a dependency on `System.Reflection.Metadata` for reading the assembly.
 
 ## Contribution Bar
-- [x] [We only take fixes to maintain or improve quality](../../libraries/README.md#primary-bar)
+- [x] [We only consider fixes to maintain or improve quality](../../libraries/README.md#primary-bar)
 
 ## Deployment
 [System.Reflection.MetadataLoadContext](https://www.nuget.org/packages/System.Reflection.MetadataLoadContext) NuGet package.

--- a/src/libraries/System.Reflection.Primitives/README.md
+++ b/src/libraries/System.Reflection.Primitives/README.md
@@ -2,7 +2,7 @@
 Contains reflection types such as [TypeAttributes](https://learn.microsoft.com/dotnet/api/system.reflection.typeattributes). Some of these types are forwarded to the runtime. In the future, the non-forwarded types may be lifted to the runtime and then type forwards added.
 
 ## Contribution Bar
-- [x] [We only take fixes that unblock critical issues](../../libraries/README.md#primary-bar)
+- [x] [We only consider fixes that unblock critical issues](../../libraries/README.md#primary-bar)
 
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 

--- a/src/libraries/System.Reflection.Primitives/README.md
+++ b/src/libraries/System.Reflection.Primitives/README.md
@@ -1,7 +1,7 @@
 # System.Reflection.Primitives
 Contains reflection types such as [TypeAttributes](https://learn.microsoft.com/dotnet/api/system.reflection.typeattributes). Some of these types are forwarded to the runtime. In the future, the non-forwarded types may be lifted to the runtime and then type forwards added.
 
-## Status: [Legacy](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we only take fixes that unblock critical issues](../../libraries/README.md#contribution-bar)
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 
 ## Deployment

--- a/src/libraries/System.Reflection.Primitives/README.md
+++ b/src/libraries/System.Reflection.Primitives/README.md
@@ -1,7 +1,9 @@
 # System.Reflection.Primitives
 Contains reflection types such as [TypeAttributes](https://learn.microsoft.com/dotnet/api/system.reflection.typeattributes). Some of these types are forwarded to the runtime. In the future, the non-forwarded types may be lifted to the runtime and then type forwards added.
 
-## Contribution Bar: [we only take fixes that unblock critical issues](../../libraries/README.md#contribution-bar)
+## Contribution Bar
+- [x] [We only take fixes that unblock critical issues](../../libraries/README.md#primary-bar)
+
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 
 ## Deployment

--- a/src/libraries/System.Reflection.TypeExtensions/README.md
+++ b/src/libraries/System.Reflection.TypeExtensions/README.md
@@ -2,7 +2,7 @@
 This is a facade assembly that has extension methods for common reflection types.
 
 ## Contribution Bar
-- [x] [We only take fixes that unblock critical issues](../../libraries/README.md#primary-bar)
+- [x] [We only consider fixes that unblock critical issues](../../libraries/README.md#primary-bar)
 
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 

--- a/src/libraries/System.Reflection.TypeExtensions/README.md
+++ b/src/libraries/System.Reflection.TypeExtensions/README.md
@@ -1,7 +1,9 @@
 # System.Reflection.TypeExtensions
 This is a facade assembly that has extension methods for common reflection types.
 
-## Contribution Bar: [we only take fixes that unblock critical issues](../../libraries/README.md#contribution-bar)
+## Contribution Bar
+- [x] [We only take fixes that unblock critical issues](../../libraries/README.md#primary-bar)
+
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 
 ## Deployment

--- a/src/libraries/System.Reflection.TypeExtensions/README.md
+++ b/src/libraries/System.Reflection.TypeExtensions/README.md
@@ -1,7 +1,7 @@
 # System.Reflection.TypeExtensions
 This is a facade assembly that has extension methods for common reflection types.
 
-## Status: [Legacy](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we only take fixes that unblock critical issues](../../libraries/README.md#contribution-bar)
 This package was used in the past to expose common functionality across different runtimes in a uniform way. It continues to ship as part of the shared framework, but it is frozen for compatibility.
 
 ## Deployment

--- a/src/libraries/System.Reflection/README.md
+++ b/src/libraries/System.Reflection/README.md
@@ -3,8 +3,10 @@ This is the primary reflection assembly. It is used for late-bound introspection
 
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.
 
-## Status: [Active](../../libraries/README.md#development-statuses)
+## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
 Although these common types are mature, the code base continues to evolve for better performance and to keep up with language and runtime enhancements such as byref-like types.
+
+See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection+label%3A%22help+wanted%22) issues.
 
 ## Source
 

--- a/src/libraries/System.Reflection/README.md
+++ b/src/libraries/System.Reflection/README.md
@@ -4,8 +4,8 @@ This is the primary reflection assembly. It is used for late-bound introspection
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.
 
 ## Contribution Bar
-- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
-- [x] [We take PRs that target this library for new source code analyzers](../../libraries/README.md#secondary-bars)
+- [x] [We consider new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
+- [x] [We consider PRs that target this library for new source code analyzers](../../libraries/README.md#secondary-bars)
 
 Although the types are mature, the code base continues to evolve for better performance and to keep up with language and runtime enhancements such as byref-like types.
 

--- a/src/libraries/System.Reflection/README.md
+++ b/src/libraries/System.Reflection/README.md
@@ -3,8 +3,11 @@ This is the primary reflection assembly. It is used for late-bound introspection
 
 Documentation can be found at https://learn.microsoft.com/dotnet/api/system.reflection.
 
-## Contribution Bar: [we take new features, new APIs and performance changes](../../libraries/README.md#contribution-bar)
-Although these common types are mature, the code base continues to evolve for better performance and to keep up with language and runtime enhancements such as byref-like types.
+## Contribution Bar
+- [x] [We take new features, new APIs and performance changes](../../libraries/README.md#primary-bar)
+- [x] [We take PRs that target this library for new source code analyzers](../../libraries/README.md#secondary-bars)
+
+Although the types are mature, the code base continues to evolve for better performance and to keep up with language and runtime enhancements such as byref-like types.
 
 See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Reflection+label%3A%22help+wanted%22) issues.
 


### PR DESCRIPTION
An update to https://github.com/dotnet/runtime/pull/76567 based on various discussions.

Instead of using "Active", "Inactive" and "Legacy" for the "Status", change wording to "contribution bar" that more accurately describes what type of PRs and issues are expected for each library. The contribution bar essentially is the acceptable risk and investment level for each library given the current status of the library and is composed of a single primary bar and optional secondary bars.

cc @joperezr per our offline review
