### PR TITLE
[release/7.0] Don't bind against non-shipping contract assemblies

### DIFF
--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -20,6 +20,17 @@
     <HasMatchingContract Condition="'$(HasMatchingContract)' == '' and Exists('$(ContractProject)')">true</HasMatchingContract>
     <!-- Disable API compat if the project doesn't have reference assembly -->
     <RunApiCompat Condition="'$(HasMatchingContract)' != 'true'">false</RunApiCompat>
+    <!-- Don't build against reference assemblies when projects are packable and the tfm is not the latest .NETCoreApp as
+         such reference assemblies don't ship to customers and only exist for tooling scenarios. -->
+    <AnnotateTargetPathWithContract Condition="'$(AnnotateTargetPathWithContract)' == '' and
+                                               '$(HasMatchingContract)' == 'true' and
+                                               (
+                                                '$(IsPackable)' != 'true' or
+                                                (
+                                                 '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                                                 '$(TargetFrameworkVersion)' == 'v$(NetCoreAppCurrentVersion)'
+                                                )
+                                               )">true</AnnotateTargetPathWithContract>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceAssemblyProject)' == 'true' or '$(IsPartialFacadeAssembly)' == 'true'">
@@ -36,7 +47,7 @@
 
   <!-- Allow P2Ps that target a source project to build against the corresponding ref project. -->
   <Target Name="AnnotateTargetPathWithTargetPlatformMonikerWithReferenceAssembly"
-          Condition="'$(HasMatchingContract)' == 'true'"
+          Condition="'$(AnnotateTargetPathWithContract)' == 'true'"
           DependsOnTargets="ResolveProjectReferences"
           AfterTargets="GetTargetPathWithTargetPlatformMoniker">
     <ItemGroup>

--- a/src/libraries/System.DirectoryServices/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.DirectoryServices/src/ILLink/ILLink.Suppressions.xml
@@ -5,7 +5,7 @@
       <argument>ILLink</argument>
       <argument>IL2050</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.DirectoryServices.Interop.UnsafeNativeMethods.ADsOpenObject(System.String,System.String,System.String,System.Int32,System.Guid@,System.Object@)</property>
