### PR TITLE
Scale back PGO and jit-experimental testing

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -602,7 +602,6 @@ jobs:
             - fullpgo_methodprofiling
             - fullpgo_random_gdv
             - fullpgo_random_gdv_methodprofiling_only
-            - fullpgo_random_edge
             - fullpgo_random_gdv_edge
         ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
           longRunningGcTests: true

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -238,7 +238,7 @@ jobs:
         value: 180
       - name: timeoutPerTestInMinutes
         value: 30
-    - ${{ if in(parameters.testGroup, 'pgo') }}:
+    - ${{ if in(parameters.testGroup, 'pgo', 'pgostress') }}:
       - name: timeoutPerTestCollectionInMinutes
         value: 120
     - ${{ if in(parameters.testGroup, 'jit-cfg') }}:
@@ -260,13 +260,13 @@ jobs:
         timeoutInMinutes: 300
       ${{ else }}:
         timeoutInMinutes: 200
-    ${{ if in(parameters.testGroup, 'outerloop', 'jit-experimental', 'jit-cfg') }}:
+    ${{ if in(parameters.testGroup, 'outerloop', 'jit-cfg') }}:
       timeoutInMinutes: 270
     ${{ if in(parameters.testGroup, 'gc-longrunning', 'gc-simulator') }}:
       timeoutInMinutes: 480
     ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-random', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'gcstress0x3-gcstress0xc', 'ilasm') }}:
       timeoutInMinutes: 390
-    ${{ if in(parameters.testGroup, 'gcstress-extra', 'r2r-extra', 'clrinterpreter', 'pgo') }}:
+    ${{ if in(parameters.testGroup, 'gcstress-extra', 'r2r-extra', 'clrinterpreter', 'pgo', 'pgostress', 'jit-experimental') }}:
       timeoutInMinutes: 510
     ${{ if eq(parameters.testGroup, 'jitstress-isas-x86') }}:
       timeoutInMinutes: 960
@@ -588,15 +588,22 @@ jobs:
           - gcstress0xc
         ${{ if in(parameters.testGroup, 'pgo') }}:
           scenarios:
-          - nopgo
           - defaultpgo
-          - dynamicpgo
-          - fullpgo
-          - fullpgo_methodprofiling
-          - fullpgo_random_gdv
-          - fullpgo_random_gdv_methodprofiling_only
-          - fullpgo_random_edge
-          - fullpgo_random_gdv_edge
+        ${{ if in(parameters.testGroup, 'pgostress') }}:
+          # We run a limited number of scenarios on the win-arm64 queues as we hit frequent timeouts on those queues otherwise.
+          # The loss of coverage is not critical as win-arm64/win-arm32 are practically equivalent to linux-arm64/linux-arm32 to the JIT.
+          ${{ if and(eq(parameters.osGroup, 'windows'), or(eq(parameters.archType, 'arm64'), eq(parameters.archType, 'arm'))) }}:
+            scenarios:
+            - fullpgo
+            - fullpgo_random_gdv_edge
+          ${{ else }}:
+            scenarios:
+            - fullpgo
+            - fullpgo_methodprofiling
+            - fullpgo_random_gdv
+            - fullpgo_random_gdv_methodprofiling_only
+            - fullpgo_random_edge
+            - fullpgo_random_gdv_edge
         ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
           longRunningGcTests: true
           scenarios:
@@ -616,15 +623,19 @@ jobs:
           - jitelthookenabled
           - jitelthookenabled_tiered
         ${{ if in(parameters.testGroup, 'jit-experimental') }}:
