### PR TITLE
Add AVX-512 testing pipeline

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -212,7 +212,7 @@ jobs:
       # gc reliability may take up to 2 hours to shutdown. Some scenarios have very long iteration times.
       - name: timeoutPerTestInMinutes
         value: 240
-    - ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-random', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'jitelthookenabled' ) }}:
+    - ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-random', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstress-isas-avx512', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'jitelthookenabled' ) }}:
       - name: timeoutPerTestCollectionInMinutes
         value: 120
       - name: timeoutPerTestInMinutes
@@ -268,7 +268,7 @@ jobs:
       timeoutInMinutes: 390
     ${{ if in(parameters.testGroup, 'gcstress-extra', 'r2r-extra', 'clrinterpreter', 'pgo', 'pgostress', 'jit-experimental') }}:
       timeoutInMinutes: 510
-    ${{ if eq(parameters.testGroup, 'jitstress-isas-x86') }}:
+    ${{ if in(parameters.testGroup, 'jitstress-isas-x86', 'jitstress-isas-avx512') }}:
       timeoutInMinutes: 960
 
     steps:
@@ -525,6 +525,9 @@ jobs:
           - jitstress_isas_2_x86_nosse41
           - jitstress_isas_2_x86_nosse42
           - jitstress_isas_2_x86_nossse3
+        ${{ if in(parameters.testGroup, 'jitstress-isas-avx512') }}:
+          scenarios:
+          - jitstress_isas_avx512_forceevex
         ${{ if in(parameters.testGroup, 'jitstressregs-x86') }}:
           scenarios:
           - jitstressregs1_x86_noavx

--- a/eng/pipelines/coreclr/jitstress-isas-avx512.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-avx512.yml
@@ -1,0 +1,60 @@
+trigger:
+  batch: false
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - src/coreclr/jit/instrsxarch.h
+    - src/coreclr/jit/emitxarch.cpp
+    - src/coreclr/jit/emitxarch.h
+
+schedules:
+- cron: "30 19 * * 6"
+  displayName: Sat at 11:30 AM (UTC-8:00)
+  branches:
+    include:
+    - main
+  always: true
+
+extends:
+  template:  /eng/pipelines/common/templates/single-stage-pipeline-with-resources.yml
+  parameters:
+    jobs:
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - OSX_x64
+        - windows_x64
+        - windows_x86
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress-isas-avx512
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: jitstress-isas-avx512
+
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - Linux_x64
+        - OSX_x64
+        - windows_x64
+        - windows_x86
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: jitstress-isas-avx512
+          liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/jitstress-isas-avx512.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-avx512.yml
@@ -27,8 +27,9 @@ extends:
         jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
         buildConfig: checked
         platforms:
-        - Linux_x64
-        - OSX_x64
+        # Current Linux and OSX x64 pipelines do not have machines which support AVX-512.
+        # - Linux_x64
+        # - OSX_x64
         - windows_x64
         - windows_x86
         - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
@@ -49,8 +50,9 @@ extends:
         jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
         buildConfig: checked
         platforms:
