### PR TITLE
Fix netfx build for S.S.C.Xml nuget package

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <Compile Include="System.Security.Cryptography.Xml.cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
-    <Compile Include="System.Security.Cryptography.Xml.netframework.cs" Condition="'$(TargetFrameworkIdentifier)' == 'NETFramework'" />
+    <Compile Include="System.Security.Cryptography.Xml.netframework.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/libraries/System.Threading.AccessControl/ref/System.Threading.AccessControl.csproj
+++ b/src/libraries/System.Threading.AccessControl/ref/System.Threading.AccessControl.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <Compile Include="System.Threading.AccessControl.Extensions.cs" />
     <Compile Include="System.Threading.AccessControl.cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
-    <Compile Include="System.Threading.AccessControl.netframework.cs" Condition="'$(TargetFrameworkIdentifier)' == 'NETFramework'" />
+    <Compile Include="System.Threading.AccessControl.netframework.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Fixes #78652.

Manually verified that the net462/ref.dll and net462/lib.dll were missing the typefowards before, and they're present after.