### PR TITLE
Performance improvements to vectorized Span.Reverse

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
@@ -1129,21 +1130,23 @@ namespace System
 
         public static void Reverse(ref byte buf, nuint length)
         {
-            if (Avx2.IsSupported && (nuint)Vector256<byte>.Count * 2 <= length)
+            Debug.Assert(length > 1);
+
+            nint remainder = (nint)length;
+            nint offset = 0;
+
+            if (Avx2.IsSupported && remainder >= Vector256<byte>.Count)
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // first 128-bit lane
                     15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0); // second 128-bit lane
-                nuint numElements = (nuint)Vector256<byte>.Count;
-                nuint numIters = (length / numElements) / 2;
-                for (nuint i = 0; i < numIters; i++)
-                {
-                    nuint firstOffset = i * numElements;
-                    nuint lastOffset = length - ((1 + i) * numElements);
 
-                    // Load in values from beginning and end of the array.
-                    Vector256<byte> tempFirst = Vector256.LoadUnsafe(ref buf, firstOffset);
-                    Vector256<byte> tempLast = Vector256.LoadUnsafe(ref buf, lastOffset);
+                nint lastOffset = remainder - Vector256<byte>.Count;
+                do
+                {
+                    // Load the values into vectors
+                    Vector256<byte> tempFirst = Vector256.LoadUnsafe(ref buf, (nuint)offset);
+                    Vector256<byte> tempLast = Vector256.LoadUnsafe(ref buf, (nuint)lastOffset);
 
                     // Avx2 operates on two 128-bit lanes rather than the full 256-bit vector.
                     // Perform a shuffle to reverse each 128-bit lane, then permute to finish reversing the vector:
@@ -1170,24 +1173,23 @@ namespace System
                     tempLast = Avx2.Permute2x128(tempLast, tempLast, 0b00_01);
 
                     // Store the reversed vectors
-                    tempLast.StoreUnsafe(ref buf, firstOffset);
-                    tempFirst.StoreUnsafe(ref buf, lastOffset);
-                }
-                buf = ref Unsafe.Add(ref buf, numIters * numElements);
-                length -= numIters * numElements * 2;
-            }
-            else if (Vector128.IsHardwareAccelerated && (nuint)Vector128<byte>.Count * 2 <= length)
-            {
-                nuint numElements = (nuint)Vector128<byte>.Count;
-                nuint numIters = (length / numElements) / 2;
-                for (nuint i = 0; i < numIters; i++)
-                {
-                    nuint firstOffset = i * numElements;
-                    nuint lastOffset = length - ((1 + i) * numElements);
+                    tempLast.StoreUnsafe(ref buf, (nuint)offset);
+                    tempFirst.StoreUnsafe(ref buf, (nuint)lastOffset);
 
-                    // Load in values from beginning and end of the array.
-                    Vector128<byte> tempFirst = Vector128.LoadUnsafe(ref buf, firstOffset);
-                    Vector128<byte> tempLast = Vector128.LoadUnsafe(ref buf, lastOffset);
+                    offset += Vector256<byte>.Count;
+                    lastOffset -= Vector256<byte>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + Vector256<byte>.Count - offset;
+            }
+            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<byte>.Count)
+            {
+                nint lastOffset = remainder - Vector128<byte>.Count;
+                do
+                {
+                    // Load the values into vectors
+                    Vector128<byte> tempFirst = Vector128.LoadUnsafe(ref buf, (nuint)offset);
+                    Vector128<byte> tempLast = Vector128.LoadUnsafe(ref buf, (nuint)lastOffset);
 
                     // Shuffle to reverse each vector:
                     //     +---------------------------------------------------------------+
@@ -1203,15 +1205,58 @@ namespace System
                         (byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
 
                     // Store the reversed vectors
-                    tempLast.StoreUnsafe(ref buf, firstOffset);
-                    tempFirst.StoreUnsafe(ref buf, lastOffset);
-                }
-                buf = ref Unsafe.Add(ref buf, numIters * numElements);
-                length -= numIters * numElements * 2;
+                    tempLast.StoreUnsafe(ref buf, (nuint)offset);
+                    tempFirst.StoreUnsafe(ref buf, (nuint)lastOffset);
+
+                    offset += Vector128<byte>.Count;
+                    lastOffset -= Vector128<byte>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + Vector128<byte>.Count - offset;
             }
 
-            // Store any remaining values one-by-one
-            ReverseInner(ref buf, length);
+            if (remainder >= sizeof(long))
+            {
+                nint lastOffset = (nint)length - offset - sizeof(long);
+                do
+                {
+                    long tempFirst = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref buf, offset));
+                    long tempLast = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref buf, lastOffset));
+
+                    // swap and store in reversed position
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref buf, offset), BinaryPrimitives.ReverseEndianness(tempLast));
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref buf, lastOffset), BinaryPrimitives.ReverseEndianness(tempFirst));
+
+                    offset += sizeof(long);
+                    lastOffset -= sizeof(long);
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + sizeof(long) - offset;
+            }
+
+            if (remainder >= sizeof(int))
+            {
+                nint lastOffset = (nint)length - offset - sizeof(int);
+                do
+                {
+                    int tempFirst = Unsafe.ReadUnaligned<int>(ref Unsafe.Add(ref buf, offset));
+                    int tempLast = Unsafe.ReadUnaligned<int>(ref Unsafe.Add(ref buf, lastOffset));
+
+                    // swap and store in reversed position
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref buf, offset), BinaryPrimitives.ReverseEndianness(tempLast));
+                    Unsafe.WriteUnaligned(ref Unsafe.Add(ref buf, lastOffset), BinaryPrimitives.ReverseEndianness(tempFirst));
+
+                    offset += sizeof(int);
+                    lastOffset -= sizeof(int);
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + sizeof(int) - offset;
+            }
+
+            if (remainder > 1)
+            {
+                ReverseInner(ref Unsafe.Add(ref buf, offset), (nuint)remainder);
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1136,7 +1136,7 @@ namespace System
             nint offset = 0;
 
             // overlapping has a positive performance benefit around 48 elements
-            if (Avx2.IsSupported && remainder >= Vector256<byte>.Count * 1.5)
+            if (Avx2.IsSupported && remainder >= (nint)(Vector256<byte>.Count * 1.5))
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // first 128-bit lane

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1135,7 +1135,7 @@ namespace System
             nint remainder = (nint)length;
             nint offset = 0;
 
-            if (Avx2.IsSupported && remainder >= Vector256<byte>.Count)
+            if (Avx2.IsSupported && remainder >= Vector256<byte>.Count * 2)
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // first 128-bit lane
@@ -1182,7 +1182,7 @@ namespace System
 
                 remainder = lastOffset + Vector256<byte>.Count - offset;
             }
