### PR TITLE
Emit less jump-stubs on x64

### DIFF
--- a/src/coreclr/inc/corjitflags.h
+++ b/src/coreclr/inc/corjitflags.h
@@ -73,7 +73,7 @@ public:
         CORJIT_FLAG_BBINSTR                 = 29, // Collect basic block profile information
         CORJIT_FLAG_BBOPT                   = 30, // Optimize method based on profile information
         CORJIT_FLAG_FRAMED                  = 31, // All methods have an EBP frame
-        CORJIT_FLAG_UNUSED12                = 32,
+        CORJIT_FLAG_DYNAMIC                 = 32, // Method is dynamic
         CORJIT_FLAG_PUBLISH_SECRET_PARAM    = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
         CORJIT_FLAG_UNUSED13                = 34,
         CORJIT_FLAG_SAMPLING_JIT_BACKGROUND = 35, // JIT is being invoked as a result of stack sampling for hot methods in the background

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -842,9 +842,8 @@ void Compiler::eeDispVar(ICorDebugInfo::NativeVarInfo* var)
     {
         name = "typeCtx";
     }
-    gtDispLclVar(var->varNumber, false);
-    printf("(%10s) : From %08Xh to %08Xh, in ", (VarNameToStr(name) == nullptr) ? "UNKNOWN" : VarNameToStr(name),
-           var->startOffset, var->endOffset);
+    printf("%3d(%10s) : From %08Xh to %08Xh, in ", var->varNumber,
+           (VarNameToStr(name) == nullptr) ? "UNKNOWN" : VarNameToStr(name), var->startOffset, var->endOffset);
 
     switch ((CodeGenInterface::siVarLocType)var->loc.vlType)
     {

--- a/src/coreclr/jit/jitee.h
+++ b/src/coreclr/jit/jitee.h
@@ -63,7 +63,7 @@ public:
         JIT_FLAG_BBINSTR                 = 29, // Collect basic block profile information
         JIT_FLAG_BBOPT                   = 30, // Optimize method based on profile information
         JIT_FLAG_FRAMED                  = 31, // All methods have an EBP frame
-        JIT_FLAG_UNUSED12                = 32,
+        JIT_FLAG_DYNAMIC                 = 32, // Method is dynamic
         JIT_FLAG_PUBLISH_SECRET_PARAM    = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
         JIT_FLAG_UNUSED13                = 34,
         JIT_FLAG_SAMPLING_JIT_BACKGROUND = 35, // JIT is being invoked as a result of stack sampling for hot methods in the background
@@ -201,6 +201,7 @@ public:
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_BBOPT, JIT_FLAG_BBOPT);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_FRAMED, JIT_FLAG_FRAMED);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM, JIT_FLAG_PUBLISH_SECRET_PARAM);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DYNAMIC, JIT_FLAG_DYNAMIC);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SAMPLING_JIT_BACKGROUND, JIT_FLAG_SAMPLING_JIT_BACKGROUND);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS, JIT_FLAG_USE_PINVOKE_HELPERS);
         FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE, JIT_FLAG_REVERSE_PINVOKE);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -4622,9 +4622,14 @@ bool Lowering::IsRMWMemOpRootedAtStoreInd(GenTree* tree, GenTree** outIndirCandi
     return true;
 }
 
-// anything is in range for AMD64
+// Assume addr is always in range, in the worst case we'll end up with a jump-stub if it's not
 bool Lowering::IsCallTargetInRange(void* addr)
 {
+    // Try to avoid jump-stubs for dynamic code.
+    if (comp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_DYNAMIC))
+    {
+        return comp->info.compCompHnd->getRelocTypeHint(addr) == IMAGE_REL_BASED_REL32;
+    }
     return true;
 }
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1415,7 +1415,7 @@ namespace Internal.JitInterface
         CORJIT_FLAG_BBINSTR = 29, // Collect basic block profile information
         CORJIT_FLAG_BBOPT = 30, // Optimize method based on profile information
         CORJIT_FLAG_FRAMED = 31, // All methods have an EBP frame
-        CORJIT_FLAG_UNUSED8 = 32,
+        CORJIT_FLAG_DYNAMIC = 32, // Method is dynamic
         CORJIT_FLAG_PUBLISH_SECRET_PARAM = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
         CORJIT_FLAG_UNUSED9 = 34,
         CORJIT_FLAG_SAMPLING_JIT_BACKGROUND = 35, // JIT is being invoked as a result of stack sampling for hot methods in the background

--- a/src/coreclr/vm/tieredcompilation.cpp
+++ b/src/coreclr/vm/tieredcompilation.cpp
@@ -1050,6 +1050,11 @@ CORJIT_FLAGS TieredCompilationManager::GetJitFlags(PrepareCodeConfig *config)
     if (nativeCodeVersion.IsDefaultVersion() && !config->WasTieringDisabledBeforeJitting())
     {
         MethodDesc *methodDesc = nativeCodeVersion.GetMethodDesc();
+        if (methodDesc->IsDynamicMethod())
+        {
+            flags.Set(CORJIT_FLAGS::CORJIT_FLAG_DYNAMIC);
+        }
+
         if (!methodDesc->IsEligibleForTieredCompilation())
         {
             _ASSERTE(nativeCodeVersion.GetOptimizationTier() == NativeCodeVersion::OptimizationTierOptimized);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77638, reduces number of jump stubs emitted from 44k to zero.

Codegen example for a method not within reloc32 reach:
```csharp
static object Foo() => new object();
```
```asm
G_M29399_IG01:              ;; offset=0000H
       4883EC28             sub      rsp, 40
G_M29399_IG02:              ;; offset=0004H
       48B9E0950831F87F0000 mov      rcx, 0x7FF8310895E0      ; System.Object
       48B88004BB90F87F0000 mov      rax, 0x7FF890BB0480      ; function address
       FFD0                 call     rax ; CORINFO_HELP_NEWSFAST
       90                   nop      
G_M29399_IG03:              ;; offset=001BH
       4883C428             add      rsp, 40
       C3                   ret      
; Total bytes of code 32
```
where previously we emitted just a call to a jump-stub.