### PR TITLE
[mono][wasm] Disable AOTing methods which contain catch clauses insid…

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -6667,8 +6667,6 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 	if (cfg->llvm_only && cfg->interp && cfg->method == method && !cfg->deopt && !cfg->interp_entry_only) {
 		if (header->num_clauses) {
-			/* deopt is only disabled for gsharedvt */
-			g_assert (cfg->gsharedvt);
 			for (guint i = 0; i < header->num_clauses; ++i) {
 				MonoExceptionClause *clause = &header->clauses [i];
 				/* Finally clauses are checked after the remove_finally pass */


### PR DESCRIPTION
…e finally/filter clauses.

When the ENDFINALLY opcode of the outer clause is encountered while executing the inner catch clause from run_with_il_state (), it will assert since it doesn't know where to continue execution.