### PR TITLE
Modify ARM64 thunktemplates.S to make it work with GNU ld

### DIFF
--- a/src/coreclr/vm/arm64/thunktemplates.S
+++ b/src/coreclr/vm/arm64/thunktemplates.S
@@ -4,7 +4,7 @@
 #include "unixasmmacros.inc"
 #include "asmconstants.h"
 
-#define DATA_SLOT(stub, field) (C_FUNC(stub##Code\PAGE_SIZE) + \PAGE_SIZE + stub##Data__##field)
+#define DATA_SLOT(stub, field) . - (. - C_FUNC(stub##Code\PAGE_SIZE)) + \PAGE_SIZE + stub##Data__##field
 
     .irp PAGE_SIZE, 4096, 8192, 16384, 32768, 65536
 


### PR DESCRIPTION
Currently the ld linker links incorrectly the compiled thunktemplates.S for ARM64 and puts wrong offsets into all the LDR instructions. Only the LLVM lld linker works correctly.

I have looked into it and it turns out the assembler was putting in relocations that the linker then replaced by fixed offsets. That's where the GNU ld made the mistake.
I have figured out a slight modification of expressing the addresses in the data page referenced by those LDR instructions so that the assembler doesn't produce any relocs and so the linker cannot cause any problems.