### PR TITLE
Update NugetPackagingVersion to 6.2.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -175,7 +175,7 @@
     <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildTasksCoreVersion>
     <NugetProjectModelVersion>6.2.2</NugetProjectModelVersion>
-    <NugetPackagingVersion>6.2.1</NugetPackagingVersion>
+    <NugetPackagingVersion>6.2.2</NugetPackagingVersion>
     <!-- Testing -->
     <MicrosoftNETCoreCoreDisToolsVersion>1.1.0</MicrosoftNETCoreCoreDisToolsVersion>
     <MicrosoftNETTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>


### PR DESCRIPTION
To keep in sync with NugetProjectModelVersion and also because 6.2.1 was unlisted on nuget.org. Follow-up to https://github.com/dotnet/runtime/pull/77057
