### PR TITLE
Optimize XxHash3 on ARM platform

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash3.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash3.cs
@@ -917,7 +917,8 @@ namespace System.IO.Hashing
             else
             {
                 Vector128<uint> sourceLow = Vector128.Shuffle(source, Vector128.Create(1u, 0, 3, 0));
-                return Sse2.IsSupported ? Sse2.Multiply(source, sourceLow) :
+                return Sse2.IsSupported ?
+                    Sse2.Multiply(source, sourceLow) :
                     (source & Vector128.Create(~0u, 0u, ~0u, 0u)).AsUInt64() * (sourceLow & Vector128.Create(~0u, 0u, ~0u, 0u)).AsUInt64();
             }
         }


### PR DESCRIPTION
Hey there,
This PR Fixes ARM performance for XxHash3, followup of #77756 

It is roughly 2.5x times faster than the previous version and 15% faster than the C++ version.

```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.755)
Snapdragon Compute Platform, 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.100-rc.2.22477.23
  [Host]     : .NET 7.0.0 (7.0.22.47203), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 7.0.0 (7.0.22.47203), Arm64 RyuJIT AdvSIMD


|           Method |          data |       Mean |    Error |   StdDev | Ratio |
|----------------- |-------------- |-----------:|---------:|---------:|------:|
|       XXH3Native | Byte[1048576] |  70.01 us  | 0.051 us | 0.045 us |  0.45 |
|             XXH3 | Byte[1048576] |  156.05 us | 0.089 us | 0.074 us |  1.0  |
| XXH3ARMOptimized | Byte[1048576] |  61.49 us  | 0.068 us | 0.064 us |  0.39 |
```

cc: @stephentoub, @EgorBo