### PR TITLE
unify error handling for FileStream and Pipe Streams

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/libraries/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
-    <Compile Include="UnifiedErrorHandlingTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">
@@ -23,6 +22,7 @@
     <Compile Include="NamedPipeTests\NamedPipeTest.Specific.cs" />
     <Compile Include="PipeStream.ProtectedMethods.Tests.cs" />
     <Compile Include="PipeStreamConformanceTests.cs" />
+    <Compile Include="UnifiedErrorHandlingTests.cs" />
     <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs" Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">

--- a/src/libraries/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
+++ b/src/libraries/System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="UnifiedErrorHandlingTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != ''">

--- a/src/libraries/System.IO.Pipes/tests/UnifiedErrorHandlingTests.cs
+++ b/src/libraries/System.IO.Pipes/tests/UnifiedErrorHandlingTests.cs
@@ -10,49 +10,49 @@ namespace System.IO.Pipes.Tests
     public static class UnifiedErrorHandlingTests
     {
         [Fact]
-        public static void WhenAnonymousPipeServerIsClosedAnonymousPipeClientReadReturnsZero()
+        public static void When_AnonymousPipeServer_IsClosed_AnonymousPipeClient_ReadReturnsZero()
             => DiposeServerAndVerifyClientBehaviour(
                     GetAnonymousPipeStreams(PipeDirection.Out, PipeDirection.In),
                     AssertZeroByteRead);
 
         [Fact]
-        public static void WhenAnonymousPipeServerIsClosedFileStreamClientReadReturnsZero()
+        public static void When_AnonymousPipeServer_IsClosed_FileStreamClient_ReadReturnsZero()
             => DiposeServerAndVerifyClientBehaviour(
                     GetAnonymousPipeServerAndFileStreamClient(PipeDirection.Out, FileAccess.Read),
                     AssertZeroByteRead);
 
         [Fact]
-        public static void WhenAnonymousPipeServerIsClosedAnonymousPipeClientWriteThrows()
+        public static void When_AnonymousPipeServer_IsClosed_AnonymousPipeClient_WriteThrows()
             => DiposeServerAndVerifyClientBehaviour(
                     GetAnonymousPipeStreams(PipeDirection.In, PipeDirection.Out),
                     AssertWriteThrows);
 
         [Fact]
-        public static void WhenAnonymousPipeServerIsClosedFileStreamClientWriteThrows()
+        public static void When_AnonymousPipeServer_IsClosed_FileStreamClient_WriteThrows()
             => DiposeServerAndVerifyClientBehaviour(
                     GetAnonymousPipeServerAndFileStreamClient(PipeDirection.In, FileAccess.Write),
                     AssertWriteThrows);
 
         [Fact]
-        public static Task WhenAnonymousPipeServerIsClosedAnonymousPipeClientReadAsyncReturnsZero()
+        public static Task When_AnonymousPipeServer_IsClosed_AnonymousPipeClient_ReadAsyncReturnsZero()
             => DiposeServerAndVerifyClientBehaviourAsync(
                     GetAnonymousPipeStreams(PipeDirection.Out, PipeDirection.In),
                     AssertZeroByteReadAsync);
 
         [Fact]
-        public static Task WhenAnonymousPipeServerIsClosedFileStreamClientReadAsyncReturnsZero()
+        public static Task When_AnonymousPipeServer_IsClosed_FileStreamClient_ReadAsyncReturnsZero()
             => DiposeServerAndVerifyClientBehaviourAsync(
                     GetAnonymousPipeServerAndFileStreamClient(PipeDirection.Out, FileAccess.Read),
                     AssertZeroByteReadAsync);
 
         [Fact]
-        public static Task WhenAnonymousPipeServerIsClosedAnonymousPipeClientWriteAsyncThrows()
+        public static Task When_AnonymousPipeServer_IsClosed_AnonymousPipeClient_WriteAsyncThrows()
             => DiposeServerAndVerifyClientBehaviourAsync(
                     GetAnonymousPipeStreams(PipeDirection.In, PipeDirection.Out),
                     AssertWriteAsyncThrows);
 
         [Fact]
-        public static Task WhenAnonymousPipeServerIsClosedFileStreamClientWriteAsyncThrows()
+        public static Task When_AnonymousPipeServer_IsClosed_FileStreamClient_WriteAsyncThrows()
             => DiposeServerAndVerifyClientBehaviourAsync(
                     GetAnonymousPipeServerAndFileStreamClient(PipeDirection.In, FileAccess.Write),
                     AssertWriteAsyncThrows);
@@ -62,7 +62,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
-        public static async Task WhenNamedPipeServerIsClosedNamedPipeClientReadReturnsZero(bool asyncHandles)
+        public static async Task When_NamedPipeServer_IsClosed_NamedPipeClient_ReadReturnsZero(bool asyncHandles)
             => DiposeServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In),
                     AssertZeroByteRead);
