### PR TITLE
Clean up members/signatures/visibility in deps_format/resolver

### DIFF
--- a/src/native/corehost/hostpolicy/deps_format.h
+++ b/src/native/corehost/hostpolicy/deps_format.h
@@ -30,7 +30,7 @@ public:
         : m_file_exists(false)
         , m_valid(false)
     {
-        m_valid = load(is_framework_dependent, deps_path, graph == nullptr ? m_rid_fallback_graph : *graph);
+        load(is_framework_dependent, deps_path, graph == nullptr ? m_rid_fallback_graph : *graph);
     }
 
     const std::vector<deps_entry_t>& get_entries(deps_entry_t::asset_types type) const
@@ -62,11 +62,11 @@ public:
     }
 
 private:
-    bool load_self_contained(const pal::string_t& deps_path, const json_parser_t::value_t& json, const pal::string_t& target_name);
-    bool load_framework_dependent(const pal::string_t& deps_path, const json_parser_t::value_t& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph);
-    bool load(bool is_framework_dependent, const pal::string_t& deps_path, const rid_fallback_graph_t& rid_fallback_graph);
-    bool process_runtime_targets(const json_parser_t::value_t& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph, rid_specific_assets_t* p_assets);
-    bool process_targets(const json_parser_t::value_t& json, const pal::string_t& target_name, deps_assets_t* p_assets);
+    void load_self_contained(const pal::string_t& deps_path, const json_parser_t::value_t& json, const pal::string_t& target_name);
+    void load_framework_dependent(const pal::string_t& deps_path, const json_parser_t::value_t& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph);
+    void load(bool is_framework_dependent, const pal::string_t& deps_path, const rid_fallback_graph_t& rid_fallback_graph);
+    void process_runtime_targets(const json_parser_t::value_t& json, const pal::string_t& target_name, const rid_fallback_graph_t& rid_fallback_graph, rid_specific_assets_t* p_assets);
+    void process_targets(const json_parser_t::value_t& json, const pal::string_t& target_name, deps_assets_t* p_assets);
 
     void reconcile_libraries_with_targets(
         const pal::string_t& deps_path,
@@ -75,7 +75,7 @@ private:
         const std::function<const vec_asset_t&(const pal::string_t&, size_t, bool*)>& get_assets_fn);
 
     pal::string_t get_current_rid(const rid_fallback_graph_t& rid_fallback_graph);
-    bool perform_rid_fallback(rid_specific_assets_t* portable_assets, const rid_fallback_graph_t& rid_fallback_graph);
+    void perform_rid_fallback(rid_specific_assets_t* portable_assets, const rid_fallback_graph_t& rid_fallback_graph);
 
     std::vector<deps_entry_t> m_deps_entries[deps_entry_t::asset_types::count];
 

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -83,99 +83,99 @@ namespace
 
         return path.substr(name_pos + 1);
     }
+      // -----------------------------------------------------------------------------
+      // A uniqifying append helper that doesn't let two entries with the same
+      // "asset_name" be part of the "items" paths.
+      //
+    void add_tpa_asset(
+        const deps_asset_t& asset,
+        const pal::string_t& resolved_path,
+        name_to_resolved_asset_map_t* items)
+    {
+        name_to_resolved_asset_map_t::iterator existing = items->find(asset.name);
+        if (existing == items->end())
+        {
+            if (trace::is_enabled())
+            {
+                trace::verbose(_X("Adding tpa entry: %s, AssemblyVersion: %s, FileVersion: %s"),
+                    resolved_path.c_str(),
+                    asset.assembly_version.as_str().c_str(),
+                    asset.file_version.as_str().c_str());
+            }
+
+            items->emplace(asset.name, deps_resolved_asset_t(asset, resolved_path));
+        }
+    }
+
+    // -----------------------------------------------------------------------------
+    // Load local assemblies by priority order of their file extensions and
+    // uniquified by their simple name.
+    //
+    void get_dir_assemblies(
+        const pal::string_t& dir,
+        const pal::string_t& dir_name,
+        name_to_resolved_asset_map_t* items)
+    {
+        version_t empty;
+        trace::verbose(_X("Adding files from %s dir %s"), dir_name.c_str(), dir.c_str());
+
+        // Managed extensions in priority order, pick DLL over EXE and NI over IL.
+        const pal::string_t managed_ext[] = { _X(".ni.dll"), _X(".dll"), _X(".ni.exe"), _X(".exe") };
+
+        // List of files in the dir
+        std::vector<pal::string_t> files;
+        pal::readdir(dir, &files);
+
+        for (const auto& ext : managed_ext)
+        {
+            for (const auto& file : files)
+            {
+                // Nothing to do if file length is smaller than expected ext.
+                if (file.length() <= ext.length())
+                {
+                    continue;
+                }
+
+                auto file_name = file.substr(0, file.length() - ext.length());
+                auto file_ext = file.substr(file_name.length());
+
+                // Ext did not match expected ext, skip this file.
+                if (pal::strcasecmp(file_ext.c_str(), ext.c_str()))
+                {
+                    continue;
+                }
+
+                // Already added entry for this asset, by priority order skip this ext
+                if (items->count(file_name))
+                {
+                    trace::verbose(_X("Skipping %s because the %s already exists in %s assemblies"),
+                        file.c_str(),
+                        items->find(file_name)->second.asset.relative_path.c_str(),
+                        dir_name.c_str());
+
+                    continue;
+                }
+
+                // Add entry for this asset
+                pal::string_t file_path = dir;
+                if (!file_path.empty() && file_path.back() != DIR_SEPARATOR)
+                {
+                    file_path.push_back(DIR_SEPARATOR);
+                }
+                file_path.append(file);
+
+                trace::verbose(_X("Adding %s to %s assembly set from %s"),
+                    file_name.c_str(),
+                    dir_name.c_str(),
+                    file_path.c_str());
+
+                deps_asset_t asset(file_name, file, empty, empty);
+                add_tpa_asset(asset, file_path, items);
+            }
+        }
+    }
 } // end of anonymous namespace
 
