### PR TITLE
[mono][interp] Remove an assertion.

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -6829,11 +6829,9 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			guint16 clause_index = *(ip + 1);
 
 			guint16 *ret_ip = *(guint16**)(locals + frame->imethod->clause_data_offsets [clause_index]);
-			if (!ret_ip) {
+			if (!ret_ip)
 				// this clause was called from EH, return to eh
-				g_assert (clause_args && clause_args->exec_frame == frame);
 				goto exit_clause;
-			}
 			ip = ret_ip;
 			MINT_IN_BREAK;
 		}


### PR DESCRIPTION
The assertion can be hit in normal usage on wasm when calling a catch clause inside a finally clause from interp_run_clause_with_il_state ().

Test case is TCErrorConditionWriter:var_21 () in the xml test suite.