### PR TITLE
[tests] Disable tests failing on runtime extra platforms

### DIFF
--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -17,6 +17,7 @@ namespace System.Globalization.Tests
 
 
         [ConditionalFact(nameof(SupportsIcuPackageDownload))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77485", TestPlatforms.Windows)]
         public void TestIcuAppLocal()
         {
             // We define this switch dynamically during the runtime using RemoteExecutor.

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.cs
@@ -21,6 +21,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77470", TestPlatforms.LinuxBionic)]
         public static void CreateServer_CurrentUserOnly()
         {
             // Should not throw.
@@ -29,6 +30,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77470", TestPlatforms.LinuxBionic)]
         public static void CreateServer_ConnectClient()
         {
             string name = PipeStreamConformanceTests.GetUniquePipeName();
@@ -44,6 +46,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77470", TestPlatforms.LinuxBionic)]
         public static void CreateServer_ConnectClient_UsingUnixAbsolutePath()
         {
             string name = Path.Combine("/tmp", PipeStreamConformanceTests.GetUniquePipeName());
@@ -66,6 +69,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.CurrentUserOnly, PipeDirection.In)]
         [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.CurrentUserOnly, PipeDirection.InOut)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77470", TestPlatforms.LinuxBionic)]
         public static void Connection_UnderSameUser_CurrentUserOnly_Works(PipeOptions serverPipeOptions, PipeOptions clientPipeOptions, PipeDirection clientDirection)
         {
             string name = PipeStreamConformanceTests.GetUniquePipeName();
@@ -84,6 +88,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77470", TestPlatforms.LinuxBionic)]
         public static void CreateMultipleServers_ConnectMultipleClients()
         {
             string name1 = PipeStreamConformanceTests.GetUniquePipeName();
@@ -106,6 +111,7 @@ namespace System.IO.Pipes.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77470", TestPlatforms.LinuxBionic)]
         public static void CreateMultipleServers_ConnectMultipleClients_MultipleThreads()
         {
             List<Task> tasks = new List<Task>();
@@ -132,6 +138,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeOptions.CurrentUserOnly)]
         [InlineData(PipeOptions.None)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77470", TestPlatforms.LinuxBionic)]
         public static void CreateMultipleConcurrentServers_ConnectMultipleClients(PipeOptions extraPipeOptions)
         {
             var pipeServers = new NamedPipeServerStream[5];

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.cs
@@ -20,6 +20,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateServer_CurrentUserOnly()
         {
             // Should not throw.
@@ -27,6 +28,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateServer_ConnectClient()
         {
             string name = PipeStreamConformanceTests.GetUniquePipeName();
@@ -41,6 +43,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateServer_ConnectClient_UsingUnixAbsolutePath()
         {
             string name = Path.Combine("/tmp", PipeStreamConformanceTests.GetUniquePipeName());
@@ -62,6 +65,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.None, PipeDirection.InOut)]
         [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.CurrentUserOnly, PipeDirection.In)]
         [InlineData(PipeOptions.CurrentUserOnly, PipeOptions.CurrentUserOnly, PipeDirection.InOut)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void Connection_UnderSameUser_CurrentUserOnly_Works(PipeOptions serverPipeOptions, PipeOptions clientPipeOptions, PipeDirection clientDirection)
         {
             string name = PipeStreamConformanceTests.GetUniquePipeName();
@@ -79,6 +83,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateMultipleServers_ConnectMultipleClients()
         {
             string name1 = PipeStreamConformanceTests.GetUniquePipeName();
@@ -100,6 +105,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateMultipleServers_ConnectMultipleClients_MultipleThreads()
         {
             List<Task> tasks = new List<Task>();
@@ -125,6 +131,7 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(PipeOptions.CurrentUserOnly)]
         [InlineData(PipeOptions.None)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77469", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateMultipleConcurrentServers_ConnectMultipleClients(PipeOptions extraPipeOptions)
         {
             var pipeServers = new NamedPipeServerStream[5];

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1283,6 +1283,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory]
         [MemberData(nameof(TripleBoolValues))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77474", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task LargeHeaders_TrickledOverTime_ProcessedEfficiently(bool trailingHeaders, bool async, bool lineFolds)
         {
             Memory<byte> responsePrefix = Encoding.ASCII.GetBytes(trailingHeaders


### PR DESCRIPTION
Disables tests failing in build https://dev.azure.com/dnceng-public/public/_build/results?buildId=63540&view=logs&j=55625a83-07ac-525a-fb32-9d705da79581&t=ed547991-520a-5120-9a9a-8b7bdbddb033 to make runtime-extra-platforms greener.