-            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<byte>.Count)
+            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<byte>.Count * 2)
             {
                 nint lastOffset = remainder - Vector128<byte>.Count;
                 do

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1135,7 +1135,8 @@ namespace System
             nint remainder = (nint)length;
             nint offset = 0;
 
-            if (Avx2.IsSupported && remainder >= Vector256<byte>.Count * 2)
+            // overlapping has a positive performance benefit around 48 elements
+            if (Avx2.IsSupported && remainder >= Vector256<byte>.Count * 1.5)
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // first 128-bit lane

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -733,23 +733,25 @@ namespace System
 
         public static void Reverse(ref char buf, nuint length)
         {
-            if (Avx2.IsSupported && (nuint)Vector256<short>.Count * 2 <= length)
+            Debug.Assert(length > 1);
+
+            nint remainder = (nint)length;
+            nint offset = 0;
+
+            if (Avx2.IsSupported && remainder >= Vector256<ushort>.Count)
             {
-                ref byte bufByte = ref Unsafe.As<char, byte>(ref buf);
-                nuint byteLength = length * sizeof(char);
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1, // first 128-bit lane
                     14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1); // second 128-bit lane
-                nuint numElements = (nuint)Vector256<byte>.Count;
-                nuint numIters = (byteLength / numElements) / 2;
-                for (nuint i = 0; i < numIters; i++)
-                {
-                    nuint firstOffset = i * numElements;
-                    nuint lastOffset = byteLength - ((1 + i) * numElements);
 
-                    // Load in values from beginning and end of the array.
-                    Vector256<byte> tempFirst = Vector256.LoadUnsafe(ref bufByte, firstOffset);
-                    Vector256<byte> tempLast = Vector256.LoadUnsafe(ref bufByte, lastOffset);
+                nint lastOffset = remainder - Vector256<ushort>.Count;
+                do
+                {
+                    ref byte first = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref buf, offset));
+                    ref byte last = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref buf, lastOffset));
+
+                    Vector256<byte> tempFirst = Vector256.LoadUnsafe(ref first);
+                    Vector256<byte> tempLast = Vector256.LoadUnsafe(ref last);
 
                     // Avx2 operates on two 128-bit lanes rather than the full 256-bit vector.
                     // Perform a shuffle to reverse each 128-bit lane, then permute to finish reversing the vector:
