### PR TITLE
Remove TrimStart in PAX extended attributes

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -721,7 +721,7 @@ namespace System.Formats.Tar
             {
                 return false;
             }
-            line = line.Slice(spacePos + 1).TrimStart((byte)' ');
+            line = line.Slice(spacePos + 1);
 
             // Find the equal separator.
             int equalPos = line.IndexOf((byte)'=');

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.GlobalExtendedAttributes.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.GlobalExtendedAttributes.Tests.cs
@@ -85,8 +85,10 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [InlineData("key", "value")]
-        [InlineData("key     ", "   value    ")]
-        [InlineData("      key     ", "   value    ")]
+        [InlineData("key    ", "value    ")]
+        [InlineData("    key", "    value")]
+        [InlineData("    key   ", "    value    ")]
+        [InlineData("    key spaced   ", "    value spaced    ")]
         [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
         public void GlobalExtendedAttribute_Roundtrips(string key, string value)
         {
@@ -101,7 +103,7 @@ namespace System.Formats.Tar.Tests
             {
                 PaxGlobalExtendedAttributesTarEntry entry = Assert.IsType<PaxGlobalExtendedAttributesTarEntry>(reader.GetNextEntry());
                 Assert.Equal(1, entry.GlobalExtendedAttributes.Count);
-                Assert.Equal(KeyValuePair.Create(key.TrimStart(), value), entry.GlobalExtendedAttributes.First());
+                Assert.Equal(KeyValuePair.Create(key, value), entry.GlobalExtendedAttributes.First());
             }
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -335,8 +335,10 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [InlineData("key", "value")]
-        [InlineData("key     ", "   value    ")]
-        [InlineData("      key     ", "   value    ")]
+        [InlineData("key    ", "value    ")]
+        [InlineData("    key", "    value")]
+        [InlineData("    key   ", "    value    ")]
+        [InlineData("    key spaced   ", "    value spaced    ")]
         [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
         public void PaxExtendedAttribute_Roundtrips(string key, string value)
         {
@@ -351,7 +353,7 @@ namespace System.Formats.Tar.Tests
             {
                 PaxTarEntry entry = Assert.IsType<PaxTarEntry>(reader.GetNextEntry());
                 Assert.Equal(5, entry.ExtendedAttributes.Count);
-                Assert.Contains(KeyValuePair.Create(key.TrimStart(), value), entry.ExtendedAttributes);
+                Assert.Contains(KeyValuePair.Create(key, value), entry.ExtendedAttributes);
             }
         }
 


### PR DESCRIPTION
Follow-up of https://github.com/dotnet/runtime/pull/78465

We don't want to trim the keys or the values retrieved from the extended attributes section. We want to preserved them untouched.