### PR TITLE
Fixing missing GC.KeepAlive in ComWrappers WeakReference test

### DIFF
--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
@@ -138,6 +138,7 @@ namespace ComWrappersTests
             var obj = (WeakReferenceableWrapper)cw.GetOrCreateObjectForComInstance(objRaw, CreateObjectFlags.None);
             var wr = new WeakReference<WeakReferenceableWrapper>(obj);
             ValidateWeakReferenceState(wr, expectedIsAlive: true, cw);
+            GC.KeepAlive(obj);
             return (wr, objRaw);
         }
 
@@ -147,6 +148,7 @@ namespace ComWrappersTests
             var obj = (WeakReferenceableWrapper)cw.GetOrCreateObjectForComInstance(objRaw, CreateObjectFlags.None);
             wr.SetTarget(obj);
             ValidateWeakReferenceState(wr, expectedIsAlive: true, cw);
+            GC.KeepAlive(obj);
             return objRaw;
         }
 


### PR DESCRIPTION
Fixes: #77976

Under GC stress a weakly referenced object could be gone right after creation of the WeakReference if object is otherwise unreachable. Thus non-rehydratable RCWs can become dead immediately. 
The test checks that the WeakReference is created successfully, but it needs to `GC.KeepAlive` the referenced object at least until after the check.

