### PR TITLE
Fix issue with spurious unproductive full GC which led to OOM.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -21764,7 +21764,10 @@ void gc_heap::gc1()
 #endif //BACKGROUND_GC
 #endif //MULTIPLE_HEAPS
 #ifdef USE_REGIONS
-    last_gc_before_oom = FALSE;
+    if (!(settings.concurrent))
+    {
+        last_gc_before_oom = FALSE;
+    }
 #endif //USE_REGIONS
 }
 


### PR DESCRIPTION
Problem was that a BGC was in progress when the full GC was requested by setting the last_gc_before_oom flag, and at the end of the BGC we turned off the last_gc_before_oom flag.

Fix is simply not to turn off the flag in the case of BGC.