### PR TITLE
Delete `AppDomainIterator`

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -4457,23 +4457,13 @@ void DacDbiInterfaceImpl::EnumerateAppDomains(
 
     _ASSERTE(fpCallback != NULL);
 
-    // Only include active appdomains in the enumeration.
-    // This includes appdomains sent before the AD load event,
-    // and does not include appdomains that are in shutdown after the AD exit event.
-    const BOOL bOnlyActive = TRUE;
-    AppDomainIterator iterator(bOnlyActive);
+    // It's critical that we don't yield appdomains after the unload event has been sent.
+    // See code:IDacDbiInterface#Enumeration for details.
+    AppDomain * pAppDomain = AppDomain::GetCurrentDomain();
 
-    while(iterator.Next())
-    {
-        // It's critical that we don't yield appdomains after the unload event has been sent.
-        // See code:IDacDbiInterface#Enumeration for details.
-        AppDomain * pAppDomain = iterator.GetDomain();
-
-        VMPTR_AppDomain vmAppDomain = VMPTR_AppDomain::NullPtr();
-        vmAppDomain.SetHostPtr(pAppDomain);
-
-        fpCallback(vmAppDomain, pUserData);
-    }
+    VMPTR_AppDomain vmAppDomain = VMPTR_AppDomain::NullPtr();
+    vmAppDomain.SetHostPtr(pAppDomain);
+    fpCallback(vmAppDomain, pUserData);
 }
 
 // Enumerate all Assemblies in an appdomain.

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -702,18 +702,18 @@ HRESULT ClrDataAccess::EnumMemDumpAppDomainInfo(CLRDataEnumMemoryFlags flags)
         SystemDomain::System()->GetLoaderAllocator()->EnumMemoryRegions(flags);
     }
 
-    AppDomainIterator adIter(FALSE);
+    AppDomain* appDomain = AppDomain::GetCurrentDomain();
+    if (appDomain == NULL)
+        return S_OK;
+
     EX_TRY
     {
-        while (adIter.Next())
-        {
-            CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED
-            (
-                // Note that the flags being CLRDATA_ENUM_MEM_MINI prevents
-                // you from pulling entire files loaded into memory into the dump.
-                adIter.GetDomain()->EnumMemoryRegions(flags, true);
-            );
-        }
+        CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED
+        (
+            // Note that the flags being CLRDATA_ENUM_MEM_MINI prevents
+            // you from pulling entire files loaded into memory into the dump.
+            appDomain->EnumMemoryRegions(flags, true);
+        );
     }
     EX_CATCH_RETHROW_ONLY_COR_E_OPERATIONCANCELLED
 

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2214,13 +2214,14 @@ HRESULT ClrDataAccess::GetAppDomainList(unsigned int count, CLRDATA_ADDRESS valu
 {
     SOSDacEnter();
 
-    AppDomainIterator ai(FALSE);
+    AppDomain* appDomain = AppDomain::GetCurrentDomain();
     unsigned int i = 0;
-    while (ai.Next() && (i < count))
+    if (appDomain != NULL && i < count)
     {
         if (values)
-            values[i] = HOST_CDADDR(ai.GetDomain());
-        i++;
+            values[0] = HOST_CDADDR(appDomain);
+
+        i = 1;
     }
 
     if (fetched)
@@ -2240,8 +2241,7 @@ ClrDataAccess::GetAppDomainStoreData(struct DacpAppDomainStoreData *adsData)
 
     // Get an accurate count of appdomains.
     adsData->DomainCount = 0;
-    AppDomainIterator ai(FALSE);
-    while (ai.Next())
+    if (AppDomain::GetCurrentDomain() != NULL)
         adsData->DomainCount++;
 
     SOSDacLeave();

--- a/src/coreclr/nativeaot/Runtime/eventtrace.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace.cpp
@@ -6487,18 +6487,15 @@ void ETW::EnumerationLog::EnumerationHelper(Module* moduleFilter, BaseDomain* do
         }
         else
         {
-            AppDomainIterator appDomainIterator(FALSE);
-            while (appDomainIterator.Next())
+            AppDomain * pDomain = AppDomain::GetCurrentDomain();
+            if (pDomain != NULL)
             {
-                AppDomain* pDomain = appDomainIterator.GetDomain();
-                if (pDomain != NULL)
-                {
-                    // See code:#TableLockHolder
-                    ReJitManager::TableLockHolder lkRejitMgrAD(pDomain->GetReJitManager());
+                // See code:#TableLockHolder
+                ReJitManager::TableLockHolder lkRejitMgrAD(pDomain->GetReJitManager());
 
-                    ETW::EnumerationLog::IterateAppDomain(pDomain, enumerationOptions);
-                }
+                ETW::EnumerationLog::IterateAppDomain(pDomain, enumerationOptions);
             }
+
             ETW::EnumerationLog::IterateDomain(SharedDomain::GetDomain(), enumerationOptions);
         }
     }

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -1468,8 +1468,6 @@ struct FailedAssembly {
     }
 };
 
