### PR TITLE
[6.0] Fix the tiering delay to account for changing IL/native code versions during the delay

### DIFF
--- a/src/coreclr/vm/tieredcompilation.cpp
+++ b/src/coreclr/vm/tieredcompilation.cpp
@@ -599,10 +599,17 @@ bool TieredCompilationManager::TryDeactivateTieringDelay()
                 continue;
             }
 
+            PCODE codeEntryPoint = activeCodeVersion.GetNativeCode();
+            if (codeEntryPoint == NULL)
+            {
+                // The active IL/native code version has changed since the method was queued, and the currently active version
+                // doesn't have a code entry point yet
+                continue;
+            }
+
             EX_TRY
             {
-                bool wasSet =
-                    CallCountingManager::SetCodeEntryPoint(activeCodeVersion, activeCodeVersion.GetNativeCode(), false, nullptr);
+                bool wasSet = CallCountingManager::SetCodeEntryPoint(activeCodeVersion, codeEntryPoint, false, nullptr);
                 _ASSERTE(wasSet);
             }
             EX_CATCH


### PR DESCRIPTION
- Port of https://github.com/dotnet/runtime/pull/78668
- Added a check to see if the currently active native code version has a code entry point

Fixes https://github.com/dotnet/runtime/issues/77973

## Customer Impact

Apps that use profiler APIs to modify a method's IL may occasionally crash. If a new IL code version is added to a method while it's queued for call counting during the tiering delay, after the delay expires a call counting stub may be created that when called, would cause the app to crash. A workaround is to disable tiered compilation.

## Regression?

No

## Testing

Reproed the issue by inducing the timing with code changes and verified the fix. Scanned over the few other paths where call counting stubs would be created and verified that all of them guarantee a non-null code entry point for the method.

## Risk

Low