### PR TITLE
Improve coreclr test infra

### DIFF
--- a/docs/workflow/testing/coreclr/test-configuration.md
+++ b/docs/workflow/testing/coreclr/test-configuration.md
@@ -49,8 +49,20 @@ Therefore the managed portion of each test **must not contain**:
     * e.g. `<DisableProjectBuild>true</DisableProjectBuild>`
 * Exclude test from GCStress runs by adding the following to the csproj:
     * `<GCStressIncompatible>true</GCStressIncompatible>`
+* Exclude test from HeapVerify testing runs runs by adding the following to the csproj:
+    * `<HeapVerifyIncompatible>true</HeapVerifyIncompatible>`
 * Exclude test from JIT stress runs runs by adding the following to the csproj:
     * `<JitOptimizationSensitive>true</JitOptimizationSensitive>`
+* Exclude test from NativeAOT runs runs by adding the following to the csproj:
+    * `<NativeAotIncompatible>true</NativeAotIncompatible>`
+* Exclude the test from ilasm round trip testing by adding the following to the csproj
+    * `<IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>`
+* Exclude the test for unloadability (collectible assemblies) testing
+    * `<UnloadabilityIncompatible>true</UnloadabilityIncompatible>`
+* If the test is specific for testing crossgen2, and should be compiled as such in all test modes
+    * `<AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>`
+* When `CrossGenTest` is set to false, this test is not run with standard R2R compilation even if running an R2R test pass.
+    * `<CrossGenTest>false</CrossGenTest>`
 * Add NuGet references by updating the following [test project](https://github.com/dotnet/runtime/blob/main/src/tests/Common/test_dependencies/test_dependencies.csproj).
 * Any System.Private.CoreLib types and methods used by tests must be available for building on all platforms.
 This means there must be enough implementation for the C# compiler to find the referenced types and methods. Unsupported target platforms
@@ -94,3 +106,17 @@ should simply `throw new PlatformNotSupportedException()` in its dummy method im
     * CMake reference: `<CMakeProjectReference Include="../NativeDll/CMakeLists.txt" />`
 1. Build the test.
 1. Follow the steps to re-run a failed test to validate the new test.
+
+### Creating a merged test runner project
+1. Use an existing test such as `<repo_root>\src\tests\JIT\Methodical\Methodical_d1.csproj` as a template.
+1. If your new merged test runner has MANY tests in it, and takes too long to run under GC Stress, set `<NumberOfStripesToUseInStress>` to a number such as 10 to make it possible for the test to complete in a reasonable timeframe.
+
+#### Command line arguments for merged test runner projects
+Unless tests are manually run on the command line to repro a problem, these parameters are handled internally by the test infrastructure, but for running tests locally, there are a set of standard parameters that these merged test runners support.
+
+`[testFilterString] [-stripe <whichStripe> <totalStripes>]`
+
+`testFilterString` is any string other that `-stripe`. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name).
+
+Either the -stripe <whichStripe> <totalStripes> parameter can be used or the TEST_HARNESS_STRIPE_TO_EXECUTE environment variable may be used to control striping. The TEST_HARNESS_STRIPE_TO_EXECUTE environment variable must be set to a string of the form `.<whichStripe>.<totalStripes>` if it is used. `<whichStripe>` is a 0 based index into the count of stripes, `<totalStripes>` is the total number of stripes.
+

--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -20,5 +20,11 @@ namespace TestLibrary
                                             && (AppContext.TryGetSwitch("System.Runtime.InteropServices.BuiltInComInterop.IsSupported", out bool isEnabled)
                                                 ? isEnabled
                                                 : true);
+
+        static string _variant = Environment.GetEnvironmentVariable("DOTNET_RUNTIME_VARIANT");
+
+        public static bool IsMonoLLVMAOT => _variant == "llvmaot";
+        public static bool IsMonoLLVMFULLAOT => _variant == "llvmfullaot";
+        public static bool IsMonoInterpreter => _variant == "monointerpreter";
     }
 }

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -154,7 +154,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         builder.AppendLine(string.Join("\n", aliasMap.Values.Where(alias => alias != "global").Select(alias => $"extern alias {alias};")));
         builder.AppendLine("System.Collections.Generic.HashSet<string> testExclusionList = XUnitWrapperLibrary.TestFilter.LoadTestExclusionList();");
 
-        builder.AppendLine("XUnitWrapperLibrary.TestFilter filter = new (args.Length != 0 ? args[0] : null, testExclusionList);");
+        builder.AppendLine("XUnitWrapperLibrary.TestFilter filter = new (args, testExclusionList);");
         builder.AppendLine("XUnitWrapperLibrary.TestSummary summary = new();");
         builder.AppendLine("System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();");
         builder.AppendLine("XUnitWrapperLibrary.TestOutputRecorder outputRecorder = new(System.Console.Out);");