@@ -770,27 +772,25 @@ namespace System
                     tempLast = Avx2.Permute2x128(tempLast, tempLast, 0b00_01);
 
                     // Store the reversed vectors
-                    tempLast.StoreUnsafe(ref bufByte, firstOffset);
-                    tempFirst.StoreUnsafe(ref bufByte, lastOffset);
-                }
-                bufByte = ref Unsafe.Add(ref bufByte, numIters * numElements);
-                length -= numIters * (nuint)Vector256<short>.Count * 2;
-                // Store any remaining values one-by-one
-                buf = ref Unsafe.As<byte, char>(ref bufByte);
-            }
-            else if (Vector128.IsHardwareAccelerated && (nuint)Vector128<short>.Count * 2 <= length)
-            {
-                ref short bufShort = ref Unsafe.As<char, short>(ref buf);
-                nuint numElements = (nuint)Vector128<short>.Count;
-                nuint numIters = (length / numElements) / 2;
-                for (nuint i = 0; i < numIters; i++)
-                {
-                    nuint firstOffset = i * numElements;
-                    nuint lastOffset = length - ((1 + i) * numElements);
+                    tempLast.StoreUnsafe(ref first);
+                    tempFirst.StoreUnsafe(ref last);
 
-                    // Load in values from beginning and end of the array.
-                    Vector128<short> tempFirst = Vector128.LoadUnsafe(ref bufShort, firstOffset);
-                    Vector128<short> tempLast = Vector128.LoadUnsafe(ref bufShort, lastOffset);
+                    offset += Vector256<ushort>.Count;
+                    lastOffset -= Vector256<ushort>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = (lastOffset + Vector256<ushort>.Count - offset);
+            }
+            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<ushort>.Count)
+            {
+                nint lastOffset = remainder - Vector128<ushort>.Count;
+                do
+                {
+                    ref ushort first = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, offset));
+                    ref ushort last = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, lastOffset));
+
+                    Vector128<ushort> tempFirst = Vector128.LoadUnsafe(ref first);
+                    Vector128<ushort> tempLast = Vector128.LoadUnsafe(ref last);
 
                     // Shuffle to reverse each vector:
                     //     +-------------------------------+
@@ -800,19 +800,25 @@ namespace System
                     //     +-------------------------------+
                     //     | H | G | F | E | D | C | B | A |
                     //     +-------------------------------+
-                    tempFirst = Vector128.Shuffle(tempFirst, Vector128.Create(7, 6, 5, 4, 3, 2, 1, 0));
-                    tempLast = Vector128.Shuffle(tempLast, Vector128.Create(7, 6, 5, 4, 3, 2, 1, 0));
+                    tempFirst = Vector128.Shuffle(tempFirst, Vector128.Create((ushort)7, 6, 5, 4, 3, 2, 1, 0));
+                    tempLast = Vector128.Shuffle(tempLast, Vector128.Create((ushort)7, 6, 5, 4, 3, 2, 1, 0));
 
                     // Store the reversed vectors
