### PR TITLE
[wasm][debugger] Fix justMyCode behavior

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -267,8 +267,11 @@ namespace Microsoft.WebAssembly.Diagnostics
                     if (pauseOnException != PauseOnExceptionsKind.Unset)
                         _defaultPauseOnExceptions = pauseOnException;
                 }
-                // for Dotnetdebugger.* messages, treat them as handled, thus not passing them on to the browser
-                return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
+                if (method != "DotnetDebugger.setDebuggerProperty")
+                {
+                    // for Dotnetdebugger.* messages, treat them as handled, thus not passing them on to the browser
+                    return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
+                }
             }
 
             switch (method)


### PR DESCRIPTION
`DotnetDebugger.setDebuggerProperty` does not depend of having a session.

It is difficult to test things that uses sessionId as we don't have it on our debugger-tests.

Behavior without this PR: To make JustMyCode work the customer needs to turn off and turn on it after the app is already running, otherwise the default behavior is that JustMyCode is turned off.