### PR TITLE
More robust handling of CERT_CONTEXT with multiple threads

### DIFF
--- a/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCertContextHandle.cs
+++ b/src/libraries/Common/src/Microsoft/Win32/SafeHandles/SafeCertContextHandle.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Win32.SafeHandles
             return true;
         }
 
-        public unsafe CERT_CONTEXT* CertContext
+        public unsafe CERT_CONTEXT* DangerousCertContext
         {
             get { return (CERT_CONTEXT*)handle; }
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePal.Windows.cs
@@ -80,10 +80,10 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    string keyAlgorithm = Marshal.PtrToStringAnsi(pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId)!;
-                    GC.KeepAlive(this);
-                    return keyAlgorithm;
+                    return AcquireCertContext(static certContext =>
+                    {
+                        return Marshal.PtrToStringAnsi(certContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId)!;
+                    });
                 }
             }
         }
@@ -94,39 +94,40 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    string keyAlgorithmOid = Marshal.PtrToStringAnsi(pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId)!;
-
-                    int algId;
-                    if (keyAlgorithmOid == Oids.Rsa)
-                        algId = AlgId.CALG_RSA_KEYX;  // Fast-path for the most common case.
-                    else
-                        algId = Interop.Crypt32.FindOidInfo(Interop.Crypt32.CryptOidInfoKeyType.CRYPT_OID_INFO_OID_KEY, keyAlgorithmOid, OidGroup.PublicKeyAlgorithm, fallBackToAllGroups: true).AlgId;
-
-                    unsafe
+                    return AcquireCertContext(pCertContext =>
                     {
-                        byte* NULL_ASN_TAG = (byte*)0x5;
+                        string keyAlgorithmOid = Marshal.PtrToStringAnsi(pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId)!;
 
-                        byte[] keyAlgorithmParameters;
-
-                        if (algId == AlgId.CALG_DSS_SIGN
-                            && pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.Parameters.cbData == 0
-                            && pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.Parameters.pbData.ToPointer() == NULL_ASN_TAG)
-                        {
-                            //
-                            // DSS certificates may not have the DSS parameters in the certificate. In this case, we try to build
-                            // the certificate chain and propagate the parameters down from the certificate chain.
-                            //
-                            keyAlgorithmParameters = PropagateKeyAlgorithmParametersFromChain();
-                        }
+                        int algId;
+                        if (keyAlgorithmOid == Oids.Rsa)
+                            algId = AlgId.CALG_RSA_KEYX;  // Fast-path for the most common case.
                         else
-                        {
-                            keyAlgorithmParameters = pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.Parameters.ToByteArray();
-                        }
+                            algId = Interop.Crypt32.FindOidInfo(Interop.Crypt32.CryptOidInfoKeyType.CRYPT_OID_INFO_OID_KEY, keyAlgorithmOid, OidGroup.PublicKeyAlgorithm, fallBackToAllGroups: true).AlgId;
 
-                        GC.KeepAlive(this);
-                        return keyAlgorithmParameters;
-                    }
+                        unsafe
+                        {
+                            byte* NULL_ASN_TAG = (byte*)0x5;
+
+                            byte[] keyAlgorithmParameters;
+
+                            if (algId == AlgId.CALG_DSS_SIGN
+                                && pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.Parameters.cbData == 0
+                                && pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.Parameters.pbData.ToPointer() == NULL_ASN_TAG)
+                            {
+                                //
+                                // DSS certificates may not have the DSS parameters in the certificate. In this case, we try to build
+                                // the certificate chain and propagate the parameters down from the certificate chain.
+                                //
+                                keyAlgorithmParameters = PropagateKeyAlgorithmParametersFromChain();
+                            }
+                            else
+                            {
+                                keyAlgorithmParameters = pCertContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.Parameters.ToByteArray();
+                            }
+
+                            return keyAlgorithmParameters;
+                        }
+                    });
                 }
             }
         }
@@ -168,10 +169,10 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    byte[] publicKey = pCertContext->pCertInfo->SubjectPublicKeyInfo.PublicKey.ToByteArray();
-                    GC.KeepAlive(this);
-                    return publicKey;
+                    return AcquireCertContext(static pCertContext =>
+                    {
+                        return pCertContext->pCertInfo->SubjectPublicKeyInfo.PublicKey.ToByteArray();
+                    });
                 }
             }
         }
@@ -182,11 +183,12 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    byte[] serialNumber = pCertContext->pCertInfo->SerialNumber.ToByteArray();
-                    Array.Reverse(serialNumber);
-                    GC.KeepAlive(this);
-                    return serialNumber;
+                    return AcquireCertContext(static pCertContext =>
+                    {
+                        byte[] serialNumber = pCertContext->pCertInfo->SerialNumber.ToByteArray();
+                        Array.Reverse(serialNumber);
+                        return serialNumber;
+                    });
                 }
             }
         }
