### PR TITLE
Add support for standalone GC back compatibility

### DIFF
--- a/src/coreclr/gc/gccommon.cpp
+++ b/src/coreclr/gc/gccommon.cpp
@@ -18,6 +18,7 @@ IGCHandleManager* g_theGCHandleManager;
 
 #ifdef BUILD_AS_STANDALONE
 IGCToCLR* g_theGCToCLR;
+VersionInfo g_runtimeSupportedVersion;
 #endif // BUILD_AS_STANDALONE
 
 #ifdef GC_CONFIG_DRIVEN

--- a/src/coreclr/gc/gcenv.ee.standalone.inl
+++ b/src/coreclr/gc/gcenv.ee.standalone.inl
@@ -11,6 +11,9 @@
 // will be forwarded to this interface instance.
 extern IGCToCLR* g_theGCToCLR;
 
+// GC version that the current runtime supports
+extern VersionInfo g_runtimeSupportedVersion;
+
 struct StressLogMsg;
 
 // When we are building the GC in a standalone environment, we

--- a/src/coreclr/gc/gcload.cpp
+++ b/src/coreclr/gc/gcload.cpp
@@ -43,8 +43,15 @@ extern void PopulateHandleTableDacVars(GcDacVars* dacVars);
 
 GC_EXPORT
 void
-GC_VersionInfo(/* Out */ VersionInfo* info)
+GC_VersionInfo(/* InOut */ VersionInfo* info)
 {
+#ifdef BUILD_AS_STANDALONE
+    // On entry, the info argument contains the interface version that the runtime supports.
+    // It is later used to enable backwards compatibility between the GC and the runtime.
+    // For example, GC would only call functions on g_theGCToCLR interface that the runtime
+    // supports.
+    g_runtimeSupportedVersion = *info;
+#endif
     info->MajorVersion = GC_INTERFACE_MAJOR_VERSION;
     info->MinorVersion = GC_INTERFACE_MINOR_VERSION;
     info->BuildVersion = 0;

--- a/src/coreclr/vm/gcheaputilities.cpp
+++ b/src/coreclr/vm/gcheaputilities.cpp
@@ -214,17 +214,21 @@ HRESULT LoadAndInitializeGC(LPCWSTR standaloneGcLocation)
     }
 
     g_gc_load_status = GC_LOAD_STATUS_GET_VERSIONINFO;
+    g_gc_version_info.MajorVersion = GC_INTERFACE_MAJOR_VERSION;
+    g_gc_version_info.MinorVersion = GC_INTERFACE_MINOR_VERSION;
+    g_gc_version_info.BuildVersion = 0;
     versionInfo(&g_gc_version_info);
     g_gc_load_status = GC_LOAD_STATUS_CALL_VERSIONINFO;
 
-    if (g_gc_version_info.MajorVersion != GC_INTERFACE_MAJOR_VERSION)
+    if (g_gc_version_info.MajorVersion < GC_INTERFACE_MAJOR_VERSION)
     {
-        LOG((LF_GC, LL_FATALERROR, "Loaded GC has incompatible major version number (expected %d, got %d)\n",
+        LOG((LF_GC, LL_FATALERROR, "Loaded GC has incompatible major version number (expected at least %d, got %d)\n",
             GC_INTERFACE_MAJOR_VERSION, g_gc_version_info.MajorVersion));
         return E_FAIL;
     }
 
-    if (g_gc_version_info.MinorVersion < GC_INTERFACE_MINOR_VERSION)
+    if ((g_gc_version_info.MajorVersion == GC_INTERFACE_MAJOR_VERSION) &&
+        (g_gc_version_info.MinorVersion < GC_INTERFACE_MINOR_VERSION))
     {
         LOG((LF_GC, LL_INFO100, "Loaded GC has lower minor version number (%d) than EE was compiled against (%d)\n",
             g_gc_version_info.MinorVersion, GC_INTERFACE_MINOR_VERSION));


### PR DESCRIPTION
Currently, the version of the standalone GC has to match the version that the runtime was compiled with. This change enables loosening that requirement. Runtime is allowed to use any standalone GC as long as its version is larger or equal to a defined minimum version. GC is now passed the version of GC the runtime was compiled with, and it can use it to behave in a way compatible with that version. For example, if we add new methods to the GC to EE interface, that GC can check the GC version the runtime supports and skip calling the new methods if it is running with an older runtime.