### PR TITLE
Initial mobile workload testing (Closes: #75015)

### DIFF
--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -22,9 +22,17 @@
 
   <ItemGroup>
     <_DefaultPropsForNuGetBuild Include="Configuration=$(Configuration)" />
-    <_DefaultPropsForNuGetBuild Include="TargetOS=Browser" />
-    <_DefaultPropsForNuGetBuild Include="TargetArchitecture=wasm" />
+    <_DefaultPropsForNuGetBuild Include="TargetOS=$(TargetOS)" />
+    <_DefaultPropsForNuGetBuild Include="TargetArchitecture=$(TargetArchitecture)" />
     <_DefaultPropsForNuGetBuild Include="ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' != 'browser'">
+    <WorkloadCombinationsToInstall Include="latest" Variants="latest" />
+    <WorkloadIdForTesting Include="$(TargetOS.ToLower())"
+                          ManifestName="Microsoft.NET.Workload.Mono.Toolchain"
+                          Variant="latest"
+                          Version="$(PackageVersion)"
+                          VersionBand="$(SdkBandVersion)" />
   </ItemGroup>
 
   <Target Name="_ProvisionDotNetForWorkloadTesting" Condition="!Exists($(_SdkWithNoWorkloadStampPath))">

--- a/src/mono/mobile/test-workloads.proj
+++ b/src/mono/mobile/test-workloads.proj
@@ -1,0 +1,53 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+    <PropertyGroup>
+        <ArchPrefix Condition="'$(HostOS)' == 'OSX'">arch -x86_64 </ArchPrefix>
+        <DevTeamProvisioning Condition="'$(DevTeamProvisioning)' == ''">adhoc</DevTeamProvisioning>
+    </PropertyGroup>
+    <!-- specify all known runtimes needed for each workload to install -->
+    <ItemGroup>
+        <TargetRuntime Condition="'$(Workload)' == 'ios'" Include="ios-arm" />
+        <TargetRuntime Condition="'$(Workload)' == 'ios'" Include="ios-arm64" />
+        <TargetRuntime Condition="'$(Workload)' == 'ios'" Include="iossimulator-arm64" />
+        <TargetRuntime Condition="'$(Workload)' == 'ios'" Include="iossimulator-x64" />
+        <TargetRuntime Condition="'$(Workload)' == 'ios'" Include="iossimulator-x86" />
+        <TargetRuntime Condition="'$(Workload)' == 'tvos'" Include="tvos-arm64" />
+        <TargetRuntime Condition="'$(Workload)' == 'tvos'" Include="tvossimulator-arm64" />
+        <TargetRuntime Condition="'$(Workload)' == 'tvos'" Include="tvossimulator-x64" />
+        <TargetRuntime Condition="'$(Workload)' == 'maccatalyst'" Include="maccatalyst-arm64" />
+        <TargetRuntime Condition="'$(Workload)' == 'maccatalyst'" Include="maccatalyst-x64" />
+        <TargetRuntime Condition="'$(Workload)' == 'android'" Include="android-arm" />
+        <TargetRuntime Condition="'$(Workload)' == 'android'" Include="android-arm64" />
+        <TargetRuntime Condition="'$(Workload)' == 'android'" Include="android-x64" />
+        <TargetRuntime Condition="'$(Workload)' == 'android'" Include="android-x86" />
+    </ItemGroup>
+    <Target Name="ValidateWorkload" AfterTargets="Build">
+        <Error Condition="'%(TargetRuntime.Identity)' == ''" Text="Could not determine runtimes from requested workload: $(Workload)" />
+    </Target>
+    <Target Name="BuildAllRuntimes" AfterTargets="ValidateWorkload">
+        <MSBuild Targets="BuildRuntime"
+                Projects="$(MSBuildThisFileFullPath)"
+                BuildInParallel="true"
+                Properties="TargetRid=%(TargetRuntime.Identity)" />
+    </Target>
+    <Target Name="BuildRuntime">
+        <PropertyGroup>
+            <RuntimeTargetOS>$(TargetRid.Substring(0,$(TargetRid.LastIndexOf('-'))))</RuntimeTargetOS>
+            <RuntimeTargetArchitecture>$(TargetRid.Substring($([MSBuild]::Add(1, $(TargetRid.LastIndexOf('-'))))))</RuntimeTargetArchitecture>
+        </PropertyGroup>
+
+        <Message Text="*** Building runtime for $(TargetRid)" Importance="high" />
+        <Exec ConsoleToMsBuild="true" WorkingDirectory="$(MSBuildThisFileDirectory)\..\..\.."
+              Command="$(ArchPrefix) ./build.sh mono+libs+host+packs+mono.mscordbi -os $(RuntimeTargetOS) -arch $(RuntimeTargetArchitecture) -c $(Configuration) --binaryLog /p:ContinueOnError=false /p:StopOnFirstFailure=true" />
+    </Target>
+    <Target Name="BuildCross" AfterTargets="ValidateWorkload">
+        <!-- Always x64, pending https://github.com/dotnet/runtime/pull/74428 -->
+        <Message Text="*** Building cross for $(HostOS)-x64" Importance="high"/>
+        <Exec ConsoleToMsBuild="true" WorkingDirectory="$(MSBuildThisFileDirectory)\..\..\.."
+              Command="$(ArchPrefix) ./build.sh -arch x64 -os $(HostOS) -s mono+packs -c $(Configuration) /p:MonoCrossAOTTargetOS=$(Workload) /p:BuildMonoAOTCrossCompilerOnly=true /p:CrossBuild=false"/>
+    </Target>
+    <Target Name="BuildTests">
+        <Error Condition="'$(TestOS)' == '' or '$(TestArchitecture)' == ''" Text="You need to specify a value for both TestOS and TestArchitecture properties to build a test"/>
+        <Exec ConsoleToMsBuild="true" WorkingDirectory="$(MSBuildThisFileDirectory)\..\..\.."
+              Command="$(ArchPrefix) ./build.sh -os $(TestOS) -arch $(TestArchitecture) -s libs.tests -c $(Configuration) /p:ArchiveTests=true /p:TestWorkloadBuildTests=true /p:TestAssemblies=false /p:RunSmokeTestsOnly=$(RunSmokeTestsOnly) /p:CrossBuild=false /p:BuildMonoAOTCrossCompiler=false /p:InstallWorkloadForTesting=true /p:TestUsingWorkloads=true --binaryLog /p:DevTeamProvisioning=$(DevTeamProvisioning)" />
+    </Target>
+</Project>


### PR DESCRIPTION
Based on wasm stuff by @radical, but implemented in MSbuild instead of Make because computers are cursed. 

Right now, I'm running this via:

```
./.dotnet/dotnet msbuild src/mono/mobile/test-workloads.proj /p:Workload=WORKLOADNAME /t:restore
./.dotnet/dotnet msbuild src/mono/mobile/test-workloads.proj /p:Workload=WORKLOADNAME /t:build
./.dotnet/dotnet msbuild src/mono/mobile/test-workloads.proj /p:Workload=WORKLOADNAME /t:buildtests /p:RunSmokeTestsOnly=true /p:TestOS=OSOFTESTBUILD /p:TestArchitecture=ARCHOFTESTBUILD
```

Probably needs a value for DevTeamProvisioning passing through to it too.

Just throwing this into a draft PR for some initial eyeballs. With the extra properties and slight changes, workloads-testing.targets was basically already fine. The annoyance is that you need to build so many configurations (everything within a workload, which might be 5 runtimes and 5 cross-compilers) for a simple test of a single workload (which expects all the relevant nupkgs to be available, even if you're only testing one of them).

This is Mac-only right now, because Android is a big complicated Thing for us (we use a different docker image for producing different parts of our Android workload, so can't easily do the whole build as part of a single AzDO job)

Todo:
- [ ] Hook up test running
- [ ] Yaml
- [ ] Android