### PR TITLE
Use GT_IND instead of LoadVector

### DIFF
--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -1339,6 +1339,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                 assert(sig->numArgs == 1);
             }
 
+            if (((intrinsic == NI_AdvSimd_LoadVector64) || (intrinsic == NI_AdvSimd_LoadVector128)) &&
+                !compOpportunisticallyDependsOn(InstructionSet_AdvSimd))
+            {
+                // Only canonize explicit loads when we have corresponding ISAs available
+                break;
+            }
+
             op1 = impPopStack().val;
 
             if (op1->OperIs(GT_CAST))

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -1340,9 +1340,9 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             }
 
             if (((intrinsic == NI_AdvSimd_LoadVector64) || (intrinsic == NI_AdvSimd_LoadVector128)) &&
-                !compOpportunisticallyDependsOn(InstructionSet_AdvSimd))
+                !compExactlyDependsOn(InstructionSet_AdvSimd))
             {
-                // Only canonize explicit loads when we have corresponding ISAs available
+                // Use IND for explicit loads only when we have corresponding ISAs available
                 break;
             }
 

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -1244,84 +1244,16 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
         case NI_Vector64_LoadAligned:
         case NI_Vector128_LoadAligned:
-        {
-            assert(sig->numArgs == 1);
-
-            if (!opts.MinOpts())
-            {
-                // ARM64 doesn't have aligned loads, but aligned loads are only validated to be
-                // aligned during minopts, so only skip the intrinsic handling if we're minopts
-                break;
-            }
-
-            op1 = impPopStack().val;
-
-            if (op1->OperIs(GT_CAST))
-            {
-                // Although the API specifies a pointer, if what we have is a BYREF, that's what
-                // we really want, so throw away the cast.
-                if (op1->gtGetOp1()->TypeGet() == TYP_BYREF)
-                {
-                    op1 = op1->gtGetOp1();
-                }
-            }
-
-            NamedIntrinsic loadIntrinsic = NI_Illegal;
-
-            if (simdSize == 16)
-            {
-                loadIntrinsic = NI_AdvSimd_LoadVector128;
-            }
-            else
-            {
-                loadIntrinsic = NI_AdvSimd_LoadVector64;
-            }
-
-            retNode = gtNewSimdHWIntrinsicNode(retType, op1, loadIntrinsic, simdBaseJitType, simdSize);
-            break;
-        }
-
         case NI_Vector64_LoadAlignedNonTemporal:
         case NI_Vector128_LoadAlignedNonTemporal:
-        {
             assert(sig->numArgs == 1);
-
             if (!opts.MinOpts())
             {
                 // ARM64 doesn't have aligned loads, but aligned loads are only validated to be
                 // aligned during minopts, so only skip the intrinsic handling if we're minopts
                 break;
             }
-
-            op1 = impPopStack().val;
-
-            if (op1->OperIs(GT_CAST))
-            {
-                // Although the API specifies a pointer, if what we have is a BYREF, that's what
-                // we really want, so throw away the cast.
-                if (op1->gtGetOp1()->TypeGet() == TYP_BYREF)
-                {
-                    op1 = op1->gtGetOp1();
-                }
-            }
-
-            // ARM64 has non-temporal loads (LDNP) but we don't currently support them
-
-            NamedIntrinsic loadIntrinsic = NI_Illegal;
-
-            if (simdSize == 16)
-            {
-                loadIntrinsic = NI_AdvSimd_LoadVector128;
-            }
-            else
-            {
-                loadIntrinsic = NI_AdvSimd_LoadVector64;
-            }
-
-            retNode = gtNewSimdHWIntrinsicNode(retType, op1, loadIntrinsic, simdBaseJitType, simdSize);
-            break;
-        }
-
+            FALLTHROUGH;
         case NI_AdvSimd_LoadVector64:
         case NI_AdvSimd_LoadVector128:
         case NI_Vector64_Load:
@@ -1569,52 +1501,16 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
         case NI_Vector64_StoreAligned:
         case NI_Vector128_StoreAligned:
