### PR TITLE
[hot_reload] implement param reflection

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod/ReflectionAddNewMethod.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod/ReflectionAddNewMethod.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class ReflectionAddNewMethod
+    {
+        public string ExistingMethod(string u, double f)
+	{
+            return u + f.ToString();;
+        }
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod/ReflectionAddNewMethod_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod/ReflectionAddNewMethod_v1.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.CompilerServices;
+using CancellationToken = System.Threading.CancellationToken;
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class ReflectionAddNewMethod
+    {
+        public string ExistingMethod(string u, double f)
+	{
+            return u + f.ToString();;
+        }
+
+	public double AddedNewMethod(char c, float h, string w, CancellationToken ct = default, [CallerMemberName] string callerName = "")
+	{
+	    return ((double)Convert.ToInt32(c)) + h;
+	}
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ReflectionAddNewMethod.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "ReflectionAddNewMethod.cs", "update": "ReflectionAddNewMethod_v1.cs"},
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -702,7 +702,11 @@ namespace System.Reflection.Metadata
 		Assert.True(foundCallerMemberName);
 		Assert.True(foundOptional);
 
-                // TODO: check the default values of the last two params
+                Assert.True(parms[3].HasDefaultValue);
+		Assert.True(parms[4].HasDefaultValue);
+
+		Assert.Null(parms[3].DefaultValue);
+		Assert.Equal(string.Empty, parms[4].DefaultValue);
             });
 	} 
     }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -635,46 +635,56 @@ namespace System.Reflection.Metadata
         {
             ApplyUpdateUtil.TestCase(static () =>
             {
-		var ty = typeof(System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod);
+                var ty = typeof(System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod);
                 var assm = ty.Assembly;
 
                 var allMethods = ty.GetMethods();
 
-		foreach (var m in allMethods) {
-		    Console.WriteLine ($"method: {m.Name}");
-		}
-		const int objectMethods = 4;
-		Assert.Equal (objectMethods + 1, allMethods.Length);
+                const int objectMethods = 4;
+                Assert.Equal (objectMethods + 1, allMethods.Length);
 
                 ApplyUpdateUtil.ApplyUpdate(assm);
 
-		allMethods = ty.GetMethods();
-		Assert.Equal (objectMethods + 2, allMethods.Length);
+                allMethods = ty.GetMethods();
+                Assert.Equal (objectMethods + 2, allMethods.Length);
 
-		var mi = ty.GetMethod ("AddedNewMethod");
+                var mi = ty.GetMethod ("AddedNewMethod");
 
-		Assert.NotNull (mi);
+                Assert.NotNull (mi);
 
-		var retParm = mi.ReturnParameter;
-		Assert.NotNull (retParm);
-		Console.WriteLine ($"return parm: {retParm}");
-		var retCas = retParm.GetCustomAttributes();
-		foreach (var rca in retCas) {
-		    Console.WriteLine ($" - ca: {rca}");
-		}
+                var retParm = mi.ReturnParameter;
+                Assert.NotNull (retParm);
+                Assert.NotNull (retParm.ParameterType);
+                Assert.Equal (-1, retParm.Position);
 
-		var parms = mi.GetParameters();
+                var retCas = retParm.GetCustomAttributes(false);
+                Assert.NotNull(retCas);
+                Assert.Equal(0, retCas.Length);
 
-		foreach (var parm in parms) {
-		    Console.WriteLine ($"parm: {parm}");
-		    var cas = parm.GetCustomAttributes();
-		    foreach (var ca in cas) {
-			Console.WriteLine ($" - ca: {ca}");
-		    }
-		}
+                var parms = mi.GetParameters();
+                Assert.Equal (5, parms.Length);
 
-		Assert.Equal (5, parms.Length);
-	    });
+                int parmPos = 0;
+                foreach (var parm in parms)
+                {
+                    Assert.NotNull(parm);
+                    Assert.NotNull(parm.ParameterType);
+                    Assert.Equal(parmPos, parm.Position);
+                    Assert.NotNull(parm.Name);
+                    
+                    var cas = parm.GetCustomAttributes(false);
+                    foreach (var ca in cas) {
+                        Assert.NotNull (ca);
+                    }
+
+                    parmPos++;
+                }
+
+                Assert.Equal (1, parms[4].GetCustomAttributes(false).Length);
+                Assert.Equal (typeof (CallerMemberNameAttribute), parms[4].GetCustomAttributes(false)[0].GetType());
+
+                // TODO: check the default values of the last two params
+            });
 	} 
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -684,6 +684,9 @@ namespace System.Reflection.Metadata
                     parmPos++;
                 }
 
