### PR TITLE
Use helpers in Guid's ROS<byte> constructor

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -53,20 +53,14 @@ namespace System
                 ThrowArgumentException();
             }
 
-            if (BitConverter.IsLittleEndian)
-            {
-                this = MemoryMarshal.Read<Guid>(b);
-                return;
-            }
-
-            // slower path for BigEndian:
-            this = ReadGuidLittleEndian(b);
+            this = BitConverter.IsLittleEndian ? MemoryMarshal.Read<Guid>(b) : ReadGuidLittleEndian(b);
 
             static void ThrowArgumentException()
             {
                 throw new ArgumentException(SR.Format(SR.Arg_GuidArrayCtor, "16"), nameof(b));
             }
 
+            // slower path for BigEndian:
             static Guid ReadGuidLittleEndian(ReadOnlySpan<byte> b)
             {
                 // hoist bounds checks

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -53,32 +53,28 @@ namespace System
                 ThrowArgumentException();
             }
 
-            this = BitConverter.IsLittleEndian ? MemoryMarshal.Read<Guid>(b) : ReadGuidLittleEndian(b);
+            if (BitConverter.IsLittleEndian)
+            {
+                this = MemoryMarshal.Read<Guid>(b);
+                return;
+            }
+
+            // slower path for BigEndian:
+            _k = b[15]; // hoist bounds checks
+            _a = BinaryPrimitives.ReadInt32LittleEndian(b);
+            _b = BinaryPrimitives.ReadInt16LittleEndian(b.Slice(4));
+            _c = BinaryPrimitives.ReadInt16LittleEndian(b.Slice(6));
+            _d = b[8];
+            _e = b[9];
+            _f = b[10];
+            _g = b[11];
+            _h = b[12];
+            _i = b[13];
+            _j = b[14];
 
             static void ThrowArgumentException()
             {
                 throw new ArgumentException(SR.Format(SR.Arg_GuidArrayCtor, "16"), nameof(b));
-            }
-
-            // slower path for BigEndian:
-            static Guid ReadGuidLittleEndian(ReadOnlySpan<byte> b)
-            {
-                // hoist bounds checks
-                byte k = b[15];
-
-                return new Guid(
-                    BinaryPrimitives.ReadInt32LittleEndian(b),
-                    BinaryPrimitives.ReadInt16LittleEndian(b.Slice(4)),
-                    BinaryPrimitives.ReadInt16LittleEndian(b.Slice(6)),
-                    b[8],
-                    b[9],
-                    b[10],
-                    b[11],
-                    b[12],
-                    b[13],
-                    b[14],
-                    k
-                );
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -60,7 +60,7 @@ namespace System
             }
 
             // slower path for BigEndian:
-            _k = b[15]; // hoist bounds checks
+            _k = b[15];  // hoist bounds checks
             _a = BinaryPrimitives.ReadInt32LittleEndian(b);
             _b = BinaryPrimitives.ReadInt16LittleEndian(b.Slice(4));
             _c = BinaryPrimitives.ReadInt16LittleEndian(b.Slice(6));

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -72,6 +72,7 @@ namespace System
             _i = b[13];
             _j = b[14];
 
