### PR TITLE
Extend preinitialization interpreter to support calling `string::Length`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 using ILCompiler.DependencyAnalysis;
 
@@ -402,6 +403,7 @@ namespace ILCompiler
                         break;
 
                     case ILOpcode.call:
+                    case ILOpcode.callvirt:
                         {
                             MethodDesc method = (MethodDesc)methodIL.GetObject(reader.ReadILToken());
                             MethodSignature methodSig = method.Signature;
@@ -425,6 +427,13 @@ namespace ILCompiler
                             for (int i = numParams - 1; i >= 0; i--)
                             {
                                 methodParams[i] = stack.PopIntoLocation(GetArgType(method, i));
+                            }
+
+                            if (opcode == ILOpcode.callvirt)
+                            {
+                                // Only support non-virtual methods for now + we don't emulate NRE on null this
+                                if (method.IsVirtual || methodParams[0] == null)
+                                    return Status.Fail(methodIL.OwningMethod, opcode);
                             }
 
                             Value retVal;
@@ -596,6 +605,11 @@ namespace ILCompiler
                             if (field.FieldType.IsGCPointer && value != null)
                             {
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Reference field");
+                            }
+
+                            if (field.FieldType.IsByRef)
+                            {
+                                return Status.Fail(methodIL.OwningMethod, opcode, "Byref field");
                             }
 
                             var settableInstance = instance.Value as IHasInstanceFields;
@@ -2259,28 +2273,65 @@ namespace ILCompiler
             public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter) => this;
         }
 
-        private sealed class StringInstance : ReferenceTypeValue
+        private sealed class StringInstance : ReferenceTypeValue, IHasInstanceFields
         {
-            private readonly string _value;
+            private readonly byte[] _value;
 
+            private string ValueAsString
+            {
+                get
+                {
+                    FieldDesc firstCharField = Type.GetField("_firstChar");
+                    int startOffset = firstCharField.Offset.AsInt;
+                    int length = _value.Length - startOffset - sizeof(char) /* terminating null */;
+                    return new string(MemoryMarshal.Cast<byte, char>(
+                        ((ReadOnlySpan<byte>)_value).Slice(startOffset, length)));
+                }
+            }
             public StringInstance(TypeDesc stringType, string value)
                 : base(stringType)
             {
-                _value = value;
+                _value = ConstructStringInstance(stringType, value);
+            }
+
+            private static byte[] ConstructStringInstance(TypeDesc stringType, ReadOnlySpan<char> value)
+            {
+                int pointerSize = stringType.Context.Target.PointerSize;
+                var bytes = new byte[
+                    pointerSize /* MethodTable */
+                    + sizeof(int) /* length */
+                    + (value.Length * sizeof(char)) /* bytes */
+                    + sizeof(char) /* null terminator */];
+
+                FieldDesc lengthField = stringType.GetField("_stringLength");
+                Debug.Assert(lengthField.FieldType.IsWellKnownType(WellKnownType.Int32)
+                    && lengthField.Offset.AsInt == pointerSize);
+                new FieldAccessor(bytes).SetField(lengthField, ValueTypeValue.FromInt32(value.Length));
+
+                FieldDesc firstCharField = stringType.GetField("_firstChar");
+                Debug.Assert(firstCharField.FieldType.IsWellKnownType(WellKnownType.Char)
+                    && firstCharField.Offset.AsInt == pointerSize + sizeof(int) /* length */);
+
+                value.CopyTo(MemoryMarshal.Cast<byte, char>(((Span<byte>)bytes).Slice(firstCharField.Offset.AsInt)));
+
+                return bytes;
             }
 
             public override void WriteFieldData(ref ObjectDataBuilder builder, NodeFactory factory)
             {
-                builder.EmitPointerReloc(factory.SerializedStringObject(_value));
+                builder.EmitPointerReloc(factory.SerializedStringObject(ValueAsString));
             }
 
             public override bool GetRawData(NodeFactory factory, out object data)
             {
-                data = factory.SerializedStringObject(_value);
+                data = factory.SerializedStringObject(ValueAsString);
                 return true;
             }
 
             public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter) => this;
+            Value IHasInstanceFields.GetField(FieldDesc field) => new FieldAccessor(_value).GetField(field);
+            void IHasInstanceFields.SetField(FieldDesc field, Value value) => ThrowHelper.ThrowInvalidProgramException();
+            ByRefValue IHasInstanceFields.GetFieldAddress(FieldDesc field) => new FieldAccessor(_value).GetFieldAddress(field);
         }
 
 #pragma warning disable CA1852

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -45,6 +45,7 @@ internal class Program
         TestGCInteraction.Run();
         TestDuplicatedFields.Run();
         TestInstanceDelegate.Run();
+        TestStringFields.Run();
 #else
         Console.WriteLine("Preinitialization is disabled in multimodule builds for now. Skipping test.");
 #endif
@@ -910,6 +911,37 @@ class TestInstanceDelegate
         Assert.AreEqual(42, ClassWithInstanceDelegate.Instance1());
         Assert.AreEqual(123, ClassWithInstanceDelegate.Instance2());
         Assert.AreSame(ClassWithInstanceDelegate.Target, ClassWithInstanceDelegate.Instance2.Target);
+    }
+}
+
+class TestStringFields
+{
+    class ClassAccessingLength
+    {
+        public static int Length = "Hello".Length;
+    }
+
+    class ClassAccessingNull
+    {
+        public static int Length;
+        static ClassAccessingNull()
+        {
+            string myNull = null;
+            try
+            {
+                Length = myNull.Length;
+            }
+            catch (Exception) { }
+        }
+    }
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(ClassAccessingLength));
+        Assert.AreEqual(5, ClassAccessingLength.Length);
+
+        Assert.IsLazyInitialized(typeof(ClassAccessingNull));
+        Assert.AreEqual(0, ClassAccessingNull.Length);
     }
 }
 


### PR DESCRIPTION
* Support `callvirt` to a non-virtual method
* Support accessing string's fields

A bit of progress towards https://github.com/dotnet/runtime/pull/78093#discussion_r1028400165.

Cc @dotnet/ilc-contrib 