### PR TITLE
Check field's real type before we call getArrayOrStringLength

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -2740,6 +2740,8 @@ public:
     // Returns true iff "fldHnd" represents a static field.
     virtual bool isFieldStatic(CORINFO_FIELD_HANDLE fldHnd) = 0;
 
+    // Returns Length of an Array or of a String object, otherwise -1.
+    // objHnd must be not null
     virtual int getArrayOrStringLength(CORINFO_OBJECT_HANDLE objHnd) = 0;
 
     /*********************************************************************************/

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -2741,7 +2741,7 @@ public:
     virtual bool isFieldStatic(CORINFO_FIELD_HANDLE fldHnd) = 0;
 
     // Returns Length of an Array or of a String object, otherwise -1.
-    // objHnd must be not null
+    // objHnd must not be null.
     virtual int getArrayOrStringLength(CORINFO_OBJECT_HANDLE objHnd) = 0;
 
     /*********************************************************************************/

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2303,7 +2303,7 @@ namespace Internal.JitInterface
             {
                 FrozenStringNode frozenStr => frozenStr.Data.Length,
                 FrozenObjectNode frozenObj => frozenObj.GetArrayLength(),
-                _ => throw new NotImplementedException($"Unexpected object in getArrayOrStringLength: {obj}")
+                _ => -1;
             };
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2302,8 +2302,8 @@ namespace Internal.JitInterface
             return obj switch
             {
                 FrozenStringNode frozenStr => frozenStr.Data.Length,
-                FrozenObjectNode frozenObj => frozenObj.GetArrayLength(),
-                _ => -1;
+                FrozenObjectNode frozenObj when frozenObj.ObjectType.IsArray => frozenObj.GetArrayLength(),
+                _ => -1
             };
         }
     }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1742,10 +1742,6 @@ int CEEInfo::getArrayOrStringLength(CORINFO_OBJECT_HANDLE objHnd)
     {
         arrLen = ((STRINGREF)obj)->GetStringLength();
     }
-    else
-    {
-        UNREACHABLE();
-    }
 
     EE_TO_JIT_TRANSITION();
     return arrLen;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_77968/Runtime_77968.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77968/Runtime_77968.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+class Runtime_77968
+{
+    private static readonly object o = new ();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Foo()
+    {
+        // o is not an array
+        // make sure VM doesn't assert in getArrayOrStringLength
+        return ((int[])o).Length;
+    }
+
+    private static int Main(string[] args)
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            try
+            {
+                Foo();
+            }
+            catch
+            {
+                // ignored
+            }
+            Thread.Sleep(15);
+        }
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_77968/Runtime_77968.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_77968/Runtime_77968.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77968

I assumed that anything under `GT_ARR_LENGTH` is an array (or string). It turns out it may not be. 