### PR TITLE
Invalidate FileInfo after CreateText and AppendText

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/AppendText.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/AppendText.cs
@@ -23,5 +23,17 @@ namespace System.IO.Tests
             writer.Write(content);
             writer.Dispose();
         }
+
+        [Fact]
+        public void FileInfoInvalidAfterAppendText()
+        {
+            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
+            string testFilePath = Path.Combine(testDir.FullName, GetTestFileName());
+            FileInfo info = new FileInfo(testFilePath);
+            using (StreamWriter streamWriter = info.AppendText())
+            {
+                Assert.True(info.Exists);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/AppendText.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/AppendText.cs
@@ -27,9 +27,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileInfoInvalidAfterAppendText()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            string testFilePath = Path.Combine(testDir.FullName, GetTestFileName());
-            FileInfo info = new FileInfo(testFilePath);
+            FileInfo info = new FileInfo(GetTestFilePath());
             using (StreamWriter streamWriter = info.AppendText())
             {
                 Assert.True(info.Exists);

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/CreateText.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/CreateText.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class FileInfo_CreateText_str : FileSystemTest
+    {
+        [Fact]
+        public void FileInfoInvalidAfterCreateText()
+        {
+            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
+            string testFilePath = Path.Combine(testDir.FullName, GetTestFileName());
+            FileInfo info = new FileInfo(testFilePath);
+            using (StreamWriter streamWriter = info.CreateText())
+            {
+                Assert.True(info.Exists);
+            }
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/CreateText.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/CreateText.cs
@@ -10,9 +10,7 @@ namespace System.IO.Tests
         [Fact]
         public void FileInfoInvalidAfterCreateText()
         {
-            DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            string testFilePath = Path.Combine(testDir.FullName, GetTestFileName());
-            FileInfo info = new FileInfo(testFilePath);
+            FileInfo info = new FileInfo(GetTestFilePath());
             using (StreamWriter streamWriter = info.CreateText())
             {
                 Assert.True(info.Exists);

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -213,6 +213,7 @@
     <Compile Include="File\Open.cs" />
     <Compile Include="File\OpenHandle.cs" />
     <Compile Include="FileInfo\Create.cs" />
+    <Compile Include="FileInfo\CreateText.cs" />
     <Compile Include="FileInfo\Delete.cs" />
     <Compile Include="FileInfo\Exists.cs" />
     <Compile Include="FileInfo\Extension.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -84,10 +84,10 @@ namespace System.IO
             => new StreamReader(NormalizedPath, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
 
         public StreamWriter CreateText()
-            => new StreamWriter(NormalizedPath, append: false);
+            => CreateStreamWriter(append: false);
 
         public StreamWriter AppendText()
-            => new StreamWriter(NormalizedPath, append: true);
+            => CreateStreamWriter(append: true);
 
         public FileInfo CopyTo(string destFileName) => CopyTo(destFileName, overwrite: false);
 
@@ -200,5 +200,12 @@ namespace System.IO
 
         [SupportedOSPlatform("windows")]
         public void Encrypt() => File.Encrypt(FullPath);
+
+        private StreamWriter CreateStreamWriter(bool append)
+        {
+            StreamWriter streamWriter = new StreamWriter(NormalizedPath);
+            Invalidate();
+            return streamWriter;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -203,7 +203,7 @@ namespace System.IO
 
         private StreamWriter CreateStreamWriter(bool append)
         {
-            StreamWriter streamWriter = new StreamWriter(NormalizedPath);
+            StreamWriter streamWriter = new StreamWriter(NormalizedPath, append);
             Invalidate();
             return streamWriter;
         }


### PR DESCRIPTION
Similarly to `FileInfo.Create()`, `FileInfo.CreateText()` and `FileInfo.AppendText()` now invalidate the data cached inside a `FileInfo` instance, so that `FileInfo.Exists` returns the correct value when being called afterwards.

Fix #77453