### PR TITLE
Consolidate the `GUID` to string logic

### DIFF
--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -5154,7 +5154,7 @@ void DumpCodeManager(IMAGE_COR20_HEADER *CORHeader, void* GUICookie)
     ULONG iCount = VAL32(CORHeader->CodeManagerTable.Size) / sizeof(GUID);
     for (ULONG i=0;  i<iCount;  i++)
     {
-        CHAR         rcguid[GUID_STR_BUFFER_MIN_LEN];
+        CHAR         rcguid[GUID_STR_BUFFER_LEN];
         GUID         Guid = *pcm;
         SwapGuid(&Guid);
         GuidToLPSTR(Guid, rcguid);

--- a/src/coreclr/ildasm/dasm.cpp
+++ b/src/coreclr/ildasm/dasm.cpp
@@ -5154,7 +5154,7 @@ void DumpCodeManager(IMAGE_COR20_HEADER *CORHeader, void* GUICookie)
     ULONG iCount = VAL32(CORHeader->CodeManagerTable.Size) / sizeof(GUID);
     for (ULONG i=0;  i<iCount;  i++)
     {
-        CHAR         rcguid[128];
+        CHAR         rcguid[GUID_STR_BUFFER_MIN_LEN];
         GUID         Guid = *pcm;
         SwapGuid(&Guid);
         GuidToLPSTR(Guid, rcguid);

--- a/src/coreclr/ildasm/dis.cpp
+++ b/src/coreclr/ildasm/dis.cpp
@@ -821,7 +821,7 @@ BOOL SourceLinesHelper(void *GUICookie, LineCodeDescr* pLCD, _Out_writes_(nSize)
 
     PAL_TRY(Param *, pParam, &param) {
         GUID guidLang={0},guidLangVendor={0},guidDoc={0};
-        CHAR zLang[64],zVendor[64],zDoc[64];
+        CHAR zLang[GUID_STR_BUFFER_MIN_LEN],zVendor[GUID_STR_BUFFER_MIN_LEN],zDoc[GUID_STR_BUFFER_MIN_LEN];
         ULONG32 k;
         if(pParam->pLCD->FileToken != ulWasFileToken)
         {

--- a/src/coreclr/ildasm/dis.cpp
+++ b/src/coreclr/ildasm/dis.cpp
@@ -821,7 +821,7 @@ BOOL SourceLinesHelper(void *GUICookie, LineCodeDescr* pLCD, _Out_writes_(nSize)
 
     PAL_TRY(Param *, pParam, &param) {
         GUID guidLang={0},guidLangVendor={0},guidDoc={0};
-        CHAR zLang[GUID_STR_BUFFER_MIN_LEN],zVendor[GUID_STR_BUFFER_MIN_LEN],zDoc[GUID_STR_BUFFER_MIN_LEN];
+        CHAR zLang[GUID_STR_BUFFER_LEN],zVendor[GUID_STR_BUFFER_LEN],zDoc[GUID_STR_BUFFER_LEN];
         ULONG32 k;
         if(pParam->pLCD->FileToken != ulWasFileToken)
         {

--- a/src/coreclr/ildasm/dman.cpp
+++ b/src/coreclr/ildasm/dman.cpp
@@ -120,7 +120,7 @@ void DumpScope(void* GUICookie)
     mdModule mdm;
     GUID mvid;
     WCHAR scopeName[1024];
-    CHAR guidString[1024];
+    CHAR guidString[GUID_STR_BUFFER_MIN_LEN];
     memset(scopeName,0,1024*sizeof(WCHAR));
     if(SUCCEEDED(g_pPubImport->GetScopeProps( scopeName, 1024, NULL, &mvid))&& scopeName[0])
     {

--- a/src/coreclr/ildasm/dman.cpp
+++ b/src/coreclr/ildasm/dman.cpp
@@ -120,7 +120,7 @@ void DumpScope(void* GUICookie)
     mdModule mdm;
     GUID mvid;
     WCHAR scopeName[1024];
-    CHAR guidString[GUID_STR_BUFFER_MIN_LEN];
+    CHAR guidString[GUID_STR_BUFFER_LEN];
     memset(scopeName,0,1024*sizeof(WCHAR));
     if(SUCCEEDED(g_pPubImport->GetScopeProps( scopeName, 1024, NULL, &mvid))&& scopeName[0])
     {

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -3421,7 +3421,7 @@ private:
 };
 
 // 38 characters + 1 null terminating.
-#define GUID_STR_BUFFER_MIN_LEN (ARRAY_SIZE("{12345678-1234-1234-1234-123456789abc}"))
+#define GUID_STR_BUFFER_LEN (ARRAY_SIZE("{12345678-1234-1234-1234-123456789abc}"))
 
 //*****************************************************************************
 // Convert a GUID into a pointer to a string

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -411,33 +411,6 @@ inline WCHAR* FormatInteger(WCHAR* str, size_t strCount, const char* fmt, I v)
     return str;
 }
 
-class GuidString final
-{
-    char _buffer[ARRAY_SIZE("{12345678-1234-1234-1234-123456789abc}")];
-public:
-    static void Create(const GUID& g, GuidString& ret)
-    {
-        // Ensure we always have a null
-        ret._buffer[ARRAY_SIZE(ret._buffer) - 1] = '\0';
-        sprintf_s(ret._buffer, ARRAY_SIZE(ret._buffer), "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-            g.Data1, g.Data2, g.Data3,
-            g.Data4[0], g.Data4[1],
-            g.Data4[2], g.Data4[3],
-            g.Data4[4], g.Data4[5],
-            g.Data4[6], g.Data4[7]);
-    }
-
-    const char* AsString() const
-    {
-        return _buffer;
-    }
-
-    operator const char*() const
-    {
-        return _buffer;
-    }
-};
-
 inline
 LPWSTR DuplicateString(
     LPCWSTR wszString,
@@ -3446,6 +3419,9 @@ private:
 
     BYTE m_inited;
 };
+
+// 38 characters + 1 null terminating.
+#define GUID_STR_BUFFER_MIN_LEN (ARRAY_SIZE("{12345678-1234-1234-1234-123456789abc}"))
 
 //*****************************************************************************
 // Convert a GUID into a pointer to a string

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -2895,7 +2895,7 @@ namespace Com
         {
             STANDARD_VM_CONTRACT;
 
-            WCHAR wszClsid[39];
+            WCHAR wszClsid[GUID_STR_BUFFER_MIN_LEN];
             if (GuidToLPWSTR(rclsid, wszClsid) == 0)
                 return E_UNEXPECTED;
 

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -2895,7 +2895,7 @@ namespace Com
         {
             STANDARD_VM_CONTRACT;
 
-            WCHAR wszClsid[GUID_STR_BUFFER_MIN_LEN];
+            WCHAR wszClsid[GUID_STR_BUFFER_LEN];
             if (GuidToLPWSTR(rclsid, wszClsid) == 0)
                 return E_UNEXPECTED;
 

--- a/src/coreclr/utilcode/util_nodependencies.cpp
+++ b/src/coreclr/utilcode/util_nodependencies.cpp
@@ -444,7 +444,7 @@ GuidToLPSTR(
     _Out_writes_(cchGuid) LPSTR szGuid,     // String into which the GUID is stored
                           DWORD  cchGuid)   // Count in chars
 {
-    if (cchGuid < GUID_STR_BUFFER_MIN_LEN)
+    if (cchGuid < GUID_STR_BUFFER_LEN)
         return 0;
 
     return sprintf_s(szGuid, cchGuid, "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
@@ -508,7 +508,7 @@ GuidToLPWSTR(
     // successive fields break the GUID into the form DWORD-WORD-WORD-WORD-WORD.DWORD
     // covering the 128-bit GUID. The string includes enclosing braces, which are an OLE convention.
 
-    if (cchGuid < GUID_STR_BUFFER_MIN_LEN)
+    if (cchGuid < GUID_STR_BUFFER_LEN)
         return 0;
 
     // {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}

--- a/src/coreclr/utilcode/util_nodependencies.cpp
+++ b/src/coreclr/utilcode/util_nodependencies.cpp
@@ -444,7 +444,7 @@ GuidToLPSTR(
     _Out_writes_(cchGuid) LPSTR szGuid,     // String into which the GUID is stored
                           DWORD  cchGuid)   // Count in chars
 {
-    if (cchGuid < 39)
+    if (cchGuid < GUID_STR_BUFFER_MIN_LEN)
         return 0;
 
     return sprintf_s(szGuid, cchGuid, "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
@@ -508,7 +508,7 @@ GuidToLPWSTR(
     // successive fields break the GUID into the form DWORD-WORD-WORD-WORD-WORD.DWORD
     // covering the 128-bit GUID. The string includes enclosing braces, which are an OLE convention.
 
-    if (cchGuid < 39) // 38 chars + 1 null terminating.
+    if (cchGuid < GUID_STR_BUFFER_MIN_LEN)
         return 0;
 
     // {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}

--- a/src/coreclr/vm/assemblybinder.cpp
+++ b/src/coreclr/vm/assemblybinder.cpp
@@ -44,7 +44,7 @@ NativeImage* AssemblyBinder::LoadNativeImage(Module* componentModule, LPCUTF8 na
 #ifdef FEATURE_READYTORUN
 static void MvidMismatchFatalError(GUID mvidActual, GUID mvidExpected, LPCUTF8 simpleName, bool compositeComponent, LPCUTF8 assemblyRequirementName)
 {
-    static const size_t MVID_TEXT_LENGTH = 39;
+    static const size_t MVID_TEXT_LENGTH = GUID_STR_BUFFER_MIN_LEN;
     CHAR assemblyMvidText[MVID_TEXT_LENGTH];
     GuidToLPSTR(mvidActual, assemblyMvidText);
 

--- a/src/coreclr/vm/assemblybinder.cpp
+++ b/src/coreclr/vm/assemblybinder.cpp
@@ -44,11 +44,10 @@ NativeImage* AssemblyBinder::LoadNativeImage(Module* componentModule, LPCUTF8 na
 #ifdef FEATURE_READYTORUN
 static void MvidMismatchFatalError(GUID mvidActual, GUID mvidExpected, LPCUTF8 simpleName, bool compositeComponent, LPCUTF8 assemblyRequirementName)
 {
-    static const size_t MVID_TEXT_LENGTH = GUID_STR_BUFFER_MIN_LEN;
-    CHAR assemblyMvidText[MVID_TEXT_LENGTH];
+    CHAR assemblyMvidText[GUID_STR_BUFFER_LEN];
     GuidToLPSTR(mvidActual, assemblyMvidText);
 
-    CHAR componentMvidText[MVID_TEXT_LENGTH];
+    CHAR componentMvidText[GUID_STR_BUFFER_LEN];
     GuidToLPSTR(mvidExpected, componentMvidText);
 
     SString message;

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -3652,7 +3652,7 @@ BOOL ComMethodTable::LayOutInterfaceMethodTable(MethodTable* pClsMT)
     {
         BEGIN_PROFILER_CALLBACK(CORProfilerTrackCCW());
 #if defined(_DEBUG)
-        CHAR rIID[40]; // {00000000-0000-0000-0000-000000000000}
+        CHAR rIID[GUID_STR_BUFFER_MIN_LEN];
         GuidToLPSTR(m_IID, rIID);
         LOG((LF_CORPROF, LL_INFO100, "COMClassicVTableCreated Class:%hs, IID:%s, vTbl:%#08x\n",
              pItfClass->GetDebugClassName(), rIID, pUnkVtable));
@@ -4703,7 +4703,7 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::CreateTemplate(TypeHandle thClas
                 GenerateClassItfGuid(thClass, &IClassXIID);
 
 #if defined(_DEBUG)
-            CHAR rIID[40]; // {00000000-0000-0000-0000-000000000000}
+            CHAR rIID[GUID_STR_BUFFER_MIN_LEN];
             GuidToLPSTR(IClassXIID, rIID);
             SString ssName;
             thClass.GetName(ssName);

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -3652,7 +3652,7 @@ BOOL ComMethodTable::LayOutInterfaceMethodTable(MethodTable* pClsMT)
     {
         BEGIN_PROFILER_CALLBACK(CORProfilerTrackCCW());
 #if defined(_DEBUG)
-        CHAR rIID[GUID_STR_BUFFER_MIN_LEN];
+        CHAR rIID[GUID_STR_BUFFER_LEN];
         GuidToLPSTR(m_IID, rIID);
         LOG((LF_CORPROF, LL_INFO100, "COMClassicVTableCreated Class:%hs, IID:%s, vTbl:%#08x\n",
              pItfClass->GetDebugClassName(), rIID, pUnkVtable));
@@ -4703,7 +4703,7 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::CreateTemplate(TypeHandle thClas
                 GenerateClassItfGuid(thClass, &IClassXIID);
 
 #if defined(_DEBUG)
-            CHAR rIID[GUID_STR_BUFFER_MIN_LEN];
+            CHAR rIID[GUID_STR_BUFFER_LEN];
             GuidToLPSTR(IClassXIID, rIID);
             SString ssName;
             thClass.GetName(ssName);

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -3967,7 +3967,7 @@ VOID LogInteropQI(IUnknown* pItf, REFIID iid, HRESULT hrArg, _In_z_ LPCSTR szMsg
     HRESULT             hr          = S_OK;
     SafeComHolder<IUnknown> pUnk        = NULL;
     int                 cch         = 0;
-    CHAR                szIID[64];
+    CHAR                szIID[GUID_STR_BUFFER_MIN_LEN];
 
     hr = SafeQueryInterface(pItf, IID_IUnknown, &pUnk);
 

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -3967,7 +3967,7 @@ VOID LogInteropQI(IUnknown* pItf, REFIID iid, HRESULT hrArg, _In_z_ LPCSTR szMsg
     HRESULT             hr          = S_OK;
     SafeComHolder<IUnknown> pUnk        = NULL;
     int                 cch         = 0;
-    CHAR                szIID[GUID_STR_BUFFER_MIN_LEN];
+    CHAR                szIID[GUID_STR_BUFFER_LEN];
 
     hr = SafeQueryInterface(pItf, IID_IUnknown, &pUnk);
 

--- a/src/coreclr/vm/profilinghelper.cpp
+++ b/src/coreclr/vm/profilinghelper.cpp
@@ -702,8 +702,8 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerForStartup()
         return hr;
     }
 
-    GuidString clsidUtf8;
-    GuidString::Create(clsid, clsidUtf8);
+    char clsidUtf8[GUID_STR_BUFFER_MIN_LEN];
+    GuidToLPSTR(clsid, clsidUtf8);
     hr = LoadProfiler(
         kStartupLoad,
         &clsid,
@@ -736,8 +736,8 @@ HRESULT ProfilingAPIUtility::AttemptLoadDelayedStartupProfilers()
         LOG((LF_CORPROF, LL_INFO10, "**PROF: Profiler loading from GUID/Path stored from the IPC channel."));
         CLSID *pClsid = &(item->guid);
 
-        GuidString clsidUtf8;
-        GuidString::Create(*pClsid, clsidUtf8);
+        char clsidUtf8[GUID_STR_BUFFER_MIN_LEN];
+        GuidToLPSTR(*pClsid, clsidUtf8);
         HRESULT hr = LoadProfiler(
             kStartupLoad,
             pClsid,
@@ -816,8 +816,8 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerList()
             continue;
         }
 
-        GuidString clsidUtf8;
-        GuidString::Create(clsid, clsidUtf8);
+        char clsidUtf8[GUID_STR_BUFFER_MIN_LEN];
+        GuidToLPSTR(clsid, clsidUtf8);
         hr = LoadProfiler(
             kStartupLoad,
             &clsid,

--- a/src/coreclr/vm/profilinghelper.cpp
+++ b/src/coreclr/vm/profilinghelper.cpp
@@ -702,7 +702,7 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerForStartup()
         return hr;
     }
 
-    char clsidUtf8[GUID_STR_BUFFER_MIN_LEN];
+    char clsidUtf8[GUID_STR_BUFFER_LEN];
     GuidToLPSTR(clsid, clsidUtf8);
     hr = LoadProfiler(
         kStartupLoad,
@@ -736,7 +736,7 @@ HRESULT ProfilingAPIUtility::AttemptLoadDelayedStartupProfilers()
         LOG((LF_CORPROF, LL_INFO10, "**PROF: Profiler loading from GUID/Path stored from the IPC channel."));
         CLSID *pClsid = &(item->guid);
 
-        char clsidUtf8[GUID_STR_BUFFER_MIN_LEN];
+        char clsidUtf8[GUID_STR_BUFFER_LEN];
         GuidToLPSTR(*pClsid, clsidUtf8);
         HRESULT hr = LoadProfiler(
             kStartupLoad,
@@ -816,7 +816,7 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerList()
             continue;
         }
 
-        char clsidUtf8[GUID_STR_BUFFER_MIN_LEN];
+        char clsidUtf8[GUID_STR_BUFFER_LEN];
         GuidToLPSTR(clsid, clsidUtf8);
         hr = LoadProfiler(
             kStartupLoad,

--- a/src/coreclr/vm/profilinghelper.inl
+++ b/src/coreclr/vm/profilinghelper.inl
@@ -110,7 +110,7 @@ inline void ProfilingAPIUtility::LogNoInterfaceError(REFIID iidRequested, LPCSTR
     }
     CONTRACTL_END;
 
-    char iidUtf8[GUID_STR_BUFFER_MIN_LEN];
+    char iidUtf8[GUID_STR_BUFFER_LEN];
     GuidToLPSTR(iidRequested, iidUtf8);
     ProfilingAPIUtility::LogProfError(IDS_E_PROF_NO_CALLBACK_IFACE, szCLSID, (LPCSTR)iidUtf8);
 }
@@ -176,7 +176,7 @@ inline HRESULT ProfilingAPIUtility::LoadProfilerForAttach(
     CONTRACTL_END;
 
     // Inform user we're about to try attaching the profiler
-    char clsidUtf8[GUID_STR_BUFFER_MIN_LEN];
+    char clsidUtf8[GUID_STR_BUFFER_LEN];
     GuidToLPSTR(*pClsid, clsidUtf8);
     ProfilingAPIUtility::LogProfInfo(IDS_PROF_ATTACH_REQUEST_RECEIVED, (LPCSTR)clsidUtf8);
 

--- a/src/coreclr/vm/profilinghelper.inl
+++ b/src/coreclr/vm/profilinghelper.inl
@@ -110,8 +110,8 @@ inline void ProfilingAPIUtility::LogNoInterfaceError(REFIID iidRequested, LPCSTR
     }
     CONTRACTL_END;
 
-    GuidString iidUtf8;
-    GuidString::Create(iidRequested, iidUtf8);
+    char iidUtf8[GUID_STR_BUFFER_MIN_LEN];
+    GuidToLPSTR(iidRequested, iidUtf8);
     ProfilingAPIUtility::LogProfError(IDS_E_PROF_NO_CALLBACK_IFACE, szCLSID, (LPCSTR)iidUtf8);
 }
 
@@ -176,8 +176,8 @@ inline HRESULT ProfilingAPIUtility::LoadProfilerForAttach(
     CONTRACTL_END;
 
     // Inform user we're about to try attaching the profiler
-    GuidString clsidUtf8;
-    GuidString::Create(*pClsid, clsidUtf8);
+    char clsidUtf8[GUID_STR_BUFFER_MIN_LEN];
+    GuidToLPSTR(*pClsid, clsidUtf8);
     ProfilingAPIUtility::LogProfInfo(IDS_PROF_ATTACH_REQUEST_RECEIVED, (LPCSTR)clsidUtf8);
 
     return LoadProfiler(

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -64,7 +64,7 @@ void ComClassFactory::ThrowHRMsg(HRESULT hr, DWORD dwMsgResID)
 
     SString strMessage;
     SString strResource;
-    WCHAR strClsid[39];
+    WCHAR strClsid[GUID_STR_BUFFER_MIN_LEN];
     SString strHRDescription;
 
     // Obtain the textual representation of the HRESULT.
@@ -504,7 +504,7 @@ IClassFactory *ComClassFactory::GetIClassFactory()
     {
         SString strMessage;
         SString strResource;
-        WCHAR strClsid[39];
+        WCHAR strClsid[GUID_STR_BUFFER_MIN_LEN];
         SString strHRDescription;
 
         // Obtain the textual representation of the HRESULT.
@@ -2635,7 +2635,7 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         }
 
         // Convert the IID to a string.
-        WCHAR strIID[39];
+        WCHAR strIID[GUID_STR_BUFFER_MIN_LEN];
         GuidToLPWSTR(iid, strIID);
 
         // Obtain the textual description of the HRESULT.
@@ -2653,7 +2653,7 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
             pSrcItfClass->GetGuid(&SrcItfIID, TRUE);
 
             // Convert the source interface IID to a string.
-            WCHAR strSrcItfIID[39];
+            WCHAR strSrcItfIID[GUID_STR_BUFFER_MIN_LEN];
             GuidToLPWSTR(SrcItfIID, strSrcItfIID);
 
             COMPlusThrow(kInvalidCastException, IDS_EE_RCW_INVALIDCAST_EVENTITF, strHRDescription.GetUnicode(), strComObjClassName.GetUnicode(),
@@ -2667,7 +2667,7 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         else if ((pNativeIID = MngStdInterfaceMap::GetNativeIIDForType(thCastTo)) != NULL)
         {
             // Convert the source interface IID to a string.
-            WCHAR strNativeItfIID[39];
+            WCHAR strNativeItfIID[GUID_STR_BUFFER_MIN_LEN];
             GuidToLPWSTR(*pNativeIID, strNativeItfIID);
 
             // Query for the interface to determine the failure HRESULT.

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -64,7 +64,7 @@ void ComClassFactory::ThrowHRMsg(HRESULT hr, DWORD dwMsgResID)
 
     SString strMessage;
     SString strResource;
-    WCHAR strClsid[GUID_STR_BUFFER_MIN_LEN];
+    WCHAR strClsid[GUID_STR_BUFFER_LEN];
     SString strHRDescription;
 
     // Obtain the textual representation of the HRESULT.
@@ -504,7 +504,7 @@ IClassFactory *ComClassFactory::GetIClassFactory()
     {
         SString strMessage;
         SString strResource;
-        WCHAR strClsid[GUID_STR_BUFFER_MIN_LEN];
+        WCHAR strClsid[GUID_STR_BUFFER_LEN];
         SString strHRDescription;
 
         // Obtain the textual representation of the HRESULT.
@@ -2635,7 +2635,7 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         }
 
         // Convert the IID to a string.
-        WCHAR strIID[GUID_STR_BUFFER_MIN_LEN];
+        WCHAR strIID[GUID_STR_BUFFER_LEN];
         GuidToLPWSTR(iid, strIID);
 
         // Obtain the textual description of the HRESULT.
@@ -2653,7 +2653,7 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
             pSrcItfClass->GetGuid(&SrcItfIID, TRUE);
 
             // Convert the source interface IID to a string.
-            WCHAR strSrcItfIID[GUID_STR_BUFFER_MIN_LEN];
+            WCHAR strSrcItfIID[GUID_STR_BUFFER_LEN];
             GuidToLPWSTR(SrcItfIID, strSrcItfIID);
 
             COMPlusThrow(kInvalidCastException, IDS_EE_RCW_INVALIDCAST_EVENTITF, strHRDescription.GetUnicode(), strComObjClassName.GetUnicode(),
@@ -2667,7 +2667,7 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         else if ((pNativeIID = MngStdInterfaceMap::GetNativeIIDForType(thCastTo)) != NULL)
         {
             // Convert the source interface IID to a string.
-            WCHAR strNativeItfIID[GUID_STR_BUFFER_MIN_LEN];
+            WCHAR strNativeItfIID[GUID_STR_BUFFER_LEN];
             GuidToLPWSTR(*pNativeIID, strNativeItfIID);
 
             // Query for the interface to determine the failure HRESULT.


### PR DESCRIPTION
Replace obvious uses of `GUID` to string
logic with a new constant for buffer length.

/cc @elinor-fung @am11 