### PR TITLE
Fix comment

### DIFF
--- a/src/coreclr/inc/corjitflags.h
+++ b/src/coreclr/inc/corjitflags.h
@@ -92,7 +92,7 @@ public:
         CORJIT_FLAG_NO_INLINING             = 42, // JIT should not inline any called method into this method
 
 #if defined(TARGET_ARM)
-        CORJIT_FLAG_SOFTFP_ABI              = 43, // JIT should generate PC-relative address computations instead of EE relocation records
+        CORJIT_FLAG_SOFTFP_ABI              = 43, // On ARM should enable armel calling convention
 #else // !defined(TARGET_ARM)
         CORJIT_FLAG_UNUSED16                = 43,
 #endif // !defined(TARGET_ARM)


### PR DESCRIPTION
Note that the `CORJIT_FLAG_SOFTFP_ABI` flag seems to have no effect. Likewise, there's NativeAot `ArmEl` target and related code that seems to be dead.