### PR TITLE
Fix Binding with IDictionary<,> implementer types

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -554,9 +554,9 @@ namespace Microsoft.Extensions.Configuration
         // Binds and potentially overwrites a concrete dictionary.
         // This differs from BindDictionaryInterface because this method doesn't clone
         // the dictionary; it sets and/or overwrites values directly.
-        // When a user specifies a concrete dictionary in their config class, then that
-        // value is used as-us. When a user specifies an interface (instantiated) in their config class,
-        // then it is cloned to a new dictionary, the same way as other collections.
+        // When a user specifies a concrete dictionary or a concrete class implementing IDictionary<,>
+        // in their config class, then that value is used as-is. When a user specifies an interface (instantiated)
+        // in their config class, then it is cloned to a new dictionary, the same way as other collections.
         [RequiresDynamicCode(DynamicCodeWarningMessage)]
         [RequiresUnreferencedCode("Cannot statically analyze what the element type is of the value objects in the dictionary so its members may be trimmed.")]
         private static void BindConcreteDictionary(
@@ -584,10 +584,17 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
-            Type genericType = typeof(Dictionary<,>).MakeGenericType(keyType, valueType);
-
             MethodInfo tryGetValue = dictionaryType.GetMethod("TryGetValue")!;
-            PropertyInfo setter = genericType.GetProperty("Item", DeclaredOnlyLookup)!;
+
+            Debug.Assert(dictionary is not null);
+            // dictionary should be of type Dictionary<,> or of type implementing IDictionary<,>
+            PropertyInfo setter = dictionary.GetType().GetProperty("Item", BindingFlags.Public | BindingFlags.Instance)!;
+            if (setter is null || !setter.CanWrite)
+            {
+                // Cannot set any item on the dictionary object.
+                return;
+            }
+
             foreach (IConfigurationSection child in config.GetChildren())
             {
                 try

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -584,11 +584,11 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
-            MethodInfo tryGetValue = dictionaryType.GetMethod("TryGetValue")!;
+            MethodInfo tryGetValue = dictionaryType.GetMethod("TryGetValue", BindingFlags.Public | BindingFlags.Instance)!;
 
             Debug.Assert(dictionary is not null);
             // dictionary should be of type Dictionary<,> or of type implementing IDictionary<,>
-            PropertyInfo setter = dictionary.GetType().GetProperty("Item", BindingFlags.Public | BindingFlags.Instance)!;
+            PropertyInfo? setter = dictionary.GetType().GetProperty("Item", BindingFlags.Public | BindingFlags.Instance);
             if (setter is null || !setter.CanWrite)
             {
                 // Cannot set any item on the dictionary object.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1611,17 +1611,10 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
                 .AddInMemoryCollection(dic)
                 .Build();
 
-            var _dictionary = config.Get<Dictionary<string, string>>();
-            Assert.Single(_dictionary);
-
-            var _dictionaryInterface = config.Get<IDictionary<string, string>>();
-            Assert.Single(_dictionaryInterface);
-
-            var _extendedDictionaryClass = config.Get<ExtendedDictionary<string, string>>();
-            Assert.Single(_extendedDictionaryClass);
-
-            var _implementerOfIDictionaryClass = config.Get<ImplementerOfIDictionaryClass<string, string>>();
-            Assert.Single(_implementerOfIDictionaryClass);
+            Assert.Single(config.Get<Dictionary<string, string>>());
+            Assert.Single(config.Get<IDictionary<string, string>>());
+            Assert.Single(config.Get<ExtendedDictionary<string, string>>());
+            Assert.Single(config.Get<ImplementerOfIDictionaryClass<string, string>>());
         }
 
         public class ImplementerOfIDictionaryClass<TKey, TValue> : IDictionary<TKey, TValue>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1067,7 +1067,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
                 {"AlreadyInitializedIEnumerableInterface:1", "val1"},
                 {"AlreadyInitializedIEnumerableInterface:2", "val2"},
                 {"AlreadyInitializedIEnumerableInterface:x", "valx"},
-                
+
                 {"ICollectionNoSetter:0", "val0"},
                 {"ICollectionNoSetter:1", "val1"},
             };
@@ -1601,6 +1601,69 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
         {
             public IEnumerable<int> FilteredConfigValues => ConfigValues.Where(p => p > 10);
             public IEnumerable<int> ConfigValues { get; set; }
+        }
+
+        [Fact]
+        public void DifferentDictionaryBindingCasesTest()
+        {
+            var dic = new Dictionary<string, string>() { { "key", "value" } };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(dic)
+                .Build();
+
+            var _dictionary = config.Get<Dictionary<string, string>>();
+            Assert.Single(_dictionary);
+
+            var _dictionaryInterface = config.Get<IDictionary<string, string>>();
+            Assert.Single(_dictionaryInterface);
+
+            var _extendedDictionaryClass = config.Get<ExtendedDictionary<string, string>>();
+            Assert.Single(_extendedDictionaryClass);
+
+            var _implementerOfIDictionaryClass = config.Get<ImplementerOfIDictionaryClass<string, string>>();
+            Assert.Single(_implementerOfIDictionaryClass);
+        }
+
+        public class ImplementerOfIDictionaryClass<TKey, TValue> : IDictionary<TKey, TValue>
+        {
+            private Dictionary<TKey, TValue> _dict = new();
+
+            public TValue this[TKey key] { get => _dict[key]; set => _dict[key] = value; }
+
+            public ICollection<TKey> Keys => _dict.Keys;
+
+            public ICollection<TValue> Values => _dict.Values;
+
+            public int Count => _dict.Count;
+
+            public bool IsReadOnly => false;
+
+            public void Add(TKey key, TValue value) => _dict.Add(key, value);
+
+            public void Add(KeyValuePair<TKey, TValue> item) => _dict.Add(item.Key, item.Value);
+
+            public void Clear() => _dict.Clear();
+
+            public bool Contains(KeyValuePair<TKey, TValue> item) => _dict.Contains(item);
+
+            public bool ContainsKey(TKey key) => _dict.ContainsKey(key);
+
+            public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) => throw new NotImplementedException();
+
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _dict.GetEnumerator();
+
+            public bool Remove(TKey key) => _dict.Remove(key);
+
+            public bool Remove(KeyValuePair<TKey, TValue> item) => _dict.Remove(item.Key);
+
+            public bool TryGetValue(TKey key, out TValue value) => _dict.TryGetValue(key, out value);
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _dict.GetEnumerator();
+        }
+
+        public class ExtendedDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+        {
+
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77246

In .NET 7.0 we have done some refactoring work in the configuration binding code https://github.com/dotnet/runtime/pull/68133. The refactored code work fine when binding to `IDictionary<,>`  interface or `Dictionary<,>` based class but it broke the case when using a type which implementing `IDictionary<,>` interface. The new code was always creating `Dictionary<,>` type and then getting the setter of the `Item` property from that type. But the object used in the binding is not of type `Dictionary<,>` at all and the property setter fails because it is used with wrong type. 