### PR TITLE
[wasm] Add intrinsics for clz and ctz instructions

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2384,9 +2384,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Sha256.PlatformNotSupported.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(SupportsWasmIntrinsics)' == 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Wasm\WasmBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Wasm\PackedSimd.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(SupportsWasmIntrinsics)' != 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Wasm\WasmBase.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Wasm\PackedSimd.PlatformNotSupported.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(FeaturePortableThreadPool)' == 'true'">

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Wasm;
 
 // Some routines inspired by the Stanford Bit Twiddling Hacks by Sean Eron Anderson:
 // http://graphics.stanford.edu/~seander/bithacks.html
@@ -95,7 +96,7 @@ namespace System.Numerics
         [CLSCompliant(false)]
         public static uint RoundUpToPowerOf2(uint value)
         {
-            if (Lzcnt.IsSupported || ArmBase.IsSupported || X86Base.IsSupported)
+            if (Lzcnt.IsSupported || ArmBase.IsSupported || X86Base.IsSupported || WasmBase.IsSupported)
             {
 #if TARGET_64BIT
                 return (uint)(0x1_0000_0000ul >> LeadingZeroCount(value - 1));
@@ -127,7 +128,7 @@ namespace System.Numerics
         [CLSCompliant(false)]
         public static ulong RoundUpToPowerOf2(ulong value)
         {
-            if (Lzcnt.X64.IsSupported || ArmBase.Arm64.IsSupported)
+            if (Lzcnt.X64.IsSupported || ArmBase.Arm64.IsSupported || WasmBase.IsSupported)
             {
                 int shift = 64 - LeadingZeroCount(value - 1);
                 return (1ul ^ (ulong)(shift >> 6)) << shift;
@@ -195,6 +196,11 @@ namespace System.Numerics
                 return ArmBase.LeadingZeroCount(value);
             }
 
+            if (WasmBase.IsSupported)
+            {
+                return WasmBase.LeadingZeroCount(value);
+            }
+
             // Unguarded fallback contract is 0->31, BSR contract is 0->undefined
             if (value == 0)
             {
@@ -230,6 +236,11 @@ namespace System.Numerics
             if (ArmBase.Arm64.IsSupported)
             {
                 return ArmBase.Arm64.LeadingZeroCount(value);
+            }
+
+            if (WasmBase.IsSupported)
+            {
+                return WasmBase.LeadingZeroCount(value);
             }
 
             if (X86Base.X64.IsSupported)
@@ -305,6 +316,11 @@ namespace System.Numerics
                 return 31 ^ ArmBase.LeadingZeroCount(value);
             }
 
+            if (WasmBase.IsSupported)
+            {
+                return 31 ^ WasmBase.LeadingZeroCount(value);
+            }
+
             // BSR returns the log2 result directly. However BSR is slower than LZCNT
             // on AMD processors, so we leave it as a fallback only.
             if (X86Base.IsSupported)
@@ -340,6 +356,11 @@ namespace System.Numerics
             if (X86Base.X64.IsSupported)
             {
                 return (int)X86Base.X64.BitScanReverse(value);
+            }
+
+            if (WasmBase.IsSupported)
+            {
+                return 63 ^ WasmBase.LeadingZeroCount(value);
             }
 
             uint hi = (uint)(value >> 32);
@@ -551,6 +572,11 @@ namespace System.Numerics
                 return ArmBase.LeadingZeroCount(ArmBase.ReverseElementBits(value));
             }
 
+            if (WasmBase.IsSupported)
+            {
+                return WasmBase.TrailingZeroCount(value);
+            }
+
             // Unguarded fallback contract is 0->0, BSF contract is 0->undefined
             if (value == 0)
             {
@@ -597,6 +623,11 @@ namespace System.Numerics
             if (ArmBase.Arm64.IsSupported)
             {
                 return ArmBase.Arm64.LeadingZeroCount(ArmBase.Arm64.ReverseElementBits(value));
+            }
+
+            if (WasmBase.IsSupported)
+            {
+                return WasmBase.TrailingZeroCount(value);
             }
 
             if (X86Base.X64.IsSupported)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.PlatformNotSupported.cs
@@ -6,6 +6,7 @@ using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.Wasm
 {
+    [CLSCompliant(false)]
     public abstract class WasmBase
     {
         public static bool IsSupported => false;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.PlatformNotSupported.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace System.Runtime.Intrinsics.Wasm
+{
+    public abstract class WasmBase
+    {
+        public static bool IsSupported => false;
+
+        /// <summary>
+        ///   i32.clz
+        /// </summary>
+        public static int LeadingZeroCount(int value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   i32.clz
+        /// </summary>
+        public static int LeadingZeroCount(uint value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   i64.clz
+        /// </summary>
+        public static int LeadingZeroCount(long value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   i64.clz
+        /// </summary>
+        public static int LeadingZeroCount(ulong value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   i32.ctz
+        /// </summary>
+        public static int TrailingZeroCount(int value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   i32.ctz
+        /// </summary>
+        public static int TrailingZeroCount(uint value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   i64.ctz
+        /// </summary>
+        public static int TrailingZeroCount(long value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   i64.ctz
+        /// </summary>
+        public static int TrailingZeroCount(ulong value) { throw new PlatformNotSupportedException(); }
+
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.PlatformNotSupported.cs
@@ -6,8 +6,7 @@ using System.Runtime.Intrinsics;
 
 namespace System.Runtime.Intrinsics.Wasm
 {
-    [CLSCompliant(false)]
-    public abstract class WasmBase
+    internal abstract class WasmBase
     {
         public static bool IsSupported => false;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace System.Runtime.Intrinsics.Wasm
+{
+    [Intrinsic]
+    internal abstract class WasmBase
+    {
+        public static bool IsSupported { get; }
+
+        /// <summary>
+        ///   i32.clz
+        /// </summary>
+        public static int LeadingZeroCount(int value) => LeadingZeroCount(value);
+
+        /// <summary>
+        ///   i32.clz
+        /// </summary>
+        public static int LeadingZeroCount(uint value) => LeadingZeroCount(value);
+
+        /// <summary>
+        ///   i64.clz
+        /// </summary>
+        public static int LeadingZeroCount(long value) => LeadingZeroCount(value);
+
+        /// <summary>
+        ///   i64.clz
+        /// </summary>
+        public static int LeadingZeroCount(ulong value) => LeadingZeroCount(value);
+
+        /// <summary>
+        ///   i32.ctz
+        /// </summary>
+        public static int TrailingZeroCount(int value) => TrailingZeroCount(value);
+
+        /// <summary>
+        ///   i32.ctz
+        /// </summary>
+        public static int TrailingZeroCount(uint value) => TrailingZeroCount(value);
+
+        /// <summary>
+        ///   i64.ctz
+        /// </summary>
+        public static int TrailingZeroCount(long value) => TrailingZeroCount(value);
+
+        /// <summary>
+        ///   i64.ctz
+        /// </summary>
+        public static int TrailingZeroCount(ulong value) => TrailingZeroCount(value);
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.cs
@@ -7,7 +7,6 @@ using System.Runtime.Intrinsics;
 namespace System.Runtime.Intrinsics.Wasm
 {
     [Intrinsic]
-    [CLSCompliant(false)]
     internal abstract class WasmBase
     {
         public static bool IsSupported { get; }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.cs
@@ -7,6 +7,7 @@ using System.Runtime.Intrinsics;
 namespace System.Runtime.Intrinsics.Wasm
 {
     [Intrinsic]
+    [CLSCompliant(false)]
     internal abstract class WasmBase
     {
         public static bool IsSupported { get; }

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -8416,6 +8416,7 @@ parse_cpu_features (const gchar *attr)
 	else if (!strcmp (attr + prefix, "dotprod"))
 		feature = MONO_CPU_ARM64_DP;
 #elif defined(TARGET_WASM)
+	// MONO_CPU_WASM_BASE is unconditionally set in mini_get_cpu_features.
 	if (!strcmp (attr + prefix, "simd"))
 		feature = MONO_CPU_WASM_SIMD;
 #else

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -83,18 +83,14 @@ mini_emit_inst_for_ctor (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignat
 		return ins;
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS
-#ifdef TARGET_WASM
 	if (cfg->opt & MONO_OPT_SIMD) {
-#endif
 		ins = mono_emit_simd_intrinsics (cfg, cmethod, fsig, args);
 		if (ins)
 			return ins;
-#ifdef TARGET_WASM
 	}
 #endif
-#endif
 
-	return ins;
+	return mono_emit_common_intrinsics (cfg, cmethod, fsig, args);
 }
 
 static MonoInst*
@@ -2045,16 +2041,16 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	}
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS
-#ifndef TARGET_WASM
 	if (cfg->opt & MONO_OPT_SIMD) {
-#endif
 		ins = mono_emit_simd_intrinsics (cfg, cmethod, fsig, args);
 		if (ins)
 			return ins;
-#ifndef TARGET_WASM
 	}
 #endif
-#endif
+
+	ins = mono_emit_common_intrinsics (cfg, cmethod, fsig, args);
+	if (ins)
+		return ins;
 
 	/* Fallback if SIMD is disabled */
 	if (in_corlib && 

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -83,11 +83,15 @@ mini_emit_inst_for_ctor (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignat
 		return ins;
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS
+#ifdef TARGET_WASM
 	if (cfg->opt & MONO_OPT_SIMD) {
+#endif
 		ins = mono_emit_simd_intrinsics (cfg, cmethod, fsig, args);
 		if (ins)
 			return ins;
+#ifdef TARGET_WASM
 	}
+#endif
 #endif
 
 	return ins;
@@ -2041,11 +2045,15 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	}
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS
+#ifndef TARGET_WASM
 	if (cfg->opt & MONO_OPT_SIMD) {
+#endif
 		ins = mono_emit_simd_intrinsics (cfg, cmethod, fsig, args);
 		if (ins)
 			return ins;
+#ifndef TARGET_WASM
 	}
+#endif
 #endif
 
 	/* Fallback if SIMD is disabled */

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -88,9 +88,13 @@ mini_emit_inst_for_ctor (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignat
 		if (ins)
 			return ins;
 	}
+
+	ins = mono_emit_common_intrinsics (cfg, cmethod, fsig, args);
+	if (ins)
+		return ins;
 #endif
 
-	return mono_emit_common_intrinsics (cfg, cmethod, fsig, args);
+	return ins;
 }
 
 static MonoInst*
@@ -2046,11 +2050,11 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		if (ins)
 			return ins;
 	}
-#endif
 
 	ins = mono_emit_common_intrinsics (cfg, cmethod, fsig, args);
 	if (ins)
 		return ins;
+#endif
 
 	/* Fallback if SIMD is disabled */
 	if (in_corlib && 

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -9691,7 +9691,7 @@ MONO_RESTORE_WARNING
 #endif /* defined(TARGET_X86) || defined(TARGET_AMD64) */
 
 // Shared between ARM64 and X86
-#if defined(TARGET_ARM64) || defined(TARGET_X86) || defined(TARGET_AMD64)
+#if defined(TARGET_ARM64) || defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_WASM)
 		case OP_LZCNT32:
 		case OP_LZCNT64: {
 			IntrinsicId iid = ins->opcode == OP_LZCNT32 ? INTRINS_CTLZ_I32 : INTRINS_CTLZ_I64;

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -4452,6 +4452,10 @@ mini_get_cpu_features (MonoCompile* cfg)
 	features |= MONO_CPU_ARM64_NEON;
 #endif
 
+#if defined(TARGET_WASM)
+	// All wasm VMs have this set
+	features |= MONO_CPU_WASM_BASE;
+#endif
 	// apply parameters passed via -mattr
 	return (features | mono_cpu_features_enabled) & ~mono_cpu_features_disabled;
 }

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2922,12 +2922,11 @@ MonoCPUFeatures mono_arch_get_cpu_features (void);
 #ifdef MONO_ARCH_SIMD_INTRINSICS
 void        mono_simd_simplify_indirection (MonoCompile *cfg);
 void        mono_simd_decompose_intrinsic (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins);
+MonoInst*   mono_emit_common_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 MonoInst*   mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 MonoInst*   mono_emit_simd_field_load (MonoCompile *cfg, MonoClassField *field, MonoInst *addr);
 void        mono_simd_intrinsics_init (void);
 #endif
-
-MonoInst*   mono_emit_common_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2881,7 +2881,8 @@ typedef enum {
 									  | MONO_CPU_X86_AES            | MONO_CPU_X86_POPCNT | MONO_CPU_X86_FMA,
 #endif
 #ifdef TARGET_WASM
-	MONO_CPU_WASM_SIMD = 1 << 1,
+	MONO_CPU_WASM_BASE = 1 << 1,
+	MONO_CPU_WASM_SIMD = 1 << 2,
 #endif
 #ifdef TARGET_ARM64
 	MONO_CPU_ARM64_BASE   = 1 << 1,

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2927,6 +2927,8 @@ MonoInst*   mono_emit_simd_field_load (MonoCompile *cfg, MonoClassField *field, 
 void        mono_simd_intrinsics_init (void);
 #endif
 
+MonoInst*   mono_emit_common_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
+
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared
 

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -4480,6 +4480,7 @@ arch_emit_simd_intrinsics (const char *class_ns, const char *class_name, MonoCom
 #endif
 
 #if defined(TARGET_WASM)
+static
 MonoInst*
 arch_emit_common_intrinsics (const char *class_ns, const char *class_name, MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
 {
@@ -4492,6 +4493,7 @@ arch_emit_common_intrinsics (const char *class_ns, const char *class_name, MonoC
 	return NULL;
 }
 #else
+static
 MonoInst*
 arch_emit_common_intrinsics (const char *class_ns, const char *class_name, MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
 {

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -4470,7 +4470,16 @@ arch_emit_simd_intrinsics (const char *class_ns, const char *class_name, MonoCom
 
 	return NULL;
 }
+#else
+static
+MonoInst*
+arch_emit_simd_intrinsics (const char *class_ns, const char *class_name, MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
+{
+	return NULL;
+}
+#endif
 
+#if defined(TARGET_WASM)
 MonoInst*
 arch_emit_common_intrinsics (const char *class_ns, const char *class_name, MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
 {
@@ -4483,13 +4492,6 @@ arch_emit_common_intrinsics (const char *class_ns, const char *class_name, MonoC
 	return NULL;
 }
 #else
-static
-MonoInst*
-arch_emit_simd_intrinsics (const char *class_ns, const char *class_name, MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
-{
-	return NULL;
-}
-
 MonoInst*
 arch_emit_common_intrinsics (const char *class_ns, const char *class_name, MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
 {


### PR DESCRIPTION
Add intrinsics for leading and trailing zero count for wasm.

Introduce new internal class `WasmBase` for non-SIMD wasm intrinsics. These are always used in AOT builds, unlike SIMD intrinsics, which are disabled by default.