### PR TITLE
JIT: Avoid introducing data races in RBO

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1970,9 +1970,9 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
             continue;
         }
 
-        // The local may have uses between the def and the JTRUE. Since we are
-        // using liberal VNs here we could introduce races by allowing
-        // duplicating the RHS of the assignment.
+        // The local may have uses between the def and the JTRUE. Duplicating
+        // reads is not allowed and in any case duplicating it in this case is
+        // probably not be worth it from a profitability perspective.
         //
         LclSsaVarDsc* ssaDefDsc = prevTreeLclDsc->GetPerSsaData(prevTreeLHS->AsLclVarCommon()->GetSsaNum());
         if (ssaDefDsc->GetNumUses() >= 2)


### PR DESCRIPTION
RBO can forward sub relops into upcoming conditions. We avoid doing this if the local assigned is live out of the block, but there may still be uses between the def and the condition which could cause us to duplicate reads and introduce data races.

The problem is the same as #62048, which was fixed to handle it for volatile operations. Now that we have an overapproximation of the number of SSA uses stored in their defs we can use this to handle the situation in general. This also means we no longer do the forward sub when there may be multiple uses, which makes sense from a costing perspective.

Fix #78713