-  // -----------------------------------------------------------------------------
-  // A uniqifying append helper that doesn't let two entries with the same
-  // "asset_name" be part of the "items" paths.
-  //
-void deps_resolver_t::add_tpa_asset(
-    const deps_asset_t& asset,
-    const pal::string_t& resolved_path,
-    name_to_resolved_asset_map_t* items)
-{
-    name_to_resolved_asset_map_t::iterator existing = items->find(asset.name);
-    if (existing == items->end())
-    {
-        if (trace::is_enabled())
-        {
-            trace::verbose(_X("Adding tpa entry: %s, AssemblyVersion: %s, FileVersion: %s"),
-                resolved_path.c_str(),
-                asset.assembly_version.as_str().c_str(),
-                asset.file_version.as_str().c_str());
-        }
-
-        items->emplace(asset.name, deps_resolved_asset_t(asset, resolved_path));
-    }
-}
-
-// -----------------------------------------------------------------------------
-// Load local assemblies by priority order of their file extensions and
-// uniquified by their simple name.
-//
-void deps_resolver_t::get_dir_assemblies(
-    const pal::string_t& dir,
-    const pal::string_t& dir_name,
-    name_to_resolved_asset_map_t* items)
-{
-    version_t empty;
-    trace::verbose(_X("Adding files from %s dir %s"), dir_name.c_str(), dir.c_str());
-
-    // Managed extensions in priority order, pick DLL over EXE and NI over IL.
-    const pal::string_t managed_ext[] = { _X(".ni.dll"), _X(".dll"), _X(".ni.exe"), _X(".exe") };
-
-    // List of files in the dir
-    std::vector<pal::string_t> files;
-    pal::readdir(dir, &files);
-
-    for (const auto& ext : managed_ext)
-    {
-        for (const auto& file : files)
-        {
-            // Nothing to do if file length is smaller than expected ext.
-            if (file.length() <= ext.length())
-            {
-                continue;
-            }
-
-            auto file_name = file.substr(0, file.length() - ext.length());
-            auto file_ext = file.substr(file_name.length());
-
-            // Ext did not match expected ext, skip this file.
-            if (pal::strcasecmp(file_ext.c_str(), ext.c_str()))
-            {
-                continue;
-            }
-
-            // Already added entry for this asset, by priority order skip this ext
-            if (items->count(file_name))
-            {
-                trace::verbose(_X("Skipping %s because the %s already exists in %s assemblies"),
-                    file.c_str(),
-                    items->find(file_name)->second.asset.relative_path.c_str(),
-                    dir_name.c_str());
-
-                continue;
-            }
-
-            // Add entry for this asset
-            pal::string_t file_path = dir;
-            if (!file_path.empty() && file_path.back() != DIR_SEPARATOR)
-            {
-                file_path.push_back(DIR_SEPARATOR);
-            }
-            file_path.append(file);
-
-            trace::verbose(_X("Adding %s to %s assembly set from %s"),
-                file_name.c_str(),
-                dir_name.c_str(),
-                file_path.c_str());
-
-            deps_asset_t asset(file_name, file, empty, empty);
-            add_tpa_asset(asset, file_path, items);
-        }
-    }
-}
 
 void deps_resolver_t::setup_shared_store_probes(
     const arguments_t& args)
