### PR TITLE
Reduce private points of contact between frozen collections and ImmutableArray<T>.

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <IsPackable>true</IsPackable>
@@ -24,6 +24,7 @@ The System.Collections.Immutable library is built-in as part of the shared frame
     <Compile Include="System\Collections\Frozen\FrozenHashTable.cs" />
     <Compile Include="System\Collections\Frozen\FrozenSet.cs" />
     <Compile Include="System\Collections\Frozen\FrozenSetInternalBase.cs" />
+    <Compile Include="System\Collections\Frozen\ImmutableArrayFactory.cs" />
     <Compile Include="System\Collections\Frozen\Int32FrozenDictionary.cs" />
     <Compile Include="System\Collections\Frozen\Int32FrozenSet.cs" />
     <Compile Include="System\Collections\Frozen\ItemsFrozenSet.cs" />

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/EmptyFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/EmptyFrozenDictionary.cs
@@ -14,10 +14,10 @@ namespace System.Collections.Frozen
         internal EmptyFrozenDictionary() : base(EqualityComparer<TKey>.Default) { }
 
         /// <inheritdoc />
-        private protected override ImmutableArray<TKey> KeysCore => ImmutableArray<TKey>.Empty;
+        private protected override TKey[] KeysCore => Array.Empty<TKey>();
 
         /// <inheritdoc />
-        private protected override ImmutableArray<TValue> ValuesCore => ImmutableArray<TValue>.Empty;
+        private protected override TValue[] ValuesCore => Array.Empty<TValue>();
 
         /// <inheritdoc />
         private protected override Enumerator GetEnumeratorCore() => new Enumerator(Array.Empty<TKey>(), Array.Empty<TValue>());

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/EmptyFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/EmptyFrozenSet.cs
@@ -13,7 +13,7 @@ namespace System.Collections.Frozen
         internal EmptyFrozenSet() : base(EqualityComparer<T>.Default) { }
 
         /// <inheritdoc />
-        private protected override ImmutableArray<T> ItemsCore => ImmutableArray<T>.Empty;
+        private protected override T[] ItemsCore => Array.Empty<T>();
 
         /// <inheritdoc />
         private protected override int CountCore => 0;

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -169,10 +169,10 @@ namespace System.Collections.Frozen
         /// <remarks>
         /// The order of the keys in the dictionary is unspecified, but it is the same order as the associated values returned by the <see cref="Values"/> property.
         /// </remarks>
-        public ImmutableArray<TKey> Keys => KeysCore;
+        public ImmutableArray<TKey> Keys => ImmutableArrayFactory.Create(KeysCore);
 
         /// <inheritdoc cref="Keys" />
-        private protected abstract ImmutableArray<TKey> KeysCore { get; }
+        private protected abstract TKey[] KeysCore { get; }
 
         /// <inheritdoc />
         ICollection<TKey> IDictionary<TKey, TValue>.Keys =>
@@ -191,10 +191,10 @@ namespace System.Collections.Frozen
         /// <remarks>
         /// The order of the values in the dictionary is unspecified, but it is the same order as the associated keys returned by the <see cref="Keys"/> property.
         /// </remarks>
-        public ImmutableArray<TValue> Values => ValuesCore;
+        public ImmutableArray<TValue> Values => ImmutableArrayFactory.Create(ValuesCore);
 
         /// <inheritdoc cref="Values" />
-        private protected abstract ImmutableArray<TValue> ValuesCore { get; }
+        private protected abstract TValue[] ValuesCore { get; }
 
         ICollection<TValue> IDictionary<TKey, TValue>.Values =>
             Values is { Length: > 0 } values ? values : Array.Empty<TValue>();
@@ -230,8 +230,8 @@ namespace System.Collections.Frozen
                 ThrowHelper.ThrowIfDestinationTooSmall();
             }
 
-            TKey[] keys = Keys.array!;
-            TValue[] values = Values.array!;
+            TKey[] keys = KeysCore;
+            TValue[] values = ValuesCore;
             Debug.Assert(keys.Length == values.Length);
 
             for (int i = 0; i < keys.Length; i++)

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSet.cs
@@ -127,10 +127,10 @@ namespace System.Collections.Frozen
 
         /// <summary>Gets a collection containing the values in the set.</summary>
         /// <remarks>The order of the values in the set is unspecified.</remarks>
-        public ImmutableArray<T> Items => ItemsCore;
+        public ImmutableArray<T> Items => ImmutableArrayFactory.Create(ItemsCore);
 
         /// <inheritdoc cref="Items" />
-        private protected abstract ImmutableArray<T> ItemsCore { get; }
+        private protected abstract T[] ItemsCore { get; }
 
         /// <summary>Gets the number of values contained in the set.</summary>
         public int Count => CountCore;
@@ -160,7 +160,8 @@ namespace System.Collections.Frozen
                 throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
             }
 
-            Array.Copy(Items.array!, 0, array!, index, Items.Length);
+            T[] items = ItemsCore;
+            Array.Copy(items, 0, array!, index, items.Length);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ImmutableArrayFactory.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ImmutableArrayFactory.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+
+namespace System.Collections.Frozen
+{
+    /// <summary>
+    /// Stubs to isolate the frozen collection code from the internal details of ImmutableArray
+    /// </summary>
+    /// <remarks>
+    /// This is intended to make it easier to use the frozen collections in environments/conditions
+    /// when only the public API of ImmutableArray is available.
+    /// </remarks>
+    internal static class ImmutableArrayFactory
+    {
+        public static ImmutableArray<T> Create<T>(T[] array) => new ImmutableArray<T>(array);
+    }
+}

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32FrozenDictionary.cs
@@ -35,10 +35,10 @@ namespace System.Collections.Frozen
         }
 
         /// <inheritdoc />
