### PR TITLE
Exclude unnecessary functions/fields when FEATURE_METADATA_EMIT_IN_DEBUGGER

### DIFF
--- a/src/coreclr/md/compiler/custattr_emit.cpp
+++ b/src/coreclr/md/compiler/custattr_emit.cpp
@@ -856,6 +856,7 @@ ErrExit:
 #endif //!FEATURE_METADATA_EMIT_IN_DEBUGGER
 } // RegMeta::SetCustomAttributeValue
 
+#if !defined(FEATURE_METADATA_EMIT_IN_DEBUGGER)
 //*****************************************************************************
 //*****************************************************************************
 HRESULT RegMeta::_IsKnownCustomAttribute(        // S_OK, S_FALSE, or error.
@@ -1987,5 +1988,7 @@ ErrExit:
 #ifdef _PREFAST_
 #pragma warning(pop)
 #endif
+
+#endif // !FEATURE_METADATA_EMIT_IN_DEBUGGER
 
 #endif //FEATURE_METADATA_EMIT

--- a/src/coreclr/md/compiler/emit.cpp
+++ b/src/coreclr/md/compiler/emit.cpp
@@ -1236,13 +1236,11 @@ ErrExit:
 #endif //!FEATURE_METADATA_EMIT_IN_DEBUGGER
 } // RegMeta::DefineModuleRef
 
+#if !defined(FEATURE_METADATA_EMIT_IN_DEBUGGER)
 HRESULT RegMeta::_DefineModuleRef(        // S_OK or error.
     LPCWSTR     szName,                 // [IN] DLL name
     mdModuleRef *pmur)                  // [OUT] returned module ref token
 {
-#ifdef FEATURE_METADATA_EMIT_IN_DEBUGGER
-    return E_NOTIMPL;
-#else //!FEATURE_METADATA_EMIT_IN_DEBUGGER
     HRESULT     hr = S_OK;
     ModuleRefRec *pModuleRef = 0;       // The ModuleRef record.
     RID         iModuleRef;             // Rid of new ModuleRef record.
@@ -1287,8 +1285,8 @@ HRESULT RegMeta::_DefineModuleRef(        // S_OK or error.
 ErrExit:
 
     return hr;
-#endif //!FEATURE_METADATA_EMIT_IN_DEBUGGER
 } // RegMeta::_DefineModuleRef
+#endif //!FEATURE_METADATA_EMIT_IN_DEBUGGER
 
 //*****************************************************************************
 // Set the parent for the specified MemberRef.

--- a/src/coreclr/md/compiler/regmeta.h
+++ b/src/coreclr/md/compiler/regmeta.h
@@ -1813,6 +1813,7 @@ protected:
         PCCOR_SIGNATURE pvNativeType,       // [IN] native type specification
         ULONG       cbNativeType);          // [IN] count of bytes of pvNativeType
 
+#if !defined(FEATURE_METADATA_EMIT_IN_DEBUGGER)
     HRESULT _IsKnownCustomAttribute(        // S_OK, S_FALSE, or error.
         mdToken     tkType,                 // [IN] Token of custom attribute's type.
         int         *pca);                  // [OUT] Put value from KnownCustAttr enum here.
@@ -1833,6 +1834,7 @@ protected:
         CaArg       *pArgs,                 // Pointer to args.
         CaNamedArg  *pNamedArgs,            // Pointer to named args.
         CQuickArray<BYTE> &qNativeType);    // Native type is built here.
+#endif // !FEATURE_METADATA_EMIT_IN_DEBUGGER
 
     // Find a given param of a Method.
     HRESULT _FindParamOfMethod(             // S_OK or error.
@@ -2040,7 +2042,10 @@ private:
     SetAPICallerType m_SetAPICaller;
 
     CorValidatorModuleType      m_ModuleType;
+
+#if !defined(FEATURE_METADATA_EMIT_IN_DEBUGGER)
     SHash<CustAttrHashTraits>   m_caHash;   // Hashed list of custom attribute types seen.
+#endif
 
     bool        m_bKeepKnownCa;             // Should all known CA's be kept?
 


### PR DESCRIPTION
Much of the `IMetaDataEmit` implementation is ifdef-ed to return `E_NOTIMPL` for `FEATURE_METADATA_EMIT_IN_DEBUGGER`. This moves a helper functions related to custom attribute emit that are unnecssary under that scenario to only be defined if `FEATURE_METADATA_EMIT_IN_DEBUGGER` is not.

Fixes https://github.com/dotnet/runtime/issues/78019