### PR TITLE
JIT: fix out of bounds read during SPMI collection

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -5685,7 +5685,7 @@ static unsigned InstrumentationKindToSize(ICorJitInfo::PgoInstrumentationKind ki
         case ICorJitInfo::PgoInstrumentationKind::MethodHandle:
             return sizeof(uintptr_t);
         default:
-            LogError("Unexpedted pgo schema data size (kind = %d)", kind);
+            LogError("Unexpected pgo schema data size (kind = %d)", kind);
             return 0;
     }
 }


### PR DESCRIPTION
When recording the profile data into the method context, SPMI was assuming all data items were `sizeof(uintptr_t)` which is not guaranteed. Use the proper size.

Fixes #76991.