### PR TITLE
[mono][tests] Fix FullAOT DivToMul test

### DIFF
--- a/src/tests/JIT/opt/InstructionCombining/DivToMul.cs
+++ b/src/tests/JIT/opt/InstructionCombining/DivToMul.cs
@@ -160,6 +160,13 @@ public class Program
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void AssertEquals(float expected, float actual)
     {
+        if (Single.IsNaN(expected) && Single.IsNaN(actual))
+        {
+            // There can be multiple configurations for NaN values
+            // verifying that this values are NaNs should be enough
+            return;
+        }
+
         int expectedi = BitConverter.SingleToInt32Bits(expected);
         int actuali = BitConverter.SingleToInt32Bits(actual);
         if (expectedi != actuali)
@@ -172,6 +179,13 @@ public class Program
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void AssertEquals(double expected, double actual)
     {
+        if (Double.IsNaN(expected) && Double.IsNaN(actual))
+        {
+            // There can be multiple configurations for NaN values
+            // verifying that this values are NaNs should be enough
+            return;
+        }
+
         long expectedi = BitConverter.DoubleToInt64Bits(expected);
         long actuali = BitConverter.DoubleToInt64Bits(actual);
         if (expectedi != actuali)

--- a/src/tests/JIT/opt/InstructionCombining/DivToMul.cs
+++ b/src/tests/JIT/opt/InstructionCombining/DivToMul.cs
@@ -163,7 +163,7 @@ public class Program
         if (Single.IsNaN(expected) && Single.IsNaN(actual))
         {
             // There can be multiple configurations for NaN values
-            // verifying that this values are NaNs should be enough
+            // verifying that these values are NaNs should be enough
             return;
         }
 
@@ -182,7 +182,7 @@ public class Program
         if (Double.IsNaN(expected) && Double.IsNaN(actual))
         {
             // There can be multiple configurations for NaN values
-            // verifying that this values are NaNs should be enough
+            // verifying that these values are NaNs should be enough
             return;
         }
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1408,9 +1408,6 @@
             <Issue>Crashes during LLVM AOT compilation.</Issue>
         </ExcludeList>
 
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/InstructionCombining/DivToMul/**">
-            <Issue>Doesn't pass after LLVM AOT compilation.</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/StructABI/StructABI/**">
             <Issue>Doesn't pass after LLVM AOT compilation.</Issue>
         </ExcludeList>


### PR DESCRIPTION
LLVM is optimizing divisions by -1 so that a neg operation is executed instead of a div operation.
When using NaN values, neg operation is returning a different bit configuration for NaN compared to the one returned by div. 
This change is verifying that the arguments are valid NaNs, it doesn't affect the test's purpose.