### PR TITLE
Delete `fgMorphBlockOperand`

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5774,7 +5774,7 @@ private:
     GenTree* fgMorphLeaf(GenTree* tree);
     GenTree* fgMorphOneAsgBlockOp(GenTree* tree);
     GenTree* fgMorphInitBlock(GenTree* tree);
-    GenTree* fgMorphBlockOperand(GenTree* tree, var_types asgType, ClassLayout* blockLayout, bool isBlkReqd);
+    GenTree* fgMorphBlockOperand(GenTree* tree, var_types asgType);
     GenTree* fgMorphCopyBlock(GenTree* tree);
     GenTree* fgMorphStoreDynBlock(GenTreeStoreDynBlk* tree);
     GenTree* fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optAssertionPropDone = nullptr);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5774,7 +5774,6 @@ private:
     GenTree* fgMorphLeaf(GenTree* tree);
     GenTree* fgMorphOneAsgBlockOp(GenTree* tree);
     GenTree* fgMorphInitBlock(GenTree* tree);
-    GenTree* fgMorphBlockOperand(GenTree* tree, var_types asgType);
     GenTree* fgMorphCopyBlock(GenTree* tree);
     GenTree* fgMorphStoreDynBlock(GenTreeStoreDynBlk* tree);
     GenTree* fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac, bool* optAssertionPropDone = nullptr);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8739,58 +8739,6 @@ GenTree* Compiler::fgMorphOneAsgBlockOp(GenTree* tree)
     return tree;
 }
 
