### PR TITLE
Allow inline relocations in dehydrated data

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -266,6 +266,16 @@ namespace Internal.Runtime.CompilerHelpers
                         WriteRelPtr32(pDest, ReadRelPtr32(pFixups + payload));
                         pDest += sizeof(int);
                         break;
+                    case DehydratedDataCommand.InlinePtrReloc:
+                        *(void**)pDest = ReadRelPtr32(pCurrent);
+                        pDest += sizeof(void*);
+                        pCurrent += sizeof(int);
+                        break;
+                    case DehydratedDataCommand.InlineRelPtr32Reloc:
+                        WriteRelPtr32(pDest, ReadRelPtr32(pCurrent));
+                        pDest += sizeof(int);
+                        pCurrent += sizeof(int);
+                        break;
                 }
             }
 

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -267,14 +267,20 @@ namespace Internal.Runtime.CompilerHelpers
                         pDest += sizeof(int);
                         break;
                     case DehydratedDataCommand.InlinePtrReloc:
-                        *(void**)pDest = ReadRelPtr32(pCurrent);
-                        pDest += sizeof(void*);
-                        pCurrent += sizeof(int);
+                        while (payload-- > 0)
+                        {
+                            *(void**)pDest = ReadRelPtr32(pCurrent);
+                            pDest += sizeof(void*);
+                            pCurrent += sizeof(int);
+                        }
                         break;
                     case DehydratedDataCommand.InlineRelPtr32Reloc:
-                        WriteRelPtr32(pDest, ReadRelPtr32(pCurrent));
-                        pDest += sizeof(int);
-                        pCurrent += sizeof(int);
+                        while (payload-- > 0)
+                        {
+                            WriteRelPtr32(pDest, ReadRelPtr32(pCurrent));
+                            pDest += sizeof(int);
+                            pCurrent += sizeof(int);
+                        }
                         break;
                 }
             }

--- a/src/coreclr/tools/Common/Internal/Runtime/DehydratedData.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/DehydratedData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.Runtime
@@ -21,9 +22,11 @@ namespace Internal.Runtime
         public const byte ZeroFill = 0x01;
         public const byte RelPtr32Reloc = 0x02;
         public const byte PtrReloc = 0x03;
+        public const byte InlineRelPtr32Reloc = 0x04;
+        public const byte InlinePtrReloc = 0x05;
 
-        private const byte DehydratedDataCommandMask = 0x03;
-        private const int DehydratedDataCommandPayloadShift = 2;
+        private const byte DehydratedDataCommandMask = 0x07;
+        private const int DehydratedDataCommandPayloadShift = 3;
 
         private const int MaxRawShortPayload = (1 << (8 - DehydratedDataCommandPayloadShift)) - 1;
         private const int MaxExtraPayloadBytes = 3;
@@ -77,42 +80,5 @@ namespace Internal.Runtime
 
             return pB + 1;
         }
-
-#if false
-        static void Main()
-        {
-            int command, payload;
-
-            byte[] buf = new byte[5];
-            Debug.Assert(Encode(1, 0, buf) == 1);
-            Debug.Assert(buf[0] == 1);
-            Debug.Assert(D(buf, out command, out payload) == 1 && command == 1 && payload == 0);
-            Debug.Assert(Encode(1, 1, buf) == 1);
-            Debug.Assert(buf[0] == (1 | (1 << DehydratedDataCommandPayloadShift)));
-            Debug.Assert(D(buf, out command, out payload) == 1 && command == 1 && payload == 1);
-            Debug.Assert(Encode(1, 60, buf) == 1);
-            Debug.Assert(buf[0] == (1 | (60 << DehydratedDataCommandPayloadShift)));
-            Debug.Assert(D(buf, out command, out payload) == 1 && command == 1 && payload == 60);
-            Debug.Assert(Encode(1, 61, buf) == 2);
-            Debug.Assert(buf[0] == (1 | ((MaxShortPayload + 1) << DehydratedDataCommandPayloadShift)));
-            Debug.Assert(buf[1] == 1);
-            Debug.Assert(D(buf, out command, out payload) == 2 && command == 1 && payload == 61);
-
-            Debug.Assert(Encode(3, 256, buf) == 2);
-            Debug.Assert(D(buf, out command, out payload) == 2 && command == 3 && payload == 256);
-            Debug.Assert(Encode(3, 6500, buf) == 3);
-            Debug.Assert(D(buf, out command, out payload) == 3 && command == 3 && payload == 6500);
-            Debug.Assert(Encode(3, 65000, buf) == 3);
-            Debug.Assert(D(buf, out command, out payload) == 3 && command == 3 && payload == 65000);
-            Debug.Assert(Encode(3, 100000, buf) == 4);
-            Debug.Assert(D(buf, out command, out payload) == 4 && command == 3 && payload == 100000);
-
-            static unsafe int D(byte[] bytes, out int command, out int payload)
-            {
-                fixed (byte* pBytes = bytes)
-                    return (int)(Decode(pBytes, out command, out payload) - pBytes);
-            }
-        }
-#endif
     }
 }

--- a/src/coreclr/tools/Common/Internal/Runtime/DehydratedData.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/DehydratedData.cs
@@ -30,7 +30,7 @@ namespace Internal.Runtime
 
         private const int MaxRawShortPayload = (1 << (8 - DehydratedDataCommandPayloadShift)) - 1;
         private const int MaxExtraPayloadBytes = 3;
-        private const int MaxShortPayload = MaxRawShortPayload - MaxExtraPayloadBytes;
+        public const int MaxShortPayload = MaxRawShortPayload - MaxExtraPayloadBytes;
 
         public static byte EncodeShort(int command, int commandData)
         {


### PR DESCRIPTION
This is a follow up to #77884. In the original pull request, all relocation targets went into a lookup table. This is not very efficient to represent rarely used relocs. In this update, I'm extending the dehydration format to allow representing relocations inline - instead of indirecting through the lookup table, the target immediately follows the instruction. I'm changing the emitter to emit this if there's less than 3 references to the reloc.

This produces a ~0.5% size saving. It likely also speeds up the decoding at runtime since there's less cache thrashing. On a hello world, the lookup table originally had about 11k entries. With this change, the lookup table only has 1700 entries.

Cc @dotnet/ilc-contrib 