@@ -70,8 +70,9 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static async Task WhenNamedPipeServerIsClosedFileStreamClientReadReturnsZero(bool asyncHandles)
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public static async Task When_NamedPipeServer_IsClosed_FileStreamClient_ReadReturnsZero(bool asyncHandles)
             => DiposeServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.Out, FileAccess.Read),
                     AssertZeroByteRead);
@@ -81,7 +82,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
-        public static async Task WhenNamedPipeServerIsClosedNamedPipeClientWriteThrows(bool asyncHandles)
+        public static async Task When_NamedPipeServer_IsClosed_NamedPipeClient_WriteThrows(bool asyncHandles)
             => DiposeServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.In, PipeDirection.Out),
                     AssertWriteThrows);
@@ -89,8 +90,9 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static async Task WhenNamedPipeServerIsClosedFileStreamClientWriteThrows(bool asyncHandles)
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public static async Task When_NamedPipeServer_IsClosed_FileStreamClient_WriteThrows(bool asyncHandles)
             => DiposeServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.In, FileAccess.Write),
                     AssertWriteThrows);
@@ -100,7 +102,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
-        public static async Task WhenNamedPipeServerIsClosedNamedPipeClientReadAsyncReturnsZero(bool asyncHandles)
+        public static async Task When_NamedPipeServer_IsClosed_NamedPipeClient_ReadAsyncReturnsZero(bool asyncHandles)
             => await DiposeServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In),
                     AssertZeroByteReadAsync);
@@ -108,8 +110,9 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static async Task WhenNamedPipeServerIsClosedFileStreamClientReadAsyncReturnsZero(bool asyncHandles)
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public static async Task When_NamedPipeServer_IsClosed_FileStreamClient_ReadAsyncReturnsZero(bool asyncHandles)
             => await DiposeServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.Out, FileAccess.Read),
                     AssertZeroByteReadAsync);
@@ -119,7 +122,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
-        public static async Task WhenNamedPipeServerIsClosedNamedPipeClientWriteAsyncThrows(bool asyncHandles)
+        public static async Task When_NamedPipeServer_IsClosed_NamedPipeClient_WriteAsyncThrows(bool asyncHandles)
             => await DiposeServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.In, PipeDirection.Out),
                     AssertWriteAsyncThrows);
@@ -127,8 +130,9 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static async Task WhenNamedPipeServerIsClosedFileStreamClientWriteAsyncThrows(bool asyncHandles)
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public static async Task When_NamedPipeServer_IsClosed_FileStreamClient_WriteAsyncThrows(bool asyncHandles)
             => await DiposeServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.In, FileAccess.Write),
                     AssertWriteAsyncThrows);
@@ -138,7 +142,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
-        public static async Task WhenNamedPipeServerDisconnectsNamedPipeClientReadReturnsZero(bool asyncHandles)
+        public static async Task When_NamedPipeServerDisconnectsNamedPipeClient_ReadReturnsZero(bool asyncHandles)
             => DisconnectServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In),
                     AssertZeroByteRead);
@@ -146,8 +150,9 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static async Task WhenNamedPipeServerDisconnectsFileStreamClientReadReturnsZero(bool asyncHandles)
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public static async Task When_NamedPipeServerDisconnectsFileStreamClient_ReadReturnsZero(bool asyncHandles)
             => DisconnectServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.Out, FileAccess.Read),
                     AssertZeroByteRead);
@@ -157,7 +162,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
-        public static async Task WhenNamedPipeServerDisconnectsNamedPipeClientWriteThrows(bool asyncHandles)
+        public static async Task When_NamedPipeServerDisconnectsNamedPipeClient_WriteThrows(bool asyncHandles)
             => DisconnectServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.In, PipeDirection.Out),
                     AssertWriteThrows);
@@ -165,8 +170,9 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static async Task WhenNamedPipeServerDisconnectsFileStreamClientWriteThrows(bool asyncHandles)
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public static async Task When_NamedPipeServerDisconnectsFileStreamClient_WriteThrows(bool asyncHandles)
             => DisconnectServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.In, FileAccess.Write),
                     AssertWriteThrows);