-          scenarios:
-          - jitosr_stress
-          - jitosr_pgo
-          - jitosr_stress_random
-          - jit_stress_splitting
-          - jitpartialcompilation
-          - jitpartialcompilation_osr
-          - jitpartialcompilation_osr_pgo
-          - jitobjectstackallocation
+          ${{ if and(eq(parameters.osGroup, 'windows'), or(eq(parameters.archType, 'arm64'), eq(parameters.archType, 'arm'))) }}:
+            scenarios:
+            - jitosr_stress
+            - jitpartialcompilation_pgo
+          ${{ else }}:
+            scenarios:
+            - jitosr_stress
+            - jitosr_stress_random
+            - jit_stress_splitting
+            - jitpartialcompilation
+            - jitpartialcompilation_pgo
+            - jitobjectstackallocation
+
         ${{ if in(parameters.testGroup, 'jit-cfg') }}:
           scenarios:
           - jitcfg

--- a/eng/pipelines/coreclr/pgostress.yml
+++ b/eng/pipelines/coreclr/pgostress.yml
@@ -28,7 +28,7 @@ extends:
         - windows_x86
         - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
         jobParameters:
-          testGroup: pgo-extra
+          testGroup: pgostress
 
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
@@ -37,7 +37,7 @@ extends:
         platforms:
         - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
         jobParameters:
-          testGroup: pgo-extra
+          testGroup: pgostress
 
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
@@ -55,5 +55,5 @@ extends:
         helixQueueGroup: ci
         helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
         jobParameters:
-          testGroup: pgo-extra
+          testGroup: pgostress
           liveLibrariesBuildConfig: Release

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -172,7 +172,6 @@ jobs:
               - gcstress0xc_jitstress1
               - gcstress0xc_jitstress2
               - gcstress0xc_jitminopts_heapverify1
-
             ${{ if in(parameters.coreclrTestGroup, 'pgo') }}:
               ${{ if and(eq(parameters.osGroup, 'windows'), or(eq(parameters.archType, 'arm64'), eq(parameters.archType, 'arm'))) }}:
                 scenarios:

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -177,6 +177,7 @@ jobs:
                 scenarios:
                 - defaultpgo
               ${{ else }}:
+                scenarios:
                 - fullpgo
                 - fullpgo_methodprofiling
                 - fullpgo_random_gdv

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -178,11 +178,11 @@ jobs:
                 - defaultpgo
               ${{ else }}:
                 scenarios:
+                - defaultpgo
                 - fullpgo
                 - fullpgo_methodprofiling
                 - fullpgo_random_gdv
                 - fullpgo_random_gdv_methodprofiling_only
-                - fullpgo_random_edge
                 - fullpgo_random_gdv_edge
                 - jitosr_stress
                 - jitosr_stress_random

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -172,18 +172,17 @@ jobs:
               - gcstress0xc_jitstress1
               - gcstress0xc_jitstress2
               - gcstress0xc_jitminopts_heapverify1
-            ${{ if in(parameters.coreclrTestGroup, 'pgo') }}:
-              scenarios:
-              - nopgo
-              - defaultpgo
-              - dynamicpgo
-              - fullpgo
-              - fullpgo_methodprofiling
-              - fullpgo_random_gdv
-              - fullpgo_random_gdv_methodprofiling_only
-              - fullpgo_random_edge
-              - fullpgo_random_gdv_edge
-              - jitosr_stress
-              - jitosr_stress_random
-              - jitosr_pgo
 
+            ${{ if in(parameters.coreclrTestGroup, 'pgo') }}:
+              ${{ if and(eq(parameters.osGroup, 'windows'), or(eq(parameters.archType, 'arm64'), eq(parameters.archType, 'arm'))) }}:
+                scenarios:
+                - defaultpgo
+              ${{ else }}:
+                - fullpgo
+                - fullpgo_methodprofiling
+                - fullpgo_random_gdv
+                - fullpgo_random_gdv_methodprofiling_only
+                - fullpgo_random_edge
+                - fullpgo_random_gdv_edge
+                - jitosr_stress
+                - jitosr_stress_random

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -198,11 +198,8 @@
     <TestEnvironment Include="jitosr_stress" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TC_OnStackReplacement_InitialCounter="1" OSR_HitLimit="1" TieredCompilation="1" />
     <TestEnvironment Include="jitosr_stress_random" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TC_OnStackReplacement_InitialCounter="1" OSR_HitLimit="2" TieredCompilation="1" JitRandomOnStackReplacement="15"/>
     <TestEnvironment Include="jit_stress_splitting" JitFakeProcedureSplitting="1" JitStressProcedureSplitting="1" />
