### PR TITLE
avoid allocations in SendTo and Quic

### DIFF
--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.SocketAddress.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct sockaddr_in
+        {
+            public byte sin_len;
+            public byte sin_family;
+            public ushort sin_port;
+            public fixed byte sin_addr[4];
+
+            public void SetAddressFamily(int family)
+            {
+                sin_family = (byte)family;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct sockaddr_in6
+        {
+            public byte sin_len;
+            public byte sin6_family;
+            public ushort sin6_port;
+            public uint sin6_flowinfo;
+            public fixed byte sin6_addr[16];
+            public uint sin6_scope_id;
+
+            public void SetAddressFamily(int family)
+            {
+                sin6_family = (byte)family;
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/Interop/BSD/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/BSD/System.Native/Interop.SocketAddress.cs
@@ -15,6 +15,7 @@ internal static partial class Interop
             public byte sin_family;
             public ushort sin_port;
             public fixed byte sin_addr[4];
+            private fixed byte sin_zero[8];
 
             public void SetAddressFamily(int family)
             {

--- a/src/libraries/Common/src/Interop/FreeBSD/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/FreeBSD/System.Native/Interop.SocketAddress.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal const int AF_INET = 2;
+        internal const int AF_INET6 = 28;
+    }
+}

--- a/src/libraries/Common/src/Interop/Linux/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/Linux/System.Native/Interop.SocketAddress.cs
@@ -17,6 +17,7 @@ internal static partial class Interop
             public ushort sin_family;
             public ushort sin_port;
             public fixed byte sin_addr[4];
+            private fixed byte sin_zero[8];
 
             public void SetAddressFamily(int family)
             {

--- a/src/libraries/Common/src/Interop/Linux/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/Linux/System.Native/Interop.SocketAddress.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal const int AF_INET = 2;
+        internal const int AF_INET6 = 10;
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct sockaddr_in
+        {
+            public ushort sin_family;
+            public ushort sin_port;
+            public fixed byte sin_addr[4];
+
+            public void SetAddressFamily(int family)
+            {
+                sin_family = (ushort)family;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct sockaddr_in6
+        {
+            public ushort sin6_family;
+            public ushort sin6_port;
+            public uint sin6_flowinfo;
+            public fixed byte sin6_addr[16];
+            public uint sin6_scope_id;
+
+            public void SetAddressFamily(int family)
+            {
+                sin6_family = (ushort)family;
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/Interop/OSX/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Native/Interop.SocketAddress.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal const int AF_INET = 2;
+        internal const int AF_INET6 = 30;
+    }
+}

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.SocketAddress.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal const int AF_INET = 2;
+        internal const int AF_INET6 = 23;
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct sockaddr_in
+        {
+            public ushort sin_family;
+            public ushort sin_port;
+            public fixed byte sin_addr[4];
+            private fixed byte sin_zero[8];
+
+            public void SetAddressFamily(int family)
+            {
+                sin_family = (ushort)family;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct sockaddr_in6
+        {
+            public ushort sin6_family;
+            public ushort sin6_port;
+            public uint sin6_flowinfo;
+            public fixed byte sin6_addr[16];
+            public uint sin6_scope_id;
+
+            public void SetAddressFamily(int family)
+            {
+                sin6_family = (ushort)family;
+            }
+        }
+    }
+}

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            IntPtr socketAddress,
+            byte* socketAddress,
             int socketAddressSize,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine);
@@ -29,7 +29,7 @@ internal static partial class Interop
             int bufferCount,
             out int bytesTransferred,
             SocketFlags socketFlags,
-            IntPtr socketAddress,
+            byte* socketAddress,
             int socketAddressSize,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)
@@ -47,7 +47,7 @@ internal static partial class Interop
             int bufferCount,
             [Out] out int bytesTransferred,
             SocketFlags socketFlags,
-            IntPtr socketAddress,
+            byte* socketAddress,
             int socketAddressSize,
             NativeOverlapped* overlapped,
             IntPtr completionRoutine)

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.sendto.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.sendto.cs
@@ -17,5 +17,14 @@ internal static partial class Interop
             SocketFlags socketFlags,
             byte[] socketAddress,
             int socketAddressSize);
+
+        [LibraryImport(Interop.Libraries.Ws2_32, SetLastError = true)]
+        internal static unsafe partial int sendto(
+           SafeSocketHandle socketHandle,
+           byte* pinnedBuffer,
+           int len,
+           SocketFlags socketFlags,
+           ReadOnlySpan<byte> socketAddress,
+           int socketAddressSize);
     }
 }