@@ -176,7 +182,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
-        public static async Task WhenNamedPipeServerDisconnectsNamedPipeClientReadAsyncReturnsZero(bool asyncHandles)
+        public static async Task When_NamedPipeServerDisconnectsNamedPipeClient_ReadAsyncReturnsZero(bool asyncHandles)
             => await DisconnectServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In),
                     AssertZeroByteReadAsync);
@@ -184,8 +190,9 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static async Task WhenNamedPipeServerDisconnectsFileStreamClientReadAsyncReturnsZero(bool asyncHandles)
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public static async Task When_NamedPipeServerDisconnectsFileStreamClient_ReadAsyncReturnsZero(bool asyncHandles)
             => await DisconnectServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.Out, FileAccess.Read),
                     AssertZeroByteReadAsync);
@@ -195,7 +202,7 @@ namespace System.IO.Pipes.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
-        public static async Task WhenNamedPipeServerDisconnectsNamedPipeClientWriteAsyncThrows(bool asyncHandles)
+        public static async Task When_NamedPipeServerDisconnectsNamedPipeClient_WriteAsyncThrows(bool asyncHandles)
             => await DisconnectServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.In, PipeDirection.Out),
                     AssertWriteAsyncThrows);
@@ -203,8 +210,9 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static async Task WhenNamedPipeServerDisconnectsFileStreamClientWriteAsyncThrows(bool asyncHandles)
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public static async Task When_NamedPipeServerDisconnectsFileStreamClient_WriteAsyncThrows(bool asyncHandles)
             => await DisconnectServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.In, FileAccess.Write),
                     AssertWriteAsyncThrows);
@@ -213,14 +221,14 @@ namespace System.IO.Pipes.Tests
         [InlineData(true)]
         [InlineData(false)]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public static Task WhenNamedPipeServerIsClosedCopyToAsyncJustFinishesWithoutThrowing(bool asyncHandles)
+        public static Task When_NamedPipeServer_IsClosed_CopyToAsyncJustFinishesWithoutThrowing(bool asyncHandles)
             => TestCopyToAsync(asyncHandles, dispose: true);
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public static Task WhenNamedPipeServerDisconnectsCopyToAsyncJustFinishesWithoutThrowing(bool asyncHandles)
+        public static Task When_NamedPipeServerDisconnectsCopyToAsyncJustFinishesWithoutThrowing(bool asyncHandles)
             => TestCopyToAsync(asyncHandles, dispose: false);
 
         private static async Task TestCopyToAsync(bool asyncHandles, bool dispose)
@@ -284,15 +292,31 @@ namespace System.IO.Pipes.Tests
         private static async Task<(NamedPipeServerStream server, FileStream client)> GetConnectedNamedPipeServerAndFileStreamClientStreams(
             bool asyncHandles, PipeDirection serverDirection, FileAccess clientAccess)
         {
-            PipeOptions pipeOptions = asyncHandles ? PipeOptions.Asynchronous : PipeOptions.None;
-            FileOptions fileOptions = asyncHandles ? FileOptions.Asynchronous : FileOptions.None;
-            string pipeName = PipeStreamConformanceTests.GetUniquePipeName();
-            NamedPipeServerStream server = new(pipeName, serverDirection, 1, PipeTransmissionMode.Byte, pipeOptions);
-            FileStream client = new($@"\\.\pipe\{pipeName}", FileMode.Open, clientAccess, FileShare.None, 0, fileOptions);
+            if (OperatingSystem.IsWindows())
+            {
+                PipeOptions pipeOptions = asyncHandles ? PipeOptions.Asynchronous : PipeOptions.None;
+                FileOptions fileOptions = asyncHandles ? FileOptions.Asynchronous : FileOptions.None;
+                string pipeName = PipeStreamConformanceTests.GetUniquePipeName();
+                NamedPipeServerStream server = new(pipeName, serverDirection, 1, PipeTransmissionMode.Byte, pipeOptions);
+                FileStream client = new($@"\\.\pipe\{pipeName}", FileMode.Open, clientAccess, FileShare.None, 0, fileOptions);
 
-            await server.WaitForConnectionAsync();
+                await server.WaitForConnectionAsync();
 
-            return (server, client);
+                return (server, client);
+            }
+            else
+            {
+                (NamedPipeServerStream server, NamedPipeClientStream namedPipeClient) = await GetConnectedNamedPipeStreams(
+                    asyncHandles, serverDirection, clientAccess == FileAccess.Read ? PipeDirection.In : PipeDirection.Out);
+
+                FileStream fileStreamClient = new(
+                    new SafeFileHandle(namedPipeClient.SafePipeHandle.DangerousGetHandle(), ownsHandle: true),
+                    clientAccess, bufferSize: 0, isAsync: false);
+
+                namedPipeClient.SafePipeHandle.SetHandleAsInvalid();
+
+                return (server, fileStreamClient);
+            }
         }
 
         private static void DiposeServerAndVerifyClientBehaviour((Stream server, Stream client) connectedStreams, Action<Stream> assertMethod)

