### PR TITLE
Work around invalid IR with field morphing temps

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5781,9 +5781,9 @@ private:
     void fgMorphTreeDone(GenTree* tree, bool optAssertionPropDone, bool isMorphedTree DEBUGARG(int morphNum = 0));
 
     Statement* fgMorphStmt;
+    unsigned   fgBigOffsetMorphingTemps[TYP_COUNT];
 
-    unsigned fgGetBigOffsetMorphingTemp(var_types type); // We cache one temp per type to be
-                                                         // used when morphing big offset.
+    unsigned fgGetFieldMorphingTemp(GenTreeField* type);
 
     //----------------------- Liveness analysis -------------------------------
 
@@ -5859,8 +5859,6 @@ private:
 #if !FEATURE_FIXED_OUT_ARGS
     unsigned fgThrowHlpBlkStkLevel(BasicBlock* block);
 #endif // !FEATURE_FIXED_OUT_ARGS
-
-    unsigned fgBigOffsetMorphingTemps[TYP_COUNT];
 
     unsigned fgCheckInlineDepthAndRecursion(InlineInfo* inlineInfo);
     void fgInvokeInlineeCompiler(GenTreeCall* call, InlineResult* result, InlineContext** createdContext);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3967,6 +3967,19 @@ struct GenTreeField : public GenTreeUnOp
     {
         return (gtFlags & GTF_FLD_VOLATILE) != 0;
     }
+
+    bool IsInstance() const
+    {
+        return GetFldObj() != nullptr;
+    }
+
+    bool IsOffsetKnown() const
+    {
+#ifdef FEATURE_READYTORUN
+        return gtFieldLookup.addr == nullptr;
+#endif // FEATURE_READYTORUN
+        return true;
+    }
 };
 
 // There was quite a bit of confusion in the code base about which of gtOp1 and gtOp2 was the

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5006,28 +5006,50 @@ GenTree* Compiler::fgMorphLocalVar(GenTree* tree, bool forceRemorph)
     return tree;
 }
 
-/*****************************************************************************
-  Grab a temp for big offset morphing.
-  This method will grab a new temp if no temp of this "type" has been created.
-  Or it will return the same cached one if it has been created.
-*/
-unsigned Compiler::fgGetBigOffsetMorphingTemp(var_types type)
+//------------------------------------------------------------------------
+// fgGetFieldMorphingTemp: Get a local to use for field morphing.
+//
+// We will reuse locals created when morphing field addresses, as well as
+// fields with large offsets.
+//
+// Arguments:
+//    fieldNode - The field node
+//
+// Return Value:
+//    The local number.
+//
+unsigned Compiler::fgGetFieldMorphingTemp(GenTreeField* fieldNode)
 {
-    unsigned lclNum = fgBigOffsetMorphingTemps[type];
+    assert(fieldNode->IsInstance());
 
-    if (lclNum == BAD_VAR_NUM)
+    unsigned lclNum = BAD_VAR_NUM;
+
+    if (fieldNode->IsOffsetKnown() && (fieldNode->gtFldOffset == 0))
     {
-        // We haven't created a temp for this kind of type. Create one now.
-        lclNum                         = lvaGrabTemp(false DEBUGARG("Big Offset Morphing"));
-        fgBigOffsetMorphingTemps[type] = lclNum;
+        // Quirk: always use a fresh temp for zero-offset fields. This is
+        // because temp reuse can create IR where some uses will be in
+        // positions we do not support (i. e. [use...store...user]).
+        lclNum = lvaGrabTemp(true DEBUGARG("Zero offset field obj"));
     }
     else
     {
-        // We better get the right type.
-        noway_assert(lvaTable[lclNum].TypeGet() == type);
+        var_types type = genActualType(fieldNode->GetFldObj());
+        lclNum         = fgBigOffsetMorphingTemps[type];
+
+        if (lclNum == BAD_VAR_NUM)
+        {
+            // We haven't created a temp for this kind of type. Create one now.
+            lclNum                         = lvaGrabTemp(false DEBUGARG("Field obj"));
+            fgBigOffsetMorphingTemps[type] = lclNum;
+        }
+        else
+        {
+            // We better get the right type.
+            noway_assert(lvaTable[lclNum].TypeGet() == type);
+        }
     }
 
-    noway_assert(lclNum != BAD_VAR_NUM);
+    assert(lclNum != BAD_VAR_NUM);
     return lclNum;
 }
 
@@ -5242,7 +5264,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
 
             if (!objRef->OperIs(GT_LCL_VAR) || lvaIsLocalImplicitlyAccessedByRef(objRef->AsLclVar()->GetLclNum()))
             {
-                lclNum = fgGetBigOffsetMorphingTemp(genActualType(objRef->TypeGet()));
+                lclNum = fgGetFieldMorphingTemp(tree->AsField());
 
                 // Create the "asg" node
                 asg = gtNewTempAssign(lclNum, objRef);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_77773/Runtime_77773.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77773/Runtime_77773.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+unsafe class Runtime_77773
+{
+    public static int Main(string[] args)
+    {
+        var s1 = new StructWithField { Field = 1 };
+        var s2 = new StructWithField { Field = 2 };
+
+        if (ProblemWithDirectUse(&s1, &s2, 0))
+        {
+            return 101;
+        }
+        if (ProblemWithCopyPropagation(&s1, &s2, 0))
+        {
+            return 102;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithDirectUse(StructWithField* pS1, StructWithField* pS2, nint idx)
+    {
+        return &pS1[idx].Field == &pS2[idx].Field;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool ProblemWithCopyPropagation(StructWithField* pS1, StructWithField* pS2, nint idx)
+    {
+        int* pIdx = &pS1[idx].Field;
+        JitUse(pIdx);
+        *pIdx = Ind(&pS2[idx].Field);
+
+        return pS1->Field != pS2->Field;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Ind(int* p) => *p;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void JitUse(int* p) { }
+
+    struct StructWithField
+    {
+        public int Field;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_77773/Runtime_77773.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77773/Runtime_77773.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Create unique temps for the case that can run into issues.

Fixes #77773.

Q: what makes these morphing temps so special we are only now running into issues with them?
A: they are quite unique in that they're multi-use, multi-def, and both uses and defs can appear in arbitrary places.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=72270&view=ms.vss-build-web.run-extensions-tab).