### PR TITLE
Avoiding printing twice variable live range

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2059,13 +2059,6 @@ void CodeGen::genEmitUnwindDebugGCandEH()
 
     genSetScopeInfo();
 
-#if defined(USING_VARIABLE_LIVE_RANGE) && defined(DEBUG)
-    if (compiler->verbose)
-    {
-        varLiveKeeper->dumpLvaVariableLiveRanges();
-    }
-#endif // defined(USING_VARIABLE_LIVE_RANGE) && defined(DEBUG)
-
 #ifdef LATE_DISASM
     unsigned finalHotCodeSize;
     unsigned finalColdCodeSize;

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -842,8 +842,9 @@ void Compiler::eeDispVar(ICorDebugInfo::NativeVarInfo* var)
     {
         name = "typeCtx";
     }
-    printf("%3d(%10s) : From %08Xh to %08Xh, in ", var->varNumber,
-           (VarNameToStr(name) == nullptr) ? "UNKNOWN" : VarNameToStr(name), var->startOffset, var->endOffset);
+    gtDispLclVar(var->varNumber, false);
+    printf("(%10s) : From %08Xh to %08Xh, in ", (VarNameToStr(name) == nullptr) ? "UNKNOWN" : VarNameToStr(name),
+           var->startOffset, var->endOffset);
 
     switch ((CodeGenInterface::siVarLocType)var->loc.vlType)
     {


### PR DESCRIPTION
I took this code out of [PR77289](https://github.com/dotnet/runtime/pull/77289).

Before this PR we dumped the information reported to the vm followed by all the variables live ranges. These are practically the same information, so I am adding information to what is being reported, and removing the print of the variable live ranges. Leaving `dumpLvaVariableLiveRanges` for debug purposes.

Before:

```
*************** In genSetScopeInfo()
VarLocInfo count is 5
; Variable debug info: 4 live ranges, 3 vars for method System.DateTime:ToBinary():long:this
  0(   UNKNOWN) : From 00000000h to 00000008h, in rcx
  0(   UNKNOWN) : From 00000008h to 0000002Fh, in rsi
  4(   UNKNOWN) : From 00000035h to 0000004Eh, in rdx
  6(   UNKNOWN) : From 00000051h to 00000051h, in rcx
VARIABLE LIVE RANGES:
V00 this: rsi [8, 2F)
V04 loc3: rdx [35, 4E)
V06 loc5: rcx [51, 51); rcx [51, 51)
*************** In gcInfoBlockHdrSave()
```

After:
```
*************** In genSetScopeInfo()
VarLocInfo count is 5
; Variable debug info: 4 live ranges, 3 vars for method System.DateTime:ToBinary():long:this
V00 this(   UNKNOWN) : From 00000000h to 00000008h, in rcx
V00 this(   UNKNOWN) : From 00000008h to 0000002Fh, in rsi
V04 loc3(   UNKNOWN) : From 00000035h to 0000004Eh, in rdx
V06 loc5(   UNKNOWN) : From 00000051h to 00000051h, in rcx
*************** In gcInfoBlockHdrSave()
```