### PR TITLE
[release/6.0] source-build: support building runtime using non-portable runtime packages (backport of #75597)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,6 +11,21 @@
   <Import Project="$(RepositoryEngineeringDir)liveBuilds.targets" />
   <Import Project="$(RepositoryEngineeringDir)python.targets" />
 
+  <!--
+  When .NET gets built from source, make the SDK aware there are bootstrap packages
+  for Microsoft.NETCore.App.Runtime.<rid> and Microsoft.NETCore.App.Crossgen2.<rid>.
+  -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))">
+      <RuntimePackRuntimeIdentifiers>$(PackageRID)</RuntimePackRuntimeIdentifiers>
+    </KnownFrameworkReference>
+    <KnownCrossgen2Pack Update="@(KnownCrossgen2Pack->WithMetadataValue('Identity', 'Microsoft.NETCore.App.Crossgen2')->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))">
+      <Crossgen2RuntimeIdentifiers>$(PackageRID)</Crossgen2RuntimeIdentifiers>
+    </KnownCrossgen2Pack>
+    <!-- Avoid references to Microsoft.AspNetCore.App.Runtime.<rid> -->
+    <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!--
       Define this here (not just in Versions.props) because the SDK resets it


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/75597

Per @tmds
```
Currently source-build performs a 'runtime-portable' build that produces 'linux-{arch}' packages that are used when building target runtime (non-portable).

With this change, we can use the non-portable packages that are produced by a previous (non-portable) 'runtime' build. This helps eliminate the 'runtime-portable' build.
```
# Customer impact
For distro maintainers, this removes the need for providing portable runtime packages to build non-portable runtime, thus we do not need to build runtime twice. This reduces our build time significantly.

# Testing
* unit tests in ci
* source-build build within Alpine environment passes
* Installer backport: https://github.com/dotnet/installer/pull/14816

# Risk
Low, as it is already in `main`, and only activates when `DotNetBuildFromSource=true`