### PR TITLE
[mono] MiniJIT OP_XEQUAL for floats

### DIFF
--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -855,7 +855,6 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/74781", TestRuntimes.Mono)]
         public void VectorDoubleEqualsNonCanonicalNaNTest()
         {
             // max 8 bit exponent, just under half max mantissa
@@ -880,7 +879,6 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/74781", TestRuntimes.Mono)]
         public void VectorSingleEqualsNonCanonicalNaNTest()
         {
             // max 11 bit exponent, just under half max mantissa

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -3889,7 +3889,6 @@ mono_arch_lowering_pass (MonoCompile *cfg, MonoBasicBlock *bb)
 			case MONO_TYPE_R8: opcode = OP_COMPPD; break;
 			default: opcode = OP_PCMPEQD;
 			}
-			ins->inst_c0 = 0;
 
 			NEW_SIMD_INS (cfg, ins, temp, opcode, temp_reg1, ins->sreg1, ins->sreg2);
 			NEW_SIMD_INS (cfg, ins, temp, OP_EXTRACT_MASK, temp_reg2, temp_reg1, -1);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -3886,7 +3886,7 @@ mono_arch_lowering_pass (MonoCompile *cfg, MonoBasicBlock *bb)
 			switch (ins->inst_c1)
 			{
 			case MONO_TYPE_R4: opcode = OP_COMPPS; break;
-			case MONO_TYPE_R8: opcode =  OP_COMPPD;	break;
+			case MONO_TYPE_R8: opcode = OP_COMPPD; break;
 			default: opcode = OP_PCMPEQD;
 			}
 			ins->inst_c0 = 0;

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -3891,6 +3891,7 @@ mono_arch_lowering_pass (MonoCompile *cfg, MonoBasicBlock *bb)
 			}
 
 			NEW_SIMD_INS (cfg, ins, temp, opcode, temp_reg1, ins->sreg1, ins->sreg2);
+			temp->inst_c0 = 0;
 			NEW_SIMD_INS (cfg, ins, temp, OP_EXTRACT_MASK, temp_reg2, temp_reg1, -1);
 			temp->type = STACK_I4;
 			NEW_INS (cfg, ins, temp, OP_COMPARE_IMM);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -3882,8 +3882,22 @@ mono_arch_lowering_pass (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_XEQUAL: {
 			int temp_reg1 = mono_alloc_ireg (cfg);
 			int temp_reg2 = mono_alloc_ireg (cfg);
+			int opcode= -1;
+			switch (ins->inst_c1)
+			{
+				case MONO_TYPE_R4:
+					opcode = OP_COMPPS;
+					break;
+				case MONO_TYPE_R8: {
+					opcode =  OP_COMPPD;
+					break;
+				}
+				default:
+					opcode = OP_PCMPEQD;
+			}
+			ins->inst_c0 = 0;
 
-			NEW_SIMD_INS (cfg, ins, temp, OP_PCMPEQD, temp_reg1, ins->sreg1, ins->sreg2);
+			NEW_SIMD_INS (cfg, ins, temp, opcode, temp_reg1, ins->sreg1, ins->sreg2);
 			NEW_SIMD_INS (cfg, ins, temp, OP_EXTRACT_MASK, temp_reg2, temp_reg1, -1);
 			temp->type = STACK_I4;
 			NEW_INS (cfg, ins, temp, OP_COMPARE_IMM);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -3885,15 +3885,9 @@ mono_arch_lowering_pass (MonoCompile *cfg, MonoBasicBlock *bb)
 			int opcode= -1;
 			switch (ins->inst_c1)
 			{
-				case MONO_TYPE_R4:
-					opcode = OP_COMPPS;
-					break;
-				case MONO_TYPE_R8: {
-					opcode =  OP_COMPPD;
-					break;
-				}
-				default:
-					opcode = OP_PCMPEQD;
+			case MONO_TYPE_R4: opcode = OP_COMPPS; break;
+			case MONO_TYPE_R8: opcode =  OP_COMPPD;	break;
+			default: opcode = OP_PCMPEQD;
 			}
 			ins->inst_c0 = 0;
 

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -492,7 +492,9 @@ emit_xequal (MonoCompile *cfg, MonoClass *klass, MonoInst *arg1, MonoInst *arg2)
 	else
 		return emit_simd_ins (cfg, klass, OP_XEQUAL, arg1->dreg, arg2->dreg);
 #else	
-	return emit_simd_ins (cfg, klass, OP_XEQUAL, arg1->dreg, arg2->dreg);
+	MonoInst *ins = emit_simd_ins (cfg, klass, OP_XEQUAL, arg1->dreg, arg2->dreg);
+	ins->inst_c1 = mono_class_get_context (klass)->class_inst->type_argv [0]->type;
+	return ins;
 #endif
 }
 
@@ -2312,10 +2314,7 @@ emit_sys_numerics_vector_t (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSig
 				  mono_metadata_type_equal (fsig->params [0], type) &&
 				  mono_metadata_type_equal (fsig->params [1], type));
 		switch (id) {
-			case SN_op_Equality:
-				ins = emit_xequal (cfg, klass, args [0], args [1]);
-				ins->inst_c1 = etype->type;
-				return ins;
+			case SN_op_Equality: return emit_xequal (cfg, klass, args [0], args [1]);
 			case SN_op_Inequality: return emit_not_xequal (cfg, klass, args [0], args [1]);
 			default: g_assert_not_reached ();
 		}

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -2312,7 +2312,10 @@ emit_sys_numerics_vector_t (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSig
 				  mono_metadata_type_equal (fsig->params [0], type) &&
 				  mono_metadata_type_equal (fsig->params [1], type));
 		switch (id) {
-			case SN_op_Equality: return emit_xequal (cfg, klass, args [0], args [1]);
+			case SN_op_Equality:
+				ins = emit_xequal (cfg, klass, args [0], args [1]);
+				ins->inst_c1 = etype->type;
+				return ins;
 			case SN_op_Inequality: return emit_not_xequal (cfg, klass, args [0], args [1]);
 			default: g_assert_not_reached ();
 		}

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -493,7 +493,8 @@ emit_xequal (MonoCompile *cfg, MonoClass *klass, MonoInst *arg1, MonoInst *arg2)
 		return emit_simd_ins (cfg, klass, OP_XEQUAL, arg1->dreg, arg2->dreg);
 #else	
 	MonoInst *ins = emit_simd_ins (cfg, klass, OP_XEQUAL, arg1->dreg, arg2->dreg);
-	ins->inst_c1 = mono_class_get_context (klass)->class_inst->type_argv [0]->type;
+	if (!COMPILE_LLVM (cfg))
+		ins->inst_c1 = mono_class_get_context (klass)->class_inst->type_argv [0]->type;
 	return ins;
 #endif
 }


### PR DESCRIPTION
Floating points NaN must be treated differently. Adding check to MiniJIT for `OP_XEQUAL` to use floating point comparison.

Before:
Emitting `pcmpeqd` for every input type.

Now:
Emitting `cmpeqps` and `cmpeqpd` for doubles and floats, respectively. For integer inputs emitting `pcmpeqd` as before.

Fixing : https://github.com/dotnet/runtime/issues/74781