### PR TITLE
[release/6.0] Use generated runtime.json when building shared framework packages (backport of #76068)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -253,7 +253,6 @@
     <PackageProjectUrl>https://dot.net</PackageProjectUrl>
     <Owners>microsoft,dotnetframework</Owners>
     <IncludeSymbols>true</IncludeSymbols>
-    <RuntimeIdGraphDefinitionFile>$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</RuntimeIdGraphDefinitionFile>
     <LicenseFile>$(MSBuildThisFileDirectory)LICENSE.TXT</LicenseFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -193,6 +193,8 @@
   </Target>
 
   <PropertyGroup>
-    <BundledRuntimeIdentifierGraphFile>$(RuntimeIdGraphDefinitionFile)</BundledRuntimeIdentifierGraphFile>
+    <!-- Keep in sync with outputs defined in Microsoft.NETCore.Platforms.csproj. -->
+    <BundledRuntimeIdentifierGraphFile>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.NETCore.Platforms', 'runtime.json'))</BundledRuntimeIdentifierGraphFile>
+    <BundledRuntimeIdentifierGraphFile Condition="!Exists('$(BundledRuntimeIdentifierGraphFile)')">$([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'Microsoft.NETCore.Platforms', 'src', 'runtime.json'))</BundledRuntimeIdentifierGraphFile>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <Content Condition="'$(AdditionalRuntimeIdentifiers)' == ''" Include="runtime.json" PackagePath="/" />
-    <Content Condition="'$(AdditionalRuntimeIdentifiers)' != ''" Include="$(IntermediateOutputPath)runtime.json" PackagePath="/" />
+    <Content Condition="'$(AdditionalRuntimeIdentifiers)' != ''" Include="$(BaseOutputPath)runtime.json" PackagePath="/" />
     <Content Include="$(PlaceholderFile)" PackagePath="lib/netstandard1.0" />
   </ItemGroup>
 
@@ -50,12 +50,12 @@
     <PackageReference Include="NuGet.ProjectModel" Version="$(NugetProjectModelVersion)" />
   </ItemGroup>
 
-  <Target Name="GenerateRuntimeJson" Condition="'$(AdditionalRuntimeIdentifiers)' != ''" BeforeTargets="GenerateNuspec">
+  <Target Name="GenerateRuntimeJson" AfterTargets="Build" Condition="'$(AdditionalRuntimeIdentifiers)' != ''">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
                           AdditionalRuntimeIdentifiers="$(AdditionalRuntimeIdentifiers)"
                           AdditionalRuntimeIdentifierParent="$(AdditionalRuntimeIdentifierParent)"
-                          RuntimeJson="$(IntermediateOutputPath)runtime.json"
+                          RuntimeJson="$(BaseOutputPath)runtime.json"
                           UpdateRuntimeFiles="True" />
   </Target>
 

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -92,7 +92,7 @@
           Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
     <!-- Shared framework deps file generation. Produces a test shared-framework deps file. -->
     <GenerateTestSharedFrameworkDepsFile SharedFrameworkDirectory="$(NetCoreAppCurrentTestHostSharedFrameworkPath)"
-                                         RuntimeGraphFiles="$(RuntimeIdGraphDefinitionFile)"
+                                         RuntimeGraphFiles="$(BundledRuntimeIdentifierGraphFile)"
                                          TargetRuntimeIdentifier="$(PackageRID)" />
   </Target>
 


### PR DESCRIPTION
Backport of #76068

Per @tmds
```
Fixes https://github.com/dotnet/runtime/issues/53550
Based on https://github.com/dotnet/runtime/pull/69455

With this change, when I build:

./build.sh /p:DotnetBuildFromSource=true /p:AdditionalRuntimeIdentifiers=fedora.45-x64
The new rid shows up in the packages:

artifacts/obj/Microsoft.NETCore.App.Bundle/Debug/net7.0/linux-x64/output/shared/Microsoft.NETCore.App/8.0.0-dev/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Composite.Bundle/Debug/net7.0/linux-x64/output/shared/Microsoft.NETCore.App/8.0.0-dev/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Runtime.Composite/Debug/net7.0/linux-x64/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Runtime.Composite/Debug/net7.0/linux-x64/output/shared/Microsoft.NETCore.App/8.0.0-dev/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Runtime/Debug/net7.0/linux-x64/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/obj/Microsoft.NETCore.App.Runtime/Debug/net7.0/linux-x64/output/shared/Microsoft.NETCore.App/8.0.0-dev/Microsoft.NETCore.App.deps.json:    "fedora.45-x64": [
artifacts/bin/Microsoft.NETCore.Platforms/Debug/runtime.json:    "fedora.45-x64": {
```
# Customer impact
Allows for proper fllow of additional runtime identifiers, allowing builds on yet-to-be-introduced RIDs to pass

# Testing
* unit tests in ci
* source-build build within Alpine environment passes
* Installer backport: https://github.com/dotnet/installer/pull/14816

# Risk
Low, as it is more relevant to source-build