### PR TITLE
Fix source-build prebuilts introduced by analyzers

### DIFF
--- a/src/coreclr/tools/Directory.Build.props
+++ b/src/coreclr/tools/Directory.Build.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsShipping>false</IsShipping>
     <SignAssembly>false</SignAssembly>
-    <RunAnalyzers>false</RunAnalyzers>
     <!-- None of the tools is localized. Strip System.CommandLine localized resources from the output. -->
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
   </PropertyGroup>

--- a/src/coreclr/tools/ILVerification/ILVerification.csproj
+++ b/src/coreclr/tools/ILVerification/ILVerification.csproj
@@ -9,6 +9,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <Import Project="ILVerification.projitems" />

--- a/src/coreclr/tools/ILVerify/ILVerify.csproj
+++ b/src/coreclr/tools/ILVerify/ILVerify.csproj
@@ -7,6 +7,7 @@
     <UseAppHost>false</UseAppHost>
     <RollForward>Major</RollForward>
     <DefineConstants>ILVERIFY;$(DefineConstants)</DefineConstants>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <Import Project="..\ILVerification\ILVerification.projitems" />

--- a/src/coreclr/tools/InjectResource/InjectResource.csproj
+++ b/src/coreclr/tools/InjectResource/InjectResource.csproj
@@ -8,6 +8,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <IsShipping>false</IsShipping>
     <OutputPath>$(RuntimeBinDir)\InjectResource</OutputPath>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/SuperFileCheck/SuperFileCheck.csproj
+++ b/src/coreclr/tools/SuperFileCheck/SuperFileCheck.csproj
@@ -11,6 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(RuntimeBinDir)\SuperFileCheck</OutputPath>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/DesktopCompatibleTask.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/DesktopCompatibleTask.cs
@@ -23,13 +23,13 @@ namespace Build.Tasks
             AssemblyName referenceName = new AssemblyName(AppDomain.CurrentDomain.ApplyPolicy(args.Name));
 
             string fileName = referenceName.Name + ".dll";
-            string assemblyPath = null;
-            string probingPath = null;
-            Assembly assm = null;
+            string assemblyPath;
+            string probingPath;
+            Assembly assm;
 
             // look next to requesting assembly
             assemblyPath = args.RequestingAssembly?.Location;
