### PR TITLE
[release/6.0] Revert banana RID source build changes from arcade

### DIFF
--- a/eng/common/templates/steps/source-build.yml
+++ b/eng/common/templates/steps/source-build.yml
@@ -63,6 +63,11 @@ steps:
       targetRidArgs='/p:TargetRid=${{ parameters.platform.targetRID }}'
     fi
 
+    runtimeOsArgs=
+    if [ '${{ parameters.platform.runtimeOS }}' != '' ]; then
+      runtimeOsArgs='/p:RuntimeOS=${{ parameters.platform.runtimeOS }}'
+    fi
+
     publishArgs=
     if [ '${{ parameters.platform.skipPublishValidation }}' != 'true' ]; then
       publishArgs='--publish'
@@ -75,6 +80,7 @@ steps:
       $internalRuntimeDownloadArgs \
       $internalRestoreArgs \
       $targetRidArgs \
+      $runtimeOsArgs \
       /p:SourceBuildNonPortable=${{ parameters.platform.nonPortable }} \
       /p:ArcadeBuildFromSource=true
   displayName: Build


### PR DESCRIPTION
I had originally restored these lines in the [arcade dependencies update PR](https://github.com/dotnet/runtime/pull/78062) with [this commit](https://github.com/dotnet/runtime/pull/78062/commits/08214fd1960e94176b1ea5f622102f4b0c7aa638), but a subsequent automated update reverted my commit. Since the CI had already finished with all the concerns resolved, I didn't want to restart the CI, and instead I'm sending this in a separate change.

This was also addressed directly in the arcade repo: https://github.com/dotnet/arcade/pull/11604 but this PR is to unblock us for now. /cc @ayakael