### PR TITLE
Exclude dynamic libraries in AppleAppBuilder for iOS device

### DIFF
--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -211,6 +211,10 @@ internal sealed class Xcode
     {
         // bundle everything as resources excluding native files
         var excludes = new List<string> { ".dll.o", ".dll.s", ".dwarf", ".m", ".h", ".a", ".bc", "libmonosgen-2.0.dylib", "libcoreclr.dylib" };
+        if (forceAOT)
+        {
+            excludes.Add(".dylib");
+        }
         if (optimized)
         {
             excludes.Add(".pdb");

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -211,7 +211,7 @@ internal sealed class Xcode
     {
         // bundle everything as resources excluding native files
         var excludes = new List<string> { ".dll.o", ".dll.s", ".dwarf", ".m", ".h", ".a", ".bc", "libmonosgen-2.0.dylib", "libcoreclr.dylib" };
-        if (forceAOT)
+        if (!preferDylibs)
         {
             excludes.Add(".dylib");
         }


### PR DESCRIPTION
AppleAppBuilder for iOS device uses static linking but doesn't exclude dynamic libraries from the disk which results in disk size overhead.

https://github.com/dotnet/runtime/blob/1205538e7a619e294fec7dc059df66072d302462/src/tasks/AppleAppBuilder/Xcode.cs#L316-L333


The same task is used for iOSSimulator where dynamic libraries are used, so the change excludes `.dylib` only when `preferDylibs=true`. Disk size reduction is ~2MB for the Mono sample iOS app.