### PR TITLE
Clarify System.Diagnostics.Process' README

### DIFF
--- a/src/libraries/System.Diagnostics.Process/README.md
+++ b/src/libraries/System.Diagnostics.Process/README.md
@@ -10,4 +10,4 @@ Documentation can be found at https://learn.microsoft.com/dotnet/api/system.diag
 See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-System.Diagnostics.Process+label%3A%22help+wanted%22) issues.
 
 ## Deployment
-`System.Diagnostics.Process` is included in the shared framework and also provided as a [NuGet package](https://www.nuget.org/packages/System.Diagnostics.Process).
+`System.Diagnostics.Process` is included in the shared framework. The package does not need to be installed into any project compatible with .NET Standard 2.0.


### PR DESCRIPTION
It should say that you shall not install a NuGet package if your TFM is Netstandard2.0 compatible.