### PR TITLE
Fix op_Inequality for `Vector64<T>`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
@@ -274,12 +274,12 @@ namespace System.Runtime.Intrinsics
         {
             for (int index = 0; index < Count; index++)
             {
-                if (Scalar<T>.Equals(left.GetElementUnsafe(index), right.GetElementUnsafe(index)))
+                if (!Scalar<T>.Equals(left.GetElementUnsafe(index), right.GetElementUnsafe(index)))
                 {
-                    return false;
+                    return true;
                 }
             }
-            return true;
+            return false;
         }
 
         /// <summary>Shifts each element of a vector left by the specified amount.</summary>


### PR DESCRIPTION
Recent changes to the implementation of the `Vector64<T>` type caused a regression to the fallback path for inequality. In particular it changed from inequality to checking of all elements were unequal, which is a different operation.