### PR TITLE
Improve IndexOfAnyAsciiSearcher ARM throughput

### DIFF
--- a/src/libraries/System.Memory/tests/Span/IndexOfAny.byte.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAny.byte.cs
@@ -561,7 +561,6 @@ namespace System.SpanTests
             // There is some special handling we have to do for ASCII needles to properly filter out non-ASCII results
             ReadOnlySpan<byte> needleValues = needleContainsZero ? "AEIOU\0"u8 : "AEIOU!"u8;
             IndexOfAnyValues<byte> needle = IndexOfAnyValues.Create(needleValues);
-            Assert.Contains("Ascii", needle.GetType().Name);
 
             ReadOnlySpan<byte> repeatingHaystack = "AaAaAaAaAaAa"u8;
             Assert.Equal(0, repeatingHaystack.IndexOfAny(needle));

--- a/src/libraries/System.Memory/tests/Span/IndexOfAny.char.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAny.char.cs
@@ -807,7 +807,6 @@ namespace System.SpanTests
             // There is some special handling we have to do for ASCII needles to properly filter out non-ASCII results
             ReadOnlySpan<char> needleValues = needleContainsZero ? "AEIOU\0" : "AEIOU!";
             IndexOfAnyValues<char> needle = IndexOfAnyValues.Create(needleValues);
-            Assert.Contains("Ascii", needle.GetType().Name);
 
             ReadOnlySpan<char> repeatingHaystack = "AaAaAaAaAaAa";
             Assert.Equal(0, repeatingHaystack.IndexOfAny(needle));


### PR DESCRIPTION
Also solves an edge-case bug for byte overloads on ARM64 where we'd get false positives (negatives for Except) when haystack values were exactly 128 above a value in the needle.
Closes #78718

Before
|             Method | Length |       Needle |      Mean |     Error |
|------------------- |------- |------------- |----------:|----------:|
| IndexOfAny128_Char | 100000 | AlphaNumeric |  18.27 us |  0.035 us |
| IndexOfAny128_Byte | 100000 | AlphaNumeric |  11.37 us |  0.032 us |

After
|             Method | Length |       Needle |      Mean |     Error |
|------------------- |------- |------------- |----------:|----------:|
| IndexOfAny128_Char | 100000 | AlphaNumeric | 16.363 us | 0.3711 us |
| IndexOfAny128_Byte | 100000 | AlphaNumeric |  9.621 us | 0.0884 us |