### PR TITLE
Rename COMPlus_ to DOTNET_ for IntMultipliy.csproj test

### DIFF
--- a/src/tests/JIT/opt/Multiply/IntMultiply.csproj
+++ b/src/tests/JIT/opt/Multiply/IntMultiply.csproj
@@ -11,7 +11,7 @@
       <HasDisasmCheck>true</HasDisasmCheck>
     </Compile>
 
-    <CLRTestEnvironmentVariable Include="COMPlus_TieredCompilation" Value="0" />
-    <CLRTestEnvironmentVariable Include="COMPlus_JITMinOpts" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It looks like we use `DOTNET_JITMinOpts` now instead of `COMPlus_JITMinOpts` so this should resolve: https://github.com/dotnet/runtime/issues/77299