### PR TITLE
Teach internal `printf` about 'z'

### DIFF
--- a/src/coreclr/pal/src/cruntime/printfcpp.cpp
+++ b/src/coreclr/pal/src/cruntime/printfcpp.cpp
@@ -222,7 +222,7 @@ BOOL Internal_ExtractFormatA(CPalThread *pthrCurrent, LPCSTR *Fmt, LPSTR Out, LP
         *Prefix = PFF_PREFIX_LONGLONG;
     }
 #endif
-    if ((*Fmt)[0] == 'I')
+    if ((*Fmt)[0] == 'I' || (*Fmt)[0] == 'z')
     {
         /* grab prefix of 'I64' for __int64 */
         if ((*Fmt)[1] == '6' && (*Fmt)[2] == '4')

--- a/src/coreclr/pal/src/cruntime/silent_printf.cpp
+++ b/src/coreclr/pal/src/cruntime/silent_printf.cpp
@@ -477,6 +477,14 @@ BOOL Silent_ExtractFormatA(LPCSTR *Fmt, LPSTR Out, LPINT Flags, LPINT Width, LPI
         *Fmt += 3;
         *Prefix = PFF_PREFIX_LONGLONG;
     }
+    /* grab a prefix of 'z' */
+    else if (**Fmt == 'z')
+    {
+#ifdef HOST_64BIT
+        *Prefix = PFF_PREFIX_LONGLONG;
+#endif
+        ++(*Fmt);
+    }
     /* grab a prefix of 'h' */
     else if (**Fmt == 'h')
     {

--- a/src/coreclr/pal/src/safecrt/input.inl
+++ b/src/coreclr/pal/src/safecrt/input.inl
@@ -351,6 +351,7 @@ static int __check_float_string(size_t nFloatStrUsed,
                             break;
 
 #if _INTEGRAL_MAX_BITS >= 64
+                        case _T('z'):
                         case _T('I'):
                             if ( (*(format + 1) == _T('6')) &&
                                  (*(format + 2) == _T('4')) )

--- a/src/coreclr/pal/src/safecrt/output.inl
+++ b/src/coreclr/pal/src/safecrt/output.inl
@@ -394,14 +394,16 @@ static const unsigned char __lookuptable_s[] = {
  /* 'u' */  0x08,
  /* 'v' */  0x00,
  /* 'w' */  0x07,
- /* 'x' */  0x08
+ /* 'x' */  0x08,
+ /* 'y' */  0x00,
+ /* 'z' */  0x57
 };
 //#endif  /* defined (_UNICODE) || defined (CPRFLAG) */
 
 #endif  /* FORMAT_VALIDATIONS */
 
 #define FIND_CHAR_CLASS(lookuptbl, c)      \
-        ((c) < _T(' ') || (c) > _T('x') ? \
+        ((c) < _T(' ') || (c) > _T('z') ? \
             CH_OTHER            \
             :               \
         (enum CHARTYPE)(lookuptbl[(c)-_T(' ')] & 0xF))
@@ -776,6 +778,7 @@ int __cdecl _output (
                 }
                 break;
 
+            case _T('z'):
             case _T('I'):
                 /*
                  * In order to handle the I, I32, and I64 size modifiers, we

--- a/src/coreclr/pal/src/safecrt/safecrt_output_l.cpp
+++ b/src/coreclr/pal/src/safecrt/safecrt_output_l.cpp
@@ -311,7 +311,9 @@ const char __lookuptable[] = {
  /* 'u' */  0x08,
  /* 'v' */  0x00,
  /* 'w' */  0x07,
- /* 'x' */  0x08
+ /* 'x' */  0x08,
+ /* 'y' */  0x00,
+ /* 'z' */  0x37
 };
 
 #endif  /* defined (_UNICODE) || defined (CPRFLAG) */
@@ -322,7 +324,7 @@ const char __lookuptable[] = {
 #endif  /* FORMAT_VALIDATIONS */
 
 #define FIND_CHAR_CLASS(lookuptbl, c)      \
-        ((c) < _T(' ') || (c) > _T('x') ? \
+        ((c) < _T(' ') || (c) > _T('z') ? \
             CH_OTHER            \
             :               \
         (enum CHARTYPE)(lookuptbl[(c)-_T(' ')] & 0xF))
@@ -696,6 +698,7 @@ int __cdecl _output (
                 }
                 break;
 
+            case _T('z'):
             case _T('I'):
                 /*
                  * In order to handle the I, I32, and I64 size modifiers, we


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/78623

Caused by https://github.com/dotnet/runtime/pull/78434

In a previous PR, an attempt was made to remove
most Windows specific format flags. However, the
internal `printf` version we are using doesn't know
about the 'z' flag. In order to transition to the correct
flags, so we can remove our `printf`, we need to teach
our `printf` about modern flags.

/cc @markples @janvorli 