### PR TITLE
Upgrade dotnet version needed to build benchmarks in superpmi

### DIFF
--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -60,74 +60,74 @@ extends:
         jobParameters:
           testGroup: outerloop
 
-    # - template: /eng/pipelines/common/platform-matrix.yml
-    #   parameters:
-    #     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-    #     buildConfig: checked
-    #     platforms:
-    #     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    #     jobParameters:
-    #       testGroup: outerloop
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+        buildConfig: checked
+        platforms:
+        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+        jobParameters:
+          testGroup: outerloop
 
-    # - template: /eng/pipelines/common/platform-matrix.yml
-    #   parameters:
-    #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-    #     buildConfig: checked
-    #     platforms:
-    #     - OSX_arm64
-    #     - Linux_arm
-    #     - Linux_arm64
-    #     - Linux_x64
-    #     - windows_x64
-    #     - windows_x86
-    #     - windows_arm64
-    #     helixQueueGroup: ci
-    #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    #     jobParameters:
-    #       testGroup: outerloop
-    #       liveLibrariesBuildConfig: Release
-    #       collectionType: pmi
-    #       collectionName: libraries
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          collectionType: pmi
+          collectionName: libraries
 
-    # - template: /eng/pipelines/common/platform-matrix.yml
-    #   parameters:
-    #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-    #     buildConfig: checked
-    #     platforms:
-    #     - OSX_arm64
-    #     - Linux_arm
-    #     - Linux_arm64
-    #     - Linux_x64
-    #     - windows_x64
-    #     - windows_x86
-    #     - windows_arm64
-    #     helixQueueGroup: ci
-    #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    #     jobParameters:
-    #       testGroup: outerloop
-    #       liveLibrariesBuildConfig: Release
-    #       collectionType: pmi
-    #       collectionName: libraries_tests
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          collectionType: pmi
+          collectionName: libraries_tests
 
-    # - template: /eng/pipelines/common/platform-matrix.yml
-    #   parameters:
-    #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-    #     buildConfig: checked
-    #     platforms:
-    #     - OSX_arm64
-    #     - Linux_arm
-    #     - Linux_arm64
-    #     - Linux_x64
-    #     - windows_x64
-    #     - windows_x86
-    #     - windows_arm64
-    #     helixQueueGroup: ci
-    #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    #     jobParameters:
-    #       testGroup: outerloop
-    #       liveLibrariesBuildConfig: Release
-    #       collectionType: crossgen2
-    #       collectionName: libraries
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: ci
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          collectionType: crossgen2
+          collectionName: libraries
 
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
@@ -149,24 +149,24 @@ extends:
           collectionType: run
           collectionName: benchmarks
 
-    # #
-    # # Collection of coreclr test run
-    # #
-    # - template: /eng/pipelines/common/platform-matrix.yml
-    #   parameters:
-    #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-    #     buildConfig: checked
-    #     platforms:
-    #     - OSX_arm64
-    #     - Linux_arm
-    #     - Linux_arm64
-    #     - Linux_x64
-    #     - windows_x64
-    #     - windows_x86
-    #     - windows_arm64
-    #     helixQueueGroup: superpmi
-    #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    #     jobParameters:
-    #       testGroup: outerloop
-    #       liveLibrariesBuildConfig: Release
-    #       SuperPmiCollect: true
+    #
+    # Collection of coreclr test run
+    #
+    - template: /eng/pipelines/common/platform-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+        buildConfig: checked
+        platforms:
+        - OSX_arm64
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - windows_x64
+        - windows_x86
+        - windows_arm64
+        helixQueueGroup: superpmi
+        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+        jobParameters:
+          testGroup: outerloop
+          liveLibrariesBuildConfig: Release
+          SuperPmiCollect: true

