### PR TITLE
[release/7.0] Fix bug in String.Equals unrolling for CJK single-char strings

### DIFF
--- a/src/coreclr/jit/importer_vectorization.cpp
+++ b/src/coreclr/jit/importer_vectorization.cpp
@@ -380,7 +380,7 @@ GenTree* Compiler::impExpandHalfConstEqualsSWAR(
         //   [ ch1 ]
         //   [value]
         //
-        return impCreateCompareInd(data, TYP_SHORT, dataOffset, cns[0], cmpMode);
+        return impCreateCompareInd(data, TYP_USHORT, dataOffset, cns[0], cmpMode);
     }
     if (len == 2)
     {

--- a/src/tests/JIT/opt/Vectorization/StringEquals.cs
+++ b/src/tests/JIT/opt/Vectorization/StringEquals.cs
@@ -22,7 +22,7 @@ public class StringEquals
         }
 
         Console.WriteLine(testCount);
-        return testCount == 25920 ? 100 : 0;
+        return testCount == 27888 ? 100 : 0;
     }
 }
 
@@ -195,10 +195,22 @@ public static class Tests
     [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_157(string s) => ValidateEquals(s == "2ж1311a23b2212aЙ21Й11жb3233bb3a1", s, "2ж1311a23b2212aЙ21Й11жb3233bb3a1");
     [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_158(string s) => ValidateEquals(s == "01Й11113ь3Й32a3ьЙЙ3Й32b2ab221310", s, "01Й11113ь3Й32a3ьЙЙ3Й32b2ab221310");
     [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_159(string s) => ValidateEquals(s == "a120213b11211\0223223312ьь1Й3222Й", s, "a120213b11211\0223223312ьь1Й3222Й");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_160(string s) => ValidateEquals(s == "\u9244", s, "\u9244");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_161(string s) => ValidateEquals(s == "\u9244\u9244", s, "\u9244\u9244");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_162(string s) => ValidateEquals(s == "\u9244\u9244\u9244", s, "\u9244\u9244\u9244");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_163(string s) => ValidateEquals(s == "\uFFFF", s, "\uFFFF");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_164(string s) => ValidateEquals(s == "\uFFFF\uFFFF", s, "\uFFFF\uFFFF");
+    [MethodImpl(MethodImplOptions.NoInlining)] public static void Equals_165(string s) => ValidateEquals(s == "\uFFFF\uFFFF\uFFFF", s, "\uFFFF\uFFFF\uFFFF");
 
     public static readonly string[] s_TestData =
     {
         null,
+        "\u9244",
+        "\u9244\u9244",
+        "\u9244\u9244\u9244",
+        "\uFFFF",
+        "\uFFFF\uFFFF",
+        "\uFFFF\uFFFF\uFFFF",
         "",
         "\0",
         "a",

--- a/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWIth.cs
+++ b/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWIth.cs
@@ -18,7 +18,7 @@ public class UnrollEqualsStartsWIth
         int testCount = 0;
         foreach (var testType in testTypes)
             testCount += RunTests(testType);
-        return testCount == 113652 ? 100 : 0;
+        return testCount == 127512 ? 100 : 0;
     }
 
     public static int RunTests(Type type)
@@ -37,6 +37,12 @@ public class UnrollEqualsStartsWIth
 
         string[] testData =
         {
+            "\u9244",
+            "\u9244\u9244",
+            "\u9244\u9244\u9244",
+            "\uFFFF",
+            "\uFFFF\uFFFF",
+            "\uFFFF\uFFFF\uFFFF",
             "",
             string.Empty,
             "a",


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/78190 to release/7.0

## Customer Impact
Fixes https://github.com/dotnet/runtime/issues/78169 regression introduced in the String.Equals/StartsWith unrolling optimization in NET 7.0. 
```csharp
const String v1 = "鉄";
var v2 = v1;
Console.WriteLine($"{v1 == v2}, {v1.Equals(v2, StringComparison.Ordinal)}, {v1.Equals(v2,StringComparison.OrdinalIgnoreCase)}");
```
Prints different values depending on code being optimized or not (by jit). All comparisons against single-char literals of certain symbols (all two-bytes chars which pass this check: `bool IsAffected(char c) => (((ushort)c) >> 15) == 1;`) of CJK languages are affected so we probably want to land the fix it as soon as possible.

## Testing
We had a pretty big test coverage for all sorts of inputs for that optimizations, unfortunately, for the non-ASCII one we didn't use any of CJK symbols. Added CJK and did a fuzzy testing locally via a hand-written test generator for this API.

## Risk
Low
