### PR TITLE
Remove SystemReflectionMetadataLoadContextVersion from Versions.prop

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -127,7 +127,6 @@
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
     <SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
-    <SystemReflectionMetadataLoadContextVersion>6.0.0</SystemReflectionMetadataLoadContextVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>


### PR DESCRIPTION
The last usage was removed in https://github.com/dotnet/runtime/commit/1f0a0960029f58a2363a6610b04c62265366f39d