### PR TITLE
[release/6.0] Fix process aborts when using cryptographic primitives with empty input for Android

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherOneShotTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherOneShotTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 namespace System.Security.Cryptography.Encryption.RC2.Tests
 {
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
+    [ConditionalClass(typeof(RC2Factory), nameof(RC2Factory.IsSupported))]
     public class RC2CipherOneShotTests : SymmetricOneShotBase
     {
         protected override byte[] Key => new byte[]

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp.c
@@ -50,9 +50,7 @@ static jobject GetMessageDigestInstance(JNIEnv* env, intptr_t type)
 
 int32_t CryptoNative_EvpDigestOneShot(intptr_t type, void* source, int32_t sourceSize, uint8_t* md, uint32_t* mdSize)
 {
-    abort_if_invalid_pointer_argument (source);
-
-    if (!type || !md || !mdSize || sourceSize < 0)
+    if (!type || !md || !mdSize || sourceSize < 0 || (sourceSize > 0 && !source))
         return FAIL;
 
     JNIEnv* env = GetJNIEnv();

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
@@ -82,10 +82,10 @@ int32_t CryptoNative_HmacReset(jobject ctx)
 
 int32_t CryptoNative_HmacUpdate(jobject ctx, uint8_t* data, int32_t len)
 {
-    if (!ctx)
+    // Callers are expected to skip update calls with no data.
+    if (!ctx || !data || len <= 0)
         return FAIL;
 
-    abort_if_invalid_pointer_argument (data);
     JNIEnv* env = GetJNIEnv();
     jbyteArray dataBytes = make_java_byte_array(env, len);
     (*env)->SetByteArrayRegion(env, dataBytes, 0, len, (jbyte*)data);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.c
@@ -44,9 +44,11 @@ PALEXPORT void AndroidCryptoNative_RsaDestroy(RSA* rsa)
 
 PALEXPORT int32_t AndroidCryptoNative_RsaPublicEncrypt(int32_t flen, uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
 {
-    abort_if_invalid_pointer_argument (from);
     abort_if_invalid_pointer_argument (to);
     abort_if_invalid_pointer_argument (rsa);
+
+    if ((flen > 0 && !from) || flen < 0)
+        return RSA_FAIL;
 
     JNIEnv* env = GetJNIEnv();
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -94,6 +94,11 @@ namespace Internal.Cryptography
 
             public override void AppendHashData(ReadOnlySpan<byte> data)
             {
+                if (data.IsEmpty)
+                {
+                    return;
+                }
+
                 _running = true;
                 Check(Interop.Crypto.EvpDigestUpdate(_ctx, data, data.Length));
             }
@@ -166,6 +171,11 @@ namespace Internal.Cryptography
 
             public override void AppendHashData(ReadOnlySpan<byte> data)
             {
+                if (data.IsEmpty)
+                {
+                    return;
+                }
+
                 _running = true;
                 Check(Interop.Crypto.HmacUpdate(_hmacCtx, data, data.Length));
             }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/61827 to release/6.0.

/cc @bartonjs @steveisok 

## Customer Impact

Reported by a customer is https://github.com/dotnet/runtime/issues/77258. Customers that use HMAC APIs to append data, or use APIs that append HMAC data, and that data is empty will see a process crash (SIGABRT) in Android.

Some higher-level APIs such as HKDF or `ECDiffieHellman` will append empty data the HMAC. Customers using these APIs that do that have no reasonable work around.

## Testing

These changes have been present in .NET 7 for quite some time. Existing tests caught this behavior for .NET 7.

## Risk

Low. The changes are well understood and isolated.

IMPORTANT: Is this backport for a servicing release? If so and this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.