### PR TITLE
[mono] Don't use lld on s390x architecture

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -132,8 +132,8 @@ if [[ -z "$CC" ]]; then
     exit 1
 fi
 
-# Only lld version >= 9 can be considered stable
-if [[ "$compiler" == "clang" && "$majorVersion" -ge 9 ]]; then
+# Only lld version >= 9 can be considered stable. lld doesn't support s390x.
+if [[ "$compiler" == "clang" && "$majorVersion" -ge 9 && "$build_arch" != "s390x" ]]; then
     if "$CC" -fuse-ld=lld -Wl,--version >/dev/null 2>&1; then
         LDFLAGS="-fuse-ld=lld"
     fi


### PR DESCRIPTION
It doesn't work there. Fixes https://github.com/dotnet/runtime/issues/78026

arcade PR: https://github.com/dotnet/arcade/pull/11544