### PR TITLE
[wasm] Use "node:crypto" to polyfill getRandomValues on older node

### DIFF
--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -7,6 +7,7 @@ import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, ENVIRONMENT_IS_WEB, ENVIRONM
 import { afterUpdateGlobalBufferAndViews } from "./memory";
 import { replaceEmscriptenPThreadLibrary } from "./pthreads/shared/emscripten-replacements";
 import { DotnetModuleConfigImports, EarlyReplacements } from "./types";
+import { TypedArray } from "./types/emscripten";
 
 let node_fs: any | undefined = undefined;
 let node_url: any | undefined = undefined;
@@ -194,6 +195,22 @@ export async function init_polyfills_async(): Promise<void> {
         if (globalThis.performance === dummyPerformance) {
             const { performance } = INTERNAL.require("perf_hooks");
             globalThis.performance = performance;
+        }
+
+        if (!globalThis.crypto) {
+            globalThis.crypto = <any>{};
+        }
+        if (!globalThis.crypto.getRandomValues) {
+            const nodeCrypto = INTERNAL.require("node:crypto");
+            if (nodeCrypto.webcrypto) {
+                globalThis.crypto = nodeCrypto.webcrypto;
+            } else if (nodeCrypto.randomBytes) {
+                globalThis.crypto.getRandomValues = (buffer: TypedArray) => {
+                    if (buffer) {
+                        buffer.set(nodeCrypto.randomBytes(buffer.length));
+                    }
+                };
+            }
         }
     }
 }

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -23,18 +23,6 @@ if (is_node && process.versions.node.split(".")[0] < 14) {
     throw new Error(`NodeJS at '${process.execPath}' has too low version '${process.versions.node}'`);
 }
 
-if (typeof globalThis.crypto === 'undefined') {
-    // **NOTE** this is a simple insecure polyfill for testing purposes only
-    // /dev/random doesn't work on js shells, so define our own
-    // See library_fs.js:createDefaultDevices ()
-    globalThis.crypto = {
-        getRandomValues: function (buffer) {
-            for (let i = 0; i < buffer.length; i++)
-                buffer[i] = (Math.random() * 256) | 0;
-        }
-    }
-}
-
 let v8args;
 if (typeof arguments !== "undefined") {
     // this must be captured in top level scope in V8

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -23,6 +23,18 @@ if (is_node && process.versions.node.split(".")[0] < 14) {
     throw new Error(`NodeJS at '${process.execPath}' has too low version '${process.versions.node}'`);
 }
 
+if (!is_node && !is_browser && typeof globalThis.crypto === 'undefined') {
+    // **NOTE** this is a simple insecure polyfill for testing purposes only
+    // /dev/random doesn't work on js shells, so define our own
+    // See library_fs.js:createDefaultDevices ()
+    globalThis.crypto = {
+        getRandomValues: function (buffer) {
+            for (let i = 0; i < buffer.length; i++)
+                buffer[i] = (Math.random() * 256) | 0;
+        }
+    }
+}
+
 let v8args;
 if (typeof arguments !== "undefined") {
     // this must be captured in top level scope in V8


### PR DESCRIPTION
- Use `"node:crypto"` when `globalThis.crypto` is undefined or doesn't have `getRandomValues`.
- Polyfill `getRandomValues` from `webcrypto` when available
- Polyfill `getRandomValues` using `randomBytes` on even older node

Fixes https://github.com/dotnet/runtime/issues/77927