### PR TITLE
Fix globalization test on Mono

### DIFF
--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -45,7 +45,7 @@ namespace System.Globalization.Tests
 
                 // Now call globalization API to ensure the binding working without any problem.
                 Assert.Equal(-1, ci.CompareInfo.Compare("sample\u0000", "Sample\u0000", CompareOptions.IgnoreSymbols));
-            }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
+            }, new RemoteInvokeOptions { CheckExitCode = false, StartInfo = psi }).Dispose();
         }
     }
 }

--- a/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
+++ b/src/libraries/System.Globalization/tests/IcuAppLocal/IcuAppLocal.cs
@@ -31,6 +31,9 @@ namespace System.Globalization.Tests
 
             RemoteExecutor.Invoke(() =>
             {
+                // Start with calling Globalization to force the initialization.
+                CultureInfo ci = CultureInfo.GetCultureInfo("en-US");
+
                 Type? interopGlobalization = Type.GetType("Interop+Globalization, System.Private.CoreLib");
                 Assert.NotNull(interopGlobalization);
 
@@ -41,7 +44,7 @@ namespace System.Globalization.Tests
                 Assert.Equal(0x44020009, (int)methodInfo.Invoke(null, null));
 
                 // Now call globalization API to ensure the binding working without any problem.
-                Assert.Equal(-1, CultureInfo.GetCultureInfo("en-US").CompareInfo.Compare("sample\u0000", "Sample\u0000", CompareOptions.IgnoreSymbols));
+                Assert.Equal(-1, ci.CompareInfo.Compare("sample\u0000", "Sample\u0000", CompareOptions.IgnoreSymbols));
             }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77485

Modify the test a little to force initializing the globalization stack before testing.