### PR TITLE
[release/6.0] Bump consumed dependency of Microsoft.Windows.Compatibility

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsVersion>4.3.0</SystemCollectionsVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
-    <SystemDataSqlClientVersion>4.8.4</SystemDataSqlClientVersion>
+    <SystemDataSqlClientVersion>4.8.5</SystemDataSqlClientVersion>
     <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>
     <SystemDiagnosticsContractsVersion>4.3.0</SystemDiagnosticsContractsVersion>
     <SystemDynamicRuntimeVersion>4.3.0</SystemDynamicRuntimeVersion>


### PR DESCRIPTION
In the branding PR, we already enabled the package for building on the next servicing release: https://github.com/dotnet/runtime/pull/77750/files so there was no need to add it here.