### PR TITLE
Improving log output when an argument is a single non-object array

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
@@ -28,6 +28,12 @@ namespace Microsoft.Extensions.Logging
 
         public FormattedLogValues(string? format, params object?[]? values)
         {
+            // corrects when a single non-object array value is cast to object[]
+            if (values != null && values.GetType() != typeof(object[]))
+            {
+                values = new object[] { values };
+            }
+
             if (values != null && values.Length != 0 && format != null)
             {
                 if (_count >= MaxCachedFormatters)

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerFactoryTest.cs
@@ -397,11 +397,11 @@ namespace Microsoft.Extensions.Logging.Test
 
             Activity activity = new Activity("ScopeActivity");
             activity.Start();
-            logger.LogInformation("Message1");
+            logger.LogInformation("Hello {arg}", new[] { "a", "b", "c" });
             string traceIdActivityLogString = GetActivityLogString(ActivityTrackingOptions.TraceId);
             activity.Stop();
 
-            Assert.Equal("Message1", loggerProvider.LogText[0]);
+            Assert.Equal("Hello a, b, c", loggerProvider.LogText[0]);
             Assert.Equal(traceIdActivityLogString, loggerProvider.LogText[1]);
             Assert.Equal(2, loggerProvider.LogText.Count); // Ensure that the additional scopes for tags and baggage aren't added.
         }


### PR DESCRIPTION
### Explanation of the issue

Consider code sample:

```cs
var logger = LoggerFactory.Create(config => config.AddConsole()).CreateLogger("Program");
logger.LogInformation("Hello {arg}", new[] { "a", "b", "c" });
```

Actual behavior:
```
info: Program[0]
      Hello a
```

Expected:
```
info: Program[0]
Hello System.String[]
```
or
```
info: Program[0]
      Hello a, b, c
```

### Summary of investigation

Refer to this statement in `LogValuesFormatter`:

https://github.com/dotnet/runtime/blob/fbc20578253e0deb7267eea5a02b680c3cfe0e2a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs#L151

Assuming `_format` is `"Hello {0}"` and `formattedValues` is any of the three cases below (easy to paste into https://dotnetfiddle.net/):

Code:
```cs
using System;
using System.Globalization;
					
public class Program
{
	public static void Main()
	{
		object?[]? formattedValues;

// case 1
		formattedValues = new string[] { "a", "b", "c" };
		var formatted =
			string.Format(CultureInfo.InvariantCulture, "Hello {0}", formattedValues ?? Array.Empty<object>());

		// output is "Hello a"
                Console.WriteLine(formatted);

// case 2
		formattedValues = new ABC[] { new ABC("1"), new ABC("2"), new ABC("3") };
		formatted =
			string.Format(CultureInfo.InvariantCulture, "Hello {0}", formattedValues ?? Array.Empty<object>());

		// output is "Hello 1"
                Console.WriteLine(formatted);  // output is "Hello 1"

// case 3
		formattedValues = new object[1] { new string[] { "a", "b", "c" } };
		formatted =
			string.Format(CultureInfo.InvariantCulture, "Hello {0}", formattedValues ?? Array.Empty<object>());

		// output is "Hello System.String[]"
                Console.WriteLine(formatted);  // output is "Hello System.String[]"
	}

	private class ABC
	{
		private readonly string _a;
		public ABC(string a)
		{
			_a = a;
		}
		public override string ToString() { return _a; }
	}
}
```

the output is as follows:

```
Hello a
Hello 1
Hello System.String[]
```

This means when the single argument to format for logging is not an object array we fallback whatever `string.Format` in the above statement does. We should rather fix this by relying on how `LogValuesFormatter` knows to format an argument (here `IEnumerable`) as seen in the code snippet below: (by casting the single non-object array to an object array)

In the code snippet below `LogValuesFormatter` has logic to use `ToString()` on IEnumerable argument during format and make it output comma separated to-stringed elements:

https://github.com/dotnet/runtime/blob/fbc20578253e0deb7267eea5a02b680c3cfe0e2a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs#L229-L247

Fixes #77335