-                    tempLast.StoreUnsafe(ref bufShort, firstOffset);
-                    tempFirst.StoreUnsafe(ref bufShort, lastOffset);
-                }
-                bufShort = ref Unsafe.Add(ref bufShort, numIters * numElements);
-                length -= numIters * (nuint)Vector128<short>.Count * 2;
-                // Store any remaining values one-by-one
-                buf = ref Unsafe.As<short, char>(ref bufShort);
+                    tempLast.StoreUnsafe(ref first);
+                    tempFirst.StoreUnsafe(ref last);
+
+                    offset += Vector128<ushort>.Count;
+                    lastOffset -= Vector128<ushort>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = (lastOffset + Vector128<ushort>.Count - offset);
             }
-            ReverseInner(ref buf, length);
+
+            // Store any remaining values one-by-one
+            if (remainder > 1)
+            {
+                ReverseInner(ref Unsafe.Add(ref buf, offset), (nuint)remainder);
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -738,7 +738,7 @@ namespace System
             nint remainder = (nint)length;
             nint offset = 0;
 
-            if (Avx2.IsSupported && remainder >= Vector256<ushort>.Count)
+            if (Avx2.IsSupported && remainder >= Vector256<ushort>.Count * 2)
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1, // first 128-bit lane
@@ -781,7 +781,7 @@ namespace System
 
                 remainder = (lastOffset + Vector256<ushort>.Count - offset);
             }
