### PR TITLE
Implement Equals & GetHashCode for LingerOption - fix Socket outerloop tests

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/LingerOption.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/LingerOption.cs
@@ -41,5 +41,12 @@ namespace System.Net.Sockets
                 _lingerTime = value;
             }
         }
+
+        public override bool Equals(object? comparand)
+        {
+            return comparand is LingerOption option && option.Enabled == _enabled && option.LingerTime == _lingerTime;
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
     }
 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/LingerOption.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/LingerOption.cs
@@ -47,6 +47,6 @@ namespace System.Net.Sockets
             return comparand is LingerOption option && option.Enabled == _enabled && option.LingerTime == _lingerTime;
         }
 
-        public override int GetHashCode() => base.GetHashCode();
+        public override int GetHashCode() => HashCode.Combine(_enabled, _lingerTime);
     }
 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -283,9 +283,17 @@ namespace System.Net.Sockets
             // Try to detect if a property gets added that we're not copying correctly.
             foreach (PropertyInfo pi in typeof(Socket).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
             {
-                object? origValue = pi.GetValue(source);
-                object? cloneValue = pi.GetValue(this);
-                Debug.Assert(Equals(origValue, cloneValue), $"{pi.Name}. Expected: {origValue}, Actual: {cloneValue}");
+                try
+                {
+                    object? origValue = pi.GetValue(source);
+                    object? cloneValue = pi.GetValue(this);
+
+                    Debug.Assert(Equals(origValue, cloneValue), $"{pi.Name}. Expected: {origValue}, Actual: {cloneValue}");
+                }
+                catch (TargetInvocationException ex) when (ex.InnerException is SocketException se && se.SocketErrorCode == SocketError.OperationNotSupported)
+                {
+                    // macOS fails to retrieve DontFragment and MulticastLoopback at the moment
+                }
             }
 #endif
             return this;


### PR DESCRIPTION
This is regression from https://github.com/dotnet/runtime/pull/74645 & https://github.com/dotnet/runtime/pull/73499
On Linux and macOS the test fail on Debug Assert 
```
     System.Net.Sockets.Tests.DualModeConnectToDnsEndPoint.DualModeConnect_DnsEndPointToHost_Helper [SKIP]
        Condition(s) not met: "LocalhostIsBothIPv4AndIPv6"
  Process terminated. Assertion failed.
  LingerState. Expected: System.Net.Sockets.LingerOption, Actual: System.Net.Sockets.LingerOption
     at System.Net.Sockets.Socket.CopyStateFromSource(Socket source) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs:line 288
     at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationAccept(SocketAddress remoteSocketAddress) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs:line 348
     at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationSyncSuccess(Int32 bytesTransferred, SocketFlags flags) in /home/furt/github/wfurt-
```

macOS additionally fails with exception as some of the gutters are not supported
```
     System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Supported_Success [SKIP]
        Condition(s) not met: "SupportsRawSockets"
  Unhandled exception. Unhandled exception. System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
   ---> System.Net.Sockets.SocketException (45): Operation not supported
     at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, Boolean disconnectOnFailure, String callerName) in /Users/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs:line 3660
     at System.Net.Sockets.Socket.UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, String callerName) in /Users/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs:line 3651
     at System.Net.Sockets.Socket.GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName) in /Users/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs:line 2024
     at System.Net.Sockets.Socket.get_DontFragment() in /Users/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs:line 642
     at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
     at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr) in /Users/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvoker.cs:line 59
     --- End of inner exception stack trace ---
```

with this I can run tests with `/p:outerloop=true` once again on Unix