### PR TITLE
Remove pointer relocs from GC statics

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -206,13 +206,6 @@ namespace ILCompiler.DependencyAnalysis
                 }
             });
 
-            _GCStaticsPreInitDataNodes = new NodeCache<MetadataType, GCStaticsPreInitDataNode>((MetadataType type) =>
-            {
-                ISymbolNode gcStaticsNode = TypeGCStaticsSymbol(type);
-                Debug.Assert(gcStaticsNode is GCStaticsNode);
-                return ((GCStaticsNode)gcStaticsNode).NewPreInitDataNode();
-            });
-
             _GCStaticIndirectionNodes = new NodeCache<MetadataType, EmbeddedObjectNode>((MetadataType type) =>
             {
                 ISymbolNode gcStaticsNode = TypeGCStaticsSymbol(type);
@@ -625,13 +618,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(!TypeCannotHaveEEType(type));
             return _GCStatics.GetOrAdd(type);
-        }
-
-        private NodeCache<MetadataType, GCStaticsPreInitDataNode> _GCStaticsPreInitDataNodes;
-
-        public GCStaticsPreInitDataNode GCStaticsPreInitDataNode(MetadataType type)
-        {
-            return _GCStaticsPreInitDataNodes.GetOrAdd(type);
         }
 
         private NodeCache<MetadataType, EmbeddedObjectNode> _GCStaticIndirectionNodes;


### PR DESCRIPTION
For every type with a GC static base (i.e. something with static fields that contain references to the GC heap) we are generating a small data structure that has up to two pointers in it:

* The first pointer points to a fake `MethodTable` that is used to allocate the static base on the GC heap (and assists in reporting GC pointers within that data).
* The second pointer potentially points to data that was generated when interpreting the `.cctor` and gets memcopied to the GC static base at startup

These pointers can be relative pointers, so I'm doing that. Saves about 2 kB on a hello world on Windows. The savings will be closer to 0.5% on Linux due to getting rid of the full pointers (each costs extra 24 bytes on Linux).

Cc @dotnet/ilc-contrib 