+            [StackTraceHidden]
             static void ThrowArgumentException()
             {
                 throw new ArgumentException(SR.Format(SR.Arg_GuidArrayCtor, "16"), nameof(b));

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -50,7 +50,7 @@ namespace System
         {
             if (b.Length != 16)
             {
-                throw new ArgumentException(SR.Format(SR.Arg_GuidArrayCtor, "16"), nameof(b));
+                ThrowArgumentException();
             }
 
             if (BitConverter.IsLittleEndian)
@@ -60,17 +60,32 @@ namespace System
             }
 
             // slower path for BigEndian:
-            _k = b[15];  // hoist bounds checks
-            _a = BinaryPrimitives.ReadInt32LittleEndian(b);
-            _b = BinaryPrimitives.ReadInt16LittleEndian(b.Slice(4));
-            _c = BinaryPrimitives.ReadInt16LittleEndian(b.Slice(6));
-            _d = b[8];
-            _e = b[9];
-            _f = b[10];
-            _g = b[11];
-            _h = b[12];
-            _i = b[13];
-            _j = b[14];
+            this = ReadGuidLittleEndian(b);
+
+            static void ThrowArgumentException()
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_GuidArrayCtor, "16"), nameof(b));
+            }
+
+            static Guid ReadGuidLittleEndian(ReadOnlySpan<byte> b)
+            {
+                // hoist bounds checks
+                byte k = b[15];
+
+                return new Guid(
+                    BinaryPrimitives.ReadInt32LittleEndian(b),
+                    BinaryPrimitives.ReadInt16LittleEndian(b.Slice(4)),
+                    BinaryPrimitives.ReadInt16LittleEndian(b.Slice(6)),
+                    b[8],
+                    b[9],
+                    b[10],
+                    b[11],
+                    b[12],
+                    b[13],
+                    b[14],
+                    k
+                );
+            }
         }
 
         [CLSCompliant(false)]


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/78440. ([SharpLab demo](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCEBXAMy5il3YBLAHbYoATwDcNek1YAlDsIyD8MFgEllfCAAcAynwBugsDFzTqNeTGwATAPLCANuP27swgDzBxGGAB8DADiMBjBHIJ2bH7mABQAlAwAvEHCMADuDL7+ANoAugDedAh05GgMJXSkFVUAzLWl6JWlAKyNdEgdAOwdABwdAJwd2B3AHWAddh0wHVyN5HQAvpY0EVEMALLkiSlpmSGRdnGh4Ucx/riJCavU63akW6S7qQzpWffPp/cX8Qk3NBouX0GCgHDAGAAMthxBAOBg4tDYfCANIiOwsQwARw4MGUgmwzgS+RosHsEBc4gYuFB4IwhyipBohRoDDZDF0UEERmw/gYZLsFNcDBE9IA+thLOyOVyeXyBUKqbgABbQcXAKXsznc3kwfm2QWU6mqqDisCatnauV6hVGnJ6sV2C0ynXyg2K7KxBhimDOq26/Xku1esVcP2ygO24X270Ac3Drpt7uDfLFyoT1sDhujIcEGcjyZzqYAVvm3UGiw6ANbO1ns4h1BkPOKihijY1q7IVFWdyaevnTft62ZDhjzUexiox5VTr2CWd84sLvVVhJ1tks6jS6USlJt5074B7jXr7disB782nnd2PdO6/sn1730Ptmhvdh19xvfxr9pvfpn+gh7nmf7FnupZ/lWe41qeSyAlu9aNp8cQ2PYTiuO4ng+LEQTAGuiEbl+ghcAwcTACwkJ4rGGDKgwACEyQMOQSAEdu7Kbux7EACrKlAEAZAAglAsYcGoygAKIIGYugqBSiQHuy8FWIR24kWRbCCBgADCFJGHw/hQJouCQlpGDODAEnCHYBLCGxXGcVx0q0YIuB7psMD4NA4ibGIKqEiwaF2F4nwBORAKqU5xDdIpbLKV+LluUxQX3KZGDmZZ1m2eFsUMF+zBIEwKAMLx/FCSJYl4hgUkyXJwiJF+jlOWytFlW8BzCaJ4nVdJMCyYI8kAES/G2UBQDCY7QE2DD4BwNLZMOCDYBCwosUObnOBSsYsINFSiGoEBcOFEVOfFkX1mtnwMClRxpRlVk2Z4qEGhhbgeN49p4fZ7FNc1MbQUxwC5OQrT5Ll0pftK0XtRkcSQ1xmmiBIAAKXL4Fp3LmIFBpaBgdSkHdFkPdl+FoPD7GI2I4io6oGP6QIQW4yxhOZY99UUfozimDAcQoP8ZPnc1DCUyjaN01jjPKMzZlE1lT0c1zZhxKxCQC0L7FA30+Rq+r0pA4M2vk9uQOLIbgt/cD5Bm7revA6Q1s22yJt1A7jsmygrs21WRsnVxynSspSxAA))
Moves the big endian path and exception throwing to a helper, resulting in improved codegen when the constructor is inlined.