### PR TITLE
[mono] Added null-checks for LDFLDA on pointers.

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6034,19 +6034,10 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					/* TODO: metadata-update: implement me. If it's an added field, emit a call to the helper method instead of MINT_LDFLDA_UNSAFE */
 					g_assert (!m_field_is_from_update (field));
 					int foffset = m_class_is_valuetype (klass) ? m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject) : m_field_get_offset (field);
-					if (td->sp->type == STACK_TYPE_O) {
-						interp_add_ins (td, MINT_LDFLDA);
-						td->last_ins->data [0] = GINT_TO_UINT16 (foffset);
-					} else {
-						int sp_type = td->sp->type;
-						g_assert (sp_type == STACK_TYPE_MP || sp_type == STACK_TYPE_I);
-						if (foffset) {
-							interp_add_ins (td, MINT_LDFLDA_UNSAFE);
-							td->last_ins->data [0] = GINT_TO_UINT16 (foffset);
-						} else {
-							interp_add_ins (td, MINT_MOV_P);
-						}
-					}
+					int sp_type = td->sp->type;
+					g_assert (sp_type == STACK_TYPE_MP || sp_type == STACK_TYPE_I || sp_type == STACK_TYPE_O);
+					interp_add_ins (td, MINT_LDFLDA);
+					td->last_ins->data [0] = GINT_TO_UINT16 (foffset);
 					interp_ins_set_sreg (td->last_ins, td->sp [0].local);
 					push_simple_type (td, STACK_TYPE_MP);
 					interp_ins_set_dreg (td->last_ins, td->sp [-1].local);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6034,10 +6034,19 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					/* TODO: metadata-update: implement me. If it's an added field, emit a call to the helper method instead of MINT_LDFLDA_UNSAFE */
 					g_assert (!m_field_is_from_update (field));
 					int foffset = m_class_is_valuetype (klass) ? m_field_get_offset (field) - MONO_ABI_SIZEOF (MonoObject) : m_field_get_offset (field);
-					int sp_type = td->sp->type;
-					g_assert (sp_type == STACK_TYPE_MP || sp_type == STACK_TYPE_I || sp_type == STACK_TYPE_O);
-					interp_add_ins (td, MINT_LDFLDA);
-					td->last_ins->data [0] = GINT_TO_UINT16 (foffset);
+					if (td->sp->type == STACK_TYPE_O || td->sp->type == STACK_TYPE_I) {
+						interp_add_ins (td, MINT_LDFLDA);
+						td->last_ins->data [0] = GINT_TO_UINT16 (foffset);
+					} else {
+						int sp_type = td->sp->type;
+						g_assert (sp_type == STACK_TYPE_MP);
+						if (foffset) {
+							interp_add_ins (td, MINT_LDFLDA_UNSAFE);
+							td->last_ins->data [0] = GINT_TO_UINT16 (foffset);
+						} else {
+							interp_add_ins (td, MINT_MOV_P);
+						}
+					}
 					interp_ins_set_sreg (td->last_ins, td->sp [0].local);
 					push_simple_type (td, STACK_TYPE_MP);
 					interp_ins_set_dreg (td->last_ins, td->sp [-1].local);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10007,7 +10007,7 @@ calli_end:
 				}
 
 				if (il_op == MONO_CEE_LDFLDA) {
-					if (sp [0]->type == STACK_OBJ) {
+					if (sp [0]->type == STACK_OBJ || sp [0]->type == STACK_PTR) {
 						MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, sp [0]->dreg, 0);
 						MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
 					}

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1478,9 +1478,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_15291/GitHub_15291/**">
             <Issue>Doesn't pass after LLVM AOT compilation.</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_77640/Runtime_77640/**">
-            <Issue>https://github.com/dotnet/runtime/issues/77647</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b16928/b16928/**">
             <Issue>Doesn't pass after LLVM AOT compilation.</Issue>
         </ExcludeList>


### PR DESCRIPTION
Addresses the issue #77647 by adding a null check when translating the CIL opcode LDFLDA operating on a pointer into Mono IR. The appropriate unit test is reenabled for Mono.