--- a/src/libraries/Common/src/System/Net/SockAddr.cs
+++ b/src/libraries/Common/src/System/Net/SockAddr.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+namespace System.Net.Sockets
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal partial struct SockAddr
+    {
+        internal const int IPv4AddressSize = 4;
+        internal const int IPv6AddressSize = 16;
+
+        [FieldOffset(0)]
+        public Interop.Sys.sockaddr_in Ipv4;
+        [FieldOffset(0)]
+        public Interop.Sys.sockaddr_in6 Ipv6;
+
+        public int Family => Ipv4.sin_family;
+
+        public unsafe SockAddr(IPEndPoint endPoint)
+        {
+            if (endPoint.AddressFamily == AddressFamily.InterNetwork)
+            {
+                Ipv4.sin_family = Interop.Sys.AF_INET;
+                Ipv4.sin_port = (ushort)IPAddress.HostToNetworkOrder((short)endPoint.Port);
+                Span<byte> address = MemoryMarshal.CreateSpan(ref Ipv4.sin_addr[0], IPv4AddressSize);
+                if (!endPoint.Address.TryWriteBytes(address, out int bytesWritten) || bytesWritten != IPv4AddressSize)
+                {
+                    throw new SocketException((int)SocketError.InvalidArgument);
+                }
+            }
+            else if (endPoint.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                Ipv6.sin6_family = Interop.Sys.AF_INET6;
+                Ipv6.sin6_port = (ushort)IPAddress.HostToNetworkOrder((short)endPoint.Port);
+                Span<byte> address = MemoryMarshal.CreateSpan(ref Ipv6.sin6_addr[0], IPv6AddressSize);
+                if (!endPoint.Address.TryWriteBytes(address, out int bytesWritten) || bytesWritten != IPv6AddressSize)
+                {
+                    throw new SocketException((int)SocketError.InvalidArgument);
+                }
+            }
+            else
+            {
+                // Next IP version???
+                throw new SocketException((int)SocketError.AddressFamilyNotSupported);
+            }
+        }
+
+        public AddressFamily AddressFamily
+        {
+            get
+            {
+                switch (Family)
+                {
+                    case Interop.Sys.AF_INET: return AddressFamily.InterNetwork;
+                    case Interop.Sys.AF_INET6: return AddressFamily.InterNetworkV6;
+                    default:
+                        throw new SocketException((int)SocketError.AddressFamilyNotSupported);
+                }
+            }
+        }
+
+        public ushort GetPort()
+        {
+            if (AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                return (ushort)IPAddress.NetworkToHostOrder((short)Ipv6.sin6_port);
+            }
+            else if (AddressFamily == AddressFamily.InterNetwork)
+            {
+                return (ushort)IPAddress.NetworkToHostOrder((short)Ipv4.sin_port);
+            }
+            else
+            {
+                throw new SocketException((int)SocketError.AddressFamilyNotSupported);
+            }
+        }
+
+        public unsafe IPAddress GetIPAddress()
+        {
+            if (AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                return new IPAddress(MemoryMarshal.CreateSpan(ref Ipv6.sin6_addr[0], IPv6AddressSize), Ipv6.sin6_scope_id);
+            }
+            else if (AddressFamily == AddressFamily.InterNetwork)
+            {
+                return new IPAddress(MemoryMarshal.CreateSpan(ref Ipv4.sin_addr[0], IPv4AddressSize));
+            }
+            else
+            {
+                throw new SocketException((int)SocketError.AddressFamilyNotSupported);
+            }
+        }
+
+        public IPEndPoint GetIPEndPoint()
+        {
+            return new IPEndPoint(GetIPAddress(), GetPort());
+        }
+
+        public void SetAddressFamily(AddressFamily family) => Ipv4.SetAddressFamily((int)family);
+    }
+}

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -25,10 +25,7 @@
     <Compile Include="$(CommonPath)System\Net\ArrayBuffer.cs" Link="Common\System\Net\ArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\MultiArrayBuffer.cs" Link="Common\System\Net\MultiArrayBuffer.cs" />
     <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs" Link="Common\System\Net\Logging\NetEventSource.Common.cs" />