@@ -162,14 +162,43 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
 
         ITestReporterWrapper reporter = new WrapperLibraryTestSummaryReporting("summary", "filter", "outputRecorder");
 
-        foreach (ITestInfo test in testInfos)
+        StringBuilder testExecutorBuilder = new();
+        int testsLeftInCurrentTestExecutor = 0;
+        int currentTestExecutor = 0;
+        int totalTestsEmitted = 0;
+
+        if (testInfos.Length > 0)
         {
-            builder.AppendLine(test.GenerateTestExecution(reporter));
+            // Break tests into groups of 50 so that we don't create an unreasonably large main method
+            // Excessively large methods are known to take a long time to compile, and use excessive stack
+            // leading to test failures.
+            foreach (ITestInfo test in testInfos)
+            {
+                if (testsLeftInCurrentTestExecutor == 0)
+                {
+                    if (currentTestExecutor != 0)
+                        testExecutorBuilder.AppendLine("}");
+                    currentTestExecutor++;
+                    testExecutorBuilder.AppendLine($"void TestExecutor{currentTestExecutor}(){{");
+                    builder.AppendLine($"TestExecutor{currentTestExecutor}();");
+                    testsLeftInCurrentTestExecutor = 50; // Break test executors into groups of 50, which empircally seems to work well
+                }
+                testExecutorBuilder.AppendLine(test.GenerateTestExecution(reporter));
+                totalTestsEmitted++;
+                testsLeftInCurrentTestExecutor--;
+            }
+            testExecutorBuilder.AppendLine("}");
         }
 
-        builder.AppendLine($@"System.IO.File.WriteAllText(""{assemblyName}.testResults.xml"", summary.GetTestResultOutput(""{assemblyName}""));");
+        builder.AppendLine($@"string testResults = summary.GetTestResultOutput(""{assemblyName}"");");
+        builder.AppendLine($@"string workitemUploadRoot = System.Environment.GetEnvironmentVariable(""HELIX_WORKITEM_UPLOAD_ROOT"");");
+        builder.AppendLine($@"if (workitemUploadRoot != null) System.IO.File.WriteAllText(System.IO.Path.Combine(workitemUploadRoot, ""{assemblyName}.testResults.xml.txt""), testResults);");
+        builder.AppendLine($@"System.IO.File.WriteAllText(""{assemblyName}.testResults.xml"", testResults);");
         builder.AppendLine("return 100;");
 
+        builder.Append(testExecutorBuilder);
+
+        builder.AppendLine("public static class TestCount { public const int Count = " + totalTestsEmitted.ToString() + "; }");
         return builder.ToString();
     }
 
@@ -193,13 +222,36 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
 
         ITestReporterWrapper reporter = new WrapperLibraryTestSummaryReporting("summary", "filter", "outputRecorder");
 
-        foreach (ITestInfo test in testInfos)
+        StringBuilder testExecutorBuilder = new();
+        int testsLeftInCurrentTestExecutor = 0;
+        int currentTestExecutor = 0;
+
+        if (testInfos.Length > 0)
         {
-            builder.AppendLine(test.GenerateTestExecution(reporter));
+            // Break tests into groups of 50 so that we don't create an unreasonably large main method
+            // Excessively large methods are known to take a long time to compile, and use excessive stack
+            // leading to test failures.
+            foreach (ITestInfo test in testInfos)
+            {
+                if (testsLeftInCurrentTestExecutor == 0)
+                {
+                    if (currentTestExecutor != 0)
+                        testExecutorBuilder.AppendLine("}");
+                    currentTestExecutor++;
+                    testExecutorBuilder.AppendLine($"static void TestExecutor{currentTestExecutor}(XUnitWrapperLibrary.TestSummary summary, XUnitWrapperLibrary.TestFilter filter, XUnitWrapperLibrary.TestOutputRecorder outputRecorder, System.Diagnostics.Stopwatch stopwatch){{");
+                    builder.AppendLine($"TestExecutor{currentTestExecutor}(summary, filter, outputRecorder, stopwatch);");
+                    testsLeftInCurrentTestExecutor = 50; // Break test executors into groups of 50, which empirically seems to work well
+                }
+                testExecutorBuilder.AppendLine(test.GenerateTestExecution(reporter));
+                testsLeftInCurrentTestExecutor--;
+            }
+            testExecutorBuilder.AppendLine("}");
         }
 
         builder.AppendLine("return summary;");
         builder.AppendLine("}");
