### PR TITLE
System.DirectoryServices.Protocols.LdapConnection: allow non-ASCII Passwords on Linux Systems

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -175,7 +175,7 @@ namespace System.DirectoryServices.Protocols
 
         internal static string PtrToString(IntPtr requestName) => Marshal.PtrToStringAnsi(requestName);
 
-        internal static IntPtr StringToPtr(string s) => Marshal.StringToHGlobalAnsi(s);
+        internal static IntPtr StringToPtr(string s) => Marshal.StringToHGlobalAuto(s);
 
         /// <summary>
         /// Function that will be sent to the Sasl interactive bind procedure which will resolve all Sasl challenges


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/76426