### PR TITLE
Place dispatch cells in dehydrated section

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -10,7 +10,7 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public class InterfaceDispatchCellNode : EmbeddedObjectNode, ISymbolDefinitionNode
+    public sealed class InterfaceDispatchCellNode : EmbeddedObjectNode, ISymbolDefinitionNode
     {
         private readonly MethodDesc _targetMethod;
         private readonly string _callSiteIdentifier;
@@ -111,11 +111,6 @@ namespace ILCompiler.DependencyAnalysis
                 // 32 bits on targets whose pointer size is 64 bit.
                 objData.EmitInt(0);
             }
-        }
-
-        protected override void OnMarked(NodeFactory factory)
-        {
-            factory.InterfaceDispatchCellSection.AddEmbeddedObject(this);
         }
 
         public override int ClassCode => -2023802120;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellSectionNode.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -14,17 +14,15 @@ namespace ILCompiler.DependencyAnalysis
     /// Represents a section of the executable where interface dispatch cells and their slot information
     /// is stored.
     /// </summary>
-    public class InterfaceDispatchCellSectionNode : ArrayOfEmbeddedDataNode<InterfaceDispatchCellNode>
+    public class InterfaceDispatchCellSectionNode : DehydratableObjectNode, ISymbolDefinitionNode
     {
-        public InterfaceDispatchCellSectionNode(NodeFactory factory)
-            : base("__InterfaceDispatchCellSection_Start", "__InterfaceDispatchCellSection_End", new DispatchCellComparer(factory))
-        {
-        }
-
-        protected override void GetElementDataForNodes(ref ObjectDataBuilder builder, NodeFactory factory, bool relocsOnly)
+        protected override ObjectData GetDehydratableData(NodeFactory factory, bool relocsOnly)
         {
             if (relocsOnly)
-                return;
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, Array.Empty<ISymbolDefinitionNode>());
+
+            var builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.AddSymbol(this);
 
             // The interface dispatch cell has an alignment requirement of 2 * [Pointer size] as part of the
             // synchronization mechanism of the two values in the runtime.
@@ -48,7 +46,7 @@ namespace ILCompiler.DependencyAnalysis
             //
             int runLength = 0;
             int currentSlot = NoSlot;
-            foreach (InterfaceDispatchCellNode node in NodesList)
+            foreach (InterfaceDispatchCellNode node in new SortedSet<InterfaceDispatchCellNode>(factory.MetadataManager.GetInterfaceDispatchCells(), new DispatchCellComparer(factory)))
             {
                 MethodDesc targetMethod = node.TargetMethod;
                 int targetSlot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod, targetMethod.OwningType);
@@ -83,9 +81,22 @@ namespace ILCompiler.DependencyAnalysis
                 builder.EmitZeroPointer();
                 builder.EmitNaturalInt(currentSlot);
             }
+
+            return builder.ToObjectData();
         }
 
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+            => sb.Append(nameMangler.CompilationUnitPrefix).Append("__InterfaceDispatchCellSection_Start");
+        protected override ObjectNodeSection GetDehydratedSection(NodeFactory factory) => ObjectNodeSection.DataSection;
+        protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
         public override int ClassCode => -1389343;
+
+        public int Offset => 0;
+
+        public override bool IsShareable => false;
+
+        public override bool StaticDependenciesAreComputed => true;
 
         /// <summary>
         /// Comparer that groups interface dispatch cells by their slot number.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -50,7 +50,6 @@ namespace ILCompiler.DependencyAnalysis
             MetadataManager = metadataManager;
             LazyGenericsPolicy = lazyGenericsPolicy;
             _importedNodeProvider = importedNodeProvider;
-            InterfaceDispatchCellSection = new InterfaceDispatchCellSectionNode(this);
             PreinitializationManager = preinitializationManager;
         }
 
@@ -1129,7 +1128,7 @@ namespace ILCompiler.DependencyAnalysis
 
         internal ModuleInitializerListNode ModuleInitializerList = new ModuleInitializerListNode();
 
-        public InterfaceDispatchCellSectionNode InterfaceDispatchCellSection { get; }
+        public InterfaceDispatchCellSectionNode InterfaceDispatchCellSection = new InterfaceDispatchCellSectionNode();
 
         public ReadyToRunHeaderNode ReadyToRunHeader;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -49,6 +49,7 @@ namespace ILCompiler
         protected readonly ManifestResourceBlockingPolicy _resourceBlockingPolicy;
         protected readonly DynamicInvokeThunkGenerationPolicy _dynamicInvokeThunkGenerationPolicy;
 
+        private readonly List<InterfaceDispatchCellNode> _interfaceDispatchCells = new List<InterfaceDispatchCellNode>();
         private readonly SortedSet<NonGCStaticsNode> _cctorContextsGenerated = new SortedSet<NonGCStaticsNode>(CompilerComparer.Instance);
         private readonly SortedSet<TypeDesc> _typesWithEETypesGenerated = new SortedSet<TypeDesc>(TypeSystemComparer.Instance);
         private readonly SortedSet<TypeDesc> _typesWithConstructedEETypesGenerated = new SortedSet<TypeDesc>(TypeSystemComparer.Instance);
@@ -256,6 +257,11 @@ namespace ILCompiler
 
                 if (dictionaryNode.OwningEntity is MethodDesc method && AllMethodsCanBeReflectable)
                     _reflectableMethods.Add(method);
+            }
+
+            if (obj is InterfaceDispatchCellNode dispatchCell)
+            {
+                _interfaceDispatchCells.Add(dispatchCell);
             }
 
             if (obj is StructMarshallingDataNode structMarshallingDataNode)
@@ -652,6 +658,11 @@ namespace ILCompiler
         {
             EnsureMetadataGenerated(factory);
             return _stackTraceMappings;
+        }
+
+        internal IEnumerable<InterfaceDispatchCellNode> GetInterfaceDispatchCells()
+        {
+            return _interfaceDispatchCells;
         }
 
         internal IEnumerable<NonGCStaticsNode> GetCctorContextMapping()


### PR DESCRIPTION
Similar to #78688 - changing the base type of the node to allow dehydration and keep track of dispatch cells in the metadata manager.

Saves ~0.2% on Hello World on Windows, likely closer to 1% on Linux because this is a full pointer reloc.

This required a small change in the dehydration logic since now we have relocs with deltas - references to symbols that are offset by some number of bytes.

Relocs with deltas are represented with the inline reloc format. I tried to extend the "popular symbol lookup table" to allow referencing things with deltas, but it didn't bring a meaningful improvement so not including that part. It might bring more meaningful savings if we find a way to get rid of the delta:

https://github.com/dotnet/runtime/blob/722745e84adc199ead013b97ca3fa0c4e3802bb9/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs#L103-L104

Cc @dotnet/ilc-contrib 