### PR TITLE
[Android] Prevent exceptions with a 'Success' message in System.Net.NetworkInformation

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.EnumerateInterfaceAddresses.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.EnumerateInterfaceAddresses.cs
@@ -52,7 +52,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_EnumerateGatewayAddressesForInterface")]
         public static unsafe partial int EnumerateGatewayAddressesForInterface(void* context, uint interfaceIndex, delegate* unmanaged<void*, IpAddressInfo*, void> onGatewayFound);
 
-        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNetworkInterfaces")]
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNetworkInterfaces", SetLastError = true)]
         public static unsafe partial int GetNetworkInterfaces(int* count, NetworkInterfaceInfo** addrs, int* addressCount, IpAddressInfo** aa);
 
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.NetworkChange.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.NetworkChange.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             AvailabilityChanged = 2
         }
 
-        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateNetworkChangeListenerSocket")]
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateNetworkChangeListenerSocket", SetLastError = true)]
         public static unsafe partial Error CreateNetworkChangeListenerSocket(IntPtr* socket);
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadEvents")]


### PR DESCRIPTION
There is a problem with permissions in new Android API levels (target SDK version 30+) causing `NetworkChange.NetworkAddressChanged` and `NetworkInterface.GetAllNetworkInterfaces` to throw an exception. The exception message would simply say "Success" which is quite confusing:

```
System.Net.NetworkInformation.NetworkInformationException (0x80004005): Success
   at System.Net.NetworkInformation.NetworkChange.CreateSocket()
   at System.Net.NetworkInformation.NetworkChange.add_NetworkAvailabilityChanged(NetworkAvailabilityChangedEventHandler )
   at Program.<Main>$(String[] ) in /.../dotnet/runtime/src/mono/sample/Android/Program.cs:line 10
```

The message is obtained by calling `Interop.Sys.GetLastErrorInfo().GetErrorMessage()` and the error code from `Marshal.GetLastPInvokeError()`, but the last pinvoke error code isn't preserved. This PR doesn't fix the underlying problem with accessing the network information but it fixes the exception message to reduce developer confusion.

The fixed exception stack trace:

```
System.Net.NetworkInformation.NetworkInformationException (13): Permission denied
   at System.Net.NetworkInformation.NetworkChange.CreateSocket()
   at System.Net.NetworkInformation.NetworkChange.add_NetworkAddressChanged(NetworkAddressChangedEventHandler )
   at Program.<Main>$(String[] ) in /.../dotnet/runtime/src/mono/sample/Android/Program.cs:line 9
```

Ref #77822
Ref #77938