### PR TITLE
source-build: set the properties to build for mono runtime.

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -49,6 +49,7 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnableNgenOptimization=false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:AdditionalRuntimeIdentifierParent=$(BaseOS)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnablePackageValidation=false</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) /p:PrimaryRuntimeFlavor=Mono /p:RuntimeFlavor=Mono</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
https://github.com/dotnet/installer/pull/14792 enables building .NET from source with mono runtime instead of coreclr for 'any' architecture.
This sets the runtime properties to build with mono runtime instead of coreclr.

@ViktorHofer @MichaelSimons @crummel ptal.