### PR TITLE
Adding check on R2RDump

### DIFF
--- a/src/coreclr/tools/r2rdump/Program.cs
+++ b/src/coreclr/tools/r2rdump/Program.cs
@@ -445,7 +445,7 @@ namespace R2RDump
                 {
                     // parse the ReadyToRun image
                     ReadyToRunReader r2r = new(model, filename);
-
+                    r2r.ValidateDebugInfo = Get(_command.ValidateDebugInfo);
                     if (disasm)
                     {
                         disassembler = new Disassembler(r2r, model);

--- a/src/coreclr/tools/r2rdump/R2RDumpRootCommand.cs
+++ b/src/coreclr/tools/r2rdump/R2RDumpRootCommand.cs
@@ -76,6 +76,8 @@ namespace R2RDump
             new(new[] { "--signatureBinary", "--sb" }, "Append signature binary to its textual representation");
         public Option<bool> InlineSignatureBinary { get; } =
             new(new[] { "--inlineSignatureBinary", "--isb" }, "Embed binary signature into its textual representation");
+        public Option<bool> ValidateDebugInfo { get; } =
+            new(new[] { "--validateDebugInfo", "--val" }, "Validate functions reported debug info.");
 
         public ParseResult Result;
 
@@ -118,6 +120,7 @@ namespace R2RDump
 
             AddOption(SignatureBinary);
             AddOption(InlineSignatureBinary);
+            AddOption(ValidateDebugInfo);
 
             this.SetHandler(context =>
             {

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -93,7 +93,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
             __Command+=" dotnet"
         fi
         __R2RDumpCommand=$__Command" $CORE_ROOT/R2RDump/R2RDump.dll"
-        __R2RDumpCommand+=" --header --sc --in $__OutputFile --out $__OutputFile.r2rdump"
+        __R2RDumpCommand+=" --header --sc --in $__OutputFile --out $__OutputFile.r2rdump --val"
         __Command+=" $CORE_ROOT/crossgen2/crossgen2.dll"
         __Command+=" @$__ResponseFile"
         __Command+=" $ExtraCrossGen2Args"
@@ -239,7 +239,7 @@ if defined RunCrossGen2 (
         set __Command=!__Command! "dotnet"
     )
     set __R2RDumpCommand=!__Command! "!CORE_ROOT!\r2rdump\r2rdump.dll"
-    set __R2RDumpCommand=!__R2RDumpCommand! --header --sc --in !__OutputFile! --out !__OutputFile!.r2rdump
+    set __R2RDumpCommand=!__R2RDumpCommand! --header --sc --in !__OutputFile! --out !__OutputFile!.r2rdump --val
     set __Command=!__Command! "!CORE_ROOT!\crossgen2\crossgen2.dll"
     set __Command=!__Command! @"!__ResponseFile!"
     set __Command=!__Command! !ExtraCrossGen2Args!

--- a/src/tests/readytorun/r2rdump/BasicTests/R2RDumpTest.csproj
+++ b/src/tests/readytorun/r2rdump/BasicTests/R2RDumpTest.csproj
@@ -4,6 +4,7 @@
     <CLSCompliant>false</CLSCompliant>
     <CoreClrDir>..\..\..\..\..\..\</CoreClrDir>
     <R2RDumpCommand>$(CoreClrDir)artifacts\bin\coreclr\$(TargetOS).$(TargetArchitecture).$(Configuration)\netcoreapp2.0\R2RDump.dll</R2RDumpCommand>
+    <R2RDumpCommandArguments>-x -v --ignoreSensitive --val</R2RDumpCommandArguments>
     <DotnetToolCommand>$(CoreClrDir).dotnet\dotnet</DotnetToolCommand>
     <BashCoreClrDir>../../../../../../</BashCoreClrDir>
     <BashR2RDumpCommand>$(BashCoreClrDir)artifacts/bin/coreclr/$(TargetOS).$(TargetArchitecture).$(Configuration)/netcoreapp2.0/R2RDump.dll</BashR2RDumpCommand>
@@ -36,10 +37,10 @@ $(CLRTestBatchPreCommands)
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out GcInfoTransitions.ni.dll GcInfoTransitions.dll
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out GenericFunctions.ni.dll GenericFunctions.dll
 %Core_Root%\crossgen /readytorun /platform_assemblies_paths %Core_Root%%3B%25CD% /out MultipleRuntimeFunctions.ni.dll MultipleRuntimeFunctions.dll
-$(DotnetToolCommand) $(R2RDumpCommand) --in HelloWorld.ni.dll --out HelloWorld-test.xml -x -v --ignoreSensitive
-$(DotnetToolCommand) $(R2RDumpCommand) --in GcInfoTransitions.ni.dll --out GcInfoTransitions-test.xml -x -v --ignoreSensitive
-$(DotnetToolCommand) $(R2RDumpCommand) --in GenericFunctions.ni.dll --out GenericFunctions-test.xml -x -v --ignoreSensitive
-$(DotnetToolCommand) $(R2RDumpCommand) --in MultipleRuntimeFunctions.ni.dll --out MultipleRuntimeFunctions-test.xml -x -v --ignoreSensitive
+$(DotnetToolCommand) $(R2RDumpCommand) --in HelloWorld.ni.dll --out HelloWorld-test.xml $(R2RDumpCommandArguments)
+$(DotnetToolCommand) $(R2RDumpCommand) --in GcInfoTransitions.ni.dll --out GcInfoTransitions-test.xml $(R2RDumpCommandArguments)
+$(DotnetToolCommand) $(R2RDumpCommand) --in GenericFunctions.ni.dll --out GenericFunctions-test.xml $(R2RDumpCommandArguments)
+$(DotnetToolCommand) $(R2RDumpCommand) --in MultipleRuntimeFunctions.ni.dll --out MultipleRuntimeFunctions-test.xml $(R2RDumpCommandArguments)
 ]]></CLRTestBatchPreCommands>
     <CLRTestBashPreCommands><![CDATA[
 $(CLRTestBashPreCommands)
@@ -47,10 +48,10 @@ $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out GcInfoTransitions.ni.dll GcInfoTransitions.dll
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out GenericFunctions.ni.dll GenericFunctions.dll
 $CORE_ROOT/crossgen -readytorun -platform_assemblies_paths $CORE_ROOT:`pwd` -out MultipleRuntimeFunctions.ni.dll MultipleRuntimeFunctions.dll
-$(BashDotnetToolCommand) $(BashR2RDumpCommand) --in HelloWorld.ni.dll --out HelloWorld-test.xml -x -v --ignoreSensitive
-$(BashDotnetToolCommand) $(BashR2RDumpCommand) --in GcInfoTransitions.ni.dll --out GcInfoTransitions-test.xml -x -v --ignoreSensitive
-$(BashDotnetToolCommand) $(BashR2RDumpCommand) --in GenericFunctions.ni.dll --out GenericFunctions-test.xml -x -v --ignoreSensitive
-$(BashDotnetToolCommand) $(BashR2RDumpCommand) --in MultipleRuntimeFunctions.ni.dll --out MultipleRuntimeFunctions-test.xml -x -v --ignoreSensitive
+$(BashDotnetToolCommand) $(BashR2RDumpCommand) --in HelloWorld.ni.dll --out HelloWorld-test.xml $(R2RDumpCommandArguments)
+$(BashDotnetToolCommand) $(BashR2RDumpCommand) --in GcInfoTransitions.ni.dll --out GcInfoTransitions-test.xml $(R2RDumpCommandArguments)
+$(BashDotnetToolCommand) $(BashR2RDumpCommand) --in GenericFunctions.ni.dll --out GenericFunctions-test.xml $(R2RDumpCommandArguments)
+$(BashDotnetToolCommand) $(BashR2RDumpCommand) --in MultipleRuntimeFunctions.ni.dll --out MultipleRuntimeFunctions-test.xml $(R2RDumpCommandArguments)
 ]]></CLRTestBashPreCommands>
   </PropertyGroup>
 </Project>

--- a/src/tests/readytorun/r2rdump/BasicTests/rebaseline.cmd
+++ b/src/tests/readytorun/r2rdump/BasicTests/rebaseline.cmd
@@ -12,25 +12,25 @@ set tests=HelloWorld GcInfoTransitions GenericFunctions MultipleRuntimeFunctions
 (for %%a in (%tests%) do (
     "%RepoRoot%dotnet.cmd" build /p:TargetArchitecture=x64 /p:TargetOS=windows /p:Configuration=Checked "%ProjectDir%tests\src\readytorun\r2rdump\files\%%a.csproj"
     %ProjectDir%artifacts\tests\windows.x64.Checked\Tests\Core_Root\crossgen /readytorun /platform_assemblies_paths %ProjectDir%artifacts\tests\windows.x64.Checked\Tests\Core_Root /out %%a.ni.dll %ProjectDir%artifacts\tests\windows.x64.Checked\readytorun\r2rdump\files\%%a\%%a.dll
-    "%RepoRoot%dotnet.cmd" %ProjectDir%artifacts\bin\coreclr\windows.x64.Checked\netcoreapp2.0\R2RDump.dll --in %%a.ni.dll --out %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x64.Checked\%%a.xml -x -v --ignoreSensitive
+    "%RepoRoot%dotnet.cmd" %ProjectDir%artifacts\bin\coreclr\windows.x64.Checked\netcoreapp2.0\R2RDump.dll --in %%a.ni.dll --out %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x64.Checked\%%a.xml -x -v --ignoreSensitive --val
 ))
 
 (for %%a in (%tests%) do (
     "%RepoRoot%dotnet.cmd" build /p:TargetArchitecture=x64 /p:TargetOS=windows /p:Configuration=Debug "%ProjectDir%tests\src\readytorun\r2rdump\files\%%a.csproj"
     %ProjectDir%artifacts\tests\windows.x64.Debug\Tests\Core_Root\crossgen /readytorun /platform_assemblies_paths %ProjectDir%artifacts\tests\windows.x64.Debug\Tests\Core_Root /out %%a.ni.dll %ProjectDir%artifacts\tests\windows.x64.Debug\readytorun\r2rdump\files\%%a\%%a.dll
-    "%RepoRoot%dotnet.cmd" %ProjectDir%artifacts\bin\coreclr\windows.x64.Debug\netcoreapp2.0\R2RDump.dll --in %%a.ni.dll --out %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x64.Debug\%%a.xml -x -v --ignoreSensitive
+    "%RepoRoot%dotnet.cmd" %ProjectDir%artifacts\bin\coreclr\windows.x64.Debug\netcoreapp2.0\R2RDump.dll --in %%a.ni.dll --out %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x64.Debug\%%a.xml -x -v --ignoreSensitive --val
 ))
 
 (for %%a in (%tests%) do (
     "%RepoRoot%dotnet.cmd" build /p:TargetArchitecture=x86 /p:TargetOS=windows /p:Configuration=Release "%ProjectDir%tests\src\readytorun\r2rdump\files\%%a.csproj"
     %ProjectDir%artifacts\tests\windows.x86.Release\Tests\Core_Root\crossgen /readytorun /platform_assemblies_paths %ProjectDir%artifacts\tests\windows.x86.Release\Tests\Core_Root /out %%a.ni.dll %ProjectDir%artifacts\tests\windows.x86.Release\readytorun\r2rdump\files\%%a\%%a.dll
-    "%RepoRoot%dotnet.cmd" %ProjectDir%artifacts\bin\coreclr\windows.x86.Release\netcoreapp2.0\R2RDump.dll --in %%a.ni.dll --out %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x86.Release\%%a.xml -x -v --ignoreSensitive
+    "%RepoRoot%dotnet.cmd" %ProjectDir%artifacts\bin\coreclr\windows.x86.Release\netcoreapp2.0\R2RDump.dll --in %%a.ni.dll --out %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x86.Release\%%a.xml -x -v --ignoreSensitive --val
 ))
 
 (for %%a in (%tests%) do (
     "%RepoRoot%dotnet.cmd" build /p:TargetArchitecture=x86 /p:TargetOS=windows /p:Configuration=Debug "%ProjectDir%tests\src\readytorun\r2rdump\files\%%a.csproj"
     %ProjectDir%artifacts\tests\windows.x86.Debug\Tests\Core_Root\crossgen /readytorun /platform_assemblies_paths %ProjectDir%artifacts\tests\windows.x86.Debug\Tests\Core_Root /out %%a.ni.dll %ProjectDir%artifacts\tests\windows.x86.Debug\readytorun\r2rdump\files\%%a\%%a.dll
-    "%RepoRoot%dotnet.cmd" %ProjectDir%artifacts\bin\coreclr\windows.x86.Debug\netcoreapp2.0\R2RDump.dll --in %%a.ni.dll --out %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x86.Debug\%%a.xml -x -v --ignoreSensitive
+    "%RepoRoot%dotnet.cmd" %ProjectDir%artifacts\bin\coreclr\windows.x86.Debug\netcoreapp2.0\R2RDump.dll --in %%a.ni.dll --out %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x86.Debug\%%a.xml -x -v --ignoreSensitive --val
 ))
 
 COPY /Y %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x64.Checked\*.xml %ProjectDir%tests\src\readytorun\r2rdump\files\windows.x64.Release\

--- a/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTester.cs
+++ b/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTester.cs
@@ -56,7 +56,7 @@ namespace R2RDumpTests
                 UseShellExecute = false,
                 FileName = DotNetAbsolutePath,
                 // TODO, what flags do we like to test?
-                Arguments = string.Join(" ", new string[]{"exec", R2RDumpAbsolutePath, "--in", CoreLibAbsolutePath, "--out", OutputFile})
+                Arguments = string.Join(" ", new string[]{"exec", R2RDumpAbsolutePath, "--in", CoreLibAbsolutePath, "--out", OutputFile, "--val"})
             };
 
             Process process = Process.Start(processStartInfo);


### PR DESCRIPTION
Continuing with @cshung [comment](https://github.com/dotnet/runtime/pull/77289#issuecomment-1301607022).

There shouldn't be variable debug information reported with an empty range. This PR adds the validation check to existent function validation taken place when dumping R2R images. Check is not applied by default, and a command line argument of R2RDump is added to run it. The argument is added to existent projects running tests with R2RDump.