### PR TITLE
Use TaskDialog for error dialog in Windows GUI apps

### DIFF
--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 result.Should().Fail()
                     .And.ExitWith(1)
                     .And.HaveStdOutContaining($"{GetHostFxrPath} failed: 0x{Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x")}")
-                    .And.HaveStdErrContaining($"The folder [{Path.Combine(dotNetRoot, "host", "fxr")}] does not exist");
+                    .And.HaveStdErrContaining($"[{Path.Combine(dotNetRoot, "host", "fxr")}] does not exist");
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -534,7 +534,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
                     .And.HaveStdErrContaining("&gui=true")
-                    .And.HaveStdErrMatching($"dialog message: (?>.|\\s)*{System.Text.RegularExpressions.Regex.Escape(expectedMissingFramework)}");
+                    .And.HaveStdErrMatching($"details: (?>.|\\s)*{System.Text.RegularExpressions.Regex.Escape(expectedMissingFramework)}");
             }
         }
 

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -259,10 +259,21 @@ namespace
                 const pal::char_t prefix_before_7_0[] = _X("The framework '");
                 const pal::char_t suffix_before_7_0[] = _X(" was not found.");
                 const pal::char_t custom_prefix[] = _X("  _ ");
-                if (utils::starts_with(line, prefix, true)
+                bool has_prefix = utils::starts_with(line, prefix, true);
+                if (has_prefix
                     || (utils::starts_with(line, prefix_before_7_0, true) && utils::ends_with(line, suffix_before_7_0, true)))
                 {
-                    details.append(line);
+                    details.append(_X("Required: "));
+                    if (has_prefix)
+                    {
+                        details.append(line.substr(utils::strlen(prefix) - 1));
+                    }
+                    else
+                    {
+                        size_t prefix_len = utils::strlen(prefix_before_7_0) - 1;
+                        details.append(line.substr(prefix_len, line.length() - prefix_len - utils::strlen(suffix_before_7_0)));
+                    }
+
                     details.append(_X("\n\n"));
                     foundCustomMessage = true;
                 }

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -81,14 +81,19 @@ namespace
         return msg;
     }
 
-    pal::string_t get_runtime_not_found_message()
+    void open_url(const pal::char_t* url)
     {
-        pal::string_t msg = INSTALL_NET_DESKTOP_ERROR_MESSAGE _X("\n\n");
-        msg.append(get_apphost_details_message());
-        return msg;
+        // Open the URL in default browser
+        ::ShellExecuteW(
+            nullptr,
+            _X("open"),
+            url,
+            nullptr,
+            nullptr,
+            SW_SHOWNORMAL);
     }
 
