### PR TITLE
Call RhNewArray through RuntimeImports

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.NativeAot.cs
@@ -26,11 +26,11 @@ namespace System
         }
 
         [Intrinsic]
-        protected internal unsafe object MemberwiseClone()
+        protected internal object MemberwiseClone()
         {
-            object clone = this.GetMethodTable()->IsArray ?
-                RuntimeImports.RhNewArray(this.GetMethodTable(), Unsafe.As<Array>(this).Length) :
-                RuntimeImports.RhNewObject(this.GetMethodTable());
+            object clone = this.GetEETypePtr().IsArray ?
+                RuntimeImports.RhNewArray(this.GetEETypePtr(), Unsafe.As<Array>(this).Length) :
+                RuntimeImports.RhNewObject(this.GetEETypePtr());
 
             // copy contents of "this" to the clone
 
@@ -38,7 +38,7 @@ namespace System
             ref byte src = ref this.GetRawData();
             ref byte dst = ref clone.GetRawData();
 
-            if (this.GetMethodTable()->HasGCPointers)
+            if (this.GetEETypePtr().HasPointers)
                 Buffer.BulkMoveWithWriteBarrier(ref dst, ref src, byteCount);
             else
                 Buffer.Memmove(ref dst, ref src, byteCount);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.NativeAot.cs
@@ -29,8 +29,8 @@ namespace System
         protected internal unsafe object MemberwiseClone()
         {
             object clone = this.GetMethodTable()->IsArray ?
-                RuntimeExports.RhNewArray(this.GetMethodTable(), Unsafe.As<Array>(this).Length) :
-                RuntimeExports.RhNewObject(this.GetMethodTable());
+                RuntimeImports.RhNewArray(this.GetMethodTable(), Unsafe.As<Array>(this).Length) :
+                RuntimeImports.RhNewObject(this.GetMethodTable());
 
             // copy contents of "this" to the clone
 


### PR DESCRIPTION
RuntimeExports type is not accessible in the split Runtime.Base/System.Private.CoreLib mode (without INPLACE_RUNTIME defined in CoreLib.csproj).

This was the mode we used in .NET Native where Runtime.Base compiled into mrt100_app.dll and not into the app itself.