### PR TITLE
Remove ENABLE_VISIBILITY_HIDDEN from mono.proj

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -404,7 +404,6 @@
     <!-- iOS/tvOS device specific options -->
     <ItemGroup Condition="('$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true') or ('$(TargetstvOS)' == 'true' and '$(TargetstvOSSimulator)' != 'true')">
       <_MonoCMakeArgs Include="-DENABLE_MINIMAL=jit,logging" />
-      <_MonoCMakeArgs Include="-DENABLE_VISIBILITY_HIDDEN=1"/>
       <_MonoCMakeArgs Include="-DENABLE_LAZY_GC_THREAD_CREATION=1"/>
       <_MonoCMakeArgs Include="-DENABLE_ICALL_EXPORT=1"/>
       <_MonoCFLAGS Include="-Werror=partial-availability" />


### PR DESCRIPTION
It was never wired up in the CMake based build system and we set visibility hidden by default now.