### PR TITLE
Console.Unix: don't calculate cached cursor position from the last column.

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1029,7 +1029,16 @@ namespace System
                     byte c = bufPtr[i];
                     if (c < 127 && c >= 32) // ASCII/UTF-8 characters that take up a single position
                     {
-                        IncrementX();
+                        left++;
+
+                        // After printing in the last column, setting CursorLeft is expected to
+                        // place the cursor back in that same row.
+                        // Invalidate the cursor position rather than moving it to the next row.
+                        if (left >= width)
+                        {
+                            InvalidateCachedCursorPosition();
+                            return;
+                        }
                     }
                     else if (c == (byte)'\r')
                     {
@@ -1038,7 +1047,12 @@ namespace System
                     else if (c == (byte)'\n')
                     {
                         left = 0;
-                        IncrementY();
+                        top++;
+
+                        if (top >= height)
+                        {
+                            top = height - 1;
+                        }
                     }
                     else if (c == (byte)'\b')
                     {
@@ -1056,25 +1070,6 @@ namespace System
 
                 // We pass cursorVersion because it may have changed the earlier check by calling GetWindowSize.
                 SetCachedCursorPosition(left, top, cursorVersion);
-
-                void IncrementY()
-                {
-                    top++;
-                    if (top >= height)
-                    {
-                        top = height - 1;
-                    }
-                }
-
-                void IncrementX()
-                {
-                    left++;
-                    if (left >= width)
-                    {
-                        left = 0;
-                        IncrementY();
-                    }
-                }
             }
         }
 

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -324,6 +324,17 @@ namespace System
         }
 
         [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void CursorLeftFromLastColumn()
+        {
+            Console.CursorLeft = Console.BufferWidth - 1;
+            Console.Write("2");
+            Console.CursorLeft = 0;
+            Console.Write("1");
+            Console.WriteLine();
+            AssertUserExpectedResults("single line with '1' at the start and '2' at the end.");
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
         [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on Browser, iOS, MacCatalyst, or tvOS.")]
         public static void ResizeTest()
         {


### PR DESCRIPTION
After printing in the last column, setting CursorLeft is expected to place the cursor back in that same row.

Fixes https://github.com/dotnet/runtime/issues/77995.

@adamsitnik ptal.

cc @qt-kaneko