### PR TITLE
Fix recurisve `Monitor.TryEnter` to not return false due to a race condition

### DIFF
--- a/src/coreclr/vm/syncblk.inl
+++ b/src/coreclr/vm/syncblk.inl
@@ -632,10 +632,10 @@ FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread
         return AwareLock::EnterHelperResult_Contention;
     }
 
-    // The header is transitioning - treat this as if the lock was taken
+    // The header is transitioning - use the slow path
     if (oldValue & BIT_SBLK_SPIN_LOCK)
     {
-        return AwareLock::EnterHelperResult_Contention;
+        return AwareLock::EnterHelperResult_UseSlowPath;
     }
 
     // Here we know we have the "thin lock" layout, but the lock is not free.


### PR DESCRIPTION
A race condition when the object header is transitioning to a sync block can cause a concurrent recursive `TryEnter` to return false.

Fixes https://github.com/dotnet/runtime/issues/76660