### PR TITLE
Fix STRESS_64RSLT_MUL stress mode to avoid creating unnecessary IR

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2440,6 +2440,13 @@ Compiler::fgWalkResult Compiler::fgStress64RsltMulCB(GenTree** pTree, fgWalkData
         return WALK_CONTINUE;
     }
 
+    if (tree->gtGetOp1()->IsIntegralConst(0) || tree->gtGetOp2()->IsIntegralConst(0))
+    {
+        // Skip morphing cases with constant multiply by zero; it interferes with address mode formation
+        // in unoptimized code where it doesn't expect to see the IR nodes created here.
+        return WALK_CONTINUE;
+    }
+
     JITDUMP("STRESS_64RSLT_MUL before:\n");
     DISPTREE(tree);
 


### PR DESCRIPTION
Issue https://github.com/dotnet/runtime/issues/77152 is an assert in unoptimized code where the IR constructs an addressing mode from a tree including a GT_MUL with op2 of zero, hence it ignores op1, but then asserts because it only expects a limited set of IR nodes to be in the op1 tree.

This fixes this one particular case by avoiding creating the extra nodes in this stress mode. In normal optimized code, the MUL with zero would be folded.

Fixes #77152