### PR TITLE
Allow interop resolvers to return self handle

### DIFF
--- a/src/mono/mono/utils/mono-dl.c
+++ b/src/mono/mono/utils/mono-dl.c
@@ -176,8 +176,9 @@ fix_libc_name (const char *name)
  * mono_dl_open_self:
  * \param error pointer to MonoError
  *
- * Returns a handle to the main program, on android x86 it's not possible to
- * call dl_open(null), it returns a null handle, so this function returns RTLD_DEFAULT
+ * Returns a handle to the main program, on Android it's not possible to
+ * call dl_open(null) with RTLD_LAZY, it returns a null handle, so this
+ * function uses RTLD_NOW.
  * handle in this platform.
  * \p error points to MonoError where an error will be stored in
  * case of failure.   The error needs to be cleared when done using it, \c mono_error_cleanup.
@@ -187,7 +188,7 @@ MonoDl*
 mono_dl_open_self (MonoError *error)
 {
 
-#if defined(TARGET_ANDROID) && !defined(WIN32)
+#if defined(TARGET_ANDROID)
 	MonoDl *module;
 	module = (MonoDl *) g_malloc (sizeof (MonoDl));
 	if (!module) {
@@ -195,7 +196,7 @@ mono_dl_open_self (MonoError *error)
 		return NULL;
 	}
 	mono_refcount_init (module, NULL);
-	module->handle = RTLD_DEFAULT;
+	module->handle = dlopen(NULL, RTLD_NOW);
 	module->dl_fallback = NULL;
 	module->full_name = NULL;
 	return module;

--- a/src/mono/mono/utils/mono-dl.c
+++ b/src/mono/mono/utils/mono-dl.c
@@ -188,7 +188,7 @@ MonoDl*
 mono_dl_open_self (MonoError *error)
 {
 
-#if defined(TARGET_ANDROID)
+#if defined(TARGET_ANDROID) && !defined(WIN32)
 	MonoDl *module;
 	module = (MonoDl *) g_malloc (sizeof (MonoDl));
 	if (!module) {

--- a/src/native/libs/System.Native/pal_dynamicload.c
+++ b/src/native/libs/System.Native/pal_dynamicload.c
@@ -56,12 +56,6 @@ void SystemNative_FreeLibrary(void* handle)
     dlclose(handle);
 }
 
-#ifdef TARGET_ANDROID
-void* SystemNative_GetDefaultSearchOrderPseudoHandle(void)
-{
-    return (void*)RTLD_DEFAULT;
-}
-#else
 static void* volatile g_defaultSearchOrderPseudoHandle = NULL;
 void* SystemNative_GetDefaultSearchOrderPseudoHandle(void)
 {
@@ -69,11 +63,16 @@ void* SystemNative_GetDefaultSearchOrderPseudoHandle(void)
     void* defaultSearchOrderPseudoHandle = (void*)g_defaultSearchOrderPseudoHandle;
     if (defaultSearchOrderPseudoHandle == NULL)
     {
+#ifdef TARGET_ANDROID
+        int flag = RTLD_NOW;
+#else
+        int flag = RTLD_LAZY;
+#endif
+
         // Assign back to the static as well as the local here.
         // We don't need to check for a race between two threads as the value returned by
         // dlopen here will always be the same in a given environment.
-        g_defaultSearchOrderPseudoHandle = defaultSearchOrderPseudoHandle = dlopen(NULL, RTLD_LAZY);
+        g_defaultSearchOrderPseudoHandle = defaultSearchOrderPseudoHandle = dlopen(NULL, flag);
     }
     return defaultSearchOrderPseudoHandle;
 }
-#endif

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.cs
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+using Xunit;
+
+public static class MainProgramHandleTests
+{
+    private static IntPtr s_handle;
+
+    static MainProgramHandleTests() => NativeLibrary.SetDllImportResolver(typeof(MainProgramHandleTests).Assembly,
+        (string libraryName, Assembly asm, DllImportSearchPath? dllImportSearchPath) =>
+        {
+            if (libraryName == "Self")
+            {
+                s_handle = NativeLibrary.GetMainProgramHandle();
+                Assert.NotEqual(IntPtr.Zero, s_handle);
+                return s_handle;
+            }
+
+            return IntPtr.Zero;
+        });
+
+    public static int Main()
+    {
+        try
+        {
+            free(s_handle);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Test Failure: {e}");
+            return 101;
+        }
+
+        return 100;
+    }
+
+    [DllImport("Self")]
+    private static extern int free(IntPtr arg);
+}

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.cs
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.cs
@@ -11,14 +11,16 @@ using Xunit;
 
 public static class MainProgramHandleTests
 {
+    private static IntPtr s_handle;
+
     static MainProgramHandleTests() => NativeLibrary.SetDllImportResolver(typeof(MainProgramHandleTests).Assembly,
         (string libraryName, Assembly asm, DllImportSearchPath? dllImportSearchPath) =>
         {
             if (libraryName == "Self")
             {
-                IntPtr handle = NativeLibrary.GetMainProgramHandle();
-                Assert.NotEqual(IntPtr.Zero, handle);
-                return handle;
+                s_handle = NativeLibrary.GetMainProgramHandle();
+                Assert.NotEqual(IntPtr.Zero, s_handle);
+                return s_handle;
             }
 
             return IntPtr.Zero;
@@ -28,8 +30,7 @@ public static class MainProgramHandleTests
     {
         try
         {
-            int parentPid = getppid();
-            Console.WriteLine("Parent PID is: {0}", parentPid);
+            free(s_handle);
         }
         catch (Exception e)
         {
@@ -41,5 +42,5 @@ public static class MainProgramHandleTests
     }
 
     [DllImport("Self")]
-    private static extern int getppid();
+    private static extern void free(IntPtr arg);
 }

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.cs
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.cs
@@ -11,16 +11,14 @@ using Xunit;
 
 public static class MainProgramHandleTests
 {
-    private static IntPtr s_handle;
-
     static MainProgramHandleTests() => NativeLibrary.SetDllImportResolver(typeof(MainProgramHandleTests).Assembly,
         (string libraryName, Assembly asm, DllImportSearchPath? dllImportSearchPath) =>
         {
             if (libraryName == "Self")
             {
-                s_handle = NativeLibrary.GetMainProgramHandle();
-                Assert.NotEqual(IntPtr.Zero, s_handle);
-                return s_handle;
+                IntPtr handle = NativeLibrary.GetMainProgramHandle();
+                Assert.NotEqual(IntPtr.Zero, handle);
+                return handle;
             }
 
             return IntPtr.Zero;
@@ -30,7 +28,8 @@ public static class MainProgramHandleTests
     {
         try
         {
-            free(s_handle);
+            int parentPid = getppid();
+            Console.WriteLine("Parent PID is: {0}", parentPid);
         }
         catch (Exception e)
         {
@@ -42,5 +41,5 @@ public static class MainProgramHandleTests
     }
 
     [DllImport("Self")]
-    private static extern int free(IntPtr arg);
+    private static extern int getppid();
 }

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' == 'true' or '$(RuntimeVariant)' == 'monointerpreter'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MainProgramHandleTests.cs" />

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' == 'true' or '$(RuntimeVariant)' == 'monointerpreter'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MainProgramHandleTests.cs" />

--- a/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
+++ b/src/tests/Interop/NativeLibrary/MainProgramHandle/MainProgramHandleTests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="MainProgramHandleTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2606,9 +2606,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/Interop/NativeLibrary/MainProgramHandle/**">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/eh/basics/throwinfilter_il_d/**">
             <Issue>https://github.com/dotnet/runtime/issues/47624</Issue>
         </ExcludeList>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2606,6 +2606,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/DelegatePInvoke/DelegatePInvokeTest/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/Interop/NativeLibrary/MainProgramHandle/**">
+            <Issue>needs triage</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/eh/basics/throwinfilter_il_d/**">
             <Issue>https://github.com/dotnet/runtime/issues/47624</Issue>
         </ExcludeList>


### PR DESCRIPTION
When user-defined resolvers return self handle via `GetMainProgramHandle()`, we lookup the cached handle in mono and fail to find one because `internal_module` is not cached in `native_library_module_map`.

Fix is to test the resolver returned handle against self; before the map lookup (which happens under the lock).

Close #77985.