### PR TITLE
Be more precise about choosing what to DNER in block morphing

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -934,8 +934,10 @@ void MorphCopyBlockHelper::MorphStructCases()
     //
     bool requiresCopyBlock = false;
 
-    // If either src or dest is a reg-sized non-field-addressed struct, keep the copyBlock.
-    if ((m_dstVarDsc != nullptr && m_dstVarDsc->lvRegStruct) || (m_srcVarDsc != nullptr && m_srcVarDsc->lvRegStruct))
+    // If either src or dest is a reg-sized non-field-addressed struct, keep the copyBlock;
+    // this will avoid having to DNER the enregisterable local when creating LCL_FLD nodes.
+    if ((m_dst->OperIs(GT_LCL_VAR) && m_dstVarDsc->lvRegStruct) ||
+        (m_src->OperIs(GT_LCL_VAR) && m_srcVarDsc->lvRegStruct))
     {
         requiresCopyBlock = true;
     }


### PR DESCRIPTION
Unblock some "SingleLclVarAsg" morphing:

```diff
- (m_dstDoFldAsg=true) this requires a CopyBlock.
+ (m_dstDoFldAsg=true) using field by field assignments.

-Local V29 should not be enregistered because: written/read in a block op
+Local V26 should not be enregistered because: was accessed as a local field

 Local V26 should not be enregistered because: cast takes addr
 MorphCopyBlock (after):
-               [000427] -A---------                         *  ASG       struct (copy)
-               [000425] D----+-N---                         +--*  LCL_VAR   struct<System.Runtime.Intrinsics.Vector64`1[System.Byte], 8>(P) V29 tmp16
-                                                            +--*    long   V29._00 (offs=0x00) -> V74 tmp61
-               [000831] n----------                         \--*  OBJ       struct<System.Runtime.Intrinsics.Vector64`1[System.Byte], 8>
-               [000387] -----+-----                            \--*  ADDR      byref
-               [000386] -----+-N---                               \--*  LCL_VAR   simd16<System.Runtime.Intrinsics.Vector128`1[System.Byte]> V26 tmp13
+               [000833] -A---+-----                         *  ASG       long
+               [000831] D------N---                         +--*  LCL_VAR   long   V74 tmp61
+               [000832] -----------                         \--*  LCL_FLD   long   V26 tmp13        [+0]
```

Improvements are expected, with a few RA/order-related regressions.