### PR TITLE
Move usages of `COMPlus_` var to `DOTNET_` fallback

### DIFF
--- a/src/coreclr/inc/eventtrace.h
+++ b/src/coreclr/inc/eventtrace.h
@@ -134,7 +134,7 @@ namespace ETW
         static BOOL s_fHeapAllocHighEventEnabledNow;
         static BOOL s_fHeapAllocLowEventEnabledNow;
 
-        // If COMPLUS_UNSUPPORTED_ETW_ObjectAllocationEventsPerTypePerSec is set, then
+        // If DOTNET_UNSUPPORTED_ETW_ObjectAllocationEventsPerTypePerSec is set, then
         // this is used to determine the event frequency, overriding
         // s_nDefaultMsBetweenEvents above (regardless of which
         // GCSampledObjectAllocation*Keyword was used)

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -3576,9 +3576,9 @@ INT32 WideCharToMultiByte(LPCWSTR wszSrcStr, LPSTR szDstStr);
 
 #include <rotor_pal.h>
 
-// The possible value of COMPlus_ETWEnabled should be '0' or '1'
+// The possible value of DOTNET_ETWEnabled or COMPlus_ETWEnabled should be '0' or '1'
 #define SIZE_ETWEnabled 2
-// The possible value of COMPlus_EventInfo should be a string in the following format:
+// The possible value of DOTNET_ETWEnabled or COMPlus_EventInfo should be a string in the following format:
 // GUID:HexNumfer:Level
 // GUID: For example e13c0d23-ccbc-4e12-931b-d9cc2eee27e4 (36 bytes)
 // HewNumber: 0xffffffff (10 bytes)
@@ -3588,21 +3588,24 @@ INT32 WideCharToMultiByte(LPCWSTR wszSrcStr, LPSTR szDstStr);
 
 ULONG ETW::CEtwTracer::Register()
 {
-    // Get Env Var COMPlus_ETWEnabled
-    char szETWEnabled[SIZE_ETWEnabled];
-    DWORD newLen = GetEnvironmentVariableA("COMPlus_ETWEnabled", szETWEnabled, SIZE_ETWEnabled);
+    // Get Env Var DOTNET_ETWEnabled or COMPlus_ETWEnabled
+    char szETWEnabled[SIZE_ETWEnabled] = { '\0' };
+    DWORD newLen = GetEnvironmentVariableA("DOTNET_ETWEnabled", szETWEnabled, SIZE_ETWEnabled);
+    newLen = szETWEnabled[0] != '\0' ? newLen : GetEnvironmentVariableA("COMPlus_ETWEnabled", szETWEnabled, SIZE_ETWEnabled);
     if (newLen == 0 || newLen >= SIZE_ETWEnabled || strcmp(szETWEnabled, "1") != 0)
         return 0;
 
-    // Get Env Var COMPlus_EventInfo
-    char szEventInfo[SIZE_EventInfo];
-    newLen = GetEnvironmentVariableA("COMPlus_EventInfo", szEventInfo, SIZE_EventInfo);
+    // Get Env Var DOTNET_EventInfo or COMPlus_EventInfo
+    char szEventInfo[SIZE_EventInfo] = { '\0' };
+    newLen = GetEnvironmentVariableA("DOTNET_EventInfo", szEventInfo, SIZE_EventInfo);
+    newLen = szEventInfo[0] != '\0' ? newLen : GetEnvironmentVariableA("COMPlus_EventInfo", szEventInfo, SIZE_EventInfo);
     if (newLen == 0 || newLen >= SIZE_EventInfo || strchr(szEventInfo, ' ') != NULL)
         return 0;
 
-    // Get Env Var COMPlus_EventLogFileName
-    char szEventLogFN[_MAX_FNAME];
-    newLen = GetEnvironmentVariableA("COMPlus_EventLogFileName", szEventLogFN, _MAX_FNAME);
+    // Get Env Var DOTNET_EventLogFileName or COMPlus_EventLogFileName
+    char szEventLogFN[_MAX_FNAME] = { '\0' };
+    newLen = GetEnvironmentVariableA("DOTNET_EventLogFileName", szEventLogFN, _MAX_FNAME);
+    newLen = szEventLogFN[0] != '\0' ? newLen : GetEnvironmentVariableA("COMPlus_EventLogFileName", szEventLogFN, _MAX_FNAME);
     if (newLen == 0 || newLen >= _MAX_FNAME || strchr(szEventLogFN, '|') != NULL)
         return 0;
     char szEventLogFullPath[_MAX_PATH];

--- a/src/coreclr/nativeaot/Runtime/eventtrace.h
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.h
@@ -112,7 +112,7 @@ namespace ETW
         static BOOL s_fHeapAllocHighEventEnabledNow;
         static BOOL s_fHeapAllocLowEventEnabledNow;
 
-        // If COMPLUS_UNSUPPORTED_ETW_ObjectAllocationEventsPerTypePerSec is set, then
+        // If DOTNET_UNSUPPORTED_ETW_ObjectAllocationEventsPerTypePerSec is set, then
         // this is used to determine the event frequency, overriding
         // s_nDefaultMsBetweenEvents above (regardless of which
         // GCSampledObjectAllocation*Keyword was used)

--- a/src/coreclr/tools/r2rtest/CompilerRunner.cs
+++ b/src/coreclr/tools/r2rtest/CompilerRunner.cs
@@ -207,7 +207,7 @@ namespace R2RTest
 
             if (!string.IsNullOrEmpty(_options.GCStress))
             {
-                processParameters.EnvironmentOverrides["COMPlus_GCStress"] = _options.GCStress;
+                processParameters.EnvironmentOverrides["DOTNET_GCStress"] = _options.GCStress;
             }
 
             if (_options.ExecutionTimeoutMinutes != 0)
@@ -224,7 +224,8 @@ namespace R2RTest
             }
 
             // TODO: support for tier jitting - for now we just turn it off as it may distort the JIT statistics
