### PR TITLE
Remove unnecessary code from #77068

### DIFF
--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -248,12 +248,7 @@ ep_provider_add_event (
 	// Keyword bits 44-47 are reserved for use by EventSources, and every EventSource sets them all.
 	// We filter out those bits here so later comparisons don't have to take them in to account. Without
 	// filtering, EventSources wouldn't show up with Keywords=0.
-	uint64_t session_mask = ~0xF00000000000;
-	// -1 is special, it means all keywords. Don't change it.
-	uint64_t all_keywords = (uint64_t)(-1);
-	if (keywords != all_keywords) {
-		keywords &= session_mask;
-	}
+	keywords &= ~0xF00000000000;
 
 	EventPipeEvent *instance = ep_event_alloc (
 		provider,


### PR DESCRIPTION
The check for keywords==0xFFFFFFFFFFFFFFFF was introduced in the first iteration of the code where it was checking in the event enabled computation, but once it was moved to ep_provider_add_event it is no longer necessary. 