### PR TITLE
[release/6.0] Define __cpuid{ex} only when there's no builtin one (backport of #73065)

### DIFF
--- a/eng/common/native/find-native-compiler.sh
+++ b/eng/common/native/find-native-compiler.sh
@@ -55,7 +55,7 @@ if [ -z "$CLR_CC" ]; then
     # Set default versions
     if [ -z "$majorVersion" ]; then
         # note: gcc (all versions) and clang versions higher than 6 do not have minor version in file name, if it is zero.
-        if [ "$compiler" = "clang" ]; then versions=( 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
+        if [[ "$compiler" == "clang" ]]; then versions=( 15 14 13 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
         elif [ "$compiler" = "gcc" ]; then versions=( 9 8 7 6 5 4.9 ); fi
 
         for version in "${versions[@]}"; do

--- a/src/coreclr/gc/env/gcenv.base.h
+++ b/src/coreclr/gc/env/gcenv.base.h
@@ -43,6 +43,10 @@
 #define SSIZE_T_MAX ((ptrdiff_t)(SIZE_T_MAX / 2))
 #endif
 
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 #ifndef _INC_WINDOWS
 // -----------------------------------------------------------------------------------------------------------
 //
@@ -191,26 +195,15 @@ typedef DWORD (WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
  #endif
 #else // _MSC_VER
 
-#ifdef __llvm__
-#define HAS_IA32_PAUSE __has_builtin(__builtin_ia32_pause)
-#define HAS_IA32_MFENCE __has_builtin(__builtin_ia32_mfence)
-#else
-#define HAS_IA32_PAUSE 0
-#define HAS_IA32_MFENCE 0
-#endif
-
-// Only clang defines __has_builtin, so we first test for a GCC define
-// before using __has_builtin.
-
 #if defined(__i386__) || defined(__x86_64__)
 
-#if (__GNUC__ > 4 && __GNUC_MINOR > 7) || HAS_IA32_PAUSE
+#if __has_builtin(__builtin_ia32_pause)
  // clang added this intrinsic in 3.8
  // gcc added this intrinsic by 4.7.1
  #define YieldProcessor __builtin_ia32_pause
 #endif // __has_builtin(__builtin_ia32_pause)
 
-#if defined(__GNUC__) || HAS_IA32_MFENCE
+#if __has_builtin(__builtin_ia32_mfence)
  // clang has had this intrinsic since at least 3.0
  // gcc has had this intrinsic since forever
  #define MemoryBarrier __builtin_ia32_mfence

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -575,12 +575,6 @@ void GCToOSInterface::FlushProcessWriteBuffers()
 // otherwise raises a SIGTRAP.
 void GCToOSInterface::DebugBreak()
 {
-    // __has_builtin is only defined by clang. GCC doesn't have a debug
-    // trap intrinsic anyway.
-#ifndef __has_builtin
- #define __has_builtin(x) 0
-#endif // __has_builtin
-
 #if __has_builtin(__builtin_debugtrap)
     __builtin_debugtrap();
 #else

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -4092,15 +4092,11 @@ inline WCHAR *PAL_wcsstr(WCHAR* S, const WCHAR* P)
 }
 #endif
 
-#if defined(__llvm__)
-#define HAS_ROTL __has_builtin(_rotl)
-#define HAS_ROTR __has_builtin(_rotr)
-#else
-#define HAS_ROTL 0
-#define HAS_ROTR 0
+#ifndef __has_builtin
+#define __has_builtin(x) 0
 #endif
 
-#if !HAS_ROTL
+#if !__has_builtin(_rotl)
 /*++
 Function:
 _rotl
@@ -4118,14 +4114,14 @@ unsigned int __cdecl _rotl(unsigned int value, int shift)
     retval = (value << shift) | (value >> (sizeof(int) * CHAR_BIT - shift));
     return retval;
 }
-#endif // !HAS_ROTL
+#endif // !__has_builtin(_rotl)
 
 // On 64 bit unix, make the long an int.
 #ifdef HOST_64BIT
 #define _lrotl _rotl
-#endif // HOST_64BIT
+#endif
 
-#if !HAS_ROTR
+#if !__has_builtin(_rotr)
 
 /*++
 Function:
@@ -4145,7 +4141,7 @@ unsigned int __cdecl _rotr(unsigned int value, int shift)
     return retval;
 }
 
-#endif // !HAS_ROTR
+#endif // !__has_builtin(_rotr)
 
 PALIMPORT int __cdecl abs(int);
 // clang complains if this is declared with __int64

--- a/src/coreclr/vm/amd64/unixstubs.cpp
+++ b/src/coreclr/vm/amd64/unixstubs.cpp
@@ -10,6 +10,7 @@ extern "C"
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
+#if !__has_builtin(__cpuid)
     void __cpuid(int cpuInfo[4], int function_id)
     {
         // Based on the Clang implementation provided in cpuid.h:
@@ -20,7 +21,9 @@ extern "C"
             : "0"(function_id)
         );
     }
+#endif
 
+#if !__has_builtin(__cpuidex)
     void __cpuidex(int cpuInfo[4], int function_id, int subFunction_id)
     {
         // Based on the Clang implementation provided in cpuid.h:
@@ -31,6 +34,7 @@ extern "C"
             : "0"(function_id), "2"(subFunction_id)
         );
     }
+#endif
 
     DWORD xmmYmmStateSupport()
     {


### PR DESCRIPTION
# Customer impact
Without this, build with clang15 fails.

# Testing
* unit tests in ci
* source-build build within Alpine environment passes

# Risk
Low, as it is already in `main`, and only activates when these variables aren't defined

---

Backport of #73065 and #73905

Per @am11:
```
Fix clang 15 RC1 build: error: definition of builtin function '__cpuid'.
Also add clang 15 autodetection; upstream PR https://github.com/dotnet/arcade/pull/10199.
```
```
* gcc < v10 does not define the __has_builtin macro which I missed in unixstubs.cpp when making the previous change: https://github.com/dotnet/runtime/commit/992cf8c97cc71d4ca9a0a11e6604a6716ed4cefc. Some community legs like illumos use gcc v8.4 which were failing.
* gcc v10+ supports __has_builtin macro which was being skipped due to version based conditions and we were forcing the fallback code path.
This PR moves __has_builtin macro check in two root headers which cover all the sources that are using it (pal.h and gcenv.base.h)
```