-    void enable_visual_styles()
+    bool enable_visual_styles()
     {
         // Create an activation context using a manifest that enables visual styles
         // See https://learn.microsoft.com/windows/win32/controls/cookbook-overview
@@ -99,7 +104,7 @@ namespace
         if (len == 0 || len >= MAX_PATH)
         {
             trace::verbose(_X("GetWindowsDirectory failed. Error code: %d"), ::GetLastError());
-            return;
+            return false;
         }
 
         pal::string_t manifest(buf);
@@ -112,17 +117,113 @@ namespace
         if (context_handle == INVALID_HANDLE_VALUE)
         {
             trace::verbose(_X("CreateActCtxW failed using manifest '%s'. Error code: %d"), manifest.c_str(), ::GetLastError());
-            return;
+            return false;
         }
 
         ULONG_PTR cookie;
         if (::ActivateActCtx(context_handle, &cookie) == FALSE)
         {
             trace::verbose(_X("ActivateActCtx failed. Error code: %d"), ::GetLastError());
-            return;
+            return false;
         }
 
-        return;
+        return true;
+    }
+
+    void append_hyperlink(pal::string_t& str, const pal::char_t* url)
+    {
+        str.append(_X("<A HREF=\""));
+        str.append(url);
+        str.append(_X("\">"));
+
+        // & indicates an accelerator key when in hyperlink text.
+        // Replace & with && such that the single ampersand is shown.
+        for (int i = 0; i < pal::strlen(url); ++i)
+        {
+            str.push_back(url[i]);
+            if (url[i] == _X('&'))
+                str.push_back(_X('&'));
+        }
+
+        str.append(_X("</A>"));
+    }
+
+    bool try_show_error_with_task_dialog(
+        const pal::char_t *executable_name,
+        const pal::char_t *instruction,
+        const pal::char_t *details,
+        const pal::char_t *docs_link_intro,
+        const pal::char_t *url)
+    {
+        HMODULE comctl32 = ::LoadLibraryExW(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (comctl32 == nullptr)
+            return false;
+
+        typedef HRESULT (WINAPI* task_dialog_indirect)(
+            const TASKDIALOGCONFIG* pTaskConfig,
+            int* pnButton,
+            int* pnRadioButton,
+            BOOL* pfVerificationFlagChecked);
+
+        task_dialog_indirect task_dialog_indirect_func = (task_dialog_indirect)::GetProcAddress(comctl32, "TaskDialogIndirect");
+        if (task_dialog_indirect_func == nullptr)
+        {
+            ::FreeLibrary(comctl32);
+            return false;
+        }
+
+        TASKDIALOGCONFIG config{0};
+        config.cbSize = sizeof(TASKDIALOGCONFIG);
+        config.dwFlags = TDF_ENABLE_HYPERLINKS | TDF_SIZE_TO_CONTENT | TDF_USE_COMMAND_LINKS;
+        config.dwCommonButtons = TDCBF_CLOSE_BUTTON;
+        config.pszWindowTitle = executable_name;
+        config.pszMainInstruction = instruction;
+
+        // Use the application's icon if available
+        HMODULE exe_module = ::GetModuleHandleW(nullptr);
+        assert(exe_module != nullptr);
+        if (::FindResourceW(exe_module, IDI_APPLICATION, RT_GROUP_ICON) != nullptr)
+        {
+            config.hInstance = exe_module;
+            config.pszMainIcon = IDI_APPLICATION;
+        }
+        else
+        {
+            config.pszMainIcon = TD_ERROR_ICON;
+        }
+
+        pal::string_t content(details);
+        content.append(docs_link_intro);
+        content.append(_X("\n"));
+        append_hyperlink(content, DOTNET_APP_LAUNCH_FAILED_URL);
+        config.pszContent = content.c_str();
+
+        int download_button_id = 1000;
+        TASKDIALOG_BUTTON download_button { download_button_id, _X("Download it now\n") _X("You will need to run the downloaded installer") };
+        config.cButtons = 1;
+        config.pButtons = &download_button;
+        config.nDefaultButton = download_button_id;
+
+        pal::string_t expanded_info(_X("Download link:\n"));
+        append_hyperlink(expanded_info, url);
+        config.pszExpandedInformation = expanded_info.c_str();
+
+        // Callback to handle hyperlink clicks
+        config.pfCallback = [](HWND hwnd, UINT uNotification, WPARAM wParam, LPARAM lParam, LONG_PTR lpRefData) -> HRESULT
+        {
+            if (uNotification == TDN_HYPERLINK_CLICKED && lParam != NULL)
+                open_url(reinterpret_cast<LPCWSTR>(lParam));
+
+            return S_OK;
+        };
+
+        int clicked_button;
+        bool succeeded = SUCCEEDED(task_dialog_indirect_func(&config, &clicked_button, nullptr, nullptr));
+        if (succeeded && clicked_button == download_button_id)
+            open_url(url);
+
+        ::FreeLibrary(comctl32);
+        return succeeded;
     }
 
     void show_error_dialog(const pal::char_t* executable_name, int error_code)
@@ -131,11 +232,13 @@ namespace
         if (pal::getenv(_X("DOTNET_DISABLE_GUI_ERRORS"), &gui_errors_disabled) && pal::xtoi(gui_errors_disabled.c_str()) == 1)
             return;
 
-        pal::string_t dialogMsg;
+        const pal::char_t* instruction = nullptr;
+        pal::string_t details;
         pal::string_t url;
         if (error_code == StatusCode::CoreHostLibMissingFailure)
         {
-            dialogMsg = get_runtime_not_found_message();
+            instruction = INSTALL_NET_DESKTOP_ERROR_MESSAGE;
+            details = get_apphost_details_message();
             pal::string_t line;
             pal::stringstream_t ss(g_buffered_errors);
             while (std::getline(ss, line, _X('\n')))
@@ -150,7 +253,7 @@ namespace
         {
             // We don't have a great way of passing out different kinds of detailed error info across components, so
             // just match the expected error string. See fx_resolver.messages.cpp.
-            dialogMsg = pal::string_t(INSTALL_OR_UPDATE_NET_ERROR_MESSAGE _X("\n\n"));
+            instruction = INSTALL_OR_UPDATE_NET_ERROR_MESSAGE;
             pal::string_t line;
             pal::stringstream_t ss(g_buffered_errors);
             bool foundCustomMessage = false;
@@ -163,15 +266,15 @@ namespace
                 if (utils::starts_with(line, prefix, true)
                     || (utils::starts_with(line, prefix_before_7_0, true) && utils::ends_with(line, suffix_before_7_0, true)))
                 {
-                    dialogMsg.append(line);
-                    dialogMsg.append(_X("\n\n"));
+                    details.append(line);
+                    details.append(_X("\n\n"));
                     foundCustomMessage = true;
                 }
                 else if (utils::starts_with(line, custom_prefix, true))
                 {
-                    dialogMsg.erase();
-                    dialogMsg.append(line.substr(utils::strlen(custom_prefix)));
-                    dialogMsg.append(_X("\n\n"));
+                    details.erase();
+                    details.append(line.substr(utils::strlen(custom_prefix)));
+                    details.append(_X("\n\n"));
                     foundCustomMessage = true;
                 }
                 else if (try_get_url_from_line(line, url))
@@ -181,7 +284,7 @@ namespace
             }
 
             if (!foundCustomMessage)
-                dialogMsg.append(get_apphost_details_message());
+                details.append(get_apphost_details_message());
         }
         else if (error_code == StatusCode::BundleExtractionFailure)
         {
@@ -191,14 +294,15 @@ namespace
             {
                 if (utils::starts_with(line, _X("Bundle header version compatibility check failed."), true))
                 {
-                    dialogMsg = get_runtime_not_found_message();
+                    instruction = INSTALL_NET_DESKTOP_ERROR_MESSAGE;
+                    details = get_apphost_details_message();
                     url = get_download_url();
                     url.append(_X("&apphost_version="));
                     url.append(_STRINGIFY(COMMON_HOST_PKG_VER));
                 }
             }
 
-            if (dialogMsg.empty())
+            if (instruction == nullptr)
                 return;
         }
         else
@@ -206,29 +310,32 @@ namespace
             return;
         }
 
