### PR TITLE
Fix CreateDirectory exception in crossgen2

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -397,7 +397,11 @@ namespace ILCompiler
         {
             EcmaModule inputModule = NodeFactory.TypeSystemContext.GetModuleFromPath(inputFile);
 
-            Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
+            string outputFileDir = Path.GetDirectoryName(outputFile);
+            if (!string.IsNullOrEmpty(outputFileDir))
+            {
+                Directory.CreateDirectory(outputFileDir);
+            }
 
             ReadyToRunFlags flags =
                 ReadyToRunFlags.READYTORUN_FLAG_Component |


### PR DESCRIPTION
When I invoke crossgen2.exe directly (for composite mode) and pass just file names from the current directory it throws an exception trying to create an empty directory.

Another issue with crossgen2 composite that it doesn't work with `*.dll` wildcard on windows - it complains on native libraries.