### PR TITLE
Add and use a MakeSrcRegOptional that validates IsSafeToContainMem was called

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -40,6 +40,7 @@ void Lowering::MakeSrcContained(GenTree* parentNode, GenTree* childNode) const
 {
     assert(!parentNode->OperIsLeaf());
     assert(childNode->canBeContained());
+
     childNode->SetContained();
     assert(childNode->isContained());
 
@@ -56,6 +57,34 @@ void Lowering::MakeSrcContained(GenTree* parentNode, GenTree* childNode) const
                     comp->dspTreeID(parentNode));
             assert(isSafeToContainMem);
         }
+    }
+#endif
+}
+
+//------------------------------------------------------------------------
+// MakeSrcRegOptional: Make "childNode" a regOptional node
+//
+// Arguments:
+//    parentNode - is a non-leaf node that can regOptional its 'childNode'
+//    childNode  - is an op that will now be regOptional to its parent.
+//
+void Lowering::MakeSrcRegOptional(GenTree* parentNode, GenTree* childNode) const
+{
+    assert(!parentNode->OperIsLeaf());
+
+    childNode->SetRegOptional();
+    assert(childNode->IsRegOptional());
+
+#ifdef DEBUG
+    // Verify caller of this method checked safety.
+    //
+    const bool isSafeToContainMem = IsSafeToContainMem(parentNode, childNode);
+
+    if (!isSafeToContainMem)
+    {
+        JITDUMP("** Unsafe regOptional of [%06u] in [%06u}\n", comp->dspTreeID(childNode),
+                comp->dspTreeID(parentNode));
+        assert(isSafeToContainMem);
     }
 #endif
 }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -82,8 +82,7 @@ void Lowering::MakeSrcRegOptional(GenTree* parentNode, GenTree* childNode) const
 
     if (!isSafeToContainMem)
     {
-        JITDUMP("** Unsafe regOptional of [%06u] in [%06u}\n", comp->dspTreeID(childNode),
-                comp->dspTreeID(parentNode));
+        JITDUMP("** Unsafe regOptional of [%06u] in [%06u}\n", comp->dspTreeID(childNode), comp->dspTreeID(parentNode));
         assert(isSafeToContainMem);
     }
 #endif

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -89,6 +89,33 @@ void Lowering::MakeSrcRegOptional(GenTree* parentNode, GenTree* childNode) const
 }
 
 //------------------------------------------------------------------------
