### PR TITLE
Aging dependent handles

### DIFF
--- a/src/coreclr/gc/handletablescan.cpp
+++ b/src/coreclr/gc/handletablescan.cpp
@@ -844,7 +844,7 @@ void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sca
                         _UNCHECKED_OBJECTREF pSecondary = pUserDataBlock[handleIndexInBlock];
                         if (pSecondary)
                         {
-                            int secondaryAge = g_theGCHeap->WhichGeneration(pSecondary);
+                            int secondaryAge = GetConvertedGeneration(pSecondary);
                             if (minAge > secondaryAge)
                                 minAge = secondaryAge;
                         }

--- a/src/coreclr/gc/objecthandle.cpp
+++ b/src/coreclr/gc/objecthandle.cpp
@@ -1815,6 +1815,7 @@ void Ref_AgeHandles(uint32_t condemned, uint32_t maxgen, ScanContext* sc)
 #ifdef FEATURE_VARIABLE_HANDLES
         HNDTYPE_VARIABLE,
 #endif
+        HNDTYPE_DEPENDENT,
 #ifdef FEATURE_REFCOUNTED_HANDLES
         HNDTYPE_REFCOUNTED,
 #endif
@@ -1868,13 +1869,13 @@ void Ref_RejuvenateHandles(uint32_t condemned, uint32_t maxgen, ScanContext* sc)
         HNDTYPE_WEAK_SHORT,
         HNDTYPE_WEAK_LONG,
 
-
         HNDTYPE_STRONG,
 
         HNDTYPE_PINNED,
 #ifdef FEATURE_VARIABLE_HANDLES
         HNDTYPE_VARIABLE,
 #endif
+        HNDTYPE_DEPENDENT,
 #ifdef FEATURE_REFCOUNTED_HANDLES
         HNDTYPE_REFCOUNTED,
 #endif


### PR DESCRIPTION
We do not age dependent handles like all other kinds of handles. As a result dependent handles stay in Gen 0 and get visited on every GC. That is unnecessary work when dependent handles refer to tenured objects, which is a common case.

This change enables aging of dependent handles (and rejuvenation, when needed).
