### PR TITLE
Fold static readonly struct X = <zero> to a jit-time const, e.g. Guid.Empty

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4210,9 +4210,14 @@ GenTree* Compiler::impImportStaticReadOnlyField(CORINFO_FIELD_HANDLE field, CORI
                 JITDUMP("success! Optimizing to ASG(struct, 0).");
                 unsigned structTempNum = lvaGrabTemp(true DEBUGARG("folding static ro fld empty struct"));
                 lvaSetStruct(structTempNum, fieldClsHnd, false);
-                GenTreeLclVar* tree = gtNewLclvNode(structTempNum, TYP_STRUCT);
-                impAppendTree(gtNewBlkOpNode(tree, gtNewIconNode(0), false, false), CHECK_SPILL_NONE, impCurStmtDI);
-                return gtNewLclvNode(structTempNum, TYP_STRUCT);
+
+                // realType is either struct or SIMD
+                var_types      realType  = lvaGetRealType(structTempNum);
+                GenTreeLclVar* structLcl = gtNewLclvNode(structTempNum, realType);
+                impAppendTree(gtNewBlkOpNode(structLcl, gtNewIconNode(0), false, false), CHECK_SPILL_NONE,
+                              impCurStmtDI);
+
+                return gtNewLclvNode(structTempNum, realType);
             }
 
             JITDUMP("getReadonlyStaticFieldValue returned false - bail out.");

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4242,11 +4242,11 @@ GenTree* Compiler::impImportStaticReadOnlyField(CORINFO_FIELD_HANDLE field, CORI
 
                 unsigned structTempNum = lvaGrabTemp(true DEBUGARG("folding static ro fld empty struct"));
                 lvaSetStruct(structTempNum, fieldClsHnd, false);
-                GenTree* tree = impCreateLocalNode(structTempNum DEBUGARG(0));
+                GenTreeLclVar* tree = impCreateLocalNode(structTempNum DEBUGARG(0));
                 impAppendTree(tree, CHECK_SPILL_NONE, impCurStmtDI);
                 impAppendTree(gtNewBlkOpNode(gtClone(tree), gtNewIconNode(0), false, false), CHECK_SPILL_NONE,
                               impCurStmtDI);
-                return gtClone(tree);
+                return gtClone(tree); // clonning GenTreeLclVar node
             }
 
             JITDUMP("struct has complex layout - bail out.");

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4210,9 +4210,9 @@ GenTree* Compiler::impImportStaticReadOnlyField(CORINFO_FIELD_HANDLE field, CORI
                 JITDUMP("success! Optimizing to ASG(struct, 0).");
                 unsigned structTempNum = lvaGrabTemp(true DEBUGARG("folding static ro fld empty struct"));
                 lvaSetStruct(structTempNum, fieldClsHnd, false);
-                GenTreeLclVar* tree = impCreateLocalNode(structTempNum DEBUGARG(0));
+                GenTreeLclVar* tree = gtNewLclvNode(structTempNum, TYP_STRUCT);
                 impAppendTree(gtNewBlkOpNode(tree, gtNewIconNode(0), false, false), CHECK_SPILL_NONE, impCurStmtDI);
-                return gtClone(tree); // clonning GenTreeLclVar node
+                return gtNewLclvNode(structTempNum, TYP_STRUCT);
             }
 
             JITDUMP("getReadonlyStaticFieldValue returned false - bail out.");

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -868,6 +868,7 @@ namespace System
 
         public bool Equals(Guid g) => EqualsCore(this, g);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool EqualsCore(in Guid left, in Guid right)
         {
             if (Vector128.IsHardwareAccelerated)


### PR DESCRIPTION
This PR does two things:
1) Imports all `static readonly <struct> = 0` as `ASG(struct, 0)` - it's mostly for `Guid.Empty` (and e.g. `decimal.Zero`)
2) Adds `AggressiveInlining` to `Guid.EqualsCore`

Overall jit-diff (-f -cctors) is negative (`-28473 bytes`) so no significant size regressions due to AggressiveInlining.

