### PR TITLE
[PERF]Make mono dotnet pathing dynamic

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -30,9 +30,9 @@ jobs:
       buildConfig: release
       platforms:
       - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
+      # - windows_x64
+      # - windows_x86
+      # - Linux_musl_x64
       jobParameters:
         testGroup: perf
 
@@ -58,49 +58,49 @@ jobs:
           archiveType: tar
           tarCompression: gz
 
-  # build mono Android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AndroidMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Android Mono Artifacts
-          artifactName: AndroidMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  # # build mono Android scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - Android_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: AndroidMono
+  #       isOfficialBuild: false
+  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #       extraStepsParameters:
+  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #         includeRootFolder: true
+  #         displayName: Android Mono Artifacts
+  #         artifactName: AndroidMonoarm64
+  #         archiveExtension: '.tar.gz'
+  #         archiveType: tar
+  #         tarCompression: gz
 
-  # build mono iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - iOS_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: iOSMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: iOS Mono Artifacts
-          artifactName: iOSMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  # # build mono iOS scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - iOS_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: iOSMono
+  #       isOfficialBuild: false
+  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #       extraStepsParameters:
+  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #         includeRootFolder: true
+  #         displayName: iOS Mono Artifacts
+  #         artifactName: iOSMonoarm64
+  #         archiveExtension: '.tar.gz'
+  #         archiveType: tar
+  #         tarCompression: gz
 
   # build mono
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -111,107 +111,107 @@ jobs:
       platforms:
       - Linux_x64
 
-  # run mono and maui android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      variables:
-        - name: mauiVersion
-          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet7.outputs['getMauiVersion.mauiVersion'] ]
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMono
-        projectFile: android_scenarios.proj
-        runKind: android_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        additionalSetupParameters: "-MauiVersion $env:mauiVersion"
+  # # run mono and maui android scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - Windows_x64
+  #     variables:
+  #       - name: mauiVersion
+  #         value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet7.outputs['getMauiVersion.mauiVersion'] ]
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: AndroidMono
+  #       projectFile: android_scenarios.proj
+  #       runKind: android_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfpixel4a'
+  #       additionalSetupParameters: "-MauiVersion $env:mauiVersion"
 
-  # run mono iOS scenarios and maui iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - OSX_x64
-      variables:
-        - name: mauiVersion
-          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet7.outputs['getMauiVersion.mauiVersion'] ]
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfiphone12mini'
-        iOSLlvmBuild: False
-        additionalSetupParameters: "--mauiversion $(mauiVersion)"
+  # # run mono iOS scenarios and maui iOS scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - OSX_x64
+  #     variables:
+  #       - name: mauiVersion
+  #         value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet7.outputs['getMauiVersion.mauiVersion'] ]
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: iOSMono
+  #       projectFile: ios_scenarios.proj
+  #       runKind: ios_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfiphone12mini'
+  #       iOSLlvmBuild: False
+  #       additionalSetupParameters: "--mauiversion $(mauiVersion)"
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - OSX_x64
-      variables:
-        - name: mauiVersion
-          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet7.outputs['getMauiVersion.mauiVersion'] ]
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfiphone12mini'
-        iOSLlvmBuild: True
-        additionalSetupParameters: "--mauiversion $(mauiVersion)"
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - OSX_x64
+  #     variables:
+  #       - name: mauiVersion
+  #         value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet7.outputs['getMauiVersion.mauiVersion'] ]
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: iOSMono
+  #       projectFile: ios_scenarios.proj
+  #       runKind: ios_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfiphone12mini'
+  #       iOSLlvmBuild: True
+  #       additionalSetupParameters: "--mauiversion $(mauiVersion)"
 
-  # run maui android scenarios for net6
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      variables:
-        - name: mauiVersion
-          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet6.outputs['getMauiVersion.mauiVersion'] ]
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMobileNet6
-        projectFile: android_scenarios_net6.proj
-        runKind: android_scenarios_net6
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        additionalSetupParameters: "-MauiVersion $env:mauiVersion"
+  # # run maui android scenarios for net6
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - Windows_x64
+  #     variables:
+  #       - name: mauiVersion
+  #         value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet6.outputs['getMauiVersion.mauiVersion'] ]
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: AndroidMobileNet6
+  #       projectFile: android_scenarios_net6.proj
+  #       runKind: android_scenarios_net6
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfpixel4a'
+  #       additionalSetupParameters: "-MauiVersion $env:mauiVersion"
 
