### PR TITLE
Fix inconsistency in Regex infinite timeout usages

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -203,7 +203,7 @@ namespace System.Text.RegularExpressions.Generator
                         $"internal static readonly TimeSpan {DefaultTimeoutFieldName} = AppContext.GetData(\"REGEX_DEFAULT_MATCH_TIMEOUT\") is TimeSpan timeout ? timeout : Regex.InfiniteMatchTimeout;",
                         $"",
                         $"/// <summary>Whether <see cref=\"{DefaultTimeoutFieldName}\"/> is non-infinite.</summary>",
-                        $"internal static readonly bool {HasDefaultTimeoutFieldName} = {DefaultTimeoutFieldName} != Timeout.InfiniteTimeSpan;",
+                        $"internal static readonly bool {HasDefaultTimeoutFieldName} = {DefaultTimeoutFieldName} != Regex.InfiniteMatchTimeout;",
                     });
                 }
             }
@@ -248,7 +248,7 @@ namespace System.Text.RegularExpressions.Generator
         /// <summary>Gets a C# expression representing the specified timeout value.</summary>
         private static string GetTimeoutExpression(int matchTimeout) =>
             matchTimeout == Timeout.Infinite ?
-                "Timeout.InfiniteTimeSpan" :
+                "Regex.InfiniteMatchTimeout" :
                 $"TimeSpan.FromMilliseconds({matchTimeout.ToString(CultureInfo.InvariantCulture)})";
 
         /// <summary>Adds the IsWordChar helper to the required helpers collection.</summary>


### PR DESCRIPTION
In the Regex source generator, there is an inconsistency in which "timeout constant" we are comparing against vs. which constant we are setting when the timeout isn't specified.

Fixing it to always use Regex.InfiniteMatchTimeout.

I could have gone either way on this - there are 2 references to each in the generated code.

On one hand, if we always use `Timeout.InfiniteTimeSpan` and just leave `Regex.InfiniteMatchTimeout` as a public API for back-compat, this one unused field could be trimmed away. (an extremely minor deal)

On the other hand, if we use `Timeout.InfiniteTimeSpan` here, we should change all the places internally to use it as well, for consistency. Since this was a larger change, and doesn't really have that much benefit, I chose the simpler change. But I can easily be convinced the other way as well.