### PR TITLE
Fix parameters order when creating XmlConfigurationElementTextContent object

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlStreamConfigurationProvider.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Extensions.Configuration.Xml
                                     var lineInfo = reader as IXmlLineInfo;
                                     var lineNumber = lineInfo?.LineNumber;
                                     var linePosition = lineInfo?.LinePosition;
-                                    parent.TextContent = new XmlConfigurationElementTextContent(string.Empty, lineNumber, linePosition);
+                                    parent.TextContent = new XmlConfigurationElementTextContent(string.Empty, linePosition, lineNumber);
                                 }
                             }
                             break;
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.Configuration.Xml
 
                                 XmlConfigurationElement parent = currentPath.Peek();
 
-                                parent.TextContent = new XmlConfigurationElementTextContent(reader.Value, lineNumber, linePosition);
+                                parent.TextContent = new XmlConfigurationElementTextContent(reader.Value, linePosition, lineNumber);
                             }
                             break;
                         case XmlNodeType.XmlDeclaration:

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
@@ -689,6 +689,31 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
         }
 
         [Fact]
+        public void ThrowExceptionWhenDuplicateKeyOfElementContents()
+        {
+            var xml =
+                @"<settings>
+                    <Data>
+                        <DefaultConnection>
+                            <ConnectionString>TestConnectionString</ConnectionString>
+                            <Provider>SqlClient</Provider>
+                        </DefaultConnection>
+                    </Data>
+                    <data name='defaultconnection'>
+                        <ConnectionString>TestConnectionString1</ConnectionString>
+                        <provider>NewProvider</provider>
+                    </data>
+                </settings>";
+            var xmlConfigSrc = new XmlConfigurationProvider(new XmlConfigurationSource());
+            var expectedMsg = SR.Format(SR.Error_KeyIsDuplicated, "data:defaultconnection:ConnectionString",
+                SR.Format(SR.Msg_LineInfo, 9, 43));
+
+            var exception = Assert.Throws<FormatException>(() => xmlConfigSrc.Load(TestStreamHelpers.StringToStream(xml)));
+
+            Assert.Equal(expectedMsg, exception.Message);
+        }
+
+        [Fact]
         public void XmlConfiguration_Throws_On_Missing_Configuration_File()
         {
             var ex = Assert.Throws<FileNotFoundException>(() => new ConfigurationBuilder().AddXmlFile("NotExistingConfig.xml", optional: false).Build());


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/78212