### PR TITLE
Optimize (WasmRoot|WasmExternalRoot).clear

### DIFF
--- a/src/mono/wasm/runtime/roots.ts
+++ b/src/mono/wasm/runtime/roots.ts
@@ -288,9 +288,7 @@ class WasmJsOwnedRoot<T extends MonoObject> implements WasmRoot<T> {
 
     set(value: T): T {
         if (value === <any>0) {
-            // Don't use .set since it involves a gc write barrier, and the write barrier
-            //  is unnecessary overhead for zeroing that shows up in profiles.
-            // The write barrier is only necessary when storing a managed pointer into
+            // The expensive write barrier is only necessary when storing a managed pointer into
             //  a root because doing that changes its reachability/liveness
             const address32 = this.__buffer.get_address_32(this.__index);
             Module.HEAPU32[address32] = 0;
@@ -391,9 +389,7 @@ class WasmExternalRoot<T extends MonoObject> implements WasmRoot<T> {
 
     set(value: T): T {
         if (value === <any>0) {
-            // Don't use .set since it involves a gc write barrier, and the write barrier
-            //  is unnecessary overhead for zeroing that shows up in profiles.
-            // The write barrier is only necessary when storing a managed pointer into
+            // The expensive write barrier is only necessary when storing a managed pointer into
             //  a root because doing that changes its reachability/liveness
             Module.HEAPU32[<any>this.__external_address >>> 2] = 0;
         } else {


### PR DESCRIPTION
This PR optimizes the wasm root `clear` and `set` methods to not use a write barrier when zeroing a root, because the write barrier is expensive and not really necessary. The downside is this could cause an object to live slightly too long in some cases, but we call `clear` a LOT for correctness so the cost has a significant impact on interop speed, at least according to browser-bench.

Before:
| measurement | time |
|-:|-:|
|             JSInterop, LegacyExportInt |     6.9038ms |
|          JSInterop, LegacyExportString |    33.4786ms |
|                 JSInterop, JSExportInt |     3.5533ms |
|              JSInterop, JSExportString |    31.2959ms |

After:
| measurement | time |
|-:|-:|
|             JSInterop, LegacyExportInt |     6.1863ms |
|          JSInterop, LegacyExportString |    30.1000ms |
|                 JSInterop, JSExportInt |     3.6297ms |
|              JSInterop, JSExportString |    28.9896ms |

This optimization improves the legacy export performance since we use a root to store the return value. String stuff uses roots too, as do some of the other JS wrappers and such.

Note that these tests have significant timing variance from run to run because they spend a lot of time in the JS and C# garbage collectors (mostly due to the string allocations)