### PR TITLE
Use char.IsAsciiLetter in the Regex runtime

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4464,8 +4464,8 @@ namespace System.Text.RegularExpressions.Generator
             // Next, handle simple sets of two ASCII letter ranges that are cased versions of each other, e.g. [A-Za-z].
             // This can be implemented as if it were a single range, with an additional bitwise operation.
             if (RegexCharClass.TryGetDoubleRange(charClass, out (char LowInclusive, char HighInclusive) rangeLower, out (char LowInclusive, char HighInclusive) rangeUpper) &&
-                IsAsciiLetter(rangeUpper.LowInclusive) &&
-                IsAsciiLetter(rangeUpper.HighInclusive) &&
+                CharExtensions.IsAsciiLetter(rangeUpper.LowInclusive) &&
+                CharExtensions.IsAsciiLetter(rangeUpper.HighInclusive) &&
                 (rangeLower.LowInclusive | 0x20) == rangeUpper.LowInclusive &&
                 (rangeLower.HighInclusive | 0x20) == rangeUpper.HighInclusive)
             {
@@ -4632,11 +4632,6 @@ namespace System.Text.RegularExpressions.Generator
                     $"((ch = {chExpr}) < 128 || RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
             }
         }
-
-        /// <summary>Gets whether the specified character is an ASCII letter.</summary>
-        /// <remarks>Needed because RegexGenerator targets netstandard2.0, and can't use char.IsAsciiLetter.</remarks>
-        private static bool IsAsciiLetter(char c) =>
-            (uint)((c | 0x20) - 'a') <= 'z' - 'a';
 
         /// <summary>
         /// Replaces <see cref="AdditionalDeclarationsPlaceholder"/> in <paramref name="writer"/> with

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4464,8 +4464,8 @@ namespace System.Text.RegularExpressions.Generator
             // Next, handle simple sets of two ASCII letter ranges that are cased versions of each other, e.g. [A-Za-z].
             // This can be implemented as if it were a single range, with an additional bitwise operation.
             if (RegexCharClass.TryGetDoubleRange(charClass, out (char LowInclusive, char HighInclusive) rangeLower, out (char LowInclusive, char HighInclusive) rangeUpper) &&
-                RegexCharClass.IsAsciiLetter(rangeUpper.LowInclusive) &&
-                RegexCharClass.IsAsciiLetter(rangeUpper.HighInclusive) &&
+                IsAsciiLetter(rangeUpper.LowInclusive) &&
+                IsAsciiLetter(rangeUpper.HighInclusive) &&
                 (rangeLower.LowInclusive | 0x20) == rangeUpper.LowInclusive &&
                 (rangeLower.HighInclusive | 0x20) == rangeUpper.HighInclusive)
             {
@@ -4632,6 +4632,11 @@ namespace System.Text.RegularExpressions.Generator
                     $"((ch = {chExpr}) < 128 || RegexRunner.CharInClass((char)ch, {Literal(charClass)}))";
             }
         }
+
+        /// <summary>Gets whether the specified character is an ASCII letter.</summary>
+        /// <remarks>Needed because RegexGenerator targets netstandard2.0, and can't use char.IsAsciiLetter.</remarks>
+        private static bool IsAsciiLetter(char c) =>
+            (uint)((c | 0x20) - 'a') <= 'z' - 'a';
 
         /// <summary>
         /// Replaces <see cref="AdditionalDeclarationsPlaceholder"/> in <paramref name="writer"/> with

--- a/src/libraries/System.Text.RegularExpressions/gen/Stubs.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/Stubs.cs
@@ -58,6 +58,13 @@ namespace System
             return length;
         }
     }
+
+    internal static class CharExtensions
+    {
+        /// <summary>Gets whether the specified character is an ASCII letter.</summary>
+        public static bool IsAsciiLetter(char c) =>
+            (uint)((c | 0x20) - 'a') <= 'z' - 'a';
+    }
 }
 
 namespace System.Buffers

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -990,10 +990,6 @@ namespace System.Text.RegularExpressions
             return true;
         }
 
-        /// <summary>Gets whether the specified character is an ASCII letter.</summary>
-        public static bool IsAsciiLetter(char c) =>
-            (uint)((c | 0x20) - 'a') <= 'z' - 'a';
-
         /// <summary>Gets whether we can iterate through the set list pairs in order to completely enumerate the set's contents.</summary>
         /// <remarks>This may enumerate negated characters if the set is negated.  This will return false if the set has subtraction.</remarks>
         private static bool CanEasilyEnumerateSetContents(string set) =>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -5359,8 +5359,8 @@ namespace System.Text.RegularExpressions
             // Next, handle simple sets of two ASCII letter ranges that are cased versions of each other, e.g. [B-Db-d].
             // This can be implemented as if it were a single range, with an additional bitwise operation.
             if (RegexCharClass.TryGetDoubleRange(charClass, out (char LowInclusive, char HighInclusive) rangeLower, out (char LowInclusive, char HighInclusive) rangeUpper) &&
-                RegexCharClass.IsAsciiLetter(rangeUpper.LowInclusive) &&
-                RegexCharClass.IsAsciiLetter(rangeUpper.HighInclusive) &&
+                char.IsAsciiLetter(rangeUpper.LowInclusive) &&
+                char.IsAsciiLetter(rangeUpper.HighInclusive) &&
                 (rangeLower.LowInclusive | 0x20) == rangeUpper.LowInclusive &&
                 (rangeLower.HighInclusive | 0x20) == rangeUpper.HighInclusive)
             {


### PR DESCRIPTION
Need to move the duplicated IsAsciiLetter method to just the source generator, since the source generator can't reference the char API. That way the runtime doesn't need to pay for a duplicated method.