### PR TITLE
[release/7.0] Tar: Remove invalidation of whitespace in PAX extended attributes

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -725,12 +725,6 @@ namespace System.Formats.Tar
             }
             line = line.Slice(spacePos + 1).TrimStart((byte)' ');
 
-            // If there are any more spaces, it's malformed.
-            if (line.IndexOf((byte)' ') >= 0)
-            {
-                return false;
-            }
-
             // Find the equal separator.
             int equalPos = line.IndexOf((byte)'=');
             if (equalPos < 0)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -723,7 +723,7 @@ namespace System.Formats.Tar
             {
                 return false;
             }
-            line = line.Slice(spacePos + 1).TrimStart((byte)' ');
+            line = line.Slice(spacePos + 1);
 
             // Find the equal separator.
             int equalPos = line.IndexOf((byte)'=');

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -219,5 +219,32 @@ namespace System.Formats.Tar.Tests
 
             Assert.Equal(2, Directory.GetFileSystemEntries(destination.Path, "*", SearchOption.AllDirectories).Count());
         }
+
+        [Fact]
+        public async Task PaxNameCollision_DedupInExtendedAttributesAsync()
+        {
+            using TempDirectory root = new();
+
+            string sharedRootFolders = Path.Join(root.Path, "folder with spaces", new string('a', 100));
+            string path1 = Path.Join(sharedRootFolders, "entry 1 with spaces.txt");
+            string path2 = Path.Join(sharedRootFolders, "entry 2 with spaces.txt");
+
+            await using MemoryStream stream = new();
+            await using (TarWriter writer = new(stream, TarEntryFormat.Pax, leaveOpen: true))
+            {
+                // Paths don't fit in the standard 'name' field, but they differ in the filename,
+                // which is fully stored as an extended attribute
+                PaxTarEntry entry1 = new(TarEntryType.RegularFile, path1);
+                await writer.WriteEntryAsync(entry1);
+                PaxTarEntry entry2 = new(TarEntryType.RegularFile, path2);
+                await writer.WriteEntryAsync(entry2);
+            }
+            stream.Position = 0;
+
+            await TarFile.ExtractToDirectoryAsync(stream, root.Path, overwriteFiles: true);
+
+            Assert.True(File.Exists(path1));
+            Assert.True(Path.Exists(path2));
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.GlobalExtendedAttributes.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.GlobalExtendedAttributes.Tests.cs
@@ -85,8 +85,10 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [InlineData("key", "value")]
-        [InlineData("key     ", "   value    ")]
-        [InlineData("      key     ", "   value    ")]
+        [InlineData("key    ", "value    ")]
+        [InlineData("    key", "    value")]
+        [InlineData("    key   ", "    value    ")]
+        [InlineData("    key spaced   ", "    value spaced    ")]
         [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
         public void GlobalExtendedAttribute_Roundtrips(string key, string value)
         {
@@ -101,7 +103,7 @@ namespace System.Formats.Tar.Tests
             {
                 PaxGlobalExtendedAttributesTarEntry entry = Assert.IsType<PaxGlobalExtendedAttributesTarEntry>(reader.GetNextEntry());
                 Assert.Equal(1, entry.GlobalExtendedAttributes.Count);
-                Assert.Equal(KeyValuePair.Create(key.TrimStart(), value), entry.GlobalExtendedAttributes.First());
+                Assert.Equal(KeyValuePair.Create(key, value), entry.GlobalExtendedAttributes.First());
             }
         }
     }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -327,8 +327,10 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [InlineData("key", "value")]
-        [InlineData("key     ", "   value    ")]
-        [InlineData("      key     ", "   value    ")]
+        [InlineData("key    ", "value    ")]
+        [InlineData("    key", "    value")]
+        [InlineData("    key   ", "    value    ")]
+        [InlineData("    key spaced   ", "    value spaced    ")]
         [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
         public void PaxExtendedAttribute_Roundtrips(string key, string value)
         {
@@ -343,7 +345,7 @@ namespace System.Formats.Tar.Tests
             {
                 PaxTarEntry entry = Assert.IsType<PaxTarEntry>(reader.GetNextEntry());
                 Assert.Equal(5, entry.ExtendedAttributes.Count);
-                Assert.Contains(KeyValuePair.Create(key.TrimStart(), value), entry.ExtendedAttributes);
+                Assert.Contains(KeyValuePair.Create(key, value), entry.ExtendedAttributes);
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -325,6 +325,28 @@ namespace System.Formats.Tar.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => reader.GetNextEntry());
         }
 
+        [Theory]
+        [InlineData("key", "value")]
+        [InlineData("key     ", "   value    ")]
+        [InlineData("      key     ", "   value    ")]
+        [InlineData("many sla/s\\hes", "/////////////\\\\\\///////////")]
+        public void PaxExtendedAttribute_Roundtrips(string key, string value)
+        {
+            var stream = new MemoryStream();
+            using (var writer = new TarWriter(stream, leaveOpen: true))
+            {
+                writer.WriteEntry(new PaxTarEntry(TarEntryType.Directory, "entryName", new Dictionary<string, string>() { { key, value } }));
+            }
+
+            stream.Position = 0;
+            using (var reader = new TarReader(stream))
+            {
+                PaxTarEntry entry = Assert.IsType<PaxTarEntry>(reader.GetNextEntry());
+                Assert.Equal(5, entry.ExtendedAttributes.Count);
+                Assert.Contains(KeyValuePair.Create(key.TrimStart(), value), entry.ExtendedAttributes);
+            }
+        }
+
         private static void VerifyDataStreamOfTarUncompressedInternal(string testFolderName, string testCaseName, bool copyData)
         {
             using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, testFolderName, testCaseName);


### PR DESCRIPTION
Manual backport of #78465, #78707 and #78744 to `release/7.0`.

## Customer Impact

A customer reported #78456, in which they described that when a PAX entry in a tar archive contained extended attributes with whitespace characters, these characters would get treated as the end of the key or value, or would get trimmed.

The bug surfaced when extracting an archive that contained entries with filenames longer than what could fit in the standard `name` metadata field. In these cases, the expected behavior is to have the full path name added to the extended attributes dictionary as the value of the `path` key, and the standard `name` field is ignored.

But when the path contains spaces, we were considering the space as the ending character of the value. If two entries with very long paths get truncated in the same space, then when we extracted them, the file path would be the same, causing our `TarFile` extraction methods to think we had an existing file in disk, and we would throw.

The fix consisted in removing the logic that ignored or trimmed the whitespace in the middle of the path. We already know how long the key or the value in the dictionary is supposed to be, so there's no need to truncate.

Also, the Tar specs did not explicitly specify that spaces should be disallowed in keys or values, so we are providing more usage flexibility to users.

## Testing

Added unit tests to verify:

- Roundtrip: Adding keys or values with whitespaces to pax entries, then writing them to a tar archive, then reading that archive back, and verifying the entries did not get their extended attributes trimmed or truncated.
- Customer scenario: Added tests that verified the exact problem the customer reported with really long paths that contained spaces, to ensure we were not truncating or trimming the path, and the two files were not considered collisions.

## Risk

Low. This is a bug in a new feature in 7.0, and we are removing logic that is not explicitly indicated in the Tar spec.