### PR TITLE
Use IndexOfAnyValues in Regex.Escape

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -2076,7 +2076,7 @@ namespace System.Text.RegularExpressions
             // '  a  b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x  y  z  {  |  }  ~
                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Q, S, 0, 0, 0};
 
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
         private static readonly IndexOfAnyValues<char> s_metachars =
             IndexOfAnyValues.Create("\t\n\f\r #$()*+.?[\\^{|");
 


### PR DESCRIPTION
Contributes to #78204

| Method | Toolchain |               Input |        Mean |     Error | Ratio |
|------- |---------- |-------------------- |------------:|----------:|------:|
| Escape |      main | \\\\\\\\(...)\\\\\\\\ [100] | 729.5873 ns | 4.3207 ns |  1.00 |
| Escape |        pr | \\\\\\\\(...)\\\\\\\\ [100] | 933.7590 ns | 4.9799 ns |  1.28 |
|        |           |                     |             |           |       |
| Escape |      main | aaaa(...)aaaa [100] |  64.3942 ns | 0.2537 ns |  1.00 |
| Escape |        pr | aaaa(...)aaaa [100] |   8.3966 ns | 0.0516 ns |  0.13 |