### PR TITLE
Fix JSON required read-only properties used as parametrized ctor

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfoOfT.cs
@@ -21,6 +21,8 @@ namespace System.Text.Json.Serialization.Metadata
             Debug.Assert(parameterInfoValues.ParameterType == typeof(T));
             Debug.Assert(matchingPropertyInfo.IsConfigured);
 
+            matchingPropertyInfo.MarkAsConstructorParameter();
+
             MatchingProperty = matchingPropertyInfo;
             DefaultValue = parameterInfoValues.HasDefaultValue && parameterInfoValues.DefaultValue is not null
                 ? (T)parameterInfoValues.DefaultValue

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -606,6 +606,17 @@ namespace System.Text.Json.Serialization.Metadata
                 {
                     ConfigureConstructorParameters();
                 }
+
+                // Check for misuse of required properties
+                // Ideally this check should be done during property.EnsureConfigured but at that point we have no knowledge about parametrized constructors
+                // and we cannot check if property is read-only correctly
+                foreach (KeyValuePair<string, JsonPropertyInfo> jsonPropertyInfoKv in PropertyCache.List)
+                {
+                    JsonPropertyInfo jsonPropertyInfo = jsonPropertyInfoKv.Value;
+                    jsonPropertyInfo.ValidateRequiredPropertyConfiguration();
+                }
+
+                ExtensionDataProperty?.ValidateRequiredPropertyConfiguration();
             }
 
             if (ElementType != null)
@@ -1006,6 +1017,7 @@ namespace System.Text.Json.Serialization.Metadata
             public JsonPropertyInfo JsonPropertyInfo { get; }
         }
 
+        [MemberNotNull(nameof(PropertyCache))]
         internal void ConfigureProperties()
         {
             Debug.Assert(Kind == JsonTypeInfoKind.Object);

--- a/src/libraries/System.Text.Json/tests/Common/RequiredKeywordTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/RequiredKeywordTests.cs
@@ -286,6 +286,67 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public async void ClassWithReadOnlyRequiredMemberInitializedInParameterizedCtor()
+        {
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
+            AssertJsonTypeInfoHasRequiredProperties(GetTypeInfo<PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor>(options),
+                nameof(PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor.Name));
+
+            var obj = new PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor("foo");
+
+            string json = await Serializer.SerializeWrapper(obj, options);
+            Assert.Equal("""{"Name":"foo"}""", json);
+
+            var deserialized = await Serializer.DeserializeWrapper<PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor>(json, options);
+            Assert.Equal(obj.Name, deserialized.Name);
+
+            json = "{}";
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(async () => await Serializer.DeserializeWrapper<PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor>(json, options));
+            Assert.Contains("Name", exception.Message);
+        }
+
+        public class PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor
+        {
+            [JsonRequired]
+            public string Name { get; }
+
+            public PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor(string name)
+            {
+                Name = name;
+            }
+        }
+
+        [Fact]
+        public async void ClassWithInitOnlyRequiredMemberInitializedInParameterizedCtor()
+        {
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
+            AssertJsonTypeInfoHasRequiredProperties(GetTypeInfo<PersonWithInitOnlyRequiredMemberInitializedInParameterizedCtor>(options),
+                nameof(PersonWithInitOnlyRequiredMemberInitializedInParameterizedCtor.Name));
+
+            var obj = new PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor("foo");
+
+            string json = await Serializer.SerializeWrapper(obj, options);
+            Assert.Equal("""{"Name":"foo"}""", json);
+
+            var deserialized = await Serializer.DeserializeWrapper<PersonWithInitOnlyRequiredMemberInitializedInParameterizedCtor>(json, options);
+            Assert.Equal(obj.Name, deserialized.Name);
+
+            json = "{}";
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(async () => await Serializer.DeserializeWrapper<PersonWithInitOnlyRequiredMemberInitializedInParameterizedCtor>(json, options));
+            Assert.Contains("Name", exception.Message);
+        }
+
+        public class PersonWithInitOnlyRequiredMemberInitializedInParameterizedCtor
+        {
+            public required string Name { get; init; }
+
+            public PersonWithInitOnlyRequiredMemberInitializedInParameterizedCtor(string name)
+            {
+                Name = name;
+            }
+        }
+
+        [Fact]
         public async Task ClassWithRequiredKeywordAndSetsRequiredMembersOnCtorWorks()
         {
             AssertJsonTypeInfoHasRequiredProperties(GetTypeInfo<PersonWithRequiredMembersAndSetsRequiredMembers>(Serializer.DefaultOptions)
@@ -492,20 +553,19 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task RequiredNonDeserializablePropertyThrows()
         {
-            JsonSerializerOptions options = Serializer.GetDefaultOptionsWithMetadataModifier(static ti =>
-            {
-                for (int i = 0; i < ti.Properties.Count; i++)
-                {
-                    if (ti.Properties[i].Name == nameof(PersonWithRequiredMembers.FirstName))
-                    {
-                        ti.Properties[i].Set = null;
-                    }
-                }
-            });
-
+            JsonSerializerOptions options = JsonSerializerOptions.Default;
             string json = """{"FirstName":"foo","MiddleName":"","LastName":"bar"}""";
-            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.DeserializeWrapper<PersonWithRequiredMembers>(json, options));
-            Assert.Contains(nameof(PersonWithRequiredMembers.FirstName), exception.Message);
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await Serializer.DeserializeWrapper<PersonWithRequiredReadOnlyMember>(json, options));
+            Assert.Contains(nameof(PersonWithRequiredReadOnlyMember.FirstName), exception.Message);
+        }
+
+        public class PersonWithRequiredReadOnlyMember
+        {
+            [JsonRequired]
+            public string FirstName { get; }
+            public string MiddleName { get; set; } = "";
+            [JsonRequired]
+            public string LastName { get; set; }
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/RequiredKeywordTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/RequiredKeywordTests.cs
@@ -29,6 +29,9 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(ClassWithRequiredExtensionDataProperty))]
         [JsonSerializable(typeof(ClassWithRequiredKeywordAndJsonRequiredCustomAttribute))]
         [JsonSerializable(typeof(ClassWithCustomRequiredPropertyName))]
+        [JsonSerializable(typeof(PersonWithReadOnlyRequiredMemberInitializedInParameterizedCtor))]
+        [JsonSerializable(typeof(PersonWithInitOnlyRequiredMemberInitializedInParameterizedCtor))]
+        [JsonSerializable(typeof(PersonWithRequiredReadOnlyMember))]
         internal sealed partial class RequiredKeywordTestsContext : JsonSerializerContext
         {
         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/78098

Fixes following scenario:

```csharp
using System.Text.Json.Serialization;

const string input = """{"value":1}""";
var obj = System.Text.Json.JsonSerializer.Deserialize<RequiredAttributeCtor>(input);

public sealed class RequiredAttributeCtor
{
    private int _value;

    [JsonPropertyName("value")]
    [JsonRequired]
    public int Value
    {
        get => _value;
        // Works when you uncomment:
        // set { throw new NotImplementedException(); }
        // Without setter:
        // Unhandled exception. System.InvalidOperationException: JsonPropertyInfo 'value' defined in type 'JsonRequired+RequiredAttributeCtor' is marked required but does not specify a setter.
    }

    public RequiredAttributeCtor(int value)
    {
        _value = value;
    }
}
```