### PR TITLE
Remove char[] allocations from RegistryKey and List copy to Array

### DIFF
--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -791,16 +791,17 @@ namespace Microsoft.Win32
                 return Array.Empty<string>();
             }
 
-            List<string> names = new List<string>(subkeys);
-            Span<char> name = stackalloc char[MaxKeyLength + 1];
+            string[] names = new string[subkeys];
+            Span<char> nameSpan = stackalloc char[MaxKeyLength + 1];
 
             int result;
-            int nameLength = name.Length;
+            int nameLength = nameSpan.Length;
+            int cpt = 0;
 
             while ((result = Interop.Advapi32.RegEnumKeyEx(
                 _hkey,
-                names.Count,
-                ref MemoryMarshal.GetReference(name),
+                cpt,
+                ref MemoryMarshal.GetReference(nameSpan),
                 ref nameLength,
                 null,
                 null,
@@ -810,8 +811,14 @@ namespace Microsoft.Win32
                 switch (result)
                 {
                     case Interop.Errors.ERROR_SUCCESS:
-                        names.Add(new string(name.Slice(0, nameLength)));
-                        nameLength = name.Length;
+
+                        if (cpt >= names.Length) // possible new item during loop
+                        {
+                            Array.Resize(ref names, names.Length * 2);
+                        }
+
+                        names[cpt++] = new string(nameSpan.Slice(0, nameLength));
+                        nameLength = nameSpan.Length;
                         break;
                     default:
                         // Throw the error
@@ -820,7 +827,13 @@ namespace Microsoft.Win32
                 }
             }
 
-            return names.ToArray();
+            // Shrink array to fit found items, if necessary
+            if (cpt < names.Length)
+            {
+                Array.Resize(ref names, cpt);
+            }
+
+            return names;
         }
 
         /// <summary>Retrieves the count of values.</summary>

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -811,7 +811,6 @@ namespace Microsoft.Win32
                 switch (result)
                 {
                     case Interop.Errors.ERROR_SUCCESS:
-
                         if (cpt >= names.Length) // possible new item during loop
                         {
                             Array.Resize(ref names, names.Length * 2);
@@ -820,6 +819,7 @@ namespace Microsoft.Win32
                         names[cpt++] = new string(nameSpan.Slice(0, nameLength));
                         nameLength = nameSpan.Length;
                         break;
+
                     default:
                         // Throw the error
                         Win32Error(result, null);

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -784,7 +784,6 @@ namespace Microsoft.Win32
         /// <returns>All subkey names.</returns>
         public string[] GetSubKeyNames()
         {
-            EnsureNotDisposed();
             int subkeys = SubKeyCount;
 
             if (subkeys <= 0)
@@ -858,8 +857,6 @@ namespace Microsoft.Win32
         /// <returns>All value names.</returns>
         public unsafe string[] GetValueNames()
         {
-            EnsureNotDisposed();
-
             int values = ValueCount;
 
             if (values <= 0)


### PR DESCRIPTION
This is a rewrote of closed PR #78558 - because of the merge #77996.

Replace List by string[] to avoid List.ToArray() copy (it must handle rare cases where there are more or less elements during the loop).
Avoid redondant verification EnsureNotDisposed() already called by SubKeyCount & ValueCount.