### PR TITLE
Fix a signed/unsigned comparison warning

### DIFF
--- a/src/coreclr/nativeaot/Runtime/GCMemoryHelpers.inl
+++ b/src/coreclr/nativeaot/Runtime/GCMemoryHelpers.inl
@@ -238,7 +238,7 @@ FORCEINLINE void InlinedBulkWriteBarrier(void* pMemStart, size_t cbMemSize)
             // heap validation.
 
             uintptr_t* realSlot = (uintptr_t*)pMemStart;
-            uintptr_t slotCount = cbMemSize / sizeof(uintptr_t);
+            ptrdiff_t slotCount = (ptrdiff_t)(cbMemSize / sizeof(uintptr_t));
             ASSERT(slotCount < (uintptr_t*)g_GCShadowEnd - shadowSlot);
             do
             {


### PR DESCRIPTION
This bug was found when I tried to enable `WRITE_BARRIER_CHECK` under NativeAOT in an attempt to diagnose https://github.com/dotnet/runtime/issues/76801.

On line 242, we are comparing `slotCount` and the difference between the two pointers.  The difference could be a signed number, therefore the compiler flagged a warning and broke the build.

Doing a cast fixed that.

Together with https://github.com/dotnet/runtime/pull/77011, and a hack in `gcrhenv.cpp` to turn on `HeapVerify` to 2, I am able to turn on the write barrier shadow check and found no violation.