-        {
-            assert(sig->numArgs == 2);
-            var_types simdType = getSIMDTypeForSize(simdSize);
-
-            if (!opts.MinOpts())
-            {
-                // ARM64 doesn't have aligned stores, but aligned stores are only validated to be
-                // aligned during minopts, so only skip the intrinsic handling if we're minopts
-                break;
-            }
-
-            impSpillSideEffect(true,
-                               verCurrentState.esStackDepth - 2 DEBUGARG("Spilling op1 side effects for HWIntrinsic"));
-
-            op2 = impPopStack().val;
-            op1 = impSIMDPopStack(simdType);
-
-            retNode = gtNewSimdHWIntrinsicNode(retType, op2, op1, NI_AdvSimd_Store, simdBaseJitType, simdSize);
-            break;
-        }
-
         case NI_Vector64_StoreAlignedNonTemporal:
         case NI_Vector128_StoreAlignedNonTemporal:
-        {
             assert(sig->numArgs == 2);
-            var_types simdType = getSIMDTypeForSize(simdSize);
-
             if (!opts.MinOpts())
             {
                 // ARM64 doesn't have aligned stores, but aligned stores are only validated to be
                 // aligned during minopts, so only skip the intrinsic handling if we're minopts
                 break;
             }
-
-            impSpillSideEffect(true,
-                               verCurrentState.esStackDepth - 2 DEBUGARG("Spilling op1 side effects for HWIntrinsic"));
-
-            op2 = impPopStack().val;
-            op1 = impSIMDPopStack(simdType);
-
-            // ARM64 has non-temporal stores (STNP) but we don't currently support them
-
-            retNode = gtNewSimdHWIntrinsicNode(retType, op2, op1, NI_AdvSimd_Store, simdBaseJitType, simdSize);
-            break;
-        }
-
+            FALLTHROUGH;
         case NI_AdvSimd_Store:
         case NI_Vector64_Store:
         case NI_Vector128_Store:

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -1816,7 +1816,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
             }
 
             retNode = gtNewIndir(retType, op1);
-            retNode->gtFlags |= GTF_IND_UNALIGNED;
+            retNode->gtFlags |= GTF_IND_UNALIGNED | GTF_GLOB_REF;
             break;
         }
 

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -1816,6 +1816,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
             }
 
             retNode = gtNewIndir(retType, op1);
+            retNode->gtFlags |= GTF_IND_UNALIGNED;
             break;
         }
 

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -1766,6 +1766,14 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                 assert(sig->numArgs == 1);
             }
 
+            if (((intrinsic == NI_SSE_LoadVector128) && !compOpportunisticallyDependsOn(InstructionSet_SSE)) ||
+                ((intrinsic == NI_SSE2_LoadVector128) && !compOpportunisticallyDependsOn(InstructionSet_SSE2)) ||
+                ((intrinsic == NI_AVX_LoadVector256) && !compOpportunisticallyDependsOn(InstructionSet_AVX)))
+            {
+                // Only canonize explicit loads when we have corresponding ISAs available
+                break;
+            }
+
             op1 = impPopStack().val;
 
             if (op1->OperIs(GT_CAST))

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -1766,11 +1766,11 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                 assert(sig->numArgs == 1);
             }
 
-            if (((intrinsic == NI_SSE_LoadVector128) && !compOpportunisticallyDependsOn(InstructionSet_SSE)) ||
-                ((intrinsic == NI_SSE2_LoadVector128) && !compOpportunisticallyDependsOn(InstructionSet_SSE2)) ||
-                ((intrinsic == NI_AVX_LoadVector256) && !compOpportunisticallyDependsOn(InstructionSet_AVX)))
+            if (((intrinsic == NI_SSE_LoadVector128) && !compExactlyDependsOn(InstructionSet_SSE)) ||
+                ((intrinsic == NI_SSE2_LoadVector128) && !compExactlyDependsOn(InstructionSet_SSE2)) ||
+                ((intrinsic == NI_AVX_LoadVector256) && !compExactlyDependsOn(InstructionSet_AVX)))
             {
-                // Only canonize explicit loads when we have corresponding ISAs available
+                // Use IND for explicit loads only when we have corresponding ISAs available
                 break;
             }
 

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -1657,42 +1657,6 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
             break;
         }
 
