### PR TITLE
[MONO][MARSHAL] Initialize ilgen with a flag

### DIFF
--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -2717,13 +2717,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 static MonoMarshalIlgenCallbacks *
 get_marshal_cb (void)
 {
-	if (G_UNLIKELY (!ilgen_cb_inited)) {
-#ifdef ENABLE_ILGEN
-		mono_marshal_ilgen_init ();
-#else
-		mono_marshal_noilgen_init_heavyweight ();
-#endif
-	}
+	g_assert(ilgen_cb_inited);
 	return &ilgen_marshal_cb;
 }
 
@@ -2804,7 +2798,7 @@ mono_emit_marshal_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 }
 
 void
-mono_marshal_ilgen_init (void)
+mono_marshal_ilgen_init_internal (void)
 {
 	MonoMarshalIlgenCallbacks cb;
 	cb.version = MONO_MARSHAL_CALLBACKS_VERSION;

--- a/src/mono/mono/metadata/marshal-ilgen.h
+++ b/src/mono/mono/metadata/marshal-ilgen.h
@@ -39,4 +39,8 @@ mono_emit_marshal_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	      MonoMarshalSpec *spec, int conv_arg,
 	      MonoType **conv_arg_type, MarshalAction action,  MonoMarshalLightweightCallbacks* lightweigth_cb);
 
+
+void
+mono_marshal_ilgen_init_internal (void);
+ 
 #endif // __MARSHAL_ILGEN_H__

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -68,17 +68,17 @@ get_method_image (MonoMethod *method)
 	return m_class_get_image (method->klass);
 }
 
-static gboolean embedder_requests_ilgen_callbacks = FALSE;
+static gboolean ilgen_callbacks_requested = FALSE;
 MONO_API void
 mono_marshal_ilgen_init (void)
 {
-  	embedder_requests_ilgen_callbacks = TRUE;
+  	ilgen_callbacks_requested = TRUE;
 }
 
 gboolean
