### PR TITLE
Fix sprintf deprecation error with Xcode 14.1

### DIFF
--- a/src/tests/Common/Platform/platformdefines.cpp
+++ b/src/tests/Common/Platform/platformdefines.cpp
@@ -170,7 +170,7 @@ error_t TP_putenv_s(LPWSTR name, LPWSTR value)
         return 0;
 #else
     int retVal = 0;
-    size_t assignmentSize = sizeof(char) * (TP_slen(name) + TP_slen(value) + 1);
+    size_t assignmentSize = sizeof(char) * (TP_slen(name) + TP_slen(value) + 1 + 1);
     char *assignment = (char*) malloc(assignmentSize);
     snprintf(assignment, assignmentSize, "%s=%s", HackyConvertToSTR(name), HackyConvertToSTR(value));
 

--- a/src/tests/Common/Platform/platformdefines.cpp
+++ b/src/tests/Common/Platform/platformdefines.cpp
@@ -170,8 +170,9 @@ error_t TP_putenv_s(LPWSTR name, LPWSTR value)
         return 0;
 #else
     int retVal = 0;
-    char *assignment = (char*) malloc(sizeof(char) * (TP_slen(name) + TP_slen(value) + 1));
-    sprintf(assignment, "%s=%s", HackyConvertToSTR(name), HackyConvertToSTR(value));
+    size_t assignmentSize = sizeof(char) * (TP_slen(name) + TP_slen(value) + 1);
+    char *assignment = (char*) malloc(assignmentSize);
+    snprintf(assignment, assignmentSize, "%s=%s", HackyConvertToSTR(name), HackyConvertToSTR(value));
 
     if (0 != putenv(assignment))
         retVal = 2;

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
@@ -569,12 +569,12 @@ DLL_EXPORT bool __stdcall StructTest_Array(NativeSequentialStruct *nss, int leng
             return false;
         if (nss[i].b != i*i)
             return false;
-        sprintf(expected, "%d", i);
+        snprintf(expected, sizeof(expected), "%d", i);
 
         if (CompareAnsiString(expected, nss[i].str) == 0)
             return false;
 
-        sprintf(expected, "u8%d", i);
+        snprintf(expected, sizeof(expected), "u8%d", i);
 
         if (CompareAnsiString(expected, nss[i].u8str) == 0)
             return false;


### PR DESCRIPTION
When compiling tests using Xcode 14.1, I got the following error message:

> error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
