### PR TITLE
Clearing all cards for free regions

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -11271,7 +11271,7 @@ void gc_heap::clear_region_info (heap_segment* region)
         clear_brick_table (heap_segment_mem (region), heap_segment_reserved (region));
     }
 
-    clear_card_for_addresses (get_region_start (region), heap_segment_allocated (region));
+    clear_card_for_addresses (get_region_start (region), heap_segment_reserved (region));
 
 #ifdef BACKGROUND_GC
     ::record_changed_seg ((uint8_t*)region, heap_segment_reserved (region),
@@ -11709,7 +11709,7 @@ void gc_heap::clear_gen1_cards()
         heap_segment* region = generation_start_segment (generation_of (1));
         while (region)
         {
-            clear_card_for_addresses (get_region_start (region), heap_segment_allocated (region));
+            clear_card_for_addresses (get_region_start (region), heap_segment_reserved (region));
             region = heap_segment_next (region);
         }
 #else //USE_REGIONS

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -11271,7 +11271,7 @@ void gc_heap::clear_region_info (heap_segment* region)
         clear_brick_table (heap_segment_mem (region), heap_segment_reserved (region));
     }
 
-    // we should really clear cards as well!!
+    clear_card_for_addresses (get_region_start (region), heap_segment_allocated (region));
 
 #ifdef BACKGROUND_GC
     ::record_changed_seg ((uint8_t*)region, heap_segment_reserved (region),
@@ -11709,7 +11709,7 @@ void gc_heap::clear_gen1_cards()
         heap_segment* region = generation_start_segment (generation_of (1));
         while (region)
         {
-            clear_card_for_addresses (heap_segment_mem (region), heap_segment_allocated (region));
+            clear_card_for_addresses (get_region_start (region), heap_segment_allocated (region));
             region = heap_segment_next (region);
         }
 #else //USE_REGIONS


### PR DESCRIPTION
This change fixed two issues associated with card table clearing.

When we return a region to the free region list, we can clear the cards. 

If we use `heap_segment_mem (region)`, this will always be 0x20 bytes after the start of the page. The `align_on_card` logic inside `clear_card_for_addresses` will skip resetting the card for the first page.

Before these fixes, https://github.com/dotnet/runtime/issues/76801 is always failing with `*card_word == 1`. This is because the initial card (i.e. the least significant bit) cannot be reset because of the alignment.

After these fixes, the test case no longer fails locally after running for 4 hours in a loop.