### PR TITLE
Fix #77642 to update instruction to build, test, and get code coverage result in code-coverage.md

### DIFF
--- a/docs/workflow/building/libraries/code-coverage.md
+++ b/docs/workflow/building/libraries/code-coverage.md
@@ -48,7 +48,7 @@ The results for this one library will then be available in this index.htm file, 
 
 For example, to build, test, and get code coverage results for the System.Diagnostics.Debug library, from the root of the repo one can do:
 
-    dotnet build src\System.Diagnostics.Debug\tests /t:Test /p:Coverage=true
+    dotnet build src\libraries\System.Diagnostics.Debug\tests /t:Test /p:Coverage=true
 
 And then once the run completes:
 


### PR DESCRIPTION
Fix #77642 to update instruction to build, test, and get code coverage result in `code-coverage.md`

This PR is to update the sample instruction o build, test, and get code coverage result in `code-coverage.md` when running `dotnet build` to run test for .NET libraries.

For example: (after I change to use correct folder)

![image](https://user-images.githubusercontent.com/8773147/198852115-cc637db5-1400-4830-bab7-4475505371c8.png)

Please review, and thanks in advance! 🙂 