-    <TestEnvironment Include="jitosr_pgo" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />
     <TestEnvironment Include="jitpartialcompilation" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" />
     <TestEnvironment Include="jitpartialcompilation_pgo" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />
-    <TestEnvironment Include="jitpartialcompilation_osr"  TC_OnStackReplacement="1" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" />
-    <TestEnvironment Include="jitpartialcompilation_osr_pgo"  TC_OnStackReplacement="1" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />
     <TestEnvironment Include="jitobjectstackallocation" JitObjectStackAllocation="1" TieredCompilation="0" />
     <TestEnvironment Include="jitcfg" JitForceControlFlowGuard="1" />
     <TestEnvironment Include="jitcfg_dispatcher_always" JitForceControlFlowGuard="1" JitCFGUseDispatcher="1" />
@@ -210,9 +207,7 @@
     <TestEnvironment Include="jitcfg_gcstress0xc" JitForceControlFlowGuard="1" GCStress="0xC" />
     <TestEnvironment Include="ilasmroundtrip" RunningIlasmRoundTrip="1" />
     <TestEnvironment Include="clrinterpreter" TieredCompilation="1" />
-    <TestEnvironment Include="nopgo" JitDisablePGO="1" TieredCompilation="1" />
-    <TestEnvironment Include="defaultpgo" TieredPGO="1" TieredCompilation="1" />
-    <TestEnvironment Include="dynamicpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" />
+    <TestEnvironment Include="defaultpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" />
     <TestEnvironment Include="fullpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0"/>
     <TestEnvironment Include="fullpgo_methodprofiling" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" />
     <TestEnvironment Include="fullpgo_random_gdv" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomlyCollect64BitCounts="1" />

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -212,7 +212,6 @@
     <TestEnvironment Include="fullpgo_methodprofiling" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" />
     <TestEnvironment Include="fullpgo_random_gdv" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="fullpgo_random_gdv_methodprofiling_only" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitClassProfiling="0" JitDelegateProfiling="1" JitVTableProfiling="1" JitRandomlyCollect64BitCounts="1" />
-    <TestEnvironment Include="fullpgo_random_edge" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomEdgeCounts="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="fullpgo_random_gdv_edge" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomEdgeCounts="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' == 'true'" GCName="clrgc.dll"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' != 'true'" GCName="libclrgc.so"/>


### PR DESCRIPTION
Introduce pgostress job that runs weekly instead of daily and move most of the `runtime-coreclr pgo` scenarios to this job. Scale back on win-arm/win-arm64 testing in pgo, libraries-pgo and jit-experimental. Clean up jobs in general based on new defaults.

* Remove nopgo run
* Remove dynamicpgo and set TC_QuickJitForLoops=1 explicitly in defaultpgo. Since this is default in x64/arm64 the only difference was in x86/arm32, and I don't think TieredPGO+QuickJitForLoops=0 is important enough to warrant a full run. Let me know if you disagree.
* Remove jitosr_pgo, jitpartialcompilation_osr, jitpartialcompilation_osr_pgo. These are equivalent to other configurations with the current defaults.
* Remove `fullpgo_random_edge` in favor of just `fullpgo_random_gdv_edge`
* Update jit-experimental's timeout to be in line with the PGO job timeout, given that this is running priority 1 tests and frequently times out too.
* Scale back win-arm32 and win-arm64 testing in pgo, libraries-pgo and jit-experimental. Run fewer of the scenarios in these pipelines under win-arm and win-arm64 since these queues are relatively weak, and the differences to the JIT between these configurations and linux-arm/linux-arm64 are relatively minor.