### PR TITLE
[wasm] Bump tests timeout 15mins to 30mins, for ..

### DIFF
--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -34,6 +34,7 @@
     <InstallChromeForTests Condition="'$(InstallChromeForTests)' == '' and
                                         ('$(ContinuousIntegrationBuild)' != 'true' or Exists('/.dockerenv')) and
                                         '$(Scenario)' == 'WasmTestOnBrowser'">true</InstallChromeForTests>
+    <_XHarnessTestsTimeout>00:30:00</_XHarnessTestsTimeout>
   </PropertyGroup>
 
   <!-- On CI this is installed as part of pretest, but it should still be installed
@@ -106,6 +107,7 @@
     <_XHarnessArgs Condition="'$(_UseWasmSymbolicator)' == 'true'" >$(_XHarnessArgs) --symbol-patterns wasm-symbol-patterns.txt</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(_UseWasmSymbolicator)' == 'true'" >$(_XHarnessArgs) --symbolicator WasmSymbolicator.dll,Microsoft.WebAssembly.Internal.SymbolicatorWrapperForXHarness</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(_WasmBrowserPathForTests)' != ''" >$(_XHarnessArgs) &quot;--browser-path=$(_WasmBrowserPathForTests)&quot;</_XHarnessArgs>
+    <_XHarnessArgs Condition="'$(_XHarnessTestsTimeout)' != ''   " >$(_XHarnessArgs) &quot;--timeout=$(_XHarnessTestsTimeout)&quot;</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(WasmXHarnessArgsCli)' != ''"      >$(_XHarnessArgs) $(WasmXHarnessArgsCli)</_XHarnessArgs>
 
     <!-- There two flavors of WasmXHarnessArgs and WasmXHarnessMonoArgs, one is MSBuild property and the other is environment variable -->

--- a/src/mono/sample/wasm/console-v8/Makefile
+++ b/src/mono/sample/wasm/console-v8/Makefile
@@ -12,6 +12,6 @@ endif
 
 PROJECT_NAME=Wasm.Console.V8.Sample.csproj
 CONSOLE_DLL=Wasm.Console.V8.Sample.dll
-MAIN_JS=v8shim.cjs
+MAIN_JS=main.mjs
 
 run: run-console


### PR DESCRIPTION
.. `xharness`.

Some library tests, like `System.Text.RegularExpressions.Tests` can take more than 15mins.

- Also, fix building `console-v8` sample with `make`