### PR TITLE
`ComputeManagedAssembliesToCompileToNative`: Make `microsoft.netcore.app` check case-insensitive.

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -116,7 +116,7 @@ namespace Build.Tasks
                 }
 
                 // Prototype aid - remove the native CoreCLR runtime pieces from the publish folder
-                if (itemSpec.Contains("microsoft.netcore.app") && (itemSpec.Contains("\\native\\") || itemSpec.Contains("/native/")))
+                if (itemSpec.IndexOf("microsoft.netcore.app", StringComparison.OrdinalIgnoreCase) != -1 && (itemSpec.Contains("\\native\\") || itemSpec.Contains("/native/")))
                 {
                     assembliesToSkipPublish.Add(taskItem);
                     continue;


### PR DESCRIPTION
The inputs can come from SDK pack paths where the `Microsoft.NETCore.App` part of the path is *not* lower case, resulting in files such as `coreclr.dll`, `createdump.exe`, etc being copied to the publish directory.

---

![image](https://user-images.githubusercontent.com/44076/200577687-f9f19fec-fad8-4b64-9188-0aac9d23f6ab.png)

```
$ ls -l bin/Debug/net7.0/win-x64/publish
total 38640
-rwxr-xr-x 1 alex 197609  1813896 Dec 16  2020 Microsoft.DiaSymReader.Native.amd64.dll
-rwxr-xr-x 1 alex 197609   828032 Sep 22 23:27 System.IO.Compression.Native.dll
-rwxr-xr-x 1 alex 197609   309376 Sep 22 23:26 clretwrc.dll
-rwxr-xr-x 1 alex 197609   663168 Sep 22 23:26 clrgc.dll
-rwxr-xr-x 1 alex 197609  1532544 Sep 22 23:26 clrjit.dll
-rwxr-xr-x 1 alex 197609  5102208 Sep 22 23:26 coreclr.dll
-rwxr-xr-x 1 alex 197609    61128 Sep 22 23:26 createdump.exe
-rwxr-xr-x 1 alex 197609  1315224 Sep 22 20:18 mscordaccore.dll
-rwxr-xr-x 1 alex 197609  1315224 Sep 22 20:18 mscordaccore_amd64_amd64_7.0.22.47203.dll
-rwxr-xr-x 1 alex 197609  1247104 Sep 22 20:18 mscordbi.dll
-rwxr-xr-x 1 alex 197609   136832 Sep 22 23:26 mscorrc.dll
-rwxr-xr-x 1 alex 197609   534416 Sep 22 20:16 msquic.dll
-rwxr-xr-x 1 alex 197609  5915648 Nov  8 13:41 tests.exe
-rw-r--r-- 1 alex 197609 18763776 Nov  8 13:41 tests.pdb
```

---

Seems like this might be worth including in .NET 7.0.1 as the aforementioned result, at least for me, was quite confusing. It also means that people can't simply zip up the `publish` directory without first removing all of these unnecessary files.

cc @MichalStrehovsky, @kant2002