### PR TITLE
Add missing docs for `M.E.Configuration.Xml`

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlDocumentDecryptor.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlDocumentDecryptor.cs
@@ -48,8 +48,11 @@ namespace Microsoft.Extensions.Configuration.Xml
         }
 
         /// <summary>
-        /// Returns an XmlReader that decrypts data transparently.
+        /// Creates an <see cref="XmlReader"/> that decrypts data transparently.
         /// </summary>
+        /// <param name="input">The input <see cref="Stream"/> to read the XML configuration data from.</param>
+        /// <param name="settings">The settings for the new <see cref="XmlReader"/> instance.</param>
+        /// <returns>An <see cref="XmlReader"/> that decrypts data transparently.</returns>
         public XmlReader CreateDecryptingXmlReader(Stream input, XmlReaderSettings? settings)
         {
             // XML-based configurations aren't really all that big, so we can buffer


### PR DESCRIPTION
I did a quick skim over dotnet/runtime repo for

- `Microsoft.Extensions.Configuration`
- `Microsoft.Extensions.Configuration.CommandLine`
- `Microsoft.Extensions.Configuration.Ini`
- `Microsoft.Extensions.Configuration.Json`
- `Microsoft.Extensions.Configuration.Memory`

and noticed no change is needed here. All listed APIs already have xml docs in the source code.
The default ctors maybe are just missing in the dotnet-api-docs repo itself. No action needed on dotnet/runtime repo side.
Also note, `Microsoft.Extensions.Configuration.NewtonsoftJson` source code does not live in dotnet/runtime.

For dotnet/runtime repo seems we'd want to just docs on one API over in this PR.

Contributes to: #43869