-            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<ushort>.Count)
+            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<ushort>.Count * 2)
             {
                 nint lastOffset = remainder - Vector128<ushort>.Count;
                 do

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -739,7 +739,7 @@ namespace System
             nint offset = 0;
 
             // overlapping has a positive performance benefit around 24 elements
-            if (Avx2.IsSupported && remainder >= Vector256<ushort>.Count * 1.5)
+            if (Avx2.IsSupported && remainder >= (nint)(Vector256<ushort>.Count * 1.5))
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1, // first 128-bit lane

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -738,7 +738,8 @@ namespace System
             nint remainder = (nint)length;
             nint offset = 0;
 
-            if (Avx2.IsSupported && remainder >= Vector256<ushort>.Count * 2)
+            // overlapping has a positive performance benefit around 24 elements
+            if (Avx2.IsSupported && remainder >= Vector256<ushort>.Count * 1.5)
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1, // first 128-bit lane

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -408,19 +408,19 @@ namespace System
 
         public static void Reverse(ref int buf, nuint length)
         {
-            if (Avx2.IsSupported && (nuint)Vector256<int>.Count * 2 <= length)
-            {
-                nuint numElements = (nuint)Vector256<int>.Count;
-                nuint numIters = (length / numElements) / 2;
-                Vector256<int> reverseMask = Vector256.Create(7, 6, 5, 4, 3, 2, 1, 0);
-                for (nuint i = 0; i < numIters; i++)
-                {
-                    nuint firstOffset = i * numElements;
-                    nuint lastOffset = length - ((1 + i) * numElements);
+            Debug.Assert(length > 1);
 
+            nint remainder = (nint)length;
+            nint offset = 0;
+
+            if (Avx2.IsSupported && remainder >= Vector256<int>.Count)
+            {
+                nint lastOffset = remainder - Vector256<int>.Count;
+                do
+                {
                     // Load the values into vectors
-                    Vector256<int> tempFirst = Vector256.LoadUnsafe(ref buf, firstOffset);
-                    Vector256<int> tempLast = Vector256.LoadUnsafe(ref buf, lastOffset);
+                    Vector256<int> tempFirst = Vector256.LoadUnsafe(ref buf, (nuint)offset);
+                    Vector256<int> tempLast = Vector256.LoadUnsafe(ref buf, (nuint)lastOffset);
 
                     // Permute to reverse each vector:
                     //     +-------------------------------+
@@ -430,28 +430,27 @@ namespace System
                     //     +-------------------------------+
                     //     | H | G | F | E | D | C | B | A |
                     //     +-------------------------------+
-                    tempFirst = Avx2.PermuteVar8x32(tempFirst, reverseMask);
-                    tempLast = Avx2.PermuteVar8x32(tempLast, reverseMask);
+                    tempFirst = Avx2.PermuteVar8x32(tempFirst, Vector256.Create(7, 6, 5, 4, 3, 2, 1, 0));
+                    tempLast = Avx2.PermuteVar8x32(tempLast, Vector256.Create(7, 6, 5, 4, 3, 2, 1, 0));
 
-                    // Store the values into final location
-                    tempLast.StoreUnsafe(ref buf, firstOffset);
-                    tempFirst.StoreUnsafe(ref buf, lastOffset);
-                }
-                buf = ref Unsafe.Add(ref buf, numIters * numElements);
-                length -= numIters * numElements * 2;
+                    // Store the reversed vectors
+                    tempLast.StoreUnsafe(ref buf, (nuint)offset);
+                    tempFirst.StoreUnsafe(ref buf, (nuint)lastOffset);
+
+                    offset += Vector256<int>.Count;
+                    lastOffset -= Vector256<int>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + Vector256<int>.Count - offset;
             }
-            else if (Vector128.IsHardwareAccelerated && (nuint)Vector128<int>.Count * 2 <= length)
+            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<int>.Count)
             {
-                nuint numElements = (nuint)Vector128<int>.Count;
-                nuint numIters = (length / numElements) / 2;
-                for (nuint i = 0; i < numIters; i++)
+                nint lastOffset = remainder - Vector128<int>.Count;
+                do
                 {
-                    nuint firstOffset = i * numElements;
-                    nuint lastOffset = length - ((1 + i) * numElements);
-
-                    // Load the values into vectors
-                    Vector128<int> tempFirst = Vector128.LoadUnsafe(ref buf, firstOffset);
-                    Vector128<int> tempLast = Vector128.LoadUnsafe(ref buf, lastOffset);
+                    // Load in values from beginning and end of the array.
+                    Vector128<int> tempFirst = Vector128.LoadUnsafe(ref buf, (nuint)offset);
+                    Vector128<int> tempLast = Vector128.LoadUnsafe(ref buf, (nuint)lastOffset);
 
                     // Shuffle to reverse each vector:
                     //     +---------------+
@@ -464,30 +463,39 @@ namespace System
                     tempFirst = Vector128.Shuffle(tempFirst, Vector128.Create(3, 2, 1, 0));
                     tempLast = Vector128.Shuffle(tempLast, Vector128.Create(3, 2, 1, 0));
 
-                    // Store the values into final location
-                    tempLast.StoreUnsafe(ref buf, firstOffset);
-                    tempFirst.StoreUnsafe(ref buf, lastOffset);
-                }
-                buf = ref Unsafe.Add(ref buf, numIters * numElements);
-                length -= numIters * numElements * 2;
+                    // Store the reversed vectors
+                    tempLast.StoreUnsafe(ref buf, (nuint)offset);
+                    tempFirst.StoreUnsafe(ref buf, (nuint)lastOffset);
+
+                    offset += Vector128<int>.Count;
+                    lastOffset -= Vector128<int>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + Vector128<int>.Count - offset;
             }
 
-            ReverseInner(ref buf, length);
+            // Store any remaining values one-by-one
+            if (remainder > 1)
+            {
+                ReverseInner(ref Unsafe.Add(ref buf, offset), (nuint)remainder);
+            }
         }
 
         public static void Reverse(ref long buf, nuint length)
         {
-            if (Avx2.IsSupported && (nuint)Vector256<long>.Count * 2 <= length)
+            Debug.Assert(length > 1);
+
+            nint remainder = (nint)length;
+            nint offset = 0;
+
+            if (Avx2.IsSupported && remainder >= Vector256<long>.Count)
             {
-                nuint numElements = (nuint)Vector256<long>.Count;
-                nuint numIters = (length / numElements) / 2;
-                for (nuint i = 0; i < numIters; i++)
+                nint lastOffset = remainder - Vector256<long>.Count;
+                do
                 {
-                    nuint firstOffset = i * numElements;
-                    nuint lastOffset = length - ((1 + i) * numElements);
                     // Load the values into vectors
-                    Vector256<long> tempFirst = Vector256.LoadUnsafe(ref buf, firstOffset);
-                    Vector256<long> tempLast = Vector256.LoadUnsafe(ref buf, lastOffset);
+                    Vector256<long> tempFirst = Vector256.LoadUnsafe(ref buf, (nuint)offset);
+                    Vector256<long> tempLast = Vector256.LoadUnsafe(ref buf, (nuint)lastOffset);
 
                     // Permute to reverse each vector:
                     //     +---------------+
@@ -500,24 +508,24 @@ namespace System
                     tempFirst = Avx2.Permute4x64(tempFirst, 0b00_01_10_11);
                     tempLast = Avx2.Permute4x64(tempLast, 0b00_01_10_11);
 
-                    // Store the values into final location
-                    tempLast.StoreUnsafe(ref buf, firstOffset);
-                    tempFirst.StoreUnsafe(ref buf, lastOffset);
-                }
-                buf = ref Unsafe.Add(ref buf, numIters * numElements);
-                length -= numIters * numElements * 2;
+                    // Store the reversed vectors
+                    tempLast.StoreUnsafe(ref buf, (nuint)offset);
+                    tempFirst.StoreUnsafe(ref buf, (nuint)lastOffset);
+
+                    offset += Vector256<long>.Count;
+                    lastOffset -= Vector256<long>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + Vector256<long>.Count - offset;
             }
-            else if (Vector128.IsHardwareAccelerated && (nuint)Vector128<long>.Count * 2 <= length)
+            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<long>.Count)
             {
-                nuint numElements = (nuint)Vector128<long>.Count;
-                nuint numIters = (length / numElements) / 2;
-                for (nuint i = 0; i < numIters; i++)
+                nint lastOffset = remainder - Vector128<long>.Count;
+                do
                 {
-                    nuint firstOffset = i * numElements;
-                    nuint lastOffset = length - ((1 + i) * numElements);
-                    // Load the values into vectors
-                    Vector128<long> tempFirst = Vector128.LoadUnsafe(ref buf, firstOffset);
-                    Vector128<long> tempLast = Vector128.LoadUnsafe(ref buf, lastOffset);
+                    // Load in values from beginning and end of the array.
+                    Vector128<long> tempFirst = Vector128.LoadUnsafe(ref buf, (nuint)offset);
+                    Vector128<long> tempLast = Vector128.LoadUnsafe(ref buf, (nuint)lastOffset);
 
                     // Shuffle to reverse each vector:
                     //     +-------+
@@ -530,22 +538,29 @@ namespace System
                     tempFirst = Vector128.Shuffle(tempFirst, Vector128.Create(1, 0));
                     tempLast = Vector128.Shuffle(tempLast, Vector128.Create(1, 0));
 
-                    // Store the values into final location
-                    tempLast.StoreUnsafe(ref buf, firstOffset);
-                    tempFirst.StoreUnsafe(ref buf, lastOffset);
-                }
-                buf = ref Unsafe.Add(ref buf, numIters * numElements);
-                length -= numIters * (nuint)Vector128<long>.Count * 2;
+                    // Store the reversed vectors
+                    tempLast.StoreUnsafe(ref buf, (nuint)offset);
+                    tempFirst.StoreUnsafe(ref buf, (nuint)lastOffset);
+
+                    offset += Vector128<long>.Count;
+                    lastOffset -= Vector128<long>.Count;
+                } while (lastOffset >= offset);
+
+                remainder = lastOffset + Vector128<long>.Count - offset;
             }
 
             // Store any remaining values one-by-one
-            ReverseInner(ref buf, length);
+            if (remainder > 1)
+            {
+                ReverseInner(ref Unsafe.Add(ref buf, offset), (nuint)remainder);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Reverse<T>(ref T elements, nuint length)
         {
-            Debug.Assert(length > 0);
+            Debug.Assert(length > 1);
+
             if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
@@ -569,6 +584,7 @@ namespace System
                     return;
                 }
             }
+
             ReverseInner(ref elements, length);
         }
 
