### PR TITLE
[Release/7.0] Issue ICorProfiler ModuleLoadFinished callbacks for dynamic modules

### DIFF
--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -810,6 +810,14 @@ void DomainAssembly::DeliverSyncEvents()
 
     GetModule()->NotifyEtwLoadFinished(S_OK);
 
+#ifdef PROFILING_SUPPORTED
+    if (!IsProfilerNotified())
+    {
+        SetProfilerNotified();
+        GetModule()->NotifyProfilerLoadFinished(S_OK);
+    }
+#endif
+
 #ifdef DEBUGGING_SUPPORTED
     GCX_COOP();
     if (!IsDebuggerNotified())


### PR DESCRIPTION
Backport of #77068 to release/7.0

## Customer Impact
In 7.0 we introduced a regression where we do not issue ModuleLoadFinished callbacks for dynamic modules. ModuleLoadFinished is the opportunity for profilers to change metadata/IL in the target assembly. We have a customer reporting this as blocking in #76016

## Testing
Customer tested that the scenario is fixed with a private build

## Risk
Low, the fix is targeted and very few lines of code