### PR TITLE
JIT: Clean up inliner substitution

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2583,7 +2583,7 @@ public:
     GenTree* gtNewMustThrowException(unsigned helper, var_types type, CORINFO_CLASS_HANDLE clsHnd);
 
     GenTreeLclFld* gtNewLclFldNode(unsigned lnum, var_types type, unsigned offset);
-    GenTree* gtNewInlineCandidateReturnExpr(GenTree* inlineCandidate, var_types type, BasicBlockFlags bbFlags);
+    GenTreeRetExpr* gtNewInlineCandidateReturnExpr(GenTreeCall* inlineCandidate, var_types type);
 
     GenTreeField* gtNewFieldRef(var_types type, CORINFO_FIELD_HANDLE fldHnd, GenTree* obj = nullptr, DWORD offset = 0);
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -100,7 +100,7 @@ public:
 
         if (tree->OperIs(GT_RET_EXPR))
         {
-            UpdateInlineReturnExpressionPlaceHolder(tree, user);
+            UpdateInlineReturnExpressionPlaceHolder(use, user);
         }
 
 #if FEATURE_MULTIREG_RET
@@ -121,9 +121,10 @@ public:
             {
                 GenTree* effectiveValue = value->gtEffectiveVal(/*commaOnly*/ true);
 
-                noway_assert(!varTypeIsStruct(effectiveValue) || (effectiveValue->OperGet() != GT_RET_EXPR) ||
-                             !m_compiler->IsMultiRegReturnedType(effectiveValue->AsRetExpr()->gtRetClsHnd,
-                                                                 CorInfoCallConvExtension::Managed));
+                noway_assert(
+                    !varTypeIsStruct(effectiveValue) || (effectiveValue->OperGet() != GT_RET_EXPR) ||
+                    !m_compiler->IsMultiRegReturnedType(effectiveValue->AsRetExpr()->gtInlineCandidate->gtRetClsHnd,
+                                                        CorInfoCallConvExtension::Managed));
             }
         }
 
@@ -144,8 +145,8 @@ private:
     // inline return expression placeholder if there is one.
     //
     // Arguments:
-    //    pTree -- pointer to tree to examine for updates
-    //    data  -- context data for the tree walk
+    //    use -- edge for the tree that is a GT_RET_EXPR node
+    //    parent -- node containing the edge
     //
     // Returns:
     //    fgWalkResult indicating the walk should continue; that
@@ -175,30 +176,31 @@ private:
     //    the functions makes necessary updates. It could happen if there was
     //    an implicit conversion in the inlinee body.
     //
-    void UpdateInlineReturnExpressionPlaceHolder(GenTree* tree, GenTree* parent)
+    void UpdateInlineReturnExpressionPlaceHolder(GenTree** use, GenTree* parent)
     {
         CORINFO_CLASS_HANDLE retClsHnd = NO_CLASS_HANDLE;
 
-        while (tree->OperIs(GT_RET_EXPR))
+        while ((*use)->OperIs(GT_RET_EXPR))
         {
+            GenTree* tree = *use;
             // We are going to copy the tree from the inlinee,
             // so record the handle now.
             //
             if (varTypeIsStruct(tree))
             {
-                retClsHnd = tree->AsRetExpr()->gtRetClsHnd;
+                retClsHnd = tree->AsRetExpr()->gtInlineCandidate->gtRetClsHnd;
             }
 
             // Skip through chains of GT_RET_EXPRs (say from nested inlines)
             // to the actual tree to use.
             //
-            BasicBlockFlags bbFlags;
-            GenTree*        inlineCandidate = tree;
+            BasicBlock* inlineeBB;
+            GenTree*    inlineCandidate = tree;
             do
             {
                 GenTreeRetExpr* retExpr = inlineCandidate->AsRetExpr();
-                inlineCandidate         = retExpr->gtInlineCandidate;
-                bbFlags                 = retExpr->bbFlags;
+                inlineCandidate         = retExpr->gtSubstExpr;
+                inlineeBB               = retExpr->gtSubstBB;
             } while (inlineCandidate->OperIs(GT_RET_EXPR));
 
             // We might as well try and fold the return value. Eg returns of
@@ -235,9 +237,13 @@ private:
                 }
             }
 