-        private protected override ImmutableArray<int> KeysCore => new ImmutableArray<int>(_hashTable.HashCodes);
+        private protected override int[] KeysCore => _hashTable.HashCodes;
 
         /// <inheritdoc />
-        private protected override ImmutableArray<TValue> ValuesCore => new ImmutableArray<TValue>(_values);
+        private protected override TValue[] ValuesCore => _values;
 
         /// <inheritdoc />
         private protected override Enumerator GetEnumeratorCore() => new Enumerator(_hashTable.HashCodes, _values);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Int32FrozenSet.cs
@@ -26,7 +26,7 @@ namespace System.Collections.Frozen
         }
 
         /// <inheritdoc />
-        private protected override ImmutableArray<int> ItemsCore => new ImmutableArray<int>(_hashTable.HashCodes);
+        private protected override int[] ItemsCore => _hashTable.HashCodes;
 
         /// <inheritdoc />
         private protected override Enumerator GetEnumeratorCore() => new Enumerator(_hashTable.HashCodes);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ItemsFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/ItemsFrozenSet.cs
@@ -30,7 +30,7 @@ namespace System.Collections.Frozen
         }
 
         /// <inheritdoc />
-        private protected sealed override ImmutableArray<T> ItemsCore => new ImmutableArray<T>(_items);
+        private protected sealed override T[] ItemsCore => _items;
 
         /// <inheritdoc />
         private protected sealed override Enumerator GetEnumeratorCore() => new Enumerator(_items);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/KeysAndValuesFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/KeysAndValuesFrozenDictionary.cs
@@ -36,10 +36,10 @@ namespace System.Collections.Frozen
         }
 
         /// <inheritdoc />
-        private protected sealed override ImmutableArray<TKey> KeysCore => new ImmutableArray<TKey>(_keys);
+        private protected sealed override TKey[] KeysCore => _keys;
 
         /// <inheritdoc />
-        private protected sealed override ImmutableArray<TValue> ValuesCore => new ImmutableArray<TValue>(_values);
+        private protected sealed override TValue[] ValuesCore => _values;
 
         /// <inheritdoc />
         private protected sealed override Enumerator GetEnumeratorCore() => new Enumerator(_keys, _values);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/LengthBucketsFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/LengthBucketsFrozenDictionary.cs
@@ -98,10 +98,10 @@ namespace System.Collections.Frozen
         }
 
         /// <inheritdoc />
-        private protected override ImmutableArray<string> KeysCore => new ImmutableArray<string>(_keys);
+        private protected override string[] KeysCore => _keys;
 
         /// <inheritdoc />
-        private protected override ImmutableArray<TValue> ValuesCore => new ImmutableArray<TValue>(_values);
+        private protected override TValue[] ValuesCore => _values;
 
         /// <inheritdoc />
         private protected override Enumerator GetEnumeratorCore() => new Enumerator(_keys, _values);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/LengthBucketsFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/LengthBucketsFrozenSet.cs
@@ -92,7 +92,7 @@ namespace System.Collections.Frozen
         }
 
         /// <inheritdoc />
-        private protected override ImmutableArray<string> ItemsCore => new ImmutableArray<string>(_items);
+        private protected override string[] ItemsCore => _items;
 
         /// <inheritdoc />
         private protected override Enumerator GetEnumeratorCore() => new Enumerator(_items);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/OrdinalStringFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/OrdinalStringFrozenDictionary.cs
@@ -48,10 +48,10 @@ namespace System.Collections.Frozen
         }
 
         /// <inheritdoc />
-        private protected override ImmutableArray<string> KeysCore => new ImmutableArray<string>(_keys);
+        private protected override string[] KeysCore => _keys;
 
         /// <inheritdoc />
-        private protected override ImmutableArray<TValue> ValuesCore => new ImmutableArray<TValue>(_values);
+        private protected override TValue[] ValuesCore => _values;
 
         /// <inheritdoc />
         private protected override Enumerator GetEnumeratorCore() => new Enumerator(_keys, _values);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/OrdinalStringFrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/OrdinalStringFrozenSet.cs
@@ -40,7 +40,7 @@ namespace System.Collections.Frozen
         }
 
         /// <inheritdoc />
-        private protected override ImmutableArray<string> ItemsCore => new ImmutableArray<string>(_items);
+        private protected override string[] ItemsCore => _items;
 
         /// <inheritdoc />
         private protected override Enumerator GetEnumeratorCore() => new Enumerator(_items);


### PR DESCRIPTION
This change is intended to make it easier to use the frozen collections in environments/conditions when only the public API of ImmutableArray is available. There are two things which are changed:

1. Uses of the internal ImmutableArray ctor are replaced by the one-line ImmutableArrayFactory.Create stub, which is easy to replace in above mentioned environments/conditions.

2. Uses of the internal ImmutableArray.array property are trivially eliminated by using the public API surface.