### PR TITLE
Exclude param/return/exception tags from summary block

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -389,8 +389,8 @@ namespace System
 
         /// <summary>
         /// Get a count of the bytes allocated over the lifetime of the process.
-        /// <param name="precise">If true, gather a precise number, otherwise gather a fairly count. Gathering a precise value triggers at a significant performance penalty.</param>
         /// </summary>
+        /// <param name="precise">If true, gather a precise number, otherwise gather a fairly count. Gathering a precise value triggers at a significant performance penalty.</param>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern long GetTotalAllocatedBytes(bool precise = false);
 
@@ -795,8 +795,8 @@ namespace System
         /// <summary>
         /// Gets the Configurations used by the Garbage Collector. The value of these configurations used don't necessarily have to be the same as the ones that are passed by the user.
         /// For example for the "GCHeapCount" configuration, if the user supplies a value higher than the number of CPUs, the configuration that will be used is that of the number of CPUs.
-        /// <returns> A Read Only Dictionary with configuration names and values of the configuration as the keys and values of the dictionary, respectively.</returns>
         /// </summary>
+        /// <returns> A Read Only Dictionary with configuration names and values of the configuration as the keys and values of the dictionary, respectively.</returns>
         public static unsafe IReadOnlyDictionary<string, object> GetConfigurationVariables()
         {
             GCConfigurationContext context = new GCConfigurationContext

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
@@ -637,8 +637,8 @@ namespace System
         /// <summary>
         /// Gets the Configurations used by the Garbage Collector. The value of these configurations used don't necessarily have to be the same as the ones that are passed by the user.
         /// For example for the "GCHeapCount" configuration, if the user supplies a value higher than the number of CPUs, the configuration that will be used is that of the number of CPUs.
-        /// <returns> A Read Only Dictionary with configuration names and values of the configuration as the keys and values of the dictionary, respectively.</returns>
         /// </summary>
+        /// <returns> A Read Only Dictionary with configuration names and values of the configuration as the keys and values of the dictionary, respectively.</returns>
         public static unsafe IReadOnlyDictionary<string, object> GetConfigurationVariables()
         {
             GCConfigurationContext context = new GCConfigurationContext

--- a/src/libraries/Common/src/System/IO/RowConfigReader.cs
+++ b/src/libraries/Common/src/System/IO/RowConfigReader.cs
@@ -20,8 +20,8 @@ namespace System.IO
 
         /// <summary>
         /// Constructs a new RowConfigReader which reads from the given string.
-        /// <param name="buffer">The string to parse through.</param>
         /// </summary>
+        /// <param name="buffer">The string to parse through.</param>
         public RowConfigReader(string buffer)
         {
             _buffer = buffer;
@@ -31,9 +31,9 @@ namespace System.IO
 
         /// <summary>
         /// Constructs a new RowConfigReader which reads from the given string.
+        /// </summary>
         /// <param name="buffer">The string to parse through.</param>
         /// <param name="comparisonKind">The comparison kind to use.</param>
-        /// </summary>
         public RowConfigReader(string buffer, StringComparison comparisonKind)
         {
             _buffer = buffer;

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -306,8 +306,8 @@ namespace System.Collections.Generic
 
             /// <summary>
             /// Checks whether this subset is out of date, and updates it if necessary.
-            /// <param name="updateCount">Updates the count variable if necessary.</param>
             /// </summary>
+            /// <param name="updateCount">Updates the count variable if necessary.</param>
             internal override void VersionCheck(bool updateCount = false) => VersionCheckImpl(updateCount);
 
             private void VersionCheckImpl(bool updateCount)

--- a/src/libraries/System.Composition.AttributedModel/src/System/Composition/Convention/AttributedModelProvider.cs
+++ b/src/libraries/System.Composition.AttributedModel/src/System/Composition/Convention/AttributedModelProvider.cs
@@ -20,10 +20,10 @@ namespace System.Composition.Convention
         public abstract IEnumerable<Attribute> GetCustomAttributes(System.Type reflectedType, MemberInfo member);
 
         /// <summary>
+        /// </summary>
         /// <param name="reflectedType">The reflectedType the type used to retrieve the parameterInfo.</param>
         /// <param name="parameter">The member to supply attributes for.</param>
         /// <returns>The list of applied attributes.</returns>
-        /// </summary>
         public abstract IEnumerable<Attribute> GetCustomAttributes(System.Type reflectedType, ParameterInfo parameter);
     }
 }

--- a/src/libraries/System.Management/src/System/Management/ManagementException.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementException.cs
@@ -687,8 +687,8 @@ namespace System.Management
         /// <summary>
         /// <para>Initializes a new instance of the <see cref='System.Management.ManagementException'/>
         /// class with a specified error message.</para>
-        /// <param name='message'>The message that describes the error.</param>
         /// </summary>
+        /// <param name='message'>The message that describes the error.</param>
         public ManagementException(string message):this(ManagementStatus.Failed, message, null)
         {
 
@@ -696,11 +696,11 @@ namespace System.Management
 
         /// <summary>
         /// <para>Initializes a empty new instance of the <see cref='System.Management.ManagementException'/> class </para>
+        /// </summary>
         /// <param name='message'>The message that describes the error.</param>
         /// <param name='innerException'>The exception that is the cause of the current exception. If the innerException
         /// parameter is not a null reference (Nothing in Visual Basic), the current exception is raised in a catch
         /// block that handles the inner exception.</param>
-        /// </summary>
         public ManagementException(string message, Exception innerException):this(innerException, message, null)
         {
             // if the exception passed is not a ManagementException, then initialize the ErrorCode to Failed

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/IPinnable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/IPinnable.cs
@@ -11,8 +11,8 @@ namespace System.Buffers
         /// <summary>
         /// Call this method to indicate that the IPinnable object can not be moved by the garbage collector.
         /// The address of the pinned object can be taken.
-        /// <param name="elementIndex">The offset to the element within the memory at which the returned <see cref="MemoryHandle"/> points to.</param>
         /// </summary>
+        /// <param name="elementIndex">The offset to the element within the memory at which the returned <see cref="MemoryHandle"/> points to.</param>
         MemoryHandle Pin(int elementIndex);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.Base64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.Base64.cs
@@ -13,12 +13,11 @@ namespace System
         /// Decode the span of UTF-16 encoded text represented as base 64 into binary data.
         /// If the input is not a multiple of 4, or contains illegal characters, it will decode as much as it can, to the largest possible multiple of 4.
         /// This invariant allows continuation of the parse with a slower, whitespace-tolerant algorithm.
-        ///
+        /// </summary>
         /// <param name="utf16">The input span which contains UTF-16 encoded text in base 64 that needs to be decoded.</param>
         /// <param name="bytes">The output span which contains the result of the operation, i.e. the decoded binary data.</param>
         /// <param name="consumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
         /// <param name="written">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
-        /// </summary>
         /// <returns>Returns:
         /// - true  - The entire input span was successfully parsed.
         /// - false - Only a part of the input span was successfully parsed. Failure causes may include embedded or trailing whitespace,

--- a/src/libraries/System.Private.CoreLib/src/System/Memory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Memory.cs
@@ -355,22 +355,20 @@ namespace System
         /// Copies the contents of the memory into the destination. If the source
         /// and destination overlap, this method behaves as if the original values are in
         /// a temporary location before the destination is overwritten.
-        ///
+        /// </summary>
         /// <param name="destination">The Memory to copy items into.</param>
         /// <exception cref="System.ArgumentException">
         /// Thrown when the destination is shorter than the source.
         /// </exception>
-        /// </summary>
         public void CopyTo(Memory<T> destination) => Span.CopyTo(destination.Span);
 
         /// <summary>
         /// Copies the contents of the memory into the destination. If the source
         /// and destination overlap, this method behaves as if the original values are in
         /// a temporary location before the destination is overwritten.
-        ///
+        /// </summary>
         /// <returns>If the destination is shorter than the source, this method
         /// return false and no data is written to the destination.</returns>
-        /// </summary>
         /// <param name="destination">The span to copy items into.</param>
         public bool TryCopyTo(Memory<T> destination) => Span.TryCopyTo(destination.Span);
 
@@ -378,10 +376,10 @@ namespace System
         /// Creates a handle for the memory.
         /// The GC will not move the memory until the returned <see cref="MemoryHandle"/>
         /// is disposed, enabling taking and using the memory's address.
+        /// </summary>
         /// <exception cref="System.ArgumentException">
         /// An instance with nonprimitive (non-blittable) members cannot be pinned.
         /// </exception>
-        /// </summary>
         public unsafe MemoryHandle Pin()
         {
             // Just like the Span property getter, we have special support for a mutable Memory<char>

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Globalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Globalization.cs
@@ -26,10 +26,10 @@ namespace System
 
         /// <summary>
         /// Returns a value indicating whether the specified <paramref name="value"/> occurs within the <paramref name="span"/>.
+        /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
-        /// </summary>
         public static bool Contains(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
             return IndexOf(span, value, comparisonType) >= 0;
@@ -38,10 +38,10 @@ namespace System
         /// <summary>
         /// Determines whether this <paramref name="span"/> and the specified <paramref name="other"/> span have the same characters
         /// when compared using the specified <paramref name="comparisonType"/> option.
+        /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="other">The value to compare with the source span.</param>
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="other"/> are compared.</param>
-        /// </summary>
         [Intrinsic] // Unrolled and vectorized for half-constant input (Ordinal)
         public static bool Equals(this ReadOnlySpan<char> span, ReadOnlySpan<char> other, StringComparison comparisonType)
         {
@@ -89,10 +89,10 @@ namespace System
         /// <summary>
         /// Compares the specified <paramref name="span"/> and <paramref name="other"/> using the specified <paramref name="comparisonType"/>,
         /// and returns an integer that indicates their relative position in the sort order.
+        /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="other">The value to compare with the source span.</param>
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="other"/> are compared.</param>
-        /// </summary>
         public static int CompareTo(this ReadOnlySpan<char> span, ReadOnlySpan<char> other, StringComparison comparisonType)
         {
             string.CheckStringComparison(comparisonType);
@@ -120,10 +120,10 @@ namespace System
 
         /// <summary>
         /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/> in the current <paramref name="span"/>.
+        /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
-        /// </summary>
         public static int IndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
             string.CheckStringComparison(comparisonType);
@@ -151,10 +151,10 @@ namespace System
 
         /// <summary>
         /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the current <paramref name="span"/>.
+        /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
-        /// </summary>
         public static int LastIndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
             string.CheckStringComparison(comparisonType);

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -2428,13 +2428,12 @@ namespace System
         /// Copies the contents of the array into the span. If the source
         /// and destinations overlap, this method behaves as if the original values in
         /// a temporary location before the destination is overwritten.
-        ///
+        /// </summary>
         ///<param name="source">The array to copy items from.</param>
         /// <param name="destination">The span to copy items into.</param>
         /// <exception cref="System.ArgumentException">
         /// Thrown when the destination Span is shorter than the source array.
         /// </exception>
-        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyTo<T>(this T[]? source, Span<T> destination)
         {
@@ -2445,13 +2444,12 @@ namespace System
         /// Copies the contents of the array into the memory. If the source
         /// and destinations overlap, this method behaves as if the original values are in
         /// a temporary location before the destination is overwritten.
-        ///
+        /// </summary>
         ///<param name="source">The array to copy items from.</param>
         /// <param name="destination">The memory to copy items into.</param>
         /// <exception cref="System.ArgumentException">
         /// Thrown when the destination is shorter than the source array.
         /// </exception>
-        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyTo<T>(this T[]? source, Memory<T> destination)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
@@ -277,22 +277,20 @@ namespace System
         /// Copies the contents of the read-only memory into the destination. If the source
         /// and destination overlap, this method behaves as if the original values are in
         /// a temporary location before the destination is overwritten.
-        ///
+        /// </summary>
         /// <param name="destination">The Memory to copy items into.</param>
         /// <exception cref="System.ArgumentException">
         /// Thrown when the destination is shorter than the source.
         /// </exception>
-        /// </summary>
         public void CopyTo(Memory<T> destination) => Span.CopyTo(destination.Span);
 
         /// <summary>
         /// Copies the contents of the readonly-only memory into the destination. If the source
         /// and destination overlap, this method behaves as if the original values are in
         /// a temporary location before the destination is overwritten.
-        ///
+        /// </summary>
         /// <returns>If the destination is shorter than the source, this method
         /// return false and no data is written to the destination.</returns>
-        /// </summary>
         /// <param name="destination">The span to copy items into.</param>
         public bool TryCopyTo(Memory<T> destination) => Span.TryCopyTo(destination.Span);
 
@@ -300,10 +298,10 @@ namespace System
         /// Creates a handle for the memory.
         /// The GC will not move the memory until the returned <see cref="MemoryHandle"/>
         /// is disposed, enabling taking and using the memory's address.
+        /// </summary>
         /// <exception cref="System.ArgumentException">
         /// An instance with nonprimitive (non-blittable) members cannot be pinned.
         /// </exception>
-        /// </summary>
         public unsafe MemoryHandle Pin()
         {
             // It's possible that the below logic could result in an AV if the struct

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -177,10 +177,10 @@ namespace System
 
         /// <summary>
         /// This method is not supported as spans cannot be boxed. To compare two spans, use operator==.
+        /// </summary>
         /// <exception cref="System.NotSupportedException">
         /// Always thrown by this method.
         /// </exception>
-        /// </summary>
         [Obsolete("Equals() on ReadOnlySpan will always throw an exception. Use the equality operator instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object? obj) =>
@@ -188,10 +188,10 @@ namespace System
 
         /// <summary>
         /// This method is not supported as spans cannot be boxed.
+        /// </summary>
         /// <exception cref="System.NotSupportedException">
         /// Always thrown by this method.
         /// </exception>
-        /// </summary>
         [Obsolete("GetHashCode() on ReadOnlySpan will always throw an exception.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() =>
@@ -272,12 +272,11 @@ namespace System
         /// Copies the contents of this read-only span into destination span. If the source
         /// and destinations overlap, this method behaves as if the original values in
         /// a temporary location before the destination is overwritten.
-        ///
+        /// </summary>
         /// <param name="destination">The span to copy items into.</param>
         /// <exception cref="System.ArgumentException">
         /// Thrown when the destination Span is shorter than the source Span.
         /// </exception>
-        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void CopyTo(Span<T> destination)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -428,8 +428,8 @@ namespace System.Runtime.InteropServices
 
         /// <summary>
         /// Reads a structure of type T out of a span of bytes.
-        /// <returns>If the span is too small to contain the type T, return false.</returns>
         /// </summary>
+        /// <returns>If the span is too small to contain the type T, return false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryRead<T>(ReadOnlySpan<byte> source, out T value)
             where T : struct
@@ -467,8 +467,8 @@ namespace System.Runtime.InteropServices
 
         /// <summary>
         /// Writes a structure of type T into a span of bytes.
-        /// <returns>If the span is too small to contain the type T, return false.</returns>
         /// </summary>
+        /// <returns>If the span is too small to contain the type T, return false.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryWrite<T>(Span<byte> destination, ref T value)
             where T : struct

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -182,10 +182,10 @@ namespace System
 
         /// <summary>
         /// This method is not supported as spans cannot be boxed. To compare two spans, use operator==.
+        /// </summary>
         /// <exception cref="System.NotSupportedException">
         /// Always thrown by this method.
         /// </exception>
-        /// </summary>
         [Obsolete("Equals() on Span will always throw an exception. Use the equality operator instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object? obj) =>
@@ -193,10 +193,10 @@ namespace System
 
         /// <summary>
         /// This method is not supported as spans cannot be boxed.
+        /// </summary>
         /// <exception cref="System.NotSupportedException">
         /// Always thrown by this method.
         /// </exception>
-        /// </summary>
         [Obsolete("GetHashCode() on Span will always throw an exception.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() =>


### PR DESCRIPTION
This fixes Visual Studio tooltip rendering e.g. parameter documentation as part
of the method summary.

main:
![image](https://user-images.githubusercontent.com/919634/199064311-41ea66dc-4c41-4f5a-87a6-8f2ef6ce85c8.png)
![image](https://user-images.githubusercontent.com/919634/199062751-8c947f2f-e5bc-412b-8dd3-182ffdbccb44.png)

PR:
![image](https://user-images.githubusercontent.com/919634/199062825-673a2cc8-77cc-482f-80cb-e6981c6ade63.png)
![image](https://user-images.githubusercontent.com/919634/199062888-40ff6fe4-c290-45b0-9925-894a3f5f1623.png)
