### PR TITLE
Add additional case where public signing cannot be used

### DIFF
--- a/docs/project/public-signing.md
+++ b/docs/project/public-signing.md
@@ -16,6 +16,7 @@ Known issues when debugging and testing public signed assemblies on .NET Framewo
 - You will not be able to install the assembly to the [Global Assembly Cache (GAC)](https://msdn.microsoft.com/en-us/library/yf1d93sz.aspx)
 - You will not be able to load the assembly in an AppDomain where shadow copying is turned on.
 - You will not be able to load the assembly in a partially trusted AppDomain
+- You will not be able to pre-compile ASP.NET applications
 
 The `corflags.exe` tool that ships with the .NET Framework SDK can show whether a binary is delay-signed or strong-named. For a delay-signed assembly it may show:
 


### PR DESCRIPTION
When building an ASP.NET project with `<PrecompileBeforePublish>True</PrecompileBeforePublish>` and a public signed (https://github.com/dotnet/runtime/blob/main/docs/project/public-signing.md) assembly I get the following error
error ASPCONFIG: Could not load file or assembly 'Foo, Version=10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. Strong name signature could not be verified.  The assembly may have been tampered with, or it was delay signed but not fully signed with the correct private key. (Exception from HRESULT: 0x80131045)