-            processParameters.EnvironmentOverrides["COMPLUS_TieredCompilation"] = "0";
+            processParameters.EnvironmentOverrides["DOTNET_TieredCompilation"] = "0";
+            processParameters.EnvironmentOverrides["COMPlus_TieredCompilation"] = "0";
 
             processParameters.CollectJittedMethods = !noEtw;
             if (!noEtw)

--- a/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
+++ b/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
@@ -65,6 +65,13 @@ namespace R2RTest
         {
             ProcessParameters processParameters = base.CompilationProcess(outputFileName, inputAssemblyFileNames);
             processParameters.Arguments = $"{Crossgen2Path} {processParameters.Arguments}";
+            // DOTNET_ variables
+            processParameters.EnvironmentOverrides["DOTNET_GCStress"] = "";
+            processParameters.EnvironmentOverrides["DOTNET_HeapVerify"] = "";
+            processParameters.EnvironmentOverrides["DOTNET_ReadyToRun"] = "";
+            processParameters.EnvironmentOverrides["DOTNET_GCName"] = "";
+
+            // COMPlus_ variables
             processParameters.EnvironmentOverrides["COMPlus_GCStress"] = "";
             processParameters.EnvironmentOverrides["COMPlus_HeapVerify"] = "";
             processParameters.EnvironmentOverrides["COMPlus_ReadyToRun"] = "";
@@ -75,7 +82,7 @@ namespace R2RTest
         protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
         {
             ProcessParameters processParameters = base.ExecutionProcess(modules, folders, noEtw);
-            processParameters.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
+            processParameters.EnvironmentOverrides["DOTNET_ReadyToRun"] = "1";
             return processParameters;
         }
 

--- a/src/coreclr/tools/r2rtest/JitRunner.cs
+++ b/src/coreclr/tools/r2rtest/JitRunner.cs
@@ -40,7 +40,8 @@ namespace R2RTest
         protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
         {
             ProcessParameters processParameters = base.ExecutionProcess(modules, folders, noEtw);
-            processParameters.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "0";
+            processParameters.EnvironmentOverrides["DOTNET_ReadyToRun"] = "0";
+            processParameters.EnvironmentOverrides["COMPlus_ReadyToRun"] = "0";
             return processParameters;
         }
 

--- a/src/coreclr/tools/superpmi/readme.md
+++ b/src/coreclr/tools/superpmi/readme.md
@@ -41,7 +41,7 @@ each recorded function. The generated results are compared with a built-in
 SuperPMI "near differ", which depends on an external disassembler component
 called `coredistools`. Typically, scripting has SuperPMI generate a list of
 functions with differences, then the script re-invokes each JIT to generate
-disassembly output (using `COMPlus_JitDisasm`) for each differing function.
+disassembly output (using `DOTNET_JitDisasm`) for each differing function.
 These are then compared either visually, or with the jitutils tool
 `jit-analyze`, or both.
 
@@ -121,7 +121,7 @@ Set the following environment variables:
 ```
 SuperPMIShimLogPath=<full path to an existing, empty temporary directory>
 SuperPMIShimPath=<full path to clrjit.dll, the "standalone" JIT>
-COMPlus_JitName=superpmi-shim-collector.dll
+DOTNET_JitName=superpmi-shim-collector.dll
 ```
 
 for example, on Windows:
@@ -130,7 +130,7 @@ for example, on Windows:
 mkdir f:\spmi\temp
 set SuperPMIShimLogPath=f:\spmi\temp
 set SuperPMIShimPath=f:\gh\runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\clrjit.dll
-set COMPlus_JitName=superpmi-shim-collector.dll
+set DOTNET_JitName=superpmi-shim-collector.dll
 ```
 
 (On Linux, use `libclrjit.so` and `libsuperpmi-shim-collector.so`.

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
@@ -22,19 +22,19 @@
 
 JitHost* g_ourJitHost;
 
-// RecordVariable: return `true` if the given COMPlus variable `key` should be recorded
+// RecordVariable: return `true` if the given DOTNET variable `key` should be recorded
 // in the method context.
 bool RecordVariable(const WCHAR* key)
 {
-    // Special-case: we don't want to store some COMPlus variables during
+    // Special-case: we don't want to store some DOTNET variables during
     // collections that we don't want to see on replay:
-    //   COMPlus_JitName -- used to get the VM to load the SuperPMI collection shim
+    //   DOTNET_JitName -- used to get the VM to load the SuperPMI collection shim
     //                      without requiring the shim to overwrite the original JIT.
     //                      This JIT doesn't care about this on SuperPMI replay, but
     //                      we don't need to waste the space in the MC file storing it.
-    //   COMPlus_AltJitName -- if collecting with an altjit, this is set. The JIT doesn't
+    //   DOTNET_AltJitName -- if collecting with an altjit, this is set. The JIT doesn't
     //                      use this on replay, but it doesn't need to be stored.
-    //   COMPlus_EnableExtraSuperPmiQueries -- used to force the JIT to ask additional
+    //   DOTNET_EnableExtraSuperPmiQueries -- used to force the JIT to ask additional
     //                      questions during SuperPMI collection. We don't want to store
     //                      this variable because we don't want to replay using it.
 

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -136,12 +136,12 @@ void CommandLine::DumpHelp(const char* program)
     printf(" -jitoption [force] key=value\n");
     printf("     Set the JIT option named \"key\" to \"value\" for JIT 1 if the option was not set.\n");
     printf("     With optional force flag overwrites the existing value if it was already set.\n");
-    printf("     NOTE: do not use a \"COMPlus_\" prefix, \"key\" and \"value\" are case sensitive!\n");
+    printf("     NOTE: do not use a \"DOTNET_\" prefix, \"key\" and \"value\" are case sensitive!\n");
     printf("\n");
     printf(" -jit2option [force] key=value\n");
     printf("     Set the JIT option named \"key\" to \"value\" for JIT 2 if the option was not set.\n");
     printf("     With optional force flag overwrites the existing value if it was already set.\n");
-    printf("     NOTE: do not use a \"COMPlus_\" prefix, \"key\" and \"value\" are case sensitive!\n");
+    printf("     NOTE: do not use a \"DOTNET_\" prefix, \"key\" and \"value\" are case sensitive!\n");
     printf("\n");
     printf("Inputs are case sensitive.\n");
     printf("\n");

--- a/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/icorjitinfo.cpp
@@ -1222,13 +1222,15 @@ const char16_t* MyICJI::getJitTimeLogFilename()
     // we have the ability to replay this, but we treat it in this case as EE context
     //  return jitInstance->eec->jitTimeLogFilename;
 
-    // We want to be able to set COMPLUS_JitTimeLogFile when replaying, to collect JIT
+    // We want to be able to set DOTNET_JitTimeLogFile or COMPlus_JitTimeLogFile when replaying, to collect JIT
     // statistics. So, just do a getenv() call. This isn't quite as thorough as
     // the normal CLR config value functions (which also check the registry), and we've
     // also hard-coded the variable name here instead of using:
     //      CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitTimeLogFile);
     // like in the VM, but it works for our purposes.
-    return (const char16_t*)GetEnvironmentVariableWithDefaultW(W("COMPlus_JitTimeLogFile"));
+    const char16_t* dotnetVar = (const char16_t*)GetEnvironmentVariableWithDefaultW(W("DOTNET_JitTimeLogFile"));
+    return dotnetVar != nullptr ? dotnetVar :
+        (const char16_t*)GetEnvironmentVariableWithDefaultW(W("COMPlus_JitTimeLogFile"));
 }
 
 /*********************************************************************************/


### PR DESCRIPTION
Following up on https://github.com/dotnet/runtime/pull/77025 for the remaining `COMPlus_` usages in `src/coreclr/{tools,nativeaot}`.