+      <property name="Target">M:System.DirectoryServices.UnsafeNativeMethods.ADsOpenObject(System.String,System.String,System.String,System.Int32,System.Guid@,System.Object@)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsOptions.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsOptions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     internal enum AdsOptions
     {

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsPropertyOperation.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsPropertyOperation.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     internal enum AdsPropertyOperation
     {

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsSearchColumn.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsSearchColumn.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct AdsSearchColumn

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsSearchPreferenceInfo.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsSearchPreferenceInfo.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     [StructLayout(LayoutKind.Sequential)]
     internal struct AdsSearchPreferenceInfo

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsSearchPreferences.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsSearchPreferences.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     internal enum AdsSearchPreferences
     {

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsSortKey.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsSortKey.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     [StructLayout(LayoutKind.Sequential)]
     internal struct AdsSortKey

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsType.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsType.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     internal enum AdsType
     {

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsValue2.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsValue2.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     [StructLayout(LayoutKind.Sequential)]
     internal struct Ads_Pointer

--- a/src/libraries/System.DirectoryServices/src/Interop/AdsValueHelper2.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/AdsValueHelper2.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Globalization;
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     [StructLayout(LayoutKind.Sequential)]
     internal struct SystemTime

--- a/src/libraries/System.DirectoryServices/src/Interop/NativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/NativeMethods.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     internal static class NativeMethods
     {

--- a/src/libraries/System.DirectoryServices/src/Interop/SafeNativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/SafeNativeMethods.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Security;
 using System.Runtime.InteropServices;
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
     internal static partial class SafeNativeMethods
     {

--- a/src/libraries/System.DirectoryServices/src/Interop/UnsafeNativeMethods.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/UnsafeNativeMethods.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security;
 
-namespace System.DirectoryServices.Interop
+namespace System.DirectoryServices
 {
 
     [StructLayout(LayoutKind.Explicit)]

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DomainController.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DomainController.cs
@@ -410,7 +410,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 // Increment the RIDAvailablePool by 30k.
                 if (role == ActiveDirectoryRole.RidRole)
                 {
-                    System.DirectoryServices.Interop.UnsafeNativeMethods.IADsLargeInteger ridPool = (System.DirectoryServices.Interop.UnsafeNativeMethods.IADsLargeInteger)roleObjectEntry.Properties[PropertyManager.RIDAvailablePool].Value!;
+                    System.DirectoryServices.UnsafeNativeMethods.IADsLargeInteger ridPool = (System.DirectoryServices.UnsafeNativeMethods.IADsLargeInteger)roleObjectEntry.Properties[PropertyManager.RIDAvailablePool].Value!;
 
                     // check the overflow of the low part
                     if (ridPool.LowPart + UpdateRidPoolSeizureValue < ridPool.LowPart)

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/AuthenticationTypes.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/AuthenticationTypes.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.DirectoryServices.Interop;
-
 namespace System.DirectoryServices
 {
     /// <devdoc>

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntries.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntries.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.InteropServices;
 using System.Collections;
-using System.DirectoryServices.Interop;
 
 namespace System.DirectoryServices
 {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.InteropServices;
 using System.Diagnostics;
-using System.DirectoryServices.Interop;
 using System.ComponentModel;
 using System.Threading;
 using System.Reflection;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntryConfiguration.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntryConfiguration.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.DirectoryServices.Interop;
 using System.ComponentModel;
 
 namespace System.DirectoryServices

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
@@ -4,7 +4,6 @@
 using System.Runtime.InteropServices;
 using System.Collections;
 using System.Collections.Specialized;
-using System.DirectoryServices.Interop;
 using System.ComponentModel;
 
 using INTPTR_INTPTRCAST = System.IntPtr;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryServicesCOMException.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryServicesCOMException.cs
@@ -4,7 +4,6 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
-using System.DirectoryServices.Interop;
 
 namespace System.DirectoryServices
 {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/PropertyCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/PropertyCollection.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.InteropServices;
 using System.Collections;
-using System.DirectoryServices.Interop;
 using System.Globalization;
 
 namespace System.DirectoryServices

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/PropertyValueCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/PropertyValueCollection.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.DirectoryServices.Interop;
 
 namespace System.DirectoryServices
 {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SchemaNameCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SchemaNameCollection.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.DirectoryServices.Interop;
 
 namespace System.DirectoryServices
 {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SearchResultCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/SearchResultCollection.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Collections;
-using System.DirectoryServices.Interop;
 using System.Text;
 
 using INTPTR_INTPTRCAST = System.IntPtr;

--- a/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/CodeExporter.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/CodeExporter.cs
@@ -520,8 +520,8 @@ namespace System.Runtime.Serialization
             CodeAttributeDeclaration generatedCodeAttribute = new CodeAttributeDeclaration(typeof(GeneratedCodeAttribute).FullName!);
 
             AssemblyName assemblyName = Assembly.GetExecutingAssembly().GetName();
-            generatedCodeAttribute.Arguments.Add(new CodeAttributeArgument(new CodePrimitiveExpression(assemblyName.Name)));
-            generatedCodeAttribute.Arguments.Add(new CodeAttributeArgument(new CodePrimitiveExpression(assemblyName.Version?.ToString())));
+            generatedCodeAttribute.Arguments.Add(new CodeAttributeArgument(new CodePrimitiveExpression(assemblyName.Name!)));
+            generatedCodeAttribute.Arguments.Add(new CodeAttributeArgument(new CodePrimitiveExpression(assemblyName.Version?.ToString()!)));
 
             // System.Diagnostics.DebuggerStepThroughAttribute not allowed on enums
             // ensure that the attribute is only generated on types that are not enums
@@ -820,7 +820,7 @@ namespace System.Runtime.Serialization
             {
                 ContractCodeDomInfo baseContractCodeDomInfo = GetContractCodeDomInfo(classDataContract.BaseContract);
                 Debug.Assert(baseContractCodeDomInfo.IsProcessed, "Cannot generate code for type if code for base type has not been generated");
-                type.BaseTypes.Add(baseContractCodeDomInfo.TypeReference);
+                type.BaseTypes.Add(baseContractCodeDomInfo.TypeReference!);
                 AddBaseMemberNames(baseContractCodeDomInfo, contractCodeDomInfo);
                 if (baseContractCodeDomInfo.ReferencedTypeExists)
                 {
@@ -1153,7 +1153,7 @@ namespace System.Runtime.Serialization
             {
                 ContractCodeDomInfo baseContractCodeDomInfo = GetContractCodeDomInfo(classDataContract.BaseContract);
                 GenerateType(classDataContract.BaseContract, baseContractCodeDomInfo);
-                type.BaseTypes.Add(baseContractCodeDomInfo.TypeReference);
+                type.BaseTypes.Add(baseContractCodeDomInfo.TypeReference!);
                 if (baseContractCodeDomInfo.ReferencedTypeExists)
                 {
                     Type? actualType = (Type?)baseContractCodeDomInfo.TypeReference?.UserData[s_codeUserDataActualTypeKey];
@@ -1238,7 +1238,7 @@ namespace System.Runtime.Serialization
             Debug.Assert(contractCodeDomInfo.TypeDeclaration != null);
 
             CodeTypeDeclaration generatedType = contractCodeDomInfo.TypeDeclaration;
-            generatedType.BaseTypes.Add(baseTypeReference);
+            generatedType.BaseTypes.Add(baseTypeReference!);
             CodeAttributeDeclaration collectionContractAttribute = new CodeAttributeDeclaration(GetClrTypeFullName(typeof(CollectionDataContractAttribute)));
             collectionContractAttribute.Arguments.Add(new CodeAttributeArgument(ImportGlobals.NameProperty, new CodePrimitiveExpression(dataContractName)));
             collectionContractAttribute.Arguments.Add(new CodeAttributeArgument(ImportGlobals.NamespaceProperty, new CodePrimitiveExpression(collectionContract.XmlName.Namespace)));
@@ -1673,7 +1673,7 @@ namespace System.Runtime.Serialization
 
         private static CodePrimitiveExpression NullReference
         {
-            get { return new CodePrimitiveExpression(null); }
+            get { return new CodePrimitiveExpression(null!); }
         }
 
         private CodeParameterDeclarationExpression SerializationInfoParameter
@@ -1784,12 +1784,12 @@ namespace System.Runtime.Serialization
                         new CodeTypeReferenceExpression(GetCodeTypeReference(typeof(XmlSerializableServices))),
                         nameof(XmlSerializableServices.AddDefaultSchema),
                         new CodeArgumentReferenceExpression(paramDeclaration.Name),
-                        new CodeFieldReferenceExpression(null, TypeNameFieldName)
+                        new CodeFieldReferenceExpression(null!, TypeNameFieldName)
                     )
                 );
                 getSchemaStaticMethod.Statements.Add(
                     new CodeMethodReturnStatement(
-                        new CodeFieldReferenceExpression(null, TypeNameFieldName)
+                        new CodeFieldReferenceExpression(null!, TypeNameFieldName)
                     )
                 );
                 return getSchemaStaticMethod;


### PR DESCRIPTION
Tell-mode only change that is required to service OOB packages in runtime's release/7.0 branch.

Manual backport of c8503d39053f9e0d94716a23c406b66f126ca259
Fixes https://github.com/dotnet/runtime/issues/77988
Unblocks https://github.com/dotnet/runtime/pull/78532

Introduce the AnnotateTargetPathWithContract switch to make it configure-able when a source project should return the reference project's assembly instead of the source assembly, when other projects compile
against it. Set it so that reference assemblies are only returned for NetCoreAppCurrent tfms or when the project isn't packable.

- Fix System.DirectoryServices.AccountManagement build

System.DirectoryServices.AccountManagement now builds against src/System.DirectoryServices instead of ref/System.DirectoryServices (because the package doesn't contain the ref assembly).

Because of that, the compiler now gets confused because of the System.DirectoryServices.Interop namespace and the global Interop class. This happens even though the DirectoryServices.Interop namespace doesn't include any public types.

That results in the following errors:

```
src\libraries\System.DirectoryServices.AccountManagement\src\System\DirectoryServices\AccountManagement\AD\SidList.cs(50,26): error CS0246: The type or namespace name 'SID_AND_ATTRIBUTES' could not be found (are you missing a using directive or an assembly reference?)
src\libraries\System.DirectoryServices.AccountManagement\src\System\DirectoryServices\AccountManagement\interopt.cs(439,20): error CS0246: The type or namespace name 'UNICODE_INTPTR_STRING' could not be found (are you missing a using directive or an assembly reference?) This commit fixes that by removing the System.DirectoryServices.Interop namespace and moving the types into the parent namespace.
```

- Suppress nullable warnings in Serialization.Schema

Now that Schema compiles against the source assembly of System.CodeDom, it receives nullability errors. I'm suppressing them manually for now but am filing an issue to correctly fix those.

Related: https://github.com/dotnet/runtime/issues/78036