-class AppDomainIterator;
-
 const DWORD DefaultADID = 1;
 
 // An Appdomain is the managed equivalent of a process.  It is an isolation unit (conceptually you don't
@@ -1974,29 +1972,6 @@ public:
 
     static void ExceptionUnwind(Frame *pFrame);
 
-#ifdef _DEBUG
-
-    BOOL IsHeldByIterator()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_dwIterHolders>0;
-    }
-
-    void IteratorRelease()
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(m_dwIterHolders);
-        InterlockedDecrement(&m_dwIterHolders);
-    }
-
-
-    void IteratorAcquire()
-    {
-        LIMITED_METHOD_CONTRACT;
-        InterlockedIncrement(&m_dwIterHolders);
-    }
-
-#endif
     BOOL IsActive()
     {
         LIMITED_METHOD_DAC_CONTRACT;
@@ -2016,7 +1991,6 @@ public:
         return m_Stage > STAGE_CREATING;
 #endif
     }
-
 
     static void RaiseExitProcessEvent();
     Assembly* RaiseResourceResolveEvent(DomainAssembly* pAssembly, LPCSTR szName);
@@ -2208,10 +2182,6 @@ private:
 
     ArrayList        m_failedAssemblies;
 
-#ifdef _DEBUG
-    Volatile<LONG> m_dwIterHolders;
-#endif
-
     //
     // DAC iterator for failed assembly loads
     //
@@ -2348,8 +2318,6 @@ typedef VPTR(class SystemDomain) PTR_SystemDomain;
 class SystemDomain : public BaseDomain
 {
     friend class AppDomainNative;
-    friend class AppDomainIterator;
-    friend class UnsafeAppDomainIterator;
     friend class ClrDataAccess;
 
     VPTR_VTABLE_CLASS(SystemDomain, BaseDomain)
@@ -2674,132 +2642,6 @@ public:
 #endif
 
 };  // class SystemDomain
-
-
-//
-// an UnsafeAppDomainIterator is used to iterate over all existing domains
-//
-// The iteration is guaranteed to include all domains that exist at the
-// start & end of the iteration. This iterator is considered unsafe because it does not
-// reference count the various appdomains, and can only be used when the runtime is stopped,
-// or external synchronization is used. (and therefore no other thread may cause the appdomain list to change.)
-// In CoreCLR, this iterator doesn't use a list as there is at most 1 AppDomain, and instead will find the only AppDomain, or not.
-//
-class UnsafeAppDomainIterator
-{
-    friend class SystemDomain;
-public:
-    UnsafeAppDomainIterator(BOOL bOnlyActive)
-    {
-        m_bOnlyActive = bOnlyActive;
-    }
-
-    void Init()
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_iterationCount = 0;
-        m_pCurrent = NULL;
-    }
-
-    BOOL Next()
-    {
-        WRAPPER_NO_CONTRACT;
-
-        if (m_iterationCount == 0)
-        {
-            m_iterationCount++;
-            m_pCurrent = AppDomain::GetCurrentDomain();
-            if (m_pCurrent != NULL &&
-                (m_bOnlyActive ?
-                 m_pCurrent->IsActive() : m_pCurrent->IsValid()))
-            {
-                return TRUE;
-            }
-        }
-
-        m_pCurrent = NULL;
-        return FALSE;
-    }
-
-    AppDomain * GetDomain()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-
-        return m_pCurrent;
-    }
-
-  private:
-
-    int                 m_iterationCount;
-    AppDomain *         m_pCurrent;
-    BOOL                m_bOnlyActive;
-};  // class UnsafeAppDomainIterator
-
-//
-// an AppDomainIterator is used to iterate over all existing domains.
-//
-// The iteration is guaranteed to include all domains that exist at the
-// start & end of the iteration.  Any domains added or deleted during
-// iteration may or may not be included.  The iterator also guarantees
-// that the current iterated appdomain (GetDomain()) will not be deleted.
-//
-
-class AppDomainIterator : public UnsafeAppDomainIterator
-{
-    friend class SystemDomain;
-
-  public:
-    AppDomainIterator(BOOL bOnlyActive) : UnsafeAppDomainIterator(bOnlyActive)
-    {
-        WRAPPER_NO_CONTRACT;
-        Init();
-    }
-
-    ~AppDomainIterator()
-    {
-        WRAPPER_NO_CONTRACT;
-
-#ifndef DACCESS_COMPILE
-        if (GetDomain() != NULL)
-        {
-#ifdef _DEBUG
-            GetDomain()->IteratorRelease();
-#endif
-            GetDomain()->Release();
-        }
-#endif
-    }
-
-    BOOL Next()
-    {
-        WRAPPER_NO_CONTRACT;
-
-#ifndef DACCESS_COMPILE
-        if (GetDomain() != NULL)
-        {
-#ifdef _DEBUG
-            GetDomain()->IteratorRelease();
-#endif
-            GetDomain()->Release();
-        }
-
-        SystemDomain::LockHolder lh;
-#endif
-
-        if (UnsafeAppDomainIterator::Next())
-        {
-#ifndef DACCESS_COMPILE
-            GetDomain()->AddRef();
-#ifdef _DEBUG
-            GetDomain()->IteratorAcquire();
-#endif
-#endif
-            return TRUE;
-        }
-
-        return FALSE;
-    }
-};  // class AppDomainIterator
 
 #include "comreflectioncache.inl"
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2491,17 +2491,11 @@ void Module::SetSymbolBytes(LPCBYTE pbSyms, DWORD cbSyms)
     // the assembly was loaded in.</REVISIT_TODO>
     if (CORDebuggerAttached())
     {
-        AppDomainIterator i(FALSE);
-
-        while (i.Next())
+        AppDomain *pDomain = AppDomain::GetCurrentDomain();
+        if (pDomain->IsDebuggerAttached() && (GetDomain() == SystemDomain::System() ||
+                                                pDomain->ContainsAssembly(m_pAssembly)))
         {
-            AppDomain *pDomain = i.GetDomain();
-
-            if (pDomain->IsDebuggerAttached() && (GetDomain() == SystemDomain::System() ||
-                                                  pDomain->ContainsAssembly(m_pAssembly)))
-            {
-                g_pDebugInterface->SendUpdateModuleSymsEventAndBlock(this, pDomain);
-            }
+            g_pDebugInterface->SendUpdateModuleSymsEventAndBlock(this, pDomain);
         }
     }
 }

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -7668,14 +7668,10 @@ VOID ETW::EnumerationLog::EnumerationHelper(Module *moduleFilter, BaseDomain *do
         }
         else
         {
-            AppDomainIterator appDomainIterator(FALSE);
-            while(appDomainIterator.Next())
+            AppDomain *pDomain = AppDomain::GetCurrentDomain();
+            if (pDomain != NULL)
             {
-                AppDomain *pDomain = appDomainIterator.GetDomain();
-                if (pDomain != NULL)
-                {
-                    ETW::EnumerationLog::IterateAppDomain(pDomain, enumerationOptions);
-                }
+                ETW::EnumerationLog::IterateAppDomain(pDomain, enumerationOptions);
             }
         }
     }

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -1318,9 +1318,7 @@ static void ReleaseRCWsInCaches(LPVOID pCtxCookie)
 
     // Go through all the app domains and for each one release all the
     // RCW's that live in the current context.
