### PR TITLE
Convert pointers in a couple tables to relative

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -132,7 +132,7 @@ namespace Internal.Runtime.CompilerHelpers
             IntPtr staticsSection = RuntimeImports.RhGetModuleSection(typeManager, ReadyToRunSectionType.GCStaticRegion, out length);
             if (staticsSection != IntPtr.Zero)
             {
-                Debug.Assert(length % IntPtr.Size == 0);
+                Debug.Assert(length % (MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint)) == 0);
 
                 object[] spine = InitializeStatics(staticsSection, length);
 
@@ -170,31 +170,39 @@ namespace Internal.Runtime.CompilerHelpers
 
         private static unsafe void RunInitializers(TypeManagerHandle typeManager, ReadyToRunSectionType section)
         {
-            var initializers = (delegate*<void>*)RuntimeImports.RhGetModuleSection(typeManager, section, out int length);
-            Debug.Assert(length % IntPtr.Size == 0);
-            int count = length / IntPtr.Size;
-            for (int i = 0; i < count; i++)
+            var pInitializers = (byte*)RuntimeImports.RhGetModuleSection(typeManager, section, out int length);
+            Debug.Assert(length % (MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint)) == 0);
+
+            for (byte* pCurrent = pInitializers;
+                pCurrent < (pInitializers + length);
+                pCurrent += MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint))
             {
-                initializers[i]();
+                var initializer = MethodTable.SupportsRelativePointers ? (delegate*<void>)ReadRelPtr32(pCurrent) : (delegate*<void>)pCurrent;
+                initializer();
             }
+
+            static void* ReadRelPtr32(void* address)
+                => (byte*)address + *(int*)address;
         }
 
         private static unsafe object[] InitializeStatics(IntPtr gcStaticRegionStart, int length)
         {
-            IntPtr gcStaticRegionEnd = (IntPtr)((byte*)gcStaticRegionStart + length);
+            byte* gcStaticRegionEnd = (byte*)gcStaticRegionStart + length;
 
-            object[] spine = new object[length / IntPtr.Size];
+            object[] spine = new object[length / (MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint))];
 
             ref object rawSpineData = ref Unsafe.As<byte, object>(ref Unsafe.As<RawArrayData>(spine).Data);
 
             int currentBase = 0;
-            for (IntPtr** block = (IntPtr**)gcStaticRegionStart; block < (IntPtr**)gcStaticRegionEnd; block++)
+            for (byte* block = (byte*)gcStaticRegionStart;
+                block < gcStaticRegionEnd;
+                block += MethodTable.SupportsRelativePointers ? sizeof(int) : sizeof(nint))
             {
                 // Gc Static regions can be shared by modules linked together during compilation. To ensure each
                 // is initialized once, the static region pointer is stored with lowest bit set in the image.
                 // The first time we initialize the static region its pointer is replaced with an object reference
                 // whose lowest bit is no longer set.
-                IntPtr* pBlock = *block;
+                IntPtr* pBlock = MethodTable.SupportsRelativePointers ? (IntPtr*)ReadRelPtr32(block) : *(IntPtr**)block;
                 nint blockAddr = MethodTable.SupportsRelativePointers ? (nint)ReadRelPtr32(pBlock) : *pBlock;
                 if ((blockAddr & GCStaticRegionConstants.Uninitialized) == GCStaticRegionConstants.Uninitialized)
                 {

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -902,7 +902,10 @@ namespace Internal.Runtime
                         return DynamicTemplateType->DispatchMap;
                 }
 
-                return ((DispatchMap**)TypeManager.DispatchMap)[idxDispatchMap];
+                if (SupportsRelativePointers)
+                    return (DispatchMap*)FollowRelativePointer((int*)TypeManager.DispatchMap + idxDispatchMap);
+                else
+                    return ((DispatchMap**)TypeManager.DispatchMap)[idxDispatchMap];
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EmbeddedPointerIndirectionNode.cs
@@ -30,8 +30,16 @@ namespace ILCompiler.DependencyAnalysis
 
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
-            dataBuilder.RequireInitialPointerAlignment();
-            dataBuilder.EmitPointerReloc(Target);
+            if (factory.Target.SupportsRelativePointers)
+            {
+                dataBuilder.RequireInitialAlignment(sizeof(int));
+                dataBuilder.EmitReloc(Target, RelocType.IMAGE_REL_BASED_RELPTR32);
+            }
+            else
+            {
+                dataBuilder.RequireInitialPointerAlignment();
+                dataBuilder.EmitPointerReloc(Target);
+            }
         }
 
         // At minimum, Target needs to be reported as a static dependency by inheritors.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ModuleInitializerListNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ModuleInitializerListNode.cs
@@ -141,7 +141,11 @@ namespace ILCompiler.DependencyAnalysis
 
             foreach (var module in sortedModules)
             {
-                builder.EmitPointerReloc(factory.MethodEntrypoint(module.GetGlobalModuleType().GetStaticConstructor()));
+                IMethodNode entrypoint = factory.MethodEntrypoint(module.GetGlobalModuleType().GetStaticConstructor());
+                if (factory.Target.SupportsRelativePointers)
+                    builder.EmitReloc(entrypoint, RelocType.IMAGE_REL_BASED_RELPTR32);
+                else
+                    builder.EmitPointerReloc(entrypoint);
             }
 
             var result = builder.ToObjectData();


### PR DESCRIPTION
`EmbeddedPointerIndirection` is used in:

* Array of pointers to dispatch maps
* Array of pointers to GC static infos
* Array of pointers to eager constructors

I'm also updating array of module initializers emission since the code to interpret this table at runtime is the same as eager constructors.

I'd guess this saves another ~1% on Linux. I didn't measure Windows this time. There will a couple kilobytes of savings for hello world on Windows for sure.

Cc @dotnet/ilc-contrib 