### PR TITLE
[wasm] Test for header trimming not supported on NodeJS

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -3681,7 +3681,7 @@ namespace System.Net.Http.Functional.Tests
     {
         public SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http11(ITestOutputHelper output) : base(output) { }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNodeJS))]
         [InlineData("foo ", "bar ")]
         [InlineData("foo", " bar")]
         [InlineData("foo", "bar\t")]


### PR DESCRIPTION
Test `SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http11.ResponseHeaders_ExtraWhitespace_Trimmed` is not supported on NodeJS.
Test introduced in the https://github.com/dotnet/runtime/pull/74393.
Closes https://github.com/dotnet/runtime/issues/77631.