-    AppDomainIterator i(TRUE);
-    while (i.Next())
-        i.GetDomain()->ReleaseRCWs(pCtxCookie);
+    AppDomain::GetCurrentDomain()->ReleaseRCWs(pCtxCookie);
 
     if (!g_fEEShutDown)
     {

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -1316,8 +1316,7 @@ static void ReleaseRCWsInCaches(LPVOID pCtxCookie)
     }
     CONTRACTL_END;
 
-    // Go through all the app domains and for each one release all the
-    // RCW's that live in the current context.
+    // Release all the RCW's that live in the AppDomain.
     AppDomain::GetCurrentDomain()->ReleaseRCWs(pCtxCookie);
 
     if (!g_fEEShutDown)

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -1467,16 +1467,11 @@ void MulticoreJitManager::StopProfileAll()
     }
     CONTRACTL_END;
 
-    AppDomainIterator domain(TRUE);
+    AppDomain * pDomain = AppDomain::GetCurrentDomain();
 
-    while (domain.Next())
+    if (pDomain != NULL)
     {
-        AppDomain * pDomain = domain.GetDomain();
-
-        if (pDomain != NULL)
-        {
-            pDomain->GetMulticoreJitManager().StopProfile(true);
-        }
+        pDomain->GetMulticoreJitManager().StopProfile(true);
     }
 }
 
@@ -1508,16 +1503,11 @@ void MulticoreJitManager::DisableMulticoreJit()
 
 #ifdef PROFILING_SUPPORTED
 
-    AppDomainIterator domain(TRUE);
+    AppDomain * pDomain = AppDomain::GetCurrentDomain();
 
-    while (domain.Next())
+    if (pDomain != NULL)
     {
-        AppDomain * pDomain = domain.GetDomain();
-
-        if (pDomain != NULL)
-        {
-            pDomain->GetMulticoreJitManager().AbortProfile();
-        }
+        pDomain->GetMulticoreJitManager().AbortProfile();
     }
 
 #endif


### PR DESCRIPTION
We only have one `AppDomain`, which is set once and always active once set.

cc @dotnet/dotnet-diag - most of the updated usage was for DAC