### PR TITLE
Fix the TimeSpan comment about internal representation.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -12,11 +12,11 @@ namespace System
     // TimeSpan represents a duration of time.  A TimeSpan can be negative
     // or positive.
     //
-    // TimeSpan is internally represented as a number of milliseconds.  While
-    // this maps well into units of time such as hours and days, any
-    // periods longer than that aren't representable in a nice fashion.
+    // TimeSpan is internally represented as a number of ticks. A tick is equal
+    // to 100 nanoseconds. While this maps well into units of time such as hours
+    // and days, any periods longer than that aren't representable in a nice fashion.
     // For instance, a month can be between 28 and 31 days, while a year
-    // can contain 365 or 364 days.  A decade can have between 1 and 3 leapyears,
+    // can contain 365 or 366 days.  A decade can have between 1 and 3 leapyears,
     // depending on when you map the TimeSpan into the calendar.  This is why
     // we do not provide Years() or Months().
     //


### PR DESCRIPTION
This PR fixes comments only. It is part of issue dotnet/dotnet-api-docs#9156.