### PR TITLE
Make DependencyGraphViewer a WinExe

### DIFF
--- a/src/coreclr/tools/aot/DependencyGraphViewer/DependencyGraphViewer.csproj
+++ b/src/coreclr/tools/aot/DependencyGraphViewer/DependencyGraphViewer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppToolCurrent)-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <RootNamespace>DependencyLogViewer</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
It was WinExe in the CoreRT but this was somehow lost when porting it over to runtime repo.

I also wanted to make it re-launch itself as admin if someone clicks the ETW button and is not an admin already. But boy did we make it difficult to get to the name of the running program! One would think that `Environment.GetCommandLineArgs()[0]` will have it, but it only has it when published as single file or AOT, otherwise it's the name of the entrypoint assembly, which might be correct in some sense, but not in the sense of "the command line that launched the process".

Cc @dotnet/ilc-contrib 