-        dialogMsg.append(
-            _X("Learn about "));
-        dialogMsg.append(error_code == StatusCode::FrameworkMissingFailure ? _X("framework resolution:") : _X("runtime installation:"));
-        dialogMsg.append(_X("\n") DOTNET_APP_LAUNCH_FAILED_URL _X("\n\n")
-            _X("Would you like to download it now?"));
-
         assert(url.length() > 0);
         assert(is_gui_application());
         url.append(_X("&gui=true"));
 
-        enable_visual_styles();
+        const pal::char_t* doc_link_intro = error_code == StatusCode::FrameworkMissingFailure
+            ? LEARN_ABOUT_FRAMEWORK_RESOLUTION
+            : LEARN_ABOUT_RUNTIME_INSTALLATION;
 
-        trace::verbose(_X("Showing error dialog for application: '%s' - error code: 0x%x - url: '%s' - dialog message: %s"), executable_name, error_code, url.c_str(), dialogMsg.c_str());
-        if (::MessageBoxW(nullptr, dialogMsg.c_str(), executable_name, MB_ICONERROR | MB_YESNO) == IDYES)
+        trace::verbose(_X("Showing error dialog for application: '%s' - error code: 0x%x - url: '%s' - details: %s"), executable_name, error_code, url.c_str(), details.c_str());
+
+        if (enable_visual_styles())
         {
-            // Open the URL in default browser
-            ::ShellExecuteW(
-                nullptr,
-                _X("open"),
-                url.c_str(),
-                nullptr,
-                nullptr,
-                SW_SHOWNORMAL);
+            // Task dialog requires enabling visual styles
+            if (try_show_error_with_task_dialog(executable_name, instruction, details.c_str(), doc_link_intro, url.c_str()))
+                return;
+        }
+
+        pal::string_t dialog_message(instruction);
+        dialog_message.append(_X("\n\n"));
+        dialog_message.append(details);
+        dialog_message.append(doc_link_intro);
+        dialog_message.append(_X("\n") DOTNET_APP_LAUNCH_FAILED_URL _X("\n\n")
+            _X("Would you like to download it now?"));
+        if (::MessageBoxW(nullptr, dialog_message.c_str(), executable_name, MB_ICONERROR | MB_YESNO) == IDYES)
+        {
+            open_url(url.c_str());
         }
     }
 }

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -138,7 +138,7 @@ namespace
 
         // & indicates an accelerator key when in hyperlink text.
         // Replace & with && such that the single ampersand is shown.
