### PR TITLE
Fix unzipping 4GB+ zip files

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -199,7 +199,10 @@ namespace System.IO.Compression
                 if (extraField.Size < sizeof(long))
                     return true;
 
-                bool readAllFields = extraField.Size == sizeof(long) + sizeof(long) + sizeof(long) + sizeof(int);
+                // Advancing the stream (by reading from it) is possible only when:
+                // 1. There is an explicit ask to do that (valid files, corresponding boolean flag(s) set to true, #77159).
+                // 2. When the size indicates that all the information is available ("slightly invalid files", #49580).
+                bool readAllFields = extraField.Size >= sizeof(long) + sizeof(long) + sizeof(long) + sizeof(int);
 
                 long value64 = readUncompressedSize || readAllFields ? reader.ReadInt64() : -1;
                 if (readUncompressedSize)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -199,28 +199,30 @@ namespace System.IO.Compression
                 if (extraField.Size < sizeof(long))
                     return true;
 
-                long value64 = reader.ReadInt64();
+                bool readAllFields = extraField.Size == sizeof(long) + sizeof(long) + sizeof(long) + sizeof(int);
+
+                long value64 = readUncompressedSize || readAllFields ? reader.ReadInt64() : -1;
                 if (readUncompressedSize)
                     zip64Block._uncompressedSize = value64;
 
                 if (ms.Position > extraField.Size - sizeof(long))
                     return true;
 
-                value64 = reader.ReadInt64();
+                value64 = readCompressedSize || readAllFields ? reader.ReadInt64() : -1;
                 if (readCompressedSize)
                     zip64Block._compressedSize = value64;
 
                 if (ms.Position > extraField.Size - sizeof(long))
                     return true;
 
-                value64 = reader.ReadInt64();
+                value64 = readLocalHeaderOffset || readAllFields ? reader.ReadInt64() : -1;
                 if (readLocalHeaderOffset)
                     zip64Block._localHeaderOffset = value64;
 
                 if (ms.Position > extraField.Size - sizeof(int))
                     return true;
 
-                int value32 = reader.ReadInt32();
+                int value32 = readStartDiskNumber || readAllFields ? reader.ReadInt32() : -1;
                 if (readStartDiskNumber)
                     zip64Block._startDiskNumber = value32;
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -200,34 +200,54 @@ namespace System.IO.Compression
                     return true;
 
                 // Advancing the stream (by reading from it) is possible only when:
-                // 1. There is an explicit ask to do that (valid files, corresponding boolean flag(s) set to true, #77159).
-                // 2. When the size indicates that all the information is available ("slightly invalid files", #49580).
+                // 1. There is an explicit ask to do that (valid files, corresponding boolean flag(s) set to true).
+                // 2. When the size indicates that all the information is available ("slightly invalid files").
                 bool readAllFields = extraField.Size >= sizeof(long) + sizeof(long) + sizeof(long) + sizeof(int);
 
-                long value64 = readUncompressedSize || readAllFields ? reader.ReadInt64() : -1;
                 if (readUncompressedSize)
-                    zip64Block._uncompressedSize = value64;
+                {
+                    zip64Block._uncompressedSize = reader.ReadInt64();
+                }
+                else if (readAllFields)
+                {
+                    _ = reader.ReadInt64();
+                }
 
                 if (ms.Position > extraField.Size - sizeof(long))
                     return true;
 
-                value64 = readCompressedSize || readAllFields ? reader.ReadInt64() : -1;
                 if (readCompressedSize)
-                    zip64Block._compressedSize = value64;
+                {
+                    zip64Block._compressedSize = reader.ReadInt64();
+                }
+                else if (readAllFields)
+                {
+                    _ = reader.ReadInt64();
+                }
 
                 if (ms.Position > extraField.Size - sizeof(long))
                     return true;
 
-                value64 = readLocalHeaderOffset || readAllFields ? reader.ReadInt64() : -1;
                 if (readLocalHeaderOffset)
-                    zip64Block._localHeaderOffset = value64;
+                {
+                    zip64Block._localHeaderOffset = reader.ReadInt64();
+                }
+                else if (readAllFields)
+                {
+                    _ = reader.ReadInt64();
+                }
 
                 if (ms.Position > extraField.Size - sizeof(int))
                     return true;
 
-                int value32 = readStartDiskNumber || readAllFields ? reader.ReadInt32() : -1;
                 if (readStartDiskNumber)
-                    zip64Block._startDiskNumber = value32;
+                {
+                    zip64Block._startDiskNumber = reader.ReadInt32();
+                }
+                else if (readAllFields)
+                {
+                    _ = reader.ReadInt32();
+                }
 
                 // original values are unsigned, so implies value is too big to fit in signed integer
                 if (zip64Block._uncompressedSize < 0) throw new InvalidDataException(SR.FieldTooBigUncompressedSize);

--- a/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -37,6 +37,7 @@
     <Compile Include="$(CommonTestPath)System\IO\Compression\StreamHelpers.cs" Link="Common\System\IO\Compression\StreamHelpers.cs" />
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs" Link="Common\System\IO\TempFile.cs" />
     <Compile Include="$(CommonTestPath)System\IO\Compression\ZipTestHelper.cs" Link="Common\System\IO\Compression\ZipTestHelper.cs" />
+    <Compile Include="$(CommonTestPath)TestUtilities\System\DisableParallelization.cs" Link="Common\TestUtilities\System\DisableParallelization.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs" Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs" Link="Common\System\IO\ConnectedStreams.cs" />
     <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="ProductionCode\Common\System\Net\MultiArrayBuffer.cs" />