+                foreach (var ca in parms[4].GetCustomAttributes(false)) {
+                        Console.WriteLine (" - parm[4] has {0}", ca);
+                }
                 Assert.Equal (1, parms[4].GetCustomAttributes(false).Length);
                 Assert.Equal (typeof (CallerMemberNameAttribute), parms[4].GetCustomAttributes(false)[0].GetType());
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -702,6 +702,9 @@ namespace System.Reflection.Metadata
 		Assert.True(foundCallerMemberName);
 		Assert.True(foundOptional);
 
+		// n.b. this typeof() also makes the rest of the test work on Wasm with aggressive trimming.
+		Assert.Equal (typeof(System.Threading.CancellationToken), parms[3].ParameterType);
+
                 Assert.True(parms[3].HasDefaultValue);
 		Assert.True(parms[4].HasDefaultValue);
 

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -638,14 +638,18 @@ namespace System.Reflection.Metadata
                 var ty = typeof(System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod);
                 var assm = ty.Assembly;
 
-                var allMethods = ty.GetMethods();
+		var bindingFlags = BindingFlags.Instance | BindingFlags.Public;
+                var allMethods = ty.GetMethods(bindingFlags);
 
-                const int objectMethods = 4;
+                int objectMethods = typeof(object).GetMethods(bindingFlags).Length;
                 Assert.Equal (objectMethods + 1, allMethods.Length);
 
                 ApplyUpdateUtil.ApplyUpdate(assm);
+                ApplyUpdateUtil.ClearAllReflectionCaches();
 
-                allMethods = ty.GetMethods();
+                ty = typeof(System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod);
+
+                allMethods = ty.GetMethods(bindingFlags);
                 Assert.Equal (objectMethods + 2, allMethods.Length);
 
                 var mi = ty.GetMethod ("AddedNewMethod");

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -629,5 +629,52 @@ namespace System.Reflection.Metadata
                 System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.ZExistingClass.ExistingMethod ();
             });
         }
+
+        [ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
+        public static void TestReflectionAddNewMethod()
+        {
+            ApplyUpdateUtil.TestCase(static () =>
+            {
+		var ty = typeof(System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod);
+                var assm = ty.Assembly;
+
+                var allMethods = ty.GetMethods();
+
+		foreach (var m in allMethods) {
+		    Console.WriteLine ($"method: {m.Name}");
+		}
+		const int objectMethods = 4;
+		Assert.Equal (objectMethods + 1, allMethods.Length);
+
+                ApplyUpdateUtil.ApplyUpdate(assm);
+
+		allMethods = ty.GetMethods();
+		Assert.Equal (objectMethods + 2, allMethods.Length);
+
+		var mi = ty.GetMethod ("AddedNewMethod");
+
+		Assert.NotNull (mi);
+
+		var retParm = mi.ReturnParameter;
+		Assert.NotNull (retParm);
+		Console.WriteLine ($"return parm: {retParm}");
+		var retCas = retParm.GetCustomAttributes();
+		foreach (var rca in retCas) {
+		    Console.WriteLine ($" - ca: {rca}");
+		}
+
+		var parms = mi.GetParameters();
+
+		foreach (var parm in parms) {
+		    Console.WriteLine ($"parm: {parm}");
+		    var cas = parm.GetCustomAttributes();
+		    foreach (var ca in cas) {
+			Console.WriteLine ($" - ca: {ca}");
+		    }
+		}
+
+		Assert.Equal (5, parms.Length);
+	    });
+	} 
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Reflection.Metadata
@@ -684,11 +685,22 @@ namespace System.Reflection.Metadata
                     parmPos++;
                 }
 
