### PR TITLE
Use zero register in csel when possible

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -4746,9 +4746,12 @@ void CodeGen::genCodeForSelect(GenTreeConditional* tree)
         prevCond = GenCondition::NE;
     }
 
+    assert(!op1->isContained() || op1->IsIntegralConst(0));
+    assert(!op2->isContained() || op2->IsIntegralConst(0));
+
     regNumber               targetReg = tree->GetRegNum();
-    regNumber               srcReg1   = genConsumeReg(op1);
-    regNumber               srcReg2   = genConsumeReg(op2);
+    regNumber               srcReg1   = op1->IsIntegralConst(0) ? REG_ZR : genConsumeReg(op1);
+    regNumber               srcReg2   = op2->IsIntegralConst(0) ? REG_ZR : genConsumeReg(op2);
     const GenConditionDesc& prevDesc  = GenConditionDesc::Get(prevCond);
 
     emit->emitIns_R_R_R_COND(INS_csel, attr, targetReg, srcReg1, srcReg2, JumpKindToInsCond(prevDesc.jumpKind1));

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -525,8 +525,8 @@ void emitter::emitInsSanityCheck(instrDesc* id)
         case IF_DR_3D: // DR_3D   X..........mmmmm cccc..nnnnnmmmmm      Rd Rn Rm cond
             assert(isValidGeneralDatasize(id->idOpSize()));
             assert(isGeneralRegister(id->idReg1()));
-            assert(isGeneralRegister(id->idReg2()));
-            assert(isGeneralRegister(id->idReg3()));
+            assert(isGeneralRegisterOrZR(id->idReg2()));
+            assert(isGeneralRegisterOrZR(id->idReg3()));
             assert(isValidImmCond(emitGetInsSC(id)));
             break;
 
@@ -7345,8 +7345,8 @@ void emitter::emitIns_R_R_R_COND(
         case INS_csinv:
         case INS_csneg:
             assert(isGeneralRegister(reg1));
-            assert(isGeneralRegister(reg2));
-            assert(isGeneralRegister(reg3));
+            assert(isGeneralRegisterOrZR(reg2));
+            assert(isGeneralRegisterOrZR(reg3));
             cfi.cond = cond;
             fmt      = IF_DR_3D;
             break;

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2463,6 +2463,13 @@ void Lowering::ContainCheckSelect(GenTreeConditional* node)
             ContainCheckCompare(startOfChain->AsOp());
         }
     }
+
+    if(node->gtOp1->IsIntegralConst(0)) {
+        MakeSrcContained(node, node->gtOp1);
+    }
+    if(node->gtOp2->IsIntegralConst(0)) {
+        MakeSrcContained(node, node->gtOp2);
+    }
 }
 
 #endif // TARGET_ARM64

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2464,10 +2464,12 @@ void Lowering::ContainCheckSelect(GenTreeConditional* node)
         }
     }
 
-    if(node->gtOp1->IsIntegralConst(0)) {
+    if (node->gtOp1->IsIntegralConst(0))
+    {
         MakeSrcContained(node, node->gtOp1);
     }
-    if(node->gtOp2->IsIntegralConst(0)) {
+    if (node->gtOp2->IsIntegralConst(0))
+    {
         MakeSrcContained(node, node->gtOp2);
     }
 }


### PR DESCRIPTION
For 
```
static void foo(int a, int b) {
    if(a == 5) {
        b = 0;
    }
    consume<int>(a, b);
}
```

Without this patch we get
```
...
2A1F03E2          mov     w2, wzr     <=== avoidable mov
7100141F          cmp     w0, #5
1A810041          csel    w1, w2, w1, eq
D29EA202          movz    x2, #0xF510
F2A85BC2          movk    x2, #0x42DE LSL #16
F2DFFFE2          movk    x2, #0xFFFF LSL #32
F9400042          ldr     x2, [x2]
D63F0040          blr     x2
...
```
After:
```
...
7100141F          cmp     w0, #5
1A8103E1          csel    w1, wzr, w1, eq
D29EA202          movz    x2, #0xF510
F2AF0D62          movk    x2, #0x786B LSL #16
F2DFFFE2          movk    x2, #0xFFFF LSL #32
F9400042          ldr     x2, [x2]
D63F0040          blr     x2
...
```