### PR TITLE
[mono] Avoid returning true from RuntimeType.IsActualEnum for generic…

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1277,7 +1277,7 @@ namespace System
         public override bool IsEnum => GetBaseType() == EnumType;
 
         // Returns true for actual enum types only.
-        internal bool IsActualEnum => RuntimeTypeHandle.GetBaseType(this) == EnumType;
+        internal bool IsActualEnum => !IsGenericParameter && RuntimeTypeHandle.GetBaseType(this) == EnumType;
 
         public override GenericParameterAttributes GenericParameterAttributes
         {


### PR DESCRIPTION
… parameters.

Related: https://github.com/dotnet/runtime/pull/71685.