### PR TITLE
Move `LibraryImport`s of `System.Data.OleDb` to `Common\src\Interop`

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitForMultipleObjects.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitForMultipleObjects.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Kernel32
+    {
+        [LibraryImport(Libraries.Kernel32, SetLastError = true)]
+        internal static unsafe partial int WaitForMultipleObjects(uint nCount, nint* handles, [MarshalAs(UnmanagedType.Bool)] bool waitAll, uint timeout);
+    }
+}

--- a/src/libraries/System.Data.OleDb/src/SafeNativeMethods.cs
+++ b/src/libraries/System.Data.OleDb/src/SafeNativeMethods.cs
@@ -35,15 +35,6 @@ namespace System.Data.Common
             return actualPtr;
         }
 
-        [LibraryImport(Interop.Libraries.Kernel32, SetLastError = true)]
-        internal static partial int ReleaseSemaphore(IntPtr handle, int releaseCount, IntPtr previousCount);
-
-        [LibraryImport(Interop.Libraries.Kernel32, SetLastError = true)]
-        internal static partial int WaitForMultipleObjectsEx(uint nCount, IntPtr lpHandles, [MarshalAs(UnmanagedType.Bool)] bool bWaitAll, uint dwMilliseconds, [MarshalAs(UnmanagedType.Bool)] bool bAlertable);
-
-        [LibraryImport(Interop.Libraries.Kernel32/*, SetLastError=true*/)]
-        internal static partial int WaitForSingleObjectEx(IntPtr lpHandles, uint dwMilliseconds, [MarshalAs(UnmanagedType.Bool)] bool bAlertable);
-
         internal sealed class Wrapper
         {
             private Wrapper() { }

--- a/src/libraries/System.Data.OleDb/src/System.Data.OleDb.csproj
+++ b/src/libraries/System.Data.OleDb/src/System.Data.OleDb.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -39,6 +39,12 @@ System.Data.OleDb.OleDbTransaction</PackageDescription>
              Link="Common\Interop\Windows\Kernel32\Interop.GetCurrentProcessId.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LocalAlloc.cs"
              Link="Common\Interop\Windows\Kernel32\Interop.LocalAlloc.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.Semaphore.cs"
+             Link="Common\Interop\Windows\Kernel32\Interop.Semaphore.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs"
+             Link="Common\Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.WaitForMultipleObjects.cs"
+             Link="Common\Interop\Windows\Kernel32\Interop.WaitForMultipleObjects.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\OleAut32\Interop.SysAllocStringLen.cs"
              Link="Common\Interop\Windows\OleAut32\Interop.SysAllocStringLen.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\OleAut32\Interop.SetErrorInfo.cs"

--- a/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
 using SysTx = System.Transactions;
 
 namespace System.Data.ProviderBase
@@ -223,9 +224,9 @@ namespace System.Data.ProviderBase
             // Using an AutoResetEvent does not have that complication.
             private readonly Semaphore _creationSemaphore;
 
-            private readonly SafeHandle _poolHandle;
-            private readonly SafeHandle _errorHandle;
-            private readonly SafeHandle _creationHandle;
+            private readonly SafeWaitHandle _poolHandle;
+            private readonly SafeWaitHandle _errorHandle;
+            private readonly SafeWaitHandle _creationHandle;
 
             private readonly int _releaseFlags;
 
@@ -274,7 +275,7 @@ namespace System.Data.ProviderBase
                 }
             }
 
-            internal SafeHandle CreationHandle
+            internal SafeWaitHandle CreationHandle
             {
                 get { return _creationHandle; }
             }
@@ -351,7 +352,7 @@ namespace System.Data.ProviderBase
         private readonly WaitCallback _poolCreateRequest;
 
         private int _waitCount;
-        private readonly PoolWaitHandles _waitHandles;
+        private PoolWaitHandles _waitHandles;
 
         private Exception? _resError;
         private volatile bool _errorOccurred;
@@ -1121,7 +1122,11 @@ namespace System.Data.ProviderBase
                         }
                         finally
                         {
-                            waitResult = SafeNativeMethods.WaitForMultipleObjectsEx(waitHandleCount, _waitHandles.DangerousGetHandle(), false, waitForMultipleObjectsTimeout, false);
+                            unsafe
+                            {
+                                nint* handle = (nint*)_waitHandles.DangerousGetHandle();
+                                waitResult = Interop.Kernel32.WaitForMultipleObjects(waitHandleCount, handle, false, waitForMultipleObjectsTimeout);
+                            }
 
                             // call GetHRForLastWin32Error immediately after after the native call
                             if (waitResult == WAIT_FAILED)
@@ -1252,8 +1257,8 @@ namespace System.Data.ProviderBase
                     {
                         if (CREATION_HANDLE == waitResult)
                         {
-                            int result = SafeNativeMethods.ReleaseSemaphore(_waitHandles.CreationHandle.DangerousGetHandle(), 1, IntPtr.Zero);
-                            if (0 == result)
+                            bool result = Interop.Kernel32.ReleaseSemaphore(_waitHandles.CreationHandle, 1, out _);
+                            if (!result)
                             { // failure case
                                 releaseSemaphoreResult = Marshal.GetHRForLastWin32Error();
                             }
@@ -1440,7 +1445,7 @@ namespace System.Data.ProviderBase
                             { }
                             finally
                             {
-                                waitResult = SafeNativeMethods.WaitForSingleObjectEx(_waitHandles.CreationHandle.DangerousGetHandle(), timeout, false);
+                                waitResult = Interop.Kernel32.WaitForSingleObject(_waitHandles.CreationHandle, (int)timeout);
                             }
                             if (WAIT_OBJECT_0 == waitResult)
                             {
@@ -1495,7 +1500,7 @@ namespace System.Data.ProviderBase
                             if (WAIT_OBJECT_0 == waitResult)
                             {
                                 // reuse waitResult and ignore its value
-                                waitResult = SafeNativeMethods.ReleaseSemaphore(_waitHandles.CreationHandle.DangerousGetHandle(), 1, IntPtr.Zero);
+                                waitResult = Interop.Kernel32.ReleaseSemaphore(_waitHandles.CreationHandle, 1, out _) ? 1 : 0;
                             }
                             if (mustRelease)
                             {


### PR DESCRIPTION
Contributes to #28035.

I also changed a few `SafeHandle`s to `SafeWaitHandle`s to match the already existing Kernel32 API `WaitForSingleObject`.
The tests are passing so I don't see any problem here since it's not part of a public API.