### PR TITLE
Change IMarshallingGenerator.AsNativeType to return ManagedTypeInfo instead of TypeSyntax

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Marshaling/BaseJSGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Marshaling/BaseJSGenerator.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Interop.JavaScript
             Type = marshalerType;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info) => _inner.AsNativeType(info);
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _inner.AsNativeType(info);
         public ParameterSyntax AsParameter(TypePositionInfo info) => _inner.AsParameter(info);
         public bool IsSupported(TargetFramework target, Version version) => _inner.IsSupported(target, version);
         public virtual bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => _inner.UsesNativeIdentifier(info, context);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Marshaling/EmptyJSGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Marshaling/EmptyJSGenerator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Interop.JavaScript
 {
     internal sealed class EmptyJSGenerator : IJSMarshallingGenerator
     {
-        public TypeSyntax AsNativeType(TypePositionInfo info) => info.ManagedType.Syntax;
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info) => info.ManagedType;
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
         public IEnumerable<ExpressionSyntax> GenerateBind(TypePositionInfo info, StubCodeContext context) => Array.Empty<ExpressionSyntax>();
         public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info) => SignatureBehavior.ManagedTypeAndAttributes;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BlittableMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BlittableMarshaller.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Interop
     {
         public bool IsSupported(TargetFramework target, Version version) => true;
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
-            return info.ManagedType.Syntax;
+            return info.ManagedType;
         }
 
         public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