-    <Compile Include="$(CommonPath)System\Net\StreamBuffer.cs" Link="Common\System\Net\StreamBuffer.cs" />
-    <Compile Include="$(CommonPath)System\Net\SocketAddress.cs" Link="Common\System\Net\SocketAddress.cs" />
-    <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs" Link="Common\System\Net\IPAddressParserStatics.cs" />
-    <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs" Link="Common\System\Net\Internals\IPEndPointExtensions.cs" />
+    <Compile Include="$(CommonPath)System\Net\SockAddr.cs" Link="Common\System\Net\SockAddr.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TlsAlertMessage.cs"
              Link="Common\System\Net\Security\TlsAlertMessage.cs" />
   </ItemGroup>
@@ -55,7 +52,7 @@
     <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.MsgEncodingType.cs" Link="Common\Interop\Windows\Crypt32\Interop.Interop.MsgEncodingType.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs" Link="Common\Interop\Windows\SChannel\Interop.SECURITY_STATUS.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Windows.cs" Link="Common\System\Net\Security\CertificateValidation.Windows.cs" />
-    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs" Link="Common\System\Net\SocketAddressPal.Windows.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.SocketAddress.cs" Link="Common\Interop\Windows\WinSock\Interop.SocketAddress.cs" />
   </ItemGroup>
   <!-- Unix (OSX + Linux) specific files -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Linux' or '$(TargetPlatformIdentifier)' == 'OSX' or '$(TargetPlatformIdentifier)' == 'FreeBSD'">
@@ -79,22 +76,26 @@
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs" Link="Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs" />
-    <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs" Link="Common\System\Net\SocketAddressPal.Unix.cs" />
   </ItemGroup>
   <!-- Linux specific files -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Linux'">
     <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Unix.cs" Link="Common\System\Net\Security\CertificateValidation.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Linux\Interop.Libraries.cs" Link="Common\Interop\Linux\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Linux\System.Native\Interop.SocketAddress.cs" Link="Common\Interop\Linux\System.Native\Interop.SocketAddress.cs" />
   </ItemGroup>
   <!-- FreeBSD specific files -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'FreeBSD' ">
     <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Unix.cs" Link="Common\System\Net\Security\CertificateValidation.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\FreeBSD\Interop.Libraries.cs" Link="Common\Interop\FreeBSD\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.SocketAddress.cs" Link="Common\Interop\BSD\System.Native\Interop.SocketAddress.cs" />
+    <Compile Include="$(CommonPath)Interop\FreeBSD\System.Native\Interop.SocketAddress.cs" Link="Common\Interop\FreeBSD\System.Native\Interop.SocketAddress.cs" />
   </ItemGroup>
   <!-- OSX specific files -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'OSX'">
     <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.OSX.cs" Link="Common\System\Net\Security\CertificateValidation.OSX.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs" Link="Common\Interop\OSX\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.SocketAddress.cs" Link="Common\Interop\BSD\System.Native\Interop.SocketAddress.cs" />
+    <Compile Include="$(CommonPath)Interop\OSX\System.Native\Interop.SocketAddress.cs" Link="Common\Interop\OSX\System.Native\Interop.SocketAddress.cs" />
   </ItemGroup>
 
   <!-- Project references -->

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicHelpers.cs
@@ -35,23 +35,12 @@ internal static class MsQuicHelpers
         return false;
     }
 
