### PR TITLE
[release/6.0] Clear OpenSSL error queues before reading/writing SSL data

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -406,11 +406,15 @@ int32_t CryptoNative_SslSessionReused(SSL* ssl)
 
 int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
+    ERR_clear_error();
+
     return SSL_write(ssl, buf, num);
 }
 
 int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
 {
+    ERR_clear_error();
+
     return SSL_read(ssl, buf, num);
 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/73610.

# Description

The linked issue describes sporadic failures when making HTTP requests using HttpClient. The gist of the issue is that some previous operation left an error record in the OpenSSL error queue which led to the an exception during decrypting the HTTP response.

This PR fixes the issue by ignoring any pre-existing errors when encrypting/decrypting SSL messages.

# Customer Impact

Customers hitting the issue would see sporadic random failures making HTTP requests (the original issue claims about 0.1%).

# Regression

The original issue suggests this is a regression between 3.1 and 6.0.

The issue is not present in 7.0 because of PR #65148 addressed the problem in 7.0.

# Testing

Tested against a repro project provided by a customer hitting the same problem.

# Risk

Low. Cleaning the error queue more often is unlikely to introduce issues.