-                foreach (var ca in parms[4].GetCustomAttributes(false)) {
-                        Console.WriteLine (" - parm[4] has {0}", ca);
-                }
-                Assert.Equal (1, parms[4].GetCustomAttributes(false).Length);
-                Assert.Equal (typeof (CallerMemberNameAttribute), parms[4].GetCustomAttributes(false)[0].GetType());
+		var parmAttrs = parms[4].GetCustomAttributes(false);
+                Assert.Equal (2, parmAttrs.Length);
+		bool foundCallerMemberName = false;
+		bool foundOptional = false;
+		foreach (var pa in parmAttrs) {
+		    if (typeof (CallerMemberNameAttribute).Equals(pa.GetType()))
+		    {
+			foundCallerMemberName = true;
+		    }
+		    if (typeof (OptionalAttribute).Equals(pa.GetType()))
+		    {
+			foundOptional = true;
+		    }
+		}
+		Assert.True(foundCallerMemberName);
+		Assert.True(foundOptional);
 
                 // TODO: check the default values of the last two params
             });

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -62,6 +62,7 @@
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddStaticLambda\System.Reflection.Metadata.ApplyUpdate.Test.AddStaticLambda.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.StaticLambdaRegression\System.Reflection.Metadata.ApplyUpdate.Test.StaticLambdaRegression.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewType.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />

--- a/src/mono/mono/component/hot_reload-internals.h
+++ b/src/mono/mono/component/hot_reload-internals.h
@@ -87,7 +87,6 @@ typedef struct _MonoClassMetadataUpdateEvent {
 } MonoClassMetadataUpdateEvent;
 
 typedef struct _MonoMethodMetadataUpdateParamInfo {
-	uint32_t method_token; /* which method is this about */
 	uint32_t first_param_token; /* a Param token */
 	uint32_t param_count;
 } MonoMethodMetadataUpdateParamInfo;

--- a/src/mono/mono/component/hot_reload-internals.h
+++ b/src/mono/mono/component/hot_reload-internals.h
@@ -86,4 +86,10 @@ typedef struct _MonoClassMetadataUpdateEvent {
 	uint32_t token; /* the Event table token where this event was defined. */
 } MonoClassMetadataUpdateEvent;
 
+typedef struct _MonoMethodMetadataUpdateParamInfo {
+	uint32_t method_token; /* which method is this about */
+	uint32_t first_param_token; /* a Param token */
+	uint32_t param_count;
+} MonoMethodMetadataUpdateParamInfo;
+
 #endif/*_MONO_COMPONENT_HOT_RELOAD_INTERNALS_H*/

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -110,6 +110,9 @@ hot_reload_get_num_methods_added (MonoClass *klass);
 static const char *
 hot_reload_get_capabilities (void);
 
+static uint32_t
+hot_reload_stub_get_method_params (MonoImage *base_image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -142,7 +145,8 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_added_fields_iter,
 	&hot_reload_get_num_fields_added,
 	&hot_reload_get_num_methods_added,
-	&hot_reload_get_capabilities
+	&hot_reload_get_capabilities,
+	&hot_reload_stub_get_method_params,
 };
 
 static bool
