### PR TITLE
Unify RunCrossGen2 environment variable to be set to 1 instead of "true"

### DIFF
--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -60,9 +60,9 @@ if /i "%1" == "jitforcerelocs"                          (set DOTNET_ForceRelocs=
 if /i "%1" == "ilasmroundtrip"                          (set __IlasmRoundTrip=1&shift&goto Arg_Loop)
 
 if /i "%1" == "printlastresultsonly"                    (set __PrintLastResultsOnly=1&shift&goto Arg_Loop)
-if /i "%1" == "runcrossgen2tests"                       (set RunCrossGen2=true&shift&goto Arg_Loop)
+if /i "%1" == "runcrossgen2tests"                       (set RunCrossGen2=1&shift&goto Arg_Loop)
 REM This test feature is currently intentionally undocumented
-if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=true&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
+if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=1&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
 if /i "%1" == "link"                                    (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "gcname"                                  (set DOTNET_GCName=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "timeout"                                 (set __TestTimeout=%2&shift&shift&goto Arg_Loop)

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -62,7 +62,7 @@ if /i "%1" == "ilasmroundtrip"                          (set __IlasmRoundTrip=1&
 if /i "%1" == "printlastresultsonly"                    (set __PrintLastResultsOnly=1&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgen2tests"                       (set RunCrossGen2=1&shift&goto Arg_Loop)
 REM This test feature is currently intentionally undocumented
-if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=1&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
+if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=1&set CrossgenLargeVersionBubble=1&shift&goto Arg_Loop)
 if /i "%1" == "link"                                    (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "gcname"                                  (set DOTNET_GCName=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "timeout"                                 (set __TestTimeout=%2&shift&shift&goto Arg_Loop)

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -868,7 +868,7 @@ def run_tests(args,
     if args.run_crossgen2_tests:
         print("Running tests R2R (Crossgen2)")
         print("Setting RunCrossGen2=true")
-        os.environ["RunCrossGen2"] = "true"
+        os.environ["RunCrossGen2"] = "1"
 
     if args.large_version_bubble:
         print("Large Version Bubble enabled")

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -867,12 +867,12 @@ def run_tests(args,
 
     if args.run_crossgen2_tests:
         print("Running tests R2R (Crossgen2)")
-        print("Setting RunCrossGen2=true")
+        print("Setting RunCrossGen2=1")
         os.environ["RunCrossGen2"] = "1"
 
     if args.large_version_bubble:
         print("Large Version Bubble enabled")
-        os.environ["LargeVersionBubble"] = "true"
+        os.environ["LargeVersionBubble"] = "1"
 
     if args.limited_core_dumps:
         setup_coredump_generation(args.host_os)


### PR DESCRIPTION
Various places were setting this to "true" and various other places to "1". Always use "1" in the environment variable and "true" in the msbuild property. This fixes local runs of crossgen2 tests (using src/tests/run.cmd runcrossgen2tests) -- these were not skipping FileCheck tests before as the test wrapper script only checks for "1".