### PR TITLE
Fix mono arm assert with large return structs

### DIFF
--- a/src/mono/mono/mini/mini-arm.c
+++ b/src/mono/mono/mini/mini-arm.c
@@ -6313,8 +6313,12 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	if (cinfo->ret.storage == RegTypeStructByAddr) {
 		ArgInfo *ainfo = &cinfo->ret;
 		inst = cfg->vret_addr;
-		g_assert (arm_is_imm12 (inst->inst_offset));
-		ARM_STR_IMM (code, ainfo->reg, inst->inst_basereg, inst->inst_offset);
+		if (arm_is_imm12 (inst->inst_offset)) {
+			ARM_STR_IMM (code, ainfo->reg, inst->inst_basereg, inst->inst_offset);
+		} else {
+			code = mono_arm_emit_load_imm (code, ARMREG_LR, inst->inst_offset);
+			ARM_STR_REG_REG (code, ainfo->reg, inst->inst_basereg, ARMREG_LR);
+		}
 	}
 
 	if (sig->call_convention == MONO_CALL_VARARG) {

--- a/src/tests/JIT/Regression/JitBlue/GitHub_77854/GitHub_77854.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_77854/GitHub_77854.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Runtime.InteropServices;
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        new Program().TestFunction();
+        return 100;
+    }
+
+    private TestStruct CreateStruct(FourKStruct s, int i)
+    {
+        return new TestStruct { s = s, i = i };
+    }
+
+    private TestStruct TestFunction()
+    {
+        return CreateStruct(new FourKStruct(), 42);
+    }
+
+    private struct TestStruct
+    {
+        public FourKStruct s;
+        public int i;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential, Size=4096)]
+public partial struct FourKStruct
+{
+    internal byte bytes;
+}

--- a/src/tests/JIT/Regression/JitBlue/GitHub_77854/GitHub_77854.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_77854/GitHub_77854.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When the return struct is large the store instruction offset is too large. When this happens, put the large offset in a register.