### PR TITLE
Place frozen objects into dehydrated section

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
@@ -40,8 +40,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 AlignNextObject(ref builder, factory);
 
-                if (!relocsOnly)
-                    node.InitializeOffsetFromBeginningOfArray(builder.CountBytes);
+                node.InitializeOffsetFromBeginningOfArray(builder.CountBytes);
 
                 int initialOffset = builder.CountBytes;
                 node.EncodeData(ref builder, factory, relocsOnly);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
@@ -1,34 +1,57 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+using System;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public class ArrayOfFrozenObjectsNode<TEmbedded> : ArrayOfEmbeddedDataNode<TEmbedded>
-        where TEmbedded : EmbeddedObjectNode
+    public class ArrayOfFrozenObjectsNode : DehydratableObjectNode, ISymbolDefinitionNode
     {
-        public ArrayOfFrozenObjectsNode(string startSymbolMangledName, string endSymbolMangledName, IComparer<TEmbedded> nodeSorter) : base(startSymbolMangledName, endSymbolMangledName, nodeSorter)
+        private readonly ObjectAndOffsetSymbolNode _endSymbol;
+        public ISymbolNode EndSymbol => _endSymbol;
+
+        public ArrayOfFrozenObjectsNode()
         {
+            _endSymbol = new ObjectAndOffsetSymbolNode(this, 0, "__FrozenSegmentEnd", true);
         }
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+            => sb.Append(nameMangler.CompilationUnitPrefix).Append("__FrozenSegmentStart");
+
+        public int Offset => 0;
 
         private static void AlignNextObject(ref ObjectDataBuilder builder, NodeFactory factory)
         {
             builder.EmitZeros(AlignmentHelper.AlignUp(builder.CountBytes, factory.Target.PointerSize) - builder.CountBytes);
         }
 
-        protected override void GetElementDataForNodes(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
+        protected override ObjectData GetDehydratableData(NodeFactory factory, bool relocsOnly)
         {
-            foreach (EmbeddedObjectNode node in NodesList)
+            // This is a summary node
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
+
+            var builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.AddSymbol(this);
+            foreach (EmbeddedObjectNode node in factory.MetadataManager.GetFrozenObjects())
             {
                 AlignNextObject(ref builder, factory);
 
                 if (!relocsOnly)
                     node.InitializeOffsetFromBeginningOfArray(builder.CountBytes);
 
+                int initialOffset = builder.CountBytes;
                 node.EncodeData(ref builder, factory, relocsOnly);
+                int objectSize = builder.CountBytes - initialOffset;
+                int minimumObjectSize = EETypeNode.GetMinimumObjectSize(factory.TypeSystemContext);
+                if (objectSize < minimumObjectSize)
+                {
+                    builder.EmitZeros(minimumObjectSize - objectSize);
+                }
+
                 if (node is ISymbolDefinitionNode)
                 {
                     builder.AddSymbol((ISymbolDefinitionNode)node);
@@ -38,8 +61,20 @@ namespace ILCompiler.DependencyAnalysis
             // Terminate with a null pointer as expected by the GC
             AlignNextObject(ref builder, factory);
             builder.EmitZeroPointer();
+
+            _endSymbol.SetSymbolOffset(builder.CountBytes);
+            builder.AddSymbol(_endSymbol);
+
+            return builder.ToObjectData();
         }
 
+        protected override ObjectNodeSection GetDehydratedSection(NodeFactory factory) => ObjectNodeSection.DataSection;
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
         public override int ClassCode => -1771336339;
+
+        public override bool IsShareable => false;
+
+        public override bool StaticDependenciesAreComputed => true;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenObjectNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenObjectNode.cs
@@ -13,7 +13,7 @@ namespace ILCompiler.DependencyAnalysis
     /// Represents a frozen object that is statically preallocated within the data section
     /// of the executable instead of on the GC heap.
     /// </summary>
-    public class FrozenObjectNode : EmbeddedObjectNode, ISymbolDefinitionNode
+    public sealed class FrozenObjectNode : EmbeddedObjectNode, ISymbolDefinitionNode
     {
         private readonly MetadataType _owningType;
         private readonly TypePreinit.ISerializableReference _data;
@@ -58,20 +58,11 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
-            int initialOffset = dataBuilder.CountBytes;
-
             // Sync Block
             dataBuilder.EmitZeroPointer();
 
             // byte contents
             _data.WriteContent(ref dataBuilder, this, factory);
-
-            int objectSize = dataBuilder.CountBytes - initialOffset;
-            int minimumObjectSize = EETypeNode.GetMinimumObjectSize(factory.TypeSystemContext);
-            if (objectSize < minimumObjectSize)
-            {
-                dataBuilder.EmitZeros(minimumObjectSize - objectSize);
-            }
         }
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
@@ -93,11 +84,6 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             return dependencies;
-        }
-
-        protected override void OnMarked(NodeFactory factory)
-        {
-            factory.FrozenSegmentRegion.AddEmbeddedObject(this);
         }
 
         public override int ClassCode => 1789429316;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -1122,10 +1122,7 @@ namespace ILCompiler.DependencyAnalysis
             "__DispatchMapTableEnd",
             new SortableDependencyNode.ObjectNodeComparer(CompilerComparer.Instance));
 
-        public ArrayOfEmbeddedDataNode<EmbeddedObjectNode> FrozenSegmentRegion = new ArrayOfFrozenObjectsNode<EmbeddedObjectNode>(
-            "__FrozenSegmentRegionStart",
-            "__FrozenSegmentRegionEnd",
-            new SortableDependencyNode.EmbeddedObjectNodeComparer(CompilerComparer.Instance));
+        public ArrayOfFrozenObjectsNode FrozenSegmentRegion = new ArrayOfFrozenObjectsNode();
 
         internal ModuleInitializerListNode ModuleInitializerList = new ModuleInitializerListNode();
 
@@ -1158,7 +1155,7 @@ namespace ILCompiler.DependencyAnalysis
             ReadyToRunHeader.Add(ReadyToRunSectionType.EagerCctor, EagerCctorTable, EagerCctorTable.StartSymbol, EagerCctorTable.EndSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.TypeManagerIndirection, TypeManagerIndirection, TypeManagerIndirection);
             ReadyToRunHeader.Add(ReadyToRunSectionType.InterfaceDispatchTable, DispatchMapTable, DispatchMapTable.StartSymbol);
-            ReadyToRunHeader.Add(ReadyToRunSectionType.FrozenObjectRegion, FrozenSegmentRegion, FrozenSegmentRegion.StartSymbol, FrozenSegmentRegion.EndSymbol);
+            ReadyToRunHeader.Add(ReadyToRunSectionType.FrozenObjectRegion, FrozenSegmentRegion, FrozenSegmentRegion, FrozenSegmentRegion.EndSymbol);
             ReadyToRunHeader.Add(ReadyToRunSectionType.ModuleInitializerList, ModuleInitializerList, ModuleInitializerList, ModuleInitializerList.EndSymbol);
 
             var commonFixupsTableNode = new ExternalReferencesTableNode("CommonFixupsTable", this);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -56,6 +56,7 @@ namespace ILCompiler
         private readonly SortedSet<MethodDesc> _reflectableMethods = new SortedSet<MethodDesc>(TypeSystemComparer.Instance);
         private readonly SortedSet<GenericDictionaryNode> _genericDictionariesGenerated = new SortedSet<GenericDictionaryNode>(CompilerComparer.Instance);
         private readonly SortedSet<IMethodBodyNode> _methodBodiesGenerated = new SortedSet<IMethodBodyNode>(CompilerComparer.Instance);
+        private readonly SortedSet<EmbeddedObjectNode> _frozenObjects = new SortedSet<EmbeddedObjectNode>(CompilerComparer.Instance);
         private readonly SortedSet<TypeGVMEntriesNode> _typeGVMEntries
             = new SortedSet<TypeGVMEntriesNode>(Comparer<TypeGVMEntriesNode>.Create((a, b) => TypeSystemComparer.Instance.Compare(a.AssociatedType, b.AssociatedType)));
         private readonly SortedSet<DefType> _typesWithDelegateMarshalling = new SortedSet<DefType>(TypeSystemComparer.Instance);
@@ -271,6 +272,16 @@ namespace ILCompiler
             if (obj is NativeLayoutTemplateMethodSignatureVertexNode templateMethodEntry)
             {
                 _templateMethodEntries.Add(templateMethodEntry);
+            }
+
+            if (obj is FrozenObjectNode frozenObj)
+            {
+                _frozenObjects.Add(frozenObj);
+            }
+
+            if (obj is FrozenStringNode frozenStr)
+            {
+                _frozenObjects.Add(frozenStr);
             }
         }
 
@@ -687,6 +698,11 @@ namespace ILCompiler
         public IEnumerable<MethodDesc> GetReflectableMethods()
         {
             return _reflectableMethods;
+        }
+
+        public IEnumerable<EmbeddedObjectNode> GetFrozenObjects()
+        {
+            return _frozenObjects;
         }
 
         internal IEnumerable<IMethodBodyNode> GetCompiledMethodBodies()


### PR DESCRIPTION
Saves 1% in size on a Hello World on Windows, more on Linux because we're getting rid of full pointers.

* Instead of using `ArrayOfEmbeddedDataNode` as the base for the frozen object region, derive from `DehydratableObjectNode` directly. The base class wasn't really saving us much work over `ObjectNode` anyway.
* Move the "align object to minimum size" code to the central location while I'm touching it.
* Keep track of all frozen objects in the `MetadataManager`. This is the general pattern we follow elsewhere. The old pattern where the frozen object adds itself from the callback also works, but this matches the approach we use for other summarized node kinds.

Cc @dotnet/ilc-contrib 