+
+        builder.Append(testExecutorBuilder);
 
         return builder.ToString();
     }
@@ -354,7 +406,8 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                             testInfos,
                             conditionType,
                             conditionMembers,
-                            aliasMap[conditionType.ContainingAssembly.MetadataName]);
+                            aliasMap[conditionType.ContainingAssembly.MetadataName],
+                            false /* do not negate the condition, as this attribute indicates that a test will be run */);
                         break;
                     }
                 case "Xunit.OuterloopAttribute":
@@ -373,7 +426,8 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                             testInfos,
                             conditionType,
                             filterAttribute.ConstructorArguments[2].Values,
-                            aliasMap[conditionType.ContainingAssembly.MetadataName]);
+                            aliasMap[conditionType.ContainingAssembly.MetadataName],
+                            true /* negate the condition, as this attribute indicates that a test will NOT be run */);
                         break;
                     }
                     else if (filterAttribute.AttributeConstructor.Parameters.Length == 4)
@@ -667,9 +721,12 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         ImmutableArray<ITestInfo> testInfos,
         ITypeSymbol conditionType,
         ImmutableArray<TypedConstant> values,
-        string externAlias)
+        string externAlias,
+        bool negate)
     {
         string condition = string.Join("&&", values.Select(v => $"{externAlias}::{conditionType.ToDisplayString(FullyQualifiedWithoutGlobalNamespace)}.{v.Value}"));
+        if (negate)
+            condition = $"!({condition})";
         return ImmutableArray.CreateRange<ITestInfo>(testInfos.Select(m => new ConditionalTest(m, condition)));
     }
 

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -118,14 +118,50 @@ public class TestFilter
     // issues.targets file as a split model would be very confusing for developers
     // and test monitors.
     private readonly HashSet<string>? _testExclusionList;
+    private readonly int _stripe = 0;
+    private readonly int _stripeCount = 1;
+    private int _shouldRunQuery = -1;
 
-    public TestFilter(string? filterString, HashSet<string>? testExclusionList)
+    public TestFilter(string? filterString, HashSet<string>? testExclusionList) : 
+        this(filterString == null ? Array.Empty<string>() : new string[]{filterString}, testExclusionList)
     {
+    }
+
+    public TestFilter(string[] filterArgs, HashSet<string>? testExclusionList)
+    {
+        string? filterString = null;
+
+        for (int i = 0; i < filterArgs.Length; i++)
+        {
+            if (filterArgs[i].StartsWith("-stripe"))
+            {
+                _stripe = Int32.Parse(filterArgs[++i]);
+                _stripeCount = Int32.Parse(filterArgs[++i]);
+            }
+            else
+            {
+                if (filterString == null)
+                    filterString = filterArgs[0];
+            }
+        }
+
+        var stripeEnvironment = Environment.GetEnvironmentVariable("TEST_HARNESS_STRIPE_TO_EXECUTE");
+        if (!String.IsNullOrEmpty(stripeEnvironment) && stripeEnvironment != ".0.1")
+        {
+            var stripes = stripeEnvironment.Split('.');
+            if (stripes.Length == 3)
+            {
+                Console.WriteLine($"Test striping enabled via TEST_HARNESS_STRIPE_TO_EXECUTE environment variable set to '{stripeEnvironment}'");
+                _stripe = Int32.Parse(stripes[1]);
+                _stripeCount = Int32.Parse(stripes[2]);
+            }
+        }
+
         if (filterString is not null)
         {
             if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
             {
-                throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterString));
+                throw new ArgumentException("Complex test filter expressions ar e not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterString));
             }
             _filter = new NameClause(TermKind.FullyQualifiedName, filterString, substring: true);
         }
@@ -140,15 +176,26 @@ public class TestFilter
 
     public bool ShouldRunTest(string fullyQualifiedName, string displayName, string[]? traits = null)
     {
+        bool shouldRun = false;
         if (_testExclusionList is not null && _testExclusionList.Contains(displayName.Replace("\\", "/")))
         {
-            return false;
+            shouldRun = false;
         }
-        if (_filter is null)
+        else if (_filter is null)
         {
-            return true;
+            shouldRun = true;
         }
-        return _filter.IsMatch(fullyQualifiedName, displayName, traits ?? Array.Empty<string>());
+        else
+        {
+            shouldRun = _filter.IsMatch(fullyQualifiedName, displayName, traits ?? Array.Empty<string>());
+        }
+
+        if (shouldRun)
+        {
+            // Test stripe, if true, then report success
+            return ((System.Threading.Interlocked.Increment(ref _shouldRunQuery)) % _stripeCount) == _stripe;
+        }
+        return false;
     }
     
     public static HashSet<string> LoadTestExclusionList()

