### PR TITLE
Extending variable live ranges in more cases

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -8730,7 +8730,7 @@ void CodeGenInterface::VariableLiveKeeper::VariableLiveDescriptor::startLiveRang
 
     if (!m_VariableLiveRanges->empty() &&
         siVarLoc::Equals(&varLocation, &(m_VariableLiveRanges->back().m_VarLocation)) &&
-        m_VariableLiveRanges->back().m_EndEmitLocation.IsPreviousInsNum(emit))
+        m_VariableLiveRanges->back().m_EndEmitLocation.IsLessOneInsAway(emit))
     {
         JITDUMP("Extending debug range...\n");
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -79,7 +79,7 @@ bool emitLocation::IsLessOneInsAway(emitter* emit) const
     // Within the same IG?
     if (ig == emit->emitCurIG)
     {
-        return (emitGetInsNumFromCodePos(codePos) == emitGetInsNumFromCodePos(emit->emitCurOffset()) - 1);
+        return emitGetInsNumFromCodePos(emit->emitCurOffset()) <= emitGetInsNumFromCodePos(codePos) - 1;
     }
 
     // Spanning an IG boundary?

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -65,13 +65,14 @@ UNATIVE_OFFSET emitLocation::GetFuncletPrologOffset(emitter* emit) const
 }
 
 //------------------------------------------------------------------------
-// IsPreviousInsNum: Returns true if the emitter is on the next instruction
-//  of the same group as this emitLocation.
+// IsLessOneInsAway: Returns true if the emitter is on the same or next
+// emitted location. That means the same or next instruction at the same
+// group as this emitLocation or at the beginning of the next group.
 //
 // Arguments:
 //  emit - an emitter* instance
 //
-bool emitLocation::IsPreviousInsNum(emitter* emit) const
+bool emitLocation::IsLessOneInsAway(emitter* emit) const
 {
     assert(Valid());
 
@@ -84,7 +85,7 @@ bool emitLocation::IsPreviousInsNum(emitter* emit) const
     // Spanning an IG boundary?
     if (ig->igNext == emit->emitCurIG)
     {
-        return (emitGetInsNumFromCodePos(codePos) == ig->igInsCnt) && (emit->emitCurIGinsCnt == 1);
+        return (emitGetInsNumFromCodePos(codePos) == ig->igInsCnt) && (emit->emitCurIGinsCnt <= 1);
     }
 
     return false;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -79,7 +79,7 @@ bool emitLocation::IsLessOneInsAway(emitter* emit) const
     // Within the same IG?
     if (ig == emit->emitCurIG)
     {
-        return emitGetInsNumFromCodePos(emit->emitCurOffset()) <= emitGetInsNumFromCodePos(codePos) - 1;
+        return emitGetInsNumFromCodePos(emit->emitCurOffset()) <= emitGetInsNumFromCodePos(codePos) + 1;
     }
 
     // Spanning an IG boundary?

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -190,7 +190,7 @@ public:
 
     UNATIVE_OFFSET GetFuncletPrologOffset(emitter* emit) const;
 
-    bool IsPreviousInsNum(emitter* emit) const;
+    bool IsLessOneInsAway(emitter* emit) const;
 
 #ifdef DEBUG
     void Print(LONG compMethodID) const;


### PR DESCRIPTION
While debugging [Issue 47202](https://github.com/dotnet/runtime/issues/47202), I found that variables can die and born again without an instruction being emitted nor the emitter moving.

Here is an example from https://github.com/dotnet/runtime/pull/77289#issuecomment-1287469703:

I found a case where a variable (V06) dies (in [000054]) at the beginning of a basic block (BB05), and becomes alive (in [000016]) before an instruction is emitter. We would want to extend the live ranges in this case:

```
                                                                        /--*  t52    long   
Generating: N087 ( 10, 16) [000054] DA---------                         *  STORE_LCL_VAR long   V06 loc5         d:3 rcx REG rcx
							V06 in reg rcx is becoming live  [000054]
							Live regs: 00000000 {} => 00000002 {rcx}
							Live vars: {} => {V06}
New debug range: first
IN000f:        jmp      L_M3923_BB06

Variable Live Range History Dump for BB04
V04 loc3: rdx [(G_M3923_IG03,ins#5,ofs#27), (G_M3923_IG04,ins#1,ofs#10)]
V06 loc5: rcx [(G_M3923_IG04,ins#2,ofs#13), ...]

=============== Generating BB05 [060..06B), preds={BB01} succs={BB06} flags=0x00000000.20010020: i label LIR 
BB05 IN (1)={V09    }
     OUT(1)={    V06}

Recording Var Locations at start of BB05
  V09(rcx)
Change life 0000000000000008 {V06} -> 0000000000000002 {V09}
							V06 in reg rcx is becoming dead  [------]
							Live regs: (unchanged) 00000000 {}
							V09 in reg rcx is becoming live  [------]
							Live regs: 00000000 {} => 00000002 {rcx}
							Live regs: (unchanged) 00000002 {rcx}
							GC regs: (unchanged) 00000000 {}
							Byref regs: (unchanged) 00000000 {}

      L_M3923_BB05:

      G_M3923_IG04:        ; offs=000044H, funclet=00, bbWeight=0.50, byref
Mapped BB05 to G_M3923_IG05
Label: IG05, GCvars=0000000000000000 {}, gcrefRegs=00000000 {}, byrefRegs=00000000 {}

Scope info: begin block BB05, IL range [060..06B)
Added IP mapping: 0x0061 STACK_EMPTY (G_M3923_IG05,ins#0,ofs#0) label
Generating: N091 (???,???) [000093] -----------                            IL_OFFSET void   INLRT @ 0x061[E-] REG NA
Generating: N093 (  1,  1) [000086] -----------                   t86 =    LCL_VAR   long   V09 cse0         u:1 rcx (last use) REG rcx <l:$100, c:$140>
                                                                        /--*  t86    long   
Generating: N095 (  5,  4) [000016] DA--G------                         *  STORE_LCL_VAR long   V06 loc5         d:2 rcx REG rcx
							V09 in reg rcx is becoming dead  [000086]
							Live regs: 00000002 {rcx} => 00000000 {}
							Live vars: {V09} => {}
							V06 in reg rcx is becoming live  [000016]
							Live regs: 00000000 {} => 00000002 {rcx}
							Live vars: {} => {V06}
New debug range: new var or location
```