### PR TITLE
Removed range checks have ordered side effects (#78554)

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -9216,6 +9216,8 @@ GenTree* Compiler::optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, 
     {
         // TODO-CQ: We should also remove the GT_COMMA, but in any case we can no longer CSE the GT_COMMA.
         tree->gtFlags |= GTF_DONT_CSE;
+        // Ensure the other side of the comma can't be moved outside the checked range.
+        tree->gtGetOp2()->gtFlags |= GTF_ORDER_SIDEEFF;
     }
 
     gtUpdateSideEffects(stmt, tree);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_78554/Runtime_78554.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_78554/Runtime_78554.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_78554
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Consume(uint op)
+    {
+        return;
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static void ArrayIndexConsume(uint[] a, uint i)
+    {
+        if (i < a.Length)
+        {
+           i = a[i];
+        }
+        Consume(i);
+    }
+
+    public static int Main()
+    {
+        var arr = new uint[] { 1, 42, 3000 };
+        ArrayIndexConsume(arr, 0xffffffff);
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_78554/Runtime_78554.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_78554/Runtime_78554.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="0" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_IF_CONVERSION_COST" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Bounds checks can be removed due to assertion propagation stating that the bounds check will always pass. Once removed, nodes that constrained by the bounds check cannot be moved elsewhere as that might break the assertion.

This prevents If Conversion hoisting array loads outside of an `If` statement