### PR TITLE
SPMI: More information on CI failures

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1710,7 +1710,6 @@ class SuperPMIReplayAsmDiffs:
                                 logging.debug("%sGenerating %s", print_prefix, item_path)
                                 logging.debug("%sInvoking: %s", print_prefix, " ".join(command))
                                 proc = await asyncio.create_subprocess_shell(" ".join(command), stderr=asyncio.subprocess.PIPE, env=modified_env)
-                                await proc.communicate()
                                 (stdout, stderr) = await proc.communicate()
                                 if os.path.exists(item_path):
                                     with open(item_path, 'r') as file_handle:

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1711,8 +1711,13 @@ class SuperPMIReplayAsmDiffs:
                                 logging.debug("%sInvoking: %s", print_prefix, " ".join(command))
                                 proc = await asyncio.create_subprocess_shell(" ".join(command), stderr=asyncio.subprocess.PIPE, env=modified_env)
                                 await proc.communicate()
-                                with open(item_path, 'r') as file_handle:
-                                    generated_txt = file_handle.read()
+                                (stdout, stderr) = await proc.communicate()
+                                if os.path.exists(item_path):
+                                    with open(item_path, 'r') as file_handle:
+                                        generated_txt = file_handle.read()
+                                else:
+                                    raise Exception("No JitStdOutFile was created. Exit code: {}\n\nstdout:\n{}\n\nstderr:\n{}".format(proc.returncode, stdout.decode(), stderr.decode()))
+
                                 return generated_txt
 
                             # Generate diff and base JIT dumps

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -218,6 +218,11 @@ def main(main_args):
         "-log_level", "debug",
         "-log_file", log_file])
 
+    failed = False
+    if return_code != 0:
+        print("Failed during asmdiffs")
+        failed = True
+
     print("Running superpmi.py tpdiff")
 
     overall_md_tpdiff_summary_file = os.path.join(spmi_location, "tpdiff_summary.md")
@@ -239,6 +244,10 @@ def main(main_args):
         "-error_limit", "100",
         "-log_level", "debug",
         "-log_file", log_file])
+
+    if return_code != 0:
+        print("Failed during tpdiff")
+        failed = True
 
     # If there are asm diffs, and jit-analyze ran, we'll get a diff_summary.md file in the spmi_location directory.
     # We make sure the file doesn't exist before we run diffs, so we don't need to worry about superpmi.py creating
@@ -269,7 +278,7 @@ def main(main_args):
     # Finally prepare files to upload from helix.
     copy_dasm_files(spmi_location, log_directory, "{}_{}".format(platform_name, arch_name))
 
-    if return_code != 0:
+    if failed:
         print("Failure in {}".format(log_file))
         return 1
 


### PR DESCRIPTION
This enhances parts of the SPMI process with more information on failures.

Also fixes a bug I introduced when I added tpdiffs: when `asmdiffs` fails, it was not marking the entire pipeline as failing.