-            if (!String.IsNullOrEmpty(assemblyPath))
+            if (!string.IsNullOrEmpty(assemblyPath))
             {
                 probingPath = Path.Combine(Path.GetDirectoryName(assemblyPath), fileName);
                 Debug.WriteLine($"Considering {probingPath} based on RequestingAssembly");
@@ -41,7 +41,7 @@ namespace Build.Tasks
 
             // look next to the executing assembly
             assemblyPath = Assembly.GetExecutingAssembly().Location;
-            if (!String.IsNullOrEmpty(assemblyPath))
+            if (!string.IsNullOrEmpty(assemblyPath))
             {
                 probingPath = Path.Combine(Path.GetDirectoryName(assemblyPath), fileName);
 

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/DumpNativeResources.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/DumpNativeResources.cs
@@ -8,7 +8,6 @@ using System.Reflection.PortableExecutable;
 using System.Text;
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
 namespace Build.Tasks
 {
@@ -69,11 +68,11 @@ namespace Build.Tasks
     }
 
     /// <summary>
-    /// Helper class that converts from a Win32 PE resource directory format to 
+    /// Helper class that converts from a Win32 PE resource directory format to
     /// a set of RESOURCEHEADER structures (https://docs.microsoft.com/en-us/windows/desktop/menurc/resourceheader)
     /// that form the basis of Win32 RES files.
     /// </summary>
-    class ResWriter
+    internal sealed class ResWriter
     {
         private readonly PEMemoryBlock _memoryBlock;
         private readonly PEReader _peReader;
@@ -234,7 +233,7 @@ namespace Build.Tasks
         }
     }
 
-    static class ResourceHelper
+    internal static class ResourceHelper
     {
         public static void WriteNameOrId(this BinaryWriter bw, object nameOrId)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
@@ -11,6 +11,7 @@
 
     <!-- Workaround for https://github.com/dotnet/corert/issues/6306 -->
     <SkipSigning>true</SkipSigning>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
@@ -11,7 +11,6 @@
 
     <!-- Workaround for https://github.com/dotnet/corert/issues/6306 -->
     <SkipSigning>true</SkipSigning>
-    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.Assets/ILCompiler.Compiler.Tests.Assets.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/ILCompiler.Compiler.Tests.Assets/ILCompiler.Compiler.Tests.Assets.csproj
@@ -8,6 +8,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <!-- Don't add references to the netstandard platform since this is a core assembly -->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -16,7 +16,6 @@
     <Configurations>Debug;Release;Checked</Configurations>
 
     <NoWarn Condition="'$(DotNetBuildFromSource)' == 'true'">$(NoWarn);CS8524</NoWarn>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
@@ -8,7 +8,6 @@
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <RunAnalyzers>true</RunAnalyzers>
 
     <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
          the same bits tests expect to see in artifacts/crossgen2. That way we never need to wonder which

--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/ILCompiler.Diagnostics.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/ILCompiler.Diagnostics.csproj
@@ -16,6 +16,7 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <Configurations>Debug;Release;Checked</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler.MetadataTransform.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler.MetadataTransform.csproj
@@ -20,7 +20,6 @@
     <NativeFormatCommonPath>$(CommonSourcePath)Internal\NativeFormat</NativeFormatCommonPath>
     <MetadataCommonPath>$(CommonSourcePath)\Internal\Metadata\NativeFormat</MetadataCommonPath>
     <MetadataWriterPath>$(MSBuildThisFileDirectory)Internal\Metadata\NativeFormat\Writer</MetadataWriterPath>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -15,6 +15,7 @@
          binaries are up to date and which are stale. -->
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <Configurations>Debug;Release;Checked</Configurations>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
@@ -15,6 +15,7 @@
     <OutputPath>$(RuntimeBinDir)</OutputPath>
     <Platforms>AnyCPU;x64</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/ILCompiler.RyuJit.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/ILCompiler.RyuJit.csproj
@@ -15,7 +15,6 @@
          binaries are up to date and which are stale. -->
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <Configurations>Debug;Release;Checked</Configurations>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/CoreTestAssembly.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/CoreTestAssembly.csproj
@@ -11,5 +11,6 @@
     <!-- CSC needs explicit metadata version when it has no core library to reference -->
     <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/ILCompiler.TypeSystem.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/ILCompiler.TypeSystem.Tests.csproj
@@ -17,7 +17,6 @@
     
     <!-- Avoids having to include InteropStateManager.cs to get files in Common/TypeSystem/Interop/IL building -->
     <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
@@ -18,7 +18,6 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <Configurations>Debug;Release;Checked</Configurations>
     <IsTrimmable>true</IsTrimmable>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup Label="Embedded Resources">

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputPath>$(RuntimeBinDir)ilc/</OutputPath>
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <Import Project="ILCompiler.props" />

--- a/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
@@ -10,6 +10,7 @@
     <Configurations>Debug;Release;Checked</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <Target Name="GenerateReproProjectResponseFile"

--- a/src/coreclr/tools/aot/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -5,7 +5,6 @@
     <Nullable>disable</Nullable>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
 </Project>

--- a/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/Mono.Linker.Tests.Cases.csproj
@@ -8,7 +8,6 @@
     <DefineConstants>$(DefineConstants);INCLUDE_EXPECTATIONS</DefineConstants>
     <WarningLevel>0</WarningLevel>
     <AnalysisLevel>0</AnalysisLevel>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -11,7 +11,6 @@
 
     <RuntimeIdentifiers>linux-x64;win-x64;osx-x64</RuntimeIdentifiers>
     <Configurations>Debug;Release;Checked</Configurations>
-    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -14,6 +14,7 @@
     <Configurations>Debug;Release;Checked</Configurations>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EventSourceSupport>true</EventSourceSupport>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup Label="Embedded Resources">

--- a/src/coreclr/tools/dotnet-pgo/dotnet-pgo.csproj
+++ b/src/coreclr/tools/dotnet-pgo/dotnet-pgo.csproj
@@ -21,6 +21,7 @@
     <PackageReleaseNotes>$(Description)</PackageReleaseNotes>
     <RootNamespace>Microsoft.Diagnostics.Tools.Pgo</RootNamespace>
     <RollForward>Major</RollForward>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/r2rdump/R2RDump.csproj
+++ b/src/coreclr/tools/r2rdump/R2RDump.csproj
@@ -12,6 +12,7 @@
     <NoWarn>8002,NU1701</NoWarn>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <OutputPath>$(RuntimeBinDir)/R2RDump</OutputPath>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)coredistools.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />

--- a/src/coreclr/tools/r2rtest/R2RTest.csproj
+++ b/src/coreclr/tools/r2rtest/R2RTest.csproj
@@ -7,6 +7,7 @@
     <NoWarn>8002,NU1701</NoWarn>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>$(RuntimeBinDir)\R2RTest</OutputPath>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/tools/runincontext/runincontext.csproj
+++ b/src/coreclr/tools/runincontext/runincontext.csproj
@@ -6,5 +6,6 @@
     <UseAppHost>false</UseAppHost>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <OutputPath>$(RuntimeBinDir)</OutputPath>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 </Project>

--- a/src/coreclr/tools/tieringtest/tieringtest.csproj
+++ b/src/coreclr/tools/tieringtest/tieringtest.csproj
@@ -6,5 +6,6 @@
     <UseAppHost>false</UseAppHost>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <OutputPath>$(RuntimeBinDir)</OutputPath>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Use the default root settings for analyzers and disable analyzers for specific projects that are not clean instead.

Fixes #77601