### PR TITLE
Fixes a wrong not node insertion producing broken lir range on macos arm64

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2940,7 +2940,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
                 {
                     GenTree* notNode   = comp->gtNewOperNode(GT_NOT, andOp1->TypeGet(), andOp1);
                     op1->AsOp()->gtOp1 = notNode;
-                    BlockRange().InsertBefore(andOp2, notNode);
+                    BlockRange().InsertAfter(andOp1, notNode);
                 }
 
                 cmpUse.ReplaceWith(op1);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77158
Inserting not node before andOp2 was producing a faulty LIR range. Inserting after andOp1 fixes this. I thought this optimization was not affecting arm64 since there were no spmi diffs.

@jakobbotsch was spot on :)