-    internal static unsafe IPEndPoint ToIPEndPoint(this ref QuicAddr quicAddress, AddressFamily? addressFamilyOverride = null)
-    {
-        // MsQuic always uses storage size as if IPv6 was used
-        Span<byte> addressBytes = new Span<byte>((byte*)Unsafe.AsPointer(ref quicAddress), Internals.SocketAddress.IPv6AddressSize);
-        return new Internals.SocketAddress(addressFamilyOverride ?? SocketAddressPal.GetAddressFamily(addressBytes), addressBytes).GetIPEndPoint();
-    }
-
     internal static unsafe QuicAddr ToQuicAddr(this IPEndPoint iPEndPoint)
     {
         // TODO: is the layout same for SocketAddress.Buffer and QuicAddr on all platforms?
         QuicAddr result = default;
-        Span<byte> rawAddress = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref result, 1));
+        result.Address = new SockAddr(iPEndPoint);
 
-        Internals.SocketAddress address = IPEndPointExtensions.Serialize(iPEndPoint);
-        Debug.Assert(address.Size <= rawAddress.Length);
-
-        address.Buffer.AsSpan(0, address.Size).CopyTo(rawAddress);
         return result;
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Interop/msquic.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Interop/msquic.cs
@@ -6,6 +6,8 @@
 #pragma warning restore IDE0073
 
 using System;
+using System.Net;
+using System.Net.Sockets;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -108,72 +110,19 @@ namespace Microsoft.Quic
         public string Name => _name;
     }
 
-    [StructLayout(LayoutKind.Explicit)]
-    internal struct QuicAddrFamilyAndLen
-    {
-        [FieldOffset(0)]
-        public ushort sin_family;
-        [FieldOffset(0)]
-        public byte sin_len;
-        [FieldOffset(1)]
-        public byte sin_family_bsd;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal unsafe struct QuicAddrIn
-    {
-        public QuicAddrFamilyAndLen sin_family;
-        public ushort sin_port;
-        public fixed byte sin_addr[4];
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal unsafe struct QuicAddrIn6
-    {
-        public QuicAddrFamilyAndLen sin6_family;
-        public ushort sin6_port;
-        public uint sin6_flowinfo;
-        public fixed byte sin6_addr[16];
-        public uint sin6_scope_id;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
     internal struct QuicAddr
     {
-        [FieldOffset(0)]
-        public QuicAddrIn Ipv4;
-        [FieldOffset(0)]
-        public QuicAddrIn6 Ipv6;
-        [FieldOffset(0)]
-        public QuicAddrFamilyAndLen FamilyLen;
+        public SockAddr Address;
 
-        public static bool SockaddrHasLength => OperatingSystem.IsFreeBSD() || OperatingSystem.IsIOS() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS();
+        public int Family => Address.Family;
+        public Interop.Sys.sockaddr_in6 Ipv6 => Address.Ipv6;
+        public Interop.Sys.sockaddr_in Ipv4 => Address.Ipv4;
 
-        public int Family
+        public QuicAddr(IPEndPoint endPoint)
         {
-            get
-            {
-                if (SockaddrHasLength)
-                {
-                    return FamilyLen.sin_family_bsd;
-                }
-                else
-                {
-                    return FamilyLen.sin_family;
-                }
-            }
-            set
-            {
-                if (SockaddrHasLength)
-                {
-                    FamilyLen.sin_family_bsd = (byte)value;
-                }
-                else
-                {
-                    FamilyLen.sin_family = (ushort)value;
-                }
-            }
+            Address = new SockAddr(endPoint);
         }
-    }
 
+        public IPEndPoint ToIPEndPoint() => Address.GetIPEndPoint();
+    }
 }

--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)-Android;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
@@ -71,6 +71,8 @@
              Link="Common\System\Net\SocketAddress.cs" />
     <Compile Include="$(CommonPath)System\Net\TcpValidationHelpers.cs"
              Link="Common\System\Net\TcpValidationHelpers.cs" />
