### PR TITLE
Make sure to check for isUsedFromSpillTemp() before optimizing float comparison in code gen

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6459,8 +6459,8 @@ void CodeGen::genCompareFloat(GenTree* treeNode)
     // Are we evaluating this into a register?
     if (targetReg != REG_NA)
     {
-        if ((condition.GetCode() == GenCondition::FNEU) && (op1->GetRegNum() == op2->GetRegNum()) &&
-            !op1->isUsedFromSpillTemp() && !op2->isUsedFromSpillTemp())
+        if ((condition.GetCode() == GenCondition::FNEU) && op1->isUsedFromReg() && op2->isUsedFromReg() &&
+            (op1->GetRegNum() == op2->GetRegNum()))
         {
             // For floating point, `x != x` is a common way of
             // checking for NaN. So, in the case where both

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6459,7 +6459,8 @@ void CodeGen::genCompareFloat(GenTree* treeNode)
     // Are we evaluating this into a register?
     if (targetReg != REG_NA)
     {
-        if ((condition.GetCode() == GenCondition::FNEU) && (op1->GetRegNum() == op2->GetRegNum()))
+        if ((condition.GetCode() == GenCondition::FNEU) && (op1->GetRegNum() == op2->GetRegNum()) &&
+            !op1->isUsedFromSpillTemp() && !op2->isUsedFromSpillTemp())
         {
             // For floating point, `x != x` is a common way of
             // checking for NaN. So, in the case where both


### PR DESCRIPTION
When optimizing the float comparison `x != x`, we just check if the registers assigned to both the operands of `!=` are same or not , and if yes, assume that we want to check for NaN. However, one of the operand could not be live in register but is fetched from memory during the comparison. In such case, we should prohibit doing such optimization. Added the check for `isUsedFromSpillTemp()` in addition to the `RegNum()` check. 

I will do an audit of other places where this could be missing and send out a separate PR:
- Either when we do `GetRegNum()` and if there is a valid register, we should check that it is not `isUsedFromSpillTemp()`.
- When we set `GTF_NOREG_AT_USE`, also set the regnum to `REG_NA`.

More context: https://github.com/dotnet/runtime/issues/78298#issuecomment-1317426565

Fixes: https://github.com/dotnet/runtime/issues/78298