### PR TITLE
Change HttpConnection.RegisterCancellation to use a strong reference

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -51,7 +51,6 @@ namespace System.Net.Http
         private readonly HttpConnectionPool _pool;
         private readonly Stream _stream;
         private readonly TransportContext? _transportContext;
-        private readonly WeakReference<HttpConnection> _weakThisRef;
 
         private HttpRequestMessage? _currentRequest;
         private readonly byte[] _writeBuffer;
@@ -93,8 +92,6 @@ namespace System.Net.Http
 
             _writeBuffer = new byte[InitialWriteBufferSize];
             _readBuffer = new byte[InitialReadBufferSize];
-
-            _weakThisRef = new WeakReference<HttpConnection>(this);
 
             _idleSinceTickCount = Environment.TickCount64;
 
@@ -899,17 +896,12 @@ namespace System.Net.Http
             // - The registration disposes of the connection, tearing it down and causing any pending operations to wake up.
             // - Because such a tear down can result in a variety of different exception types, we check for a cancellation
             //   request and prioritize that over other exceptions, wrapping the actual exception as an inner of an OCE.
-            // - A weak reference to this HttpConnection is stored in the cancellation token, to prevent the token from
-            //   artificially keeping this connection alive.
             return cancellationToken.Register(static s =>
             {
-                var weakThisRef = (WeakReference<HttpConnection>)s!;
-                if (weakThisRef.TryGetTarget(out HttpConnection? strongThisRef))
-                {
-                    if (NetEventSource.Log.IsEnabled()) strongThisRef.Trace("Cancellation requested. Disposing of the connection.");
-                    strongThisRef.Dispose();
-                }
-            }, _weakThisRef);
+                var connection = (HttpConnection)s!;
+                if (NetEventSource.Log.IsEnabled()) connection.Trace("Cancellation requested. Disposing of the connection.");
+                connection.Dispose();
+            }, this);
         }
 
         private async ValueTask SendRequestContentAsync(HttpRequestMessage request, HttpContentWriteStream stream, bool async, CancellationToken cancellationToken)


### PR DESCRIPTION
The implementation was previously being (arguably overly) defensive about allowing the cancellation token to keep alive a connection that had otherwise become stagnant while awaiting underlying stream operations that would never complete.  This adds some overhead, causes issues for some tests, and doesn't solve meaningful problems, so we're removing it.

Should fix https://github.com/dotnet/runtime/issues/72586.