### PR TITLE
[release/6.0] Suppress warnings for deprecated keychain APIs

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain_macos.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain_macos.c
@@ -16,7 +16,10 @@ int32_t AppleCryptoNative_SecKeychainItemCopyKeychain(SecKeychainItemRef item, S
 
     if (itemType == SecKeyGetTypeID() || itemType == SecIdentityGetTypeID() || itemType == SecCertificateGetTypeID())
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         OSStatus status = SecKeychainItemCopyKeychain(item, pKeychainOut);
+#pragma clang diagnostic pop
 
         if (status == noErr)
         {
@@ -40,12 +43,18 @@ int32_t AppleCryptoNative_SecKeychainCreate(const char* pathName,
                                             const uint8_t* passphraseUtf8,
                                             SecKeychainRef* pKeychainOut)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainCreate(pathName, passphraseLength, passphraseUtf8, false, NULL, pKeychainOut);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SecKeychainDelete(SecKeychainRef keychain)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainDelete(keychain);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SecKeychainCopyDefault(SecKeychainRef* pKeychainOut)
@@ -53,7 +62,10 @@ int32_t AppleCryptoNative_SecKeychainCopyDefault(SecKeychainRef* pKeychainOut)
     if (pKeychainOut != NULL)
         *pKeychainOut = NULL;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainCopyDefault(pKeychainOut);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SecKeychainOpen(const char* pszKeychainPath, SecKeychainRef* pKeychainOut)
@@ -64,12 +76,18 @@ int32_t AppleCryptoNative_SecKeychainOpen(const char* pszKeychainPath, SecKeycha
     if (pszKeychainPath == NULL)
         return errSecParam;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainOpen(pszKeychainPath, pKeychainOut);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SecKeychainUnlock(SecKeychainRef keychain, uint32_t passphraseLength, const uint8_t* passphraseUtf8)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainUnlock(keychain, passphraseLength, passphraseUtf8, true);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SetKeychainNeverLock(SecKeychainRef keychain)
@@ -81,7 +99,10 @@ int32_t AppleCryptoNative_SetKeychainNeverLock(SecKeychainRef keychain)
         .lockInterval = INT_MAX,
     };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainSetSettings(keychain, &settings);
+#pragma clang diagnostic pop
 }
 
 static int32_t
@@ -254,7 +275,10 @@ static bool IsCertInKeychain(CFTypeRef needle, SecKeychainRef haystack)
     CFDictionarySetValue(query, kSecMatchSearchList, searchList);
     CFDictionarySetValue(query, kSecMatchItemList, itemMatch);
     CFDictionarySetValue(query, kSecClass, kSecClassCertificate);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     OSStatus status = SecItemCopyMatching(query, &result);
+#pragma clang diagnostic pop
 
     bool ret = true;
 
@@ -350,7 +374,10 @@ int32_t AppleCryptoNative_X509StoreAddCertificate(CFTypeRef certOrIdentity, SecK
     // keychain back to disk.
     if (status == noErr && privateKey != NULL)
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         status = SecKeychainItemCreateCopy((SecKeychainItemRef)privateKey, keychain, NULL, &itemCopy);
+#pragma clang diagnostic pop
     }
 
     if (status == errSecDuplicateItem)
@@ -369,7 +396,10 @@ int32_t AppleCryptoNative_X509StoreAddCertificate(CFTypeRef certOrIdentity, SecK
 
     if (status == noErr && cert != NULL)
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         status = SecKeychainItemCreateCopy((SecKeychainItemRef)cert, keychain, NULL, &itemCopy);
+#pragma clang diagnostic pop
     }
 
     if (status == errSecDuplicateItem)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509_macos.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509_macos.c
@@ -384,8 +384,10 @@ int32_t AppleCryptoNative_X509CopyWithPrivateKey(SecCertificateRef cert,
     }
 
     SecKeychainRef keyKeychain = NULL;
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     OSStatus status = SecKeychainItemCopyKeychain((SecKeychainItemRef)privateKey, &keyKeychain);
+#pragma clang diagnostic pop
     SecKeychainItemRef itemCopy = NULL;
 
     // This only happens with an ephemeral key, so the keychain we're adding it to is temporary.
@@ -536,7 +538,10 @@ int32_t AppleCryptoNative_X509MoveToKeychain(SecCertificateRef cert,
 
     SecKeychainRef curKeychain = NULL;
     SecKeyRef importedKey = NULL;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     OSStatus status = SecKeychainItemCopyKeychain((SecKeychainItemRef)cert, &curKeychain);
+#pragma clang diagnostic pop
 
     if (status == errSecNoSuchKeychain)
     {
@@ -559,7 +564,10 @@ int32_t AppleCryptoNative_X509MoveToKeychain(SecCertificateRef cert,
 
     if (status == noErr && privateKey != NULL)
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         status = SecKeychainItemCopyKeychain((SecKeychainItemRef)privateKey, &curKeychain);
+#pragma clang diagnostic pop
 
         if (status == errSecNoSuchKeychain)
         {


### PR DESCRIPTION
Backport of #77911 to release/6.0

/cc @vcsjones

## Customer Impact

This change fixes compiling with the latest Xcode tooling.

In Xcode 14.1, Apple deprecated several APIs related to their Keychain APIs. This change suppresses the obsolete warnings so the build continues. The Mac Pools for CI will need this change for CI to continue to build when the Mac Pool eventually gets updated to this version of the tooling.

## Testing

Verified compilation succeeds with Xcode 14.1 toolchain.

## Risk

Very low. This makes no functional changes, and fixes a build-break using `#pragma` directives to suppress the warning.

IMPORTANT: Is this backport for a servicing release? If so and this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