-  # run maui iOS scenarios for net6 (Maui doesn't need Llmv true build (for net6))
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - OSX_x64
-      variables:
-        - name: mauiVersion
-          value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet6.outputs['getMauiVersion.mauiVersion'] ]
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMobileNet6
-        projectFile: ios_scenarios_net6.proj
-        runKind: ios_scenarios_net6
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfiphone12mini'
-        iOSLlvmBuild: False
-        additionalSetupParameters: "--mauiversion $(mauiVersion)"
+  # # run maui iOS scenarios for net6 (Maui doesn't need Llmv true build (for net6))
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - OSX_x64
+  #     variables:
+  #       - name: mauiVersion
+  #         value: $[ dependencies.Build_iOS_arm64_release_MACiOSAndroidMauiNet6.outputs['getMauiVersion.mauiVersion'] ]
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: iOSMobileNet6
+  #       projectFile: ios_scenarios_net6.proj
+  #       runKind: ios_scenarios_net6
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfiphone12mini'
+  #       iOSLlvmBuild: False
+  #       additionalSetupParameters: "--mauiversion $(mauiVersion)"
 
   # run mono microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -248,205 +248,205 @@ jobs:
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
         logicalmachine: 'perftiger'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono aot microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #     buildConfig: release
+  #     runtimeFlavor: aot
+  #     platforms:
+  #     - Linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'AOT'
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run coreclr perftiger microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - Linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     - Linux_musl_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoPgo
+  # # run coreclr perftiger microbenchmarks pgo perf jobs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: -NoPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -DynamicPgo
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: -DynamicPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -FullPgo
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: -FullPgo
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+  # # run coreclr perfowl microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - Linux_x64
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger'
+  # # run coreclr crossgen perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - Linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: crossgen_perf.proj
+  #       runKind: crossgen_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # Uncomment to reenable package replacement
-  ## build maui runtime packs
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Android_x86
-  #    - Android_x64
-  #    - Android_arm
-  #    - Android_arm64
-  #    - MacCatalyst_x64
-  #    - iOSSimulator_x64
-  #    - iOS_arm64
-  #    - iOS_arm
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: Maui_Packs_Mono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-  #      extraStepsParameters:
-  #        name: MonoRuntimePacks
+  # # Uncomment to reenable package replacement
+  # ## build maui runtime packs
+  # #- template: /eng/pipelines/common/platform-matrix.yml
+  # #  parameters:
+  # #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  # #    buildConfig: release
+  # #    runtimeFlavor: mono
+  # #    platforms:
+  # #    - Android_x86
+  # #    - Android_x64
+  # #    - Android_arm
+  # #    - Android_arm64
+  # #    - MacCatalyst_x64
+  # #    - iOSSimulator_x64
+  # #    - iOS_arm64
+  # #    - iOS_arm
+  # #    jobParameters:
+  # #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  # #      nameSuffix: Maui_Packs_Mono
+  # #      isOfficialBuild: false
+  # #      extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+  # #      extraStepsParameters:
+  # #        name: MonoRuntimePacks
 
