### PR TITLE
Use `init-os-and-arch.sh` in mono samples recipes

### DIFF
--- a/src/mono/sample/HelloWorld/Makefile
+++ b/src/mono/sample/HelloWorld/Makefile
@@ -1,21 +1,15 @@
 TOP=../../../../
-DOTNET:=$(TOP)./dotnet.sh
+DOTNET:=$(TOP)dotnet.sh
 DOTNET_Q_ARGS=--nologo -v:q -consoleloggerparameters:NoSummary
 
-MONO_CONFIG ?=Debug
-MONO_ARCH=x64
+MONO_CONFIG?=Debug
+MONO_ARCH?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${arch})
+TARGET_OS?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${os} | tr "[:upper:]" "[:lower:]")
 AOT?=false
 
 #NET_TRACE_PATH=<path-to-trace-of-sample>
 #PGO_BINARY_PATH=<path-to-dotnet-pgo-executable>
 #MIBC_PROFILE_PATH=<path-to-mibc-for-sample>
-
-OS := $(shell uname -s)
-ifeq ($(OS),Darwin)
-	TARGET_OS=osx
-else
-	TARGET_OS=linux
-endif
 
 MONO_ENV_OPTIONS ?=
 

--- a/src/mono/sample/mbr/apple/Makefile
+++ b/src/mono/sample/mbr/apple/Makefile
@@ -1,6 +1,7 @@
-CONFIG=Debug
-MONO_ARCH=x64
-DOTNET := ../../../../../dotnet.sh
+TOP=../../../../../
+CONFIG?=Debug
+MONO_ARCH?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${arch})
+DOTNET:=$(TOP)dotnet.sh
 
 run-sim:
 	$(DOTNET) publish -c $(CONFIG) /p:TargetOS=iOSSimulator /p:TargetArchitecture=$(MONO_ARCH) \

--- a/src/mono/sample/mbr/console/Makefile
+++ b/src/mono/sample/mbr/console/Makefile
@@ -1,19 +1,13 @@
 TOP=../../../../../
-DOTNET:=$(TOP)./dotnet.sh
+DOTNET:=$(TOP)dotnet.sh
 DOTNET_Q_ARGS=--nologo -v:q -consoleloggerparameters:NoSummary
 
 # How to build the project.  For hot reload this must be Debug
 CONFIG ?=Debug
 # How was dotnet/runtime built? should be the same as build.sh -c option
 BUILT_RUNTIME_CONFIG ?= Release
-MONO_ARCH=x64
-
-OS := $(shell uname -s)
-ifeq ($(OS),Darwin)
-	TARGET_OS=osx
-else
-	TARGET_OS=linux
-endif
+MONO_ARCH?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${arch})
+TARGET_OS?=$(shell . $(TOP)eng/native/init-os-and-arch.sh && echo $${os} | tr "[:upper:]" "[:lower:]")
 
 MONO_ENV_OPTIONS = --interp
 


### PR DESCRIPTION
```sh
# ./build.sh mono+libs
$ MONO_LOG_LEVEL=debug make run -C src/mono/sample/HelloWorld
```

I was using it on osx-arm64 for quick tracing, when I stumbled upon the hard-coded x64 arch. We can now also set arch from the environment `MONO_ARCH=<desired arch> make ...`.