+// TryMakeSrcContainedOrRegOptional: Tries to make "childNode" a contained or regOptional node
+//
+// Arguments:
+//    parentNode - is a non-leaf node that can contain or regOptional its 'childNode'
+//    childNode  - is an op that will now be contained or regOptional to its parent.
+//
+void Lowering::TryMakeSrcContainedOrRegOptional(GenTree* parentNode, GenTree* childNode) const
+{
+    // HWIntrinsic nodes should use TryGetContainableHWIntrinsicOp and its relevant handling
+    assert(!parentNode->OperIsHWIntrinsic());
+
+    if (!IsSafeToContainMem(parentNode, childNode))
+    {
+        return;
+    }
+
+    if (IsContainableMemoryOp(childNode))
+    {
+        MakeSrcContained(parentNode, childNode);
+    }
+    else
+    {
+        MakeSrcRegOptional(parentNode, childNode);
+    }
+}
+
+//------------------------------------------------------------------------
 // CheckImmedAndMakeContained: Checks if the 'childNode' is a containable immediate
 //    and, if so, makes it contained.
 //

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -473,10 +473,8 @@ private:
     // Tries to make 'childNode' contained or regOptional in the 'parentNode'
     inline void TryMakeSrcContainedOrRegOptional(GenTree* parentNode, GenTree* childNode) const
     {
-#if defined(FEATURE_HW_INTRINSICS)
         // HWIntrinsic nodes should use TryGetContainableHWIntrinsicOp and its relevant handling
         assert(!parentNode->OperIsHWIntrinsic());
-#endif
 
         if (!IsSafeToContainMem(parentNode, childNode))
         {

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -288,6 +288,7 @@ private:
         const bool op2Legal = isSafeToMarkOp2 && (operatorSize == genTypeSize(op2->TypeGet()));
 
         GenTree* regOptionalOperand = nullptr;
+
         if (op1Legal)
         {
             regOptionalOperand = op2Legal ? PreferredRegOptionalOperand(tree) : op1;
@@ -296,9 +297,10 @@ private:
         {
             regOptionalOperand = op2;
         }
+
         if (regOptionalOperand != nullptr)
         {
-            regOptionalOperand->SetRegOptional();
+            MakeSrcRegOptional(tree, regOptionalOperand);
         }
     }
 #endif // defined(TARGET_XARCH)
@@ -447,7 +449,7 @@ public:
     bool IsContainableBinaryOp(GenTree* parentNode, GenTree* childNode) const;
 #endif // TARGET_ARM64
 
-#ifdef FEATURE_HW_INTRINSICS
+#if defined(FEATURE_HW_INTRINSICS)
     // Tries to get a containable node for a given HWIntrinsic
     bool TryGetContainableHWIntrinsicOp(GenTreeHWIntrinsic* containingNode,
                                         GenTree**           pNode,
@@ -464,6 +466,37 @@ private:
 
     // Makes 'childNode' contained in the 'parentNode'
     void MakeSrcContained(GenTree* parentNode, GenTree* childNode) const;
+
+    // Makes 'childNode' regOptional in the 'parentNode'
+    void MakeSrcRegOptional(GenTree* parentNode, GenTree* childNode) const;
+
+    // Tries to make 'childNode' contained or regOptional in the 'parentNode'
+    inline void TryMakeSrcContainedOrRegOptional(GenTree* parentNode, GenTree* childNode) const
+    {
+#if defined(FEATURE_HW_INTRINSICS)
+        // HWIntrinsic nodes should use TryGetContainableHWIntrinsicOp and its relevant handling
+        assert(!parentNode->OperIsHWIntrinsic());
+#endif
+
+        if (!IsSafeToContainMem(parentNode, childNode))
+        {
+            return;
+        }
+
+        if (IsContainableMemoryOp(childNode))
+        {
+            MakeSrcContained(parentNode, childNode);
+        }
+        else
+        {
+            MakeSrcRegOptional(parentNode, childNode);
+        }
+    }
+
+#if defined(FEATURE_HW_INTRINSICS)
+    // Tries to make 'childNode' contained or regOptional in the 'parentNode'
+    void TryMakeSrcContainedOrRegOptional(GenTreeHWIntrinsic* parentNode, GenTree* childNode) const;
+#endif
 
     // Checks and makes 'childNode' contained in the 'parentNode'
     bool CheckImmedAndMakeContained(GenTree* parentNode, GenTree* childNode);

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -471,25 +471,7 @@ private:
     void MakeSrcRegOptional(GenTree* parentNode, GenTree* childNode) const;
 
     // Tries to make 'childNode' contained or regOptional in the 'parentNode'
-    inline void TryMakeSrcContainedOrRegOptional(GenTree* parentNode, GenTree* childNode) const
-    {
-        // HWIntrinsic nodes should use TryGetContainableHWIntrinsicOp and its relevant handling
-        assert(!parentNode->OperIsHWIntrinsic());
-
-        if (!IsSafeToContainMem(parentNode, childNode))
-        {
-            return;
-        }
-
-        if (IsContainableMemoryOp(childNode))
-        {
-            MakeSrcContained(parentNode, childNode);
-        }
-        else
-        {
-            MakeSrcRegOptional(parentNode, childNode);
-        }
-    }
+    void TryMakeSrcContainedOrRegOptional(GenTree* parentNode, GenTree* childNode) const;
 
 #if defined(FEATURE_HW_INTRINSICS)
     // Tries to make 'childNode' contained or regOptional in the 'parentNode'


### PR DESCRIPTION
The general issue was raised here: https://github.com/dotnet/runtime/pull/77798#discussion_r1013187887 and has surfaced in other areas in the past, such as #72673.

This isn't a comprehensive fix, but did grab the most obvious places. There are still a number of remaining areas where we call `SetContained` and `SetRegOptional` directly and where we should migrate them towards `MakeSrcContained/RegOptional` in the future.