### PR TITLE
Forcing auto binding redirects on Microsoft.Extensions.Logging.Console.Tests to fix test issue.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
@@ -5,6 +5,11 @@
     <TestRuntime>true</TestRuntime>
     <EnableDefaultItems>true</EnableDefaultItems>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <!-- This test project builds against implementation assemblies while the src
+    projects build against ref assemblies, so sometimes AssemblyVersions may
+    mismatch. Generating Binding redirects automatically will guarantee that for
+    these cases, the loader is still able to run the tests succesfully. -->
+    <AutoGenerateBindingRedirects Condition="'$(TargetFramework)' == '$(NetFrameworkMinimum)'">true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77988

cc: @carlossanlop @tarekgh @ViktorHofer @ericstj 