### PR TITLE
Improve IndexOfAnyInRange throughput

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1018,7 +1018,7 @@ namespace System
             {
                 if (lowInclusive is byte or sbyte)
                 {
-                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
+                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber<byte, sbyte>(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref lowInclusive),
                         Unsafe.As<T, byte>(ref highInclusive),
@@ -1027,7 +1027,7 @@ namespace System
 
                 if (lowInclusive is short or ushort or char)
                 {
-                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
+                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber<ushort, short>(
                         ref Unsafe.As<T, ushort>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, ushort>(ref lowInclusive),
                         Unsafe.As<T, ushort>(ref highInclusive),
@@ -1036,7 +1036,7 @@ namespace System
 
                 if (lowInclusive is int or uint || (IntPtr.Size == 4 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
+                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber<uint, int>(
                         ref Unsafe.As<T, uint>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, uint>(ref lowInclusive),
                         Unsafe.As<T, uint>(ref highInclusive),
@@ -1045,7 +1045,7 @@ namespace System
 
                 if (lowInclusive is long or ulong || (IntPtr.Size == 8 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
+                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber<ulong, long>(
                         ref Unsafe.As<T, ulong>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, ulong>(ref lowInclusive),
                         Unsafe.As<T, ulong>(ref highInclusive),
@@ -1084,7 +1084,7 @@ namespace System
             {
                 if (lowInclusive is byte or sbyte)
                 {
-                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
+                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber<byte, sbyte>(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref lowInclusive),
                         Unsafe.As<T, byte>(ref highInclusive),
@@ -1093,7 +1093,7 @@ namespace System
 
                 if (lowInclusive is short or ushort or char)
                 {
-                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
+                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber<ushort, short>(
                         ref Unsafe.As<T, ushort>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, ushort>(ref lowInclusive),
                         Unsafe.As<T, ushort>(ref highInclusive),
@@ -1102,7 +1102,7 @@ namespace System
 
                 if (lowInclusive is int or uint || (IntPtr.Size == 4 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
+                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber<uint, int>(
                         ref Unsafe.As<T, uint>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, uint>(ref lowInclusive),
                         Unsafe.As<T, uint>(ref highInclusive),
@@ -1111,7 +1111,7 @@ namespace System
 
                 if (lowInclusive is long or ulong || (IntPtr.Size == 8 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
+                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber<ulong, long>(
                         ref Unsafe.As<T, ulong>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, ulong>(ref lowInclusive),
                         Unsafe.As<T, ulong>(ref highInclusive),
@@ -1150,7 +1150,7 @@ namespace System
             {
                 if (lowInclusive is byte or sbyte)
                 {
-                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
+                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber<byte, sbyte>(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref lowInclusive),
                         Unsafe.As<T, byte>(ref highInclusive),
@@ -1159,7 +1159,7 @@ namespace System
 
                 if (lowInclusive is short or ushort or char)
                 {
-                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
+                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber<ushort, short>(
                         ref Unsafe.As<T, ushort>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, ushort>(ref lowInclusive),
                         Unsafe.As<T, ushort>(ref highInclusive),
@@ -1168,7 +1168,7 @@ namespace System
 
                 if (lowInclusive is int or uint || (IntPtr.Size == 4 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
+                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber<uint, int>(
                         ref Unsafe.As<T, uint>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, uint>(ref lowInclusive),
                         Unsafe.As<T, uint>(ref highInclusive),
@@ -1177,7 +1177,7 @@ namespace System
 
                 if (lowInclusive is long or ulong || (IntPtr.Size == 8 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
+                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber<ulong, long>(
                         ref Unsafe.As<T, ulong>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, ulong>(ref lowInclusive),
                         Unsafe.As<T, ulong>(ref highInclusive),
@@ -1216,7 +1216,7 @@ namespace System
             {
                 if (lowInclusive is byte or sbyte)
                 {
-                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
+                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber<byte, sbyte>(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, byte>(ref lowInclusive),
                         Unsafe.As<T, byte>(ref highInclusive),
@@ -1225,7 +1225,7 @@ namespace System
 
                 if (lowInclusive is short or ushort or char)
                 {
-                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
+                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber<ushort, short>(
                         ref Unsafe.As<T, ushort>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, ushort>(ref lowInclusive),
                         Unsafe.As<T, ushort>(ref highInclusive),
@@ -1234,7 +1234,7 @@ namespace System
 
                 if (lowInclusive is int or uint || (IntPtr.Size == 4 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
+                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber<uint, int>(
                         ref Unsafe.As<T, uint>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, uint>(ref lowInclusive),
                         Unsafe.As<T, uint>(ref highInclusive),
@@ -1243,7 +1243,7 @@ namespace System
 
                 if (lowInclusive is long or ulong || (IntPtr.Size == 8 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
+                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber<ulong, long>(
                         ref Unsafe.As<T, ulong>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, ulong>(ref lowInclusive),
                         Unsafe.As<T, ulong>(ref highInclusive),


### PR DESCRIPTION
X86 doesn't have `LessThanOrEqual` instructions for unsigned types, so `Vector256` ends up generating compat code for it.

As far as I can tell, `GreaterThan` for signed values is the only set of instructions implemented for both Vector128 and Vector256 for all relevant types (byte, ushort, uint, ulong).
As the instruction works with signed values, I used a trick of shifting the `min` value by `T.MaxValue / 2 + 1` (e.g. 128 for byte).

The diff for `IndexOfAnyInRange` looks like
```diff
M02_L06:
   vmovdqu   ymm2,ymmword ptr [rax]
   vpsubb    ymm2,ymm2,ymm0
-  vpsubb    ymm3,ymm2,[7FFADBF62500]
-  vpsubb    ymm4,ymm1,[7FFADBF62500]
-  vpcmpgtb  ymm3,ymm4,ymm3
-  vpcmpeqb  ymm2,ymm2,ymm1
-  vpor      ymm2,ymm3,ymm2
+  vpcmpgtb  ymm2,ymm2,ymm1
+  vpcmpeqd  ymm3,ymm3,ymm3
+  vpxor     ymm2,ymm2,ymm3
   vptest    ymm2,ymm2
   jne       short M02_L07
   add       rax,20
   cmp       rax,rdx
   jb        short M02_L06
```
And for `-Except-`
```diff
M02_L06:
   vmovdqu   ymm2,ymmword ptr [rax]
   vpsubb    ymm2,ymm2,ymm0
-  vpsubb    ymm3,ymm2,[7FFAE05A2560]
-  vpsubb    ymm4,ymm1,[7FFAE05A2560]
-  vpcmpgtb  ymm3,ymm4,ymm3
-  vpcmpeqb  ymm2,ymm2,ymm1
-  vpor      ymm2,ymm3,ymm2
-  vpcmpeqd  ymm3,ymm3,ymm3
-  vpxor     ymm2,ymm2,ymm3
+  vpcmpgtb  ymm2,ymm2,ymm1
   vptest    ymm2,ymm2
   jne       short M02_L07
   add       rax,20
   cmp       rax,rdx
   jb        short M02_L06
```

|                        Method | Toolchain | Length |          Mean |       Error | Ratio |
|------------------------------ |---------- |------- |--------------:|------------:|------:|
|        IndexOfAnyInRange_Byte |      main | 100000 |  3,043.334 ns |  13.2651 ns |  1.26 |
|        IndexOfAnyInRange_Byte |        pr | 100000 |  2,410.556 ns |   7.3491 ns |  1.00 |
|                               |           |        |               |             |       |
|        IndexOfAnyInRange_Char |      main | 100000 |  6,074.091 ns |  23.9299 ns |  1.26 |
|        IndexOfAnyInRange_Char |        pr | 100000 |  4,810.084 ns |  17.7448 ns |  1.00 |
|                               |           |        |               |             |       |
|       IndexOfAnyInRange_Int32 |      main | 100000 | 12,113.788 ns |  37.9048 ns |  1.26 |
|       IndexOfAnyInRange_Int32 |        pr | 100000 |  9,603.524 ns |  61.1090 ns |  1.00 |
|                               |           |        |               |             |       |
|       IndexOfAnyInRange_Int64 |      main | 100000 | 27,302.409 ns |  98.7623 ns |  1.39 |
|       IndexOfAnyInRange_Int64 |        pr | 100000 | 19,619.518 ns |  86.0047 ns |  1.00 |
|                               |           |        |               |             |       |
|  IndexOfAnyExceptInRange_Byte |      main | 100000 |  3,436.165 ns |  65.3388 ns |  1.59 |
|  IndexOfAnyExceptInRange_Byte |        pr | 100000 |  2,161.928 ns |  12.0477 ns |  1.00 |
|                               |           |        |               |             |       |
|  IndexOfAnyExceptInRange_Char |      main | 100000 |  6,751.310 ns |  21.7950 ns |  1.57 |
|  IndexOfAnyExceptInRange_Char |        pr | 100000 |  4,295.717 ns |  17.6978 ns |  1.00 |
|                               |           |        |               |             |       |
| IndexOfAnyExceptInRange_Int32 |      main | 100000 | 13,659.570 ns | 266.5208 ns |  1.59 |
| IndexOfAnyExceptInRange_Int32 |        pr | 100000 |  8,566.594 ns |  24.6370 ns |  1.00 |
|                               |           |        |               |             |       |
| IndexOfAnyExceptInRange_Int64 |      main | 100000 | 27,725.918 ns |  99.2270 ns |  1.41 |
| IndexOfAnyExceptInRange_Int64 |        pr | 100000 | 19,628.802 ns |  44.6338 ns |  1.00 |