-mono_marshal_did_embedder_request_ilgen_callbacks (void)
+mono_marshal_is_ilgen_requested (void)
 {
-	return embedder_requests_ilgen_callbacks;
+	return ilgen_callbacks_requested;
 }
 
 /**

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -68,6 +68,19 @@ get_method_image (MonoMethod *method)
 	return m_class_get_image (method->klass);
 }
 
+static gboolean embedder_requests_ilgen_callbacks = FALSE;
+MONO_API void
+mono_marshal_ilgen_init (void)
+{
+  	embedder_requests_ilgen_callbacks = TRUE;
+}
+
+gboolean
+mono_marshal_did_embedder_request_ilgen_callbacks (void)
+{
+	return embedder_requests_ilgen_callbacks;
+}
+
 /**
  * mono_mb_strdup:
  * \param mb the MethodBuilder

--- a/src/mono/mono/metadata/marshal-lightweight.h
+++ b/src/mono/mono/metadata/marshal-lightweight.h
@@ -10,6 +10,6 @@ MONO_API void
 mono_marshal_lightweight_init (void);
 
 gboolean
-mono_marshal_did_embedder_request_ilgen_callbacks (void);
+mono_marshal_is_ilgen_requested (void);
 
 #endif // __MONO_MARSHAL_LIGHTWEIGHT_H__

--- a/src/mono/mono/metadata/marshal-lightweight.h
+++ b/src/mono/mono/metadata/marshal-lightweight.h
@@ -9,4 +9,7 @@
 MONO_API void
 mono_marshal_lightweight_init (void);
 
+gboolean
+mono_marshal_did_embedder_request_ilgen_callbacks (void);
+
 #endif // __MONO_MARSHAL_LIGHTWEIGHT_H__

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6259,15 +6259,7 @@ mono_install_marshal_callbacks (MonoMarshalLightweightCallbacks *cb)
 static MonoMarshalLightweightCallbacks *
 get_marshal_cb (void)
 {
-
-	if (G_UNLIKELY (!lightweight_cb_inited)) {
-#ifdef ENABLE_ILGEN
-		mono_marshal_lightweight_init ();
-#else
-		mono_marshal_noilgen_init_lightweight ();
-#endif
-	}
-
+	g_assert (lightweight_cb_inited);
 	return &marshal_lightweight_cb;
 }
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4470,13 +4470,13 @@ mini_init (const char *filename)
 
 
 #ifdef ENABLE_ILGEN
-	mono_marshal_lightweight_init();
-  	mono_marshal_ilgen_init_internal();
+	mono_marshal_lightweight_init ();
+  	mono_marshal_ilgen_init_internal ();
 #else
-	if(! mono_marshal_did_embedder_request_ilgen_callbacks())
+	if(! mono_marshal_did_embedder_request_ilgen_callbacks ())
   	{
-		mono_marshal_lightweight_init();
-  		mono_marshal_ilgen_init_internal();
+		mono_marshal_lightweight_init ();
+  		mono_marshal_ilgen_init_internal ();
  	}
 	else{
 		mono_marshal_noilgen_init_lightweight();

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4473,7 +4473,7 @@ mini_init (const char *filename)
 	mono_marshal_lightweight_init ();
   	mono_marshal_ilgen_init_internal ();
 #else
-	if(! mono_marshal_is_ilgen_requested ())
+	if (mono_marshal_is_ilgen_requested ())
   	{
 		mono_marshal_lightweight_init ();
   		mono_marshal_ilgen_init_internal ();

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -41,6 +41,7 @@
 #include <mono/metadata/domain-internals.h>
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/mono-config.h>
+#include <mono/metadata/marshal-ilgen.h>
 #include <mono/metadata/environment.h>
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/gc-internals.h>
@@ -4466,6 +4467,22 @@ mini_init (const char *filename)
 	};
 
 	mono_component_event_pipe_100ns_ticks_start ();
+
+
+#ifdef ENABLE_ILGEN
+	mono_marshal_lightweight_init();
+  	mono_marshal_ilgen_init_internal();
+#else
+	if(! mono_marshal_did_embedder_request_ilgen_callbacks())
+  	{
+		mono_marshal_lightweight_init();
+  		mono_marshal_ilgen_init_internal();
+ 	}
+	else{
+		mono_marshal_noilgen_init_lightweight();
+		mono_marshal_noilgen_init_heavyweight ();
+	}
+#endif
 
 	MONO_VES_INIT_BEGIN ();
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4473,7 +4473,7 @@ mini_init (const char *filename)
 	mono_marshal_lightweight_init ();
   	mono_marshal_ilgen_init_internal ();
 #else
-	if(! mono_marshal_did_embedder_request_ilgen_callbacks ())
+	if(! mono_marshal_is_ilgen_requested ())
   	{
 		mono_marshal_lightweight_init ();
   		mono_marshal_ilgen_init_internal ();

--- a/src/mono/wasi/mono-wasi-driver/driver.c
+++ b/src/mono/wasi/mono-wasi-driver/driver.c
@@ -481,7 +481,6 @@ mono_wasm_load_runtime (const char *argv, int debug_level)
 	mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_ONLY);
 
 	mono_ee_interp_init (interp_opts);
-	mono_marshal_lightweight_init ();
 	mono_marshal_ilgen_init ();
 	mono_method_builder_ilgen_init ();
 	mono_sgen_mono_ilgen_init ();

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -55,7 +55,6 @@ int mono_wasm_register_root (char *start, size_t size, const char *name);
 void mono_wasm_deregister_root (char *addr);
 
 void mono_ee_interp_init (const char *opts);
-void mono_marshal_lightweight_init (void);
 void mono_marshal_ilgen_init (void);
 void mono_method_builder_ilgen_init (void);
 void mono_sgen_mono_ilgen_init (void);
@@ -586,7 +585,6 @@ mono_wasm_load_runtime (const char *unused, int debug_level)
 #endif
 #ifdef NEED_INTERP
 	mono_ee_interp_init (interp_opts);
-	mono_marshal_lightweight_init ();
 	mono_marshal_ilgen_init();
 	mono_method_builder_ilgen_init ();
 	mono_sgen_mono_ilgen_init ();


### PR DESCRIPTION
Currently, marshal ilgen callbacks are initialized lazily *or* by having embedders call `mono_marshal_ilgen_init`, and the code for doing this has a race condition. This change modifies `mono_marshal_ilgen_init` so that it sets a flag, and if the flag is set either ilgen callbacks are installed later during startup (intead  of lazily).  If the flag is not set, and ENABLE_ILGEN is false, the noilgen callbacks are installed instead.

Installation of callbacks occurs only once before any user code is executing, so there is no longer a race condition. See discussion here: https://github.com/dotnet/runtime/pull/77383#discussion_r1003451363


Fixes: https://github.com/dotnet/runtime/issues/74603
Fixes: https://github.com/dotnet/runtime/issues/77090