### PR TITLE
Fix build break due to IDE0060

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/WasmBase.PlatformNotSupported.cs
@@ -4,6 +4,8 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
+#pragma warning disable IDE0060 // Remove unused parameter
+
 namespace System.Runtime.Intrinsics.Wasm
 {
     internal abstract class WasmBase


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/72667 and https://github.com/dotnet/runtime/pull/77777 raced in CI.  Suppress the additional warnings-as-errors.