### PR TITLE
System.Diagnostics.TraceSource readme small typo

### DIFF
--- a/src/libraries/System.Diagnostics.TraceSource/README.md
+++ b/src/libraries/System.Diagnostics.TraceSource/README.md
@@ -14,4 +14,4 @@ See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3
 
 ## Deployment
 
-`System.Diagnostics.TraceSource` is provided as part of the `Microsoft.WindowsDesktop.App` shared framework.
+`System.Diagnostics.TraceSource` is provided as part of the `Microsoft.NETCore.App` shared framework.


### PR DESCRIPTION
The framework where we publish it is NETCore.App, not WindowsDesktop.