### PR TITLE
Fix the __int64 to be long long on macOS only

### DIFF
--- a/src/coreclr/inc/check.inl
+++ b/src/coreclr/inc/check.inl
@@ -220,14 +220,14 @@ inline CHECK CheckOverflow(const void *address, UINT64 offset)
     CHECK_OK;
 }
 
-#if defined(HOST_UNIX) && defined(HOST_64BIT)
+#ifdef __APPLE__
 inline CHECK CheckOverflow(const void *address, SIZE_T offset)
 {
     CHECK((UINT64) address + offset >= (UINT64) address);
 
     CHECK_OK;
 }
-#endif // HOST_UNIX && HOST_BIT64
+#endif // __APPLE__
 
 inline CHECK CheckUnderflow(UINT value1, UINT value2)
 {

--- a/src/coreclr/inc/clrtypes.h
+++ b/src/coreclr/inc/clrtypes.h
@@ -338,14 +338,14 @@ inline UINT64 AlignUp(UINT64 value, UINT alignment)
     return (value+alignment-1)&~(UINT64)(alignment-1);
 }
 
-#if defined(HOST_UNIX) && defined(HOST_64BIT)
+#ifdef __APPLE__
 inline SIZE_T AlignUp(SIZE_T value, UINT alignment)
 {
     STATIC_CONTRACT_LEAF;
     STATIC_CONTRACT_SUPPORTS_DAC;
     return (value+alignment-1)&~(SIZE_T)(alignment-1);
 }
-#endif // HOST_UNIX && HOST_BIT64
+#endif // __APPLE__
 
 inline UINT AlignDown(UINT value, UINT alignment)
 {
@@ -390,13 +390,13 @@ inline UINT AlignmentPad(UINT64 value, UINT alignment)
     return (UINT) (AlignUp(value, alignment) - value);
 }
 
-#if defined(HOST_UNIX) && defined(HOST_64BIT)
+#ifdef __APPLE__
 inline UINT AlignmentPad(SIZE_T value, UINT alignment)
 {
     STATIC_CONTRACT_WRAPPER;
     return (UINT) (AlignUp(value, alignment) - value);
 }
-#endif // HOST_UNIX && HOST_BIT64
+#endif // __APPLE__
 
 inline UINT AlignmentTrim(UINT value, UINT alignment)
 {
@@ -423,13 +423,13 @@ inline UINT AlignmentTrim(UINT64 value, UINT alignment)
     return ((UINT)value)&(alignment-1);
 }
 
-#if defined(HOST_UNIX) && defined(HOST_64BIT)
+#ifdef __APPLE__
 inline UINT AlignmentTrim(SIZE_T value, UINT alignment)
 {
     STATIC_CONTRACT_LEAF;
     STATIC_CONTRACT_SUPPORTS_DAC;
     return ((UINT)value)&(alignment-1);
 }
-#endif // HOST_UNIX && HOST_BIT64
+#endif // __APPLE__
 
 #endif  // CLRTYPES_H_

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -233,12 +233,12 @@ inline unsigned genLog2(unsigned __int64 value)
 #endif
 }
 
-#if defined(HOST_UNIX) && defined(HOST_64BIT)
+#ifdef __APPLE__
 inline unsigned genLog2(size_t value)
 {
     return genLog2((unsigned __int64)value);
 }
-#endif // HOST_UNIX && HOST_BIT64
+#endif // __APPLE__
 
 /*****************************************************************************
  *

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -634,12 +634,12 @@ inline size_t unsigned_abs(ssize_t x)
     return ((size_t)abs((__int64)x));
 }
 
-#ifdef HOST_UNIX
+#ifdef __APPLE__
 inline size_t unsigned_abs(__int64 x)
 {
     return ((size_t)abs(x));
 }
-#endif // HOST_UNIX
+#endif // __APPLE__
 #endif // TARGET_64BIT
 
 /*****************************************************************************/

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -4323,7 +4323,7 @@ inline __int64 abs(__int64 _X) {
     return llabs(_X);
 }
 
-#ifdef HOST_64BIT
+#ifdef __APPLE__
 inline __int64 abs(SSIZE_T _X) {
     return llabs((__int64)_X);
 }

--- a/src/coreclr/pal/inc/pal_mstypes.h
+++ b/src/coreclr/pal/inc/pal_mstypes.h
@@ -195,7 +195,11 @@ extern "C" {
 // they must be either signed or unsigned) and we want to be able to use
 // __int64 as though it were intrinsic
 
+#if defined(HOST_64BIT) && !defined(__APPLE__)
+#define __int64     long
+#else // HOST_64BIT && !__APPLE__
 #define __int64     long long
+#endif // HOST_64BIT && !__APPLE__
 #define __int32     int
 #define __int16     short int
 #define __int8      char        // assumes char is signed


### PR DESCRIPTION
It turned out that my recent change to redefine __int64 on Unix is actually correct for macOS only. For other 64 bit Unixes, the __int64 should be defined as long.

This change fixes it.