@@ -576,10 +592,10 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void ReverseInner<T>(ref T elements, nuint length)
         {
-            if (length <= 1)
-                return;
+            Debug.Assert(length > 1);
+
             ref T first = ref elements;
-            ref T last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, (int)length), 1);
+            ref T last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, length), 1);
             do
             {
                 T temp = first;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -413,7 +413,7 @@ namespace System
             nint remainder = (nint)length;
             nint offset = 0;
 
-            if (Avx2.IsSupported && remainder >= Vector256<int>.Count)
+            if (Avx2.IsSupported && remainder >= Vector256<int>.Count * 2)
             {
                 nint lastOffset = remainder - Vector256<int>.Count;
                 do
@@ -443,7 +443,7 @@ namespace System
 
                 remainder = lastOffset + Vector256<int>.Count - offset;
             }
-            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<int>.Count)
+            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<int>.Count * 2)
             {
                 nint lastOffset = remainder - Vector128<int>.Count;
                 do
@@ -488,7 +488,7 @@ namespace System
             nint remainder = (nint)length;
             nint offset = 0;
 
-            if (Avx2.IsSupported && remainder >= Vector256<long>.Count)
+            if (Avx2.IsSupported && remainder >= Vector256<long>.Count * 2)
             {
                 nint lastOffset = remainder - Vector256<long>.Count;
                 do
@@ -518,7 +518,7 @@ namespace System
 
                 remainder = lastOffset + Vector256<long>.Count - offset;
             }
-            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<long>.Count)
+            else if (Vector128.IsHardwareAccelerated && remainder >= Vector128<long>.Count * 2)
             {
                 nint lastOffset = remainder - Vector128<long>.Count;
                 do


### PR DESCRIPTION
See original PR: #70944
Reverted: #78605

I reverted the overlapping for int and long and and chose to keep it in-between for byte/char where it still shows an improvement to overlap.

Machine:
``` ini
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  Job-AORABE : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-BUGVTU : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
```

### Byte 
```csharp
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class ReverseBytes
{
  [Params(16, 24, 32, 36, 38, 40, 42, 44, 48, 56, 64)]
  public int NumberOfValues { get; set; }

  private byte[] _values;

  [GlobalSetup]
  public void Setup()
  {
      _values = ValuesGenerator.Array<byte>(NumberOfValues);
  }

  [Benchmark]
  public void Reverse() => _values.AsSpan().Reverse();
}
```

|  Method |                                                                                                          Toolchain | NumberOfValues |      Mean | Ratio |
|-------- |------------------------------------------------------------------------------------------------------------------- |--------------- |----------:|------:|
| **Reverse** | **main** |             **16** |  **7.880 ns** |  **1.00** |
| Reverse |   PR |             16 |  2.197 ns |  0.28 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **24** | **10.383 ns** |  **1.00** |
| Reverse |   PR |             24 |  2.772 ns |  0.27 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **32** |  **3.795 ns** |  **1.00** |
| Reverse |   PR |             32 |  2.852 ns |  0.75 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **36** |  **4.753 ns** |  **1.00** |
| Reverse |   PR |             36 |  3.373 ns |  0.71 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **38** |  **5.328 ns** |  **1.00** |
| Reverse |   PR |             38 |  3.985 ns |  0.75 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **40** |  **6.299 ns** |  **1.00** |
| Reverse |   PR |             40 |  3.387 ns |  0.54 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **42** |  **6.714 ns** |  **1.00** |
| Reverse |   PR |             42 |  4.236 ns |  0.63 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **44** |  **7.172 ns** |  **1.00** |
| Reverse |   PR |             44 |  3.479 ns |  0.49 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **48** |  **8.631 ns** |  **1.00** |
| Reverse |   PR |             48 |  4.737 ns |  0.55 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **56** | **10.799 ns** |  **1.00** |
| Reverse |   PR |             56 |  4.616 ns |  0.43 |
|         |                                                                                                                    |                |           |       |
| **Reverse** | **main** |             **64** |  **4.063 ns** |  **1.00** |
| Reverse |   PR |             64 |  3.028 ns |  0.75 |

### Char
```csharp
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class ReverseChars
{
  [Params(8, 12, 16, 20, 24, 28, 32, 40, 48)]
  public int NumberOfValues { get; set; }

  private char[] _values;

  [GlobalSetup]
  public void Setup()
  {
      // taken from dotnet/performance
      _values = ValuesGenerator.Array<char>(NumberOfValues);
  }

  [Benchmark]
  public void Reverse() => _values.AsSpan().Reverse();
}
```

|  Method |                                                                                                          Toolchain | NumberOfValues |     Mean | Ratio |
|-------- |------------------------------------------------------------------------------------------------------------------- |--------------- |---------:|------:|
| **Reverse** | **main** |              **8** | **3.918 ns** |  **1.00** |
| Reverse |   PR |              8 | 4.145 ns |  1.06 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **12** | **5.724 ns** |  **1.00** |
| Reverse |   PR |             12 | 6.470 ns |  1.13 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **16** | **3.239 ns** |  **1.00** |
| Reverse |   PR |             16 | 2.786 ns |  0.86 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **20** | **4.361 ns** |  **1.00** |
| Reverse |   PR |             20 | 4.111 ns |  0.94 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **24** | **5.996 ns** |  **1.00** |
| Reverse |   PR |             24 | 4.637 ns |  0.77 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **28** | **8.948 ns** |  **1.00** |
| Reverse |   PR |             28 | 4.648 ns |  0.52 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **32** | **3.479 ns** |  **1.00** |
| Reverse |   PR |             32 | 2.518 ns |  0.72 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **40** | **5.494 ns** |  **1.00** |
| Reverse |   PR |             40 | 5.262 ns |  0.96 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **48** | **9.208 ns** |  **1.00** |
| Reverse |   PR |             48 | 3.624 ns |  0.39 |

### Int
|  Method |                                                                                                          Toolchain | NumberOfValues |     Mean | Ratio |
|-------- |------------------------------------------------------------------------------------------------------------------- |--------------- |---------:|------:|
| **Reverse** | **main** |              **4** | **2.692 ns** |  **1.00** |
| Reverse |   PR |              4 | 1.876 ns |  0.70 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |              **8** | **3.325 ns** |  **1.00** |
| Reverse |   PR |              8 | 2.131 ns |  0.64 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **12** | **4.020 ns** |  **1.00** |
| Reverse |   PR |             12 | 3.014 ns |  0.75 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **16** | **4.275 ns** |  **1.00** |
| Reverse |   PR |             16 | 3.018 ns |  0.71 |

### Long
|  Method |                                                                                                          Toolchain | NumberOfValues |     Mean | Ratio |
|-------- |------------------------------------------------------------------------------------------------------------------- |--------------- |---------:|------:|
| **Reverse** | **main** |              **4** | **2.393 ns** |  **1.00** |
| Reverse |   PR |              4 | 2.673 ns |  1.12 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |              **8** | **2.273 ns** |  **1.00** |
| Reverse |   PR |              8 | 2.240 ns |  0.98 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **12** | **3.605 ns** |  **1.00** |
| Reverse |   PR |             12 | 2.890 ns |  0.80 |
|         |                                                                                                                    |                |          |       |
| **Reverse** | **main** |             **16** | **2.718 ns** |  **1.00** |
| Reverse |   PR |             16 | 2.708 ns |  1.00 |

@adamsitnik can you confirm if you get similar numbers on your benchmark? I think earlier we saw some slight difference between our numbers last time