-            tree->ReplaceWith(inlineCandidate, m_compiler);
+            *use          = inlineCandidate;
             m_madeChanges = true;
-            m_compiler->compCurBB->bbFlags |= (bbFlags & BBF_SPLIT_GAINED);
+
+            if (inlineeBB != nullptr)
+            {
+                m_compiler->compCurBB->bbFlags |= (inlineeBB->bbFlags & BBF_SPLIT_GAINED);
+            }
 
 #ifdef DEBUG
             if (m_compiler->verbose)
@@ -281,7 +287,7 @@ private:
                     else
                     {
                         // Just assign the inlinee to a variable to keep it simple.
-                        tree->ReplaceWith(AssignStructInlineeToVar(tree, retClsHnd), m_compiler);
+                        *use = AssignStructInlineeToVar(tree, retClsHnd);
                     }
                     m_madeChanges = true;
                 }
@@ -853,8 +859,6 @@ void Compiler::fgInvokeInlineeCompiler(GenTreeCall* call, InlineResult* inlineRe
     inlineInfo.iciStmt                = fgMorphStmt;
     inlineInfo.iciBlock               = compCurBB;
     inlineInfo.thisDereferencedFirst  = false;
-    inlineInfo.retExpr                = nullptr;
-    inlineInfo.retBB                  = nullptr;
     inlineInfo.retExprClassHnd        = nullptr;
     inlineInfo.retExprClassHndIsExact = false;
     inlineInfo.inlineResult           = inlineResult;
@@ -1006,12 +1010,12 @@ void Compiler::fgInvokeInlineeCompiler(GenTreeCall* call, InlineResult* inlineRe
     }
 #endif // DEBUG
 
-    // If there is non-NULL return, but we haven't set the pInlineInfo->retExpr,
+    // If there is non-NULL return, but we haven't set the substExpr,
     // That means we haven't imported any BB that contains CEE_RET opcode.
     // (This could happen for example for a BBJ_THROW block fall through a BBJ_RETURN block which
     // causes the BBJ_RETURN block not to be imported at all.)
     // Fail the inlining attempt
-    if (inlineCandidateInfo->fncRetType != TYP_VOID && inlineInfo.retExpr == nullptr)
+    if ((inlineCandidateInfo->fncRetType != TYP_VOID) && (inlineCandidateInfo->retExpr->gtSubstExpr == nullptr))
     {
 #ifdef DEBUG
         if (verbose)
@@ -1384,40 +1388,6 @@ _Done:
         gsCookieDummy->lvType        = TYP_INT;
         gsCookieDummy->lvIsTemp      = true; // It is not alive at all, set the flag to prevent zero-init.
         lvaSetVarDoNotEnregister(dummy DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
-    }
-
-    // If there is non-NULL return, replace the GT_CALL with its return value expression,
-    // so later it will be picked up by the GT_RET_EXPR node.
-    if ((pInlineInfo->inlineCandidateInfo->fncRetType != TYP_VOID) || (iciCall->gtReturnType == TYP_STRUCT))
-    {
-        noway_assert(pInlineInfo->retExpr);
-#ifdef DEBUG
-        if (verbose)
-        {
-            printf("\nReturn expression for call at ");
-            printTreeID(iciCall);
-            printf(" is\n");
-            gtDispTree(pInlineInfo->retExpr);
-        }
-#endif // DEBUG
-
-        // Replace the call with the return expression. Note that iciCall won't be part of the IR
-        // but may still be referenced from a GT_RET_EXPR node. We will replace GT_RET_EXPR node
-        // in UpdateInlineReturnExpressionPlaceHolder. At that time we will also update the flags
-        // on the basic block of GT_RET_EXPR node.
-        if (iciCall->gtInlineCandidateInfo->retExpr->OperGet() == GT_RET_EXPR)
-        {
-            // Save the basic block flags from the retExpr basic block.
-            iciCall->gtInlineCandidateInfo->retExpr->AsRetExpr()->bbFlags = pInlineInfo->retBB->bbFlags;
-        }
-
-        if (bottomBlock != nullptr)
-        {
-            // We've split the iciblock into two and the RET_EXPR was possibly moved to the bottomBlock
-            // so let's update its flags with retBB's ones
-            bottomBlock->bbFlags |= pInlineInfo->retBB->bbFlags & BBF_COMPACT_UPD;
-        }
-        iciCall->ReplaceWith(pInlineInfo->retExpr, this);
     }
 
     //
@@ -1839,6 +1809,7 @@ void Compiler::fgInlineAppendStatements(InlineInfo* inlineInfo, BasicBlock* bloc
     InlLclVarInfo*       lclVarInfo        = inlineInfo->lclVarInfo;
     unsigned             gcRefLclCnt       = inlineInfo->numberOfGcRefLocals;
     const unsigned       argCnt            = inlineInfo->argCnt;
+    InlineCandidateInfo* inlCandInfo       = inlineInfo->inlineCandidateInfo;
 
     for (unsigned lclNum = 0; lclNum < lclCnt; lclNum++)
     {
@@ -1873,10 +1844,9 @@ void Compiler::fgInlineAppendStatements(InlineInfo* inlineInfo, BasicBlock* bloc
         // Does the local we're about to null out appear in the return
         // expression?  If so we somehow messed up and didn't properly
         // spill the return value. See impInlineFetchLocal.
-        GenTree* retExpr = inlineInfo->retExpr;
-        if (retExpr != nullptr)
+        if ((inlCandInfo->retExpr != nullptr) && (inlCandInfo->retExpr->gtSubstExpr != nullptr))
         {
-            const bool interferesWithReturn = gtHasRef(inlineInfo->retExpr, tmpNum);
+            const bool interferesWithReturn = gtHasRef(inlCandInfo->retExpr->gtSubstExpr, tmpNum);
             noway_assert(!interferesWithReturn);
         }
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -247,6 +247,13 @@ private:
             // flags from the second-to-last inlinee's BB. Remove this once we
             // can take these changes. We still need to propagate the mandatory
             // "IR-presence" flags.
+            // Furthermore, we should really only propagate BBF_COPY_PROPAGATE
+            // flags here. BBF_SPLIT_GAINED includes BBF_PROF_WEIGHT, and
+            // propagating that has the effect that inlining a tree from a hot
+            // block into a block without profile weights means we suddenly
+            // start to see the inliner block as hot and treat future inline
+            // candidates more aggressively.
+            //
             BasicBlockFlags newBBFlags = BBF_EMPTY;
             if (prevInlineeBB != nullptr)
             {

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -281,13 +281,13 @@ private:
                     if (parent->OperIs(GT_ASG))
                     {
                         // The inlinee can only be the RHS.
-                        assert(parent->gtGetOp2() == tree);
+                        assert(parent->gtGetOp2() == *use);
                         AttachStructInlineeToAsg(parent->AsOp(), retClsHnd);
                     }
                     else
                     {
                         // Just assign the inlinee to a variable to keep it simple.
-                        *use = AssignStructInlineeToVar(tree, retClsHnd);
+                        *use = AssignStructInlineeToVar(*use, retClsHnd);
                     }
                     m_madeChanges = true;
                 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11480,10 +11480,16 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
 
         case GT_RET_EXPR:
         {
-            GenTree* const associatedTree = tree->AsRetExpr()->gtInlineCandidate;
-            printf("(inl return %s ", tree->IsCall() ? " from call" : "expr");
-            printTreeID(associatedTree);
+            GenTreeCall* inlineCand = tree->AsRetExpr()->gtInlineCandidate;
+            printf("(for ");
+            printTreeID(inlineCand);
             printf(")");
+
+            if (tree->AsRetExpr()->gtSubstExpr != nullptr)
+            {
+                printf(" -> ");
+                printTreeID(tree->AsRetExpr()->gtSubstExpr);
+            }
         }
         break;
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7364,7 +7364,7 @@ GenTreeLclFld* Compiler::gtNewLclFldNode(unsigned lnum, var_types type, unsigned
     return node;
 }
 
-GenTree* Compiler::gtNewInlineCandidateReturnExpr(GenTree* inlineCandidate, var_types type, BasicBlockFlags bbFlags)
+GenTreeRetExpr* Compiler::gtNewInlineCandidateReturnExpr(GenTreeCall* inlineCandidate, var_types type)
 {
     assert(GenTree::s_gtNodeSizes[GT_RET_EXPR] == TREE_NODE_SZ_LARGE);
 
@@ -7372,14 +7372,10 @@ GenTree* Compiler::gtNewInlineCandidateReturnExpr(GenTree* inlineCandidate, var_
 
     node->gtInlineCandidate = inlineCandidate;
 
-    node->bbFlags = bbFlags;
+    node->gtSubstExpr = nullptr;
+    node->gtSubstBB   = nullptr;
 
-    if (varTypeIsStruct(inlineCandidate) && !inlineCandidate->OperIsBlkOp())
-    {
-        node->gtRetClsHnd = gtGetStructHandle(inlineCandidate);
-    }
-
-    // GT_RET_EXPR node eventually might be bashed back to GT_CALL (when inlining is aborted for example).
+    // GT_RET_EXPR node eventually might be turned back into GT_CALL (when inlining is aborted for example).
     // Therefore it should carry the GTF_CALL flag so that all the rules about spilling can apply to it as well.
     // For example, impImportLeave or CEE_POP need to spill GT_RET_EXPR before empty the evaluation stack.
     node->gtFlags |= GTF_CALL;
@@ -17367,7 +17363,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleIfPresent(GenTree* tree)
                 structHnd = tree->AsCall()->gtRetClsHnd;
                 break;
             case GT_RET_EXPR:
-                structHnd = tree->AsRetExpr()->gtRetClsHnd;
+                structHnd = tree->AsRetExpr()->gtInlineCandidate->gtRetClsHnd;
                 break;
             case GT_FIELD:
                 info.compCompHnd->getFieldType(tree->AsField()->gtFldHnd, &structHnd);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7234,11 +7234,18 @@ protected:
 
 struct GenTreeRetExpr : public GenTree
 {
-    GenTree* gtInlineCandidate;
+    GenTreeCall* gtInlineCandidate;
 
-    BasicBlockFlags bbFlags;
+    // Expression representing gtInlineCandidate's value (e.g. spill temp or
+    // expression from inlinee, or call itself for unsuccessful inlines).
+    // Substituted by UpdateInlineReturnExpressionPlaceHolder.
+    // This tree is nullptr during the import that created the GenTreeRetExpr and is set later
+    // when handling the actual inline candidate.
+    GenTree* gtSubstExpr;
 
-    CORINFO_CLASS_HANDLE gtRetClsHnd;
+    // The basic block that gtSubstExpr comes from, to enable propagating mandatory flags.
+    // nullptr for cases where gtSubstExpr is not a tree from the inlinee.
+    BasicBlock* gtSubstBB;
 
     GenTreeRetExpr(var_types type) : GenTree(GT_RET_EXPR, type)
     {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1389,7 +1389,7 @@ DONE_CALL:
                 impAppendTree(call, CHECK_SPILL_ALL, impCurStmtDI, false);
 
                 // TODO: Still using the widened type.
-                GenTree* retExpr = gtNewInlineCandidateReturnExpr(call, genActualType(callRetTyp), compCurBB->bbFlags);
+                GenTreeRetExpr* retExpr = gtNewInlineCandidateReturnExpr(call->AsCall(), genActualType(callRetTyp));
 
                 // Link the retExpr to the call so if necessary we can manipulate it later.
                 origCall->gtInlineCandidateInfo->retExpr = retExpr;

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -606,15 +606,22 @@ struct GuardedDevirtualizationCandidateInfo : HandleHistogramProfileCandidateInf
 //
 struct InlineCandidateInfo : public GuardedDevirtualizationCandidateInfo
 {
-    CORINFO_METHOD_INFO    methInfo;
-    CORINFO_METHOD_HANDLE  ilCallerHandle; // the logical IL caller of this inlinee.
+    CORINFO_METHOD_INFO methInfo;
+
+    // the logical IL caller of this inlinee.
+    CORINFO_METHOD_HANDLE  ilCallerHandle;
     CORINFO_CLASS_HANDLE   clsHandle;
     CORINFO_CONTEXT_HANDLE exactContextHnd;
-    GenTree*               retExpr;
-    unsigned               preexistingSpillTemp;
-    unsigned               clsAttr;
-    unsigned               methAttr;
-    IL_OFFSET              ilOffset; // actual IL offset of instruction that resulted in this inline candidate
+
+    // The GT_RET_EXPR node linking back to the inline candidate.
+    GenTreeRetExpr* retExpr;
+
+    unsigned preexistingSpillTemp;
+    unsigned clsAttr;
+    unsigned methAttr;
+
+    // actual IL offset of instruction that resulted in this inline candidate
+    IL_OFFSET              ilOffset;
     CorInfoInitClassResult initClassResult;
     var_types              fncRetType;
     bool                   exactContextNeedsRuntimeLookup;
@@ -678,8 +685,6 @@ struct InlineInfo
 
     InlineResult* inlineResult;
 
-    GenTree*             retExpr; // The return expression of the inlined candidate.
-    BasicBlock*          retBB;   // The basic block of the return expression of the inlined candidate.
     CORINFO_CLASS_HANDLE retExprClassHnd;
     bool                 retExprClassHndIsExact;
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5526,9 +5526,13 @@ void Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineResult)
 {
     bool inliningFailed = false;
 
+    InlineCandidateInfo* inlCandInfo = call->gtInlineCandidateInfo;
+
     // Is this call an inline candidate?
     if (call->IsInlineCandidate())
     {
+        inlCandInfo = call->gtInlineCandidateInfo;
+
         InlineContext* createdContext = nullptr;
         // Attempt the inline
         fgMorphCallInlineHelper(call, inlineResult, &createdContext);
@@ -5582,6 +5586,7 @@ void Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineResult)
             // Detach the GT_CALL tree from the original statement by
             // hanging a "nothing" node to it. Later the "nothing" node will be removed
             // and the original GT_CALL tree will be picked up by the GT_RET_EXPR node.
+            inlCandInfo->retExpr->gtSubstExpr = call;
 
             noway_assert(fgMorphStmt->GetRootNode() == call);
             fgMorphStmt->SetRootNode(gtNewNothingNode());
@@ -5685,23 +5690,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result, 
         }
 
         lvaCount = startVars;
-
-#ifdef DEBUG
-        if (verbose)
-        {
-            // printf("Inlining failed. Restore lvaCount to %d.\n", lvaCount);
-        }
-#endif
-
-        return;
     }
-
-#ifdef DEBUG
-    if (verbose)
-    {
-        // printf("After inlining lvaCount=%d.\n", lvaCount);
-    }
-#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5531,8 +5531,6 @@ void Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineResult)
     // Is this call an inline candidate?
     if (call->IsInlineCandidate())
     {
-        inlCandInfo = call->gtInlineCandidateInfo;
-
         InlineContext* createdContext = nullptr;
         // Attempt the inline
         fgMorphCallInlineHelper(call, inlineResult, &createdContext);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5585,7 +5585,7 @@ void Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineResult)
             // hanging a "nothing" node to it. Later the "nothing" node will be removed
             // and the original GT_CALL tree will be picked up by the GT_RET_EXPR node.
             inlCandInfo->retExpr->gtSubstExpr = call;
-            inlCandInfo->retExpr->gtSubstBB = compCurBB;
+            inlCandInfo->retExpr->gtSubstBB   = compCurBB;
 
             noway_assert(fgMorphStmt->GetRootNode() == call);
             fgMorphStmt->SetRootNode(gtNewNothingNode());

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5585,6 +5585,7 @@ void Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineResult)
             // hanging a "nothing" node to it. Later the "nothing" node will be removed
             // and the original GT_CALL tree will be picked up by the GT_RET_EXPR node.
             inlCandInfo->retExpr->gtSubstExpr = call;
+            inlCandInfo->retExpr->gtSubstBB = compCurBB;
 
             noway_assert(fgMorphStmt->GetRootNode() == call);
             fgMorphStmt->SetRootNode(gtNewNothingNode());


### PR DESCRIPTION
* Stop using GenTree::ReplaceWith
* GenTreeRetExpr now directly contains its substitution members, which is a tree either from the inline candidate, a local (due to spill temps) or the call itself (due to inliner failure). In the former case, it also contains the BasicBlock the child tree comes from to ensure that its flags can be propagated once and for all during substitution.
* Make various members strongly typed, e.g. GenTreeRetExpr::gtInlineCandidate is now a GenTreeCall*, InlineCandidateInfo::retExpr is now a GenTreeRetExpr*. This is possible since we are no longer using GenTree::ReplaceWith.

Fix #75827