### PR TITLE
Workaround for msbuild issue in host tests

### DIFF
--- a/src/installer/tests/TestUtils/DotNetCli.cs
+++ b/src/installer/tests/TestUtils/DotNetCli.cs
@@ -53,6 +53,7 @@ namespace Microsoft.DotNet.Cli.Build
             newArgs.Insert(0, command);
 
             return Command.Create(DotnetExecutablePath, newArgs)
+                .EnvironmentVariable("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER", "1") // https://github.com/dotnet/runtime/issues/74328
                 .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1")
                 .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0"); // Avoid looking at machine state by default
         }


### PR DESCRIPTION
Attempt to workaround https://github.com/dotnet/runtime/issues/74328 and https://github.com/dotnet/runtime/issues/75429 in host tests.

This is the same workaround added for wasm tests in https://github.com/dotnet/runtime/pull/75743