### PR TITLE
[wasm] workaround EP sample compilation

### DIFF
--- a/src/mono/sample/wasm/browser-advanced/Program.cs
+++ b/src/mono/sample/wasm/browser-advanced/Program.cs
@@ -39,12 +39,12 @@ namespace Sample
             if (number % 2 == 0) return false;
 
             var boundary = (int)Math.Floor(Math.Sqrt(number));
-                
+
             for (int i = 3; i <= boundary; i += 2)
                 if (number % i == 0)
                     return false;
-            
-            return true;        
-        }        
+
+            return true;
+        }
     }
 }

--- a/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
+++ b/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
@@ -37,11 +37,6 @@
     <_SampleProject>Wasm.Browser.EventPipe.Sample.csproj</_SampleProject>
   </PropertyGroup>
 
-
-  <PropertyGroup>
-    <RunAnalyzers>true</RunAnalyzers>
-  </PropertyGroup>
-
   <!-- set the condition to false and you will get a CA1416 errors about calls to create DiagnosticCounter instances -->
   <ItemGroup Condition="true">
     <!-- TODO: some .props file that automates this.  Unfortunately just adding a ProjectReference to Microsoft.NET.WebAssembly.Threading.proj doesn't work - it ends up bundling the ref assemblies into the publish directory and breaking the app. -->


### PR DESCRIPTION
There is some underlying problem with `SupportedOSPlatform` for our wasm samples. This is just workaround.

Fixes https://github.com/dotnet/runtime/issues/77630