### PR TITLE
Fix bug in String.Equals unrolling for certain single-char strings

### DIFF
--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -324,11 +324,6 @@ GenTree* Compiler::impCreateCompareInd(GenTreeLclVar*        obj,
     GenTree*  addOffsetTree = gtNewOperNode(GT_ADD, TYP_BYREF, obj, offsetTree);
     GenTree*  indirTree     = gtNewIndir(type, addOffsetTree);
 
-    if (varTypeIsSmall(indirTree))
-    {
-        indirTree = gtNewCastNode(actualType, indirTree, true, varTypeToUnsigned(type));
-    }
-
     if (cmpMode == OrdinalIgnoreCase)
     {
         ssize_t mask;
@@ -385,7 +380,7 @@ GenTree* Compiler::impExpandHalfConstEqualsSWAR(
         //   [ ch1 ]
         //   [value]
         //
-        return impCreateCompareInd(data, TYP_SHORT, dataOffset, cns[0], cmpMode);
+        return impCreateCompareInd(data, TYP_USHORT, dataOffset, cns[0], cmpMode);
     }
     if (len == 2)
     {

--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -324,6 +324,11 @@ GenTree* Compiler::impCreateCompareInd(GenTreeLclVar*        obj,
     GenTree*  addOffsetTree = gtNewOperNode(GT_ADD, TYP_BYREF, obj, offsetTree);
     GenTree*  indirTree     = gtNewIndir(type, addOffsetTree);
 
+    if (varTypeIsSmall(indirTree))
+    {
+        indirTree = gtNewCastNode(actualType, indirTree, true, varTypeToUnsigned(type));
+    }
+
     if (cmpMode == OrdinalIgnoreCase)
     {
         ssize_t mask;
@@ -447,7 +452,7 @@ GenTree* Compiler::impExpandHalfConstEqualsSWAR(
             return nullptr;
         }
 
-        secondIndir = gtNewCastNode(TYP_LONG, secondIndir, true, TYP_LONG);
+        secondIndir = gtNewCastNode(TYP_LONG, secondIndir, true, TYP_ULONG);
         return gtNewOperNode(GT_EQ, TYP_INT, gtNewOperNode(GT_OR, TYP_LONG, firstIndir, secondIndir),
                              gtNewIconNode(0, TYP_LONG));
     }

--- a/src/coreclr/jit/importervectorization.cpp
+++ b/src/coreclr/jit/importervectorization.cpp
@@ -452,7 +452,7 @@ GenTree* Compiler::impExpandHalfConstEqualsSWAR(
             return nullptr;
         }
 
-        secondIndir = gtNewCastNode(TYP_LONG, secondIndir, true, TYP_ULONG);
+        secondIndir = gtNewCastNode(TYP_LONG, secondIndir, true, TYP_LONG);
         return gtNewOperNode(GT_EQ, TYP_INT, gtNewOperNode(GT_OR, TYP_LONG, firstIndir, secondIndir),
                              gtNewIconNode(0, TYP_LONG));
     }

--- a/src/tests/JIT/opt/Vectorization/StringEquals.cs
+++ b/src/tests/JIT/opt/Vectorization/StringEquals.cs
@@ -22,7 +22,7 @@ public class StringEquals
         }
 
         Console.WriteLine(testCount);
-        return testCount == 25920 ? 100 : 0;
+        return testCount == 27888 ? 100 : 0;
     }
 }
 
@@ -195,10 +195,22 @@ public static class Tests
     [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_157(string s) => ValidateEquals(s == "2ж1311a23b2212aЙ21Й11жb3233bb3a1", s, "2ж1311a23b2212aЙ21Й11жb3233bb3a1");
     [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_158(string s) => ValidateEquals(s == "01Й11113ь3Й32a3ьЙЙ3Й32b2ab221310", s, "01Й11113ь3Й32a3ьЙЙ3Й32b2ab221310");
     [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_159(string s) => ValidateEquals(s == "a120213b11211\0223223312ьь1Й3222Й", s, "a120213b11211\0223223312ьь1Й3222Й");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_160(string s) => ValidateEquals(s == "\u9244", s, "\u9244");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_161(string s) => ValidateEquals(s == "\u9244\u9244", s, "\u9244\u9244");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_162(string s) => ValidateEquals(s == "\u9244\u9244\u9244", s, "\u9244\u9244\u9244");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_163(string s) => ValidateEquals(s == "\uFFFF", s, "\uFFFF");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_164(string s) => ValidateEquals(s == "\uFFFF\uFFFF", s, "\uFFFF\uFFFF");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_165(string s) => ValidateEquals(s == "\uFFFF\uFFFF\uFFFF", s, "\uFFFF\uFFFF\uFFFF");
 
     public static readonly string[] s_TestData =
     {
         null,
+        "\u9244",
+        "\u9244\u9244",
+        "\u9244\u9244\u9244",
+        "\uFFFF",
+        "\uFFFF\uFFFF",
+        "\uFFFF\uFFFF\uFFFF",
         "",
         "\0",
         "a",

--- a/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWIth.cs
+++ b/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWIth.cs
@@ -18,7 +18,7 @@ public class UnrollEqualsStartsWIth
         int testCount = 0;
         foreach (var testType in testTypes)
             testCount += RunTests(testType);
-        return testCount == 113652 ? 100 : 0;
+        return testCount == 127512 ? 100 : 0;
     }
 
     public static int RunTests(Type type)
@@ -37,6 +37,12 @@ public class UnrollEqualsStartsWIth
 
         string[] testData =
         {
+            "\u9244",
+            "\u9244\u9244",
+            "\u9244\u9244\u9244",
+            "\uFFFF",
+            "\uFFFF\uFFFF",
+            "\uFFFF\uFFFF\uFFFF",
             "",
             string.Empty,
             "a",


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/78169 bug

For single-char strings with "signed" bit (e.g. `((ushort)'鉄') >> 15`) we used to do sign-extension instead of zero-extension 😞 
From my understanding, only single-char strings (length == 1) of certain two-bytes languages/symbols are affected (looks like mostly around CJK languages). Still, definitely needs to be backported to 7.0

