### PR TITLE
Add `DllCharacteristics.ForceIntegrity` and `ControlFlowGuard`.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -3248,12 +3248,14 @@ namespace System.Reflection.PortableExecutable
         ThreadTerm = (ushort)8,
         HighEntropyVirtualAddressSpace = (ushort)32,
         DynamicBase = (ushort)64,
+        ForceIntegrity = (ushort)128,
         NxCompatible = (ushort)256,
         NoIsolation = (ushort)512,
         NoSeh = (ushort)1024,
         NoBind = (ushort)2048,
         AppContainer = (ushort)4096,
         WdmDriver = (ushort)8192,
+        ControlFlowGuard = (ushort)16384,
         TerminalServerAware = (ushort)32768,
     }
     public enum Machine : ushort

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
@@ -81,6 +81,11 @@ namespace System.Reflection.PortableExecutable
         DynamicBase = 0x0040,
 
         /// <summary>
+        /// The image requires to be signed before it runs.
+        /// </summary>
+        ForceIntegrity = 0x0080,
+
+        /// <summary>
         /// Image is NX compatible.
         /// </summary>
         NxCompatible = 0x0100,
@@ -110,6 +115,14 @@ namespace System.Reflection.PortableExecutable
         /// </summary>
         WdmDriver = 0x2000,
 
+        /// <summary>
+        /// The image supports Control Flow Guard.
+        /// </summary>
+        ControlFlowGuard = 0x4000,
+
+        /// <summary>
+        /// The image is Terminal Server aware.
+        /// </summary>
         TerminalServerAware = 0x8000,
     }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEFileFlags.cs
@@ -81,7 +81,7 @@ namespace System.Reflection.PortableExecutable
         DynamicBase = 0x0040,
 
         /// <summary>
-        /// The image requires to be signed before it runs.
+        /// Code integrity checks are enforced.
         /// </summary>
         ForceIntegrity = 0x0080,
 


### PR DESCRIPTION
Fixes #71362.

Documentation was inspired from https://microsoft.github.io/AttackSurfaceAnalyzer/v2.2/api/AttackSurfaceAnalyzer.Types.DLLCHARACTERISTICS.html. I also documented `TerminalServerAware`.