### PR TITLE
Fix expensive typo in JsonNode

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.To.cs
@@ -6,7 +6,7 @@ namespace System.Text.Json.Nodes
     public abstract partial class JsonNode
     {
         // linker-safe default JsonSerializerOptions instance used by JsonNode methods.
-        private protected readonly JsonSerializerOptions s_defaultOptions = new();
+        private protected static readonly JsonSerializerOptions s_defaultOptions = new();
 
         /// <summary>
         ///   Converts the current instance to string in JSON format.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/78089 (but assuming this is the right fix, we should backport this to release/7.0)