--- a/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="ZipArchive\zip_InvalidParametersAndStrangeFiles.cs" />
     <Compile Include="ZipArchive\zip_ManualAndCompatibilityTests.cs" />
     <Compile Include="ZipArchive\zip_netcoreappTests.cs" />
+    <Compile Include="ZipArchive\zip_LargeFiles.cs" />
     <Compile Include="ZipArchive\zip_ReadTests.cs" />
     <Compile Include="ZipArchive\zip_UpdateTests.cs" />
     <Compile Include="ZipArchive\zip_UpdateTests.Comments.cs" />

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
@@ -1,43 +1,52 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.Compression.Tests
 {
     public class zip_LargeFiles : ZipFileTestBase
     {
-        [Fact]
-        public static void ZipUnzip4GBFile()
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized))] // don't run it on slower runtimes
+        [OuterLoop("It takes more than 10 minutes")]
+        public static void UnzipOver4GBZipFile()
         {
             Random random = new (12345); // use const seed for reproducible results
             byte[] buffer = new byte[1_000_000]; // 1 MB
+            Dictionary<string, byte[]> entiresContent = new();
 
-            string filePath = Path.Combine("ZipTestData", "large.zip");
-            DirectoryInfo tempDir = Directory.CreateDirectory(Path.Combine("ZipTestData", "large"));
+            string zipArchivePath = Path.Combine("ZipTestData", "over4GB.zip");
+            DirectoryInfo tempDir = Directory.CreateDirectory(Path.Combine("ZipTestData", "over4GB"));
 
             try
             {
                 for (int i = 0; i < 4_500; i++)
                 {
                     random.NextBytes(buffer);
-                    File.WriteAllBytes(Path.Combine(tempDir.FullName, $"{i}.test"), buffer);
+
+                    string entryName = $"{i}.test";
+                    File.WriteAllBytes(Path.Combine(tempDir.FullName, entryName), buffer);
+                    entiresContent.Add(entryName, buffer.ToArray());
                 }
 
-                ZipFile.CreateFromDirectory(tempDir.FullName, filePath);
+                ZipFile.CreateFromDirectory(tempDir.FullName, zipArchivePath);
 
-                using ZipArchive zipArchive = ZipFile.OpenRead(filePath);
+                using ZipArchive zipArchive = ZipFile.OpenRead(zipArchivePath);
                 foreach (ZipArchiveEntry entry in zipArchive.Entries)
                 {
                     using Stream entryStream = entry.Open();
                     Assert.True(entryStream.CanRead);
+                    entryStream.ReadExactly(buffer);
+                    Assert.Equal(entiresContent[entry.Name], buffer);
                 }
             }
             finally
             {
-                if (File.Exists(filePath))
+                if (File.Exists(zipArchivePath))
                 {
-                    File.Delete(filePath);
+                    File.Delete(zipArchivePath);
                 }
 
                 tempDir.Delete(recursive: true);

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.IO.Compression.Tests
+{
+    public class zip_LargeFiles : ZipFileTestBase
+    {
+        [Fact]
+        public static void ZipUnzip4GBFile()
+        {
+            Random random = new (12345); // use const seed for reproducible results
+            byte[] buffer = new byte[1_000_000]; // 1 MB
+
+            string filePath = Path.Combine("ZipTestData", "large.zip");
+            DirectoryInfo tempDir = Directory.CreateDirectory(Path.Combine("ZipTestData", "large"));
+
+            try
+            {
+                for (int i = 0; i < 4_500; i++)
+                {
+                    random.NextBytes(buffer);
+                    File.WriteAllBytes(Path.Combine(tempDir.FullName, $"{i}.test"), buffer);
+                }
+
+                ZipFile.CreateFromDirectory(tempDir.FullName, filePath);
+
+                using ZipArchive zipArchive = ZipFile.OpenRead(filePath);
+                foreach (ZipArchiveEntry entry in zipArchive.Entries)
+                {
+                    using Stream entryStream = entry.Open();
+                    Assert.True(entryStream.CanRead);
+                }
+            }
+            finally
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+
+                tempDir.Delete(recursive: true);
+            }
+        }
+    }
+}

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
@@ -16,8 +16,8 @@ namespace System.IO.Compression.Tests
         {
             byte[] buffer = GC.AllocateUninitializedArray<byte>(1_000_000_000); // 1 GB
 
-            string zipArchivePath = Path.Combine("ZipTestData", "over4GB.zip");
-            DirectoryInfo tempDir = Directory.CreateDirectory(Path.Combine("ZipTestData", "over4GB"));
+            string zipArchivePath = Path.Combine(Path.GetTempPath(), "over4GB.zip");
+            DirectoryInfo tempDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "over4GB"));
 
             try
             {


### PR DESCRIPTION
fixes #77159 without reverting #68106

I've tried to keep the changes as small as possible to make it easier to review and backport.

Explanation: for a file that is over 4 GB after zipping, some of the entries were reporting `extraField.Size == 8`, but `readUncompressedSize`, `readCompressedSize` and `readStartDiskNumber` equal `false` and `readLocalHeaderOffset` equal true. So what the code was doing, was reading first int64, not using it and exiting:

https://github.com/dotnet/runtime/blob/f7e6cf145e4b18f12675d7f0f0eb7d5216cd1a80/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs#L202-L207

The fix is to allow advancing the stream (by reading from it) only when all 4 fields are provided (`extraField.Size == 28`) or when they are explicitly requested (the boolean flags set to true)

