### PR TITLE
JIT: Fix GenTreeCall::Equals for virtual vs static calls

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2236,6 +2236,12 @@ bool GenTreeCall::Equals(GenTreeCall* c1, GenTreeCall* c2)
             return false;
         }
 #endif
+
+        if ((c1->gtCallType == CT_USER_FUNC) &&
+            ((c1->gtCallMoreFlags & GTF_CALL_VIRT_KIND_MASK) != (c2->gtCallMoreFlags & GTF_CALL_VIRT_KIND_MASK)))
+        {
+            return false;
+        }
     }
     else
     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_77710/Runtime_77710.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77710/Runtime_77710.cs
@@ -21,14 +21,19 @@ public class Runtime_77710
 
         if (Base.BaseCalls != 1)
         {
-            Console.WriteLine("Expected BaseCalls to be 1, is actually {0}", Base.BaseCalls);
+            Console.WriteLine("FAIL: Expected BaseCalls to be 1, is actually {0}", Base.BaseCalls);
             result = -1;
         }
 
         if (Derived.DerivedCalls != 1)
         {
-            Console.WriteLine("Expected DerivedCalls to be 1, is actually {0}", Derived.DerivedCalls);
+            Console.WriteLine("FAIL: Expected DerivedCalls to be 1, is actually {0}", Derived.DerivedCalls);
             result = -1;
+        }
+
+        if (result == 100)
+        {
+            Console.WriteLine("PASS");
         }
 
         return result;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_77710/Runtime_77710.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77710/Runtime_77710.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Runtime_77710
+{
+    public static int Main()
+    {
+        return Test(new Derived());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Test(Base b)
+    {
+        b.M(callBase: false, recursing: false);
+        b.M(callBase: true, recursing: false);
+
+        int result = 100;
+
+        if (Base.BaseCalls != 1)
+        {
+            Console.WriteLine("Expected BaseCalls to be 1, is actually {0}", Base.BaseCalls);
+            result = -1;
+        }
+
+        if (Derived.DerivedCalls != 1)
+        {
+            Console.WriteLine("Expected DerivedCalls to be 1, is actually {0}", Derived.DerivedCalls);
+            result = -1;
+        }
+
+        return result;
+    }
+
+    private class Base
+    {
+        public static int BaseCalls;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public virtual int M(bool callBase, bool recursing)
+        {
+            BaseCalls++;
+            return 0;
+        }
+    }
+
+    private class Derived : Base
+    {
+        public static int DerivedCalls;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public override int M(bool callBase, bool recursing)
+        {
+            if (recursing)
+            {
+                DerivedCalls++;
+                return 0;
+            }
+
+            if (callBase)
+            {
+                base.M(false, true);
+            }
+            else
+            {
+                M(false, true);
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_77710/Runtime_77710.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77710/Runtime_77710.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix #77710