### PR TITLE
Remove the invalid assert

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Windows.cs
@@ -431,8 +431,6 @@ namespace System.Globalization
         // Get native two digit year max
         internal static int GetTwoDigitYearMax(CalendarId calendarId)
         {
-            Debug.Assert(GlobalizationMode.UseNls);
-
             return GlobalizationMode.Invariant ? Invariant.iTwoDigitYearMax :
                     CallGetCalendarInfoEx(null, calendarId, CAL_ITWODIGITYEARMAX, out int twoDigitYearMax) ?
                         twoDigitYearMax :


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77451

Recently we had the change to enable calling the method `CalendarData.GetTwoDigitYearMax` when running with `ICU` mode. This method was asserting it is running on `NLS`  mode which is not valid assertion any more. The change here is to remove the wrong assert to avoid firing in the debug builds. 