### PR TITLE
Correct minimum memory size value from 200MB to 20MB

### DIFF
--- a/src/mono/mono/utils/memfuncs.c
+++ b/src/mono/mono/utils/memfuncs.c
@@ -70,7 +70,7 @@
 			__d [__i] = NULL;		\
 	} while (0)
 
-#define MINMEMSZ 209715200      /* Minimum restricted memory size */
+#define MINMEMSZ 20971520	/* Minimum restricted memory size - 20MB */
 
 /**
  * mono_gc_bzero_aligned:


### PR DESCRIPTION
Typo caused value to be 200MB instead of 20MB.