@@ -341,6 +345,12 @@ static const char *
 hot_reload_get_capabilities (void)
 {
 	return "";
+}
+
+static uint32_t
+hot_reload_stub_get_method_params (MonoImage *base_image, uint32_t methoddef_token, uint32_t *out_param_count_opt)
+{
+	return 0;
 }
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -3212,6 +3212,10 @@ hot_reload_get_method_params (MonoImage *base_image, uint32_t methoddef_token, u
 	g_assert (base_info);
 
 	/* FIXME: locking in case the hash table grows */
+
+	if (!base_info->method_params)
+		return 0;
+
 	MonoMethodMetadataUpdateParamInfo* info = NULL;
 	info = g_hash_table_lookup (base_info->method_params, GUINT_TO_POINTER (methoddef_token));
 	if (!info) {

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2392,11 +2392,6 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 			 */
 			if (is_addition) {
 				g_assert (add_field_method != 0);
-				/* 			
-				 * FIXME: we need a lookaside table (like member_parent) for every place
-				 * that looks at MONO_METHOD_PARAMLIST
-				 */
-
 				uint32_t parent_type_token = hot_reload_method_parent (image_base, add_field_method);
 				g_assert (parent_type_token != 0); // we added a parameter to a method that was added
 				if (pass2_context_is_skeleton (ctx, parent_type_token)) {

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -48,6 +48,7 @@ typedef struct _MonoComponentHotReload {
 	uint32_t (*get_num_fields_added) (MonoClass *klass);
 	uint32_t (*get_num_methods_added) (MonoClass *klass);
 	const char* (*get_capabilities) (void);
+	uint32_t (*get_method_params) (MonoImage *base_image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -2252,10 +2252,18 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 
 	/* FIXME: metadata-update - lookup added params */
 	param_list = mono_metadata_decode_row_col (ca, method_index - 1, MONO_METHOD_PARAMLIST);
-	if (method_index == table_info_get_rows (ca)) {
-		param_last = table_info_get_rows (&image->tables [MONO_TABLE_PARAM]) + 1;
+	if (G_UNLIKELY (param_list == 0 && image->has_updates)) {
+		uint32_t count;
+		param_list = mono_metadata_update_get_method_params (image, mono_metadata_make_token (MONO_TABLE_METHOD, method_index), &count);
+		if (!param_list)
+			return NULL;
+		param_last = param_list + count;
 	} else {
-		param_last = mono_metadata_decode_row_col (ca, method_index, MONO_METHOD_PARAMLIST);
+		if (method_index == table_info_get_rows (ca)) {
+			param_last = table_info_get_rows (&image->tables [MONO_TABLE_PARAM]) + 1;
+		} else {
+			param_last = mono_metadata_decode_row_col (ca, method_index, MONO_METHOD_PARAMLIST);
+		}
 	}
 	ca = &image->tables [MONO_TABLE_PARAM];
 

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -2250,7 +2250,7 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 		return NULL;
 	ca = &image->tables [MONO_TABLE_METHOD];
 
-	/* FIXME: metadata-update */
+	/* FIXME: metadata-update - lookup added params */
 	param_list = mono_metadata_decode_row_col (ca, method_index - 1, MONO_METHOD_PARAMLIST);
 	if (method_index == table_info_get_rows (ca)) {
 		param_last = table_info_get_rows (&image->tables [MONO_TABLE_PARAM]) + 1;

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -2250,7 +2250,6 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 		return NULL;
 	ca = &image->tables [MONO_TABLE_METHOD];
 
-	/* FIXME: metadata-update - lookup added params */
 	param_list = mono_metadata_decode_row_col (ca, method_index - 1, MONO_METHOD_PARAMLIST);
 	if (G_UNLIKELY (param_list == 0 && image->has_updates)) {
 		uint32_t count;

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -2248,22 +2248,12 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 	method_index = mono_method_get_index (method);
 	if (!method_index)
 		return NULL;
-	ca = &image->tables [MONO_TABLE_METHOD];
 
-	param_list = mono_metadata_decode_row_col (ca, method_index - 1, MONO_METHOD_PARAMLIST);
-	if (G_UNLIKELY (param_list == 0 && image->has_updates)) {
-		uint32_t count;
-		param_list = mono_metadata_update_get_method_params (image, mono_metadata_make_token (MONO_TABLE_METHOD, method_index), &count);
-		if (!param_list)
-			return NULL;
-		param_last = param_list + count;
-	} else {
-		if (method_index == table_info_get_rows (ca)) {
-			param_last = table_info_get_rows (&image->tables [MONO_TABLE_PARAM]) + 1;
-		} else {
-			param_last = mono_metadata_decode_row_col (ca, method_index, MONO_METHOD_PARAMLIST);
-		}
-	}
+	param_list = mono_metadata_get_method_params (image, method_index, &param_last);
+
+	if (!param_list)
+		return NULL;
+
 	ca = &image->tables [MONO_TABLE_PARAM];
 
 	found = FALSE;

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1472,6 +1472,11 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 
 		param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
 
+		if (G_UNLIKELY (param_index == 0)) {
+			/* TODO: metadata-dupate: get the method param rows */
+			return;
+		}
+
 		if (idx < table_info_get_rows (methodt))
 			lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);
 		else
@@ -1566,6 +1571,11 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 	if (idx > 0) {
 		guint32 cols [MONO_PARAM_SIZE];
 		guint param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
+
+		if (G_UNLIKELY (param_index == 0)) {
+			/* TODO metadata-update: can we have marshaling info on added methods? */
+			return;
+		}
 
 		if (idx < table_info_get_rows (methodt))
 			lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1512,6 +1512,9 @@ mono_method_get_param_token (MonoMethod *method, int index)
 	if (idx > 0) {
 		guint param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
 
+		if (G_UNLIKELY (param_index == 0 && klass_image->has_updates)) {
+			param_index = mono_metadata_update_get_method_params (klass_image, mono_metadata_make_token (MONO_TABLE_METHOD, idx), NULL);
+		}
 		if (index == -1)
 			/* Return value */
 			return mono_metadata_make_token (MONO_TABLE_PARAM, 0);

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1409,7 +1409,6 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 {
 	int i, lastp;
 	MonoClass *klass;
-	MonoTableInfo *methodt;
 	MonoTableInfo *paramt;
 	MonoMethodSignature *signature;
 	guint32 idx;
@@ -1463,27 +1462,18 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 		return;
 	}
 
-	methodt = &klass_image->tables [MONO_TABLE_METHOD];
 	paramt = &klass_image->tables [MONO_TABLE_PARAM];
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
+
 		guint32 cols [MONO_PARAM_SIZE];
 		guint param_index;
 
-		param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
+		param_index = mono_metadata_get_method_params (klass_image, idx, (uint32_t*)&lastp);
 
-		if (G_UNLIKELY (param_index == 0 && klass_image->has_updates)) {
-			uint32_t count;
-			param_index = mono_metadata_update_get_method_params (klass_image, mono_metadata_make_token (MONO_TABLE_METHOD, idx), &count);
-			if (!param_index)
-				return;
-			lastp = param_index + count;
-		} else {
-			if (idx < table_info_get_rows (methodt))
-				lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);
-			else
-				lastp = table_info_get_rows (paramt) + 1;
-		}
+		if (!param_index)
+			return;
+
 		for (i = param_index; i < lastp; ++i) {
 			mono_metadata_decode_row (paramt, i -1, cols, MONO_PARAM_SIZE);
 			if (cols [MONO_PARAM_SEQUENCE] && cols [MONO_PARAM_SEQUENCE] <= signature->param_count) /* skip return param spec and bounds check*/
@@ -1499,7 +1489,6 @@ guint32
 mono_method_get_param_token (MonoMethod *method, int index)
 {
 	MonoClass *klass = method->klass;
-	MonoTableInfo *methodt;
 	guint32 idx;
 
 	mono_class_init_internal (klass);
@@ -1507,14 +1496,10 @@ mono_method_get_param_token (MonoMethod *method, int index)
 	MonoImage *klass_image = m_class_get_image (klass);
 	g_assert (!image_is_dynamic (klass_image));
 
-	methodt = &klass_image->tables [MONO_TABLE_METHOD];
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
-		guint param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
-
-		if (G_UNLIKELY (param_index == 0 && klass_image->has_updates)) {
-			param_index = mono_metadata_update_get_method_params (klass_image, mono_metadata_make_token (MONO_TABLE_METHOD, idx), NULL);
-		}
+		guint param_index = mono_metadata_get_method_params (klass_image, idx, NULL);
+		
 		if (index == -1)
 			/* Return value */
 			return mono_metadata_make_token (MONO_TABLE_PARAM, 0);
@@ -1533,7 +1518,6 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 {
 	int i, lastp;
 	MonoClass *klass = method->klass;
-	MonoTableInfo *methodt;
 	MonoTableInfo *paramt;
 	MonoMethodSignature *signature;
 	guint32 idx;
@@ -1571,26 +1555,15 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 	mono_class_init_internal (klass);
 
 	MonoImage *klass_image = m_class_get_image (klass);
-	methodt = &klass_image->tables [MONO_TABLE_METHOD];
 	paramt = &klass_image->tables [MONO_TABLE_PARAM];
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
 		guint32 cols [MONO_PARAM_SIZE];
-		guint param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
+		guint param_index = mono_metadata_get_method_params (klass_image, idx, (uint32_t*)&lastp);
 
-		if (G_UNLIKELY (param_index == 0 && klass_image->has_updates)) {
-			uint32_t count;
-			param_index = mono_metadata_update_get_method_params (klass_image, mono_metadata_make_token (MONO_TABLE_METHOD, idx), &count);
-			if (!param_index)
-				return;
-			lastp = param_index + count;
-		} else {
-			if (idx < table_info_get_rows (methodt))
-				lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);
-			else
-				lastp = table_info_get_rows (paramt) + 1;
-		}
-		
+		if (!param_index)
+			return;
+
 		for (i = param_index; i < lastp; ++i) {
 			mono_metadata_decode_row (paramt, i -1, cols, MONO_PARAM_SIZE);
 
@@ -1614,7 +1587,6 @@ mono_method_has_marshal_info (MonoMethod *method)
 {
 	int i, lastp;
 	MonoClass *klass = method->klass;
-	MonoTableInfo *methodt;
 	MonoTableInfo *paramt;
 	guint32 idx;
 
@@ -1634,26 +1606,15 @@ mono_method_has_marshal_info (MonoMethod *method)
 	mono_class_init_internal (klass);
 
 	MonoImage *klass_image = m_class_get_image (klass);
-	methodt = &klass_image->tables [MONO_TABLE_METHOD];
 	paramt = &klass_image->tables [MONO_TABLE_PARAM];
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
 		guint32 cols [MONO_PARAM_SIZE];
-		guint param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
+		guint param_index = mono_metadata_get_method_params (klass_image, idx, (uint32_t*)&lastp);
 
-		if (G_UNLIKELY (param_index == 0 && klass_image->has_updates)) {
-			uint32_t count;
-			param_index = mono_metadata_update_get_method_params (klass_image, mono_metadata_make_token (MONO_TABLE_METHOD, idx), &count);
-			if (!param_index)
-				return FALSE;
-			lastp = param_index + count;
-		} else {
-			if (idx + 1 < table_info_get_rows (methodt))
-				lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);
-			else
-				lastp = table_info_get_rows (paramt) + 1;
-		}
-		
+		if (!param_index)
+			return FALSE;
+
 		for (i = param_index; i < lastp; ++i) {
 			mono_metadata_decode_row (paramt, i -1, cols, MONO_PARAM_SIZE);
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1248,4 +1248,7 @@ mono_metadata_table_to_ptr_table (int table_num)
 	}
 }
 
+uint32_t
+mono_metadata_get_method_params (MonoImage *image, uint32_t method_idx, uint32_t *last_param_out);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -230,3 +230,9 @@ mono_metadata_update_get_num_methods_added (MonoClass *klass)
 {
 	return mono_component_hot_reload()->get_num_methods_added (klass);
 }
+
+uint32_t
+mono_metadata_update_get_method_params (MonoImage *image, uint32_t methoddef_token, uint32_t *out_param_count_opt)
+{
+	return mono_component_hot_reload()->get_method_params (image, methoddef_token, out_param_count_opt);
+}

--- a/src/mono/mono/metadata/metadata-update.h
+++ b/src/mono/mono/metadata/metadata-update.h
@@ -93,4 +93,7 @@ mono_metadata_update_get_num_fields_added (MonoClass *klass);
 
 uint32_t
 mono_metadata_update_get_num_methods_added (MonoClass *klass);
+
+uint32_t
+mono_metadata_update_get_method_params (MonoImage *image, uint32_t methoddef_token, uint32_t *out_param_count_opt);
 #endif /*__MONO_METADATA_UPDATE_H__*/

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2277,21 +2277,12 @@ gboolean
 mono_metadata_method_has_param_attrs (MonoImage *m, int def)
 {
 	MonoTableInfo *paramt = &m->tables [MONO_TABLE_PARAM];
-	MonoTableInfo *methodt = &m->tables [MONO_TABLE_METHOD];
-	guint lastp, i, param_index = mono_metadata_decode_row_col (methodt, def - 1, MONO_METHOD_PARAMLIST);
+	guint lastp, i, param_index;
 
-	if (G_UNLIKELY (param_index == 0 && m->has_updates)) {
-		uint32_t count;
-		param_index = mono_metadata_update_get_method_params (m, mono_metadata_make_token (MONO_TABLE_METHOD, def), &count);
-		if (!param_index)
-			return FALSE;
-		lastp = param_index + count;
-	} else {
-		if (GINT_TO_UINT32(def) < table_info_get_rows (methodt))
-			lastp = mono_metadata_decode_row_col (methodt, def, MONO_METHOD_PARAMLIST);
-		else
-			lastp = table_info_get_rows (&m->tables [MONO_TABLE_PARAM]) + 1;
-	}
+	param_index = mono_metadata_get_method_params (m, def, (uint32_t*)&lastp);
+
+	if (!param_index)
+		return FALSE;
 
 	for (i = param_index; i < lastp; ++i) {
 		guint32 flags = mono_metadata_decode_row_col (paramt, i - 1, MONO_PARAM_FLAGS);
@@ -2317,23 +2308,14 @@ int*
 mono_metadata_get_param_attrs (MonoImage *m, int def, guint32 param_count)
 {
 	MonoTableInfo *paramt = &m->tables [MONO_TABLE_PARAM];
-	MonoTableInfo *methodt = &m->tables [MONO_TABLE_METHOD];
 	guint32 cols [MONO_PARAM_SIZE];
-	guint lastp, i, param_index = mono_metadata_decode_row_col (methodt, def - 1, MONO_METHOD_PARAMLIST);
+	guint lastp, i, param_index;
 	int *pattrs = NULL;
 
-	if (G_UNLIKELY (param_index == 0 && m->has_updates)) {
-			uint32_t count;
-			param_index = mono_metadata_update_get_method_params (m, mono_metadata_make_token (MONO_TABLE_METHOD, def), &count);
-			if (!param_index)
-				return NULL;
-			lastp = param_index + count;
-	} else {
-		if (GINT_TO_UINT32(def) < mono_metadata_table_num_rows (m, MONO_TABLE_METHOD))
-			lastp = mono_metadata_decode_row_col (methodt, def, MONO_METHOD_PARAMLIST);
-		else
-			lastp = table_info_get_rows (paramt) + 1;
-	}
+	param_index = mono_metadata_get_method_params (m, def, (uint32_t*)&lastp);
+
+	if (!param_index)
+		return NULL;
 
 	for (i = param_index; i < lastp; ++i) {
 		mono_metadata_decode_row (paramt, i - 1, cols, MONO_PARAM_SIZE);
@@ -8130,4 +8112,41 @@ mono_metadata_get_class_guid (MonoClass* klass, guint8* guid, MonoError *error)
 	else
 		g_warning ("Generated GUIDs only implemented for interfaces!");
 #endif
+}
+
+uint32_t
+mono_metadata_get_method_params (MonoImage *image, uint32_t method_idx, uint32_t *last_param_out)
+{
+	if (last_param_out)
+		*last_param_out = 0;
+	if (!method_idx)
+		return 0;
+
+	MonoTableInfo *methodt = &image->tables [MONO_TABLE_METHOD];
+
+	uint32_t param_index, lastp;
+
+	param_index = mono_metadata_decode_row_col (methodt, method_idx - 1, MONO_METHOD_PARAMLIST);
+
+	if (G_UNLIKELY (param_index == 0 && image->has_updates)) {
+		uint32_t count;
+		param_index = mono_metadata_update_get_method_params (image, mono_metadata_make_token (MONO_TABLE_METHOD, method_idx), &count);
+		if (!param_index)
+			return 0;
+		lastp = param_index + count;
+	} else {
+		/* lastp is the starting param index for the next method in the table, or
+		 * one past the last row if this is the last method
+		 */
+
+		if (method_idx < table_info_get_rows (methodt))
+			lastp = mono_metadata_decode_row_col (methodt, method_idx, MONO_METHOD_PARAMLIST);
+		else
+			lastp = table_info_get_rows (&image->tables [MONO_TABLE_PARAM]) + 1;
+	}
+
+	if (last_param_out)
+		*last_param_out = lastp;
+
+	return param_index;
 }

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1392,7 +1392,6 @@ get_default_param_value_blobs (MonoMethod *method, char **blobs, guint32 *types)
 	MonoMethodSignature *methodsig = mono_method_signature_internal (method);
 
 	MonoTableInfo *constt;
-	MonoTableInfo *methodt;
 	MonoTableInfo *paramt;
 
 	if (!methodsig->param_count)
@@ -1412,30 +1411,16 @@ get_default_param_value_blobs (MonoMethod *method, char **blobs, guint32 *types)
 		return;
 	}
 
-	methodt = &image->tables [MONO_TABLE_METHOD];
 	paramt = &image->tables [MONO_TABLE_PARAM];
 	constt = &image->tables [MONO_TABLE_CONSTANT];
 
 	idx = mono_method_get_index (method);
 	g_assert (idx != 0);
 
-	/* lastp is the starting param index for the next method in the table, or
-	 * one past the last row if this is the last method
-	 */
-	/* FIXME: metadata-update : will this work with added methods - no, needs a change */
-	param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
-	if (G_UNLIKELY (param_index == 0 && image->has_updates)) {
-		uint32_t count;
-		param_index = mono_metadata_update_get_method_params (image, mono_metadata_make_token (MONO_TABLE_METHOD, idx), &count);
-		if (!param_index)
-			return;
-		lastp = param_index + count;
-	} else {
-		if (!mono_metadata_table_bounds_check (image, MONO_TABLE_METHOD, idx + 1))
-			lastp = mono_metadata_decode_row_col (methodt, idx, MONO_METHOD_PARAMLIST);
-		else
-			lastp = table_info_get_rows (paramt) + 1;
-	}
+	param_index = mono_metadata_get_method_params (image, idx, &lastp);
+
+	if (!param_index)
+		return;
 
 	for (i = param_index; i < lastp; ++i) {
 		guint32 paramseq;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77512

When a method is added, the paramlist column in the MethodDef is empty.  Instead, the parameter info is added by separate EnCLog "Add Param" commands.  Store that info in the image, keyed on the method definition token.