### PR TITLE
Make DAC logging opt-in

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -7180,7 +7180,9 @@ CLRDataCreateInstance(REFIID iid,
     {
         return hr;
     }
-
+#ifdef LOGGING
+    InitializeLogging();
+#endif
     hr = pClrDataAccess->QueryInterface(iid, iface);
 
     pClrDataAccess->Release();

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1169,12 +1169,6 @@ void DacDbiInterfaceImpl::GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly,
 
     *pLocalSigToken = GetILCodeAndSigHelper(pModule, pMethodDesc, functionToken, methodRVA, pCodeInfo);
 
-#ifdef LOGGING
-    else
-    {
-        LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: GetMethodImplProps failed!\n"));
-    }
-#endif
 } // GetILCodeAndSig
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/inc/log.h
+++ b/src/coreclr/inc/log.h
@@ -86,11 +86,36 @@ bool LoggingEnabled();
 bool LoggingOn(DWORD facility, DWORD level);
 bool Logging2On(DWORD facility, DWORD level);
 
-#define LOG(x)      do { if (LoggingEnabled()) { LogSpew x; } } while (0)
+#ifdef DACCESS_COMPILE
 
-#define LOG2(x)     do { if (LoggingEnabled()) { LogSpew2 x; } } while (0)
+/*
+ *
+ * Logging for the DAC is an incomplete feature, see more in
+ * https://github.com/dotnet/runtime/issues/77922
+ *
+ * As of now, logging need to be opt-in. Any logging done through
+ * DAC_LOG (or it variants) will be available in the log for both the runtime and the DAC build
+ * And the normal LOG macro will be available only for the runtime.
+ *
+ */
 
-#define LOGALWAYS(x)   LogSpewAlways x
+#define LOG(x)           do {  } while (0)
+#define LOG2(x)          do {  } while (0)
+#define LOGALWAYS(x)     do {  } while (0)
+#define DAC_LOG(x)       do { if (LoggingEnabled()) { LogSpew x; } } while (0)
+#define DAC_LOG2(x)      do { if (LoggingEnabled()) { LogSpew2 x; } } while (0)
+#define DAC_LOGALWAYS(x) LogSpewAlways x
+
+#else 
+
+#define LOG(x)           do { if (LoggingEnabled()) { LogSpew x; } } while (0)
+#define LOG2(x)          do { if (LoggingEnabled()) { LogSpew2 x; } } while (0)
+#define LOGALWAYS(x)     LogSpewAlways x
+#define DAC_LOG(x)       LOG(x)
+#define DAC_LOG2(x)      LOG2(x)
+#define DAC_LOGALWAYS(x) LOGALWAYS(x)
+
+#endif
 
 #endif
 

--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -29,7 +29,7 @@
 
 #define FEATURE_SHARE_GENERIC_CODE
 
-#if defined(_DEBUG) && !defined(DACCESS_COMPILE)
+#if defined(_DEBUG)
     #define LOGGING
 #endif
 


### PR DESCRIPTION
This change enables `LOGGING` for the DAC build. That will allow us to use logging to diagnose DAC-related issues.

Because of the reasons listed in #77922, I am not able to turn it on for all existing logging statements. For now, we will use an alternative macro named `DAC_LOG` (currently not used yet) to do logging in the DAC instead.

To enable a logging statement, simply change `LOG` to `DAC_LOG`, which will enable it for both the runtime and the DAC. With proper care for pointers, it will work.