### PR TITLE
Fix Configuration with IList and ICollection

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -357,11 +357,6 @@ namespace Microsoft.Extensions.Configuration
                     }
                     else
                     {
-                        // For other mutable interfaces like ICollection<> and ISet<>, we prefer copying values and setting them
-                        // on a new instance of the interface over populating the existing instance implementing the interface.
-                        // This has already been done, so there's not need to check again. For dictionaries, we fill the existing
-                        // instance if there is one (which hasn't happened yet), and only create a new instance if necessary.
-
                         bindingPoint.SetValue(CreateInstance(type, config, options));
                     }
                 }
@@ -594,10 +589,12 @@ namespace Microsoft.Extensions.Configuration
 
             Debug.Assert(dictionary is not null);
 
-            MethodInfo tryGetValue = dictionary.GetType().GetMethod("TryGetValue", BindingFlags.Public | BindingFlags.Instance)!;
+            Type dictionaryObjectType = dictionary.GetType();
+
+            MethodInfo tryGetValue = dictionaryObjectType.GetMethod("TryGetValue", BindingFlags.Public | BindingFlags.Instance)!;
 
             // dictionary should be of type Dictionary<,> or of type implementing IDictionary<,>
-            PropertyInfo? setter = dictionary.GetType().GetProperty("Item", BindingFlags.Public | BindingFlags.Instance);
+            PropertyInfo? setter = dictionaryObjectType.GetProperty("Item", BindingFlags.Public | BindingFlags.Instance);
             if (setter is null || !setter.CanWrite)
             {
                 // Cannot set any item on the dictionary object.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -393,6 +393,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("val1", list[2]);
             Assert.Equal("val2", list[3]);
             Assert.Equal("valx", list[4]);
+
+            // Ensure expandability of the returned list
+            options.AlreadyInitializedListInterface.Add("ExtraItem");
+            Assert.Equal(6, options.AlreadyInitializedListInterface.Count);
+            Assert.Equal("ExtraItem", options.AlreadyInitializedListInterface[5]);
         }
 
         [Fact]
@@ -1098,6 +1103,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(2, options.ICollectionNoSetter.Count);
             Assert.Equal("val0", options.ICollectionNoSetter.ElementAt(0));
             Assert.Equal("val1", options.ICollectionNoSetter.ElementAt(1));
+
+            // Ensure expandability of the returned collection
+            options.ICollectionNoSetter.Add("ExtraItem");
+            Assert.Equal(3, options.ICollectionNoSetter.Count);
+            Assert.Equal("ExtraItem", options.ICollectionNoSetter.ElementAt(2));
         }
 
         [Fact]
@@ -1218,6 +1228,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("val1", array[1]);
             Assert.Equal("val2", array[2]);
             Assert.Equal("valx", array[3]);
+
+            // Ensure expandability of the returned collection
+            options.ICollection.Add("ExtraItem");
+            Assert.Equal(5, options.ICollection.Count);
+            Assert.Equal("ExtraItem", options.ICollection.ElementAt(4));
         }
 
         [Fact]
@@ -1246,6 +1261,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("val1", list[1]);
             Assert.Equal("val2", list[2]);
             Assert.Equal("valx", list[3]);
+
+            // Ensure expandability of the returned list
+            options.IList.Add("ExtraItem");
+            Assert.Equal(5, options.IList.Count);
+            Assert.Equal("ExtraItem", options.IList[4]);
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/77725

In .NET 7.0 we had some code refactoring and fixes in configuration. This change had been handling the binding to `ICollction<T>` and `IList<T>` by creating underlying `Array<T>` object. It is obvious the returned object is not expandable which means users cannot add more items to that object. This is wrong and regression from previous versions of .NET/Core. The fix here is in case of binding to `ICollction<T>` and `IList<T>`, we'll create `List<T>` object instead which is expandable and allow adding more items to such object. 

#77725 is a good example demonstrating this problem. 