### PR TITLE
Arm64: Support additional condition checks in select nodes

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -4752,6 +4752,17 @@ void CodeGen::genCodeForSelect(GenTreeConditional* tree)
     const GenConditionDesc& prevDesc  = GenConditionDesc::Get(prevCond);
 
     emit->emitIns_R_R_R_COND(INS_csel, attr, targetReg, srcReg1, srcReg2, JumpKindToInsCond(prevDesc.jumpKind1));
+
+    // Some conditions require an additional condition check.
+    if (prevDesc.oper == GT_OR)
+    {
+        emit->emitIns_R_R_R_COND(INS_csel, attr, targetReg, srcReg1, targetReg, JumpKindToInsCond(prevDesc.jumpKind2));
+    }
+    else if (prevDesc.oper == GT_AND)
+    {
+        emit->emitIns_R_R_R_COND(INS_csel, attr, targetReg, targetReg, srcReg2, JumpKindToInsCond(prevDesc.jumpKind2));
+    }
+
     regSet.verifyRegUsed(targetReg);
     genProduceReg(tree);
 }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4853,7 +4853,8 @@ bool Compiler::optIfConvert(BasicBlock* block)
     }
 
     // Invert the condition.
-    cond->gtOper = GenTree::ReverseRelop(cond->gtOper);
+    GenTree* revCond = gtReverseCond(cond);
+    assert(cond == revCond); // Ensure `gtReverseCond` did not create a new node.
 
     // Create a select node.
     GenTreeConditional* select =

--- a/src/tests/JIT/opt/Compares/compares.cs
+++ b/src/tests/JIT/opt/Compares/compares.cs
@@ -72,6 +72,111 @@ public class FullRangeComparisonTest
     
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool EqualsOrGreaterThan_MaxValue_LHSConst_SideEffects(SideEffects c) => c.B <= 255;
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void consume<T>(T a1, T a2) {}
+
+    /* If conditions that are consumed. */
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Eq_byte_consume(byte a1, byte a2) {
+        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
+        //ARM64-FULL-LINE-NEXT: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, eq
+        if (a1 == a2) { a1 = 10; }
+        consume<byte>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Ne_short_consume(short a1, short a2)
+    {
+        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ne
+        if (a1 != a2) { a1 = 11; }
+        consume<short>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Lt_int_consume(int a1, int a2)
+    {
+        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, lt
+        if (a1 < a2) { a1 = 12; }
+        consume<int>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Le_long_consume(long a1, long a2)
+    {
+        //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, le
+        if (a1 <= a2) { a1 = 13; }
+        consume<long>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Gt_ushort_consume(ushort a1, ushort a2)
+    {
+        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, gt
+        if (a1 > a2) { a1 = 14; }
+        consume<ushort>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Ge_uint_consume(uint a1, uint a2)
+    {
+        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ge
+        if (a1 >= a2) { a1 = 15; }
+        consume<uint>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Eq_ulong_consume(ulong a1, ulong a2)
+    {
+        //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, eq
+        if (a1 == a2) { a1 = 16; }
+        consume<ulong>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Ne_float_int_consume(float f1, float f2, int a1, int a2)
+    {
+        //ARM64-FULL-LINE: fcmp {{s[0-9]+}}, {{s[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ne
+        if (f1 != f2) { a1 = 17; }
+        consume<float>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Lt_double_long_consume(double f1, double f2, long a1, long a2)
+    {
+        //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, lt
+        if (f1 < f2) { a1 = 18; }
+        consume<double>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Eq_double_long_consume(double f1, double f2, long a1, long a2)
+    {
+        //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, eq
+        if (f1 == f2) { a1 = 18; }
+        consume<double>(a1, a2);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Ne_double_int_consume(double f1, double f2, int a1, int a2)
+    {
+        //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ne
+        if (f1 != f2) { a1 = 18; }
+        consume<double>(a1, a2);
+    }
+
     public static int Main()
     {
         // Optimize comparison with full range values
@@ -197,7 +302,19 @@ public class FullRangeComparisonTest
             Console.WriteLine("FullRangeComparisonTest:EqualsOrGreaterThan_MaxValue_LHSConst_SideEffects(null) failed");
             return 101;
         }
-      
+
+        Eq_byte_consume(10, 11);
+        Ne_short_consume(10, 11);
+        Lt_int_consume(10, 11);
+        Le_long_consume(10, 11);
+        Gt_ushort_consume(10, 11);
+        Ge_uint_consume(10, 11);
+        Eq_ulong_consume(10, 11);
+        Ne_float_int_consume(10.1F, 11.1F, 12, 13);
+        Lt_double_long_consume(10.1, 11.1, 12, 13);
+        Eq_double_long_consume(10.1, 11.1, 12, 13);
+        Ne_double_int_consume(10.1, 11.1, 12, 13);
+
         Console.WriteLine("PASSED");
         return 100;
     }

--- a/src/tests/JIT/opt/Compares/compares.csproj
+++ b/src/tests/JIT/opt/Compares/compares.csproj
@@ -3,10 +3,15 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType>PdbOnly</DebugType>
+    <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildProjectName).cs" />
+    <Compile Include="$(MSBuildProjectName).cs">
+      <HasDisasmCheck>true</HasDisasmCheck>
+    </Compile>
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Generating a FEQ or FNEU can generate an incorrect compare.

Firstly, the optimizer needs changing to ensure the NAN flag is correct.

Once that is fixed, it's not possible to generate a test to trigger the code in codegen (as there are no CIL beq.un or bne instructions). However, the codegen code was wrong.

Alternatively, given it's untested, it might be better to replace the codegen changes with some asserts?

I've added some general compare consume tests to ensure everything is generated ok.