### PR TITLE
Remove unnecessary % in ToFourDigitYear

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendarHelper.cs
@@ -533,8 +533,7 @@ namespace System.Globalization
 
             if (year < 100)
             {
-                int y = year % 100;
-                return (twoDigitYearMax / 100 - (y > twoDigitYearMax % 100 ? 1 : 0)) * 100 + y;
+                return (twoDigitYearMax / 100 - (year > twoDigitYearMax % 100 ? 1 : 0)) * 100 + year;
             }
 
             if (year < m_minYear || year > m_maxYear)
@@ -543,6 +542,7 @@ namespace System.Globalization
                             nameof(year),
                             SR.Format(SR.ArgumentOutOfRange_Range, m_minYear, m_maxYear));
             }
+
             // If the year value is above 100, just return the year value.  Don't have to do
             // the TwoDigitYearMax comparison.
             return year;


### PR DESCRIPTION
From previous checks we know year >= 0 && year < 100, so year % 100 == year.

Fixes https://github.com/dotnet/runtime/issues/78627