### PR TITLE
Fix `--singlemethodname`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -615,8 +615,7 @@ namespace ILCompiler
             if (method == null)
                 throw new CommandLineException($"Method '{singleMethodName}' not found in '{singleMethodTypeName}'");
 
-            if (method.HasInstantiation != (singleMethodGenericArgs.Length != 0) ||
-                (method.HasInstantiation && (method.Instantiation.Length != singleMethodGenericArgs.Length)))
+            if (method.Instantiation.Length != singleMethodGenericArgs.Length)
             {
                 throw new CommandLineException(
                     $"Expected {method.Instantiation.Length} generic arguments for method '{singleMethodName}' on type '{singleMethodTypeName}'");

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -615,7 +615,7 @@ namespace ILCompiler
             if (method == null)
                 throw new CommandLineException($"Method '{singleMethodName}' not found in '{singleMethodTypeName}'");
 
-            if (method.HasInstantiation != (singleMethodGenericArgs != null) ||
+            if (method.HasInstantiation != (singleMethodGenericArgs.Length != 0) ||
                 (method.HasInstantiation && (method.Instantiation.Length != singleMethodGenericArgs.Length)))
             {
                 throw new CommandLineException(


### PR DESCRIPTION
Single method compilation mode broke with the change to use System.CommandLine. "Not specified" no longer means `null`.

Cc @dotnet/ilc-contrib 