### PR TITLE
SPMI: Extend list of unrecorded environment variables

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
@@ -26,26 +26,75 @@ JitHost* g_ourJitHost;
 // in the method context.
 bool RecordVariable(const WCHAR* key)
 {
-    // Special-case: we don't want to store some DOTNET variables during
-    // collections that we don't want to see on replay:
-    //   DOTNET_JitName -- used to get the VM to load the SuperPMI collection shim
-    //                      without requiring the shim to overwrite the original JIT.
-    //                      This JIT doesn't care about this on SuperPMI replay, but
-    //                      we don't need to waste the space in the MC file storing it.
-    //   DOTNET_AltJitName -- if collecting with an altjit, this is set. The JIT doesn't
-    //                      use this on replay, but it doesn't need to be stored.
-    //   DOTNET_EnableExtraSuperPmiQueries -- used to force the JIT to ask additional
-    //                      questions during SuperPMI collection. We don't want to store
-    //                      this variable because we don't want to replay using it.
+    // Special cases: we don't want to store some DOTNET variables during
+    // collections, typically when they refer to file paths or simply because
+    // it does not make sense to replay with it.
 
-    if ((_wcsicmp(key, W("JitName")) == 0) ||
-        (_wcsicmp(key, W("AltJitName")) == 0) ||
-        (_wcsicmp(key, W("EnableExtraSuperPmiQueries")) == 0))
+    static const WCHAR* s_ignoredVars[] = {
+        W("EnableExtraSuperPmiQueries"),
+        W("JitDisasm"),
+        W("JitDump"),
+        W("JitDasmWithAlignmentBoundaries"),
+        W("JitDumpASCII"),
+        W("JitHashBreak"),
+        W("JitHashDump"),
+        W("JitHashHalt"),
+        W("JitOrder"),
+        W("JitPrintInlinedMethods"),
+        W("JitPrintDevirtualizedMethods"),
+        W("JitBreak"),
+        W("JitDebugBreak"),
+        W("JitDisasmAssemblies"),
+        W("JitDisasmWithGC"),
+        W("JitDisasmWithDebugInfo"),
+        W("JitDisasmSpilled"),
+        W("JitDumpTier0"),
+        W("JitDumpAtOSROffset"),
+        W("JitDumpInlinePhases"),
+        W("JitEHDump"),
+        W("JitExclude"),
+        W("JitGCDump"),
+        W("JitDebugDump"),
+        W("JitHalt"),
+        W("JitImportBreak"),
+        W("JitInclude"),
+        W("JitLateDisasm"),
+        W("JitUnwindDump"),
+        W("JitDumpFg"),
+        W("JitDumpFgDir"),
+        W("JitDumpFgPhase"),
+        W("JitDumpFgPrePhase"),
+        W("JitDumpFgDot"),
+        W("JitDumpFgEH"),
+        W("JitDumpFgLoops"),
+        W("JitDumpFgConstrained"),
+        W("JitDumpFgBlockID"),
+        W("JitDumpFgBlockFlags"),
+        W("JitDumpFgLoopFlags"),
+        W("JitDumpFgBlockOrder"),
+        W("JITLateDisasmTo"),
+        W("JitDisasmSummary"),
+        W("JitStdOutFile"),
+        W("WriteRichDebugInfoFile"),
+        W("JitFuncInfoLogFile"),
+        W("JitTimeLogCsv"),
+        W("JitMeasureNowayAssertFile"),
+        W("JitInlineDumpData"),
+        W("JitInlineDumpXml"),
+        W("JitInlineDumpXmlFile"),
+        W("JitInlinePolicyDumpXml"),
+        W("JitInlineReplayFile"),
+        W("JitFunctionFile")
+    };
+
+    for (const WCHAR* ignoredVar : s_ignoredVars)
     {
-        return false;
+        if (_wcsicmp(key, ignoredVar) == 0)
+        {
+            return false;
+        }
     }
 
-    // By default, we record everything.
     return true;
 }
 


### PR DESCRIPTION
We are currently hitting issues when there are diffs in the FileCheck tests because they are recorded with JitStdOutFile and the SPMI driver does not override this correctly. Add this and a lot of other environment variables to the list of variables we do not record.

This big list of string compares may look somewhat scary but we only query the config once during startup of the JIT, so it isn't a problem. I was not able to measure anything significant when collecting a simple "Hello, world!" C# app.

For this list I simply went through the variables and added the ones I don't think it makes sense to record into the collection. Let me know if any of them seem unreasonable.