### PR TITLE
Fix Arm64 Emulated TLS

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm64/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/GcProbe.S
@@ -98,7 +98,11 @@ PROBE_FRAME_SIZE = 0xD0  // 4 * 8  for fixed part of PInvokeTransitionFrame (fp,
 .macro FixupHijackedCallstack
 
     // x2 <- GetThread()
+#ifdef FEATURE_EMULATED_TLS
+    GETTHREAD_ETLS_2
+#else
     INLINE_GETTHREAD x2
+#endif
 
     //
     // Fix the stack by restoring the original return address

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosarm64.inc
@@ -237,6 +237,17 @@ C_FUNC(\Name):
     EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 32
 .endm
 
+.macro GETTHREAD_ETLS_2
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -32           // ;; Push down stack pointer and store FP and LR
+    stp         x0, x1, [sp, #0x10]
+
+    bl C_FUNC(RhpGetThread)
+    mov x2, x0
+
+    ldp         x0, x1, [sp, #0x10]
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 32
+.endm
+
 .macro GETTHREAD_ETLS_3
     PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -48           // ;; Push down stack pointer and store FP and LR
     stp         x0, x1, [sp, #0x10]


### PR DESCRIPTION
Fix missing ifdef FEATURE_EMULATED_TLS introduced by #73216 for Android Arm64.