### PR TITLE
[tests] Disable tests failing on runtime extra platforms

### DIFF
--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -17,6 +17,7 @@ namespace System.Globalization.Tests
 
 
         [ConditionalFact(nameof(SupportsIcuPackageDownload))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77485", TestPlatforms.Windows)]
         public void TestIcuAppLocal()
         {
             // We define this switch dynamically during the runtime using RemoteExecutor.

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1283,6 +1283,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory]
         [MemberData(nameof(TripleBoolValues))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77474", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
         public async Task LargeHeaders_TrickledOverTime_ProcessedEfficiently(bool trailingHeaders, bool async, bool lineFolds)
         {
             Memory<byte> responsePrefix = Encoding.ASCII.GetBytes(trailingHeaders

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1283,7 +1283,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory]
         [MemberData(nameof(TripleBoolValues))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/77474", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroidX86))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77474", TestPlatforms.Android)]
         public async Task LargeHeaders_TrickledOverTime_ProcessedEfficiently(bool trailingHeaders, bool async, bool lineFolds)
         {
             Memory<byte> responsePrefix = Encoding.ASCII.GetBytes(trailingHeaders

--- a/src/libraries/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -44,6 +44,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77526", TestPlatforms.Browser)]
         public static void SyndicationFeed_Load_Write_RSS_Feed()
         {
             string path = Path.GetTempFileName();


### PR DESCRIPTION
Disables tests failing in build https://dev.azure.com/dnceng-public/public/_build/results?buildId=63540&view=logs&j=55625a83-07ac-525a-fb32-9d705da79581&t=ed547991-520a-5120-9a9a-8b7bdbddb033 to make runtime-extra-platforms greener.