-  # build maui app net7.0
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - iOS_arm64
-      jobParameters:
-      # Uncomment to reenable package replacement for main
-        #dependsOn:
-        #  - Build_Android_arm_release_Maui_Packs_Mono
-        #  - Build_Android_arm64_release_Maui_Packs_Mono
-        #  - Build_Android_x86_release_Maui_Packs_Mono
-        #  - Build_Android_x64_release_Maui_Packs_Mono
-        #  - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-        #  - Build_iOSSimulator_x64_release_Maui_Packs_Mono
-        #  - Build_iOS_arm_release_Maui_Packs_Mono
-        #  - Build_iOS_arm64_release_Maui_Packs_Mono
-        buildArgs: -s mono -c $(_BuildConfig)
-        nameSuffix: MACiOSAndroidMauiNet7
-        isOfficialBuild: false
-        pool:
-          vmImage: 'macos-12'
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps-net7.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: MAC, iOS, and Android Maui Artifacts Net7
-          artifactName: MACiOSAndroidMauiArmNet7
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  # # build maui app net7.0
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - iOS_arm64
+  #     jobParameters:
+  #     # Uncomment to reenable package replacement for main
+  #       #dependsOn:
+  #       #  - Build_Android_arm_release_Maui_Packs_Mono
+  #       #  - Build_Android_arm64_release_Maui_Packs_Mono
+  #       #  - Build_Android_x86_release_Maui_Packs_Mono
+  #       #  - Build_Android_x64_release_Maui_Packs_Mono
+  #       #  - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+  #       #  - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+  #       #  - Build_iOS_arm_release_Maui_Packs_Mono
+  #       #  - Build_iOS_arm64_release_Maui_Packs_Mono
+  #       buildArgs: -s mono -c $(_BuildConfig)
+  #       nameSuffix: MACiOSAndroidMauiNet7
+  #       isOfficialBuild: false
+  #       pool:
+  #         vmImage: 'macos-12'
+  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps-net7.yml
+  #       extraStepsParameters:
+  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #         includeRootFolder: true
+  #         displayName: MAC, iOS, and Android Maui Artifacts Net7
+  #         artifactName: MACiOSAndroidMauiArmNet7
+  #         archiveExtension: '.tar.gz'
+  #         archiveType: tar
+  #         tarCompression: gz
 
-    # build maui app net6.0
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - iOS_arm64
-      jobParameters:
-        buildArgs: -s mono -c $(_BuildConfig)
-        nameSuffix: MACiOSAndroidMauiNet6
-        isOfficialBuild: false
-        pool:
-          vmImage: 'macos-12'
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps-net6.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: MAC, iOS, and Android Maui Artifacts Net6
-          artifactName: MACiOSAndroidMauiArmNet6
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  #   # build maui app net6.0
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - iOS_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono -c $(_BuildConfig)
+  #       nameSuffix: MACiOSAndroidMauiNet6
+  #       isOfficialBuild: false
+  #       pool:
+  #         vmImage: 'macos-12'
+  #       extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps-net6.yml
+  #       extraStepsParameters:
+  #         rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #         includeRootFolder: true
+  #         displayName: MAC, iOS, and Android Maui Artifacts Net6
+  #         artifactName: MACiOSAndroidMauiArmNet6
+  #         archiveExtension: '.tar.gz'
+  #         archiveType: tar
+  #         tarCompression: gz

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -40,12 +40,12 @@ extends:
   parameters:
     jobs:
 
