### PR TITLE
Decrease backlog cleanup inactivity threshold

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1411,7 +1411,7 @@
         {
           "name": "noActivitySince",
           "parameters": {
-            "days": 1827
+            "days": 1644
           }
         },
         {


### PR DESCRIPTION
Decreases the inactivity threshold for `backlog-cleanup-candidate` automation from 5 years to 4.5 years. This change will directly impact [approximately 100 inactive issues in our backlog](https://issuesof.net/?q=repo%3Aruntime%20is%3Aopen%20is%3Aissue%20updated%3A%3C2018-04-20%20group%3Aarea-pod%20group-sort%3Acount-desc).