### PR TITLE
[release/6.0] Always generate metadata for dynamic methods

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -12594,15 +12594,6 @@ void ReflectionModule::CaptureModuleMetaDataToMemory()
     }
     CONTRACTL_END;
 
-    // If a debugger is attached, then the CLR will still send ClassLoad notifications for dynamic modules,
-    // which mean we still need to keep the metadata available. This is the same as Whidbey.
-    // An alternative (and better) design would be to suppress ClassLoad notifications too, but then we'd
-    // need some way of sending a "catchup" notification to the debugger after we re-enable notifications.
-    if (!CORDebuggerAttached())
-    {
-        return;
-    }
-
     // Do not release the emitter. This is a weak reference.
     IMetaDataEmit *pEmitter = this->GetEmitter();
     _ASSERTE(pEmitter != NULL);


### PR DESCRIPTION
We have had multiple customer and partner team reports of the following error in Visual Studio while attempting to attach to a .NET 6 process:

![image](https://user-images.githubusercontent.com/12520929/197237823-fa9864a7-bfcc-4d5f-a0f4-ad73589053b4.png)

Customer and partner reports include: #69841, ["The application is in break mode" despite hitting resolved breakpoint](https://developercommunity.visualstudio.com/t/The-application-is-in-break-mode-despi/10120899), and #62977.  We have also had internal teams reach out to us via email encountering this problem.  

The root issue is described in #62977.  This is an unintended side effect of #57069. As it stands now we won't generate metadata for dynamic modules unless a debugger is attached. Without the metadata, the .NET debugging services API is unable to walk the stack resulting in the error in VS shown above.

### Customer Impact
Customers attaching to their process after a dynamic method has been created can trigger this error.  We have seen this reproduce with F5 debugging on Azure Functions Visual Studio projects as well as customers using Debug->Attach dialog in VS.  

### Risk
Very low as it restores the original behavior before #57069 for debugger metadata generation for dynamic methods.  

### Testing
This fix is a backport of #72315 and has been manually tested/verified by internal partner teams with private 6.0 builds backporting this fix. 