-    - template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
-      parameters:
-        collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
-        ${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
-          runProfile: 'non-v8'
-        ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
-          runProfile: 'v8'
+    # - template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
+    #   parameters:
+    #     collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
+    #     ${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+    #       runProfile: 'non-v8'
+    #     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
+    #       runProfile: 'v8'
 
     - template: /eng/pipelines/coreclr/perf-non-wasm-jobs.yml

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -373,23 +373,25 @@ jobs:
       condition: and(succeeded(), ne(variables.runtimeFlavorName, 'Mono'), ne('${{ parameters.runtimeType }}', 'wasm'))
 
     # Copy the runtime directory into the testhost folder to include OOBs.
-    - ${{ if and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), eq(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6'))) }}:
-      - powershell: |
-          $xml = [Xml] (Get-Content $(Build.SourcesDirectory)\eng\Versions.props)
-          $productVersion = $xml.Project.PropertyGroup.productVersion
-          echo productVersion: $productVersion
-          echo "##vso[task.setvariable variable=productVersion]$productVersion"
-        displayName: 'Get product version for mono-dotnet (Windows)'
-      
-      - script: "build.cmd -subset libs.pretest -configuration release -ci -arch $(archType) -testscope innerloop /p:RuntimeArtifactsPath=$(librariesDownloadDir)\\bin\\mono\\$(osGroup).$(archType).$(buildConfigUpper) /p:RuntimeFlavor=mono;xcopy $(Build.SourcesDirectory)\\artifacts\\bin\\runtime\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\* $(Build.SourcesDirectory)\\artifacts\\bin\\testhost\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\shared\\Microsoft.NETCore.App\\$(productVersion) /E /I /Y;xcopy $(Build.SourcesDirectory)\\artifacts\\bin\\testhost\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\* $(Build.SourcesDirectory)\\.dotnet-mono /E /I /Y;copy $(Build.SourcesDirectory)\\artifacts\\bin\\coreclr\\$(osGroup).$(archType).$(buildConfigUpper)\\corerun.exe $(Build.SourcesDirectory)\\.dotnet-mono\\shared\\Microsoft.NETCore.App\\$(productVersion)\\corerun.exe"
-        displayName: "Create mono dotnet (Windows)"
+    - powershell: |
+        $xml = [Xml] (Get-Content $(Build.SourcesDirectory)\eng\Versions.props)
+        $productVersion = $xml.Project.PropertyGroup.productVersion
+        echo productVersion: $productVersion
+        echo "##vso[task.setvariable variable=productVersion]$productVersion"
+      displayName: 'Get product version for mono-dotnet (Windows)'
+      condition: and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), eq(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6')))
+    
+    - script: "build.cmd -subset libs.pretest -configuration release -ci -arch $(archType) -testscope innerloop /p:RuntimeArtifactsPath=$(librariesDownloadDir)\\bin\\mono\\$(osGroup).$(archType).$(buildConfigUpper) /p:RuntimeFlavor=mono;xcopy $(Build.SourcesDirectory)\\artifacts\\bin\\runtime\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\* $(Build.SourcesDirectory)\\artifacts\\bin\\testhost\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\shared\\Microsoft.NETCore.App\\$(productVersion) /E /I /Y;xcopy $(Build.SourcesDirectory)\\artifacts\\bin\\testhost\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\* $(Build.SourcesDirectory)\\.dotnet-mono /E /I /Y;copy $(Build.SourcesDirectory)\\artifacts\\bin\\coreclr\\$(osGroup).$(archType).$(buildConfigUpper)\\corerun.exe $(Build.SourcesDirectory)\\.dotnet-mono\\shared\\Microsoft.NETCore.App\\$(productVersion)\\corerun.exe"
+      displayName: "Create mono dotnet (Windows)"
+      condition: and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), eq(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6')))
 
-    - ${{ if and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), ne(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6'))) }}:
-      - bash: |
-          productVersion=$(sed -n 's/.*<ProductVersion>\(.*\)<\/ProductVersion>/\1/p' eng/Versions.props)
-          echo productVersion: $productVersion
-          echo "##vso[task.setvariable variable=productVersion]$productVersion"
-        displayName: 'Get product version for mono-dotnet (Linux)'
+    - bash: |
+        productVersion=$(sed -n 's/.*<ProductVersion>\(.*\)<\/ProductVersion>/\1/p' eng/Versions.props)
+        echo productVersion: $productVersion
+        echo "##vso[task.setvariable variable=productVersion]$productVersion"
+      displayName: 'Get product version for mono-dotnet (Linux)'
+      condition: and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), ne(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6')))
 
-      - script: "mkdir $(Build.SourcesDirectory)/.dotnet-mono;./build.sh -subset libs.pretest -configuration release -ci -arch $(archType) -testscope innerloop /p:RuntimeArtifactsPath=$(librariesDownloadDir)/bin/mono/$(osGroup).$(archType).$(buildConfigUpper) /p:RuntimeFlavor=mono;cp $(Build.SourcesDirectory)/artifacts/bin/runtime/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/* $(Build.SourcesDirectory)/artifacts/bin/testhost/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/shared/Microsoft.NETCore.App/$(productVersion) -rf;cp $(Build.SourcesDirectory)/artifacts/bin/testhost/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/* $(Build.SourcesDirectory)/.dotnet-mono -r;cp $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(buildConfigUpper)/corerun $(Build.SourcesDirectory)/.dotnet-mono/shared/Microsoft.NETCore.App/$(productVersion)/corerun"
-        displayName: "Create mono dotnet (Linux)"
+    - script: "mkdir $(Build.SourcesDirectory)/.dotnet-mono;./build.sh -subset libs.pretest -configuration release -ci -arch $(archType) -testscope innerloop /p:RuntimeArtifactsPath=$(librariesDownloadDir)/bin/mono/$(osGroup).$(archType).$(buildConfigUpper) /p:RuntimeFlavor=mono;cp $(Build.SourcesDirectory)/artifacts/bin/runtime/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/* $(Build.SourcesDirectory)/artifacts/bin/testhost/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/shared/Microsoft.NETCore.App/$(productVersion) -rf;cp $(Build.SourcesDirectory)/artifacts/bin/testhost/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/* $(Build.SourcesDirectory)/.dotnet-mono -r;cp $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(buildConfigUpper)/corerun $(Build.SourcesDirectory)/.dotnet-mono/shared/Microsoft.NETCore.App/$(productVersion)/corerun"
+      displayName: "Create mono dotnet (Linux)"
+      condition: and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), ne(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6')))

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -373,10 +373,23 @@ jobs:
       condition: and(succeeded(), ne(variables.runtimeFlavorName, 'Mono'), ne('${{ parameters.runtimeType }}', 'wasm'))
 
     # Copy the runtime directory into the testhost folder to include OOBs.
-    - script: "build.cmd -subset libs.pretest -configuration release -ci -arch $(archType) -testscope innerloop /p:RuntimeArtifactsPath=$(librariesDownloadDir)\\bin\\mono\\$(osGroup).$(archType).$(buildConfigUpper) /p:RuntimeFlavor=mono;xcopy $(Build.SourcesDirectory)\\artifacts\\bin\\runtime\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\* $(Build.SourcesDirectory)\\artifacts\\bin\\testhost\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\shared\\Microsoft.NETCore.App\\8.0.0 /E /I /Y;xcopy $(Build.SourcesDirectory)\\artifacts\\bin\\testhost\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\* $(Build.SourcesDirectory)\\.dotnet-mono /E /I /Y;copy $(Build.SourcesDirectory)\\artifacts\\bin\\coreclr\\$(osGroup).$(archType).$(buildConfigUpper)\\corerun.exe $(Build.SourcesDirectory)\\.dotnet-mono\\shared\\Microsoft.NETCore.App\\8.0.0\\corerun.exe"
-      displayName: "Create mono dotnet (Windows)"
-      condition: and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), eq(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6')))
+    - ${{ if and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), eq(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6'))) }}:
+      - powershell: |
+          $xml = [Xml] (Get-Content $(Build.SourcesDirectory)\eng\Versions.props)
+          $productVersion = $xml.Project.PropertyGroup.productVersion
+          echo productVersion: $productVersion
+          echo "##vso[task.setvariable variable=productVersion]$productVersion"
+        displayName: 'Get product version for mono-dotnet (Windows)'
+      
+      - script: "build.cmd -subset libs.pretest -configuration release -ci -arch $(archType) -testscope innerloop /p:RuntimeArtifactsPath=$(librariesDownloadDir)\\bin\\mono\\$(osGroup).$(archType).$(buildConfigUpper) /p:RuntimeFlavor=mono;xcopy $(Build.SourcesDirectory)\\artifacts\\bin\\runtime\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\* $(Build.SourcesDirectory)\\artifacts\\bin\\testhost\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\shared\\Microsoft.NETCore.App\\$(productVersion) /E /I /Y;xcopy $(Build.SourcesDirectory)\\artifacts\\bin\\testhost\\net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)\\* $(Build.SourcesDirectory)\\.dotnet-mono /E /I /Y;copy $(Build.SourcesDirectory)\\artifacts\\bin\\coreclr\\$(osGroup).$(archType).$(buildConfigUpper)\\corerun.exe $(Build.SourcesDirectory)\\.dotnet-mono\\shared\\Microsoft.NETCore.App\\$(productVersion)\\corerun.exe"
+        displayName: "Create mono dotnet (Windows)"
 
-    - script: "mkdir $(Build.SourcesDirectory)/.dotnet-mono;./build.sh -subset libs.pretest -configuration release -ci -arch $(archType) -testscope innerloop /p:RuntimeArtifactsPath=$(librariesDownloadDir)/bin/mono/$(osGroup).$(archType).$(buildConfigUpper) /p:RuntimeFlavor=mono;cp $(Build.SourcesDirectory)/artifacts/bin/runtime/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/* $(Build.SourcesDirectory)/artifacts/bin/testhost/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/shared/Microsoft.NETCore.App/8.0.0 -rf;cp $(Build.SourcesDirectory)/artifacts/bin/testhost/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/* $(Build.SourcesDirectory)/.dotnet-mono -r;cp $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(buildConfigUpper)/corerun $(Build.SourcesDirectory)/.dotnet-mono/shared/Microsoft.NETCore.App/8.0.0/corerun"
-      displayName: "Create mono dotnet (Linux)"
-      condition: and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), ne(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6')))
+    - ${{ if and(and(succeeded(), eq(variables.runtimeFlavorName, 'Mono')), ne(variables.osGroup, 'windows'), not(in('${{ parameters.runtimeType }}', 'AndroidMono', 'iOSMono', 'AndroidMobileNet6', 'iOSMobileNet6'))) }}:
+      - bash: |
+          productVersion=$(sed -n 's/.*<ProductVersion>\(.*\)<\/ProductVersion>/\1/p' eng/Versions.props)
+          echo productVersion: $productVersion
+          echo "##vso[task.setvariable variable=productVersion]$productVersion"
+        displayName: 'Get product version for mono-dotnet (Linux)'
+
+      - script: "mkdir $(Build.SourcesDirectory)/.dotnet-mono;./build.sh -subset libs.pretest -configuration release -ci -arch $(archType) -testscope innerloop /p:RuntimeArtifactsPath=$(librariesDownloadDir)/bin/mono/$(osGroup).$(archType).$(buildConfigUpper) /p:RuntimeFlavor=mono;cp $(Build.SourcesDirectory)/artifacts/bin/runtime/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/* $(Build.SourcesDirectory)/artifacts/bin/testhost/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/shared/Microsoft.NETCore.App/$(productVersion) -rf;cp $(Build.SourcesDirectory)/artifacts/bin/testhost/net7.0-$(osGroup)-$(buildConfigUpper)-$(archType)/* $(Build.SourcesDirectory)/.dotnet-mono -r;cp $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(buildConfigUpper)/corerun $(Build.SourcesDirectory)/.dotnet-mono/shared/Microsoft.NETCore.App/$(productVersion)/corerun"
+        displayName: "Create mono dotnet (Linux)"

--- a/eng/testing/performance/microbenchmarks.proj
+++ b/eng/testing/performance/microbenchmarks.proj
@@ -49,10 +49,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoDotnet)' == 'true' and '$(AGENT_OS)' == 'Windows_NT'">
-    <CoreRunArgument>--corerun %HELIX_CORRELATION_PAYLOAD%\dotnet-mono\shared\Microsoft.NETCore.App\8.0.0\corerun.exe</CoreRunArgument>
+    <CoreRunArgument>--corerun %HELIX_CORRELATION_PAYLOAD%\dotnet-mono\shared\Microsoft.NETCore.App\$(ProductVersion)\corerun.exe</CoreRunArgument>
   </PropertyGroup>
   <PropertyGroup Condition="'$(MonoDotnet)' == 'true' and '$(AGENT_OS)' != 'Windows_NT'">
-    <CoreRunArgument>--corerun $(BaseDirectory)/dotnet-mono/shared/Microsoft.NETCore.App/8.0.0/corerun</CoreRunArgument>
+    <CoreRunArgument>--corerun $(BaseDirectory)/dotnet-mono/shared/Microsoft.NETCore.App/$(ProductVersion)/corerun</CoreRunArgument>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseCoreRun)' == 'true'">


### PR DESCRIPTION
PR to update for: https://github.com/dotnet/performance/issues/2733. This changes the product versions in the mono-dotnet creation paths to be generated from the eng/Versions.props file instead of having to be manually updated.  