### PR TITLE
Improve AllVars bit set

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3037,6 +3037,18 @@ public:
     unsigned lvaTrackedCount;             // actual # of locals being tracked
     unsigned lvaTrackedCountInSizeTUnits; // min # of size_t's sufficient to hold a bit for all the locals being tracked
 
+    unsigned lvaAllVarsCount;             // # of locals being tracked in the AllVarsBitSet
+    unsigned lvaAllVarsCountInSizeTUnits; // min # of size_t's sufficient to hold bits for the AllVarsBitSet
+
+    void SetLvaCount(unsigned count)
+    {
+        lvaCount = count;
+
+        lvaAllVarsCount = min(lvaCount, lclMAX_ALLSET_TRACKED);
+        lvaAllVarsCountInSizeTUnits =
+            roundUp((unsigned)lvaAllVarsCount, (unsigned)(sizeof(size_t) * 8)) / unsigned(sizeof(size_t) * 8);
+    }
+
 #ifdef DEBUG
     VARSET_TP lvaTrackedVars; // set of tracked variables
 #endif

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1699,8 +1699,10 @@ inline unsigned Compiler::lvaGrabTemp(bool shortLifetime DEBUGARG(const char* re
 
         unsigned tmpNum = pComp->lvaGrabTemp(shortLifetime DEBUGARG(reason));
         lvaTable        = pComp->lvaTable;
-        lvaCount        = pComp->lvaCount;
         lvaTableCnt     = pComp->lvaTableCnt;
+
+        SetLvaCount(pComp->lvaCount);
+
         return tmpNum;
     }
 
@@ -1738,7 +1740,7 @@ inline unsigned Compiler::lvaGrabTemp(bool shortLifetime DEBUGARG(const char* re
     }
 
     const unsigned tempNum = lvaCount;
-    lvaCount++;
+    SetLvaCount(lvaCount + 1);
 
     // Initialize lvType, lvIsTemp and lvOnFrame
     lvaTable[tempNum].lvType    = TYP_UNDEF;
@@ -1783,8 +1785,10 @@ inline unsigned Compiler::lvaGrabTemps(unsigned cnt DEBUGARG(const char* reason)
         unsigned tmpNum = impInlineInfo->InlinerCompiler->lvaGrabTemps(cnt DEBUGARG(reason));
 
         lvaTable    = impInlineInfo->InlinerCompiler->lvaTable;
-        lvaCount    = impInlineInfo->InlinerCompiler->lvaCount;
         lvaTableCnt = impInlineInfo->InlinerCompiler->lvaTableCnt;
+
+        SetLvaCount(impInlineInfo->InlinerCompiler->lvaCount);
+
         return tmpNum;
     }
 
@@ -1832,14 +1836,16 @@ inline unsigned Compiler::lvaGrabTemps(unsigned cnt DEBUGARG(const char* reason)
     }
 
     unsigned tempNum = lvaCount;
+    unsigned newTemp;
 
-    while (cnt--)
+    for (newTemp = lvaCount; cnt > 0; cnt--, newTemp++)
     {
-        lvaTable[lvaCount].lvType    = TYP_UNDEF; // Initialize lvType, lvIsTemp and lvOnFrame
-        lvaTable[lvaCount].lvIsTemp  = false;
-        lvaTable[lvaCount].lvOnFrame = true;
-        lvaCount++;
+        lvaTable[newTemp].lvType    = TYP_UNDEF; // Initialize lvType, lvIsTemp and lvOnFrame
+        lvaTable[newTemp].lvIsTemp  = false;
+        lvaTable[newTemp].lvOnFrame = true;
     }
+
+    SetLvaCount(newTemp);
 
     return tempNum;
 }
@@ -1859,8 +1865,10 @@ inline unsigned Compiler::lvaGrabTempWithImplicitUse(bool shortLifetime DEBUGARG
         unsigned tmpNum = impInlineInfo->InlinerCompiler->lvaGrabTempWithImplicitUse(shortLifetime DEBUGARG(reason));
 
         lvaTable    = impInlineInfo->InlinerCompiler->lvaTable;
-        lvaCount    = impInlineInfo->InlinerCompiler->lvaCount;
         lvaTableCnt = impInlineInfo->InlinerCompiler->lvaTableCnt;
+
+        SetLvaCount(impInlineInfo->InlinerCompiler->lvaCount);
+
         return tmpNum;
     }
 

--- a/src/coreclr/jit/compilerbitsettraits.hpp
+++ b/src/coreclr/jit/compilerbitsettraits.hpp
@@ -70,14 +70,13 @@ BitSetSupport::BitSetOpCounter* TrackedVarBitSetTraits::GetOpCounter(Compiler* c
 // static
 unsigned AllVarBitSetTraits::GetSize(Compiler* comp)
 {
-    return min(comp->lvaCount, lclMAX_ALLSET_TRACKED);
+    return comp->lvaAllVarsCount;
 }
 
 // static
 unsigned AllVarBitSetTraits::GetArrSize(Compiler* comp)
 {
-    const unsigned elemBits = 8 * sizeof(size_t);
-    return roundUp(GetSize(comp), elemBits) / elemBits;
+    return comp->lvaAllVarsCountInSizeTUnits;
 }
 
 // static

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -185,8 +185,7 @@ void Compiler::lvaInitTypeRef()
         info.compTypeCtxtArg = BAD_VAR_NUM;
     }
 
-    lvaCount = info.compLocalsCount = info.compArgsCount + info.compMethodInfo->locals.numArgs;
-
+    info.compLocalsCount   = info.compArgsCount + info.compMethodInfo->locals.numArgs;
     info.compILlocalsCount = info.compILargsCount + info.compMethodInfo->locals.numArgs;
 
     /* Now allocate the variable descriptor table */
@@ -194,12 +193,15 @@ void Compiler::lvaInitTypeRef()
     if (compIsForInlining())
     {
         lvaTable    = impInlineInfo->InlinerCompiler->lvaTable;
-        lvaCount    = impInlineInfo->InlinerCompiler->lvaCount;
         lvaTableCnt = impInlineInfo->InlinerCompiler->lvaTableCnt;
+
+        SetLvaCount(impInlineInfo->InlinerCompiler->lvaCount);
 
         // No more stuff needs to be done.
         return;
     }
+
+    SetLvaCount(info.compLocalsCount);
 
     lvaTableCnt = lvaCount * 2;
 
@@ -3640,6 +3642,9 @@ void Compiler::lvaSortByRefCount()
 {
     lvaTrackedCount             = 0;
     lvaTrackedCountInSizeTUnits = 0;
+
+    lvaAllVarsCount             = 0;
+    lvaAllVarsCountInSizeTUnits = 0;
 
 #ifdef DEBUG
     VarSetOps::AssignNoCopy(this, lvaTrackedVars, VarSetOps::MakeEmpty(this));

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3643,9 +3643,6 @@ void Compiler::lvaSortByRefCount()
     lvaTrackedCount             = 0;
     lvaTrackedCountInSizeTUnits = 0;
 
-    lvaAllVarsCount             = 0;
-    lvaAllVarsCountInSizeTUnits = 0;
-
 #ifdef DEBUG
     VarSetOps::AssignNoCopy(this, lvaTrackedVars, VarSetOps::MakeEmpty(this));
 #endif

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5571,7 +5571,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result, 
             new (&lvaTable[i], jitstd::placement_t()) LclVarDsc(); // call the constructor.
         }
 
-        lvaCount = startVars;
+        SetLvaCount(startVars);
     }
 }
 


### PR DESCRIPTION
Cache the bit size and array size to avoid computation in these functions (GetArrSize() in particular is extremely hot).

To avoid changing behavior, recalculate these pre-computed values every time the number of locals change, since that is how they were implemented. Note that once you start using the bitset you can't change the number of locals (that would also change the bitset "epoch").