### PR TITLE
[wasm] Jiterpreter cleanup

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2649,7 +2649,7 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 
 #if JITERPRETER_ENABLE_JIT_CALL_TRAMPOLINES
 	// FIXME: thread safety
-	if (jiterpreter_jit_call_enabled) {
+	if (mono_opt_jiterpreter_jit_call_enabled) {
 		WasmJitCallThunk thunk = cinfo->jiterp_thunk;
 		if (thunk) {
 			MonoFtnDesc ftndesc = {0};
@@ -2659,7 +2659,7 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 			extra_arg = cinfo->no_wrapper ? cinfo->extra_arg : &ftndesc;
 			interp_push_lmf (&ext, frame);
 			if (
-				jiterpreter_wasm_eh_enabled ||
+				mono_opt_jiterpreter_wasm_eh_enabled ||
 				(mono_aot_mode != MONO_AOT_MODE_LLVMONLY_INTERP)
 			) {
 				thunk (extra_arg, ret_sp, sp, &thrown);
@@ -3223,7 +3223,7 @@ interp_create_method_pointer_llvmonly (MonoMethod *method, gboolean unbox, MonoE
 	// FIXME: We don't support generating wasm trampolines for high arg counts yet
 	if (
 		(sig->param_count <= MAX_INTERP_ENTRY_ARGS) &&
-		jiterpreter_interp_entry_enabled
+		mono_opt_jiterpreter_interp_entry_enabled
 	) {
 		jiterp_preserve_module();
 
@@ -7512,7 +7512,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		}
 
 		MINT_IN_CASE(MINT_TIER_PREPARE_JITERPRETER) {
-			if (jiterpreter_traces_enabled) {
+			if (mono_opt_jiterpreter_traces_enabled) {
 				// We may lose a race with another thread here so we need to use volatile and be careful
 				volatile guint16 *mutable_ip = (volatile guint16*)ip;
 				/*

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -40,50 +40,12 @@ void jiterp_preserve_module (void);
 #include <mono/mini/aot-runtime.h>
 #include <mono/mini/llvm-runtime.h>
 #include <mono/mini/llvmonly-runtime.h>
+#include <mono/utils/options.h>
 
 #include "jiterpreter.h"
 
 static gint32 jiterpreter_abort_counts[MINT_LASTOP + 1] = { 0 };
 static int64_t jiterp_trace_bailout_counts[256] = { 0 };
-
-#if FEATURE_WASM_THREADS
-// the jiterpreter is not yet thread safe due to the need to synchronize function pointers
-//  and wasm modules between threads. before these can be enabled we need to implement all that
-gboolean jiterpreter_traces_enabled       = FALSE,
-	jiterpreter_interp_entry_enabled  = FALSE,
-	jiterpreter_jit_call_enabled      = FALSE,
-#else
-// traces_enabled controls whether the jiterpreter will JIT individual interpreter opcode traces
-gboolean jiterpreter_traces_enabled       = FALSE,
-// interp_entry_enabled controls whether specialized interp_entry wrappers will be jitted
-	jiterpreter_interp_entry_enabled  = FALSE,
-// jit_call_enabled controls whether do_jit_call will use specialized trampolines for hot call sites
-	jiterpreter_jit_call_enabled      = FALSE,
-#endif
-// if enabled, we will insert trace entry points at backwards branch targets, so that we can
-//  JIT loop bodies
-	jiterpreter_backward_branch_entries_enabled = TRUE,
-// if enabled, after a call instruction terminates a trace, we will attempt to start a new
-//  one at the next basic block. this allows jitting loop bodies that start with 'if (x) continue' etc
-	jiterpreter_call_resume_enabled = TRUE,
-// enables using WASM try/catch_all instructions where appropriate (currently only do_jit_call),
-//  will be automatically turned off if the instructions are not available.
-	jiterpreter_wasm_eh_enabled     = TRUE,
-// For locations where the jiterpreter heuristic says we will be unable to generate
-//  a trace, insert an entry point opcode anyway. This enables collecting accurate
-//  stats for options like estimateHeat, but raises overhead.
-	jiterpreter_always_generate     = FALSE,
-// Automatically prints stats at app exit or when jiterpreter_dump_stats is called
-	jiterpreter_stats_enabled       = FALSE,
-// Continue counting hits for traces that fail to compile and use it to estimate
-//  the relative importance of the opcode that caused them to abort
-	jiterpreter_estimate_heat       = FALSE,
-// Count the number of times a trace bails out (branch taken, etc) and for what reason
-	jiterpreter_count_bailouts      = FALSE;
-
-gint32 jiterpreter_options_version = 0,
-// any trace that doesn't have at least this many meaningful (non-nop) opcodes in it will be rejected
-	jiterpreter_minimum_trace_length = 8;
 
 // This function pointer is used by interp.c to invoke jit_call_cb for exception handling purposes
 // See jiterpreter-jit-call.ts mono_jiterp_do_jit_call_indirect
@@ -892,7 +854,7 @@ should_generate_trace_here (InterpBasicBlock *bb, InterpInst *last_ins) {
 		switch (category) {
 			case TRACE_ABORT: {
 				jiterpreter_abort_counts[ins->opcode]++;
-				return current_trace_length >= jiterpreter_minimum_trace_length;
+				return current_trace_length >= mono_opt_jiterpreter_minimum_trace_length;
 			}
 			case TRACE_IGNORE:
 				break;
@@ -902,7 +864,7 @@ should_generate_trace_here (InterpBasicBlock *bb, InterpInst *last_ins) {
 		}
 
 		// Once we know the trace is long enough we can stop scanning.
-		if (current_trace_length >= jiterpreter_minimum_trace_length)
+		if (current_trace_length >= mono_opt_jiterpreter_minimum_trace_length)
 			return TRUE;
 	}
 
@@ -922,7 +884,7 @@ should_generate_trace_here (InterpBasicBlock *bb, InterpInst *last_ins) {
 void
 jiterp_insert_entry_points (void *_td)
 {
-	if (!jiterpreter_traces_enabled)
+	if (!mono_opt_jiterpreter_traces_enabled)
 		return;
 	TransformData *td = (TransformData *)_td;
 
@@ -937,7 +899,7 @@ jiterp_insert_entry_points (void *_td)
 
 		// If backwards branches target a block, enter a trace there so that
 		//  after the backward branch we can re-enter jitted code
-		if (jiterpreter_backward_branch_entries_enabled && bb->backwards_branch_target)
+		if (mono_opt_jiterpreter_backward_branch_entries_enabled && bb->backwards_branch_target)
 			is_backwards_branch = TRUE;
 
 		gboolean enabled = (is_backwards_branch || is_resume_or_first);
@@ -948,10 +910,10 @@ jiterp_insert_entry_points (void *_td)
 		//  of the same method in order to handle loops and resuming
 		gboolean should_generate = enabled && should_generate_trace_here(bb, td->last_ins);
 
-		if (jiterpreter_call_resume_enabled && bb->contains_call_instruction)
+		if (mono_opt_jiterpreter_call_resume_enabled && bb->contains_call_instruction)
 			enter_at_next = TRUE;
 
-		if (jiterpreter_always_generate)
+		if (mono_opt_jiterpreter_always_generate)
 			should_generate = TRUE;
 
 		if (enabled && should_generate) {
@@ -975,97 +937,33 @@ mono_jiterp_parse_option (const char *option)
 	if (!option || (*option == 0))
 		return FALSE;
 
-	const char *mtl = "jiterpreter-minimum-trace-length=";
-	const int mtl_l = strlen(mtl);
+	const char *arr[2] = { option, NULL };
+	int temp;
+	mono_options_parse_options(arr, 1, &temp, NULL);
 
-	if (!strcmp (option, "jiterpreter-enable-traces"))
-		jiterpreter_traces_enabled = TRUE;
-	else if (!strcmp (option, "jiterpreter-disable-traces"))
-		jiterpreter_traces_enabled = FALSE;
-	else if (!strcmp (option, "jiterpreter-enable-interp-entry"))
-		jiterpreter_interp_entry_enabled = TRUE;
-	else if (!strcmp (option, "jiterpreter-disable-interp-entry"))
-		jiterpreter_interp_entry_enabled = FALSE;
-	else if (!strcmp (option, "jiterpreter-enable-jit-call"))
-		jiterpreter_jit_call_enabled = TRUE;
-	else if (!strcmp (option, "jiterpreter-disable-jit-call"))
-		jiterpreter_jit_call_enabled = FALSE;
-	else if (!strcmp (option, "jiterpreter-enable-backward-branches"))
-		jiterpreter_backward_branch_entries_enabled = TRUE;
-	else if (!strcmp (option, "jiterpreter-disable-backward-branches"))
-		jiterpreter_backward_branch_entries_enabled = FALSE;
-	else if (!strcmp (option, "jiterpreter-enable-call-resume"))
-		jiterpreter_call_resume_enabled = TRUE;
-	else if (!strcmp (option, "jiterpreter-disable-call-resume"))
-		jiterpreter_call_resume_enabled = FALSE;
-	else if (!strcmp (option, "jiterpreter-enable-wasm-eh"))
-		jiterpreter_wasm_eh_enabled = TRUE;
-	else if (!strcmp (option, "jiterpreter-disable-wasm-eh"))
-		jiterpreter_wasm_eh_enabled = FALSE;
-	else if (!strcmp (option, "jiterpreter-always-generate"))
-		jiterpreter_always_generate = TRUE;
-	else if (!strcmp (option, "jiterpreter-enable-all"))
-		jiterpreter_traces_enabled = jiterpreter_interp_entry_enabled = jiterpreter_jit_call_enabled = TRUE;
-	else if (!strcmp (option, "jiterpreter-disable-all"))
-		jiterpreter_traces_enabled = jiterpreter_interp_entry_enabled = jiterpreter_jit_call_enabled = FALSE;
-	else if (!strcmp (option, "jiterpreter-enable-stats"))
-		jiterpreter_stats_enabled = TRUE;
-	else if (!strcmp (option, "jiterpreter-disable-stats"))
-		jiterpreter_stats_enabled = FALSE;
-	else if (!strcmp (option, "jiterpreter-estimate-heat"))
-		jiterpreter_always_generate = jiterpreter_estimate_heat = TRUE;
-	else if (!strcmp (option, "jiterpreter-count-bailouts"))
-		jiterpreter_always_generate = jiterpreter_count_bailouts = TRUE;
-	else if (!strncmp (option, mtl, mtl_l))
-		jiterpreter_minimum_trace_length = atoi(option + mtl_l);
-	else
-		return FALSE;
-
-	jiterpreter_options_version++;
+	mono_options_version++;
 	return TRUE;
 }
 
 // When jiterpreter options change we increment this version so that the typescript knows
 //  it will have to re-query all the option values
 EMSCRIPTEN_KEEPALIVE gint32
-mono_jiterp_get_options_version () {
-	return jiterpreter_options_version;
+mono_jiterp_get_options_version ()
+{
+	return mono_options_version;
 }
 
-// The typescript uses this to query the full jiterpreter configuration so it can behave
-//  appropriately (minimum trace length, EH enabled state, etc)
-EMSCRIPTEN_KEEPALIVE gint32
-mono_jiterp_get_option (const char * option) {
-	if (!strcmp (option, "jiterpreter-enable-traces"))
-		return jiterpreter_traces_enabled;
-	else if (!strcmp (option, "jiterpreter-enable-interp-entry"))
-		return jiterpreter_interp_entry_enabled;
-	else if (!strcmp (option, "jiterpreter-enable-jit-call"))
-		return jiterpreter_jit_call_enabled;
-	else if (!strcmp (option, "jiterpreter-enable-all"))
-		return jiterpreter_traces_enabled && jiterpreter_interp_entry_enabled && jiterpreter_jit_call_enabled;
-	else if (!strcmp (option, "jiterpreter-enable-backward-branches"))
-		return jiterpreter_backward_branch_entries_enabled;
-	else if (!strcmp (option, "jiterpreter-enable-call-resume"))
-		return jiterpreter_call_resume_enabled;
-	else if (!strcmp (option, "jiterpreter-enable-wasm-eh"))
-		return jiterpreter_wasm_eh_enabled;
-	else if (!strcmp (option, "jiterpreter-always-generate"))
-		return jiterpreter_always_generate;
-	else if (!strcmp (option, "jiterpreter-enable-stats"))
-		return jiterpreter_stats_enabled;
-	else if (!strcmp (option, "jiterpreter-minimum-trace-length"))
-		return jiterpreter_minimum_trace_length;
-	else if (!strcmp (option, "jiterpreter-estimate-heat"))
-		return jiterpreter_estimate_heat;
-	else if (!strcmp (option, "jiterpreter-count-bailouts"))
-		return jiterpreter_count_bailouts;
-	else
-		return -1;
+EMSCRIPTEN_KEEPALIVE char *
+mono_jiterp_get_options_as_json ()
+{
+	char * buf = g_malloc0(8192);
+	mono_options_get_as_json(buf, 8192);
+	return buf;
 }
 
 EMSCRIPTEN_KEEPALIVE void
-mono_jiterp_update_jit_call_dispatcher (WasmDoJitCall dispatcher) {
+mono_jiterp_update_jit_call_dispatcher (WasmDoJitCall dispatcher)
+{
 	// If we received a 0 dispatcher that means the TS side failed to compile
 	//  any kind of dispatcher - this likely indicates that content security policy
 	//  blocked the use of Module.addFunction

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -939,9 +939,7 @@ mono_jiterp_parse_option (const char *option)
 
 	const char *arr[2] = { option, NULL };
 	int temp;
-	mono_options_parse_options(arr, 1, &temp, NULL);
-
-	mono_options_version++;
+	mono_options_parse_options (arr, 1, &temp, NULL);
 	return TRUE;
 }
 
@@ -956,8 +954,8 @@ mono_jiterp_get_options_version ()
 EMSCRIPTEN_KEEPALIVE char *
 mono_jiterp_get_options_as_json ()
 {
-	char * buf = g_malloc0(8192);
-	mono_options_get_as_json(buf, 8192);
+	char * buf = g_malloc0 (8192);
+	mono_options_get_as_json (buf, 8192);
 	return buf;
 }
 

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -954,9 +954,7 @@ mono_jiterp_get_options_version ()
 EMSCRIPTEN_KEEPALIVE char *
 mono_jiterp_get_options_as_json ()
 {
-	char * buf = g_malloc0 (8192);
-	mono_options_get_as_json (buf, 8192);
-	return buf;
+	return mono_options_get_as_json ();
 }
 
 EMSCRIPTEN_KEEPALIVE void

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -84,10 +84,6 @@ mono_jiterp_do_jit_call_indirect (
 	gpointer cb, gpointer arg, gboolean *out_thrown
 );
 
-extern gboolean jiterpreter_traces_enabled;
-extern gboolean jiterpreter_interp_entry_enabled;
-extern gboolean jiterpreter_jit_call_enabled;
-extern gboolean jiterpreter_wasm_eh_enabled;
 extern WasmDoJitCall jiterpreter_do_jit_call;
 
 #endif // HOST_BROWSER

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -61,6 +61,50 @@ DEFINE_BOOL(wasm_exceptions, "wasm-exceptions", FALSE, "Enable codegen for WASM 
 DEFINE_BOOL(wasm_gc_safepoints, "wasm-gc-safepoints", FALSE, "Use GC safepoints on WASM")
 DEFINE_BOOL(aot_lazy_assembly_load, "aot-lazy-assembly-load", FALSE, "Load assemblies referenced by AOT images lazily")
 
+#if HOST_BROWSER
+
+// the jiterpreter is not yet thread safe due to the need to synchronize function pointers
+//  and wasm modules between threads. before these can be enabled we need to implement all that
+#if FEATURE_WASM_THREADS
+// traces_enabled controls whether the jiterpreter will JIT individual interpreter opcode traces
+DEFINE_BOOL_READONLY(jiterpreter_traces_enabled, "jiterpreter-traces-enabled", FALSE, "JIT interpreter opcode traces into WASM")
+// interp_entry_enabled controls whether specialized interp_entry wrappers will be jitted
+DEFINE_BOOL_READONLY(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry-enabled", FALSE, "JIT specialized WASM interp_entry wrappers")
+// jit_call_enabled controls whether do_jit_call will use specialized trampolines for hot call sites
+DEFINE_BOOL_READONLY(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", FALSE, "JIT specialized WASM do_jit_call trampolines")
+#else
+// traces_enabled controls whether the jiterpreter will JIT individual interpreter opcode traces
+DEFINE_BOOL(jiterpreter_traces_enabled, "jiterpreter-traces-enabled", TRUE, "JIT interpreter opcode traces into WASM")
+// interp_entry_enabled controls whether specialized interp_entry wrappers will be jitted
+DEFINE_BOOL(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry-enabled", TRUE, "JIT specialized WASM interp_entry wrappers")
+// jit_call_enabled controls whether do_jit_call will use specialized trampolines for hot call sites
+DEFINE_BOOL(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", TRUE, "JIT specialized WASM do_jit_call trampolines")
+#endif // FEATURE_WASM_THREADS
+
+// enables using WASM try/catch_all instructions where appropriate (currently only do_jit_call),
+//  will be automatically turned off if the instructions are not available.
+DEFINE_BOOL(jiterpreter_wasm_eh_enabled, "jiterpreter-wasm-eh-enabled", TRUE, "Enable the use of WASM Exception Handling in JITted code")
+// if enabled, we will insert trace entry points at backwards branch targets, so that we can
+//  JIT loop bodies
+DEFINE_BOOL(jiterpreter_backward_branch_entries_enabled, "jiterpreter-backward-branch-entries-enabled", TRUE, "Insert trace entry points at backward branch targets")
+// if enabled, after a call instruction terminates a trace, we will attempt to start a new
+//  one at the next basic block. this allows jitting loop bodies that start with 'if (x) continue' etc
+DEFINE_BOOL(jiterpreter_call_resume_enabled, "jiterpreter-call-resume-enabled", TRUE, "Insert trace entry points after function calls")
+// For locations where the jiterpreter heuristic says we will be unable to generate
+//  a trace, insert an entry point opcode anyway. This enables collecting accurate
+//  stats for options like estimateHeat, but raises overhead.
+DEFINE_BOOL(jiterpreter_always_generate, "jiterpreter-always-generate", FALSE, "Always insert trace entry points for more accurate statistics")
+// Automatically prints stats at app exit or when jiterpreter_dump_stats is called
+DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", FALSE, "Automatically print jiterpreter statistics")
+// Continue counting hits for traces that fail to compile and use it to estimate
+//  the relative importance of the opcode that caused them to abort
+DEFINE_BOOL(jiterpreter_estimate_heat, "jiterpreter-estimate-heat", FALSE, "Maintain accurate hit count for all trace entry points")
+// Count the number of times a trace bails out (branch taken, etc) and for what reason
+DEFINE_BOOL(jiterpreter_count_bailouts, "jiterpreter-count-bailouts", FALSE, "Maintain accurate count of all trace bailouts based on cause")
+// any trace that doesn't have at least this many meaningful (non-nop) opcodes in it will be rejected
+DEFINE_INT(jiterpreter_minimum_trace_length, "jiterpreter-minimum-trace-length", 8, "Reject traces shorter than this number of meaningful opcodes")
+#endif // HOST_BROWSER
+
 /* Cleanup */
 #undef DEFINE_OPTION_FULL
 #undef DEFINE_OPTION_READONLY

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -74,11 +74,11 @@ DEFINE_BOOL_READONLY(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry
 DEFINE_BOOL_READONLY(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", FALSE, "JIT specialized WASM do_jit_call trampolines")
 #else
 // traces_enabled controls whether the jiterpreter will JIT individual interpreter opcode traces
-DEFINE_BOOL(jiterpreter_traces_enabled, "jiterpreter-traces-enabled", TRUE, "JIT interpreter opcode traces into WASM")
+DEFINE_BOOL(jiterpreter_traces_enabled, "jiterpreter-traces-enabled", FALSE, "JIT interpreter opcode traces into WASM")
 // interp_entry_enabled controls whether specialized interp_entry wrappers will be jitted
-DEFINE_BOOL(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry-enabled", TRUE, "JIT specialized WASM interp_entry wrappers")
+DEFINE_BOOL(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry-enabled", FALSE, "JIT specialized WASM interp_entry wrappers")
 // jit_call_enabled controls whether do_jit_call will use specialized trampolines for hot call sites
-DEFINE_BOOL(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", TRUE, "JIT specialized WASM do_jit_call trampolines")
+DEFINE_BOOL(jiterpreter_jit_call_enabled, "jiterpreter-jit-call-enabled", FALSE, "JIT specialized WASM do_jit_call trampolines")
 #endif // FEATURE_WASM_THREADS
 
 // enables using WASM try/catch_all instructions where appropriate (currently only do_jit_call),

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -249,93 +249,78 @@ mono_options_parse_options (const char **argv, int argc, int *out_argc, MonoErro
 	*out_argc = aindex;
 }
 
-static char *
-strncat_safe (char *destination, const char *source, char *end)
-{
-	if (destination >= end)
-		return end;
-
-	return strncat (destination, source, end - destination);
-}
-
-static char *
-strncat_option_json (char *destination, MonoOptionType type, const void *value, char *end)
+static void
+string_append_option_json (GString *destination, MonoOptionType type, const void *value)
 {
 	switch (type) {
 	case MONO_OPTION_BOOL:
 	case MONO_OPTION_BOOL_READONLY:
-		return strncat_safe (destination, *(gboolean*)value ? "true" : "false", end);
+		g_string_append (destination, *(gboolean*)value ? "true" : "false");
+		return;
 
-	case MONO_OPTION_INT: {
-		char * buf = option_value_to_str (type, value);
-		char * result = strncat_safe (destination, buf, end);
-		g_free(buf);
-		return result;
-	}
+	case MONO_OPTION_INT:
+		g_string_append_printf (destination, "%d", *(int*)value);
+		return;
 
 	case MONO_OPTION_STRING: {
 		char ch;
 		const char * src = *(char**)value;
-		if (!src || !*src)
-			return strncat_safe (destination, "\"\"", end);
+		if (!src || !*src) {
+			g_string_append (destination, "\"\"");
+			return;
+		}
 
-		destination = strncat_safe (destination, "\"", end);
+		g_string_append (destination, "\"");
 		while ((ch = *src) != 0) {
-			if (destination >= (end - 2))
-				break;
-
 			switch (ch) {
 				case '\'':
 				case '\"':
 				case '\\':
-					*destination++ = '\\';
-					*destination++ = ch;
+					g_string_append_c (destination, '\\');
+					g_string_append_c (destination, ch);
 					break;
 				default:
-					if (ch < 32) {
-						char * buf = g_strdup_printf ("\\u%04X", ch);
-						destination = strncat_safe (destination, buf, end);
-						g_free(buf);
-					} else
-						*destination++ = *src;
+					if (ch < 32)
+						g_string_append_printf (destination, "\\u%04X", ch);
+					else
+						g_string_append_c (destination, ch);
 					break;
 			}
 
 			src++;
 		}
 
-		destination = strncat_safe (destination, "\"", end);
-		return destination;
+		g_string_append (destination, "\"");
+		return;
 	}
 
 	default:
 		g_assert_not_reached ();
-		return NULL;
+		return;
 	}
 }
 
-void
-mono_options_get_as_json (char *result_buffer, int result_buffer_size)
+char *
+mono_options_get_as_json (void)
 {
-	char *end = result_buffer + result_buffer_size - 1,
-		*destination = result_buffer;
+	char *result_str;
+	GString *result = g_string_new("{\n");
 	gboolean need_comma = FALSE;
-
-	*destination = 0;
-	strncpy (destination, "{\n", result_buffer_size);
 
 #define DEFINE_OPTION_READONLY(option_type, ctype, c_name, cmd_name, def_value, comment) DEFINE_OPTION_FULL(option_type, ctype, c_name, cmd_name, def_value, comment)
 #define DEFINE_OPTION_FULL(option_type, ctype, c_name, cmd_name, def_value, comment) do { \
 		if (need_comma) \
-			destination = strncat_safe (destination, ",\n", end); \
-		destination = strncat_safe (destination, "  \"", end); \
-		destination = strncat_safe (destination, cmd_name, end); \
-		destination = strncat_safe (destination, "\": ", end); \
-		destination = strncat_option_json (destination, option_type, &mono_opt_##c_name, end); \
+			g_string_append (result, ",\n"); \
+		g_string_append_printf (result, "  \"%s\": ", cmd_name); \
+		string_append_option_json (result, option_type, &mono_opt_##c_name); \
 		need_comma = TRUE; \
 	} while (0);
 
 #include "options-def.h"
 
-	destination = strncat_safe (destination, need_comma ? "\n}" : "}", end);
+	g_string_append(result, "\n}");
+
+	result_str = result->str;
+	g_string_free(result, FALSE);
+	return result_str;
 }

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -276,9 +276,10 @@ strncat_option_json (char *destination, MonoOptionType type, const void *value, 
 	case MONO_OPTION_STRING: {
 		char ch;
 		const char * src = *(char**)value;
-		if (!src)
+		if (!src || !*src)
 			return strncat_safe (destination, "\"\"", end);
 
+		destination = strncat_safe (destination, "\"", end);
 		while ((ch = *src) != 0) {
 			if (destination >= (end - 1))
 				return destination;
@@ -302,6 +303,7 @@ strncat_option_json (char *destination, MonoOptionType type, const void *value, 
 
 			src++;
 		}
+		destination = strncat_safe (destination, "\"", end);
 	}
 
 	default:

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -257,7 +257,7 @@ strncat_safe (char *destination, const char *source, char *end)
 	if (destination >= end)
 		return end;
 
-	return strncat(destination, source, end - destination);
+	return strncat (destination, source, end - destination);
 }
 
 static char *
@@ -266,11 +266,11 @@ strncat_option_json (char *destination, MonoOptionType type, const void *value, 
 	switch (type) {
 	case MONO_OPTION_BOOL:
 	case MONO_OPTION_BOOL_READONLY:
-		return strncat_safe(destination, *(gboolean*)value ? "true" : "false", end);
+		return strncat_safe (destination, *(gboolean*)value ? "true" : "false", end);
 
 	case MONO_OPTION_INT: {
-		char * buf = option_value_to_str(type, value);
-		char * result = strncat_safe(destination, buf, end);
+		char * buf = option_value_to_str (type, value);
+		char * result = strncat_safe (destination, buf, end);
 		g_free(buf);
 		return result;
 	}
@@ -279,7 +279,7 @@ strncat_option_json (char *destination, MonoOptionType type, const void *value, 
 		char ch;
 		const char * src = *(char**)value;
 		if (!src)
-			return strncat_safe(destination, "\"\"", end);
+			return strncat_safe (destination, "\"\"", end);
 
 		while ((ch = *src) != 0) {
 			if (destination >= (end - 1))
@@ -295,7 +295,7 @@ strncat_option_json (char *destination, MonoOptionType type, const void *value, 
 				default:
 					if (ch < 32) {
 						char * buf = g_strdup_printf ("\\u%04X", ch);
-						destination = strncat_safe(destination, buf, end);
+						destination = strncat_safe (destination, buf, end);
 						g_free(buf);
 					} else
 						*destination++ = *src;
@@ -320,20 +320,20 @@ mono_options_get_as_json (char *result_buffer, int result_buffer_size)
 	gboolean need_comma = FALSE;
 
 	*destination = 0;
-	strncpy(destination, "{\n", result_buffer_size);
+	strncpy (destination, "{\n", result_buffer_size);
 
 #define DEFINE_OPTION_READONLY(option_type, ctype, c_name, cmd_name, def_value, comment) DEFINE_OPTION_FULL(option_type, ctype, c_name, cmd_name, def_value, comment)
 #define DEFINE_OPTION_FULL(option_type, ctype, c_name, cmd_name, def_value, comment) do { \
 		if (need_comma) \
-			destination = strncat_safe(destination, ",\n", end); \
-		destination = strncat_safe(destination, "  \"", end); \
-		destination = strncat_safe(destination, cmd_name, end); \
-		destination = strncat_safe(destination, "\": ", end); \
-		destination = strncat_option_json(destination, option_type, &mono_opt_##c_name, end); \
+			destination = strncat_safe (destination, ",\n", end); \
+		destination = strncat_safe (destination, "  \"", end); \
+		destination = strncat_safe (destination, cmd_name, end); \
+		destination = strncat_safe (destination, "\": ", end); \
+		destination = strncat_option_json (destination, option_type, &mono_opt_##c_name, end); \
 		need_comma = TRUE; \
 	} while (0);
 
 #include "options-def.h"
 
-	destination = strncat_safe(destination, need_comma ? "\n}" : "}", end);
+	destination = strncat_safe (destination, need_comma ? "\n}" : "}", end);
 }

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -107,12 +107,10 @@ get_option_hash ()
 	 * We lost a data race. Accept our fate and free our copy of the table.
 	 * FIXME: It's possible to lose the race with precise timing and fail to free the extra table.
 	*/
-	if (_option_hash) {
+	if (_option_hash)
 		g_hash_table_destroy(result);
-		result = _option_hash;
-	} else {
+	else
 		_option_hash = result;
-	}
 
 	return _option_hash;
 }

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -256,11 +256,11 @@ string_append_option_json (GString *destination, MonoOptionType type, const void
 	case MONO_OPTION_BOOL:
 	case MONO_OPTION_BOOL_READONLY:
 		g_string_append (destination, *(gboolean*)value ? "true" : "false");
-		return;
+		break;
 
 	case MONO_OPTION_INT:
 		g_string_append_printf (destination, "%d", *(int*)value);
-		return;
+		break;
 
 	case MONO_OPTION_STRING: {
 		char ch;
@@ -291,12 +291,12 @@ string_append_option_json (GString *destination, MonoOptionType type, const void
 		}
 
 		g_string_append (destination, "\"");
-		return;
+		break;
 	}
 
 	default:
 		g_assert_not_reached ();
-		return;
+		break;
 	}
 }
 

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -281,8 +281,8 @@ strncat_option_json (char *destination, MonoOptionType type, const void *value, 
 
 		destination = strncat_safe (destination, "\"", end);
 		while ((ch = *src) != 0) {
-			if (destination >= (end - 1))
-				return destination;
+			if (destination >= (end - 2))
+				break;
 
 			switch (ch) {
 				case '\'':
@@ -303,7 +303,9 @@ strncat_option_json (char *destination, MonoOptionType type, const void *value, 
 
 			src++;
 		}
+
 		destination = strncat_safe (destination, "\"", end);
+		return destination;
 	}
 
 	default:

--- a/src/mono/mono/utils/options.h
+++ b/src/mono/mono/utils/options.h
@@ -22,8 +22,13 @@ MONO_BEGIN_DECLS
 #include "options-def.h"
 MONO_END_DECLS
 
+extern int mono_options_version;
+
 void mono_options_print_usage (void);
 
 void mono_options_parse_options (const char **args, int argc, int *out_argc, MonoError *error);
+
+/* Writes json representing all current option values into the provided buffer. */
+void mono_options_get_as_json (char *result_buffer, int result_buffer_size);
 
 #endif

--- a/src/mono/mono/utils/options.h
+++ b/src/mono/mono/utils/options.h
@@ -28,7 +28,7 @@ void mono_options_print_usage (void);
 
 void mono_options_parse_options (const char **args, int argc, int *out_argc, MonoError *error);
 
-/* Writes json representing all current option values into the provided buffer. */
-void mono_options_get_as_json (char *result_buffer, int result_buffer_size);
+/* returns a json blob representing the current values of all options */
+char * mono_options_get_as_json (void);
 
 #endif

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -172,7 +172,7 @@ try {
     globalThis.mainApp.PageShow = globalThis.mainApp.pageShow.bind(globalThis.mainApp);
 
     const runtime = await dotnet
-        .withRuntimeOptions(["--jiterpreter-enable-stats"])
+        .withRuntimeOptions(["--jiterpreter-stats-enabled"])
         .withElementOnExit()
         .withExitCodeLogging()
         .create();

--- a/src/mono/sample/wasm/simple-raytracer/main.js
+++ b/src/mono/sample/wasm/simple-raytracer/main.js
@@ -20,7 +20,7 @@ const exports = await getAssemblyExports(config.mainAssemblyName);
 globalThis.onClick = exports.Program.OnClick;
 
 await dotnet
-    .withRuntimeOptions(["--jiterpreter-enable-stats"])
+    .withRuntimeOptions(["--jiterpreter-stats-enabled"])
     .run();
 const btnRender = document.getElementById("btnRender");
 btnRender.disabled = false;

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -109,7 +109,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_type_is_byref", "number", ["number"]],
     [true, "mono_jiterp_get_size_of_stackval", "number", []],
     [true, "mono_jiterp_parse_option", "number", ["string"]],
-    [true, "mono_jiterp_get_option", "number", ["string"]],
+    [true, "mono_jiterp_get_options_as_json", "number", []],
     [true, "mono_jiterp_get_options_version", "number", []],
     [true, "mono_jiterp_adjust_abort_count", "number", ["number", "number"]],
     [true, "mono_jiterp_register_jit_call_thunk", "void", ["number", "number"]],
@@ -243,7 +243,7 @@ export interface t_Cwraps {
     mono_jiterp_get_size_of_stackval (): number;
     mono_jiterp_type_get_raw_value_size (type: MonoType): number;
     mono_jiterp_parse_option (name: string): number;
-    mono_jiterp_get_option (name: string): number;
+    mono_jiterp_get_options_as_json (): number;
     mono_jiterp_get_options_version (): number;
     mono_jiterp_adjust_abort_count (opcode: number, delta: number): number;
     mono_jiterp_register_jit_call_thunk (cinfo: number, func: number): void;

--- a/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
+++ b/src/mono/wasm/runtime/jiterpreter-interp-entry.ts
@@ -12,7 +12,7 @@ import cwraps from "./cwraps";
 import {
     WasmValtype, WasmBuilder, addWasmFunctionPointer,
     _now, elapsedTimes, counters, getRawCwrap, importDef,
-    getWasmFunctionTable
+    getWasmFunctionTable, recordFailure
 } from "./jiterpreter-support";
 
 // Controls miscellaneous diagnostic output.
@@ -323,7 +323,8 @@ function flush_wasm_entry_trampoline_jit_queue () {
         rejected = false;
         // console.error(`${traceName} failed: ${exc} ${exc.stack}`);
         // HACK: exc.stack is enormous garbage in v8 console
-        console.error(`MONO_WASM: interp_entry trampoline jit failed: ${exc}`);
+        console.error(`MONO_WASM: interp_entry code generation failed: ${exc}`);
+        recordFailure();
     } finally {
         const finished = _now();
         if (compileStarted) {

--- a/src/mono/wasm/runtime/jiterpreter-jit-call.ts
+++ b/src/mono/wasm/runtime/jiterpreter-jit-call.ts
@@ -10,7 +10,7 @@ import {
 import { WasmOpcode } from "./jiterpreter-opcodes";
 import {
     WasmValtype, WasmBuilder, addWasmFunctionPointer as addWasmFunctionPointer,
-    _now, elapsedTimes, counters, getWasmFunctionTable, applyOptions
+    _now, elapsedTimes, counters, getWasmFunctionTable, applyOptions, recordFailure
 } from "./jiterpreter-support";
 import cwraps from "./cwraps";
 
@@ -389,7 +389,8 @@ export function mono_interp_flush_jitcall_queue () : void {
         rejected = false;
         // console.error(`${traceName} failed: ${exc} ${exc.stack}`);
         // HACK: exc.stack is enormous garbage in v8 console
-        console.error(`jit failed: ${exc}`);
+        console.error(`MONO_WASM: jit_call code generation failed: ${exc}`);
+        recordFailure();
     } finally {
         const finished = _now();
         if (compileStarted) {

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -6,6 +6,8 @@ import { Module } from "./imports";
 import { WasmOpcode } from "./jiterpreter-opcodes";
 import cwraps from "./cwraps";
 
+export const maxFailures = 4;
+
 // uint16
 export declare interface MintOpcodePtr extends NativePointer {
     __brand: "MintOpcodePtr"
@@ -605,6 +607,7 @@ export const counters = {
     tracesCompiled: 0,
     entryWrappersCompiled: 0,
     jitCallsCompiled: 0,
+    failures: 0
 };
 
 export const _now = (globalThis.performance && globalThis.performance.now)
@@ -695,6 +698,18 @@ export function append_memmove_dest_src (builder: WasmBuilder, count: number) {
     }
 }
 
+export function recordFailure () : void {
+    counters.failures++;
+    if (counters.failures >= maxFailures) {
+        console.log(`MONO_WASM: Disabling jiterpreter after ${counters.failures} failures`);
+        applyOptions(<any>{
+            enableTraces: false,
+            enableInterpEntry: false,
+            enableJitCall: false
+        });
+    }
+}
+
 export function getRawCwrap (name: string): Function {
     const result = (<any>Module)["asm"][name];
     if (typeof (result) !== "function")
@@ -727,18 +742,17 @@ export type JiterpreterOptions = {
     minimumTraceLength: number;
 }
 
-const optionNames : { [jsName: string] : [string, string] | string } = {
-    "enableAll": ["jiterpreter-enable-all", "jiterpreter-disable-all"],
-    "enableTraces": ["jiterpreter-enable-traces", "jiterpreter-disable-traces"],
-    "enableInterpEntry": ["jiterpreter-enable-interp-entry", "jiterpreter-disable-interp-entry"],
-    "enableJitCall": ["jiterpreter-enable-jit-call", "jiterpreter-disable-jit-call"],
-    "enableBackwardBranches": ["jiterpreter-enable-backward-branches", "jiterpreter-disable-backward-branches"],
-    "enableCallResume": ["jiterpreter-enable-call-resume", "jiterpreter-disable-call-resume"],
-    "enableWasmEh": ["jiterpreter-enable-wasm-eh", "jiterpreter-disable-wasm-eh"],
-    "enableStats": ["jiterpreter-enable-stats", "jiterpreter-disable-stats"],
-    "alwaysGenerate": ["jiterpreter-always-generate", ""],
-    "estimateHeat": ["jiterpreter-estimate-heat", ""],
-    "countBailouts": ["jiterpreter-count-bailouts", ""],
+const optionNames : { [jsName: string] : string } = {
+    "enableTraces": "jiterpreter-traces-enabled",
+    "enableInterpEntry": "jiterpreter-interp-entry-enabled",
+    "enableJitCall": "jiterpreter-jit-call-enabled",
+    "enableBackwardBranches": "jiterpreter-backward-branch-entries-enabled",
+    "enableCallResume": "jiterpreter-call-resume-enabled",
+    "enableWasmEh": "jiterpreter-wasm-eh-enabled",
+    "enableStats": "jiterpreter-stats-enabled",
+    "alwaysGenerate": "jiterpreter-always-generate",
+    "estimateHeat": "jiterpreter-estimate-heat",
+    "countBailouts": "jiterpreter-count-bailouts",
     "minimumTraceLength": "jiterpreter-minimum-trace-length",
 };
 
@@ -756,9 +770,9 @@ export function applyOptions (options: JiterpreterOptions) {
 
         const v = (<any>options)[k];
         if (typeof (v) === "boolean")
-            cwraps.mono_jiterp_parse_option(v ? info[0] : info[1]);
+            cwraps.mono_jiterp_parse_option((v ? "--" : "--no-") + info);
         else if (typeof (v) === "number")
-            cwraps.mono_jiterp_parse_option(`${info}=${v}`);
+            cwraps.mono_jiterp_parse_option(`--${info}=${v}`);
         else
             console.error(`Jiterpreter option must be a boolean or a number but was ${typeof(v)} '${v}'`);
     }
@@ -775,14 +789,17 @@ export function getOptions () {
 }
 
 function updateOptions () {
-    const table = <any>{};
-    optionTable = table;
+    const pJson = cwraps.mono_jiterp_get_options_as_json();
+    const json = Module.UTF8ToString(<any>pJson);
+    // console.log(`options=${json}`);
+    Module._free(<any>pJson);
+    const blob = JSON.parse(json);
+
+    optionTable = <any>{};
     for (const k in optionNames) {
         const info = optionNames[k];
-        if (Array.isArray(info))
-            table[k] = cwraps.mono_jiterp_get_option(info[0]) > 0;
-        else
-            table[k] = cwraps.mono_jiterp_get_option(info);
+        (<any>optionTable)[k] = blob[info];
     }
-    // console.log(`options=${JSON.stringify(table)}`);
+
+    // console.log(`optionTable=${JSON.stringify(optionTable)}`);
 }

--- a/src/mono/wasm/runtime/jiterpreter-support.ts
+++ b/src/mono/wasm/runtime/jiterpreter-support.ts
@@ -791,7 +791,6 @@ export function getOptions () {
 function updateOptions () {
     const pJson = cwraps.mono_jiterp_get_options_as_json();
     const json = Module.UTF8ToString(<any>pJson);
-    // console.log(`options=${json}`);
     Module._free(<any>pJson);
     const blob = JSON.parse(json);
 
@@ -800,6 +799,4 @@ function updateOptions () {
         const info = optionNames[k];
         (<any>optionTable)[k] = blob[info];
     }
-
-    // console.log(`optionTable=${JSON.stringify(optionTable)}`);
 }

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -14,7 +14,7 @@ import {
     MintOpcodePtr, WasmValtype, WasmBuilder, addWasmFunctionPointer,
     copyIntoScratchBuffer, _now, elapsedTimes, append_memset_dest,
     append_memmove_dest_src, counters, getRawCwrap, importDef,
-    JiterpreterOptions, getOptions
+    JiterpreterOptions, getOptions, recordFailure
 } from "./jiterpreter-support";
 
 // Controls miscellaneous diagnostic output.
@@ -631,7 +631,8 @@ function generate_wasm (
     } catch (exc: any) {
         threw = true;
         rejected = false;
-        console.error(`MONO_WASM: ${traceName} failed: ${exc} ${exc.stack}`);
+        console.error(`MONO_WASM: ${traceName} code generation failed: ${exc} ${exc.stack}`);
+        recordFailure();
         return 0;
     } finally {
         const finished = _now();


### PR DESCRIPTION
* Expand options.h api with ability to dump options as a JSON blob.
* Migrate jiterpreter configuration to options.h
* Disable jiterpreter automatically after multiple JIT failures
Blocks #78428