### PR TITLE
Fix morph issue with fgOptimizeEqualityComparisonWithConst

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11418,12 +11418,8 @@ GenTree* Compiler::fgOptimizeEqualityComparisonWithConst(GenTreeOp* cmp)
                 rshiftOp->gtOp1 = andOp->gtGetOp2();
                 andOp->gtOp2    = rshiftOp;
 
-                rshiftOp->SetAllEffectsFlags(rshiftOp->gtGetOp1(), rshiftOp->gtGetOp2());
                 rshiftOp->SetOper(GT_LSH);
-                if (rshiftOp->OperRequiresCallFlag(this))
-                {
-                    rshiftOp->gtFlags |= GTF_CALL;
-                }
+                gtUpdateNodeSideEffects(rshiftOp);
             }
 
             // Reverse the condition if necessary.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11420,6 +11420,10 @@ GenTree* Compiler::fgOptimizeEqualityComparisonWithConst(GenTreeOp* cmp)
 
                 rshiftOp->SetAllEffectsFlags(rshiftOp->gtGetOp1(), rshiftOp->gtGetOp2());
                 rshiftOp->SetOper(GT_LSH);
+                if (rshiftOp->OperRequiresCallFlag(this))
+                {
+                    rshiftOp->gtFlags |= GTF_CALL;
+                }
             }
 
             // Reverse the condition if necessary.


### PR DESCRIPTION
- On arm32 a shift of a long requires a helper call, but the optimization in fgOptimizeEqualityComparisonWithConst for converting a right shift into a left shift was not keeping the GTF_CALL flag on the GenTree node.

This fix unblocks #74886

The issue manifests in an assert
```
Assertion failed '!"Missing flags on tree"' in 'JIT.HardwareIntrinsics.Arm._ArmBase.Arm64.ScalarUnaryOpTest__LeadingZeroCount_Int64:ValidateResult(long,int,System.String):this' during 'Morph - Global' (IL size 175; hash 0x7f7fb7e2; FullOpts)

Missing flags on tree [000013]: -C---------
               [000013] -----+------                        *  LSH       long  
               [000015] -----+------                        +--*  CNS_LNG   long   0x0000000000000001
               [000012] -----+------                        \--*  AND       int   
               [000010] -----+------                           +--*  LCL_VAR   int    V06 loc2         
               [000011] -----+------                           \--*  CNS_INT   int    63
```

The effect on the morphed tree is instead of generating
```
Morphing BB03 of 'JIT.HardwareIntrinsics.Arm._ArmBase.Arm64.ScalarUnaryOpTest__LeadingZeroCount_Int64:ValidateResult(long,int,System.String):this'

fgMorphTree BB03, STMT00004 (before)
               [000025] --C---------                        *  JTRUE     void  
               [000024] --C---------                        \--*  NE        int   
               [000019] --C---------                           +--*  EQ        int   
               [000016] --C---------                           |  +--*  AND       long  
               [000013] --C---------                           |  |  +--*  RSZ       long  
               [000009] ------------                           |  |  |  +--*  LCL_VAR   long   V01 arg1         
               [000012] ------------                           |  |  |  \--*  AND       int   
               [000010] ------------                           |  |  |     +--*  LCL_VAR   int    V06 loc2         
               [000011] ------------                           |  |  |     \--*  CNS_INT   int    63
               [000015] ------------                           |  |  \--*  CNS_LNG   long   0x0000000000000001
               [000018] ------------                           |  \--*  CNS_LNG   long   0x0000000000000000
               [000023] ------------                           \--*  CNS_INT   int    0

fgMorphTree BB03, STMT00004 (after)
               [000025] --C--+------                        *  JTRUE     void  
               [000019] J-C--+-N--S-                        \--*  EQ        int   
               [000016] --C--+----S-                           +--*  AND       long  
               [000009] -----+------                           |  +--*  LCL_VAR   long   V01 arg1         
*               [000013] -----+------                           |  \--*  LSH       long  
               [000015] -----+------                           |     +--*  CNS_LNG   long   0x0000000000000001
               [000012] -----+------                           |     \--*  AND       int   
               [000010] -----+------                           |        +--*  LCL_VAR   int    V06 loc2         
               [000011] -----+------                           |        \--*  CNS_INT   int    63
               [000018] -----+------                           \--*  CNS_LNG   long   0x0000000000000000
```

With the fix

```
Morphing BB03 of 'JIT.HardwareIntrinsics.Arm._ArmBase.Arm64.ScalarUnaryOpTest__LeadingZeroCount_Int64:ValidateResult(long,int,System.String):this'

fgMorphTree BB03, STMT00004 (before)
               [000025] --C---------                        *  JTRUE     void  
               [000024] --C---------                        \--*  NE        int   
               [000019] --C---------                           +--*  EQ        int   
               [000016] --C---------                           |  +--*  AND       long  
               [000013] --C---------                           |  |  +--*  RSZ       long  
               [000009] ------------                           |  |  |  +--*  LCL_VAR   long   V01 arg1         
               [000012] ------------                           |  |  |  \--*  AND       int   
               [000010] ------------                           |  |  |     +--*  LCL_VAR   int    V06 loc2         
               [000011] ------------                           |  |  |     \--*  CNS_INT   int    63
               [000015] ------------                           |  |  \--*  CNS_LNG   long   0x0000000000000001
               [000018] ------------                           |  \--*  CNS_LNG   long   0x0000000000000000
               [000023] ------------                           \--*  CNS_INT   int    0

fgMorphTree BB03, STMT00004 (after)
               [000025] --C--+------                        *  JTRUE     void  
               [000019] J-C--+-N--S-                        \--*  EQ        int   
               [000016] --C--+----S-                           +--*  AND       long  
               [000009] -----+------                           |  +--*  LCL_VAR   long   V01 arg1         
*               [000013] --C--+------                           |  \--*  LSH       long  
               [000015] -----+------                           |     +--*  CNS_LNG   long   0x0000000000000001
               [000012] -----+------                           |     \--*  AND       int   
               [000010] -----+------                           |        +--*  LCL_VAR   int    V06 loc2         
               [000011] -----+------                           |        \--*  CNS_INT   int    63
               [000018] -----+------                           \--*  CNS_LNG   long   0x0000000000000000
```