### PR TITLE
Use IndexOfAnyValues in System.Net.Http

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -406,12 +406,10 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            if (HttpRuleParser.IsTokenChar(value[startIndex]))
+            int tokenLength = HttpRuleParser.GetTokenLength(value, startIndex);
+            if (tokenLength > 0)
             {
                 // No reason for integers to be quoted, so this should be the hot path.
-
-                int tokenLength = HttpRuleParser.GetTokenLength(value, startIndex);
-
                 readLength = tokenLength;
                 return HeaderUtilities.TryParseInt32(value, startIndex, tokenLength, out result);
             }
@@ -471,9 +469,10 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            if (HttpRuleParser.IsTokenChar(value[startIndex]))
+            int tokenLength = HttpRuleParser.GetTokenLength(value, startIndex);
+            if (tokenLength > 0)
             {
-                readLength = HttpRuleParser.GetTokenLength(value, startIndex);
+                readLength = tokenLength;
                 return true;
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeader.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/KnownHeader.cs
@@ -12,13 +12,13 @@ namespace System.Net.Http.Headers
             this(name, HttpHeaderType.Custom, parser: null, knownValues: null, http2StaticTableIndex, http3StaticTableIndex)
         {
             Debug.Assert(!string.IsNullOrEmpty(name));
-            Debug.Assert(name[0] == ':' || HttpRuleParser.GetTokenLength(name, 0) == name.Length);
+            Debug.Assert(name[0] == ':' || HttpRuleParser.IsToken(name));
         }
 
         public KnownHeader(string name, HttpHeaderType headerType, HttpHeaderParser? parser, string[]? knownValues = null, int? http2StaticTableIndex = null, int? http3StaticTableIndex = null)
         {
             Debug.Assert(!string.IsNullOrEmpty(name));
-            Debug.Assert(name[0] == ':' || HttpRuleParser.GetTokenLength(name, 0) == name.Length);
+            Debug.Assert(name[0] == ':' || HttpRuleParser.IsToken(name));
 
             Name = name;
             HeaderType = headerType;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMethod.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMethod.cs
@@ -82,7 +82,7 @@ namespace System.Net.Http
             {
                 throw new ArgumentException(SR.net_http_argument_empty_string, nameof(method));
             }
-            if (HttpRuleParser.GetTokenLength(method, 0) != method.Length)
+            if (!HttpRuleParser.IsToken(method))
             {
                 throw new FormatException(SR.net_http_httpmethod_format_error);
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Text;
 
@@ -8,7 +9,17 @@ namespace System.Net.Http
 {
     internal static class HttpRuleParser
     {
-        private static readonly bool[] s_tokenChars = CreateTokenChars();
+        // token = 1*<any CHAR except CTLs or separators>
+        // CTL = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+        private static readonly IndexOfAnyValues<char> s_tokenChars =
+            IndexOfAnyValues.Create("!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~");
+
+        private static readonly IndexOfAnyValues<byte> s_tokenBytes =
+            IndexOfAnyValues.Create("!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~"u8);
+
+        private static readonly IndexOfAnyValues<char> s_hostDelimiterChars =
+            IndexOfAnyValues.Create("/ \t\r,");
+
         private const int MaxNestedCount = 5;
 
         internal const char CR = (char)13;
@@ -18,98 +29,22 @@ namespace System.Net.Http
 
         internal static Encoding DefaultHttpEncoding => Encoding.Latin1;
 
-        private static bool[] CreateTokenChars()
-        {
-            // token = 1*<any CHAR except CTLs or separators>
-            // CTL = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
-
-            var tokenChars = new bool[128]; // All elements default to "false".
-
-            for (int i = 33; i < 127; i++) // Skip Space (32) & DEL (127).
-            {
-                tokenChars[i] = true;
-            }
-
-            // Remove separators: these are not valid token characters.
-            tokenChars[(byte)'('] = false;
-            tokenChars[(byte)')'] = false;
-            tokenChars[(byte)'<'] = false;
-            tokenChars[(byte)'>'] = false;
-            tokenChars[(byte)'@'] = false;
-            tokenChars[(byte)','] = false;
-            tokenChars[(byte)';'] = false;
-            tokenChars[(byte)':'] = false;
-            tokenChars[(byte)'\\'] = false;
-            tokenChars[(byte)'"'] = false;
-            tokenChars[(byte)'/'] = false;
-            tokenChars[(byte)'['] = false;
-            tokenChars[(byte)']'] = false;
-            tokenChars[(byte)'?'] = false;
-            tokenChars[(byte)'='] = false;
-            tokenChars[(byte)'{'] = false;
-            tokenChars[(byte)'}'] = false;
-
-            return tokenChars;
-        }
-
-        internal static bool IsTokenChar(char character)
-        {
-            // Must be between 'space' (32) and 'DEL' (127).
-            if (character > 127)
-            {
-                return false;
-            }
-
-            return s_tokenChars[character];
-        }
-
         internal static int GetTokenLength(string input, int startIndex)
         {
-            Debug.Assert(input != null);
+            Debug.Assert(input is not null);
 
-            if (startIndex >= input.Length)
-            {
-                return 0;
-            }
+            ReadOnlySpan<char> slice = input.AsSpan(startIndex);
 
-            int current = startIndex;
+            int index = slice.IndexOfAnyExcept(s_tokenChars);
 
-            while (current < input.Length)
-            {
-                if (!IsTokenChar(input[current]))
-                {
-                    return current - startIndex;
-                }
-                current++;
-            }
-            return input.Length - startIndex;
+            return index < 0 ? slice.Length : index;
         }
 
-        internal static bool IsToken(string input)
-        {
-            for (int i = 0; i < input.Length; i++)
-            {
-                if (!IsTokenChar(input[i]))
-                {
-                    return false;
-                }
-            }
+        internal static bool IsToken(ReadOnlySpan<char> input) =>
+            input.IndexOfAnyExcept(s_tokenChars) < 0;
 
-            return true;
-        }
-
-        internal static bool IsToken(ReadOnlySpan<byte> input)
-        {
-            for (int i = 0; i < input.Length; i++)
-            {
-                if (!IsTokenChar((char)input[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
+        internal static bool IsToken(ReadOnlySpan<byte> input) =>
+            input.IndexOfAnyExcept(s_tokenBytes) < 0;
 
         internal static string GetTokenString(ReadOnlySpan<byte> input)
         {
@@ -147,10 +82,8 @@ namespace System.Net.Http
             return input.Length - startIndex;
         }
 
-        internal static bool ContainsNewLine(string value, int startIndex = 0)
-        {
-            return value.AsSpan(startIndex).IndexOfAny('\r', '\n') != -1;
-        }
+        internal static bool ContainsNewLine(string value, int startIndex = 0) =>
+            value.AsSpan(startIndex).IndexOfAny('\r', '\n') >= 0;
 
         internal static int GetNumberLength(string input, int startIndex, bool allowDecimal)
         {
@@ -206,41 +139,33 @@ namespace System.Net.Http
                 return 0;
             }
 
+            ReadOnlySpan<char> slice = input.AsSpan(startIndex);
+
             // A 'host' is either a token (if 'allowToken' == true) or a valid host name as defined by the URI RFC.
             // So we first iterate through the string and search for path delimiters and whitespace. When found, stop
             // and try to use the substring as token or URI host name. If it works, we have a host name, otherwise not.
-            int current = startIndex;
-            bool isToken = true;
-            while (current < input.Length)
+            int index = slice.IndexOfAny(s_hostDelimiterChars);
+            if (index >= 0)
             {
-                char c = input[current];
-                if (c == '/')
+                if (index == 0)
+                {
+                    return 0;
+                }
+
+                if (slice[index] == '/')
                 {
                     return 0; // Host header must not contain paths.
                 }
 
-                if ((c == ' ') || (c == '\t') || (c == '\r') || (c == ','))
-                {
-                    break; // We hit a delimiter (',' or whitespace). Stop here.
-                }
-
-                isToken = isToken && IsTokenChar(c);
-
-                current++;
+                slice = slice.Slice(0, index);
             }
 
-            int length = current - startIndex;
-            if (length == 0)
+            if ((allowToken && IsToken(slice)) || IsValidHostName(slice))
             {
-                return 0;
+                return slice.Length;
             }
 
-            if ((!allowToken || !isToken) && !IsValidHostName(input.AsSpan(startIndex, length)))
-            {
-                return 0;
-            }
-
-            return length;
+            return 0;
         }
 
         internal static HttpParseResult GetCommentLength(string input, int startIndex, out int length)

--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpRuleParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpRuleParserTest.cs
@@ -41,16 +41,18 @@ namespace System.Net.Http.Tests
 
         [Theory]
         [MemberData(nameof(ValidTokenCharsArguments))]
-        public void IsTokenChar_ValidTokenChars_ConsideredValid(char token)
+        public void IsToken_ValidTokenChars_ConsideredValid(char token)
         {
-            Assert.True(HttpRuleParser.IsTokenChar(token));
+            Assert.True(HttpRuleParser.IsToken(stackalloc[] { token }));
+            Assert.True(HttpRuleParser.IsToken(new ReadOnlySpan<byte>((byte)token)));
         }
 
         [Theory]
         [MemberData(nameof(InvalidTokenCharsArguments))]
-        public void IsTokenChar_InvalidTokenChars_ConsideredInvalid(char token)
+        public void IsToken_InvalidTokenChars_ConsideredInvalid(char token)
         {
-            Assert.False(HttpRuleParser.IsTokenChar(token));
+            Assert.False(HttpRuleParser.IsToken(stackalloc[] { token }));
+            Assert.False(HttpRuleParser.IsToken(new ReadOnlySpan<byte>((byte)token)));
         }
 
         [Fact]

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -41,7 +42,7 @@ namespace System.Net
 
         internal static readonly char[] PortSplitDelimiters = new char[] { ' ', ',', '\"' };
         // Space (' ') should be reserved as well per RFCs, but major web browsers support it and some web sites use it - so we support it too
-        internal const string ReservedToName = "\t\r\n=;,";
+        private static readonly IndexOfAnyValues<char> s_reservedToNameChars = IndexOfAnyValues.Create("\t\r\n=;,");
 
         private string m_comment = string.Empty; // Do not rename (binary serialization)
         private Uri? m_commentUri; // Do not rename (binary serialization)
@@ -238,7 +239,7 @@ namespace System.Net
                 || value.StartsWith('$')
                 || value.StartsWith(' ')
                 || value.EndsWith(' ')
-                || value.AsSpan().IndexOfAny(ReservedToName) >= 0)
+                || value.AsSpan().IndexOfAny(s_reservedToNameChars) >= 0)
             {
                 m_name = string.Empty;
                 return false;
@@ -346,7 +347,7 @@ namespace System.Net
                 m_name.StartsWith('$') ||
                 m_name.StartsWith(' ') ||
                 m_name.EndsWith(' ') ||
-                m_name.AsSpan().IndexOfAny(ReservedToName) >= 0)
+                m_name.AsSpan().IndexOfAny(s_reservedToNameChars) >= 0)
             {
                 if (shouldThrow)
                 {


### PR DESCRIPTION
Contributes to #78204

Example performance numbers for `HttpRuleParser.IsToken` taken from #78093's description:

|                Method | Length |             Mean |         Error |
|---------------------- |------- |-----------------:|--------------:|
| IndexOfAnyValues_Char |      1 |         2.683 ns |     0.0108 ns |
|           CurrentChar |      1 |         1.655 ns |     0.0046 ns |
| IndexOfAnyValues_Char |      7 |         7.184 ns |     0.0185 ns |
|           CurrentChar |      7 |         4.989 ns |     0.1115 ns |
| IndexOfAnyValues_Char |      8 |         2.402 ns |     0.0025 ns |
|           CurrentChar |      8 |         4.787 ns |     0.0155 ns |
| IndexOfAnyValues_Char |     16 |         2.409 ns |     0.0052 ns |
|           CurrentChar |     16 |         9.100 ns |     0.0119 ns |
| IndexOfAnyValues_Char |     32 |         3.306 ns |     0.0078 ns |
|           CurrentChar |     32 |        19.486 ns |     0.5098 ns |
| IndexOfAnyValues_Char | 100000 |     6,004.741 ns |     4.4187 ns |
|           CurrentChar | 100000 |    57,569.776 ns |    49.4496 ns |
|                       |        |                  |               |
| IndexOfAnyValues_Byte |      1 |         1.749 ns |     0.0058 ns |
|           CurrentByte |      1 |         1.677 ns |     0.0243 ns |
| IndexOfAnyValues_Byte |      7 |         4.835 ns |     0.0779 ns |
|           CurrentByte |      7 |         5.112 ns |     0.0038 ns |
| IndexOfAnyValues_Byte |      8 |         2.521 ns |     0.0046 ns |
|           CurrentByte |      8 |         5.274 ns |     0.0052 ns |
| IndexOfAnyValues_Byte |     16 |         2.519 ns |     0.0021 ns |
|           CurrentByte |     16 |         9.113 ns |     0.0166 ns |
| IndexOfAnyValues_Byte |     32 |         3.141 ns |     0.0023 ns |
|           CurrentByte |     32 |        19.417 ns |     1.0021 ns |
| IndexOfAnyValues_Byte | 100000 |     4,762.442 ns |    21.2032 ns |
|           CurrentByte | 100000 |    57,967.138 ns |    97.4594 ns |