### PR TITLE
Fix recursive assembly spec parsing with textual PGO

### DIFF
--- a/src/coreclr/vm/pgo.h
+++ b/src/coreclr/vm/pgo.h
@@ -157,7 +157,7 @@ protected:
 
 private:
     static HRESULT ComputeOffsetOfActualInstrumentationData(const ICorJitInfo::PgoInstrumentationSchema* pSchema, UINT32 countSchemaItems, size_t headerInitialSize, UINT *offsetOfActualInstrumentationData);
-    static HRESULT PgoManager::getPgoInstrumentationResultsFromText(MethodDesc* pMD, BYTE** pAllocatedData, ICorJitInfo::PgoInstrumentationSchema** ppSchema, UINT32 *pCountSchemaItems, BYTE**pInstrumentationData, ICorJitInfo::PgoSource *pPgoSource);
+    static HRESULT getPgoInstrumentationResultsFromText(MethodDesc* pMD, BYTE** pAllocatedData, ICorJitInfo::PgoInstrumentationSchema** ppSchema, UINT32 *pCountSchemaItems, BYTE**pInstrumentationData, ICorJitInfo::PgoSource *pPgoSource);
 
     static void ReadPgoData();
     static void WritePgoData();

--- a/src/coreclr/vm/pgo.h
+++ b/src/coreclr/vm/pgo.h
@@ -157,6 +157,7 @@ protected:
 
 private:
     static HRESULT ComputeOffsetOfActualInstrumentationData(const ICorJitInfo::PgoInstrumentationSchema* pSchema, UINT32 countSchemaItems, size_t headerInitialSize, UINT *offsetOfActualInstrumentationData);
+    static HRESULT PgoManager::getPgoInstrumentationResultsFromText(MethodDesc* pMD, BYTE** pAllocatedData, ICorJitInfo::PgoInstrumentationSchema** ppSchema, UINT32 *pCountSchemaItems, BYTE**pInstrumentationData, ICorJitInfo::PgoSource *pPgoSource);
 
     static void ReadPgoData();
     static void WritePgoData();

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameParser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameParser.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -205,7 +206,8 @@ namespace System.Reflection
                         if (!char.IsDigit(parts[i][j]))
                             ThrowInvalidAssemblyName();
                     }
-                    if (!(ushort.TryParse(parts[i], out versionNumbers[i])))
+
+                    if (!ushort.TryParse(parts[i], NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out versionNumbers[i]))
                     {
                         ThrowInvalidAssemblyName();
                     }


### PR DESCRIPTION
* Add thread local to skip textual PGO data if invoked recursively
* Avoid culture sensitive parsing in `AssemblyNameParser.ParseVersion` (c.f. https://github.com/dotnet/runtime/issues/77971#issuecomment-1307527740). This also avoids initializing globalization from within the parser which was causing problems for the textual PGO data.

Fix #77971