-//------------------------------------------------------------------------
-// fgMorphBlockOperand: Retype an operand of a block assignment
-//
-// Arguments:
-//    tree    - The block operand
-//    asgType - The (new) scalar type of the assignment
-//
-// Return Value:
-//    Returns the morphed block operand
-//
-GenTree* Compiler::fgMorphBlockOperand(GenTree* tree, var_types asgType)
-{
-    assert(asgType != TYP_STRUCT);
-
-    GenTree* effectiveVal = tree->gtEffectiveVal();
-    unsigned blockWidth   = genTypeSize(asgType);
-
-    if (effectiveVal->OperIsIndir())
-    {
-        GenTree* addr = effectiveVal->AsIndir()->Addr();
-        if ((addr->OperGet() == GT_ADDR) && (addr->gtGetOp1()->TypeGet() == asgType))
-        {
-            effectiveVal = addr->gtGetOp1();
-        }
-        else if (effectiveVal->OperIsBlk())
-        {
-            effectiveVal->SetOper(GT_IND);
-        }
-
-        effectiveVal->gtType = asgType;
-    }
-    else if (effectiveVal->TypeGet() != asgType)
-    {
-        if (effectiveVal->IsCall())
-        {
-#ifdef DEBUG
-            GenTreeCall* call = effectiveVal->AsCall();
-            assert(call->TypeGet() == TYP_STRUCT);
-            assert(blockWidth == info.compCompHnd->getClassSize(call->gtRetClsHnd));
-#endif
-        }
-        else
-        {
-            GenTree* addr = gtNewOperNode(GT_ADDR, TYP_BYREF, effectiveVal);
-            effectiveVal  = gtNewIndir(asgType, addr);
-        }
-    }
-
-    assert(effectiveVal->TypeIs(asgType));
-    return effectiveVal;
-}
-
 #ifdef FEATURE_SIMD
 
 //--------------------------------------------------------------------------------------------------------------

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -396,11 +396,7 @@ GenTree* MorphInitBlockHelper::MorphBlock(Compiler* comp, GenTree* tree, bool is
     JITDUMP("MorphBlock for %s tree, before:\n", (isDest ? "dst" : "src"));
     DISPTREE(tree);
 
-    // Src can be a primitive type.
-    assert(!isDest || varTypeIsStruct(tree));
-
-    GenTree* handleTree = nullptr;
-    GenTree* addr       = nullptr;
+    assert(varTypeIsStruct(tree));
 
     if (tree->OperIs(GT_COMMA))
     {
@@ -413,16 +409,7 @@ GenTree* MorphInitBlockHelper::MorphBlock(Compiler* comp, GenTree* tree, bool is
         }
     }
 
-    if (!tree->OperIsBlk())
-    {
-        JITDUMP("MorphBlock after:\n");
-        DISPTREE(tree);
-        return tree;
-    }
-
-    GenTree* blkAddr = tree->AsBlk()->Addr();
-    assert(blkAddr != nullptr);
-    assert(blkAddr->TypeIs(TYP_I_IMPL, TYP_BYREF, TYP_REF));
+    assert(!tree->OperIsIndir() || varTypeIsI(genActualType(tree->AsIndir()->Addr())));
 
     JITDUMP("MorphBlock after:\n");
     DISPTREE(tree);

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -357,13 +357,8 @@ void MorphInitBlockHelper::MorphStructCases()
 
     if (m_transformationDecision == BlockTransformation::Undefined)
     {
-        // For an InitBlock we always require a block operand.
-        m_dst = m_comp->fgMorphBlockOperand(m_dst, m_dst->TypeGet(), m_blockLayout, true /*isBlkReqd*/);
+        m_result                 = m_asg;
         m_transformationDecision = BlockTransformation::StructBlock;
-        m_dst->gtFlags |= GTF_DONT_CSE;
-        m_result                = m_asg;
-        m_result->AsOp()->gtOp1 = m_dst;
-        m_result->gtFlags |= (m_dst->gtFlags & GTF_ALL_EFFECT);
 
         if (m_dstVarDsc != nullptr)
         {
@@ -833,12 +828,27 @@ void MorphCopyBlockHelper::PrepareSrc()
         m_srcVarDsc = m_comp->lvaGetDesc(m_srcLclNum);
     }
 
-    // Verify that the types on the LHS and RHS match.
+    // Verify that the types on the LHS and RHS match and morph away "IND<struct>" nodes.
     assert(m_dst->TypeGet() == m_src->TypeGet());
-    // TODO-1stClassStructs: delete the "!IND" condition once "IND<struct>" nodes are no more.
-    if (m_dst->TypeIs(TYP_STRUCT) && !m_src->OperIs(GT_IND))
+    if (m_dst->TypeIs(TYP_STRUCT))
     {
+        // TODO-1stClassStructs: delete this once "IND<struct>" nodes are no more.
+        if (m_src->OperIs(GT_IND))
+        {
+            m_src->SetOper(m_blockLayout->IsBlockLayout() ? GT_BLK : GT_OBJ);
+            m_src->AsBlk()->SetLayout(m_blockLayout);
+            m_src->AsBlk()->gtBlkOpKind = GenTreeBlk::BlkOpKindInvalid;
+#ifndef JIT32_GCENCODER
+            m_src->AsBlk()->gtBlkOpGcUnsafe = false;
+#endif // !JIT32_GCENCODER
+        }
+
         assert(ClassLayout::AreCompatible(m_blockLayout, m_src->GetLayout(m_comp)));
+    }
+    // TODO-1stClassStructs: produce simple "IND<simd>" nodes in importer.
+    else if (m_src->OperIsBlk())
+    {
+        m_src->SetOper(GT_IND);
     }
 }
 
@@ -976,7 +986,7 @@ void MorphCopyBlockHelper::MorphStructCases()
     // promotion.
     if ((m_srcVarDsc == nullptr) && !m_src->OperIsIndir())
     {
-        JITDUMP(" src is a not an L-value");
+        JITDUMP(" src is not an L-value");
         requiresCopyBlock = true;
     }
 
@@ -1117,18 +1127,6 @@ void MorphCopyBlockHelper::MorphStructCases()
 
     if (requiresCopyBlock)
     {
-        const var_types asgType   = m_dst->TypeGet();
-        bool            isBlkReqd = (asgType == TYP_STRUCT);
-        m_dst                     = m_comp->fgMorphBlockOperand(m_dst, asgType, m_blockLayout, isBlkReqd);
-        m_dst->gtFlags |= GTF_DONT_CSE;
-        m_asg->gtOp1 = m_dst;
-
-        m_src        = m_comp->fgMorphBlockOperand(m_src, asgType, m_blockLayout, isBlkReqd);
-        m_asg->gtOp2 = m_src;
-
-        m_asg->SetAllEffectsFlags(m_dst, m_src);
-        m_asg->gtFlags |= GTF_ASG;
-
         m_result                 = m_asg;
         m_transformationDecision = BlockTransformation::StructBlock;
     }

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -407,6 +407,10 @@ GenTree* MorphInitBlockHelper::MorphBlock(Compiler* comp, GenTree* tree, bool is
         // TODO-Cleanup: this block is not needed for not struct nodes, but
         // fgMorphOneAsgBlockOp works wrong without this transformation.
         tree = MorphCommaBlock(comp, tree->AsOp());
+        if (isDest)
+        {
+            tree->SetDoNotCSE();
+        }
     }
 
     if (!tree->OperIsBlk())


### PR DESCRIPTION
No longer necessary as we don't need to compensate for invalid IR.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=80322&view=ms.vss-build-web.run-extensions-tab) - a TP improvement, plus one small diff where we don't reduce `OBJ(ADDR(LCL_VAR))` created by forward substitution, but it ends up being a bit better anyway.