### PR TITLE
Improve JIT bit sets

### DIFF
--- a/src/coreclr/jit/bitset.cpp
+++ b/src/coreclr/jit/bitset.cpp
@@ -105,9 +105,8 @@ public:
     {
         return 64;
     }
-    static unsigned GetArrSize(CompAllocator alloc, unsigned elemSize)
+    static unsigned GetArrSize(CompAllocator alloc)
     {
-        assert(elemSize == sizeof(size_t));
         return (64 / 8) / sizeof(size_t);
     }
     static unsigned GetEpoch(CompAllocator alloc)

--- a/src/coreclr/jit/bitset.h
+++ b/src/coreclr/jit/bitset.h
@@ -133,11 +133,7 @@ FORCEINLINE unsigned BitSetSupport::CountBitsInIntegral<unsigned>(unsigned c)
 //      An "adapter" class that provides methods that retrieves things from the Env:
 //        static void* Alloc(Env, size_t byteSize): Allocates memory the BitSet implementation can use.
 //        static unsigned    GetSize(Env):          the current size (= # of bits) of this bitset type.
-//        static unsigned    GetArrSize(Env, unsigned elemSize):  The number of "elemSize" chunks sufficient to hold
-//                                                                "GetSize". A given BitSet implementation must call
-//                                                                this with only one constant value. Thus, and "Env"
-//                                                                may compute this result when GetSize changes.
-//
+//        static unsigned    GetArrSize(Env):       The number of size_t chunks sufficient to hold "GetSize".
 //        static unsigned    GetEpoch(Env):         the current epoch.
 //
 // (For many instantiations, BitSetValueArgType and BitSetValueRetType will be the same as BitSetType; in cases where

--- a/src/coreclr/jit/bitsetasshortlong.h
+++ b/src/coreclr/jit/bitsetasshortlong.h
@@ -28,7 +28,7 @@ private:
 
     inline static bool IsShort(Env env)
     {
-        return BitSetTraits::GetArrSize(env, sizeof(size_t)) <= 1;
+        return BitSetTraits::GetArrSize(env) <= 1;
     }
 
     // The operations on the "long" (pointer-to-array-of-size_t) versions of the representation.
@@ -496,7 +496,7 @@ public:
                 assert(bs != BitSetOps::UninitVal());
                 m_bits = bs[0];
 
-                unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+                unsigned len = BitSetTraits::GetArrSize(env);
                 m_bsEnd      = bs + len;
             }
         }
@@ -554,7 +554,7 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
                /*BitSetTraits*/ BitSetTraits>::AssignLong(Env env, BitSetShortLongRep& lhs, BitSetShortLongRep rhs)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         lhs[i] = rhs[i];
@@ -582,7 +582,7 @@ BitSetShortLongRep BitSetOps</*BitSetType*/ BitSetShortLongRep,
 {
     assert(!IsShort(env));
     BitSetShortLongRep res = MakeUninitArrayBits(env);
-    unsigned           len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned           len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         res[i] = bs[i];
@@ -597,7 +597,7 @@ bool BitSetOps</*BitSetType*/ BitSetShortLongRep,
                /*BitSetTraits*/ BitSetTraits>::IsEmptyLong(Env env, BitSetShortLongRep bs)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         if (bs[i] != 0)
@@ -615,7 +615,7 @@ unsigned BitSetOps</*BitSetType*/ BitSetShortLongRep,
                    /*BitSetTraits*/ BitSetTraits>::CountLong(Env env, BitSetShortLongRep bs)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     unsigned res = 0;
     for (unsigned i = 0; i < len; i++)
     {
@@ -631,7 +631,7 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
                /*BitSetTraits*/ BitSetTraits>::UnionDLong(Env env, BitSetShortLongRep& bs1, BitSetShortLongRep bs2)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         bs1[i] |= bs2[i];
@@ -645,7 +645,7 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
                /*BitSetTraits*/ BitSetTraits>::DiffDLong(Env env, BitSetShortLongRep& bs1, BitSetShortLongRep bs2)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         bs1[i] &= ~bs2[i];
@@ -699,7 +699,7 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
                /*BitSetTraits*/ BitSetTraits>::ClearDLong(Env env, BitSetShortLongRep& bs)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         bs[i] = 0;
@@ -713,7 +713,7 @@ BitSetShortLongRep BitSetOps</*BitSetType*/ BitSetShortLongRep,
                              /*BitSetTraits*/ BitSetTraits>::MakeUninitArrayBits(Env env)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     assert(len > 1); // Or else would not require an array.
     return (BitSetShortLongRep)(BitSetTraits::Alloc(env, len * sizeof(size_t)));
 }
@@ -725,7 +725,7 @@ BitSetShortLongRep BitSetOps</*BitSetType*/ BitSetShortLongRep,
                              /*BitSetTraits*/ BitSetTraits>::MakeEmptyArrayBits(Env env)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     assert(len > 1); // Or else would not require an array.
     BitSetShortLongRep res = (BitSetShortLongRep)(BitSetTraits::Alloc(env, len * sizeof(size_t)));
     for (unsigned i = 0; i < len; i++)
@@ -742,7 +742,7 @@ BitSetShortLongRep BitSetOps</*BitSetType*/ BitSetShortLongRep,
                              /*BitSetTraits*/ BitSetTraits>::MakeFullArrayBits(Env env)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     assert(len > 1); // Or else would not require an array.
     BitSetShortLongRep res = (BitSetShortLongRep)(BitSetTraits::Alloc(env, len * sizeof(size_t)));
     for (unsigned i = 0; i < len - 1; i++)
@@ -777,7 +777,7 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
                                                                  BitSetShortLongRep  bs2)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         bs1[i] &= bs2[i];
