### PR TITLE
Allow DecompressionHandler to be trimmed when the application isn't using AutomaticDecompression in HttpClient.

### DIFF
--- a/src/libraries/System.Net.Http/tests/TrimmingTests/DecompressionHandlerTrimmedTest.cs
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/DecompressionHandlerTrimmedTest.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+class Program
+{
+    static async Task<int> Main(string[] args)
+    {
+        using HttpClient client = new();
+
+        // send a request, but ignore its result
+        try
+        {
+            await client.GetAsync("https://www.microsoft.com");
+        }
+        catch { }
+
+        Type decompressionHandler = GetHttpType("System.Net.Http.DecompressionHandler");
+
+        // DecompressionHandler should have been trimmed since AutomaticDecompression was not used
+        if (decompressionHandler is not null)
+        {
+            return -1;
+        }
+
+        return 100;
+    }
+
+    // The intention of this method is to ensure the trimmer doesn't preserve the Type.
+    private static Type GetHttpType(string name) =>
+        typeof(HttpClient).Assembly.GetType(name, throwOnError: false);
+}

--- a/src/libraries/System.Net.Http/tests/TrimmingTests/System.Net.Http.TrimmingTests.proj
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/System.Net.Http.TrimmingTests.proj
@@ -2,6 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <ItemGroup>
+    <TestConsoleAppSourceFiles Include="DecompressionHandlerTrimmedTest.cs" />
     <TestConsoleAppSourceFiles Include="HttpClientTest.cs">
       <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes>
     </TestConsoleAppSourceFiles>


### PR DESCRIPTION
This allow for the Brotli and Deflate compression code to be trimmed in a NativeAOT app that uses HttpClient, which is about 1 MB of size savings on Linux.

The idea is to make a Delegate that will create the DecompressionHandler object. If no one calls the setter for `SocketsHttpHandler.AutomaticDecompression`, then the Delegate stays `null` and the `DecompressionHandler` class and its dependencies can be trimmed.