--- a/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestFilter.cs
@@ -161,7 +161,7 @@ public class TestFilter
         {
             if (filterString.IndexOfAny(new[] { '!', '(', ')', '~', '=' }) != -1)
             {
-                throw new ArgumentException("Complex test filter expressions ar e not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterString));
+                throw new ArgumentException("Complex test filter expressions are not supported today. The only filters supported today are the simple form supported in 'dotnet test --filter' (substrings of the test's fully qualified name). If further filtering options are desired, file an issue on dotnet/runtime for support.", nameof(filterString));
             }
             _filter = new NameClause(TermKind.FullyQualifiedName, filterString, substring: true);
         }

--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -73,11 +73,29 @@ public class TestSummary
             string outputElement = !string.IsNullOrWhiteSpace(test.Output) ? $"<output><![CDATA[{test.Output}]]></output>" : string.Empty;
             if (test.Exception is not null)
             {
-                resultsFile.AppendLine($@"result=""Fail""><failure exception-type=""{test.Exception.GetType()}""><message><![CDATA[{test.Exception.Message}]]></message><stack-trace><![CDATA[{test.Exception.StackTrace}]]></stack-trace></failure>{outputElement}</test>");
+                string exceptionMessage = test.Exception.Message;
+                if (test.Exception is System.Reflection.TargetInvocationException tie)
+                {
+                    if (tie.InnerException != null)
+                    {
+                        exceptionMessage = $"{exceptionMessage} \n INNER EXCEPTION--\n {tie.InnerException.GetType()}--\n{tie.InnerException.Message}--\n{tie.InnerException.StackTrace}";
+                    }
+                }
+                if (string.IsNullOrWhiteSpace(exceptionMessage))
+                {
+                    exceptionMessage = "NoExceptionMessage";
+                }
+
+                string? stackTrace = test.Exception.StackTrace;
+                if (string.IsNullOrWhiteSpace(stackTrace))
+                {
+                    stackTrace = "NoStackTrace";
+                }
+                resultsFile.AppendLine($@"result=""Fail""><failure exception-type=""{test.Exception.GetType()}""><message><![CDATA[{exceptionMessage}]]></message><stack-trace><![CDATA[{stackTrace}]]></stack-trace></failure>{outputElement}</test>");
             }
             else if (test.SkipReason is not null)
             {
-                resultsFile.AppendLine($@"result=""Skip""><reason><![CDATA[{test.SkipReason}]]></reason></test>");
+                resultsFile.AppendLine($@"result=""Skip""><reason><![CDATA[{(!string.IsNullOrWhiteSpace(test.SkipReason) ? test.SkipReason : "No Known Skip Reason")}]]></reason></test>");
             }
             else
             {

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -391,6 +391,8 @@
 
     <ItemGroup>
       <!-- We need to ensure that the test run script is marked as executable. -->
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' == 'true'" Include="set TEST_HARNESS_STRIPE_TO_EXECUTE=.0.1" />
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="export TEST_HARNESS_STRIPE_TO_EXECUTE=.0.1" />
       <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="chmod +x $(_MergedWrapperRunScriptRelative)" />
       <!-- Force assemblies to lazy-load for LLVM AOT test runs to enable using tests that fail at AOT time (and as a result can't be AOTd) -->
       <HelixCommandLines Condition="'$(RuntimeVariant)' == 'llvmfullaot'" Include="$(_MergedWrapperRunScriptPrefix)$(_MergedWrapperRunScriptRelative) --aot-lazy-assembly-load" />
@@ -652,6 +654,8 @@
     <HelixPreCommand Include="export __CollectDumps=1" />
     <HelixPreCommand Include="export __CrashDumpFolder=$HELIX_DUMP_FOLDER" />
     <HelixPreCommand Include="cat $__TestEnv" />
+
+    <HelixPostCommand Include="find $HELIX_WORKITEM_PAYLOAD -name '*testResults.xml' -exec cp {} $HELIX_DUMP_FOLDER\; " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TestWrapperTargetsWindows)' != 'true' and '$(SuperPmiCollect)' == 'true' ">
@@ -738,18 +742,60 @@
     </MergedPayloads>
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- Enable stress work item striping on GCstress only -->
+    <StripeMergedStressWorkItems Condition="$(Scenario.Contains('gcstress'))">true</StripeMergedStressWorkItems>
+    <!-- Striping is only enabled for the desktop version of the test harness, disable it regardless of scenario on
+         other systems. -->
+    <StripeMergedStressWorkItems Condition="'$(TargetHasHelixXHarnessSdkSupport)' == 'true' or '$(TargetsMobile)' == 'true'">false</StripeMergedStressWorkItems>
+  </PropertyGroup>
+
+  <Target Name="FindStressMarkers" BeforeTargets="PrepareMergedStressHelixWorkItems">
+    <ItemGroup>
+      <_MergedStressWrapperMarker Condition="'$(StripeMergedStressWorkItems)'=='true'" Include="$(TestBinDir)**\*.MergedTestAssemblyForStress"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PrepareMergedStressHelixWorkItems" 
+          BeforeTargets="PrepareMergedHelixWorkItems" 
+          Condition="'$(StripeMergedStressWorkItems)'=='true'"
+          Outputs="%(_MergedStressWrapperMarker.Identity).dummy">
+    <PropertyGroup>
+      <WithoutFinalExt>%(_MergedStressWrapperMarker.Filename)</WithoutFinalExt>
+      <TotalStripes>$([System.IO.Path]::GetExtension('$(WithoutFinalExt)'))</TotalStripes>
+      <WithoutFinalExt2>$([System.IO.Path]::GetFilenameWithoutExtension('$(WithoutFinalExt)'))</WithoutFinalExt2>
+      <ActiveStripe>$([System.IO.Path]::GetExtension('$(WithoutFinalExt2)'))</ActiveStripe>
+      <WithoutFinalExt3>$([System.IO.Path]::GetFilenameWithoutExtension('$(WithoutFinalExt2)'))</WithoutFinalExt3>
+      <MergedWrapperPayloadGroup>$([System.IO.Path]::GetFilenameWithoutExtension('$(WithoutFinalExt3)'))</MergedWrapperPayloadGroup>
+      <StripePayloadGroup>$(MergedWrapperPayloadGroup)$(ActiveStripe)$(TotalStripes)</StripePayloadGroup>
+      <FullName>%(_MergedStressWrapperMarker.Identity)</FullName>
+    </PropertyGroup>
+    <ItemGroup>
+      <HelixWorkItem Include="$(StripePayloadGroup)" Condition="'%(MergedPayloads.PayloadGroup)'=='$(MergedWrapperPayloadGroup)' and ! $(FullName.Contains('MergedPayloads'))">
+        <PayloadDirectory>%(MergedPayloads.PayloadDirectory)</PayloadDirectory>
+        <Command>$([System.String]::Copy('%(MergedPayloads.MergedTestHelixCommand)').Replace('TEST_HARNESS_STRIPE_TO_EXECUTE=.0.1','TEST_HARNESS_STRIPE_TO_EXECUTE=$(ActiveStripe)$(TotalStripes)'))</Command>
+        <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
+        <DownloadFilesFromResults Condition=" '$(SuperPmiCollect)' == 'true' ">coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).mch;coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).log</DownloadFilesFromResults>
+      </HelixWorkItem>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PrepareMergedHelixWorkItems" BeforeTargets="CoreTest">
+    <ItemGroup>
+      <HelixWorkItem Include="%(MergedPayloads.PayloadGroup)" Condition="'$(TargetHasHelixXHarnessSdkSupport)' != 'true' and '$(StripeMergedStressWorkItems)'!= 'true'">
+        <PayloadDirectory>%(MergedPayloads.PayloadDirectory)</PayloadDirectory>
+        <Command>%(MergedPayloads.MergedTestHelixCommand)</Command>
+        <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
+        <DownloadFilesFromResults Condition=" '$(SuperPmiCollect)' == 'true' ">coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).mch;coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).log</DownloadFilesFromResults>
+      </HelixWorkItem>
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <HelixWorkItem Include="@(LegacyPayloads->Metadata('PayloadGroup'))" Condition="'$(TargetHasHelixXHarnessSdkSupport)' != 'true'">
       <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>
       <Command>dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs)</Command>
       <Command Condition=" '%(TestGroup)' != '' ">dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs) -trait TestGroup=%(TestGroup)</Command>