@@ -197,10 +199,10 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    string signatureAlgorithm = Marshal.PtrToStringAnsi(pCertContext->pCertInfo->SignatureAlgorithm.pszObjId)!;
-                    GC.KeepAlive(this);
-                    return signatureAlgorithm;
+                    return AcquireCertContext(static pCertContext =>
+                    {
+                        return Marshal.PtrToStringAnsi(pCertContext->pCertInfo->SignatureAlgorithm.pszObjId)!;
+                    });
                 }
             }
         }
@@ -211,10 +213,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    DateTime notAfter = pCertContext->pCertInfo->NotAfter.ToDateTime();
-                    GC.KeepAlive(this);
-                    return notAfter;
+                    return AcquireCertContext(static pCertContext => pCertContext->pCertInfo->NotAfter.ToDateTime());
                 }
             }
         }
@@ -225,10 +224,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    DateTime notBefore = pCertContext->pCertInfo->NotBefore.ToDateTime();
-                    GC.KeepAlive(this);
-                    return notBefore;
+                    return AcquireCertContext(static pCertContext => pCertContext->pCertInfo->NotBefore.ToDateTime());
                 }
             }
         }
@@ -239,10 +235,10 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    byte[] rawData = new Span<byte>(pCertContext->pbCertEncoded, pCertContext->cbCertEncoded).ToArray();
-                    GC.KeepAlive(this);
-                    return rawData;
+                    return AcquireCertContext(static pCertContext =>
+                    {
+                        return new Span<byte>(pCertContext->pbCertEncoded, pCertContext->cbCertEncoded).ToArray();
+                    });
                 }
             }
         }
@@ -253,10 +249,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_CONTEXT* pCertContext = _certContext.CertContext;
-                    int version = pCertContext->pCertInfo->dwVersion + 1;
-                    GC.KeepAlive(this);
-                    return version;
+                    return AcquireCertContext(static pCertContext => pCertContext->pCertInfo->dwVersion + 1);
                 }
             }
         }
@@ -332,11 +325,12 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    // X500DN creates a copy of the data for itself; data is kept alive with GC.KeepAlive.
-                    ReadOnlySpan<byte> encodedSubjectName = _certContext.CertContext->pCertInfo->Subject.DangerousAsSpan();
-                    X500DistinguishedName subjectName = new X500DistinguishedName(encodedSubjectName);
-                    GC.KeepAlive(this);
-                    return subjectName;
+                    return AcquireCertContext(static certContext =>
+                    {
+                        ReadOnlySpan<byte> encodedSubjectName = certContext->pCertInfo->Subject.DangerousAsSpan();
+                        X500DistinguishedName subjectName = new X500DistinguishedName(encodedSubjectName);
+                        return subjectName;
+                    });
                 }
             }
         }
@@ -347,11 +341,12 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    // X500DN creates a copy of the data for itself; data is kept alive with GC.KeepAlive.
-                    ReadOnlySpan<byte> encodedIssuerName = _certContext.CertContext->pCertInfo->Issuer.DangerousAsSpan();
-                    X500DistinguishedName issuerName = new X500DistinguishedName(encodedIssuerName);
-                    GC.KeepAlive(this);
-                    return issuerName;
+                    return AcquireCertContext(static certContext =>
+                    {
+                        ReadOnlySpan<byte> encodedIssuerName = certContext->pCertInfo->Issuer.DangerousAsSpan();
+                        X500DistinguishedName issuerName = new X500DistinguishedName(encodedIssuerName);
+                        return issuerName;
+                    });
                 }
             }
         }
@@ -367,25 +362,26 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 unsafe
                 {
-                    Interop.Crypt32.CERT_INFO* pCertInfo = _certContext.CertContext->pCertInfo;
-                    int numExtensions = pCertInfo->cExtension;
-                    X509Extension[] extensions = new X509Extension[numExtensions];
-
-                    for (int i = 0; i < numExtensions; i++)
+                    return AcquireCertContext(static certContext =>
                     {
-                        Interop.Crypt32.CERT_EXTENSION* pCertExtension = (Interop.Crypt32.CERT_EXTENSION*)pCertInfo->rgExtension.ToPointer() + i;
-                        string oidValue = Marshal.PtrToStringAnsi(pCertExtension->pszObjId)!;
-                        Oid oid = new Oid(oidValue, friendlyName: null);
-                        bool critical = pCertExtension->fCritical != 0;
+                        Interop.Crypt32.CERT_INFO* pCertInfo = certContext->pCertInfo;
+                        int numExtensions = pCertInfo->cExtension;
+                        X509Extension[] extensions = new X509Extension[numExtensions];
 
-                        // X509Extension creates a copy of the data for itself. The underlying data
-                        // is kept alive with the KeepAlive below.
-                        ReadOnlySpan<byte> rawData = pCertExtension->Value.DangerousAsSpan();
-                        extensions[i] = new X509Extension(oid, rawData, critical);
-                    }
+                        for (int i = 0; i < numExtensions; i++)
+                        {
+                            Interop.Crypt32.CERT_EXTENSION* pCertExtension = (Interop.Crypt32.CERT_EXTENSION*)pCertInfo->rgExtension.ToPointer() + i;
+                            string oidValue = Marshal.PtrToStringAnsi(pCertExtension->pszObjId)!;
+                            Oid oid = new Oid(oidValue, friendlyName: null);
+                            bool critical = pCertExtension->fCritical != 0;
 
-                    GC.KeepAlive(this);
-                    return extensions;
+                            // X509Extension creates a copy of the data for itself.
+                            ReadOnlySpan<byte> rawData = pCertExtension->Value.DangerousAsSpan();
+                            extensions[i] = new X509Extension(oid, rawData, critical);
+                        }
+
+                        return extensions;
+                    });
                 }
             }
         }
