### PR TITLE
Bigger workitem timeout (for perf slow pipeline)

### DIFF
--- a/eng/testing/performance/microbenchmarks.proj
+++ b/eng/testing/performance/microbenchmarks.proj
@@ -72,7 +72,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <WorkItemTimeout>2:30</WorkItemTimeout>
+    <WorkItemTimeout>6:00</WorkItemTimeout>
     <WorkItemTimeout Condition="'$(OnlySanityCheck)' == 'true'">1:30</WorkItemTimeout>
   </PropertyGroup>
 


### PR DESCRIPTION
Scheduled [perf-slow](https://dev.azure.com/dnceng/internal/_build?definitionId=1012&_a=summary) pipeline is currently timing out because of #78209. This PR increases the timeout, so the "slow" benchmarks have time to complete. Once the #78209 we can put it back. Other pipelines are not affected, because these finish way quicker.