### PR TITLE
[FileStream] Flush(flushToDisk: true) should always flush to disk

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Flush.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Flush.cs
@@ -18,6 +18,37 @@ namespace System.IO.Tests
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
             {
                 fs.Dispose();
+
+                Assert.Throws<ObjectDisposedException>(() => Flush(fs, flushToDisk));
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FlushThrowsForDisposedHandle_EmptyBuffer(bool? flushToDisk)
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
+            {
+                fs.SafeFileHandle.Dispose();
+
+                Assert.Throws<ObjectDisposedException>(() => Flush(fs, flushToDisk));
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FlushThrowsForDisposedHandle_NonEmptyBuffer(bool? flushToDisk)
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
+            {
+                fs.WriteByte(1); // fills the internal buffer
+
+                fs.SafeFileHandle.Dispose();
+
                 Assert.Throws<ObjectDisposedException>(() => Flush(fs, flushToDisk));
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -761,41 +761,34 @@ namespace System.IO.Strategies
 
         internal override void Flush(bool flushToDisk)
         {
-            EnsureNotClosed();
+            Debug.Assert(!_strategy.IsClosed, "FileStream responsibility");
+            Debug.Assert((_readPos == 0 && _readLen == 0 && _writePos >= 0) || (_writePos == 0 && _readPos <= _readLen),
+                "We're either reading or writing, but not both.");
 
-            // Has write data in the buffer:
             if (_writePos > 0)
             {
-                // EnsureNotClosed does not guarantee that the Stream has not been closed
-                // an example could be a call to fileStream.SafeFileHandle.Dispose()
-                // so to avoid getting exception here, we just ensure that we can Write before doing it
-                if (_strategy.CanWrite)
-                {
-                    FlushWrite();
-                    Debug.Assert(_writePos == 0 && _readPos == 0 && _readLen == 0);
-                    return;
-                }
+                FlushWrite();
             }
-
-            // Has read data in the buffer:
-            if (_readPos < _readLen)
+            else if (_readPos < _readLen)
             {
-                // If the underlying strategy is not seekable AND we have something in the read buffer, then FlushRead would throw.
-                // We can either throw away the buffer resulting in data loss (!) or ignore the Flush.
-                // (We cannot throw because it would be a breaking change.) We opt into ignoring the Flush in that situation.
                 if (_strategy.CanSeek)
                 {
                     FlushRead();
                 }
+                else
+                {
+                    // If the underlying strategy is not seekable AND we have something in the read buffer, then FlushRead would throw.
+                    // We can either throw away the buffer resulting in data loss (!) or ignore the Flush.
+                    // We cannot throw because it would be a breaking change. We opt into ignoring the Flush in that situation.
+                    return;
+                }
 
                 // If the Stream was seekable, then we should have called FlushRead which resets _readPos & _readLen.
                 Debug.Assert(_writePos == 0 && (!_strategy.CanSeek || (_readPos == 0 && _readLen == 0)));
-                return;
             }
 
-            // We had no data in the buffer, but we still need to tell the underlying strategy to flush.
+            // We still need to tell the underlying strategy to flush. It's NOP for !flushToDisk or !CanWrite.
             _strategy.Flush(flushToDisk);
-
             _writePos = _readPos = _readLen = 0;
         }
 


### PR DESCRIPTION
fixes #77373

5.0 implementation for reference:

https://github.com/dotnet/runtime/blob/fe217956fd128732279c1d01d854d025f8e225d1/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.cs#L268-L276

I've tried really hard to write a reliable test for this bug, but I've failed to do that in reasonable period of time.

Based on the [docs](https://learn.microsoft.com/en-us/windows/win32/fileio/file-caching):

> File system metadata is always cached. Therefore, to store any metadata changes to disk, the file must either be flushed or be opened with FILE_FLAG_WRITE_THROUGH.

I've tried to find some way of writing and reading the metadata and using `Flush(true)` to flush the metadata, but I was unable to find a simple and reliable solution for doing that (the metadata that we expose is refreshed without the need to flush to disk, other metdata is hard to get and either requires some dirty COM code or 3rd party or .NET Framework-only dependency to do it).