--- a/src/libraries/System.IO.Pipes/tests/UnifiedErrorHandlingTests.cs
+++ b/src/libraries/System.IO.Pipes/tests/UnifiedErrorHandlingTests.cs
@@ -60,6 +60,8 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public static async Task WhenNamedPipeServerIsClosedNamedPipeClientReadReturnsZero(bool asyncHandles)
             => DiposeServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In),
@@ -77,6 +79,8 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public static async Task WhenNamedPipeServerIsClosedNamedPipeClientWriteThrows(bool asyncHandles)
             => DiposeServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.In, PipeDirection.Out),
@@ -94,6 +98,8 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public static async Task WhenNamedPipeServerIsClosedNamedPipeClientReadAsyncReturnsZero(bool asyncHandles)
             => await DiposeServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In),
@@ -111,6 +117,8 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public static async Task WhenNamedPipeServerIsClosedNamedPipeClientWriteAsyncThrows(bool asyncHandles)
             => await DiposeServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.In, PipeDirection.Out),
@@ -128,6 +136,8 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public static async Task WhenNamedPipeServerDisconnectsNamedPipeClientReadReturnsZero(bool asyncHandles)
             => DisconnectServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In),
@@ -145,6 +155,8 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public static async Task WhenNamedPipeServerDisconnectsNamedPipeClientWriteThrows(bool asyncHandles)
             => DisconnectServerAndVerifyClientBehaviour(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.In, PipeDirection.Out),
@@ -162,6 +174,8 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public static async Task WhenNamedPipeServerDisconnectsNamedPipeClientReadAsyncReturnsZero(bool asyncHandles)
             => await DisconnectServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In),