@@ -259,9 +259,9 @@ void deps_resolver_t::setup_probe_config(
 
     setup_shared_store_probes(args);
 
-    if (m_additional_probes.size() > 0)
+    if (!args.probe_paths.empty())
     {
-        for (const auto& probe : m_additional_probes)
+        for (const auto& probe : args.probe_paths)
         {
             // Additional paths
             m_probes.push_back(probe_config_t::lookup(probe));
@@ -278,11 +278,6 @@ void deps_resolver_t::setup_probe_config(
             pc.print();
         }
     }
-}
-
-void deps_resolver_t::setup_additional_probes(const std::vector<pal::string_t>& probe_paths)
-{
-    m_additional_probes.assign(probe_paths.begin(), probe_paths.end());
 }
 
 /**
@@ -316,11 +311,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
         }
 
         const pal::string_t& probe_dir = config.probe_dir;
-        uint32_t search_options = deps_entry_t::search_options::none;
-        if (needs_file_existence_checks())
-        {
-            search_options |= deps_entry_t::search_options::file_existence;
-        }
+        uint32_t search_options = m_needs_file_existence_checks ? deps_entry_t::search_options::file_existence : deps_entry_t::search_options::none;
 
         if (config.is_fx())
         {
@@ -627,7 +618,7 @@ void deps_resolver_t::init_known_entry_path(const deps_entry_t& entry, const pal
     }
 }
 
-void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const deps_json_t::rid_fallback_graph_t* rid_fallback_graph)
+void deps_resolver_t::resolve_additional_deps(const pal::string_t& additional_deps_serialized, const deps_json_t::rid_fallback_graph_t* rid_fallback_graph)
 {
     if (!m_is_framework_dependent
         || m_host_mode == host_mode_t::libhost)
@@ -645,8 +636,6 @@ void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const dep
 
         return;
     }
-
-    pal::string_t additional_deps_serialized = args.additional_deps_serialized;
 
     if (additional_deps_serialized.empty())
     {
@@ -667,7 +656,8 @@ void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const dep
                 trace::verbose(_X("Using specified additional deps.json: '%s'"),
                     additional_deps_path.c_str());
 
-                m_additional_deps_files.push_back(additional_deps_path);
+                m_additional_deps.push_back(std::unique_ptr<deps_json_t>(
+                    new deps_json_t(true, additional_deps_path, rid_fallback_graph)));
             }
             else
             {
@@ -723,21 +713,20 @@ void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const dep
                     {
                         pal::string_t json_full_path = additional_deps_path_fx;
                         append_path(&json_full_path, json_file.c_str());
-                        m_additional_deps_files.push_back(json_full_path);
 
                         trace::verbose(_X("Using specified additional deps.json: '%s'"),
                             json_full_path.c_str());
+
+                        m_additional_deps.push_back(std::unique_ptr<deps_json_t>(
+                            new deps_json_t(true, json_full_path, rid_fallback_graph)));
                     }
                 }
             }
         }
     }
 
-    for (pal::string_t json_file : m_additional_deps_files)
-    {
-        m_additional_deps.push_back(std::unique_ptr<deps_json_t>(
-            new deps_json_t(true, json_file, rid_fallback_graph)));
-    }
+    if (!m_additional_deps.empty())
+        m_needs_file_existence_checks = true;
 }
 
 void deps_resolver_t::enum_app_context_deps_files(std::function<void(const pal::string_t&)> callback)

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -83,10 +83,9 @@ namespace
 
         return path.substr(name_pos + 1);
     }
-      // -----------------------------------------------------------------------------
-      // A uniqifying append helper that doesn't let two entries with the same
-      // "asset_name" be part of the "items" paths.
-      //
+
+    // A uniqifying append helper that doesn't let two entries with the same
+    // "asset_name" be part of the "items" paths.
     void add_tpa_asset(
         const deps_asset_t& asset,
         const pal::string_t& resolved_path,

--- a/src/native/corehost/hostpolicy/deps_resolver.h
+++ b/src/native/corehost/hostpolicy/deps_resolver.h
@@ -82,15 +82,9 @@ public:
             }
         }
 
-        resolve_additional_deps(args, root_framework_rid_fallback_graph);
+        resolve_additional_deps(args.additional_deps_serialized, root_framework_rid_fallback_graph);
 
-        setup_additional_probes(args.probe_paths);
         setup_probe_config(args);
-
-        if (m_additional_deps.size() > 0)
-        {
-            m_needs_file_existence_checks = true;
-        }
     }
 
     bool valid(pal::string_t* errors)
@@ -127,34 +121,12 @@ public:
         return true;
     }
 
-    void setup_shared_store_probes(
-        const arguments_t& args);
-
     pal::string_t get_lookup_probe_directories();
-
-    void setup_probe_config(
-        const arguments_t& args);
-
-    void setup_additional_probes(
-        const std::vector<pal::string_t>& probe_paths);
 
     bool resolve_probe_paths(
         probe_paths_t* probe_paths,
         std::unordered_set<pal::string_t>* breadcrumb,
         bool ignore_missing_assemblies = false);
-
-    void init_known_entry_path(
-        const deps_entry_t& entry,
-        const pal::string_t& path);
-
-    void resolve_additional_deps(
-        const arguments_t& args,
-        const deps_json_t::rid_fallback_graph_t* rid_fallback_graph);
-
-    const deps_json_t& get_app_deps() const
-    {
-        return *m_fx_deps[0];
-    }
 
     const deps_json_t& get_root_deps() const
     {
@@ -166,11 +138,6 @@ public:
     bool is_framework_dependent() const
     {
         return m_is_framework_dependent;
-    }
-
-    bool needs_file_existence_checks() const
-    {
-        return m_needs_file_existence_checks;
     }
 
     void get_app_dir(pal::string_t *app_dir) const
@@ -204,6 +171,24 @@ public:
     }
 
 private:
+    void setup_shared_store_probes(
+        const arguments_t& args);
+
+    void setup_probe_config(
+        const arguments_t& args);
+
+    void init_known_entry_path(
+        const deps_entry_t& entry,
+        const pal::string_t& path);
+
+    void resolve_additional_deps(
+        const pal::string_t& additional_deps_serialized,
+        const deps_json_t::rid_fallback_graph_t* rid_fallback_graph);
+
+    const deps_json_t& get_app_deps() const
+    {
+        return *m_fx_deps[0];
+    }
 
     static pal::string_t get_fx_deps(const pal::string_t& fx_dir, const pal::string_t& fx_name)
     {
@@ -225,12 +210,6 @@ private:
         pal::string_t* output,
         std::unordered_set<pal::string_t>* breadcrumb);
 
-    // Populate assemblies from the directory.
-    void get_dir_assemblies(
-        const pal::string_t& dir,
-        const pal::string_t& dir_name,
-        name_to_resolved_asset_map_t* items);
-
     // Probe entry in probe configurations and deps dir.
     bool probe_deps_entry(
         const deps_entry_t& entry,
@@ -239,17 +218,13 @@ private:
         pal::string_t* candidate,
         bool &found_in_bundle);
 
+private:
     const fx_definition_vector_t& m_fx_definitions;
 
     // Resolved deps.json for each m_fx_definitions (corresponding indices)
     std::vector<std::unique_ptr<deps_json_t>> m_fx_deps;
 
     pal::string_t m_app_dir;
-
-    void add_tpa_asset(
-        const deps_asset_t& asset,
-        const pal::string_t& resolved_path,
-        name_to_resolved_asset_map_t* items);
 
     // Mode in which the host is being run. This can dictate how dependencies should be discovered.
     const host_mode_t m_host_mode;
@@ -263,17 +238,11 @@ private:
     // Special entry for coreclr path
     pal::string_t m_coreclr_path;
 
-    // The filepaths for the app custom deps
-    std::vector<pal::string_t> m_additional_deps_files;
-
     // Custom deps files for the app
     std::vector< std::unique_ptr<deps_json_t> > m_additional_deps;
 
     // Various probe configurations.
     std::vector<probe_config_t> m_probes;
-
-    // Fallback probe dir
-    std::vector<pal::string_t> m_additional_probes;
 
     // Is the deps file for an app using shared frameworks?
     const bool m_is_framework_dependent;


### PR DESCRIPTION
Slight cleanup of `deps_format`/`deps_resolver`:
- Remove unnecessary copying of paths into members in `deps_resolver`
- Remove returns in `deps_format` load/process functions (always returning true)
- Make members private when possible