@@ -793,7 +793,7 @@ bool BitSetOps</*BitSetType*/ BitSetShortLongRep,
                                                                        BitSetShortLongRep bs2)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         if ((bs1[i] & bs2[i]) != 0)
@@ -811,7 +811,7 @@ bool BitSetOps</*BitSetType*/ BitSetShortLongRep,
                /*BitSetTraits*/ BitSetTraits>::IsEmptyUnionLong(Env env, BitSetShortLongRep bs1, BitSetShortLongRep bs2)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         if ((bs1[i] | bs2[i]) != 0)
@@ -832,7 +832,7 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
                                                              const BitSetShortLongRep in)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         out[i] = out[i] & (gen[i] | in[i]);
@@ -850,7 +850,7 @@ void BitSetOps</*BitSetType*/ BitSetShortLongRep,
                                                              const BitSetShortLongRep out)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         in[i] = use[i] | (out[i] & ~def[i]);
@@ -864,7 +864,7 @@ bool BitSetOps</*BitSetType*/ BitSetShortLongRep,
                /*BitSetTraits*/ BitSetTraits>::EqualLong(Env env, BitSetShortLongRep bs1, BitSetShortLongRep bs2)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         if (bs1[i] != bs2[i])
@@ -882,7 +882,7 @@ bool BitSetOps</*BitSetType*/ BitSetShortLongRep,
                /*BitSetTraits*/ BitSetTraits>::IsSubsetLong(Env env, BitSetShortLongRep bs1, BitSetShortLongRep bs2)
 {
     assert(!IsShort(env));
-    unsigned len = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned len = BitSetTraits::GetArrSize(env);
     for (unsigned i = 0; i < len; i++)
     {
         if ((bs1[i] & bs2[i]) != bs1[i])
@@ -901,7 +901,7 @@ const char* BitSetOps</*BitSetType*/ BitSetShortLongRep,
                       /*BitSetTraits*/ BitSetTraits>::ToStringLong(Env env, BitSetShortLongRep bs)
 {
     assert(!IsShort(env));
-    unsigned  len           = BitSetTraits::GetArrSize(env, sizeof(size_t));
+    unsigned  len           = BitSetTraits::GetArrSize(env);
     const int CharsForSizeT = sizeof(size_t) * 2;
     unsigned  allocSz       = len * CharsForSizeT + 4;
     unsigned  remaining     = allocSz;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4334,7 +4334,7 @@ public:
 
         if (verbose)
         {
-            unsigned epochArrSize = BasicBlockBitSetTraits::GetArrSize(this, sizeof(size_t));
+            unsigned epochArrSize = BasicBlockBitSetTraits::GetArrSize(this);
             printf("\nNew BlockSet epoch %d, # of blocks (including unused BB00): %u, bitset array size: %u (%s)",
                    fgCurBBEpoch, fgCurBBEpochSize, epochArrSize, (epochArrSize <= 1) ? "short" : "long");
             if ((fgCurBBEpoch != 1) && ((oldEpochArrSize <= 1) != (epochArrSize <= 1)))

--- a/src/coreclr/jit/compilerbitsettraits.h
+++ b/src/coreclr/jit/compilerbitsettraits.h
@@ -40,7 +40,7 @@ class TrackedVarBitSetTraits : public CompAllocBitSetTraits
 public:
     static inline unsigned GetSize(Compiler* comp);
 
-    static inline unsigned GetArrSize(Compiler* comp, unsigned elemSize);
+    static inline unsigned GetArrSize(Compiler* comp);
 
     static inline unsigned GetEpoch(class Compiler* comp);
 
@@ -62,7 +62,7 @@ class AllVarBitSetTraits : public CompAllocBitSetTraits
 public:
     static inline unsigned GetSize(Compiler* comp);
 
-    static inline unsigned GetArrSize(Compiler* comp, unsigned elemSize);
+    static inline unsigned GetArrSize(Compiler* comp);
 
     static inline unsigned GetEpoch(class Compiler* comp);
 
@@ -86,7 +86,7 @@ class BasicBlockBitSetTraits : public CompAllocBitSetTraits
 public:
     static inline unsigned GetSize(Compiler* comp);
 
-    static inline unsigned GetArrSize(Compiler* comp, unsigned elemSize);
+    static inline unsigned GetArrSize(Compiler* comp);
 
     static inline unsigned GetEpoch(class Compiler* comp);
 
@@ -103,11 +103,14 @@ struct BitVecTraits
 {
 private:
     unsigned  size;
+    unsigned  arraySize; // pre-computed to avoid computation in GetArrSize
     Compiler* comp;
 
 public:
     BitVecTraits(unsigned size, Compiler* comp) : size(size), comp(comp)
     {
+        const unsigned elemBits = 8 * sizeof(size_t);
+        arraySize               = roundUp(size, elemBits) / elemBits;
     }
 
     static inline void* Alloc(BitVecTraits* b, size_t byteSize);
@@ -118,7 +121,7 @@ public:
 
     static inline unsigned GetSize(BitVecTraits* b);
 
-    static inline unsigned GetArrSize(BitVecTraits* b, unsigned elemSize);
+    static inline unsigned GetArrSize(BitVecTraits* b);
 
     static inline unsigned GetEpoch(BitVecTraits* b);
 

--- a/src/coreclr/jit/compilerbitsettraits.hpp
+++ b/src/coreclr/jit/compilerbitsettraits.hpp
@@ -40,9 +40,8 @@ unsigned TrackedVarBitSetTraits::GetSize(Compiler* comp)
 }
 
 // static
-unsigned TrackedVarBitSetTraits::GetArrSize(Compiler* comp, unsigned elemSize)
+unsigned TrackedVarBitSetTraits::GetArrSize(Compiler* comp)
 {
-    assert(elemSize == sizeof(size_t));
     return comp->lvaTrackedCountInSizeTUnits;
 }
 
@@ -75,9 +74,10 @@ unsigned AllVarBitSetTraits::GetSize(Compiler* comp)
 }
 
 // static
-unsigned AllVarBitSetTraits::GetArrSize(Compiler* comp, unsigned elemSize)
+unsigned AllVarBitSetTraits::GetArrSize(Compiler* comp)
 {
-    return roundUp(GetSize(comp), elemSize);
+    const unsigned elemBits = 8 * sizeof(size_t);
+    return roundUp(GetSize(comp), elemBits) / elemBits;
 }
 
 // static
@@ -109,13 +109,12 @@ unsigned BasicBlockBitSetTraits::GetSize(Compiler* comp)
 }
 
 // static
-unsigned BasicBlockBitSetTraits::GetArrSize(Compiler* comp, unsigned elemSize)
+unsigned BasicBlockBitSetTraits::GetArrSize(Compiler* comp)
 {
     // Assert that the epoch has been initialized. This is a convenient place to assert this because
     // GetArrSize() is called for every function, via IsShort().
     assert(GetEpoch(comp) != 0);
 
-    assert(elemSize == sizeof(size_t));
     return comp->fgBBSetCountInSizeTUnits; // This is precomputed to avoid doing math every time this function is called
 }
 
@@ -158,11 +157,9 @@ unsigned BitVecTraits::GetSize(BitVecTraits* b)
 }
 
 // static
-unsigned BitVecTraits::GetArrSize(BitVecTraits* b, unsigned elemSize)
+unsigned BitVecTraits::GetArrSize(BitVecTraits* b)
 {
-    assert(elemSize == sizeof(size_t));
-    unsigned elemBits = 8 * elemSize;
-    return roundUp(b->size, elemBits) / elemBits;
+    return b->arraySize;
 }
 
 // static


### PR DESCRIPTION
1. `AllVarBitSetTraits::GetArrSize()` was allocating far too much memory: one size_t for every bit in the vector.
2. Cache the array size for `BitVecTraits::GetArrSize()` -- this function was showing up hot in a perf run (x86 SPMI replay).
3. Stop passing `sizeof(size_t)` to `GetArrSize()` -- we always assume bitsets work in size_t units.