### PR TITLE
fix MulticastLoopback option for IPv6

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -279,10 +279,12 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Fact]
-        public void MulticastLoopback_Roundtrips()
+        [Theory]
+        [InlineData(AddressFamily.InterNetwork)]
+        [InlineData(AddressFamily.InterNetworkV6)]
+        public void MulticastLoopback_Roundtrips(AddressFamily addressFamily)
         {
-            using (var udpClient = new UdpClient())
+            using (var udpClient = new UdpClient(addressFamily))
             {
                 Assert.True(udpClient.MulticastLoopback);
                 udpClient.MulticastLoopback = false;
@@ -628,10 +630,10 @@ namespace System.Net.Sockets.Tests
             using (var sender = new UdpClient(new IPEndPoint(address, 0)))
             {
                 await sender.SendAsync(new byte[1], 1, new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
-				await AssertReceiveAsync(receiver);
-				
-				await sender.SendAsync(new ReadOnlyMemory<byte>(new byte[1]), new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
-				await AssertReceiveAsync(receiver);
+                await AssertReceiveAsync(receiver);
+
+                await sender.SendAsync(new ReadOnlyMemory<byte>(new byte[1]), new IPEndPoint(address, ((IPEndPoint)receiver.Client.LocalEndPoint).Port));
+                await AssertReceiveAsync(receiver);
             }
         }
 

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -1848,6 +1848,10 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
                     *optName = IPV6_MULTICAST_IF;
                     return true;
 
+               case SocketOptionName_SO_IP_MULTICAST_LOOP:
+                    *optName = IPV6_MULTICAST_LOOP;
+                    return true;
+
                 case SocketOptionName_SO_IP_MULTICAST_TTL:
                     *optName = IPV6_MULTICAST_HOPS;
                     return true;


### PR DESCRIPTION
fixes #78275
seems like clear omission in PAL. Update test looks like:
```
strace: Process 36877 attached
[pid 36873] socket(AF_INET, SOCK_DGRAM|SOCK_CLOEXEC, IPPROTO_UDP) = 178
[pid 36873] getsockopt(178, SOL_IP, IP_MULTICAST_LOOP, [1], [4]) = 0
[pid 36873] setsockopt(178, SOL_IP, IP_MULTICAST_LOOP, [0], 4) = 0
[pid 36873] getsockopt(178, SOL_IP, IP_MULTICAST_LOOP, [0], [4]) = 0
[pid 36873] setsockopt(178, SOL_IP, IP_MULTICAST_LOOP, [1], 4) = 0
[pid 36873] getsockopt(178, SOL_IP, IP_MULTICAST_LOOP, [1], [4]) = 0
[pid 36873] shutdown(178, SHUT_RDWR)    = -1 ENOTCONN (Transport endpoint is not connected)
[pid 36873] socket(AF_INET6, SOCK_DGRAM|SOCK_CLOEXEC, IPPROTO_UDP) = 178
[pid 36873] setsockopt(178, SOL_IPV6, IPV6_V6ONLY, [1], 4) = 0
[pid 36873] getsockopt(178, SOL_IPV6, IPV6_MULTICAST_LOOP, [1], [4]) = 0
[pid 36873] setsockopt(178, SOL_IPV6, IPV6_MULTICAST_LOOP, [0], 4) = 0
[pid 36873] getsockopt(178, SOL_IPV6, IPV6_MULTICAST_LOOP, [0], [4]) = 0
[pid 36873] setsockopt(178, SOL_IPV6, IPV6_MULTICAST_LOOP, [1], 4) = 0
[pid 36873] getsockopt(178, SOL_IPV6, IPV6_MULTICAST_LOOP, [1], [4]) = 0
[pid 36873] shutdown(178, SHUT_RDWR)    = -1 ENOTCONN (Transport endpoint is not connected)
```