-      <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
-      <DownloadFilesFromResults Condition=" '$(SuperPmiCollect)' == 'true' ">coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).mch;coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).log</DownloadFilesFromResults>
-    </HelixWorkItem>
-
-    <HelixWorkItem Include="@(MergedPayloads->Metadata('PayloadGroup'))" Condition="'$(TargetHasHelixXHarnessSdkSupport)' != 'true'">
-      <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>
-      <Command>%(MergedTestHelixCommand)</Command>
       <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
       <DownloadFilesFromResults Condition=" '$(SuperPmiCollect)' == 'true' ">coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).mch;coreclr_tests.run.$(TargetOS).$(TargetArchitecture).$(Configuration).log</DownloadFilesFromResults>
     </HelixWorkItem>

--- a/src/tests/Common/mergedrunner.targets
+++ b/src/tests/Common/mergedrunner.targets
@@ -15,7 +15,7 @@
       Produce an error if any project references were removed due to conflict resolution.
       If a ProjectReference is removed due to conflict resolution, then we're likely losing test coverage as it's probably a test that has the same assembly name and version as another test.
     -->
-    <Error Text="@(_ProjectReferencesRemovedDueToConflictResolution->'This project has an assembly name identical to another project: %(FullPath)', '&#010;')" Condition="'@(_ProjectReferencesRemovedDueToConflictResolution)' != ''"  />
+    <Error Text="@(_ProjectReferencesRemovedDueToConflictResolution->'This project has an assembly name identical to another project, if this CoreCLRTestLibrary, you should reference %24(TestLibraryProjectPath) instead of constructing the path yourself: %(FullPath)', '&#010;')" Condition="'@(_ProjectReferencesRemovedDueToConflictResolution)' != ''"  />
   </Target>
   
   <Import Project="$(RepoRoot)/src/tests/Common/mergedrunnermobile.targets" Condition="'$(TargetsMobile)' == 'true'" />

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -272,6 +272,8 @@
       <!-- Mono interpreter -->
       <_TestEnvFileLine Condition="'$(RuntimeVariant)' == 'monointerpreter'" Include="set MONO_ENV_OPTIONS=--interpreter" />
 