+    <Compile Include="$(CommonPath)System\Net\SockAddr.cs"
+             Link="Common\System\Net\SockAddr.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketProtocolSupportPal.cs"
              Link="Common\System\Net\SocketProtocolSupportPal.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"
@@ -137,6 +139,8 @@
              Link="Common\Interop\Windows\WinSock\Interop.setsockopt.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.shutdown.cs"
              Link="Common\Interop\Windows\WinSock\Interop.shutdown.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.SocketAddress.cs"
+             Link="Common\Interop\Windows\WinSock\Interop.SocketAddress.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.TransmitFile.cs"
              Link="Common\Interop\Windows\WinSock\Interop.TransmitFile.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.WinsockBSD.cs"
@@ -182,7 +186,7 @@
     <Compile Include="$(CommonPath)System\Net\CompletionPortHelper.Windows.cs"
              Link="Common\System\Net\CompletionPortHelper.Windows.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Unix'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Windows' and '$(TargetPlatformIdentifier)' != ''">
     <Compile Include="System\Net\Sockets\SafeSocketHandle.Unix.cs" />
     <Compile Include="System\Net\Sockets\Socket.Unix.cs" />
     <Compile Include="System\Net\Sockets\SocketAsyncContext.Unix.cs" />
@@ -285,6 +289,22 @@
     <Compile Include="$(CommonPath)System\Net\Sockets\SocketExceptionFactory.Unix.cs"
              Link="Common\System\Net\Sockets\SocketExceptionFactory.Unix.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Android' or '$(TargetPlatformIdentifier)' == 'Linux'">
+    <Compile Include="$(CommonPath)Interop\Linux\System.Native\Interop.SocketAddress.cs"
+             Link="Common\Interop\Linux\System.Native\Interop.SocketAddress.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'iOS' or '$(TargetPlatformIdentifier)' == 'OSX' or '$(TargetPlatformIdentifier)' == 'tvOS'">
+    <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.SocketAddress.cs"
+             Link="Common\Interop\BSD\System.Native\Interop.SocketAddress.cs" />
+    <Compile Include="$(CommonPath)Interop\OSX\System.Native\Interop.SocketAddress.cs"
+             Link="Common\Interop\OSX\System.Native\Interop.SocketAddress.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'FreeBSD' ">
+    <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.SocketAddress.cs"
+             Link="Common\Interop\BSD\System.Native\Interop.SocketAddress.cs" />
+    <Compile Include="$(CommonPath)Interop\FreeBSD\System.Native\Interop.SocketAddress.cs"
+             Link="Common\Interop\FreeBSD\System.Native\Interop.SocketAddress.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Include="System.Collections" />
@@ -300,7 +320,7 @@
     <Reference Include="System.Threading.Overlapped" />
     <Reference Include="System.Threading.ThreadPool" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'Unix'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Windows'">
     <Reference Include="System.Threading.Thread" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -24,7 +24,7 @@ namespace System.Net.Sockets
         internal const int DefaultCloseTimeout = -1; // NOTE: changing this default is a breaking change.
 
         private static readonly IPAddress s_IPAddressAnyMapToIPv6 = IPAddress.Any.MapToIPv6();
-        private static readonly byte[] s_zero = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        private static ReadOnlySpan<byte> ZeroBytes => new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         private SafeSocketHandle _handle;
 
         // _rightEndPoint is null if the socket has not been bound.  Otherwise, it is an EndPoint of the
