### PR TITLE
[wasm][debugger] Never send messages from our internal protocol extensions to the browser

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -267,7 +267,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     if (pauseOnException != PauseOnExceptionsKind.Unset)
                         _defaultPauseOnExceptions = pauseOnException;
                 }
-                //ignore messages from protocol extensions even for unknown context
+                // don't pass through DotnetDebugger.* messages to the browser
                 if (method.StartsWith("DotnetDebugger.", StringComparison.Ordinal))
                     return true;
                 return false;
@@ -569,7 +569,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                     }
             }
-
+            // don't pass through DotnetDebugger.* messages to the browser
+            if (method.StartsWith("DotnetDebugger.", StringComparison.Ordinal))
+                return true;
             return false;
         }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -267,6 +267,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                     if (pauseOnException != PauseOnExceptionsKind.Unset)
                         _defaultPauseOnExceptions = pauseOnException;
                 }
+                //ignore messages from protocol extensions even for unknown context
+                if (method.StartsWith("DotnetDebugger.", StringComparison.Ordinal))
+                    return true;
                 return false;
             }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -267,7 +267,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     if (pauseOnException != PauseOnExceptionsKind.Unset)
                         _defaultPauseOnExceptions = pauseOnException;
                 }
-                // don't pass through DotnetDebugger.* messages to the browser
+                // for Dotnetdebugger.* messages, treat them as handled, thus not passing them on to the browser
                 return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
             }
 
@@ -567,7 +567,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                     }
             }
-            // don't pass through DotnetDebugger.* messages to the browser
+            // for Dotnetdebugger.* messages, treat them as handled, thus not passing them on to the browser
             return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -268,9 +268,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         _defaultPauseOnExceptions = pauseOnException;
                 }
                 // don't pass through DotnetDebugger.* messages to the browser
-                if (method.StartsWith("DotnetDebugger.", StringComparison.Ordinal))
-                    return true;
-                return false;
+                return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
             }
 
             switch (method)
@@ -570,9 +568,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
             }
             // don't pass through DotnetDebugger.* messages to the browser
-            if (method.StartsWith("DotnetDebugger.", StringComparison.Ordinal))
-                return true;
-            return false;
+            return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
         }
 
         private async Task<bool> ApplyUpdates(MessageId id, JObject args, CancellationToken token)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1644970

BrowserDebugProxy was receiving from IDE messages like `DotnetDebugger.SetProperty` from context that didn't exist, then it was returning false, then the message was sent to browser, and browser doesn't know this message and return an error, then it was printing an error like this:

`B7CCCEF5694F2EF11713AE7F86743A45:::1018 -> [Result: IsOk: False, IsErr: True, Value: , Error: {   "code": -32601,   "message": "'DotnetDebugger.setDebuggerProperty' wasn't found" } ]`

In this PR we avoid sending `DotnetDebugger.*` commands that are our own extension, and unknown to the browser.