### PR TITLE
[release/7.0] Managed EventSources do not show up by default in EventPipe sessions (#75248)

### DIFF
--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -249,7 +249,7 @@ ep_provider_add_event (
 	// We filter out those bits here so later comparisons don't have to take them in to account. Without
 	// filtering, EventSources wouldn't show up with Keywords=0.
 	uint64_t session_mask = ~0xF00000000000;
-	// -1 is special, it means all keywords. Don't change it.
+	// -1 is special, it means all keywords and gets used on internal error notifications. Don't change it.
 	uint64_t all_keywords = (uint64_t)(-1);
 	if (keywords != all_keywords) {
 		keywords &= session_mask;

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -248,7 +248,12 @@ ep_provider_add_event (
 	// Keyword bits 44-47 are reserved for use by EventSources, and every EventSource sets them all.
 	// We filter out those bits here so later comparisons don't have to take them in to account. Without
 	// filtering, EventSources wouldn't show up with Keywords=0.
-	keywords &= ~0xF00000000000;
+	uint64_t session_mask = ~0xF00000000000;
+	// -1 is special, it means all keywords. Don't change it.
+	uint64_t all_keywords = (uint64_t)(-1);
+	if (keywords != all_keywords) {
+		keywords &= session_mask;
+	}
 
 	EventPipeEvent *instance = ep_event_alloc (
 		provider,

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -245,6 +245,11 @@ ep_provider_add_event (
 
 	ep_requires_lock_not_held ();
 
+	// Keyword bits 44-47 are reserved for use by EventSources, and every EventSource sets them all.
+	// We filter out those bits here so later comparisons don't have to take them in to account. Without
+	// filtering, EventSources wouldn't show up with Keywords=0.
+	keywords &= ~0xF00000000000;
+
 	EventPipeEvent *instance = ep_event_alloc (
 		provider,
 		keywords,


### PR DESCRIPTION
Backport of #75248 to release/7.0

## Customer Impact
This is customer reported and requires deep understanding to diagnose and understand the 'fix'.

Currently if you specify Keywords==0 on an EventPipe session, you will get no events from managed EventSources by default. This is due to the fact that managed EventSources use bits 44-47 of the keywords field to keep track of which session the event belongs to. An event from a managed EventSource will have keywords 0xF00000000000 by default, even if no keywords are set on the event.

The expected behavior is that if you have a session with no keywords specified you will see any events with no keywords specified.

## Testing
Manual verification of dotnet-trace and Microsoft.Diagnostics.NETCore.Client will receive keywords as expected

## Risk
We are changing the default behavior of what events are emitted, but we are changing it to match the documentation so it should be a positive change. We have had multiple people run in to this issue and not be able to figure it out on their own.