### PR TITLE
Fix nullable annotations in ITypeDescriptorContext

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -694,9 +694,9 @@ namespace System.ComponentModel
     }
     public partial interface ITypeDescriptorContext : System.IServiceProvider
     {
-        System.ComponentModel.IContainer Container { get; }
-        object Instance { get; }
-        System.ComponentModel.PropertyDescriptor PropertyDescriptor { get; }
+        System.ComponentModel.IContainer? Container { get; }
+        object? Instance { get; }
+        System.ComponentModel.PropertyDescriptor? PropertyDescriptor { get; }
         void OnComponentChanged();
         bool OnComponentChanging();
     }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ITypeDescriptorContext.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ITypeDescriptorContext.cs
@@ -12,17 +12,17 @@ namespace System.ComponentModel
         /// <summary>
         /// Gets the container with the set of objects for this formatter.
         /// </summary>
-        IContainer Container { get; }
+        IContainer? Container { get; }
 
         /// <summary>
         /// Gets the instance that is invoking the method on the formatter object.
         /// </summary>
-        object Instance { get; }
+        object? Instance { get; }
 
         /// <summary>
         /// Retrieves the PropertyDescriptor that is surfacing the given context item.
         /// </summary>
-        PropertyDescriptor PropertyDescriptor { get; }
+        PropertyDescriptor? PropertyDescriptor { get; }
 
         /// <summary>
         /// Gets a value indicating whether this object can be changed.

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReferenceConverter.cs
@@ -147,7 +147,7 @@ namespace System.ComponentModel
                 else
                 {
                     // Now try IContainer.
-                    IContainer cont = context.Container;
+                    IContainer? cont = context.Container;
                     if (cont != null)
                     {
                         ComponentCollection objs = cont.Components;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/Design/DirectoryEntryConverter.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/Design/DirectoryEntryConverter.cs
@@ -38,7 +38,7 @@ namespace System.DirectoryServices.Design
                     {
                         newEntry = new DirectoryEntry(text);
                         s_componentsCreated[text] = newEntry;
-                        context?.Container.Add(newEntry);
+                        context?.Container?.Add(newEntry);
 
                         return newEntry;
                     }


### PR DESCRIPTION
According to:
https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.itypedescriptorcontext.container?view=net-7.0
https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.itypedescriptorcontext.instance?view=net-7.0
https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.itypedescriptorcontext.propertydescriptor?view=net-7.0
these can be null.
I bumped into this problem while annotating `GridEntry` in WinForms repository.
https://github.com/dotnet/winforms/blob/ecc6966e1eb76d7c9921638137e058f2243d7dd9/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs#L170