### PR TITLE
Disable CG on Linux musl installer jobs too

### DIFF
--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -75,6 +75,11 @@ jobs:
     crossBuild: ${{ parameters.crossBuild }}
 
     gatherAssetManifests: true
+
+    # Component governance does not work on musl machines
+    ${{ if eq(parameters.osSubGroup, '_musl') }}:
+      disableComponentGovernance: true
+
     variables:
     - ${{ each variable in parameters.variables }}:
       - ${{ variable }}


### PR DESCRIPTION
We already had the same in eng/pipelines/common/templates/runtimes/xplat-job.yml and eng/pipelines/libraries/base-job.yml, it was just missing from the installer jobs.

It fixes a warning on the Linux musl installer job:
<img width="746" alt="image" src="https://user-images.githubusercontent.com/1376924/203826702-dc9eed81-0f1e-421a-92a1-2b8496417b33.png">
