### PR TITLE
DNER multi-reg locals early if they cannot be enregistered

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -813,9 +813,12 @@ void MorphCopyBlockHelper::TrySpecialCases()
         // associate multiple SSA definitions (SSA numbers) with one store.
         m_dstVarDsc->lvIsMultiRegRet = true;
 
-        JITDUMP("Not morphing a multireg node return\n");
-        m_transformationDecision = BlockTransformation::SkipMultiRegSrc;
-        m_result                 = m_asg;
+        if (m_src->GetMultiRegCount(m_comp) == m_dstVarDsc->lvFieldCnt)
+        {
+            JITDUMP("Not morphing a multireg node return\n");
+            m_transformationDecision = BlockTransformation::SkipMultiRegSrc;
+            m_result                 = m_asg;
+        }
     }
     else if (m_src->IsCall() && m_dst->OperIs(GT_LCL_VAR) && m_dstVarDsc->CanBeReplacedWithItsField(m_comp))
     {


### PR DESCRIPTION
This makes us less eager to decompose copies, resulting in CQ improvements.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=75530&view=ms.vss-build-web.run-extensions-tab) - the larger regressions in tests are because we set DNER due to dead code.