### PR TITLE
Set DNER for all local fields

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16453,10 +16453,6 @@ void Compiler::fgMorphLocalField(GenTree* tree, GenTree* parent)
             }
             else
             {
-                // There is no existing field that has all the parts that we need
-                // So we must ensure that the struct lives in memory.
-                lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::LocalField));
-
 #ifdef DEBUG
                 // We can't convert this guy to a float because he really does have his
                 // address taken..
@@ -16471,6 +16467,12 @@ void Compiler::fgMorphLocalField(GenTree* tree, GenTree* parent)
             tree->ChangeOper(GT_LCL_VAR);
             JITDUMP("Replacing GT_LCL_FLD of struct with local var V%02u\n", lclNum);
         }
+    }
+
+    // If we haven't replaced the field, make sure to set DNER on the local.
+    if (tree->OperIs(GT_LCL_FLD))
+    {
+        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::LocalField));
     }
 }
 


### PR DESCRIPTION
I noticed our stress was deeply red, this should fix one of the offenders at least.

Fixes #77300.

[No diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=60147&view=ms.vss-build-web.run-extensions-tab).