@@ -179,6 +193,8 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [SkipOnPlatform(TestPlatforms.LinuxBionic, "SElinux blocks UNIX sockets in our CI environment")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public static async Task WhenNamedPipeServerDisconnectsNamedPipeClientWriteAsyncThrows(bool asyncHandles)
             => await DisconnectServerAndVerifyClientBehaviourAsync(
                     await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.In, PipeDirection.Out),

--- a/src/libraries/System.IO.Pipes/tests/UnifiedErrorHandlingTests.cs
+++ b/src/libraries/System.IO.Pipes/tests/UnifiedErrorHandlingTests.cs
@@ -1,0 +1,227 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+
+namespace System.IO.Pipes.Tests
+{
+    public class UnifiedErrorHandlingTests
+    {
+        [Fact]
+        public async Task WhenAnonymousPipeServerIsClosedAnonymousPipeClientReadAsyncReturnsZero()
+        {
+            (AnonymousPipeServerStream server, AnonymousPipeClientStream client) = GetAnonymousPipeStreams(PipeDirection.Out, PipeDirection.In);
+
+            await server.DisposeAsync();
+
+            await AssertZeroByteReadAsync(client);
+        }
+
+        [Fact]
+        public async Task WhenAnonymousPipeServerIsClosedFileStreamClientReadAsyncReturnsZero()
+        {
+            (AnonymousPipeServerStream server, FileStream client) = GetAnonymousPipeServerAndFileStreamClient(PipeDirection.Out, FileAccess.Read);
+
+            await server.DisposeAsync();
+
+            await AssertZeroByteReadAsync(client);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WhenNamedPipeServerIsClosedNamedPipeClientReadAsyncReturnsZero(bool asyncHandles)
+        {
+            (NamedPipeServerStream server, NamedPipeClientStream client) = await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In);
+
+            await server.DisposeAsync();
+
+            await AssertZeroByteReadAsync(client);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [PlatformSpecific(TestPlatforms.Windows)] // OS-specific accessing named pipe via path
+        public async Task WhenNamedPipeServerIsClosedFileStreamClientReadAsyncReturnsZero(bool asyncHandles)
+        {
+            (NamedPipeServerStream server, FileStream client) = await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.Out, FileAccess.Read);
+
+            await server.DisposeAsync();
+
+            await AssertZeroByteReadAsync(client);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WhenNamedPipeServerDisconnectsNamedPipeClientReadAsyncReturnsZero(bool asyncHandles)
+        {
+            (NamedPipeServerStream server, NamedPipeClientStream client) = await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In);
+
+            using (server)
+            {
+                server.Disconnect();
+
+                await AssertZeroByteReadAsync(client);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [PlatformSpecific(TestPlatforms.Windows)] // OS-specific accessing named pipe via path
+        public async Task WhenNamedPipeServerDisconnectsFileStreamClientReadAsyncReturnsZero(bool asyncHandles)
+        {
+            (NamedPipeServerStream server, FileStream client) = await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.Out, FileAccess.Read);
+
+            using (server)
+            {
+                server.Disconnect();
+
+                await AssertZeroByteReadAsync(client);
+            }
+        }
+
+        [Fact]
+        public void WhenAnonymousPipeServerIsClosedAnonymousPipeClientReadReturnsZero()
+        {
+            (AnonymousPipeServerStream server, AnonymousPipeClientStream client) = GetAnonymousPipeStreams(PipeDirection.Out, PipeDirection.In);
+
+            server.Dispose();
+
+            AssertZeroByteRead(client);
+        }
+
+        [Fact]
+        public void WhenAnonymousPipeServerIsClosedFileStreamClientReadReturnsZero()
+        {
+            (AnonymousPipeServerStream server, FileStream client) = GetAnonymousPipeServerAndFileStreamClient(PipeDirection.Out, FileAccess.Read);
+
+            server.Dispose();
+
+            AssertZeroByteRead(client);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WhenNamedPipeServerIsClosedNamedPipeClientReadReturnsZero(bool asyncHandles)
+        {
+            (NamedPipeServerStream server, NamedPipeClientStream client) = await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In);
+
+            server.Dispose();
+
+            AssertZeroByteRead(client);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public async Task WhenNamedPipeServerIsClosedFileStreamClientReadReturnsZero(bool asyncHandles)
+        {
+            (NamedPipeServerStream server, FileStream client) = await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.Out, FileAccess.Read);
+
+            server.Dispose();
+
+            AssertZeroByteRead(client);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WhenNamedPipeServerDisconnectsNamedPipeClientReadReturnsZero(bool asyncHandles)
+        {
+            (NamedPipeServerStream server, NamedPipeClientStream client) = await GetConnectedNamedPipeStreams(asyncHandles, PipeDirection.Out, PipeDirection.In);
+
+            using (server)
+            {
+                server.Disconnect();
+
+                AssertZeroByteRead(client);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public async Task WhenNamedPipeServerDisconnectsFileStreamClientReadReturnsZero(bool asyncHandles)
+        {
+            (NamedPipeServerStream server, FileStream client) = await GetConnectedNamedPipeServerAndFileStreamClientStreams(asyncHandles, PipeDirection.Out, FileAccess.Read);
+
+            using (server)
+            {
+                server.Disconnect();
+
+                AssertZeroByteRead(client);
+            }
+        }
+
+        private static async Task AssertZeroByteReadAsync(Stream client)
+        {
+            using (client)
+            {
+                Assert.Equal(0, await client.ReadAsync(new byte[100]));
+                Assert.Equal(0, await client.ReadAsync(new byte[100], 0, 100));
+            }
+        }
+
+        private static void AssertZeroByteRead(Stream client)
+        {
+            using (client)
+            {
+                Assert.Equal(0, client.Read(new byte[100]));
+                Assert.Equal(0, client.Read(new byte[100], 0, 100));
+            }
+        }
+
+        private static async Task<(NamedPipeServerStream server, NamedPipeClientStream client)> GetConnectedNamedPipeStreams(
+            bool asyncHandles, PipeDirection serverDirection, PipeDirection clientDirection)
+        {
+            PipeOptions options = asyncHandles ? PipeOptions.Asynchronous : PipeOptions.None;
+            string pipeName = PipeStreamConformanceTests.GetUniquePipeName();
+            NamedPipeServerStream server = new(pipeName, serverDirection, 1, PipeTransmissionMode.Byte, options);
+            NamedPipeClientStream client = new(".", pipeName, clientDirection, options);
+
+            await Task.WhenAll(client.ConnectAsync(), server.WaitForConnectionAsync());
+
+            return (server, client);
+        }
+
+        private static async Task<(NamedPipeServerStream server, FileStream client)> GetConnectedNamedPipeServerAndFileStreamClientStreams(
+            bool asyncHandles, PipeDirection serverDirection, FileAccess clientAccess)
+        {
+            PipeOptions pipeOptions = asyncHandles ? PipeOptions.Asynchronous : PipeOptions.None;
+            FileOptions fileOptions = asyncHandles ? FileOptions.Asynchronous : FileOptions.None;
+            string pipeName = PipeStreamConformanceTests.GetUniquePipeName();
+            NamedPipeServerStream server = new(pipeName, serverDirection, 1, PipeTransmissionMode.Byte, pipeOptions);
+            FileStream client = new($@"\\.\pipe\{pipeName}", FileMode.Open, clientAccess, FileShare.None, 0, fileOptions);
+
+            await server.WaitForConnectionAsync();
+
+            return (server, client);
+        }
+
+        private static (AnonymousPipeServerStream server, AnonymousPipeClientStream client) GetAnonymousPipeStreams(
+            PipeDirection serverDirection, PipeDirection clientDirection)
+        {
+            AnonymousPipeServerStream server = new(serverDirection);
+            AnonymousPipeClientStream client = new(clientDirection, server.ClientSafePipeHandle);
+
+            return (server, client);
+        }
+
+        private static (AnonymousPipeServerStream server, FileStream client) GetAnonymousPipeServerAndFileStreamClient(
+            PipeDirection serverDirection, FileAccess clientAccess)
+        {
+            AnonymousPipeServerStream server = new(serverDirection);
+            FileStream client = new(new SafeFileHandle(nint.Parse(server.GetClientHandleAsString()), ownsHandle: true), clientAccess);
+
+            return (server, client);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
@@ -55,19 +55,15 @@ namespace System.IO
                 }
 
                 int errorCode = FileStreamHelpers.GetLastWin32ErrorAndDisposeHandleIfInvalid(handle);
-                switch (errorCode)
+                return errorCode switch
                 {
-                    case Interop.Errors.ERROR_HANDLE_EOF:
-                        // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile#synchronization-and-file-position :
-                        // "If lpOverlapped is not NULL, then when a synchronous read operation reaches the end of a file,
-                        // ReadFile returns FALSE and GetLastError returns ERROR_HANDLE_EOF"
-                        return numBytesRead;
-                    case Interop.Errors.ERROR_BROKEN_PIPE: // For pipes, ERROR_BROKEN_PIPE is the normal end of the pipe.
-                    case Interop.Errors.ERROR_INVALID_PARAMETER when IsEndOfFileForNoBuffering(handle, fileOffset):
-                        return 0;
-                    default:
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
-                }
+                    // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile#synchronization-and-file-position:
+                    // "If lpOverlapped is not NULL, then when a synchronous read operation reaches the end of a file,
+                    // ReadFile returns FALSE and GetLastError returns ERROR_HANDLE_EOF"
+                    Interop.Errors.ERROR_HANDLE_EOF => numBytesRead,
+                    _ when IsEndOfFile(errorCode, handle, fileOffset) => 0,
+                    _ => throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path)
+                };
             }
         }
 
@@ -113,20 +109,16 @@ namespace System.IO
                         resetEvent.ReleaseRefCount(overlapped);
                     }
 
-                    switch (errorCode)
+                    if (IsEndOfFile(errorCode, handle, fileOffset))
                     {
-                        case Interop.Errors.ERROR_HANDLE_EOF: // logically success with 0 bytes read (read at end of file)
-                        case Interop.Errors.ERROR_BROKEN_PIPE:
-                        case Interop.Errors.ERROR_INVALID_PARAMETER when IsEndOfFileForNoBuffering(handle, fileOffset):
-                            // EOF on a pipe. Callback will not be called.
-                            // We clear the overlapped status bit for this special case (failure
-                            // to do so looks like we are freeing a pending overlapped later).
-                            overlapped->InternalLow = IntPtr.Zero;
-                            return 0;
-
-                        default:
-                            throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
+                        // EOF on a pipe. Callback will not be called.
+                        // We clear the overlapped status bit for this special case (failure
+                        // to do so looks like we are freeing a pending overlapped later).
+                        overlapped->InternalLow = IntPtr.Zero;
+                        return 0;
                     }
+
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
                 }
             }
             finally
