### PR TITLE
Additional Validation for PauseThresholdWriter and ResumeThresholdWriter

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -497,7 +497,8 @@ namespace System.IO.Pipelines
                     Debug.Assert(_unconsumedBytes >= 0, "Length has gone negative");
 
                     if (oldLength >= ResumeWriterThreshold &&
-                        _unconsumedBytes < ResumeWriterThreshold)
+                        (_unconsumedBytes < ResumeWriterThreshold ||
+                        (_unconsumedBytes == 0 && ResumeWriterThreshold == 0)))
                     {
                         _writerAwaitable.Complete(out completionData);
                     }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -495,8 +495,7 @@ namespace System.IO.Pipelines
                     _lastExaminedIndex = examinedSegment.RunningIndex + examinedIndex;
 
                     Debug.Assert(_unconsumedBytes >= 0, "Length has gone negative");
-
-                    Debug.Assert(ResumeWriterThreshold >= 1);
+                    Debug.Assert(ResumeWriterThreshold >= 1, "ResumeWriterThreshold is less than 1");
 
                     if (oldLength >= ResumeWriterThreshold &&
                         _unconsumedBytes < ResumeWriterThreshold)

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -496,7 +496,8 @@ namespace System.IO.Pipelines
 
                     Debug.Assert(_unconsumedBytes >= 0, "Length has gone negative");
 
-                    // ResumeWriterThreshold is always at least 1
+                    Debug.Assert(ResumeWriterThreshold >= 1);
+
                     if (oldLength >= ResumeWriterThreshold &&
                         _unconsumedBytes < ResumeWriterThreshold)
                     {

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -496,9 +496,9 @@ namespace System.IO.Pipelines
 
                     Debug.Assert(_unconsumedBytes >= 0, "Length has gone negative");
 
+                    // ResumeWriterThreshold is always at least 1
                     if (oldLength >= ResumeWriterThreshold &&
-                        (_unconsumedBytes < ResumeWriterThreshold ||
-                        (_unconsumedBytes == 0 && ResumeWriterThreshold == 0)))
+                        _unconsumedBytes < ResumeWriterThreshold)
                     {
                         _writerAwaitable.Complete(out completionData);
                     }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
@@ -54,24 +54,19 @@ namespace System.IO.Pipelines
             {
                 pauseWriterThreshold = DefaultPauseWriterThreshold;
             }
-            else if (pauseWriterThreshold < 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.pauseWriterThreshold);
-            }
 
             if (resumeWriterThreshold == -1)
             {
                 resumeWriterThreshold = DefaultResumeWriterThreshold;
             }
-            else if (resumeWriterThreshold <= 0 || resumeWriterThreshold > pauseWriterThreshold)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.resumeWriterThreshold);
-            }
 
-            // If resumeWriterThreshold is still larger than pauseWriterThreshold, need to throw exception to prevent system hanging
-            if (resumeWriterThreshold > pauseWriterThreshold)
+            if (pauseWriterThreshold < 0)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.pauseWriterThreshold);
+            }
+            else if (resumeWriterThreshold < 0 || resumeWriterThreshold > pauseWriterThreshold)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.resumeWriterThreshold);
             }
 
             Pool = pool ?? MemoryPool<byte>.Shared;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
@@ -63,9 +63,15 @@ namespace System.IO.Pipelines
             {
                 resumeWriterThreshold = DefaultResumeWriterThreshold;
             }
-            else if (resumeWriterThreshold < 0 || resumeWriterThreshold > pauseWriterThreshold)
+            else if (resumeWriterThreshold <= 0 || resumeWriterThreshold > pauseWriterThreshold)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.resumeWriterThreshold);
+            }
+
+            // If resumeWriterThreshold is still larger than pauseWriterThreshold, need to throw exception to prevent system hanging
+            if (resumeWriterThreshold > pauseWriterThreshold)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.pauseWriterThreshold);
             }
 
             Pool = pool ?? MemoryPool<byte>.Shared;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
@@ -54,17 +54,24 @@ namespace System.IO.Pipelines
             {
                 pauseWriterThreshold = DefaultPauseWriterThreshold;
             }
+            else if (pauseWriterThreshold < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.pauseWriterThreshold);
+            }
 
             if (resumeWriterThreshold == -1)
             {
                 resumeWriterThreshold = DefaultResumeWriterThreshold;
             }