-        case NI_Vector128_Load:
-        case NI_Vector256_Load:
-        {
-            assert(sig->numArgs == 1);
-
-            op1 = impPopStack().val;
-
-            if (op1->OperIs(GT_CAST))
-            {
-                // Although the API specifies a pointer, if what we have is a BYREF, that's what
-                // we really want, so throw away the cast.
-                if (op1->gtGetOp1()->TypeGet() == TYP_BYREF)
-                {
-                    op1 = op1->gtGetOp1();
-                }
-            }
-
-            NamedIntrinsic loadIntrinsic = NI_Illegal;
-
-            if (simdSize == 32)
-            {
-                loadIntrinsic = NI_AVX_LoadVector256;
-            }
-            else if (simdBaseType != TYP_FLOAT)
-            {
-                loadIntrinsic = NI_SSE2_LoadVector128;
-            }
-            else
-            {
-                loadIntrinsic = NI_SSE_LoadVector128;
-            }
-
-            retNode = gtNewSimdHWIntrinsicNode(retType, op1, loadIntrinsic, simdBaseJitType, simdSize);
-            break;
-        }
-
         case NI_Vector128_LoadAligned:
         case NI_Vector256_LoadAligned:
         {
@@ -1784,11 +1748,17 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
             break;
         }
 
+        case NI_SSE_LoadVector128:
+        case NI_SSE2_LoadVector128:
+        case NI_AVX_LoadVector256:
+        case NI_Vector128_Load:
+        case NI_Vector256_Load:
         case NI_Vector128_LoadUnsafe:
         case NI_Vector256_LoadUnsafe:
         {
             if (sig->numArgs == 2)
             {
+                assert((intrinsic == NI_Vector128_LoadUnsafe) || (intrinsic == NI_Vector256_LoadUnsafe));
                 op2 = impPopStack().val;
             }
             else

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -1815,22 +1815,7 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
                 op1 = gtNewOperNode(GT_ADD, op1->TypeGet(), op1, op2);
             }
 
-            NamedIntrinsic loadIntrinsic = NI_Illegal;
-
-            if (simdSize == 32)
-            {
-                loadIntrinsic = NI_AVX_LoadVector256;
-            }
-            else if (simdBaseType != TYP_FLOAT)
-            {
-                loadIntrinsic = NI_SSE2_LoadVector128;
-            }
-            else
-            {
-                loadIntrinsic = NI_SSE_LoadVector128;
-            }
-
-            retNode = gtNewSimdHWIntrinsicNode(retType, op1, loadIntrinsic, simdBaseJitType, simdSize);
+            retNode = gtNewIndir(retType, op1);
             break;
         }
 


### PR DESCRIPTION
I noticed a suboptimal codegen for `Guid` comparisons, lets see what diffs think about @SingleAccretion's suggestion to fix that.

Example:
```csharp
bool Test(Guid g) => g == Guid.Empty;
```

Codegen diff:
```diff
; Assembly listing for method Proga:Test(System.Guid):bool:this
G_M54240_IG01:              
-      4883EC28             sub      rsp, 40
+      4883EC18             sub      rsp, 24
       C5F877               vzeroupper 
G_M54240_IG02:              
       C5F91002             vmovupd  xmm0, xmmword ptr [rdx]
-      C5F911442418         vmovupd  xmmword ptr [rsp+18H], xmm0
-      C5F857C0             vxorps   xmm0, xmm0, xmm0
       C5F911442408         vmovupd  xmmword ptr [rsp+08H], xmm0
-      C5FA6F442418         vmovdqu  xmm0, xmmword ptr [rsp+18H]
-      C5F974442408         vpcmpeqb xmm0, xmm0, xmmword ptr [rsp+08H]
-      C5F9D7C0             vpmovmskb eax, xmm0
-      3DFFFF0000           cmp      eax, 0xFFFF
+      C5F910442408         vmovupd  xmm0, xmmword ptr [rsp+08H]
+      C4E27917C0           vptest   xmm0, xmm0
       0F94C0               sete     al
       0FB6C0               movzx    rax, al
G_M54240_IG03:              
-      4883C428             add      rsp, 40
+      4883C418             add      rsp, 24
       C3                   ret      
-; Total bytes of code 59
+; Total bytes of code 39
```