### PR TITLE
Fix commit accounting for large pages

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -11789,7 +11789,7 @@ void gc_heap::clear_gen1_cards()
 heap_segment* gc_heap::make_heap_segment (uint8_t* new_pages, size_t size, gc_heap* hp, int gen_num)
 {
     gc_oh_num oh = gen_to_oh (gen_num);
-    size_t initial_commit = SEGMENT_INITIAL_COMMIT;
+    size_t initial_commit = use_large_pages_p ? size : SEGMENT_INITIAL_COMMIT;
     int h_number =
 #ifdef MULTIPLE_HEAPS
         hp->heap_number;
@@ -11814,8 +11814,7 @@ heap_segment* gc_heap::make_heap_segment (uint8_t* new_pages, size_t size, gc_he
     heap_segment_mem (new_segment) = start;
     heap_segment_used (new_segment) = start;
     heap_segment_reserved (new_segment) = new_pages + size;
-    heap_segment_committed (new_segment) = (use_large_pages_p ?
-        heap_segment_reserved(new_segment) : (new_pages + initial_commit));
+    heap_segment_committed (new_segment) = new_pages + initial_commit;
 
     init_heap_segment (new_segment, hp
 #ifdef USE_REGIONS


### PR DESCRIPTION
This change fixes an integer underflow that happens in the commit accounting, here is the sequence of events that will lead to it.

Under `use_large_page_p`, we created a new heap segment, we passed `SEGMENT_INITIAL_COMMIT` (which is just a page) to `virtual_commit`, so `committed_by_oh[0]` is increased by `SEGMENT_INITIAL_COMMIT`.

Later, the `heap_segment_committed` value for the segment is changed to `size`, which is the full region size.

Eventually, we `return_free_region`, which will subtract `committed_by_oh[0]` by the full region size, which will lead to a subtraction integer underflow.

This will result in a huge number, and that will fail future `virtual_commit` calls, leading to unexpected OOM.

The fix simply makes sure we add the full region size to the `committed_by_oh[0]` to begin with.