-        for (int i = 0; i < pal::strlen(url); ++i)
+        for (size_t i = 0; i < pal::strlen(url); ++i)
         {
             str.push_back(url[i]);
             if (url[i] == _X('&'))

--- a/src/native/corehost/apphost/standalone/CMakeLists.txt
+++ b/src/native/corehost/apphost/standalone/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADERS
 )
 
 if(CLR_CMAKE_TARGET_WIN32)
+    add_definitions(-DUNICODE)
     list(APPEND SOURCES
         ../apphost.windows.cpp)
 

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -54,6 +54,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES GNU)
 endif()
 
 if(CLR_CMAKE_TARGET_WIN32)
+    add_definitions(-DUNICODE)
     list(APPEND SOURCES
         ../apphost.windows.cpp)
 

--- a/src/native/corehost/corehost.cpp
+++ b/src/native/corehost/corehost.cpp
@@ -87,18 +87,8 @@ bool is_exe_enabled_for_execution(pal::string_t* app_dll)
 void need_newer_framework_error(const pal::string_t& dotnet_root, const pal::string_t& host_path)
 {
     trace::error(
-        INSTALL_OR_UPDATE_NET_ERROR_MESSAGE
-        _X("\n\n")
-        _X("App: %s\n")
-        _X("Architecture: %s\n")
-        _X("App host version: %s\n")
-        _X(".NET location: %s\n")
-        _X("\n")
-        _X("Learn about runtime installation:\n")
-        DOTNET_APP_LAUNCH_FAILED_URL
-        _X("\n\n")
-        _X("Download the .NET runtime:\n")
-        _X("%s&apphost_version=%s"),
+        MISSING_RUNTIME_ERROR_FORMAT,
+        INSTALL_OR_UPDATE_NET_ERROR_MESSAGE,
         host_path.c_str(),
         get_current_arch_name(),
         _STRINGIFY(COMMON_HOST_PKG_VER),
@@ -126,7 +116,6 @@ int exe_start(const int argc, const pal::char_t* argv[])
     pal::string_t embedded_app_name;
     if (!is_exe_enabled_for_execution(&embedded_app_name))
     {
-        trace::error(_X("A fatal error was encountered. This executable was not bound to load a managed DLL."));
         return StatusCode::AppHostExeNotBoundFailure;
     }
 
@@ -165,7 +154,7 @@ int exe_start(const int argc, const pal::char_t* argv[])
         // dotnet.exe is signed by Microsoft. It is technically possible to rename the file MyApp.exe and include it in the application.
         // Then one can create a shortcut for "MyApp.exe MyApp.dll" which works. The end result is that MyApp looks like it's signed by Microsoft.
         // To prevent this dotnet.exe must not be renamed, otherwise it won't run.
-        trace::error(_X("A fatal error was encountered. Cannot execute %s when renamed to %s."), CURHOST_TYPE, own_name.c_str());
+        trace::error(_X("Error: cannot execute %s when renamed to %s."), CURHOST_TYPE, own_name.c_str());
         return StatusCode::CoreHostEntryPointFailure;
     }
 

--- a/src/native/corehost/fxr/fx_resolver.messages.cpp
+++ b/src/native/corehost/fxr/fx_resolver.messages.cpp
@@ -138,7 +138,7 @@ void fx_resolver_t::display_missing_framework_error(
     pal::string_t url = get_download_url(fx_name.c_str(), fx_version.c_str());
     trace::error(
         _X("\n")
-        _X("Learn about framework resolution:\n")
+        LEARN_ABOUT_FRAMEWORK_RESOLUTION _X("\n")
         DOTNET_APP_LAUNCH_FAILED_URL
         _X("\n\n")
         _X("To install missing framework, download:\n")

--- a/src/native/corehost/fxr/fx_resolver.messages.cpp
+++ b/src/native/corehost/fxr/fx_resolver.messages.cpp
@@ -138,7 +138,7 @@ void fx_resolver_t::display_missing_framework_error(
     pal::string_t url = get_download_url(fx_name.c_str(), fx_version.c_str());
     trace::error(
         _X("\n")
-        LEARN_ABOUT_FRAMEWORK_RESOLUTION _X("\n")
+        DOC_LINK_INTRO _X("\n")
         DOTNET_APP_LAUNCH_FAILED_URL
         _X("\n\n")
         _X("To install missing framework, download:\n")

--- a/src/native/corehost/fxr_resolver.cpp
+++ b/src/native/corehost/fxr_resolver.cpp
@@ -32,7 +32,7 @@ namespace
 
         if (max_ver == fx_ver_t())
         {
-            trace::error(_X("A fatal error occurred, the folder [%s] does not contain any version-numbered child folders"), fxr_root.c_str());
+            trace::error(_X("Error: [%s] does not contain any version-numbered child folders"), fxr_root.c_str());
             return false;
         }
 
@@ -46,7 +46,7 @@ namespace
             return true;
         }
 
-        trace::error(_X("A fatal error occurred, the required library %s could not be found in [%s]"), LIBFXR_NAME, fxr_root.c_str());
+        trace::error(_X("Error: the required library %s could not be found in [%s]"), LIBFXR_NAME, fxr_root.c_str());
 
         return false;
     }
@@ -81,7 +81,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         }
         else
         {
-            trace::error(_X("A fatal error occurred, the default install location cannot be obtained."));
+            trace::error(_X("Error: the default install location cannot be obtained."));
             return false;
         }
     }
@@ -111,21 +111,12 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         pal::string_t host_path;
         pal::get_own_executable_path(&host_path);
         trace::error(
-            INSTALL_NET_ERROR_MESSAGE
-            _X("\n\n")
-            _X("App: %s\n")
-            _X("Architecture: %s\n")
-            _X("App host version: %s\n")
-            _X(".NET location: Not found\n")
-            _X("\n")
-            _X("Learn about runtime installation:\n")
-            DOTNET_APP_LAUNCH_FAILED_URL
-            _X("\n\n")
-            _X("Download the .NET runtime:\n")
-            _X("%s&apphost_version=%s"),
+            MISSING_RUNTIME_ERROR_FORMAT,
+            INSTALL_NET_ERROR_MESSAGE,
             host_path.c_str(),
             get_current_arch_name(),
             _STRINGIFY(COMMON_HOST_PKG_VER),
+            _X("Not found"),
             get_download_url().c_str(),
             _STRINGIFY(COMMON_HOST_PKG_VER));
         return false;
@@ -150,7 +141,7 @@ bool fxr_resolver::try_get_path_from_dotnet_root(const pal::string_t& dotnet_roo
     append_path(&fxr_dir, _X("fxr"));
     if (!pal::directory_exists(fxr_dir))
     {
-        trace::error(_X("A fatal error occurred. The folder [%s] does not exist"), fxr_dir.c_str());
+        trace::error(_X("Error: [%s] does not exist"), fxr_dir.c_str());
         return false;
     }
 

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -28,8 +28,7 @@
 #define INSTALL_NET_ERROR_MESSAGE _X("You must install .NET to run this application.")
 #define INSTALL_NET_DESKTOP_ERROR_MESSAGE _X("You must install .NET Desktop Runtime to run this application.")
 
-#define LEARN_ABOUT_RUNTIME_INSTALLATION _X("Learn about runtime installation:")
-#define LEARN_ABOUT_FRAMEWORK_RESOLUTION _X("Learn about framework resolution:")
+#define DOC_LINK_INTRO _X("Learn more:")
 
 #define MISSING_RUNTIME_ERROR_FORMAT \
     _X("%s\n\n")                                \
@@ -38,7 +37,7 @@
     _X("App host version: %s\n")                \
     _X(".NET location: %s\n")                   \
     _X("\n")                                    \
-    LEARN_ABOUT_RUNTIME_INSTALLATION _X("\n")   \
+    DOC_LINK_INTRO _X("\n")                     \
     DOTNET_APP_LAUNCH_FAILED_URL                \
     _X("\n\n")                                  \
     _X("Download the .NET runtime:\n")          \

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -28,6 +28,22 @@
 #define INSTALL_NET_ERROR_MESSAGE _X("You must install .NET to run this application.")
 #define INSTALL_NET_DESKTOP_ERROR_MESSAGE _X("You must install .NET Desktop Runtime to run this application.")
 
+#define LEARN_ABOUT_RUNTIME_INSTALLATION _X("Learn about runtime installation:")
+#define LEARN_ABOUT_FRAMEWORK_RESOLUTION _X("Learn about framework resolution:")
+
+#define MISSING_RUNTIME_ERROR_FORMAT \
+    _X("%s\n\n")                                \
+    _X("App: %s\n")                             \
+    _X("Architecture: %s\n")                    \
+    _X("App host version: %s\n")                \
+    _X(".NET location: %s\n")                   \
+    _X("\n")                                    \
+    LEARN_ABOUT_RUNTIME_INSTALLATION _X("\n")   \
+    DOTNET_APP_LAUNCH_FAILED_URL                \
+    _X("\n\n")                                  \
+    _X("Download the .NET runtime:\n")          \
+    _X("%s&apphost_version=%s")
+
 #define DOTNET_ROOT_ENV_VAR _X("DOTNET_ROOT")
 
 bool ends_with(const pal::string_t& value, const pal::string_t& suffix, bool match_case);


### PR DESCRIPTION
Show runtime/framework not found error via a [task dialog](https://learn.microsoft.com/windows/win32/controls/task-dialogs) instead of a message box when possible - falls back to message box if not.

Screenshots of what it looks like with the current change are below. We can definitely move text around (for example, only include the docs link in the main text and app/architecture/framework in the collapsible details section) or do something different for the icon (for example, don't try to use the app icon and always use the standard error icon or no icon at all).

Resolves https://github.com/dotnet/runtime/issues/71288
Related: https://github.com/dotnet/runtime/issues/3816

@richlander @vitek-karas thoughts?

![image](https://user-images.githubusercontent.com/47805090/204713884-95ed5406-0a71-41a7-95fe-126188a22633.png)
![image](https://user-images.githubusercontent.com/47805090/204713982-86010422-c172-4791-a18c-d590b68fb2a4.png)

The current change also tries to use the app's icon if it exists:
![image](https://user-images.githubusercontent.com/47805090/204714476-81b28f8e-47e3-4492-947c-3a43be0f78bc.png)

The expanded details has the full details including the download link:
![image](https://user-images.githubusercontent.com/47805090/204714402-7bb64a77-0771-4cce-b73f-65ab74ab0e3a.png)
![image](https://user-images.githubusercontent.com/47805090/204714332-54aefbf8-fa5b-4189-867a-8e3d417fa51d.png)