+      <_TestEnvFileLine Condition="'$(RuntimeVariant)' != ''" Include="set DOTNET_RUNTIME_VARIANT=$(RuntimeVariant)" />
+
       <!-- CLR interpreter -->
       <_TestEnvFileLine Condition="'$(Scenario)' == 'clrinterpreter'" Include="set DOTNET_Interpret=%2A" /> <!-- %2A is asterisk / wildcard -->
       <_TestEnvFileLine Condition="'$(Scenario)' == 'clrinterpreter'" Include="set DOTNET_InterpreterHWIntrinsicsIsSupportedFalse=1" />
@@ -293,6 +295,8 @@
 
       <!-- Use Mono in Full AOT mode when running the full-AOT-compiled runtime tests -->
       <_TestEnvFileLine Condition="'$(RuntimeVariant)' == 'llvmfullaot'" Include="export MONO_ENV_OPTIONS=--full-aot" />
+
+      <_TestEnvFileLine Condition="'$(RuntimeVariant)' != ''" Include="export DOTNET_RUNTIME_VARIANT=$(RuntimeVariant)" />
 
       <!-- CLR interpreter -->
       <_TestEnvFileLine Condition="'$(Scenario)' == 'clrinterpreter'" Include="export DOTNET_Interpret=%2A" /> <!-- %2A is asterisk / wildcard -->

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -271,11 +271,135 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="ConvertCountOfStressMarkersToListPhase1" BeforeTargets="ConvertCountOfStressMarkersToListPhase1">
+    <PropertyGroup>
+      <SequenceOfSemicolons>$([System.String]::new(';',10))</SequenceOfSemicolons>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="GenerateMarkerFiles" BeforeTargets="AssignTargetPaths">
+    <PropertyGroup Condition="'$(NumberOfStripesToUseInStress)' == '' and '$(IsMergedTestRunnerAssembly)' == 'true'">
+      <NumberOfStripesToUseInStress>1</NumberOfStripesToUseInStress> <!-- Set a custom number of stripes in stress to allow very large merged groups to function in the presence of GCStress -->
+    </PropertyGroup>
+
+    <!-- Generate a set of stress marker files to be used in stress scenarios in CI runs -->
+    <ItemGroup Condition="'$(NumberOfStripesToUseInStress)' != '' and '$(IsMergedTestRunnerAssembly)' == 'true'">
+      <SequenceOfIntegers Include="0"/>
+      <SequenceOfIntegers Include="1"/>
+      <SequenceOfIntegers Include="2"/>
+      <SequenceOfIntegers Include="3"/>
+      <SequenceOfIntegers Include="4"/>
+      <SequenceOfIntegers Include="5"/>
+      <SequenceOfIntegers Include="6"/>
+      <SequenceOfIntegers Include="7"/>
+      <SequenceOfIntegers Include="8"/>
+      <SequenceOfIntegers Include="9"/>
+      <SequenceOfIntegers Include="10"/>
+      <SequenceOfIntegers Include="11"/>
+      <SequenceOfIntegers Include="12"/>
+      <SequenceOfIntegers Include="13"/>
+      <SequenceOfIntegers Include="14"/>
+      <SequenceOfIntegers Include="15"/>
+      <SequenceOfIntegers Include="16"/>
+      <SequenceOfIntegers Include="17"/>
+      <SequenceOfIntegers Include="18"/>
+      <SequenceOfIntegers Include="19"/>
+      <SequenceOfIntegers Include="20"/>
+      <SequenceOfIntegers Include="21"/>
+      <SequenceOfIntegers Include="22"/>
+      <SequenceOfIntegers Include="23"/>
+      <SequenceOfIntegers Include="24"/>
+      <SequenceOfIntegers Include="25"/>
+      <SequenceOfIntegers Include="26"/>
+      <SequenceOfIntegers Include="27"/>
+      <SequenceOfIntegers Include="28"/>
+      <SequenceOfIntegers Include="29"/>
+      <SequenceOfIntegers Include="20"/>
+      <SequenceOfIntegers Include="31"/>
+      <SequenceOfIntegers Include="32"/>
+      <SequenceOfIntegers Include="33"/>
+      <SequenceOfIntegers Include="34"/>
+      <SequenceOfIntegers Include="35"/>
+      <SequenceOfIntegers Include="36"/>
+      <SequenceOfIntegers Include="37"/>
+      <SequenceOfIntegers Include="38"/>
+      <SequenceOfIntegers Include="39"/>
+      <SequenceOfIntegers Include="40"/>
+      <SequenceOfIntegers Include="41"/>
+      <SequenceOfIntegers Include="42"/>
+      <SequenceOfIntegers Include="43"/>
+      <SequenceOfIntegers Include="44"/>
+      <SequenceOfIntegers Include="45"/>
+      <SequenceOfIntegers Include="46"/>
+      <SequenceOfIntegers Include="47"/>
+      <SequenceOfIntegers Include="48"/>
+      <SequenceOfIntegers Include="49"/>
+      <SequenceOfIntegers Include="50"/>
+      <SequenceOfIntegers Include="51"/>
+      <SequenceOfIntegers Include="52"/>
+      <SequenceOfIntegers Include="53"/>
+      <SequenceOfIntegers Include="54"/>
+      <SequenceOfIntegers Include="55"/>
+      <SequenceOfIntegers Include="56"/>
+      <SequenceOfIntegers Include="57"/>
+      <SequenceOfIntegers Include="58"/>
+      <SequenceOfIntegers Include="59"/>
+      <SequenceOfIntegers Include="60"/>
+      <SequenceOfIntegers Include="61"/>
+      <SequenceOfIntegers Include="62"/>
+      <SequenceOfIntegers Include="63"/>
+      <SequenceOfIntegers Include="64"/>
+      <SequenceOfIntegers Include="65"/>
+      <SequenceOfIntegers Include="66"/>
+      <SequenceOfIntegers Include="67"/>
+      <SequenceOfIntegers Include="68"/>
+      <SequenceOfIntegers Include="69"/>
+      <SequenceOfIntegers Include="70"/>
+      <SequenceOfIntegers Include="71"/>
+      <SequenceOfIntegers Include="72"/>
+      <SequenceOfIntegers Include="73"/>
+      <SequenceOfIntegers Include="74"/>
+      <SequenceOfIntegers Include="75"/>
+      <SequenceOfIntegers Include="76"/>
+      <SequenceOfIntegers Include="77"/>
+      <SequenceOfIntegers Include="78"/>
+      <SequenceOfIntegers Include="79"/>
+      <SequenceOfIntegers Include="80"/>
+      <SequenceOfIntegers Include="81"/>
+      <SequenceOfIntegers Include="82"/>
+      <SequenceOfIntegers Include="83"/>
+      <SequenceOfIntegers Include="84"/>
+      <SequenceOfIntegers Include="85"/>
+      <SequenceOfIntegers Include="86"/>
+      <SequenceOfIntegers Include="87"/>
+      <SequenceOfIntegers Include="88"/>
+      <SequenceOfIntegers Include="89"/>
+      <SequenceOfIntegers Include="90"/>
+      <SequenceOfIntegers Include="91"/>
+      <SequenceOfIntegers Include="92"/>
+      <SequenceOfIntegers Include="93"/>
+      <SequenceOfIntegers Include="94"/>
+      <SequenceOfIntegers Include="95"/>
+      <SequenceOfIntegers Include="96"/>
+      <SequenceOfIntegers Include="97"/>
+      <SequenceOfIntegers Include="98"/>
+      <SequenceOfIntegers Include="99"/>
+
+      <MarkerFileIntegerSequence Include="@(SequenceOfIntegers)" Condition="%(Identity)&lt;$(NumberOfStripesToUseInStress)" />
+      <MarkerFile Include="@(MarkerFileIntegerSequence->'$(IntermediateOutputPath)\$(MSBuildProjectName).MergedTestAssembly.%(Identity).$(NumberOfStripesToUseInStress).MergedTestAssemblyForStress')">
+        <Type>MergedStressTestAssembly</Type>
+      </MarkerFile>
+    </ItemGroup>
+    <Error Condition="'$(NumberOfStripesToUseInStress)' != '' and $(NumberOfStripesToUseInStress)&gt;99" Text="Attempt to split into too many stripes. Either reduce stripe count, or add more entries to SequenceOfIntegers" />
+
     <ItemGroup>
       <Content Include="$(AssemblyName).reflect.xml" Condition="Exists('$(AssemblyName).reflect.xml')" CopyToOutputDirectory="PreserveNewest" />