-        - Linux_x64
-        - OSX_x64
+        # Current Linux and OSX x64 pipelines do not have machines which support AVX-512.
+        # - Linux_x64
+        # - OSX_x64
         - windows_x64
         - windows_x86
         helixQueueGroup: ci

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8999,6 +8999,14 @@ private:
     bool canUseEvexEncoding() const
     {
 #ifdef TARGET_XARCH
+
+#ifdef DEBUG
+        if (JitConfig.JitForceEVEXEncoding())
+        {
+            return true;
+        }
+#endif // DEBUG
+
         return compOpportunisticallyDependsOn(InstructionSet_AVX512F);
 #else
         return false;
@@ -9013,17 +9021,22 @@ private:
     //
     bool DoJitStressEvexEncoding() const
     {
-#ifdef TARGET_XARCH
-// Using JitStressEvexEncoding flag will force instructions which would
+#if defined(TARGET_XARCH) && defined(DEBUG)
+// Using JitStressEVEXEncoding flag will force instructions which would
 // otherwise use VEX encoding but can be EVEX encoded to use EVEX encoding
-// This requires AVX512VL support.
-#ifdef DEBUG
+// This requires AVX512VL support. JitForceEVEXEncoding forces this encoding, thus
+// causing failure if not running on compatible hardware.
+
+        if (JitConfig.JitForceEVEXEncoding())
+        {
+            return true;
+        }
         if (JitConfig.JitStressEvexEncoding() && compOpportunisticallyDependsOn(InstructionSet_AVX512F_VL))
         {
             return true;
         }
-#endif // DEBUG
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && DEBUG
+
         return false;
     }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9022,10 +9022,10 @@ private:
     bool DoJitStressEvexEncoding() const
     {
 #if defined(TARGET_XARCH) && defined(DEBUG)
-// Using JitStressEVEXEncoding flag will force instructions which would
-// otherwise use VEX encoding but can be EVEX encoded to use EVEX encoding
-// This requires AVX512VL support. JitForceEVEXEncoding forces this encoding, thus
-// causing failure if not running on compatible hardware.
+        // Using JitStressEVEXEncoding flag will force instructions which would
+        // otherwise use VEX encoding but can be EVEX encoded to use EVEX encoding
+        // This requires AVX512VL support. JitForceEVEXEncoding forces this encoding, thus
+        // causing failure if not running on compatible hardware.
 
         if (JitConfig.JitForceEVEXEncoding())
         {

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -300,8 +300,9 @@ CONFIG_INTEGER(EnableEHWriteThru, W("EnableEHWriteThru"), 1) // Enable the regis
 CONFIG_INTEGER(EnableMultiRegLocals, W("EnableMultiRegLocals"), 1) // Enable the enregistration of locals that are
                                                                    // defined or used in a multireg context.
 #if defined(DEBUG)
-CONFIG_INTEGER(JitStressEvexEncoding, W("JitStressEvexEncoding"), 0) // Enable EVEX encoding for SIMD instructions when AVX-512VL is available.
-CONFIG_INTEGER(JitForceEVEXEncoding, W("JitForceEVEXEncoding"), 0) // Force EVEX encoding for SIMD instructions.
+CONFIG_INTEGER(JitStressEvexEncoding, W("JitStressEvexEncoding"), 0) // Enable EVEX encoding for SIMD instructions when
+                                                                     // AVX-512VL is available.
+CONFIG_INTEGER(JitForceEVEXEncoding, W("JitForceEVEXEncoding"), 0)   // Force EVEX encoding for SIMD instructions.
 #endif
 
 // clang-format off

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -300,8 +300,9 @@ CONFIG_INTEGER(EnableEHWriteThru, W("EnableEHWriteThru"), 1) // Enable the regis
 CONFIG_INTEGER(EnableMultiRegLocals, W("EnableMultiRegLocals"), 1) // Enable the enregistration of locals that are
                                                                    // defined or used in a multireg context.
 #if defined(DEBUG)
-CONFIG_INTEGER(JitStressEvexEncoding, W("JitStressEvexEncoding"), 0) // Enable EVEX encoding for SIMD instructions.
-#endif // DEBUG                                                               // DEBUG
+CONFIG_INTEGER(JitStressEvexEncoding, W("JitStressEvexEncoding"), 0) // Enable EVEX encoding for SIMD instructions when AVX-512VL is available.
+CONFIG_INTEGER(JitForceEVEXEncoding, W("JitForceEVEXEncoding"), 0) // Force EVEX encoding for SIMD instructions.
+#endif
 
 // clang-format off
 

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -35,6 +35,7 @@
       DOTNET_EnableSSE41;
       DOTNET_EnableSSE42;
       DOTNET_EnableSSSE3;
+      DOTNET_JitForceEVEXEncoding;
       DOTNET_ForceRelocs;
       DOTNET_GCStress;
       DOTNET_GCName;
@@ -151,6 +152,7 @@
     <TestEnvironment Include="jitstress_isas_2_x86_nosse41" JitStress="2" EnableSSE41="0" /> <!-- Depends on SSSE3 and SSE3_4 -->
     <TestEnvironment Include="jitstress_isas_2_x86_nosse42" JitStress="2" EnableSSE42="0" /> <!-- Depends on SSE41 -->
     <TestEnvironment Include="jitstress_isas_2_x86_nossse3" JitStress="2" EnableSSSE3="0" /> <!-- Depends on SSE3 -->
+    <TestEnvironment Include="jitstress_isas_avx512_forceevex" JitForceEVEXEncoding="1" /> <!-- Depends on AVX512 -->
     <TestEnvironment Include="jitstressregs1_x86_noavx" JitStressRegs="1" EnableAVX="0" />
     <TestEnvironment Include="jitstressregs2_x86_noavx" JitStressRegs="2" EnableAVX="0" />
     <TestEnvironment Include="jitstressregs3_x86_noavx" JitStressRegs="3" EnableAVX="0" />


### PR DESCRIPTION
Introduce DOTNET_JitForceEVEXEncoding to force EVEX encoding when possible. This will fail when not an an AVX-512 capable machine, by design (to know we are properly testing on capable machines).

Current pipeline definition only runs coreclr tests with JitForceEVEXEncoding set. Currently defined to automatically trigger when one of the JIT files instrsxarch.h, emitxarch.cpp, or emitxarch.h are changed, as it is expected these will be changed frequently as the AVX-512 feature is implemented. It is also expected this will be manually triggered as appropriate. Eventually, this pipeline will be removed and tests folded into the existing jitstress-isas-x86 pipeline.