### PR TITLE
Fix timeout in regex test

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
@@ -25,7 +25,7 @@ namespace System.Text.RegularExpressions
         private const long InfiniteMatchTimeoutTicks = -10_000; // InfiniteMatchTimeout.Ticks
 
         // Historical note:
-        // Regex.InifiniteMatchTimeout was created instead of Timeout.InfiniteTimeSpan because of:
+        // Regex.InfiniteMatchTimeout was created instead of Timeout.InfiniteTimeSpan because of:
         // 1) Concerns about a connection between Regex and multi-threading.
         // 2) Concerns around requiring an extra contract assembly reference to access Timeout.
         // Neither of these would motivate such an addition now, but the API exists.

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1253,9 +1253,10 @@ namespace System.Text.RegularExpressions.Tests
                 const string Pattern = @"^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@(([0-9a-zA-Z])+([-\w]*[0-9a-zA-Z])*\.)+[a-zA-Z]{2,9})$";
                 string input = new string('a', 50) + "@a.a";
 
-                AppDomain.CurrentDomain.SetData(RegexHelpers.DefaultMatchTimeout_ConfigKeyName, TimeSpan.FromMilliseconds(100));
-
                 Regex r = await RegexHelpers.GetRegexAsync(engine, Pattern);
+
+                // Generating the regex above itself uses a regex internally, so set the short timeout we want only after that's done
+                AppDomain.CurrentDomain.SetData(RegexHelpers.DefaultMatchTimeout_ConfigKeyName, TimeSpan.FromMilliseconds(100));
                 Assert.Throws<RegexMatchTimeoutException>(() => r.Match(input));
                 Assert.Throws<RegexMatchTimeoutException>(() => r.IsMatch(input));
                 Assert.Throws<RegexMatchTimeoutException>(() => r.Matches(input).Count);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Tests.Common.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Tests.Common.cs
@@ -107,6 +107,9 @@ namespace System.Text.RegularExpressions.Tests
         public static bool IsNonBacktracking(RegexEngine engine) =>
             engine is RegexEngine.NonBacktracking or RegexEngine.NonBacktrackingSourceGenerated;
 
+        public static bool IsSourceGenerated(RegexEngine engine) =>
+            engine is RegexEngine.SourceGenerated or RegexEngine.NonBacktrackingSourceGenerated;
+
         public static async Task<Regex> GetRegexAsync(RegexEngine engine, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern, RegexOptions? options = null, TimeSpan? matchTimeout = null)
         {
             if (options is null)


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/77814