### PR TITLE
Clean up converter initialization logic.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConverterStrategy.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ConverterStrategy.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
+
 namespace System.Text.Json
 {
     /// <summary>
@@ -13,7 +15,7 @@ namespace System.Text.Json
     internal enum ConverterStrategy : byte
     {
         /// <summary>
-        /// Default value; not used by any converter.
+        /// Default value; only used by <see cref="JsonConverterFactory"/>.
         /// </summary>
         None = 0x0,
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
@@ -12,27 +12,27 @@ namespace System.Text.Json.Serialization.Converters
     internal sealed class CastingConverter<T, TSource> : JsonConverter<T>
     {
         private readonly JsonConverter<TSource> _sourceConverter;
-
         internal override Type? KeyType => _sourceConverter.KeyType;
         internal override Type? ElementType => _sourceConverter.ElementType;
 
-        public override bool HandleNull => _sourceConverter.HandleNull;
-        internal override ConverterStrategy ConverterStrategy => _sourceConverter.ConverterStrategy;
+        public override bool HandleNull { get; }
         internal override bool SupportsCreateObjectDelegate => _sourceConverter.SupportsCreateObjectDelegate;
 
-        internal CastingConverter(JsonConverter<TSource> sourceConverter) : base(initialize: false)
+        internal CastingConverter(JsonConverter<TSource> sourceConverter)
         {
             Debug.Assert(typeof(T).IsInSubtypeRelationshipWith(typeof(TSource)));
             Debug.Assert(sourceConverter.SourceConverterForCastingConverter is null, "casting converters should not be layered.");
 
             _sourceConverter = sourceConverter;
-            Initialize();
-
             IsInternalConverter = sourceConverter.IsInternalConverter;
             IsInternalConverterForNumberType = sourceConverter.IsInternalConverterForNumberType;
-            RequiresReadAhead = sourceConverter.RequiresReadAhead;
-            CanUseDirectReadOrWrite = sourceConverter.CanUseDirectReadOrWrite;
+            ConverterStrategy = sourceConverter.ConverterStrategy;
             CanBePolymorphic = sourceConverter.CanBePolymorphic;
+
+            // Ensure HandleNull values reflect the exact configuration of the source converter
+            HandleNullOnRead = sourceConverter.HandleNullOnRead;
+            HandleNullOnWrite = sourceConverter.HandleNullOnWrite;
+            HandleNull = sourceConverter.HandleNull;
         }
 
         internal override JsonConverter? SourceConverterForCastingConverter => _sourceConverter;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json.Serialization
     internal abstract class JsonCollectionConverter<TCollection, TElement> : JsonResumableConverter<TCollection>
     {
         internal override bool SupportsCreateObjectDelegate => true;
-        internal sealed override ConverterStrategy ConverterStrategy => ConverterStrategy.Enumerable;
+        private protected sealed override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Enumerable;
         internal override Type ElementType => typeof(TElement);
 
         protected abstract void Add(in TElement value, ref ReadStack state);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization
     internal abstract class JsonDictionaryConverter<TDictionary> : JsonResumableConverter<TDictionary>
     {
         internal override bool SupportsCreateObjectDelegate => true;
-        internal sealed override ConverterStrategy ConverterStrategy => ConverterStrategy.Dictionary;
+        private protected sealed override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Dictionary;
 
         protected internal abstract bool OnWriteResume(Utf8JsonWriter writer, TDictionary dictionary, JsonSerializerOptions options, ref WriteStack state);
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpOptionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpOptionConverter.cs
@@ -11,8 +11,6 @@ namespace System.Text.Json.Serialization.Converters
     internal sealed class FSharpOptionConverter<TOption, TElement> : JsonConverter<TOption>
         where TOption : class
     {
-        // Reflect the converter strategy of the element type, since we use the identical contract for Some(_) values.
-        internal override ConverterStrategy ConverterStrategy => _converterStrategy;
         internal override Type? ElementType => typeof(TElement);
         // 'None' is encoded using 'null' at runtime and serialized as 'null' in JSON.
         public override bool HandleNull => true;
@@ -20,7 +18,6 @@ namespace System.Text.Json.Serialization.Converters
         private readonly JsonConverter<TElement> _elementConverter;
         private readonly Func<TOption, TElement> _optionValueGetter;
         private readonly Func<TElement?, TOption> _optionConstructor;
-        private readonly ConverterStrategy _converterStrategy;
 
         [RequiresUnreferencedCode(FSharpCoreReflectionProxy.FSharpCoreUnreferencedCodeMessage)]
         [RequiresDynamicCode(FSharpCoreReflectionProxy.FSharpCoreUnreferencedCodeMessage)]
@@ -29,12 +26,7 @@ namespace System.Text.Json.Serialization.Converters
             _elementConverter = elementConverter;
             _optionValueGetter = FSharpCoreReflectionProxy.Instance.CreateFSharpOptionValueGetter<TOption, TElement>();
             _optionConstructor = FSharpCoreReflectionProxy.Instance.CreateFSharpOptionSomeConstructor<TOption, TElement>();
-
-            // Workaround for the base constructor depending on the (still unset) ConverterStrategy
-            // to derive the CanUseDirectReadOrWrite and RequiresReadAhead values.
-            _converterStrategy = elementConverter.ConverterStrategy;
-            CanUseDirectReadOrWrite = elementConverter.CanUseDirectReadOrWrite;
-            RequiresReadAhead = elementConverter.RequiresReadAhead;
+            ConverterStrategy = elementConverter.ConverterStrategy;
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out TOption? value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpValueOptionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpValueOptionConverter.cs
@@ -11,8 +11,6 @@ namespace System.Text.Json.Serialization.Converters
     internal sealed class FSharpValueOptionConverter<TValueOption, TElement> : JsonConverter<TValueOption>
         where TValueOption : struct, IEquatable<TValueOption>
     {
-        // Reflect the converter strategy of the element type, since we use the identical contract for ValueSome(_) values.
-        internal override ConverterStrategy ConverterStrategy => _converterStrategy;
         internal override Type? ElementType => typeof(TElement);
         // 'ValueNone' is encoded using 'default' at runtime and serialized as 'null' in JSON.
         public override bool HandleNull => true;
@@ -20,7 +18,6 @@ namespace System.Text.Json.Serialization.Converters
         private readonly JsonConverter<TElement> _elementConverter;
         private readonly FSharpCoreReflectionProxy.StructGetter<TValueOption, TElement> _optionValueGetter;
         private readonly Func<TElement?, TValueOption> _optionConstructor;
-        private readonly ConverterStrategy _converterStrategy;
 
         [RequiresUnreferencedCode(FSharpCoreReflectionProxy.FSharpCoreUnreferencedCodeMessage)]
         [RequiresDynamicCode(FSharpCoreReflectionProxy.FSharpCoreUnreferencedCodeMessage)]
@@ -29,12 +26,7 @@ namespace System.Text.Json.Serialization.Converters
             _elementConverter = elementConverter;
             _optionValueGetter = FSharpCoreReflectionProxy.Instance.CreateFSharpValueOptionValueGetter<TValueOption, TElement>();
             _optionConstructor = FSharpCoreReflectionProxy.Instance.CreateFSharpValueOptionSomeConstructor<TValueOption, TElement>();
-
-            // Workaround for the base constructor depending on the (still unset) ConverterStrategy
-            // to derive the CanUseDirectReadOrWrite and RequiresReadAhead values.
-            _converterStrategy = elementConverter.ConverterStrategy;
-            CanUseDirectReadOrWrite = elementConverter.CanUseDirectReadOrWrite;
-            RequiresReadAhead = elementConverter.RequiresReadAhead;
+            ConverterStrategy = elementConverter.ConverterStrategy;
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out TValueOption value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -16,9 +16,6 @@ namespace System.Text.Json.Serialization.Converters
     internal sealed class JsonMetadataServicesConverter<T> : JsonResumableConverter<T>
     {
         private readonly Func<JsonConverter<T>>? _converterCreator;
-
-        private readonly ConverterStrategy _converterStrategy;
-
         private JsonConverter<T>? _converter;
 
         // A backing converter for when fast-path logic cannot be used.
@@ -28,12 +25,10 @@ namespace System.Text.Json.Serialization.Converters
             {
                 _converter ??= _converterCreator!();
                 Debug.Assert(_converter != null);
-                Debug.Assert(_converter.ConverterStrategy == _converterStrategy);
+                Debug.Assert(_converter.ConverterStrategy == ConverterStrategy);
                 return _converter;
             }
         }
-
-        internal override ConverterStrategy ConverterStrategy => _converterStrategy;
 
         internal override Type? KeyType => Converter.KeyType;
 
@@ -51,13 +46,13 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             _converterCreator = converterCreator;
-            _converterStrategy = converterStrategy;
+            ConverterStrategy = converterStrategy;
         }
 
         public JsonMetadataServicesConverter(JsonConverter<T> converter)
         {
             _converter = converter;
-            _converterStrategy = converter.ConverterStrategy;
+            ConverterStrategy = converter.ConverterStrategy;
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out T? value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/JsonObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/JsonObjectConverter.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json.Serialization
     /// </summary>
     internal abstract class JsonObjectConverter<T> : JsonResumableConverter<T>
     {
-        internal sealed override ConverterStrategy ConverterStrategy => ConverterStrategy.Object;
+        private protected sealed override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Object;
         internal sealed override Type? ElementType => null;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverter.cs
@@ -8,7 +8,7 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ObjectConverter : JsonConverter<object?>
     {
-        internal override ConverterStrategy ConverterStrategy => ConverterStrategy.Object;
+        private protected override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Object;
 
         public ObjectConverter()
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
@@ -5,7 +5,6 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class NullableConverter<T> : JsonConverter<T?> where T : struct
     {
-        internal override ConverterStrategy ConverterStrategy { get; }
         internal override Type? ElementType => typeof(T);
         public override bool HandleNull => true;
 
@@ -17,12 +16,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             _elementConverter = elementConverter;
             IsInternalConverterForNumberType = elementConverter.IsInternalConverterForNumberType;
-
-            // Workaround for the base constructor depending on the (still unset) ConverterStrategy
-            // to derive the CanUseDirectReadOrWrite and RequiresReadAhead values.
             ConverterStrategy = elementConverter.ConverterStrategy;
-            CanUseDirectReadOrWrite = elementConverter.CanUseDirectReadOrWrite;
-            RequiresReadAhead = elementConverter.RequiresReadAhead;
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out T? value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -14,7 +14,11 @@ namespace System.Text.Json.Serialization
     /// </summary>
     public abstract partial class JsonConverter
     {
-        internal JsonConverter() { }
+        internal JsonConverter()
+        {
+            IsInternalConverter = GetType().Assembly == typeof(JsonConverter).Assembly;
+            ConverterStrategy = GetDefaultConverterStrategy();
+        }
 
         /// <summary>
         /// Determines whether the type can be converted.
@@ -23,7 +27,24 @@ namespace System.Text.Json.Serialization
         /// <returns>True if the type can be converted, false otherwise.</returns>
         public abstract bool CanConvert(Type typeToConvert);
 
-        internal abstract ConverterStrategy ConverterStrategy { get; }
+        internal ConverterStrategy ConverterStrategy
+        {
+            get => _converterStrategy;
+            init
+            {
+                CanUseDirectReadOrWrite = value == ConverterStrategy.Value && IsInternalConverter;
+                RequiresReadAhead = value == ConverterStrategy.Value;
+                _converterStrategy = value;
+            }
+        }
+
+        private ConverterStrategy _converterStrategy;
+
+        /// <summary>
+        /// Invoked by the base contructor to populate the initial value of the <see cref="ConverterStrategy"/> property.
+        /// Used for declaring the default strategy for specific converter hierarchies without explicitly setting in a constructor.
+        /// </summary>
+        private protected abstract ConverterStrategy GetDefaultConverterStrategy();
 
         /// <summary>
         /// Indicates that the converter can consume the <see cref="JsonTypeInfo.CreateObject"/> delegate.
@@ -96,17 +117,17 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// Cached value of TypeToConvert.IsValueType, which is an expensive call.
         /// </summary>
-        internal bool IsValueType { get; set; }
+        internal bool IsValueType { get; init; }
 
         /// <summary>
         /// Whether the converter is built-in.
         /// </summary>
-        internal bool IsInternalConverter { get; set; }
+        internal bool IsInternalConverter { get; init; }
 
         /// <summary>
         /// Whether the converter is built-in and handles a number type.
         /// </summary>
-        internal bool IsInternalConverterForNumberType;
+        internal bool IsInternalConverterForNumberType { get; init; }
 
         /// <summary>
         /// Loosely-typed ReadCore() that forwards to strongly-typed ReadCore().

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization
         /// </summary>
         protected JsonConverterFactory() { }
 
-        internal sealed override ConverterStrategy ConverterStrategy => ConverterStrategy.None;
+        private protected override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.None;
 
         /// <summary>
         /// Create a converter for the provided <see cref="Type"/>.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -17,24 +17,10 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// When overridden, constructs a new <see cref="JsonConverter{T}"/> instance.
         /// </summary>
-        protected internal JsonConverter() : this(initialize: true)
-        { }
-
-        internal JsonConverter(bool initialize)
+        protected internal JsonConverter()
         {
             IsValueType = typeof(T).IsValueType;
-            IsInternalConverter = GetType().Assembly == typeof(JsonConverter).Assembly;
 
-            // Initialize uses abstract members, in order for them to be initialized correctly
-            // without throwing we might need to delay call to Initialize
-            if (initialize)
-            {
-                Initialize();
-            }
-        }
-
-        private protected void Initialize()
-        {
             if (HandleNull)
             {
                 HandleNullOnRead = true;
@@ -48,9 +34,6 @@ namespace System.Text.Json.Serialization
                 // 2) A converter overrode HandleNull and returned false so HandleNullOnRead and HandleNullOnWrite
                 // will be their default values of false.
             }
-
-            CanUseDirectReadOrWrite = ConverterStrategy == ConverterStrategy.Value && IsInternalConverter;
-            RequiresReadAhead = ConverterStrategy == ConverterStrategy.Value;
         }
 
         /// <summary>
@@ -66,7 +49,7 @@ namespace System.Text.Json.Serialization
             return typeToConvert == typeof(T);
         }
 
-        internal override ConverterStrategy ConverterStrategy => ConverterStrategy.Value;
+        private protected override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Value;
 
         [RequiresDynamicCode(JsonSerializer.SerializationRequiresDynamicCodeMessage)]
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
@@ -138,12 +121,12 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// Does the converter want to be called when reading null tokens.
         /// </summary>
-        internal bool HandleNullOnRead { get; private set; }
+        internal bool HandleNullOnRead { get; private protected set; }
 
         /// <summary>
         /// Does the converter want to be called for null values.
         /// </summary>
-        internal bool HandleNullOnWrite { get; private set; }
+        internal bool HandleNullOnWrite { get; private protected set; }
 
         // This non-generic API is sealed as it just forwards to the generic version.
         internal sealed override bool TryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state)


### PR DESCRIPTION
This PR

1. Resolves issues related to converters requiring delayed initialization when employing dynamic converter strategies.
2. Makes `JsonConverter.ConverterStrategy` non-virtual, a property that is read frequently in the serialization hot path.
3. ~Fixes an issue related to `CastingConverter` not reporting the correct `HandleNullValueOnRead`/`HandleNullValueOnWrite` values in certain cases.~