### PR TITLE
Fix build error due to unused windowSize parameter in pal_console.c

### DIFF
--- a/src/native/libs/System.Native/pal_console.c
+++ b/src/native/libs/System.Native/pal_console.c
@@ -46,6 +46,8 @@ int32_t SystemNative_SetWindowSize(WinSize* windowSize)
 #if HAVE_IOCTL && HAVE_TIOCSWINSZ
     return ioctl(STDOUT_FILENO, TIOCSWINSZ, windowSize);
 #else
+    // Not supported on e.g. Android. Also, prevent a compiler error because windowSize is unused
+    (void)windowSize;
     errno = ENOTSUP;
     return -1;
 #endif


### PR DESCRIPTION
```
src/native/libs/System.Native/pal_console.c(42,45): error G60964CEC: (NETCORE_ENGINEERING_TELEMETRY=Build) unused parameter 'windowSize' [-Werror,-Wunused-parameter]
```

Introduced in https://github.com/dotnet/runtime/pull/75824