@@ -1290,7 +1290,7 @@ namespace System.Net.Sockets
         public int SendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP)
         {
             ValidateBufferArguments(buffer, offset, size);
-            return SendTo(new ReadOnlySpan<byte>(buffer, offset, size), socketFlags, remoteEP);
+            return SendTo(buffer.AsSpan(offset, size), socketFlags, remoteEP);
         }
 
         // Sends data to a specific end point, starting at the indicated location in the data.

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1344,8 +1344,11 @@ namespace System.Net.Sockets
 
             if (remoteEP is IPEndPoint)
             {
-                var address = new SockAddr((IPEndPoint)remoteEP);
-                socketBuffer = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref address, 1));
+                SockAddr address =  (IsDualMode && ((IPEndPoint)remoteEP).Address.AddressFamily == AddressFamily.InterNetwork) ?
+                                        new SockAddr((IPEndPoint)remoteEP, AddressFamily.InterNetworkV6) :
+                                        new SockAddr((IPEndPoint)remoteEP);
+
+                socketBuffer = address.AsBytes();
             }
             else
             {
@@ -3013,8 +3016,10 @@ namespace System.Net.Sockets
             ReadOnlySpan<byte> socketBuffer;
             if (remoteEP is IPEndPoint)
             {
-                var address = new SockAddr((IPEndPoint)remoteEP);
-                socketBuffer = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref address, 1));
+                SockAddr address =  (IsDualMode && ((IPEndPoint)remoteEP).Address.AddressFamily == AddressFamily.InterNetwork) ?
+                                        new SockAddr((IPEndPoint)remoteEP, AddressFamily.InterNetworkV6) :
+                                        new SockAddr((IPEndPoint)remoteEP);
+                socketBuffer = address.AsBytes();
             }
             else
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1372,7 +1372,7 @@ namespace System.Net.Sockets
             if (_localEndPoint == null)
             {   // We expect that the socket will have LocalEndPoint if not bound already.
                 // Addresses are mutable so we need to create new instance.
-                //_localEndPoint = new IPEndPoint(new IPAddress(new ReadOnlySpan<byte>(s_zero, 0, AddressFamily == AddressFamily.InterNetwork ? 4 : 16)), 0);
+                // It would be nice to simply set _localEndPoint here but the logic is complicated.
                 _rightEndPoint ??= new IPEndPoint(new IPAddress(new ReadOnlySpan<byte>(s_zero, 0, AddressFamily == AddressFamily.InterNetwork ? 4 : 16)), 0);
             }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1373,7 +1373,7 @@ namespace System.Net.Sockets
             {   // We expect that the socket will have LocalEndPoint if not bound already.
                 // Addresses are mutable so we need to create new instance.
                 // It would be nice to simply set _localEndPoint here but the logic is complicated.
-                _rightEndPoint ??= new IPEndPoint(new IPAddress(new ReadOnlySpan<byte>(s_zero, 0, AddressFamily == AddressFamily.InterNetwork ? 4 : 16)), 0);
+                _rightEndPoint ??= new IPEndPoint(new IPAddress(ZeroBytes.Slice(0, AddressFamily == AddressFamily.InterNetwork ? SockAddr.IPv4AddressSize : SockAddr.IPv6AddressSize)), 0);
             }
 
             return bytesTransferred;
@@ -3025,7 +3025,7 @@ namespace System.Net.Sockets
             // Prepare for and make the native call.
             e.StartOperationCommon(this, SocketAsyncOperation.SendTo);
 
-            _rightEndPoint ??=  new IPEndPoint(new IPAddress(new ReadOnlySpan<byte>(s_zero, 0, AddressFamily == AddressFamily.InterNetwork ? SockAddr.IPv4AddressSize : SockAddr.IPv6AddressSize)), 0);
+            _rightEndPoint ??=  new IPEndPoint(new IPAddress(ZeroBytes.Slice(0, AddressFamily == AddressFamily.InterNetwork ? SockAddr.IPv4AddressSize : SockAddr.IPv6AddressSize)), 0);
             SocketError socketError;
             try
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1977,7 +1977,7 @@ namespace System.Net.Sockets
             operation.SocketAddressLen = socketAddress.Length;
             operation.BytesTransferred = bytesSent;
 
