### PR TITLE
Create a shared apicompat suppression file for CoreLib

### DIFF
--- a/src/coreclr/System.Private.CoreLib/CompatibilitySuppressions.xml
+++ b/src/coreclr/System.Private.CoreLib/CompatibilitySuppressions.xml
@@ -1,33 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Internal.Console</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:System.Runtime.CompilerServices.ICastable</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Resources.ResourceManager.BaseNameField</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Resources.ResourceSet.Reader</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0014</DiagnosticId>
-    <Target>M:System.Runtime.InteropServices.Marshal.CreateWrapperOfType(System.Object,System.Type)-&gt;object?:[T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute]</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
 </Suppressions>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -2,12 +2,6 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Internal.Console</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:Internal.DeveloperExperience.DeveloperExperience</Target>
     <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
     <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
@@ -1328,12 +1322,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:System.Runtime.CompilerServices.ICastable</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:System.Runtime.CompilerServices.ReflectionBlockedAttribute</Target>
     <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
     <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
@@ -1436,18 +1424,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Resources.ResourceManager.BaseNameField</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Resources.ResourceSet.Reader</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.ModuleHandle.#ctor(System.Reflection.Module)</Target>
     <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
     <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
@@ -1473,12 +1449,6 @@
   <Suppression>
     <DiagnosticId>CP0014</DiagnosticId>
     <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(System.Object)-&gt;object?:[T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute]</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0014</DiagnosticId>
-    <Target>M:System.Runtime.InteropServices.Marshal.CreateWrapperOfType(System.Object,System.Type)-&gt;object?:[T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute]</Target>
     <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
     <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
   </Suppression>

--- a/src/libraries/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Suppression file that is shared between the different CoreLib flavours. -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Internal.Console</Target>
+    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.CompilerServices.ICastable</Target>
+    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:System.Resources.ResourceManager.BaseNameField</Target>
+    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:System.Resources.ResourceSet.Reader</Target>
+    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:System.Runtime.InteropServices.Marshal.CreateWrapperOfType(System.Object,System.Type)-&gt;object?:[T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute]</Target>
+    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+</Suppressions>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -46,6 +46,10 @@
     <DefineConstants Condition="'$(TargetsSolaris)' == 'true'">$(DefineConstants);TARGET_SOLARIS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <ApiCompatSuppressionFile Include="$(MSBuildProjectDirectory)\CompatibilitySuppressions.xml" />
+    <ApiCompatSuppressionFile Include="$(MSBuildThisFileDirectory)CompatibilitySuppressions.xml" />
+  </ItemGroup>
+  <ItemGroup>
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.Shared.xml" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.LittleEndian.xml" Condition="'$(IsBigEndian)' != 'true'" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.32bit.xml" Condition="'$(Is64Bit)' != 'true'" />

--- a/src/mono/System.Private.CoreLib/CompatibilitySuppressions.xml
+++ b/src/mono/System.Private.CoreLib/CompatibilitySuppressions.xml
@@ -1,38 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:Internal.Console</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:System.Runtime.CompilerServices.ICastable</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Resources.ResourceManager.BaseNameField</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Resources.ResourceSet.Reader</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
     <DiagnosticId>CP0014</DiagnosticId>
     <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(System.Object)-&gt;object?:[T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute]</Target>
-    <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
-    <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0014</DiagnosticId>
-    <Target>M:System.Runtime.InteropServices.Marshal.CreateWrapperOfType(System.Object,System.Type)-&gt;object?:[T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute]</Target>
     <Left>ref/net7.0/System.Private.CoreLib.dll</Left>
     <Right>lib/net7.0/System.Private.CoreLib.dll</Right>
   </Suppression>


### PR DESCRIPTION
Having a shared apicompat suppression file allows to share suppressions that apply to all CoreLib flavours.

Helps https://github.com/dotnet/runtime/pull/78544