@@ -288,28 +280,27 @@ namespace System.IO
                 {
                     // The operation failed, or it's pending.
                     errorCode = FileStreamHelpers.GetLastWin32ErrorAndDisposeHandleIfInvalid(handle);
-                    switch (errorCode)
+
+                    if (errorCode == Interop.Errors.ERROR_IO_PENDING)
                     {
-                        case Interop.Errors.ERROR_IO_PENDING:
-                            // Common case: IO was initiated, completion will be handled by callback.
-                            // Register for cancellation now that the operation has been initiated.
-                            vts.RegisterForCancellation(cancellationToken);
-                            break;
-
-                        case Interop.Errors.ERROR_HANDLE_EOF: // logically success with 0 bytes read (read at end of file)
-                        case Interop.Errors.ERROR_BROKEN_PIPE:
-                        case Interop.Errors.ERROR_INVALID_PARAMETER when IsEndOfFileForNoBuffering(handle, fileOffset):
-                            // EOF on a pipe. Callback will not be called.
-                            // We clear the overlapped status bit for this special case (failure
-                            // to do so looks like we are freeing a pending overlapped later).
-                            nativeOverlapped->InternalLow = IntPtr.Zero;
-                            vts.Dispose();
-                            return (null, 0);
-
-                        default:
-                            // Error. Callback will not be called.
-                            vts.Dispose();
-                            return (null, errorCode);
+                        // Common case: IO was initiated, completion will be handled by callback.
+                        // Register for cancellation now that the operation has been initiated.
+                        vts.RegisterForCancellation(cancellationToken);
+                    }
+                    else if (IsEndOfFile(errorCode, handle, fileOffset))
+                    {
+                        // EOF on a pipe. Callback will not be called.
+                        // We clear the overlapped status bit for this special case (failure
+                        // to do so looks like we are freeing a pending overlapped later).
+                        nativeOverlapped->InternalLow = IntPtr.Zero;
+                        vts.Dispose();
+                        return (null, 0);
+                    }
+                    else
+                    {
+                        // Error. Callback will not be called.
+                        vts.Dispose();
+                        return (null, errorCode);
                     }
                 }
             }
