### PR TITLE
JIT: Propagate only BBF_COPY_PROPAGATE flags during inliner substitution

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -251,7 +251,7 @@ private:
             {
                 // IR may potentially contain nodes that requires mandatory BB flags to be set.
                 // Propagate those flags from the containing BB.
-                m_compiler->compCurBB->bbFlags |= inlineeBB->bbFlags & BBF_SPLIT_GAINED;
+                m_compiler->compCurBB->bbFlags |= inlineeBB->bbFlags & BBF_COPY_PROPAGATE;
             }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11587,23 +11587,10 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
                 }
             }
 
-            // TODO-Inlining: Setting gtSubstBB unconditionally here does not
-            // make sense. The intention is to be able to propagate BB flags in
-            // UpdateInlineReturnExpressionPlaceHolder, but we only need to
-            // propagate the mandatory flags in case gtSubstExpr is a tree
-            // (e.g. GT_ARR_LENGTH in gtSubstExpr means we need to set
-            // BBF_HAS_IDX_LEN on the final BB that the substituted expression
-            // ends up in -- so we should not need to set this for the spill
-            // temp cases above).
-            //
-            // However, during substitution we actually propagate all
-            // BBF_SPLIT_GAINED flags which includes BBF_PROF_WEIGHT. The net
-            // effect of this is that if we inline a tree from a hot block into
-            // a block without profile data we suddenly start to believe the
-            // inliner block is hot, and then future inline candidates are
-            // treated more aggressively. Changing this leads to large diffs.
-            assert(inlRetExpr->gtSubstExpr != nullptr);
-            inlRetExpr->gtSubstBB = compCurBB;
+            // If gtSubstExpr is an arbitrary tree then we may need to
+            // propagate mandatory "IR presence" flags (e.g. BBF_HAS_IDX_LEN)
+            // to the BB it ends up in.
+            inlRetExpr->gtSubstBB = fgNeedReturnSpillTemp() ? nullptr : compCurBB;
         }
     }
 


### PR DESCRIPTION
Quite a few diffs expected.