### PR TITLE
[JIT] VN implicit cast fix for normalize-on-load

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8354,15 +8354,13 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
         {
             // This means that there is an implicit cast on the rhs value
             // We will add a cast function to reflect the possible narrowing of the rhs value
-            GenTree* effectiveLhs = lhs->gtEffectiveVal();
-            if (effectiveLhs->OperIs(GT_LCL_VAR) && lvaGetDesc(effectiveLhs->AsLclVarCommon())->lvNormalizeOnLoad())
+            if (lhs->OperIs(GT_LCL_VAR) && lvaGetDesc(lhs->AsLclVarCommon())->lvNormalizeOnLoad())
             {
-                rhsVNPair =
-                    vnStore->VNPairForImplicitCastNormalizeOnLoad(rhsVNPair, effectiveLhs->TypeGet(), rhs->TypeGet());
+                rhsVNPair = vnStore->VNPairForImplicitCastNormalizeOnLoad(rhsVNPair, lhs->TypeGet(), rhs->TypeGet());
             }
             else
             {
-                rhsVNPair = vnStore->VNPairForCast(rhsVNPair, effectiveLhs->TypeGet(), rhs->TypeGet());
+                rhsVNPair = vnStore->VNPairForCast(rhsVNPair, lhs->TypeGet(), rhs->TypeGet());
             }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8357,8 +8357,8 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
             GenTree* effectiveLhs = lhs->gtEffectiveVal();
             if (effectiveLhs->OperIs(GT_LCL_VAR) && lvaGetDesc(effectiveLhs->AsLclVarCommon())->lvNormalizeOnLoad())
             {
-                rhsVNPair = vnStore->VNPairForImplicitCastForNormalizeOnLoad(rhsVNPair, effectiveLhs->TypeGet(),
-                                                                             rhs->TypeGet());
+                rhsVNPair =
+                    vnStore->VNPairForImplicitCastNormalizeOnLoad(rhsVNPair, effectiveLhs->TypeGet(), rhs->TypeGet());
             }
             else
             {

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -800,6 +800,13 @@ public:
                                bool         srcIsUnsigned    = false,
                                bool         hasOverflowCheck = false);
 
+    // Compute the ValueNumberPair for an implicit cast on a normalize-on-load assignment
+    ValueNumPair VNPairForImplicitCastNormalizeOnLoad(ValueNumPair srcVNPair,
+                                                      var_types    castToType,
+                                                      var_types    castFromType,
+                                                      bool         srcIsUnsigned    = false,
+                                                      bool         hasOverflowCheck = false);
+
     ValueNum EncodeBitCastType(var_types castToType, unsigned size);
 
     var_types DecodeBitCastType(ValueNum castToTypeVN, unsigned* pSize);


### PR DESCRIPTION
**Description**

@SingleAccretion @jakobbotsch After our discussions, I think this might be a fix for our issue with normalize-on-load locals and implicit casts. When I ran the diffs on my machine, it only showed 2 regressions in libraries_test and it fixes the correctness issue mentioned in this PR: https://github.com/dotnet/runtime/pull/77874

The difference does something like this, in combination with the other PR:
![image](https://user-images.githubusercontent.com/1278959/202572270-08d034b7-6e93-4736-9b35-59d64033d701.png)


**Acceptance Criteria**
- [ ] CI passes