--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -60,74 +60,74 @@ extends:
         jobParameters:
           testGroup: outerloop
 
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
-        buildConfig: checked
-        platforms:
-        - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-        jobParameters:
-          testGroup: outerloop
+    # - template: /eng/pipelines/common/platform-matrix.yml
+    #   parameters:
+    #     jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+    #     buildConfig: checked
+    #     platforms:
+    #     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    #     jobParameters:
+    #       testGroup: outerloop
 
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-        buildConfig: checked
-        platforms:
-        - OSX_arm64
-        - Linux_arm
-        - Linux_arm64
-        - Linux_x64
-        - windows_x64
-        - windows_x86
-        - windows_arm64
-        helixQueueGroup: ci
-        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-        jobParameters:
-          testGroup: outerloop
-          liveLibrariesBuildConfig: Release
-          collectionType: pmi
-          collectionName: libraries
+    # - template: /eng/pipelines/common/platform-matrix.yml
+    #   parameters:
+    #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+    #     buildConfig: checked
+    #     platforms:
+    #     - OSX_arm64
+    #     - Linux_arm
+    #     - Linux_arm64
+    #     - Linux_x64
+    #     - windows_x64
+    #     - windows_x86
+    #     - windows_arm64
+    #     helixQueueGroup: ci
+    #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    #     jobParameters:
+    #       testGroup: outerloop
+    #       liveLibrariesBuildConfig: Release
+    #       collectionType: pmi
+    #       collectionName: libraries
 
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-        buildConfig: checked
-        platforms:
-        - OSX_arm64
-        - Linux_arm
-        - Linux_arm64
-        - Linux_x64
-        - windows_x64
-        - windows_x86
-        - windows_arm64
-        helixQueueGroup: ci
-        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-        jobParameters:
-          testGroup: outerloop
-          liveLibrariesBuildConfig: Release
-          collectionType: pmi
-          collectionName: libraries_tests
+    # - template: /eng/pipelines/common/platform-matrix.yml
+    #   parameters:
+    #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+    #     buildConfig: checked
+    #     platforms:
+    #     - OSX_arm64
+    #     - Linux_arm
+    #     - Linux_arm64
+    #     - Linux_x64
+    #     - windows_x64
+    #     - windows_x86
+    #     - windows_arm64
+    #     helixQueueGroup: ci
+    #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    #     jobParameters:
+    #       testGroup: outerloop
+    #       liveLibrariesBuildConfig: Release
+    #       collectionType: pmi
+    #       collectionName: libraries_tests
 
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-        buildConfig: checked
-        platforms:
-        - OSX_arm64
-        - Linux_arm
-        - Linux_arm64
-        - Linux_x64
-        - windows_x64
-        - windows_x86
-        - windows_arm64
-        helixQueueGroup: ci
-        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-        jobParameters:
-          testGroup: outerloop
-          liveLibrariesBuildConfig: Release
-          collectionType: crossgen2
-          collectionName: libraries
+    # - template: /eng/pipelines/common/platform-matrix.yml
+    #   parameters:
+    #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+    #     buildConfig: checked
+    #     platforms:
+    #     - OSX_arm64
+    #     - Linux_arm
+    #     - Linux_arm64
+    #     - Linux_x64
+    #     - windows_x64
+    #     - windows_x86
+    #     - windows_arm64
+    #     helixQueueGroup: ci
+    #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    #     jobParameters:
+    #       testGroup: outerloop
+    #       liveLibrariesBuildConfig: Release
+    #       collectionType: crossgen2
+    #       collectionName: libraries
 
     - template: /eng/pipelines/common/platform-matrix.yml
       parameters:
@@ -149,24 +149,24 @@ extends:
           collectionType: run
           collectionName: benchmarks
 
-    #
-    # Collection of coreclr test run
-    #
-    - template: /eng/pipelines/common/platform-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-        buildConfig: checked
-        platforms:
-        - OSX_arm64
-        - Linux_arm
-        - Linux_arm64
-        - Linux_x64
-        - windows_x64
-        - windows_x86
-        - windows_arm64
-        helixQueueGroup: superpmi
-        helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-        jobParameters:
-          testGroup: outerloop
-          liveLibrariesBuildConfig: Release
-          SuperPmiCollect: true
+    # #
+    # # Collection of coreclr test run
+    # #
+    # - template: /eng/pipelines/common/platform-matrix.yml
+    #   parameters:
+    #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    #     buildConfig: checked
+    #     platforms:
+    #     - OSX_arm64
+    #     - Linux_arm
+    #     - Linux_arm64
+    #     - Linux_x64
+    #     - windows_x64
+    #     - windows_x86
+    #     - windows_arm64
+    #     helixQueueGroup: superpmi
+    #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    #     jobParameters:
+    #       testGroup: outerloop
+    #       liveLibrariesBuildConfig: Release
+    #       SuperPmiCollect: true

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -178,7 +178,7 @@ def build_and_run(coreclr_args, output_mch_name):
 
     run_command(
         [dotnet_exe, "build", project_file, "--configuration", "Release",
-         "--framework", "net7.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
+         "--framework", "net8.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
          "-o", artifacts_directory], _exit_on_fail=True)
 
     # Disable ReadyToRun so we always JIT R2R methods and collect them

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -405,7 +405,7 @@ def setup_microbenchmark(workitem_directory, arch):
         # have not published yet. As a result, we hit errors of "dotnet restore". As a workaround, hard code the
         # working version until we move to ".NET 8" in the script.
         run_command(
-            get_python_name() + [dotnet_install_script, "install", "--dotnet-versions", "7.0.100-rc.2.22458.3", "--architecture", arch, "--install-dir",
+            get_python_name() + [dotnet_install_script, "install", "--dotnet-versions", "8.0.100-alpha.1.22558.2", "--architecture", arch, "--install-dir",
                                  dotnet_directory, "--verbose"])
 
 


### PR DESCRIPTION
Update the hardcoded dotnet version needed to build MicroBenchmarks with net8.0 (similar to what we did in https://github.com/dotnet/runtime/pull/75888).