### PR TITLE
[release/6.0] [wasm][debugger] Never send messages from our internal protocol extensions to the browser

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -250,7 +250,10 @@ namespace Microsoft.WebAssembly.Diagnostics
                 await AttachToTarget(id, token);
 
             if (!contexts.TryGetValue(id, out ExecutionContext context))
-                return false;
+            {
+                // for Dotnetdebugger.* messages, treat them as handled, thus not passing them on to the browser
+                return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
+            }
 
             switch (method)
             {
@@ -536,11 +539,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
             }
 
-            //ignore all protocol extension messages not supported on .net6
-            if (method.StartsWith("DotnetDebugger.", StringComparison.Ordinal))
-                return true;
-
-            return false;
+            // for Dotnetdebugger.* messages, treat them as handled, thus not passing them on to the browser
+            return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
         }
         private async Task<bool> CallOnFunction(MessageId id, JObject args, CancellationToken token)
         {


### PR DESCRIPTION
Backport of #77616 to release/6.0

/cc @thaystg

## Customer Impact
Messages like this are printed in the console: 
`fail: Microsoft.WebAssembly.Diagnostics.DevToolsProxy[0] sending error response for id: msg-B7CCCEF5694F2EF11713AE7F86743A45:::1017 -> [Result: IsOk: False, IsErr: True, Value: , Error: {   "code": -32601,   "message": "'DotnetDebugger.setDebuggerProperty' wasn't found" } ]`

## Testing
Manually tested.

## Risk
Low risk, In this PR we avoid sending DotnetDebugger.* commands that are our own extension, and unknown to the browser.

IMPORTANT: Is this backport for a servicing release? If so and this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.