### PR TITLE
[wasm] Add warning code to all warnings produced in WasmAppBuilder

### DIFF
--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -244,7 +244,7 @@ namespace Microsoft.WebAssembly.Build.Tasks
             }
         }
 
-        private bool ShouldCompile(string srcFile, string objFile, string[] depFiles, out string reason)
+        private static bool ShouldCompile(string srcFile, string objFile, string[] depFiles, out string reason)
         {
             if (!File.Exists(srcFile))
                 throw new LogAsErrorException($"Could not find source file {srcFile}");

--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -271,8 +271,7 @@ namespace Microsoft.WebAssembly.Build.Tasks
             {
                 if (!File.Exists(inFile))
                 {
-                    reason = $"Could not find dependency file {inFile} needed for compiling {srcFile} to {outFile}";
-                    Log.LogWarning(reason);
+                    reason = $"the dependency file {inFile} needed for compiling {srcFile} to {outFile} could not be found.";
                     return true;
                 }
 

--- a/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
@@ -204,7 +204,7 @@ internal sealed class IcallTableGenerator
                 }
                 catch (NotImplementedException nie)
                 {
-                    Log.LogWarning($"Failed to generate icall function for method '[{method.DeclaringType!.Assembly.GetName().Name}] {className}::{method.Name}'" +
+                    Log.LogWarning(null, "WASM0001", "", "", 0, 0, 0, 0, $"Failed to generate icall function for method '[{method.DeclaringType!.Assembly.GetName().Name}] {className}::{method.Name}'" +
                                     $" because type '{nie.Message}' is not supported for parameter named '{par.Name}'. Ignoring.");
                     return null;
                 }

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -210,7 +210,7 @@ internal sealed class PInvokeTableGenerator
                 string imports = string.Join(Environment.NewLine,
                                             candidates.Select(
                                                 p => $"    {p.Method} (in [{p.Method.DeclaringType?.Assembly.GetName().Name}] {p.Method.DeclaringType})"));
-                Log.LogWarning($"Found a native function ({first.EntryPoint}) with varargs in {first.Module}." +
+                Log.LogWarning(null, "WASM0001", "", "", 0, 0, 0, 0, $"Found a native function ({first.EntryPoint}) with varargs in {first.Module}." +
                                  " Calling such functions is not supported, and will fail at runtime." +
                                 $" Managed DllImports: {Environment.NewLine}{imports}");
 

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -253,7 +253,7 @@ public class WasmAppBuilder : Task
                 string fullPath = assembly.GetMetadata("Identity");
                 if (string.IsNullOrEmpty(culture))
                 {
-                    Log.LogWarning($"Missing CultureName metadata for satellite assembly {fullPath}");
+                    Log.LogWarning(null, "WASM0002", "", "", 0, 0, 0, 0, $"Missing CultureName metadata for satellite assembly {fullPath}");
                     continue;
                 }
                 // FIXME: validate the culture?
@@ -290,7 +290,7 @@ public class WasmAppBuilder : Task
 
                     if (firstPath == secondPath)
                     {
-                        Log.LogWarning($"Found identical vfs mappings for target path: {targetPath}, source file: {firstPath}. Ignoring.");
+                        Log.LogWarning(null, "WASM0003", "", "", 0, 0, 0, 0, $"Found identical vfs mappings for target path: {targetPath}, source file: {firstPath}. Ignoring.");
                         continue;
                     }
 

--- a/src/tasks/WasmAppBuilder/WasmLoadAssembliesAndReferences.cs
+++ b/src/tasks/WasmAppBuilder/WasmLoadAssembliesAndReferences.cs
@@ -76,7 +76,7 @@ public class WasmLoadAssembliesAndReferences : Task
             {
                 if (SkipMissingAssemblies)
                 {
-                    Log.LogWarning($"Loading assembly reference '{aname}' for '{assembly.GetName()}' failed: {ex.Message} Skipping.");
+                    Log.LogWarning(null, "WASM0004", "", "", 0, 0, 0, 0, $"Loading assembly reference '{aname}' for '{assembly.GetName()}' failed: {ex.Message} Skipping.");
                 }
                 else
                 {


### PR DESCRIPTION
- `WASM0001` - All PInvoke related warnings
- `WASM0002` - Missing CultureName metadata for satellite assembly
- `WASM0003` - Found identical vfs mappings for target path
- `WASM0004` - Loading assembly reference '..' for '..' failed

Fixes https://github.com/dotnet/runtime/issues/78690