Benchmark:
```csharp
[Benchmark]
[ArgumentsSource(nameof(TestData1))]
public bool GuidIsEmpty(Guid g) => g == Guid.Empty; // test effect from AggressiveInling + .Empty folding

[Benchmark]
[ArgumentsSource(nameof(TestData2))]
public bool GuidsEqual(Guid g1, Guid g2) => g1 == g2; // test effect from AggressiveInling 

// Test data:

public static IEnumerable<Guid> TestData1()
{
    yield return Guid.Empty;
    yield return new Guid("503AA73D-DA86-4A7D-A369-192A1766DFA2");
}

public static IEnumerable<object[]> TestData2()
{
    yield return new object[]
    {
        new Guid("503AA73D-DA86-4A7D-A369-192A1766DFA2"), 
        Guid.Empty
    };
    yield return new object[]
    { 
        new Guid("503AA73D-DA86-4A7D-A369-192A1766DFA2"), 
        new Guid("503AA73D-DA86-4A7D-A369-192A1766DFA2")
    };
}
```

|      Method |                   Toolchain |      Mean |
|------------ |---------------------------- |----------:|
| GuidIsEmpty |      \Core_Root\corerun.exe | **0.3040 ns** |
| GuidIsEmpty | \Core_Root_base\corerun.exe | 1.0961 ns |
|             |                             |           |
| GuidIsEmpty |      \Core_Root\corerun.exe | **0.3286 ns** |
| GuidIsEmpty | \Core_Root_base\corerun.exe | 1.0916 ns |
|             |                             |           |
|  GuidsEqual |      \Core_Root\corerun.exe | **0.4003 ns** |
|  GuidsEqual | \Core_Root_base\corerun.exe | 0.9250 ns |
|             |                             |           |
|  GuidsEqual |      \Core_Root\corerun.exe | **0.4378 ns** |
|  GuidsEqual | \Core_Root_base\corerun.exe | 0.9272 ns |


### Codegen diff
```csharp
static bool IsEmpty(Guid g) => g == Guid.Empty;
```
Was:
```asm
; Assembly listing for method Program:IsEmpty(System.Guid):bool
G_M000_IG01:                ;; offset=0000H
       4883EC48             sub      rsp, 72
       C5F877               vzeroupper 
G_M000_IG02:                ;; offset=0007H
       C5F91001             vmovupd  xmm0, xmmword ptr [rcx]
       C5F911442438         vmovupd  xmmword ptr [rsp+38H], xmm0
       48B9980280E1FA010000 mov      rcx, 0x1FAE1800298 ;; boxed static Guid.Empty
       488B09               mov      rcx, gword ptr [rcx]
       C5F9104108           vmovupd  xmm0, xmmword ptr [rcx+08H]
       C5F911442428         vmovupd  xmmword ptr [rsp+28H], xmm0
       488D4C2438           lea      rcx, [rsp+38H]
       488D542428           lea      rdx, [rsp+28H]
       FF15AFB50E00         call     [System.Guid:EqualsCore(byref,byref):bool]
       90                   nop      
G_M000_IG03:                ;; offset=003AH
       4883C448             add      rsp, 72
       C3                   ret      
; Total bytes of code 63
```
Now:
```asm
; Assembly listing for method Program:IsEmpty(System.Guid):bool
G_M8154_IG01:              ;; offset=0000H
       4883EC28             sub      rsp, 40
       C5F877               vzeroupper 
G_M8154_IG02:              ;; offset=0007H
       C5F91001             vmovupd  xmm0, xmmword ptr [rcx]
       C5F911442418         vmovupd  xmmword ptr [rsp+18H], xmm0
       C5F857C0             vxorps   xmm0, xmm0, xmm0
       C5F911442408         vmovupd  xmmword ptr [rsp+08H], xmm0  ;; TODO: remove this spill
       C5FA6F442418         vmovdqu  xmm0, xmmword ptr [rsp+18H]
       C5F974442408         vpcmpeqb xmm0, xmm0, xmmword ptr [rsp+08H]
       C5F9D7C0             vpmovmskb eax, xmm0
       3DFFFF0000           cmp      eax, 0xFFFF
       0F94C0               sete     al
       0FB6C0               movzx    rax, al
G_M8154_IG03:              ;; offset=0036H
       4883C428             add      rsp, 40
       C3                   ret      
; Total bytes of code 59
```
