### PR TITLE
Avoid duplicated read

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -35683,7 +35683,7 @@ void gc_heap::revisit_written_page (uint8_t* page,
                                         no_more_loop_p = TRUE;
                                         goto end_limit;
                                     }
-                                    uint8_t* oo = *poo;
+                                    uint8_t* oo = VolatileLoadWithoutBarrier(poo);
 
                                     num_marked_objects++;
                                     background_mark_object (oo THREAD_NUMBER_ARG);


### PR DESCRIPTION
This commit fixed the issue that we have a duplicate read found in #77087.