### PR TITLE
[MONO][Marshal] Fix race condition in marshal callback installation

### DIFF
--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -35,13 +35,14 @@ void
 mono_install_marshal_callbacks_ilgen (MonoMarshalIlgenCallbacks *cb)
 {
 	g_assert (cb->version == MONO_MARSHAL_CALLBACKS_VERSION);
-	MonoMarshalIlgenCallbacks* local_cb = (MonoMarshalIlgenCallbacks*)malloc(sizeof(MonoMarshalIlgenCallbacks));
+	MonoMarshalIlgenCallbacks* local_cb = (MonoMarshalIlgenCallbacks*)g_malloc(sizeof(MonoMarshalIlgenCallbacks));
 	memcpy (local_cb, cb, sizeof (MonoMarshalIlgenCallbacks));
+	mono_memory_barrier ();
 
-	if (mono_atomic_cas_ptr((void**)&ilgen_marshal_cb, local_cb, NULL  ))
+	if (mono_atomic_cas_ptr((void**)&ilgen_marshal_cb, local_cb, NULL  ) != NULL)
 	{
 		// cas failed
-		free(local_cb);
+		g_free(local_cb);
 	}
 }
 

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6244,13 +6244,14 @@ void
 mono_install_marshal_callbacks (MonoMarshalLightweightCallbacks *cb)
 {
 	g_assert (cb->version == MONO_MARSHAL_CALLBACKS_VERSION);
-	MonoMarshalLightweightCallbacks* local_cb = (MonoMarshalLightweightCallbacks*)malloc(sizeof(MonoMarshalLightweightCallbacks));
+	MonoMarshalLightweightCallbacks* local_cb = (MonoMarshalLightweightCallbacks*)g_malloc(sizeof(MonoMarshalLightweightCallbacks));
 	memcpy (local_cb, cb, sizeof (MonoMarshalLightweightCallbacks));
+	mono_memory_barrier ();
 
-	if (mono_atomic_cas_ptr((void**)&marshal_lightweight_cb, local_cb, NULL))
+	if (mono_atomic_cas_ptr((void**)&marshal_lightweight_cb, local_cb, NULL) != NULL)
 	{
 		// cas failed
-		free(local_cb);
+		g_free(local_cb);
 	}
 }
 


### PR DESCRIPTION
This fixes a race condition on `ilgen_cb_inited`; this flag was used to determine if callbacks were already installed, but had no synchronization around it. Replaced with a pointer to a dynamically allocated buffer and a `cas`.

Fixes: https://github.com/dotnet/runtime/issues/74603
Fixes: https://github.com/dotnet/runtime/issues/77090