### PR TITLE
Add explicit null checks for zero-offset struct fields

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_77640/Runtime_77640.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77640/Runtime_77640.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+unsafe class Runtime_77640
+{
+    public static int Main(string[] args)
+    {
+        int result = 101;
+        try
+        {
+            Problem(null);
+        }
+        catch (NullReferenceException)
+        {
+            result = 100;
+        }
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int* Problem(StructWithField* p) => &p->Field;
+
+    struct StructWithField
+    {
+        public int Field;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_77640/Runtime_77640.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77640/Runtime_77640.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1478,6 +1478,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_15291/GitHub_15291/**">
             <Issue>Doesn't pass after LLVM AOT compilation.</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_77640/Runtime_77640/**">
+            <Issue>https://github.com/dotnet/runtime/issues/77647</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b16928/b16928/**">
             <Issue>Doesn't pass after LLVM AOT compilation.</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes #77640.

We expect some unavoidable regressions.