### PR TITLE
[Mono] Disable SIMD intrinsics for Vector128/64 on Arm64

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1111,6 +1111,11 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 	if (!COMPILE_LLVM (cfg))
 		return NULL;
 
+#ifdef TARGET_ARM64
+	if (!(cfg->compile_aot && cfg->full_aot && !cfg->interp))
+		return NULL;
+#endif
+
 	int id = lookup_intrins (sri_vector_methods, sizeof (sri_vector_methods), cmethod);
 	if (id == -1) {
 		//check_no_intrinsic_cattr (cmethod);


### PR DESCRIPTION
After disabling Arm intrinsics, the android team hit another issue with Vector128 when enabling LLVM. It was also a mixed mode issue. This PR disables Vector128/64 intrinsics.
Fixes #77319