### PR TITLE
Don't use IsMatchingConst in Tier0

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11971,8 +11971,7 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*    currentInterval,
     else
     {
         // Set the 'matchingConstants' set.
-        if (linearScan->compiler->opts.OptimizationEnabled() && currentInterval->isConstant &&
-            RefTypeIsDef(refPosition->refType))
+        if (currentInterval->isConstant && RefTypeIsDef(refPosition->refType))
         {
             matchingConstants = linearScan->getMatchingConstants(candidates, currentInterval, refPosition);
         }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2818,7 +2818,7 @@ regNumber LinearScan::allocateReg(Interval*    currentInterval,
             bool wasAssigned = regSelector->foundUnassignedReg() && (assignedInterval != nullptr) &&
                                (assignedInterval->physReg == foundReg);
             unassignPhysReg(availablePhysRegRecord ARM_ARG(currentInterval->registerType));
-            if (regSelector->isMatchingConstant() && compiler->opts.OptimizationEnabled())
+            if (compiler->opts.OptimizationEnabled() && regSelector->isMatchingConstant())
             {
                 assert(assignedInterval->isConstant);
                 refPosition->treeNode->SetReuseRegVal();
@@ -11971,7 +11971,7 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*    currentInterval,
     else
     {
         // Set the 'matchingConstants' set.
-        if (currentInterval->isConstant && RefTypeIsDef(refPosition->refType))
+        if (linearScan->compiler->opts.OptimizationEnabled() && currentInterval->isConstant && RefTypeIsDef(refPosition->refType))
         {
             matchingConstants = linearScan->getMatchingConstants(candidates, currentInterval, refPosition);
         }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11971,7 +11971,8 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*    currentInterval,
     else
     {
         // Set the 'matchingConstants' set.
-        if (linearScan->compiler->opts.OptimizationEnabled() && currentInterval->isConstant && RefTypeIsDef(refPosition->refType))
+        if (linearScan->compiler->opts.OptimizationEnabled() && currentInterval->isConstant &&
+            RefTypeIsDef(refPosition->refType))
         {
             matchingConstants = linearScan->getMatchingConstants(candidates, currentInterval, refPosition);
         }


### PR DESCRIPTION
According to flamegraphs, JIT spends quite a lot of time inside LSRA for Tier0. 
![image](https://user-images.githubusercontent.com/523221/200142117-e72eea41-8349-4eb8-9918-4d90d95c5685.png)

While it's justified for Importer since it ends up resolving tokens/loading types via VM, it's weird to see LSRA taking so much.

I noticed `isMatchingConstant` in the traces while in code it's already disabled for tier0 but still invoked.