### PR TITLE
Change default value of TC_OnStackReplacement_InitialCounter to 200

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -528,7 +528,7 @@ CONFIG_INTEGER(TC_OnStackReplacement, W("TC_OnStackReplacement"), 1)
 CONFIG_INTEGER(TC_OnStackReplacement, W("TC_OnStackReplacement"), 0)
 #endif // defined(TARGET_AMD64) || defined(TARGET_ARM64)
 // Initial patchpoint counter value used by jitted code
-CONFIG_INTEGER(TC_OnStackReplacement_InitialCounter, W("TC_OnStackReplacement_InitialCounter"), 1000)
+CONFIG_INTEGER(TC_OnStackReplacement_InitialCounter, W("TC_OnStackReplacement_InitialCounter"), 200)
 // Enable partial compilation for Tier0 methods
 CONFIG_INTEGER(TC_PartialCompilation, W("TC_PartialCompilation"), 0)
 // Patchpoint strategy:


### PR DESCRIPTION
As per discussion with @AndyAyersMS we want to lower the default threshold for OSR as the current value is too conservative. It turns out that it's especially painful for DynamicPGO where can stuck in a slow loop with slow instrumentation for too long (however, OSR won't get rid of them but still useful) so we want to switch to a faster version as soon as possible.

I made a lot of measurements on the SNR service and AvaloniaILSpy and I can see stable improvements for startup if we lower that value

SNR:
![image](https://user-images.githubusercontent.com/523221/198086205-2dc9cfe2-848c-49fa-b7b9-498815f0f3bf.png)

_(P95 latency during first minute till it hits the steady state, lower is better)_

Up to 9% improvement, for desktop app AvaloniaILSpy it's around 1% only (faster).
OSR methods are quite rare, e.g. in the SNR service it's 60 methods out of 200k but even just one slow loop is enough to affect the overall performance. Since they're rare jit won't spend a lot of time jitting OSR versions.