-      <MarkerFile Include="$(IntermediateOutputPath)\$(MSBuildProjectName).MergedTestAssembly" Condition="'$(IsMergedTestRunnerAssembly)' == 'true'" />
-      <MarkerFile Include="$(IntermediateOutputPath)\$(AssemblyName).NoMonoAot" Condition="'$(MonoAotIncompatible)' == 'true'" />
+      <MarkerFile Include="$(IntermediateOutputPath)\$(MSBuildProjectName).MergedTestAssembly" Condition="'$(IsMergedTestRunnerAssembly)' == 'true'">
+        <Type>MergedTestAssembly</Type>
+      </MarkerFile>
+      <MarkerFile Include="$(IntermediateOutputPath)\$(AssemblyName).NoMonoAot" Condition="'$(MonoAotIncompatible)' == 'true'">
+        <Type>NoMonoAot</Type>
+      </MarkerFile>
       <Content Include="@(MarkerFile)" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
@@ -284,20 +408,12 @@
        Condition="Exists('$(AssemblyName).reflect.xml')"/>
 
     <WriteLinesToFile
-        Condition="'$(IsMergedTestRunnerAssembly)' == 'true'"
-        File="$(IntermediateOutputPath)\$(MSBuildProjectName).MergedTestAssembly"
-        Lines="MergedTestAssembly"
+        Condition="'@(MarkerFile)' != ''"
+        File="%(Identity)"
+        Lines="%(Type)"
         Overwrite="true"
         WriteOnlyWhenDifferent="true" />
 