-
-            if (pauseWriterThreshold < 0)
+            else if (resumeWriterThreshold == 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.pauseWriterThreshold);
+                // A resumeWriterThreshold of 0 makes no sense because the writer could never resume if paused.
+                // By setting it to 1, the writer will resume only after all data is consumed.
+                resumeWriterThreshold = 1;
             }
-            else if (resumeWriterThreshold < 0 || resumeWriterThreshold > pauseWriterThreshold)
+
+            // Only validate that the resumeWriterThreshold is not too large if the writer could actually pause.
+            if (resumeWriterThreshold < 0 || (pauseWriterThreshold > 0 && resumeWriterThreshold > pauseWriterThreshold))
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.resumeWriterThreshold);
             }

--- a/src/libraries/System.IO.Pipelines/tests/PipeCompletionCallbacksTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeCompletionCallbacksTests.cs
@@ -47,7 +47,7 @@ namespace System.IO.Pipelines.Tests
         public void CompletingReaderFromWriterCallbackWorks()
         {
             var callbackRan = false;
-            var pipe = new Pipe(new PipeOptions(_pool, pauseWriterThreshold: 5, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
+            var pipe = new Pipe(new PipeOptions(_pool, pauseWriterThreshold: 5, resumeWriterThreshold: 5, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
 
             pipe.Writer.OnReaderCompleted((exception, state) => { pipe.Writer.Complete(); }, null);
 
@@ -61,7 +61,7 @@ namespace System.IO.Pipelines.Tests
         public void CompletingWriterFromReaderCallbackWorks()
         {
             var callbackRan = false;
-            var pipe = new Pipe(new PipeOptions(_pool, pauseWriterThreshold: 5, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
+            var pipe = new Pipe(new PipeOptions(_pool, pauseWriterThreshold: 5, resumeWriterThreshold: 5, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
 
             pipe.Reader.OnWriterCompleted((exception, state) => { pipe.Reader.Complete(); }, null);
 
@@ -201,7 +201,7 @@ namespace System.IO.Pipelines.Tests
         {
             var callbackRan = false;
             var continuationRan = false;
-            var pipe = new Pipe(new PipeOptions(_pool, pauseWriterThreshold: 5, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
+            var pipe = new Pipe(new PipeOptions(_pool, pauseWriterThreshold: 5, resumeWriterThreshold: 5, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
 
             pipe.Writer.OnReaderCompleted(
                 (exception, state) =>

--- a/src/libraries/System.IO.Pipelines/tests/PipeOptionsTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeOptionsTests.cs
@@ -33,8 +33,7 @@ namespace System.IO.Pipelines.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("pauseWriterThreshold", () => new PipeOptions(pauseWriterThreshold: -2));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("resumeWriterThreshold", () => new PipeOptions(resumeWriterThreshold: -2));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("resumeWriterThreshold", () => new PipeOptions(pauseWriterThreshold: 50, resumeWriterThreshold: 100));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("pauseWriterThreshold", () => new PipeOptions(pauseWriterThreshold: 1, resumeWriterThreshold: -1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("resumeWriterThreshold", () => new PipeOptions(pauseWriterThreshold: 1, resumeWriterThreshold: 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("resumeWriterThreshold", () => new PipeOptions(pauseWriterThreshold: 1, resumeWriterThreshold: -1));
         }
 
         [Theory]

--- a/src/libraries/System.IO.Pipelines/tests/PipeOptionsTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeOptionsTests.cs
@@ -33,6 +33,8 @@ namespace System.IO.Pipelines.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("pauseWriterThreshold", () => new PipeOptions(pauseWriterThreshold: -2));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("resumeWriterThreshold", () => new PipeOptions(resumeWriterThreshold: -2));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("resumeWriterThreshold", () => new PipeOptions(pauseWriterThreshold: 50, resumeWriterThreshold: 100));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("pauseWriterThreshold", () => new PipeOptions(pauseWriterThreshold: 1, resumeWriterThreshold: -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("resumeWriterThreshold", () => new PipeOptions(pauseWriterThreshold: 1, resumeWriterThreshold: 0));
         }
 
         [Theory]


### PR DESCRIPTION
Fix #75166

Add in additional checks to ensure certain edge cases identified in the issue are handled appropriately to prevent programs from hanging indefinitely.