### PR TITLE
Remove usage of ComPlus_ variables in tests

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -111,7 +111,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         echo "Response file: $__ResponseFile"
         cat $__ResponseFile
 
-        # Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
+        # Suppress some DOTNET variables for the duration of Crossgen2 execution
         export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun DOTNET_TC_OnStackReplacement DOTNET_TC_PartialCompilation
 
         echo "Running CrossGen2: $__Command"

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -113,7 +113,6 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
 
         # Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
         export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun DOTNET_TC_OnStackReplacement DOTNET_TC_PartialCompilation
-        export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun COMPlus_TC_OnStackReplacement COMPlus_TC_PartialCompilation
 
         echo "Running CrossGen2: $__Command"
         $__Command
@@ -124,7 +123,6 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         __r2rDumpExitCode=$?
 
         export DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun DOTNET_TC_OnStackReplacement DOTNET_TC_PartialCompilation
-        export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun COMPlus_TC_OnStackReplacement COMPlus_TC_PartialCompilation
         date +%H:%M:%S
       }
 
@@ -267,16 +265,10 @@ if defined RunCrossGen2 (
     set "DOTNET_GCStress="
     set "DOTNET_HeapVerify="
     set "DOTNET_ReadyToRun="
-    set "COMPlus_GCName="
-    set "COMPlus_GCStress="
-    set "COMPlus_HeapVerify="
-    set "COMPlus_ReadyToRun="
 
     REM work around problems in 6.0 OSR
     set "DOTNET_TC_OnStackReplacement="
     set "DOTNET_TC_PartialCompilation="
-    set "COMPlus_TC_OnStackReplacement="
-    set "COMPlus_TC_PartialCompilation="
 
     echo "!__Command!"
     call !__Command!

--- a/src/tests/baseservices/RuntimeConfiguration/TestConfig.cs
+++ b/src/tests/baseservices/RuntimeConfiguration/TestConfig.cs
@@ -97,7 +97,6 @@ class TestConfig
     {
         // clear some environment variables that we will set during the test run
         Environment.SetEnvironmentVariable("DOTNET_gcServer", null);
-        Environment.SetEnvironmentVariable("COMPlus_gcServer", null);
 
         string corerunPath = GetCorerunPath();
         MethodInfo[] infos = typeof(TestConfig).GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);

--- a/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
@@ -38,7 +38,7 @@ set CLRCustomTestLauncher=RunBasicTestWithMcj.cmd --runCustomTest
 $(CLRTestBashPreCommands)
 mkdir r2r
 
-# Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
+# Suppress some DOTNET variables for the duration of Crossgen2 execution
 export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
 
 "$CORE_ROOT/corerun" $CORE_ROOT/crossgen2/crossgen2.dll --out r2r/$(MSBuildProjectName).dll $(MSBuildProjectName).dll -r $CORE_ROOT/*.dll

--- a/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
@@ -28,10 +28,6 @@ set "DOTNET_GCName="
 set "DOTNET_GCStress="
 set "DOTNET_HeapVerify="
 set "DOTNET_ReadyToRun="
-set "COMPlus_GCName="
-set "COMPlus_GCStress="
-set "COMPlus_HeapVerify="
-set "COMPlus_ReadyToRun="
 
 "%CORE_ROOT%\corerun" %CORE_ROOT%\crossgen2\crossgen2.dll --out r2r\$(MSBuildProjectName).dll $(MSBuildProjectName).dll -r %CORE_ROOT%\*.dll
 
@@ -44,12 +40,10 @@ mkdir r2r
 
 # Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
 export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
-export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
 
 "$CORE_ROOT/corerun" $CORE_ROOT/crossgen2/crossgen2.dll --out r2r/$(MSBuildProjectName).dll $(MSBuildProjectName).dll -r $CORE_ROOT/*.dll
 
 export DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
-export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
 chmod +x ./RunBasicTestWithMcj.sh
 export CLRCustomTestLauncher="./RunBasicTestWithMcj.sh --runCustomTest"
 ]]></CLRTestBashPreCommands>

--- a/src/tests/readytorun/multifolder/multifolder.csproj
+++ b/src/tests/readytorun/multifolder/multifolder.csproj
@@ -89,7 +89,7 @@ $(CLRTestBashPreCommands)
     echo $__OutputDir/../FolderA/FolderA/FolderA.dll>>$__ResponseFile
     echo $__OutputDir/../FolderB/FolderB/FolderB.dll>>$__ResponseFile
 
-    # Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
+    # Suppress some DOTNET variables for the duration of Crossgen2 execution
     export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun DOTNET_TC_OnStackReplacement DOTNET_TC_PartialCompilation
 
     __Command=$_DebuggerFullPath

--- a/src/tests/readytorun/multifolder/multifolder.csproj
+++ b/src/tests/readytorun/multifolder/multifolder.csproj
@@ -42,8 +42,6 @@ $(CLRTestBatchPreCommands)
     REM Suppress GC stand alone mode for the duration of Crossgen2 execution
     set __gcStandaloneModeToRestore=!DOTNET_GCName!
     set DOTNET_GCName=
-    set __gcStandaloneModeToRestore=!COMPlus_GCName!
-    set COMPlus_GCName=
 
     set __Command=%_DebuggerFullPath%
     REM Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
@@ -93,7 +91,6 @@ $(CLRTestBashPreCommands)
 
     # Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
     export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun DOTNET_TC_OnStackReplacement DOTNET_TC_PartialCompilation
-    export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun COMPlus_TC_OnStackReplacement COMPlus_TC_PartialCompilation
 
     __Command=$_DebuggerFullPath
     # Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path

--- a/src/tests/readytorun/tests/mainv1.csproj
+++ b/src/tests/readytorun/tests/mainv1.csproj
@@ -84,7 +84,7 @@ endlocal
     <CLRTestBashPreCommands><![CDATA[
 $(CLRTestBashPreCommands)
 
-# Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
+# Suppress some DOTNET variables for the duration of Crossgen2 execution
 export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
 
 mkdir IL_DLLS

--- a/src/tests/readytorun/tests/mainv1.csproj
+++ b/src/tests/readytorun/tests/mainv1.csproj
@@ -25,10 +25,6 @@ set "DOTNET_GCName="
 set "DOTNET_GCStress="
 set "DOTNET_HeapVerify="
 set "DOTNET_ReadyToRun="
-set "COMPlus_GCName="
-set "COMPlus_GCStress="
-set "COMPlus_HeapVerify="
-set "COMPlus_ReadyToRun="
 
 md IL_DLLS
 if not exist IL_DLLS\fieldgetter.dll (
@@ -90,7 +86,6 @@ $(CLRTestBashPreCommands)
 
 # Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
 export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
-export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
 
 mkdir IL_DLLS
 

--- a/src/tests/readytorun/tests/mainv2.csproj
+++ b/src/tests/readytorun/tests/mainv2.csproj
@@ -84,7 +84,7 @@ endlocal
     <CLRTestBashPreCommands><![CDATA[
 $(CLRTestBashPreCommands)
 
-# Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
+# Suppress some DOTNET variables for the duration of Crossgen2 execution
 export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
 
 mkdir IL_DLLS

--- a/src/tests/readytorun/tests/mainv2.csproj
+++ b/src/tests/readytorun/tests/mainv2.csproj
@@ -23,10 +23,6 @@ set "DOTNET_GCName="
 set "DOTNET_GCStress="
 set "DOTNET_HeapVerify="
 set "DOTNET_ReadyToRun="
-set "COMPlus_GCName="
-set "COMPlus_GCStress="
-set "COMPlus_HeapVerify="
-set "COMPlus_ReadyToRun="
 
 md IL_DLLS
 if not exist IL_DLLS\fieldgetter.dll (
@@ -90,7 +86,6 @@ $(CLRTestBashPreCommands)
 
 # Suppress some DOTNET and COMPlus variables for the duration of Crossgen2 execution
 export -n DOTNET_GCName DOTNET_GCStress DOTNET_HeapVerify DOTNET_ReadyToRun
-export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
 
 mkdir IL_DLLS
 


### PR DESCRIPTION
In coreclr's configuration cache, DOTNET_ is preferred over COMPlus_

Fix #76484