### PR TITLE
Avoid locking during host trace flush when not necessary

### DIFF
--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -262,10 +262,6 @@ namespace pal
 
     bool getcwd(string_t* recv);
 
-    inline void file_flush(FILE* f) { std::fflush(f); }
-    inline void err_flush() { std::fflush(stderr); }
-    inline void out_flush() { std::fflush(stdout); }
-
     string_t get_current_os_rid_platform();
     inline string_t get_current_os_fallback_rid()
     {


### PR DESCRIPTION
We don't need to lock on flush when we don't have a trace file. See https://github.com/dotnet/runtime/pull/77425#issuecomment-1293818082.

Related: https://github.com/dotnet/runtime/issues/75760