### PR TITLE
Fix freebsd cross build with cmake 3.25

### DIFF
--- a/eng/common/cross/toolchain.cmake
+++ b/eng/common/cross/toolchain.cmake
@@ -1,5 +1,12 @@
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})
 
+# reset platform variables (e.g. cmake 3.25 sets LINUX=1)
+unset(LINUX)
+unset(FREEBSD)
+unset(ILLUMOS)
+unset(ANDROID)
+unset(TIZEN)
+
 set(TARGET_ARCH_NAME $ENV{TARGET_BUILD_ARCH})
 if(EXISTS ${CROSS_ROOTFS}/bin/freebsd-version)
   set(CMAKE_SYSTEM_NAME FreeBSD)

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -61,7 +61,7 @@ resources:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-webassembly
 
     - container: FreeBSD_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-12-20221026180137-3fc5553
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-12
       env:
         ROOTFS_DIR: /crossrootfs/x64
 


### PR DESCRIPTION
In cmake 3.25, the toolchain file is called with context containing `LINUX` variable set. This causes problem for non-Linux platform. Fix is to unset platform variables which we use in the toolchain file.

Upstream PR: https://github.com/dotnet/arcade/pull/11672
Fixes: #78528