### PR TITLE
Do not add null checks for boxed statics

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -953,6 +953,10 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
     {
         return (addr->gtFlags & GTF_ARR_ADDR_NONNULL) == 0;
     }
+    else if (addr->OperIs(GT_IND))
+    {
+        return (addr->gtFlags & GTF_IND_NONNULL) == 0;
+    }
     else if (addr->gtOper == GT_LCL_VAR)
     {
         unsigned varNum = addr->AsLclVarCommon()->GetLclNum();

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6563,7 +6563,7 @@ ExceptionSetFlags GenTree::OperExceptions(Compiler* comp)
         case GT_ARR_ELEM:
             if (comp->fgAddrCouldBeNull(this->AsArrElem()->gtArrObj))
             {
-                return ExceptionSetFlags::NullReferenceException;
+                return ExceptionSetFlags::NullReferenceException | ExceptionSetFlags::IndexOutOfRangeException;
             }
 
             return ExceptionSetFlags::IndexOutOfRangeException;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6566,7 +6566,7 @@ ExceptionSetFlags GenTree::OperExceptions(Compiler* comp)
                 return ExceptionSetFlags::NullReferenceException;
             }
 
-            return ExceptionSetFlags::None;
+            return ExceptionSetFlags::IndexOutOfRangeException;
 
         case GT_FIELD:
         {


### PR DESCRIPTION
While investigating #77773, I noticed we were adding null checks for `ref s_structStatic.Field`, which is not necessary.