### PR TITLE
Single File Test Runner support for Remote Executor

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -12,6 +12,10 @@
     <RunScriptCommand Condition="'$(TargetOS)' != 'windows'">chmod +rwx $(AssemblyName) &amp;&amp; ./$(AssemblyName)</RunScriptCommand>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IncludeRemoteExecutor)' == 'true'">
+    <DefineConstants>$(DefineConstants);SINGLE_FILE_REMOTE_EXECUTOR</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TestNativeAot)' != 'true'">
     <PublishSingleFile>true</PublishSingleFile>
     <UseAppHost>true</UseAppHost>

--- a/src/libraries/Common/tests/SingleFileTestRunner/SingleFileTestRunner.cs
+++ b/src/libraries/Common/tests/SingleFileTestRunner/SingleFileTestRunner.cs
@@ -24,6 +24,14 @@ public class SingleFileTestRunner : XunitTestFramework
 
     public static int Main(string[] args)
     {
+#if SINGLE_FILE_REMOTE_EXECUTOR
+        int? maybeExitCode = Microsoft.DotNet.RemoteExecutor.Program.TryExecute(args);
+        if (maybeExitCode.HasValue)
+        {
+            return maybeExitCode.Value;
+        }
+#endif // SINGLE_FILE_REMOTE_EXECUTOR
+
         var asm = typeof(SingleFileTestRunner).Assembly;
         Console.WriteLine("Running assembly:" + asm.FullName);
 


### PR DESCRIPTION
This depends on dotnet/arcade#11460 . 