@@ -587,27 +578,27 @@ namespace System.IO
                 {
                     // The operation failed, or it's pending.
                     int errorCode = FileStreamHelpers.GetLastWin32ErrorAndDisposeHandleIfInvalid(handle);
-                    switch (errorCode)
+
+                    if (errorCode == Interop.Errors.ERROR_IO_PENDING)
                     {
-                        case Interop.Errors.ERROR_IO_PENDING:
-                            // Common case: IO was initiated, completion will be handled by callback.
-                            // Register for cancellation now that the operation has been initiated.
-                            vts.RegisterForCancellation(cancellationToken);
-                            break;
-
-                        case Interop.Errors.ERROR_HANDLE_EOF: // logically success with 0 bytes read (read at end of file)
-                        case Interop.Errors.ERROR_BROKEN_PIPE:
-                            // EOF on a pipe. Callback will not be called.
-                            // We clear the overlapped status bit for this special case (failure
-                            // to do so looks like we are freeing a pending overlapped later).
-                            nativeOverlapped->InternalLow = IntPtr.Zero;
-                            vts.Dispose();
-                            return ValueTask.FromResult(0);
-
-                        default:
-                            // Error. Callback will not be called.
-                            vts.Dispose();
-                            return ValueTask.FromException<int>(Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path));
+                        // Common case: IO was initiated, completion will be handled by callback.
+                        // Register for cancellation now that the operation has been initiated.
+                        vts.RegisterForCancellation(cancellationToken);
+                    }
+                    else if (IsEndOfFile(errorCode, handle, fileOffset))
+                    {
+                        // EOF on a pipe. Callback will not be called.
+                        // We clear the overlapped status bit for this special case (failure
+                        // to do so looks like we are freeing a pending overlapped later).
+                        nativeOverlapped->InternalLow = IntPtr.Zero;
+                        vts.Dispose();
+                        return ValueTask.FromResult(0);
+                    }
+                    else
+                    {
+                        // Error. Callback will not be called.
+                        vts.Dispose();
+                        return ValueTask.FromException<int>(Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path));
                     }
                 }
             }
@@ -768,6 +759,20 @@ namespace System.IO
             {
                 CallbackResetEvent state = (CallbackResetEvent)ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped)!;
                 state.ReleaseRefCount(pOverlapped);
