### PR TITLE
Use IndexOfAnyValues in CoreLib

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -88,7 +89,8 @@ namespace System
 
         #region Private Data Members
         private readonly SafeTypeNameParserHandle m_NativeParser;
-        private static readonly char[] SPECIAL_CHARS = { ',', '[', ']', '&', '*', '+', '\\' }; /* see typeparse.h */
+        private const string SpecialChars = ",[]&*+\\"; // see typeparse.h
+        private static readonly IndexOfAnyValues<char> s_specialChars = IndexOfAnyValues.Create(SpecialChars);
         #endregion
 
         #region Constructor and Disposer
@@ -276,13 +278,18 @@ namespace System
 
         private static string EscapeTypeName(string name)
         {
-            if (name.IndexOfAny(SPECIAL_CHARS) < 0)
+            int specialCharIndex = name.AsSpan().IndexOfAny(s_specialChars);
+            if (specialCharIndex < 0)
+            {
                 return name;
+            }
 
             var sb = new ValueStringBuilder(stackalloc char[64]);
-            foreach (char c in name)
+            sb.Append(name.AsSpan(0, specialCharIndex));
+
+            foreach (char c in name.AsSpan(specialCharIndex))
             {
-                if (Array.IndexOf<char>(SPECIAL_CHARS, c) >= 0)
+                if (SpecialChars.Contains(c))
                     sb.Append('\\');
 
                 sb.Append(c);

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -19,6 +19,13 @@ namespace System
     {
         private const int StackallocIntBufferSizeLimit = 128;
 
+        // The Unicode Standard, Sec. 5.8, Recommendation R4 and Table 5-2 state that the CR, LF,
+        // CRLF, NEL, LS, FF, and PS sequences are considered newline functions. That section
+        // also specifically excludes VT from the list of newline functions, so we do not include
+        // it in the needle list.
+        private static readonly IndexOfAnyValues<char> s_newLineChars =
+            IndexOfAnyValues.Create("\r\n\f\u0085\u2028\u2029");
+
         private static void FillStringChecked(string dest, int destPos, string src)
         {
             Debug.Assert(dest != null);
@@ -1233,16 +1240,9 @@ namespace System
             // the haystack; or O(n) if no needle is found. This ensures that in the common case
             // of this method being called within a loop, the worst-case runtime is O(n) rather than
             // O(n^2), where n is the length of the input text.
-            //
-            // The Unicode Standard, Sec. 5.8, Recommendation R4 and Table 5-2 state that the CR, LF,
-            // CRLF, NEL, LS, FF, and PS sequences are considered newline functions. That section
-            // also specifically excludes VT from the list of newline functions, so we do not include
-            // it in the needle list.
-
-            const string needles = "\r\n\f\u0085\u2028\u2029";
 
             stride = default;
-            int idx = text.IndexOfAny(needles);
+            int idx = text.IndexOfAny(s_newLineChars);
             if ((uint)idx < (uint)text.Length)
             {
                 stride = 1; // needle found


### PR DESCRIPTION
Contributes to #78204

Avoids the cost of initializing the `ProbabilisticMap` on every matched value for `ReplaceLineEndings`.

|             Method | Toolchain |                Input |         Mean |      Error | Ratio |
|------------------- |---------- |--------------------- |-------------:|-----------:|------:|
| ReplaceLineEndings |      main | \n\n(...)\n\n [1000] | 26,379.96 ns | 142.148 ns |  1.00 |
| ReplaceLineEndings |        pr | \n\n(...)\n\n [1000] | 13,946.75 ns |  49.276 ns |  0.53 |
|                    |           |                      |              |            |       |
| ReplaceLineEndings |      main | aaaaa(...)aaaaa [32] |     46.70 ns |   0.179 ns |  1.00 |
| ReplaceLineEndings |        pr | aaaaa(...)aaaaa [32] |     33.29 ns |   0.356 ns |  0.71 |

---

In this case we're using `"\r\n\f\u0085\u2028\u2029"` as the needle.
We also have a bunch of uses of `char.IsWhiteSpace` where the needle likewise contains both ASCII and non-ASCII chars.

As ASCII values are more common in these cases, we could consider adding `IndexOfAnyValues` implementations with loops like this in the future:
```c#
while (remaining > vector256)
{
    var vector = Vector256.LoadUnsafe(...);
    if (AllCharsAreAscii(vector))
    {
        IndexOfAnyAsciiSearcher.Lookup(vector, _bitmap);
    }
    else
    {
        // Fallback to ProbabilisticMap or even IndexOfAny(char, char, char)
    }
}
```