### PR TITLE
Use IndexOfAnyValues in Uri

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -40,7 +40,7 @@ namespace System
         private static readonly IndexOfAnyValues<char> s_iriInvalidAsciiChars = IndexOfAnyValues.Create(
             "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000A\u000B\u000C\u000D\u000E\u000F" +
             "\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F" +
-            " !\"#$%&'()*+,/:;<=>?@[\\]^`{|}~");
+            " !\"#$%&'()*+,/:;<=>?@[\\]^`{|}~\u007F");
 
         private static readonly IndexOfAnyValues<char> s_asciiLetterUpperOrColonChars =
             IndexOfAnyValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZ:");
@@ -153,6 +153,13 @@ namespace System
                     ReadOnlySpan<char> label = hostname.Slice(0, labelLength);
                     if (!IsAscii(label))
                     {
+                        // s_iriInvalidAsciiChars confirmed everything in [0, 7F] range.
+                        // Chars in [80, A0) range are also invalid, check for them now.
+                        if (hostname.IndexOfAnyInRange('\u0080', '\u009F') >= 0)
+                        {
+                            return false;
+                        }
+
                         // Account for the ACE prefix ("xn--")
                         labelLength += 4;
 

--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -108,7 +108,7 @@ namespace System
             {
                 char c = hostname[invalidCharOrDelimiterIndex];
 
-                if (c == '/' || c == '\\' || (notImplicitFile && (c == ':' || c == '?' || c == '#')))
+                if (c is '/' or '\\' || (notImplicitFile && (c is ':' or '?' or '#')))
                 {
                     hostname = hostname.Slice(0, invalidCharOrDelimiterIndex);
                 }
@@ -121,7 +121,7 @@ namespace System
 
             length = hostname.Length;
 
-            if (hostname.IsEmpty)
+            if (length == 0)
             {
                 return false;
             }
@@ -133,7 +133,7 @@ namespace System
             //
             //      <label> -> <alphanum> [<alphanum> | <hyphen> | <underscore>] * 62
 
-            // We already verified the content, now verify the lenghts of individual labels
+            // We already verified the content, now verify the lengths of individual labels
             while (true)
             {
                 char firstChar = hostname[0];
@@ -154,7 +154,7 @@ namespace System
                     if (!IsAscii(label))
                     {
                         // s_iriInvalidAsciiChars confirmed everything in [0, 7F] range.
-                        // Chars in [80, A0) range are also invalid, check for them now.
+                        // Chars in [80, 9F] range are also invalid, check for them now.
                         if (hostname.IndexOfAnyInRange('\u0080', '\u009F') >= 0)
                         {
                             return false;

--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -61,7 +61,7 @@ namespace System
             int index = str.AsSpan(start, end - start).LastIndexOfAny(s_asciiLetterUpperOrColonChars);
             if (index >= 0)
             {
-                Debug.Assert(!str.AsSpan(start, index - start).Contains(':'),
+                Debug.Assert(!str.AsSpan(start, index).Contains(':'),
                     "A colon should appear at most once, and must never be followed by letters.");
 
                 if (str[start + index] == ':')

--- a/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -12,216 +13,174 @@ namespace System
     // The idea is to stay with static helper methods and strings
     internal static class DomainNameHelper
     {
+        // Regular ascii dot '.'
+        // IDEOGRAPHIC FULL STOP '\u3002'
+        // FULLWIDTH FULL STOP '\uFF0E'
+        // HALFWIDTH IDEOGRAPHIC FULL STOP '\uFF61'
+        // Using IndexOfAnyValues isn't beneficial here as it would defer to IndexOfAny(char, char, char, char) anyway
+        private const string IriDotCharacters = ".\u3002\uFF0E\uFF61";
+
+        // The Unicode specification allows certain code points to be normalized not to
+        // punycode, but to ASCII representations that retain the same meaning. For example,
+        // the codepoint U+00BC "Vulgar Fraction One Quarter" is normalized to '1/4' rather
+        // than being punycoded.
+        //
+        // This means that a host containing Unicode characters can be normalized to contain
+        // URI reserved characters, changing the meaning of a URI only when certain properties
+        // such as IdnHost are accessed. To be safe, disallow control characters in normalized hosts.
+        private static readonly IndexOfAnyValues<char> s_unsafeForNormalizedHostChars =
+            IndexOfAnyValues.Create(@"\/?@#:[]");
+
+        // Takes into account the additional legal domain name characters '-' and '_'
+        // Note that '_' char is formally invalid but is historically in use, especially on corpnets
+        private static readonly IndexOfAnyValues<char> s_validChars =
+            IndexOfAnyValues.Create("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz.");
+
+        // For IRI, we're accepting anything non-ascii, so invert the condition to just check for invalid ascii characters
+        private static readonly IndexOfAnyValues<char> s_iriInvalidAsciiChars = IndexOfAnyValues.Create(
+            "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000A\u000B\u000C\u000D\u000E\u000F" +
+            "\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F" +
+            " !\"#$%&'()*+,/:;<=>?@[\\]^`{|}~");
+
+        private static readonly IndexOfAnyValues<char> s_asciiLetterUpperOrColonChars =
+            IndexOfAnyValues.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZ:");
+
         private static readonly IdnMapping s_idnMapping = new IdnMapping();
 
-        internal const string Localhost = "localhost";
-        internal const string Loopback = "loopback";
+        private const string Localhost = "localhost";
+        private const string Loopback = "loopback";
+
+        // TODO https://github.com/dotnet/runtime/issues/28230: Replace once Ascii is available
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsAscii(ReadOnlySpan<char> chars) =>
+            chars.IndexOfAnyExcept((char)0, (char)127) < 0;
 
         internal static string ParseCanonicalName(string str, int start, int end, ref bool loopback)
         {
-            string? res = null;
-
-            for (int i = end - 1; i >= start; --i)
+            // Do a quick search for the colon or uppercase letters
+            int index = str.AsSpan(start, end - start).LastIndexOfAny(s_asciiLetterUpperOrColonChars);
+            if (index >= 0)
             {
-                if (char.IsAsciiLetterUpper(str[i]))
+                Debug.Assert(!str.AsSpan(start, index - start).Contains(':'),
+                    "A colon should appear at most once, and must never be followed by letters.");
+
+                if (str[start + index] == ':')
                 {
-                    res = str.Substring(start, end - start).ToLowerInvariant();
-                    break;
+                    // Shrink the slice to only include chars before the colon
+                    end = start + index;
+
+                    // Look for uppercase letters again.
+                    // The index value doesn't matter anymore (nor does the search direction), just whether we've found anything
+                    index = str.AsSpan(start, index).IndexOfAnyInRange('A', 'Z');
                 }
-                if (str[i] == ':')
-                    end = i;
             }
 
-            res ??= str.Substring(start, end - start);
+            Debug.Assert(index == -1 || char.IsAsciiLetterUpper(str[start + index]));
 
-            if (res == Localhost || res == Loopback)
+            if (index >= 0)
+            {
+                // We saw uppercase letters. Avoid allocating both the substring and the lower-cased variant.
+                return string.Create(end - start, (str, start), static (buffer, state) =>
+                {
+                    int newLength = state.str.AsSpan(state.start, buffer.Length).ToLowerInvariant(buffer);
+                    Debug.Assert(newLength == buffer.Length);
+                });
+            }
+
+            string res = str.Substring(start, end - start);
+
+            if (res is Localhost or Loopback)
             {
                 loopback = true;
                 return Localhost;
             }
+
             return res;
         }
 
-        //
-        // IsValid
-        //
-        //  Determines whether a string is a valid domain name
-        //
-        //      subdomain -> <label> | <label> "." <subdomain>
-        //
-        // Inputs:
-        //  - name as Name to test
-        //  - starting position
-        //  - ending position
-        //
-        // Outputs:
-        //  The end position of a valid domain name string, the canonical flag if found so
-        //
-        // Returns:
-        //  bool
-        //
-        //  Remarks: Optimized for speed as a most common case,
-        //           MUST NOT be used unless all input indexes are verified and trusted.
-        //
-
-        internal static unsafe bool IsValid(char* name, int pos, ref int returnedEnd, ref bool notCanonical, bool notImplicitFile)
+        public static bool IsValid(ReadOnlySpan<char> hostname, bool iri, bool notImplicitFile, out int length)
         {
-            char* curPos = name + pos;
-            char* newPos = curPos;
-            char* end = name + returnedEnd;
-            for (; newPos < end; ++newPos)
+            int invalidCharOrDelimiterIndex = iri
+                ? hostname.IndexOfAny(s_iriInvalidAsciiChars)
+                : hostname.IndexOfAnyExcept(s_validChars);
+
+            if (invalidCharOrDelimiterIndex >= 0)
             {
-                char ch = *newPos;
-                if (ch > 0x7f) return false;    // not ascii
-                if (ch < 'a') // Optimize for lower-case letters, which make up the majority of most Uris, and which are all greater than symbols checked for below
+                char c = hostname[invalidCharOrDelimiterIndex];
+
+                if (c == '/' || c == '\\' || (notImplicitFile && (c == ':' || c == '?' || c == '#')))
                 {
-                    if (ch == '/' || ch == '\\' || (notImplicitFile && (ch == ':' || ch == '?' || ch == '#')))
-                    {
-                        end = newPos;
-                        break;
-                    }
+                    hostname = hostname.Slice(0, invalidCharOrDelimiterIndex);
+                }
+                else
+                {
+                    length = 0;
+                    return false;
                 }
             }
 
-            if (end == curPos)
+            length = hostname.Length;
+
+            if (hostname.IsEmpty)
             {
                 return false;
             }
 
-            do
+            //  Determines whether a string is a valid domain name label. In keeping
+            //  with RFC 1123, section 2.1, the requirement that the first character
+            //  of a label be alphabetic is dropped. Therefore, Domain names are
+            //  formed as:
+            //
+            //      <label> -> <alphanum> [<alphanum> | <hyphen> | <underscore>] * 62
+
+            // We already verified the content, now verify the lenghts of individual labels
+            while (true)
             {
-                //  Determines whether a string is a valid domain name label. In keeping
-                //  with RFC 1123, section 2.1, the requirement that the first character
-                //  of a label be alphabetic is dropped. Therefore, Domain names are
-                //  formed as:
-                //
-                //      <label> -> <alphanum> [<alphanum> | <hyphen> | <underscore>] * 62
-
-                //find the dot or hit the end
-                newPos = curPos;
-                while (newPos < end)
-                {
-                    if (*newPos == '.') break;
-                    ++newPos;
-                }
-
-                //check the label start/range
-                if (curPos == newPos || newPos - curPos > 63 || !IsASCIILetterOrDigit(*curPos++, ref notCanonical))
+                char firstChar = hostname[0];
+                if ((!iri || firstChar < 0xA0) && !char.IsAsciiLetterOrDigit(firstChar))
                 {
                     return false;
                 }
-                //check the label content
-                while (curPos < newPos)
+
+                int dotIndex = iri
+                    ? hostname.IndexOfAny(IriDotCharacters)
+                    : hostname.IndexOf('.');
+
+                int labelLength = dotIndex < 0 ? hostname.Length : dotIndex;
+
+                if (iri && !IsAscii(hostname.Slice(0, labelLength)))
                 {
-                    if (!IsValidDomainLabelCharacter(*curPos++, ref notCanonical))
-                    {
-                        return false;
-                    }
-                }
-                ++curPos;
-            } while (curPos < end);
-
-            returnedEnd = (int)(end - name);
-            return true;
-        }
-
-        //
-        // Checks if the domain name is valid according to iri
-        // There are pretty much no restrictions and we effectively return the end of the
-        // domain name.
-        //
-        internal static unsafe bool IsValidByIri(char* name, int pos, ref int returnedEnd, ref bool notCanonical, bool notImplicitFile)
-        {
-            char* curPos = name + pos;
-            char* newPos = curPos;
-            char* end = name + returnedEnd;
-            int count = 0; // count number of octets in a label;
-
-            for (; newPos < end; ++newPos)
-            {
-                char ch = *newPos;
-                if (ch == '/' || ch == '\\' || (notImplicitFile && (ch == ':' || ch == '?' || ch == '#')))
-                {
-                    end = newPos;
-                    break;
-                }
-            }
-
-            if (end == curPos)
-            {
-                return false;
-            }
-
-            do
-            {
-                //  Determines whether a string is a valid domain name label. In keeping
-                //  with RFC 1123, section 2.1, the requirement that the first character
-                //  of a label be alphabetic is dropped. Therefore, Domain names are
-                //  formed as:
-                //
-                //      <label> -> <alphanum> [<alphanum> | <hyphen> | <underscore>] * 62
-
-                //find the dot or hit the end
-                newPos = curPos;
-                count = 0;
-                bool labelHasUnicode = false; // if label has unicode we need to add 4 to label count for xn--
-                while (newPos < end)
-                {
-                    if ((*newPos == '.') ||
-                        (*newPos == '\u3002') ||    //IDEOGRAPHIC FULL STOP
-                        (*newPos == '\uFF0E') ||    //FULLWIDTH FULL STOP
-                        (*newPos == '\uFF61'))      //HALFWIDTH IDEOGRAPHIC FULL STOP
-                        break;
-                    count++;
-                    if (*newPos > 0xFF)
-                        count++; // counts for two octets
-                    if (*newPos >= 0xA0)
-                        labelHasUnicode = true;
-
-                    ++newPos;
+                    // Account for the ACE prefix ("xn--")
+                    labelLength += 4;
                 }
 
-                //check the label start/range
-                if (curPos == newPos || (labelHasUnicode ? count + 4 : count) > 63 || ((*curPos++ < 0xA0) && !IsASCIILetterOrDigit(*(curPos - 1), ref notCanonical)))
+                if (!IriHelper.IsInInclusiveRange((uint)labelLength, 1, 63))
                 {
                     return false;
                 }
-                //check the label content
-                while (curPos < newPos)
-                {
-                    if ((*curPos++ < 0xA0) && !IsValidDomainLabelCharacter(*(curPos - 1), ref notCanonical))
-                    {
-                        return false;
-                    }
-                }
-                ++curPos;
-            } while (curPos < end);
 
-            returnedEnd = (int)(end - name);
-            return true;
+                if (dotIndex < 0)
+                {
+                    // We validated the last label
+                    return true;
+                }
+
+                hostname = hostname.Slice(dotIndex + 1);
+
+                if (hostname.IsEmpty)
+                {
+                    // Hostname ended with a dot
+                    return true;
+                }
+            }
         }
 
         /// <summary>Converts a host name into its idn equivalent.</summary>
-        internal static string IdnEquivalent(string hostname)
+        public static string IdnEquivalent(string hostname)
         {
-            if (hostname.Length == 0)
-            {
-                return hostname;
-            }
-
             // check if only ascii chars
             // special case since idnmapping will not lowercase if only ascii present
-            bool allAscii = true;
-            foreach (char c in hostname)
-            {
-                if (c > 0x7F)
-                {
-                    allAscii = false;
-                    break;
-                }
-            }
-
-            if (allAscii)
+            if (IsAscii(hostname))
             {
                 // just lowercase for ascii
                 return hostname.ToLowerInvariant();
@@ -232,7 +191,7 @@ namespace System
             try
             {
                 string asciiForm = s_idnMapping.GetAscii(bidiStrippedHost);
-                if (ContainsCharactersUnsafeForNormalizedHost(asciiForm))
+                if (asciiForm.AsSpan().IndexOfAny(s_unsafeForNormalizedHostChars) >= 0)
                 {
                     throw new UriFormatException(SR.net_uri_BadUnicodeHostForIdn);
                 }
@@ -244,55 +203,35 @@ namespace System
             }
         }
 
-        internal static bool TryGetUnicodeEquivalent(string hostname, ref ValueStringBuilder dest)
+        public static bool TryGetUnicodeEquivalent(string hostname, ref ValueStringBuilder dest)
         {
             Debug.Assert(ReferenceEquals(hostname, UriHelper.StripBidiControlCharacters(hostname, hostname)));
-
-            int curPos = 0;
 
             // We run a loop where for every label
             // a) if label is ascii and no ace then we lowercase it
             // b) if label is ascii and ace and not valid idn then just lowercase it
             // c) if label is ascii and ace and is valid idn then get its unicode eqvl
             // d) if label is unicode then clean it by running it through idnmapping
-            do
+            for (int i = 0; i < hostname.Length; i++)
             {
-                if (curPos != 0)
+                if (i != 0)
                 {
                     dest.Append('.');
                 }
 
-                bool asciiLabel = true;
+                ReadOnlySpan<char> label = hostname.AsSpan(i);
 
-                //find the dot or hit the end
-                int newPos;
-                for (newPos = curPos; (uint)newPos < (uint)hostname.Length; newPos++)
+                int dotIndex = label.IndexOfAny(IriDotCharacters);
+                if (dotIndex >= 0)
                 {
-                    char c = hostname[newPos];
-
-                    if (c == '.')
-                    {
-                        break;
-                    }
-
-                    if (c > '\x7F')
-                    {
-                        asciiLabel = false;
-
-                        if ((c == '\u3002') || // IDEOGRAPHIC FULL STOP
-                            (c == '\uFF0E') || // FULLWIDTH FULL STOP
-                            (c == '\uFF61'))   // HALFWIDTH IDEOGRAPHIC FULL STOP
-                        {
-                            break;
-                        }
-                    }
+                    label = label.Slice(0, dotIndex);
                 }
 
-                if (!asciiLabel)
+                if (!IsAscii(label))
                 {
                     try
                     {
-                        string asciiForm = s_idnMapping.GetAscii(hostname, curPos, newPos - curPos);
+                        string asciiForm = s_idnMapping.GetAscii(hostname, i, label.Length);
 
                         dest.Append(s_idnMapping.GetUnicode(asciiForm));
                     }
@@ -305,16 +244,12 @@ namespace System
                 {
                     bool aceValid = false;
 
-                    if ((uint)(curPos + 3) < (uint)hostname.Length
-                        && hostname[curPos] == 'x'
-                        && hostname[curPos + 1] == 'n'
-                        && hostname[curPos + 2] == '-'
-                        && hostname[curPos + 3] == '-')
+                    if (label.StartsWith("xn--", StringComparison.Ordinal))
                     {
                         // check ace validity
                         try
                         {
-                            dest.Append(s_idnMapping.GetUnicode(hostname, curPos, newPos - curPos));
+                            dest.Append(s_idnMapping.GetUnicode(hostname, i, label.Length));
                             aceValid = true;
                         }
                         catch (ArgumentException)
@@ -326,70 +261,15 @@ namespace System
                     if (!aceValid)
                     {
                         // for invalid aces we just lowercase the label
-                        ReadOnlySpan<char> slice = hostname.AsSpan(curPos, newPos - curPos);
-                        int charsWritten = slice.ToLowerInvariant(dest.AppendSpan(slice.Length));
-                        Debug.Assert(charsWritten == slice.Length);
+                        int charsWritten = label.ToLowerInvariant(dest.AppendSpan(label.Length));
+                        Debug.Assert(charsWritten == label.Length);
                     }
                 }
 
-                curPos = newPos + 1;
-            } while (curPos < hostname.Length);
+                i += label.Length;
+            }
 
             return true;
         }
-
-        //
-        //  Determines whether a character is a letter or digit according to the
-        //  DNS specification [RFC 1035]. We use our own variant of IsLetterOrDigit
-        //  because the base version returns false positives for non-ANSI characters
-        //
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsASCIILetterOrDigit(char character, ref bool notCanonical)
-        {
-            if (char.IsAsciiLetterLower(character) || char.IsAsciiDigit(character))
-            {
-                return true;
-            }
-
-            if (char.IsAsciiLetterUpper(character))
-            {
-                notCanonical = true;
-                return true;
-            }
-
-            return false;
-        }
-
-        //
-        //  Takes into account the additional legal domain name characters '-' and '_'
-        //  Note that '_' char is formally invalid but is historically in use, especially on corpnets
-        //
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsValidDomainLabelCharacter(char character, ref bool notCanonical)
-        {
-            if (char.IsAsciiLetterLower(character) || char.IsAsciiDigit(character) || character == '-' || character == '_')
-            {
-                return true;
-            }
-
-            if (char.IsAsciiLetterUpper(character))
-            {
-                notCanonical = true;
-                return true;
-            }
-
-            return false;
-        }
-
-        // The Unicode specification allows certain code points to be normalized not to
-        // punycode, but to ASCII representations that retain the same meaning. For example,
-        // the codepoint U+00BC "Vulgar Fraction One Quarter" is normalized to '1/4' rather
-        // than being punycoded.
-        //
-        // This means that a host containing Unicode characters can be normalized to contain
-        // URI reserved characters, changing the meaning of a URI only when certain properties
-        // such as IdnHost are accessed. To be safe, disallow control characters in normalized hosts.
-        internal static bool ContainsCharactersUnsafeForNormalizedHost(string host) =>
-            host.AsSpan().IndexOfAny(@"\/?@#:[]") >= 0;
     }
 }

--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -66,7 +66,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsInInclusiveRange(uint value, uint min, uint max)
+        public static bool IsInInclusiveRange(uint value, uint min, uint max)
             => (value - min) <= (max - min);
 
         //

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -1275,25 +1276,22 @@ namespace System
                             return UriHostNameType.IPv6;
                         }
                     }
+
                     end = name.Length;
                     if (IPv4AddressHelper.IsValid(fixedName, 0, ref end, false, false, false) && end == name.Length)
                     {
                         return UriHostNameType.IPv4;
                     }
-                    end = name.Length;
-                    bool dummyBool = false;
-                    if (DomainNameHelper.IsValid(fixedName, 0, ref end, ref dummyBool, false) && end == name.Length)
-                    {
-                        return UriHostNameType.Dns;
-                    }
+                }
 
-                    end = name.Length;
-                    dummyBool = false;
-                    if (DomainNameHelper.IsValidByIri(fixedName, 0, ref end, ref dummyBool, false)
-                        && end == name.Length)
-                    {
-                        return UriHostNameType.Dns;
-                    }
+                if (DomainNameHelper.IsValid(name, iri: false, notImplicitFile: false, out int length) && length == name.Length)
+                {
+                    return UriHostNameType.Dns;
+                }
+
+                if (DomainNameHelper.IsValid(name, iri: true, notImplicitFile: false, out length) && length == name.Length)
+                {
+                    return UriHostNameType.Dns;
                 }
 
                 //This checks the form without []
@@ -1464,33 +1462,18 @@ namespace System
                 char.IsAsciiHexDigit(pattern[index + 2]);
         }
 
-        //
+        private static readonly IndexOfAnyValues<char> s_schemeChars =
+            IndexOfAnyValues.Create("+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+
         // CheckSchemeName
         //
         //  Determines whether a string is a valid scheme name according to RFC 2396.
         //  Syntax is:
         //      scheme = alpha *(alpha | digit | '+' | '-' | '.')
-        //
-        public static bool CheckSchemeName([NotNullWhen(true)] string? schemeName)
-        {
-            if (string.IsNullOrEmpty(schemeName) || !char.IsAsciiLetter(schemeName[0]))
-            {
-                return false;
-            }
-
-            for (int i = schemeName.Length - 1; i > 0; --i)
-            {
-                if (!(char.IsAsciiLetterOrDigit(schemeName[i])
-                    || (schemeName[i] == '+')
-                    || (schemeName[i] == '-')
-                    || (schemeName[i] == '.')))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
+        public static bool CheckSchemeName([NotNullWhen(true)] string? schemeName) =>
+            !string.IsNullOrEmpty(schemeName) &&
+            !char.IsAsciiLetter(schemeName[0]) &&
+            schemeName.AsSpan().IndexOfAnyExcept(s_schemeChars) < 0;
 
         //
         // IsHexDigit
@@ -1801,11 +1784,14 @@ namespace System
         //
         // Returns true if a colon is found in the first path segment, false otherwise
         //
+        private static readonly IndexOfAnyValues<char> s_segmentSeparatorChars =
+            IndexOfAnyValues.Create(@":\/?#");
+
         private static bool CheckForColonInFirstPathSegment(string uriString)
         {
             // Check for anything that may terminate the first regular path segment
             // or an illegal colon
-            int index = uriString.AsSpan().IndexOfAny(@":\/?#");
+            int index = uriString.AsSpan().IndexOfAny(s_segmentSeparatorChars);
             return (uint)index < (uint)uriString.Length && uriString[index] == ':';
         }
 
@@ -3964,12 +3950,8 @@ namespace System
                 }
             }
 
-            // DNS name only optimization
-            // Fo an overridden parsing the optimization is suppressed since hostname can be changed to anything
-            bool dnsNotCanonical = ((syntaxFlags & UriSyntaxFlags.SimpleUserSyntax) == 0);
-
-            if (ch == '[' && syntax.InFact(UriSyntaxFlags.AllowIPv6Host)
-                && IPv6AddressHelper.IsValid(pString, start + 1, ref end))
+            if (ch == '[' && syntax.InFact(UriSyntaxFlags.AllowIPv6Host) &&
+                IPv6AddressHelper.IsValid(pString, start + 1, ref end))
             {
                 flags |= Flags.IPv6HostType;
 
@@ -3993,21 +3975,25 @@ namespace System
                 }
             }
             else if (((syntaxFlags & UriSyntaxFlags.AllowDnsHost) != 0) && !iriParsing &&
-           DomainNameHelper.IsValid(pString, start, ref end, ref dnsNotCanonical, StaticNotAny(flags, Flags.ImplicitFile)))
+                DomainNameHelper.IsValid(new ReadOnlySpan<char>(pString + start, end - start), iri: false, StaticNotAny(flags, Flags.ImplicitFile), out int domainNameLength))
             {
-                // comes here if there are only ascii chars in host with original parsing and no Iri
+                end = start + domainNameLength;
 
+                // comes here if there are only ascii chars in host with original parsing and no Iri
                 flags |= Flags.DnsHostType;
-                if (!dnsNotCanonical)
+
+                // Canonical DNS hostnames don't contain uppercase letters
+                if (new ReadOnlySpan<char>(pString + start, domainNameLength).IndexOfAnyInRange('A', 'Z') < 0)
                 {
                     flags |= Flags.CanonicalDnsHost;
                 }
             }
-            else if (((syntaxFlags & UriSyntaxFlags.AllowDnsHost) != 0)
-                    && (hostNotUnicodeNormalized || syntax.InFact(UriSyntaxFlags.AllowIdn))
-                    && DomainNameHelper.IsValidByIri(pString, start, ref end, ref dnsNotCanonical,
-                                            StaticNotAny(flags, Flags.ImplicitFile)))
+            else if (((syntaxFlags & UriSyntaxFlags.AllowDnsHost) != 0) &&
+                (hostNotUnicodeNormalized || syntax.InFact(UriSyntaxFlags.AllowIdn)) &&
+                DomainNameHelper.IsValid(new ReadOnlySpan<char>(pString + start, end - start), iri: true, StaticNotAny(flags, Flags.ImplicitFile), out domainNameLength))
             {
+                end = start + domainNameLength;
+
                 CheckAuthorityHelperHandleDnsIri(pString, start, end, hasUnicode,
                     ref flags, ref justNormalized, ref newHost, ref err);
             }

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1472,7 +1472,7 @@ namespace System
         //      scheme = alpha *(alpha | digit | '+' | '-' | '.')
         public static bool CheckSchemeName([NotNullWhen(true)] string? schemeName) =>
             !string.IsNullOrEmpty(schemeName) &&
-            !char.IsAsciiLetter(schemeName[0]) &&
+            char.IsAsciiLetter(schemeName[0]) &&
             schemeName.AsSpan().IndexOfAnyExcept(s_schemeChars) < 0;
 
         //

--- a/src/libraries/System.Private.Uri/src/System/UriBuilder.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -255,12 +256,15 @@ namespace System
 
         public override int GetHashCode() => Uri.GetHashCode();
 
+        // The following characters ("/" / "\" / "?" / "#" / "@") are from the gen-delims group.
+        // We have to escape them to avoid corrupting the rest of the Uri string.
+        // Other characters like spaces or non-ASCII will be escaped by Uri, we can ignore them here.
+        private static readonly IndexOfAnyValues<char> s_userInfoReservedChars =
+            IndexOfAnyValues.Create(@"/\?#@");
+
         private static string EncodeUserInfo(string input)
         {
-            // The following characters ("/" / "\" / "?" / "#" / "@") are from the gen-delims group.
-            // We have to escape them to avoid corrupting the rest of the Uri string.
-            // Other characters like spaces or non-ASCII will be escaped by Uri, we can ignore them here.
-            if (input.AsSpan().IndexOfAny(@"/\?#@") < 0)
+            if (input.AsSpan().IndexOfAny(s_userInfoReservedChars) < 0)
             {
                 return input;
             }

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/IdnHostNameValidationTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/IdnHostNameValidationTest.cs
@@ -100,12 +100,16 @@ namespace System.PrivateUri.Tests
         {
             string unicodeHost = "a\u00FChost.dom\u00FCin.n\u00FCet";
             string punycodeHost = "xn--ahost-kva.xn--domin-mva.xn--net-hoa";
+            string fqdnHost = "foo.bar.";
 
             // initial unicode host
             ValidateUri(scheme, unicodeHost, UriHostNameType.Dns, unicodeHost, unicodeHost, punycodeHost);
 
             // initial punycode host
             ValidateUri(scheme, punycodeHost, UriHostNameType.Dns, punycodeHost, punycodeHost, punycodeHost);
+
+            // Host ending with a dot
+            ValidateUri(scheme, fqdnHost, UriHostNameType.Dns, fqdnHost, fqdnHost, fqdnHost);
         }
 
         private static void ValidateUri(


### PR DESCRIPTION
Contributes to #78204

There are more places we can use `IndexOfAnyValues` in `System.Uri`. I'll address those in future PRs to keep them reviewable, this is complex enough as it is.

|        Method | Toolchain |                     Input |     Mean |   Error | Ratio | Allocated |
|-------------- |---------- |-------------------------- |---------:|--------:|------:|----------:|
| NewUriIdnHost |      main | `http://aaaaaaaa(...)` [50] | 428.2 ns | 2.98 ns |  1.00 |     240 B |
| NewUriIdnHost |        pr | `http://aaaaaaaa(...)` [50] | 314.0 ns | 1.31 ns |  0.73 |     240 B |
|               |           |                           |          |         |       |           |
| NewUriIdnHost |      main | `http://www.Micr(...)` [28] | 254.3 ns | 1.29 ns |  1.00 |     248 B |
| NewUriIdnHost |        pr | `http://www.Micr(...)` [28] | 232.2 ns | 0.67 ns |  0.91 |     192 B |
|               |           |                           |          |         |       |           |
| NewUriIdnHost |      main | `http://www.micr(...)` [28] | 240.6 ns | 1.09 ns |  1.00 |     192 B |
| NewUriIdnHost |        pr | `http://www.micr(...)` [28] | 224.2 ns | 0.64 ns |  0.93 |     192 B |

<details>
<summary>Benchmark code</summary>

```c#
[MemoryDiagnoser]
public class UriBenchmarks
{
    public static IEnumerable<string> Inputs()
    {
        yield return "http://www.microsoft.com/foo";
        yield return "http://www.Microsoft.com/foo";
        yield return $"http://{string.Concat(Enumerable.Repeat(new string('a', 12) + '.', 3))}/foo";
    }

    [ParamsSource(nameof(Inputs))]
    public string Input;

    [Benchmark]
    public string NewUriIdnHost() => new Uri(Input).IdnHost;
}
```

</details>