### PR TITLE
[mono][wasm] Handle delegates decorated with [UnmanagedFunctionPointe…

### DIFF
--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -79,7 +79,7 @@ internal sealed class PInvokeTableGenerator
             }
         }
 
-        if (HasAttribute(type, new string[] {"System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute"}))
+        if (HasAttribute(type, "System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute"))
         {
             var method = type.GetMethod("Invoke");
 
@@ -167,15 +167,20 @@ internal sealed class PInvokeTableGenerator
         }
     }
 
-    private static bool HasAttribute(Type type, string[] attributeNames)
+    private static bool HasAttribute(MemberInfo element, params string[] attributeNames)
     {
-        foreach (CustomAttributeData cattr in CustomAttributeData.GetCustomAttributes(type))
+        foreach (CustomAttributeData cattr in CustomAttributeData.GetCustomAttributes(element))
         {
             try
             {
                 for (int i = 0; i < attributeNames.Length; ++i)
-                    if (cattr.AttributeType.FullName == attributeNames [i])
+                {
+                    if (cattr.AttributeType.FullName == attributeNames [i] ||
+                        cattr.AttributeType.Name == attributeNames[i])
+                    {
                         return true;
+                    }
+                }
             }
             catch
             {

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -79,6 +79,22 @@ internal sealed class PInvokeTableGenerator
             }
         }
 
+        if (HasAttribute(type, new string[] {"System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute"})) {
+            var method = type.GetMethod("Invoke");
+
+            if (method != null)
+            {
+                string? signature = SignatureMapper.MethodToSignature(method!);
+                if (signature == null)
+                    {
+                        throw new NotSupportedException($"Unsupported parameter type in method '{type.FullName}.{method.Name}'");
+                    }
+
+                Log.LogMessage(MessageImportance.Low, $"Adding pinvoke signature {signature} for method '{type.FullName}.{method.Name}'");
+                signatures.Add(signature);
+            }
+        }
+
         void CollectPInvokesForMethod(MethodInfo method)
         {
             if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
@@ -149,6 +165,24 @@ internal sealed class PInvokeTableGenerator
 
             return false;
         }
+    }
+
+    private static bool HasAttribute(Type type, string[] attributeNames)
+    {
+        foreach (CustomAttributeData cattr in CustomAttributeData.GetCustomAttributes(type))
+        {
+            try
+            {
+                for (int i = 0; i < attributeNames.Length; ++i)
+                    if (cattr.AttributeType.FullName == attributeNames [i])
+                        return true;
+            }
+            catch
+            {
+                // Assembly not found, ignore
+            }
+        }
+        return false;
     }
 
     private void EmitPInvokeTable(StreamWriter w, Dictionary<string, string> modules, List<PInvoke> pinvokes)

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -79,7 +79,8 @@ internal sealed class PInvokeTableGenerator
             }
         }
 
-        if (HasAttribute(type, new string[] {"System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute"})) {
+        if (HasAttribute(type, new string[] {"System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute"}))
+        {
             var method = type.GetMethod("Invoke");
 
             if (method != null)

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -87,9 +87,8 @@ internal sealed class PInvokeTableGenerator
             {
                 string? signature = SignatureMapper.MethodToSignature(method!);
                 if (signature == null)
-                    {
-                        throw new NotSupportedException($"Unsupported parameter type in method '{type.FullName}.{method.Name}'");
-                    }
+                    throw new NotSupportedException($"Unsupported parameter type in method '{type.FullName}.{method.Name}'");
+
 
                 Log.LogMessage(MessageImportance.Low, $"Adding pinvoke signature {signature} for method '{type.FullName}.{method.Name}'");
                 signatures.Add(signature);


### PR DESCRIPTION
…r] in

the interp-to-native generator.

Fixes https://github.com/dotnet/runtime/issues/76930.