### PR TITLE
Update `lvaEnregMultiRegVars` and `lvaEnregEHVars` when switching to MinOpts

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3848,6 +3848,9 @@ _SetMinOpts:
     {
         opts.compFlags &= ~CLFLG_MAXOPT;
         opts.compFlags |= CLFLG_MINOPT;
+
+        lvaEnregEHVars &= compEnregLocals();
+        lvaEnregMultiRegVars &= compEnregLocals();
     }
 
     if (!compIsForInlining())


### PR DESCRIPTION
Should fix [stress failures](https://github.com/dotnet/runtime/pull/77238#issuecomment-1292398160) introduced by #76263.

Side note: not sure how much value does `lvaEnregMultiRegVars` offer - I've never used it personally, has anyone else?