@@ -477,9 +473,20 @@ namespace System.Security.Cryptography.X509Certificates
 
         internal SafeCertContextHandle GetCertContext()
         {
-            SafeCertContextHandle certContext = Interop.Crypt32.CertDuplicateCertificateContext(_certContext.DangerousGetHandle());
-            GC.KeepAlive(_certContext);
-            return certContext;
+            bool added = false;
+            _certContext.DangerousAddRef(ref added);
+
+            try
+            {
+                return Interop.Crypt32.CertDuplicateCertificateContext(_certContext.DangerousGetHandle());
+            }
+            finally
+            {
+                if (added)
+                {
+                    _certContext.DangerousRelease();
+                }
+            }
         }
 
         private static Interop.Crypt32.CertNameType MapNameType(X509NameType nameType)
@@ -544,5 +551,25 @@ namespace System.Security.Cryptography.X509Certificates
                 return exported;
             }
         }
+
+        private unsafe T AcquireCertContext<T>(CertContextCallback<T> callback)
+        {
+            bool added = false;
+            _certContext.DangerousAddRef(ref added);
+
+            try
+            {
+                return callback(_certContext.DangerousCertContext);
+            }
+            finally
+            {
+                if (added)
+                {
+                    _certContext.DangerousRelease();
+                }
+            }
+        }
+
+        private unsafe delegate T CertContextCallback<T>(Interop.Crypt32.CERT_CONTEXT* certContext);
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.Export.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.Export.cs
@@ -32,8 +32,10 @@ namespace System.Security.Cryptography.X509Certificates
                         {
                             unsafe
                             {
-                                byte[] rawData = new byte[pCertContext.CertContext->cbCertEncoded];
-                                Marshal.Copy((IntPtr)(pCertContext.CertContext->pbCertEncoded), rawData, 0, rawData.Length);
+                                // We can use the DangerousCertContext because the safehandle never leaves this method
+                                // and can't be disposed of by another thread.
+                                byte[] rawData = new byte[pCertContext.DangerousCertContext->cbCertEncoded];
+                                Marshal.Copy((IntPtr)(pCertContext.DangerousCertContext->pbCertEncoded), rawData, 0, rawData.Length);
                                 GC.KeepAlive(pCertContext);
                                 return rawData;
                             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Windows.cs
@@ -61,7 +61,9 @@ namespace System.Security.Cryptography.X509Certificates
             using (SafeCertContextHandle existingCertContext = ((CertificatePal)certificate).GetCertContext())
             {
                 SafeCertContextHandle? enumCertContext = null;
-                Interop.Crypt32.CERT_CONTEXT* pCertContext = existingCertContext.CertContext;
+                // We can use DangerousCertContext safely here because GetCertContext returns a duplicated context
+                // that we own and doesn't escape.
+                Interop.Crypt32.CERT_CONTEXT* pCertContext = existingCertContext.DangerousCertContext;
                 if (!Interop.crypt32.CertFindCertificateInStore(_certStore, Interop.Crypt32.CertFindType.CERT_FIND_EXISTING, pCertContext, ref enumCertContext))
                     return; // The certificate is not present in the store, simply return.
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.PublicKey.cs
@@ -135,7 +135,13 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     unsafe
                     {
-                        bool success = Interop.Crypt32.CryptImportPublicKeyInfoEx2(Interop.Crypt32.CertEncodingType.X509_ASN_ENCODING, &(certContext.CertContext->pCertInfo->SubjectPublicKeyInfo), importFlags, null, out bCryptKeyHandle);
+                        bool success = Interop.Crypt32.CryptImportPublicKeyInfoEx2(
+                            Interop.Crypt32.CertEncodingType.X509_ASN_ENCODING,
+                            &(certContext.DangerousCertContext->pCertInfo->SubjectPublicKeyInfo),
+                            importFlags,
+                            null,
+                            out bCryptKeyHandle);
+
                         if (!success)
                         {
                             Exception e = Marshal.GetHRForLastWin32Error().ToCryptographicException();


### PR DESCRIPTION
In several places we are directly accessing a SafeHandle's pointer and casting it to a `CERT_CONTEXT`. This presents an issue where the underlying X509 PAL is disposed while the `CERT_CONTEXT` is in use.

This introduces `DangerousAddRef` and `DangerousRelease` where appropriate. The `CertContext` property was renamed to `CertContextDangerous` to make it more obvious that this is basically a strongly typed version of `DangerousGetHandle()`.

In some places, `DangerousAddRef` and `DangerousRelease` don't appear necessary because the method wholly owns the safe handle and doesn't escape, so it doesn't have an issue with another thread disposing it. In those circumstances, a comment was added as appropriate.

Fixes #78560.