### PR TITLE
Fix ALC lookup from the DAC

### DIFF
--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -26,6 +26,7 @@
 #endif // !defined(DACCESS_COMPILE)
 
 #include "bundle.h"
+#include <assemblybinderutil.h>
 
 class DomainAssembly;
 
@@ -50,7 +51,7 @@ namespace BINDER_SPACE
         PEImage* GetPEImage();
         BOOL GetIsInTPA();
 
-        inline AssemblyBinder* GetBinder()
+        PTR_AssemblyBinder GetBinder()
         {
             return m_pBinder;
         }
@@ -70,21 +71,21 @@ namespace BINDER_SPACE
         LONG                     m_cRef;
         PEImage                 *m_pPEImage;
         AssemblyName            *m_pAssemblyName;
-        AssemblyBinder          *m_pBinder;
+        PTR_AssemblyBinder       m_pBinder;
         bool                     m_isInTPA;
         DomainAssembly          *m_domainAssembly;
 
+#if !defined(DACCESS_COMPILE)
         inline void SetBinder(AssemblyBinder *pBinder)
         {
             _ASSERTE(m_pBinder == NULL || m_pBinder == pBinder);
             m_pBinder = pBinder;
         }
 
-        friend class ::DefaultAssemblyBinder;
-
-#if !defined(DACCESS_COMPILE)
         friend class ::CustomAssemblyBinder;
 #endif // !defined(DACCESS_COMPILE)
+
+        friend class ::DefaultAssemblyBinder;
     };
 
 #include "assembly.inl"

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -1115,7 +1115,7 @@ PTR_AssemblyBinder PEAssembly::GetAssemblyBinder()
     PTR_BINDER_SPACE_Assembly pHostAssembly = GetHostAssembly();
     if (pHostAssembly)
     {
-        pBinder = dac_cast<PTR_AssemblyBinder>(pHostAssembly->GetBinder());
+        pBinder = pHostAssembly->GetBinder();
     }
     else
     {

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -19,8 +19,6 @@
 #include "strongnameinternal.h"
 
 #include "../binder/inc/applicationcontext.hpp"
-
-#include "assemblybinderutil.h"
 #include "../binder/inc/assemblybindercommon.hpp"
 
 #include "sha1.h"
@@ -1114,7 +1112,7 @@ PTR_AssemblyBinder PEAssembly::GetAssemblyBinder()
 
     PTR_AssemblyBinder pBinder = NULL;
 
-    BINDER_SPACE::Assembly* pHostAssembly = GetHostAssembly();
+    PTR_BINDER_SPACE_Assembly pHostAssembly = GetHostAssembly();
     if (pHostAssembly)
     {
         pBinder = dac_cast<PTR_AssemblyBinder>(pHostAssembly->GetBinder());


### PR DESCRIPTION
It seems the SOS commands for ALC lookup have
been broken for a bit. Some parts of the impl
weren't DAC-ized and caused failures.

Fixes issue found in https://github.com/dotnet/diagnostics/pull/3508

We should also backport this to .NET 7.

/cc @hoyosjs @dotnet/dotnet-diag-contrib @janvorli @elinor-fung 