@@ -51,7 +51,7 @@ namespace Microsoft.Interop
                 {
                     yield return FixedStatement(
                         VariableDeclaration(
-                            PointerType(AsNativeType(info)),
+                            PointerType(AsNativeType(info).Syntax),
                             SingletonSeparatedList(
                                 VariableDeclarator(Identifier(nativeIdentifier))
                                     .WithInitializer(EqualsValueClause(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BoolMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BoolMarshaller.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Interop
 {
     public abstract class BoolMarshallerBase : IMarshallingGenerator
     {
-        private readonly PredefinedTypeSyntax _nativeType;
+        private readonly ManagedTypeInfo _nativeType;
         private readonly int _trueValue;
         private readonly int _falseValue;
         private readonly bool _compareToTrue;
 
-        protected BoolMarshallerBase(PredefinedTypeSyntax nativeType, int trueValue, int falseValue, bool compareToTrue)
+        protected BoolMarshallerBase(ManagedTypeInfo nativeType, int trueValue, int falseValue, bool compareToTrue)
         {
             _nativeType = nativeType;
             _trueValue = trueValue;
@@ -29,7 +29,7 @@ namespace Microsoft.Interop
 
         public bool IsSupported(TargetFramework target, Version version) => true;
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
             Debug.Assert(info.ManagedType is SpecialTypeInfo(_, _, SpecialType.System_Boolean));
             return _nativeType;
@@ -66,7 +66,7 @@ namespace Microsoft.Interop
                                 SyntaxKind.SimpleAssignmentExpression,
                                 IdentifierName(nativeIdentifier),
                                 CastExpression(
-                                    AsNativeType(info),
+                                    AsNativeType(info).Syntax,
                                     ParenthesizedExpression(
                                         ConditionalExpression(IdentifierName(managedIdentifier),
                                             LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(_trueValue)),
@@ -119,7 +119,7 @@ namespace Microsoft.Interop
         /// </summary>
         /// <param name="signed">True if the byte should be signed, otherwise false</param>
         public ByteBoolMarshaller(bool signed)
-            : base(PredefinedType(Token(signed ? SyntaxKind.SByteKeyword : SyntaxKind.ByteKeyword)), trueValue: 1, falseValue: 0, compareToTrue: false)
+            : base(new SpecialTypeInfo(signed ? "sbyte" : "byte", signed ? "sbyte" : "byte", signed ? SpecialType.System_SByte : SpecialType.System_Byte), trueValue: 1, falseValue: 0, compareToTrue: false)
         {
         }
     }
@@ -137,7 +137,7 @@ namespace Microsoft.Interop
         /// </summary>
         /// <param name="signed">True if the int should be signed, otherwise false</param>
         public WinBoolMarshaller(bool signed)
-            : base(PredefinedType(Token(signed ? SyntaxKind.IntKeyword : SyntaxKind.UIntKeyword)), trueValue: 1, falseValue: 0, compareToTrue: false)
+            : base(new SpecialTypeInfo(signed ? "int" : "uint", signed ? "int" : "uint", signed ? SpecialType.System_Int32 : SpecialType.System_UInt32), trueValue: 1, falseValue: 0, compareToTrue: false)
         {
         }
     }
@@ -150,7 +150,7 @@ namespace Microsoft.Interop
         private const short VARIANT_TRUE = -1;
         private const short VARIANT_FALSE = 0;
         public VariantBoolMarshaller()
-            : base(PredefinedType(Token(SyntaxKind.ShortKeyword)), trueValue: VARIANT_TRUE, falseValue: VARIANT_FALSE, compareToTrue: true)
+            : base(new SpecialTypeInfo("short", "short", SpecialType.System_Int16), trueValue: VARIANT_TRUE, falseValue: VARIANT_FALSE, compareToTrue: true)
         {
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Interop
 {
     public sealed class Utf16CharMarshaller : IMarshallingGenerator
     {
-        private static readonly PredefinedTypeSyntax s_nativeType = PredefinedType(Token(SyntaxKind.UShortKeyword));
+        private static readonly ManagedTypeInfo s_nativeType = new SpecialTypeInfo("ushort", "ushort", SpecialType.System_UInt16);
 
         public Utf16CharMarshaller()
         {
@@ -36,7 +36,7 @@ namespace Microsoft.Interop
             return ValueBoundaryBehavior.AddressOfNativeIdentifier;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
             Debug.Assert(info.ManagedType is SpecialTypeInfo(_, _, SpecialType.System_Char));
             return s_nativeType;
@@ -70,12 +70,12 @@ namespace Microsoft.Interop
                         ),
                         // ushort* <native> = (ushort*)<pinned>;
                         LocalDeclarationStatement(
-                            VariableDeclaration(PointerType(AsNativeType(info)),
+                            VariableDeclaration(PointerType(AsNativeType(info).Syntax),
                                 SingletonSeparatedList(
                                     VariableDeclarator(nativeIdentifier)
                                         .WithInitializer(EqualsValueClause(
                                             CastExpression(
-                                                PointerType(AsNativeType(info)),
+                                                PointerType(AsNativeType(info).Syntax),
                                                 IdentifierName(PinnedIdentifier(info.InstanceIdentifier))))))))
                     );
                 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomTypeMarshallingGenerator.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Interop
             return info.IsByRef ? ValueBoundaryBehavior.AddressOfNativeIdentifier : ValueBoundaryBehavior.NativeIdentifier;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
             return _nativeTypeMarshaller.AsNativeType(info);
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Interop
     {
         public bool IsSupported(TargetFramework target, Version version) => true;
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
-            return MarshallerHelpers.SystemIntPtrType;
+            return SpecialTypeInfo.IntPtr;
         }
 
         public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ElementsMarshalling.cs
@@ -377,7 +377,7 @@ namespace Microsoft.Interop
                     List(_elementMarshaller.Generate(localElementInfo, elementSetupSubContext)
                         .Concat(elementStatements)));
 
-                if (_elementMarshaller.AsNativeType(_elementInfo) is PointerTypeSyntax elementNativeType)
+                if (_elementMarshaller.AsNativeType(_elementInfo).Syntax is PointerTypeSyntax elementNativeType)
                 {
                     PointerNativeTypeAssignmentRewriter rewriter = new(elementSetupSubContext.GetIdentifiers(localElementInfo).native, elementNativeType);
                     marshallingStatement = (StatementSyntax)rewriter.Visit(marshallingStatement);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Interop
     {
         public bool IsSupported(TargetFramework target, Version version) => true;
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
-            return info.ManagedType.Syntax;
+            return info.ManagedType;
         }
 
         public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomTypeMarshallingStrategy.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Interop
     /// </summary>
     internal interface ICustomTypeMarshallingStrategy
     {
-        TypeSyntax AsNativeType(TypePositionInfo info);
+        ManagedTypeInfo AsNativeType(TypePositionInfo info);
 
         IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Interop
         /// </summary>
         /// <param name="info">Object to marshal</param>
         /// <returns>Type syntax for the native type representing <paramref name="info"/></returns>
-        TypeSyntax AsNativeType(TypePositionInfo info);
+        ManagedTypeInfo AsNativeType(TypePositionInfo info);
 
         /// <summary>
         /// Get shape that represents the provided <paramref name="info"/> in the native signature

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Interop
         /// Get the native type syntax for <paramref name="info"/>
         /// </summary>
         /// <param name="info">Object to marshal</param>
-        /// <returns>Type syntax for the native type representing <paramref name="info"/></returns>
+        /// <returns>Managed type info for the native type representing <paramref name="info"/></returns>
         ManagedTypeInfo AsNativeType(TypePositionInfo info);
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Interop
             return generator.GetNativeSignatureBehavior(info) switch
             {
                 SignatureBehavior.ManagedTypeAndAttributes => info.ManagedType.Syntax,
-                SignatureBehavior.NativeType => generator.AsNativeType(info),
-                SignatureBehavior.PointerToNativeType => PointerType(generator.AsNativeType(info)),
+                SignatureBehavior.NativeType => generator.AsNativeType(info).Syntax,
+                SignatureBehavior.PointerToNativeType => PointerType(generator.AsNativeType(info).Syntax),
                 _ => throw new InvalidOperationException()
             };
         }
@@ -62,8 +62,8 @@ namespace Microsoft.Interop
             return Parameter(Identifier(info.InstanceIdentifier))
                 .WithType(behavior switch
                 {
-                    SignatureBehavior.NativeType => generator.AsNativeType(info),
-                    SignatureBehavior.PointerToNativeType => PointerType(generator.AsNativeType(info)),
+                    SignatureBehavior.NativeType => generator.AsNativeType(info).Syntax,
+                    SignatureBehavior.PointerToNativeType => PointerType(generator.AsNativeType(info).Syntax),
                     _ => throw new InvalidOperationException()
                 });
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Interop
             return target is TargetFramework.Net && version.Major >= 6;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
-            return MarshallerHelpers.SystemIntPtrType;
+            return SpecialTypeInfo.IntPtr;
         }
 
         public SignatureBehavior GetNativeSignatureBehavior(TypePositionInfo info)
@@ -117,7 +117,7 @@ namespace Microsoft.Interop
                         {
                             yield return LocalDeclarationStatement(
                                 VariableDeclaration(
-                                    AsNativeType(info),
+                                    AsNativeType(info).Syntax,
                                     SingletonSeparatedList(
                                         VariableDeclarator(handleValueBackupIdentifier)
                                         .WithInitializer(EqualsValueClause(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatefulMarshallingStrategy.cs
@@ -15,19 +15,19 @@ namespace Microsoft.Interop
     {
         internal const string MarshallerIdentifier = "marshaller";
         private readonly ManagedTypeInfo _marshallerType;
-        private readonly TypeSyntax _nativeTypeSyntax;
+        private readonly ManagedTypeInfo _unmanagedType;
         private readonly MarshallerShape _shape;
 
-        public StatefulValueMarshalling(ManagedTypeInfo marshallerType, TypeSyntax nativeTypeSyntax, MarshallerShape shape)
+        public StatefulValueMarshalling(ManagedTypeInfo marshallerType, ManagedTypeInfo unmanagedType, MarshallerShape shape)
         {
             _marshallerType = marshallerType;
-            _nativeTypeSyntax = nativeTypeSyntax;
+            _unmanagedType = unmanagedType;
             _shape = shape;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
-            return _nativeTypeSyntax;
+            return _unmanagedType;
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
@@ -210,7 +210,7 @@ namespace Microsoft.Interop
             _bufferElementType = bufferElementType;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
             return _innerMarshaller.AsNativeType(info);
         }
@@ -306,7 +306,7 @@ namespace Microsoft.Interop
             _numElementsExpression = numElementsExpression;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateCleanupStatements(info, context);
         public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateGuaranteedUnmarshalStatements(info, context);
 
@@ -446,7 +446,7 @@ namespace Microsoft.Interop
             _numElementsExpression = numElementsExpression;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
             StatementSyntax elementCleanup = GenerateElementCleanupStatement(info, context);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StatelessMarshallingStrategy.cs
@@ -18,19 +18,19 @@ namespace Microsoft.Interop
     internal sealed class StatelessValueMarshalling : ICustomTypeMarshallingStrategy
     {
         private readonly TypeSyntax _marshallerTypeSyntax;
-        private readonly TypeSyntax _nativeTypeSyntax;
+        private readonly ManagedTypeInfo _unmanagedType;
         private readonly MarshallerShape _shape;
 
-        public StatelessValueMarshalling(TypeSyntax marshallerTypeSyntax, TypeSyntax nativeTypeSyntax, MarshallerShape shape)
+        public StatelessValueMarshalling(TypeSyntax marshallerTypeSyntax, ManagedTypeInfo unmanagedType, MarshallerShape shape)
         {
             _marshallerTypeSyntax = marshallerTypeSyntax;
-            _nativeTypeSyntax = nativeTypeSyntax;
+            _unmanagedType = unmanagedType;
             _shape = shape;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
-            return _nativeTypeSyntax;
+            return _unmanagedType;
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
@@ -141,7 +141,7 @@ namespace Microsoft.Interop
             _isLinearCollectionMarshalling = isLinearCollectionMarshalling;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateCleanupStatements(info, context);
         public IEnumerable<StatementSyntax> GenerateGuaranteedUnmarshalStatements(TypePositionInfo info, StubCodeContext context) => _innerMarshaller.GenerateGuaranteedUnmarshalStatements(info, context);
 
@@ -247,7 +247,7 @@ namespace Microsoft.Interop
             _marshallerType = marshallerType;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _innerMarshaller.AsNativeType(info);
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
@@ -282,22 +282,22 @@ namespace Microsoft.Interop
     internal sealed class StatelessLinearCollectionBlittableElementsMarshalling : BlittableElementsMarshalling, ICustomTypeMarshallingStrategy
     {
         private readonly TypeSyntax _marshallerTypeSyntax;
-        private readonly TypeSyntax _nativeTypeSyntax;
+        private readonly ManagedTypeInfo _unmanagedType;
         private readonly MarshallerShape _shape;
         private readonly ExpressionSyntax _numElementsExpression;
 
-        public StatelessLinearCollectionBlittableElementsMarshalling(TypeSyntax marshallerTypeSyntax, TypeSyntax nativeTypeSyntax, MarshallerShape shape, TypeSyntax managedElementType, TypeSyntax unmanagedElementType, ExpressionSyntax numElementsExpression)
+        public StatelessLinearCollectionBlittableElementsMarshalling(TypeSyntax marshallerTypeSyntax, ManagedTypeInfo unmanagedType, MarshallerShape shape, TypeSyntax managedElementType, TypeSyntax unmanagedElementType, ExpressionSyntax numElementsExpression)
             : base(managedElementType, unmanagedElementType)
         {
             _marshallerTypeSyntax = marshallerTypeSyntax;
-            _nativeTypeSyntax = nativeTypeSyntax;
+            _unmanagedType = unmanagedType;
             _shape = shape;
             _numElementsExpression = numElementsExpression;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
-            return _nativeTypeSyntax;
+            return _unmanagedType;
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context) => Array.Empty<StatementSyntax>();
@@ -502,13 +502,13 @@ namespace Microsoft.Interop
     internal sealed class StatelessLinearCollectionNonBlittableElementsMarshalling : NonBlittableElementsMarshalling, ICustomTypeMarshallingStrategy
     {
         private readonly TypeSyntax _marshallerTypeSyntax;
-        private readonly TypeSyntax _nativeTypeSyntax;
+        private readonly ManagedTypeInfo _unmanagedType;
         private readonly MarshallerShape _shape;
         private readonly ExpressionSyntax _numElementsExpression;
 
         public StatelessLinearCollectionNonBlittableElementsMarshalling(
             TypeSyntax marshallerTypeSyntax,
-            TypeSyntax nativeTypeSyntax,
+            ManagedTypeInfo unmanagedType,
             MarshallerShape shape,
             TypeSyntax unmanagedElementType,
             IMarshallingGenerator elementMarshaller,
@@ -517,12 +517,12 @@ namespace Microsoft.Interop
             : base (unmanagedElementType, elementMarshaller, elementInfo)
         {
             _marshallerTypeSyntax = marshallerTypeSyntax;
-            _nativeTypeSyntax = nativeTypeSyntax;
+            _unmanagedType = unmanagedType;
             _shape = shape;
             _numElementsExpression = numElementsExpression;
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info) => _nativeTypeSyntax;
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info) => _unmanagedType;
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StaticPinnableManagedValueMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StaticPinnableManagedValueMarshaller.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Interop
         {
             if (IsPinningPathSupported(info, context))
             {
-                if (AsNativeType(info) is PointerTypeSyntax pointerType
+                if (AsNativeType(info).Syntax is PointerTypeSyntax pointerType
                     && pointerType.ElementType is PredefinedTypeSyntax predefinedType
                     && predefinedType.Keyword.IsKind(SyntaxKind.VoidKeyword))
                 {
@@ -42,7 +42,7 @@ namespace Microsoft.Interop
             return _innerMarshallingGenerator.GetValueBoundaryBehavior(info, context);
         }
 
-        public TypeSyntax AsNativeType(TypePositionInfo info)
+        public ManagedTypeInfo AsNativeType(TypePositionInfo info)
         {
             return _innerMarshallingGenerator.AsNativeType(info);
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/VariableDeclarations.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Interop
                 if (marshaller.Generator.UsesNativeIdentifier(marshaller.TypeInfo, context))
                 {
                     statementsToUpdate.Add(MarshallerHelpers.Declare(
-                        marshaller.Generator.AsNativeType(marshaller.TypeInfo),
+                        marshaller.Generator.AsNativeType(marshaller.TypeInfo).Syntax,
                         native,
                         initializeToDefault));
                 }


### PR DESCRIPTION
Change IMarshallingGenerator.AsNativeType to return a ManagedTypeInfo and not a TypeSyntax. We need to reason about this type for the unmanaged exception handling design, so using a ManagedTypeInfo is preferable. Split off from #77130 for eaiser review