-
-    <WriteLinesToFile
-        Condition="'$(MonoAotIncompatible)' == 'true'"
-        File="$(IntermediateOutputPath)\$(AssemblyName).NoMonoAot"
-        Lines="NoMonoAot"
-        Overwrite="true"
-        WriteOnlyWhenDifferent="true" />
-  
     <!-- We don't want the out-of-process test marker file to be included in referencing projects, so we don't include it as content. -->
     <WriteLinesToFile
         Condition="'$(RequiresProcessIsolation)' == 'true' and '$(BuildAsStandalone)' != 'true'"

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -129,7 +129,7 @@
     <ItemGroup>
       <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="full" />
       <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="nimt-trampolines=2000" />
-      <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="ntrampolines=10000" />
+      <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="ntrampolines=20000" />
       <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="nrgctx-fetch-trampolines=256" />
       <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="ngsharedvt-trampolines=4400" />
       <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="nftnptr-arg-trampolines=4000" />


### PR DESCRIPTION
These fixes were built for PR #74886; however, as that PR is so utterly large and unreviewable, I've pulled out the test infra changes for separate review

Changes
- Increase the number of trampolines in the llvm aot compilation process to 20,000 from 10,000 (This avoids running out of them in some of the hardware intrinsics tests
- Add a concept of striping tests when running under GC stress
  - To use this new feature, specify <NumberOfStripesToUseInStress>N</NumberOfStripesToUseInStress> within the merged test assembly. If this value is set, then the tests within that merged test assembly will be run across N different work items instead of 1 when running under any form of GC stress based scenario. At this moment the largest supported value of N is 99
- Emit the testresults.xml file as a file which is exported from the tests. This is useful for debugging testresult.xml parsing failures
- Fix the testresults summary generator to never emit an empty CDATA string. If one is present the parser may fail the parse.
- In the XUnitWrapperGenerator fix the implementation of the Outerloop and ActiveIssue when used with a conditional member.
- Add PlatformDetection.IsMonoLLVMAOT, PlatformDetection.IsMonoLLVMFULLAOT, and PlatformDetection.IsMonoInterpreter boolean properties to the PlatformDetection type for use with the ActiveIssue attribute