-            if (socketAddress.Length > 0 )
+            if (socketAddress.Length > 0)
             {
                 operation.SocketAddress = ArrayPool<byte>.Shared.Rent(socketAddress.Length);
                 socketAddress.CopyTo(operation.SocketAddress);
@@ -2035,7 +2035,7 @@ namespace System.Net.Sockets
                 BytesTransferred = bytesSent
             };
 
-            if (socketAddress.Length > 0 )
+            if (socketAddress.Length > 0)
             {
                 operation.SocketAddress = ArrayPool<byte>.Shared.Rent(socketAddress.Length);
                 socketAddress.CopyTo(operation.SocketAddress);
@@ -2076,7 +2076,7 @@ namespace System.Net.Sockets
             operation.BytesTransferred = bytesSent;
             socketAddress.CopyTo(operation.SocketAddress);
 
-            if (socketAddress.Length > 0 )
+            if (socketAddress.Length > 0)
             {
                 operation.SocketAddress = ArrayPool<byte>.Shared.Rent(socketAddress.Length);
                 socketAddress.CopyTo(operation.SocketAddress);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1193,7 +1193,7 @@ namespace System.Net.Sockets
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
-        public static SocketError SendTo(SafeSocketHandle handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, ReadOnlySpan<byte>  socketAddress, out int bytesTransferred)
+        public static SocketError SendTo(SafeSocketHandle handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, ReadOnlySpan<byte> socketAddress, out int bytesTransferred)
         {
             if (!handle.IsNonBlocking)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -300,15 +300,13 @@ namespace System.Net.Sockets
             }
         }
 
-        public static SocketError SendTo(SafeSocketHandle handle, byte[] buffer, int offset, int size, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize, out int bytesTransferred) =>
-            SendTo(handle, buffer.AsSpan(offset, size), socketFlags, peerAddress, peerAddressSize, out bytesTransferred);
+        public static unsafe SocketError SendTo(SafeSocketHandle handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, ReadOnlySpan<byte> peerAddress, out int bytesTransferred)
 
-        public static unsafe SocketError SendTo(SafeSocketHandle handle, ReadOnlySpan<byte> buffer, SocketFlags socketFlags, byte[] peerAddress, int peerAddressSize, out int bytesTransferred)
         {
             int bytesSent;
             fixed (byte* bufferPtr = &MemoryMarshal.GetReference(buffer))
             {
-                bytesSent = Interop.Winsock.sendto(handle, bufferPtr, buffer.Length, socketFlags, peerAddress, peerAddressSize);
+                bytesSent = Interop.Winsock.sendto(handle, bufferPtr, buffer.Length, socketFlags, peerAddress, peerAddress.Length);
             }
 
             if (bytesSent == (int)SocketError.SocketError)


### PR DESCRIPTION
Contributes to #30797

This is somewhat incomplete MVP. I'm looking for feedback before spending too much time.
We generally use public SocketAddress class (and internal variant) when we want to pass it to/from native network stack. For connection protocols like TCP allocation and pinning overhead is acceptable but for something like SendTo/ReceiveFrom we need to do it for every and it becomes significant. (and it also generates pauses when GC kicks in) 

To address this PR brings native `sockaddr` to managed code. We already have that somewhat for Quic so I made some cleanup and changes and I also use it for `Sockets.SendTo`. For IPv4/6 we allocate struct on stack and for rest of address families we still serialize like we used to. (could be fixed easily)

The `SendTo` would typically finish synchronously as it only depends on Kernels ability to transmit (unlike TCP when we may need to wait for ACK) but we also have cases when the operation lands on async queue. For now, this change rents buffer from array pull and it would copy the data over. We could also make the new struct part of `BufferPtrSendOperation` (or variant) but I did not want to change this at this moment. 
For reference the sizes of sock address on Linux are:
ipv4: 16, ipv6: 28 UnixDomainSocket = 110, Storage(maximum supported address) = 128

This part is easy for `Quic` as we only support operation on IP. For Quic I was also thinking about replacing the  `quicAddress` but I like it as different type so we option for modifications if we need to. 
  