### PR TITLE
[wasm] Use Helix's retry mechanism to re-run debugger tests on CI if ..

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -3,6 +3,7 @@
   "defaultOnFailure": "fail",
   "localRerunCount": 2,
   "retryOnRules": [
-    { "testAssembly": { "wildcard": "System.Net.*" } }
+    { "testAssembly": { "wildcard": "System.Net.*" } },
+    { "failureMessage": { "wildcard": "Timed out after * waiting for the browser to be ready" } }
   ]
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/WasmHostProvider.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/WasmHostProvider.cs
@@ -88,6 +88,8 @@ internal abstract class WasmHostProvider : IDisposable
         }
 
         // FIXME: use custom exception types
+        // Note: this message string is used in eng/test-configuration.json for triggering
+        //       test retries
         throw new IOException($"{messagePrefix} Timed out after {hostReadyTimeoutMs/1000}s waiting for the browser to be ready: {psi.FileName}");
 
         void ProcessOutput(string prefix, string? msg)


### PR DESCRIPTION
.. they failed while waiting for the browser to launch.

Related: https://github.com/dotnet/arcade/tree/main/src/Microsoft.DotNet.Helix/Sdk#test-retry

Fixes https://github.com/dotnet/runtime/issues/76528