### PR TITLE
[wasm] Update failure message for helix retry

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,6 +4,6 @@
   "localRerunCount": 2,
   "retryOnRules": [
     { "testAssembly": { "wildcard": "System.Net.*" } },
-    { "failureMessage": { "wildcard": "Timed out after * waiting for the browser to be ready" } }
+    { "failureMessage": { "regex": ".*Timed out after .* waiting for the browser to be ready.*" } }
   ]
 }


### PR DESCRIPTION
The message in the test report is:
```xml
<Message>System.IO.IOException : [testId: 34] Timed out after 20s waiting for the browser to be ready: C:\helix\work\correlation\chrome-win\chrome.exe</Message>
```

Update to use regex, and match the whole message.

Fixes https://github.com/dotnet/runtime/issues/76528 .