### PR TITLE
Fix single quote processing from debug output

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Also reset/set below
 set -x
 
 source_directory=$BUILD_SOURCESDIRECTORY
@@ -434,6 +435,9 @@ ci=true
 _script_dir=$(pwd)/eng/common
 . "$_script_dir/pipeline-logging-functions.sh"
 
+# Prevent vso[task.setvariable to be erroneously processed
+set +x
+
 # Make sure all of our variables are available for future steps
 Write-PipelineSetVariable -name "UseCoreRun" -value "$use_core_run" -is_multi_job_variable false
 Write-PipelineSetVariable -name "UseBaselineCoreRun" -value "$use_baseline_core_run" -is_multi_job_variable false
@@ -458,3 +462,6 @@ Write-PipelineSetVariable -name "MonoDotnet" -value "$using_mono" -is_multi_job_
 Write-PipelineSetVariable -name "WasmDotnet" -value "$using_wasm" -is_multi_job_variable false
 Write-PipelineSetVariable -Name 'iOSLlvmBuild' -Value "$iosllvmbuild" -is_multi_job_variable false
 Write-PipelineSetVariable -name "OnlySanityCheck" -value "$only_sanity" -is_multi_job_variable false
+
+# Put it back to what was set on top of this script
+set -x


### PR DESCRIPTION
The `set -x` can interfere with the `vso[task.setvariable` and that could result in [this failure](https://dev.azure.com/dnceng/internal/_build/results?buildId=2046129&view=logs&j=8acf73da-ca1d-50e8-cd01-44779728784d&t=c5ecbd77-65c2-50ec-340f-2941e86292a9&l=14). This change temporarily disables `set -x` while `Write-PipelineSetVariable` is executed.