### PR TITLE
Remove unnecessary call to type.GetFields(), add test case for literalfield

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -153,8 +153,6 @@ namespace System.Reflection
 
             Type declaringType = ResolveType(tkDeclaringType, genericTypeArguments, genericMethodArguments);
 
-            declaringType.GetFields();
-
             try
             {
                 return declaringType.GetField(fieldName,

--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -41,6 +41,7 @@ namespace System.Reflection.Tests
 {
     public class ModuleTests
     {
+        public const string ConstField = "Value";
         public static Module Module => typeof(ModuleTests).Module;
         public static Module TestModule => typeof(TestModule.Dummy).Module;
 


### PR DESCRIPTION
Fixes:[ RuntimeModule::ResolveLiteralField has unnecessary call to Type.GetFields()](https://github.com/dotnet/runtime/issues/45986)