+            }
+        }
+
+        private static bool IsEndOfFile(int errorCode, SafeFileHandle handle, long fileOffset)
+        {
+            switch (errorCode)
+            {
+                case Interop.Errors.ERROR_HANDLE_EOF: // logically success with 0 bytes read (read at end of file)
+                case Interop.Errors.ERROR_BROKEN_PIPE: // For pipes, ERROR_BROKEN_PIPE is the normal end of the pipe.
+                case Interop.Errors.ERROR_PIPE_NOT_CONNECTED: // Named pipe server has disconnected, return 0 to match NamedPipeClientStream behaviour
+                case Interop.Errors.ERROR_INVALID_PARAMETER when IsEndOfFileForNoBuffering(handle, fileOffset):
+                    return true;
+                default:
+                    return false;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
@@ -747,7 +747,7 @@ namespace System.IO
             }
         }
 
-        private static bool IsEndOfFile(int errorCode, SafeFileHandle handle, long fileOffset)
+        internal static bool IsEndOfFile(int errorCode, SafeFileHandle handle, long fileOffset)
         {
             switch (errorCode)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Windows.cs
@@ -225,40 +225,41 @@ namespace System.IO.Strategies
                         }
 
                         // If the operation did not synchronously succeed, it either failed or initiated the asynchronous operation.
-                        if (!synchronousSuccess)
+                        if (!synchronousSuccess && errorCode != Interop.Errors.ERROR_IO_PENDING)
                         {
-                            switch (errorCode)
+                            if (RandomAccess.IsEndOfFile(errorCode, handle, readAwaitable._position))
                             {
-                                case Interop.Errors.ERROR_IO_PENDING:
-                                    // Async operation in progress.
-                                    break;
-                                case Interop.Errors.ERROR_BROKEN_PIPE:
-                                case Interop.Errors.ERROR_HANDLE_EOF:
-                                    // We're at or past the end of the file, and the overlapped callback
-                                    // won't be raised in these cases. Mark it as completed so that the await
-                                    // below will see it as such.
-                                    readAwaitable.MarkCompleted();
-                                    break;
-                                default:
-                                    // Everything else is an error (and there won't be a callback).
-                                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
+                                // We're at or past the end of the file, and the overlapped callback
+                                // won't be raised in these cases. Mark it as completed so that the await
+                                // below will see it as such.
+                                readAwaitable.MarkCompleted();
+                            }
+                            else
+                            {
+                                // Everything else is an error (and there won't be a callback).
+                                throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
                             }
                         }
 
                         // Wait for the async operation (which may or may not have already completed), then throw if it failed.
                         await readAwaitable;
-                        switch (readAwaitable._errorCode)
+
+
+
+                        if (readAwaitable._errorCode != Interop.Errors.ERROR_SUCCESS)
                         {
-                            case 0: // success
-                                break;
-                            case Interop.Errors.ERROR_BROKEN_PIPE: // logically success with 0 bytes read (write end of pipe closed)
-                            case Interop.Errors.ERROR_HANDLE_EOF:  // logically success with 0 bytes read (read at end of file)
-                                Debug.Assert(readAwaitable._numBytes == 0, $"Expected 0 bytes read, got {readAwaitable._numBytes}");
-                                break;
-                            case Interop.Errors.ERROR_OPERATION_ABORTED: // canceled
+                            if (readAwaitable._errorCode == Interop.Errors.ERROR_OPERATION_ABORTED)
+                            {
                                 throw new OperationCanceledException(cancellationToken.IsCancellationRequested ? cancellationToken : new CancellationToken(true));
-                            default: // error
+                            }
+                            else if (RandomAccess.IsEndOfFile((int)readAwaitable._errorCode, handle, readAwaitable._position))
+                            {
+                                Debug.Assert(readAwaitable._numBytes == 0, $"Expected 0 bytes read, got {readAwaitable._numBytes}");
+                            }
+                            else
+                            {
                                 throw Win32Marshal.GetExceptionForWin32Error((int)readAwaitable._errorCode, handle.Path);
+                            }
                         }
 
                         // Successful operation.  If we got zero bytes, we're done: exit the read/write loop.


### PR DESCRIPTION
This PR changes `FileStream` to match `AnonymousPipe*Stream`, `NamedPipe*Stream` edge case error handling. Namely:

- when the server pipe disconnects or gets closed, a write to the client `FileStream` fails with an exception rather than reporting success and writing nothing (what we had so far).
- when the server pipe disconnects, a read from `FileStream` returns zero rather than throwing an exception (what we had so far).