### PR TITLE
Fix regression caused by #48931 - Avoid ignoring timezone data

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -38,17 +38,6 @@ namespace System
 
             HasIanaId = true;
 
-            // Handle UTC and its aliases
-            if (StringArrayContains(_id, s_UtcAliases, StringComparison.OrdinalIgnoreCase))
-            {
-                _standardDisplayName = GetUtcStandardDisplayName();
-                _daylightDisplayName = _standardDisplayName;
-                _displayName = GetUtcFullDisplayName(_id, _standardDisplayName);
-                _baseUtcOffset = TimeSpan.Zero;
-                _adjustmentRules = Array.Empty<AdjustmentRule>();
-                return;
-            }
-
             TZifHead t;
             DateTime[] dts;
             byte[] typeOfLocalTime;
@@ -95,6 +84,17 @@ namespace System
                         daylightAbbrevName = TZif_GetZoneAbbreviation(zoneAbbreviations, transitionType[i].AbbreviationIndex);
                     }
                 }
+            }
+
+            // Handle UTC and its aliases
+            if (_baseUtcOffset == TimeSpan.Zero && StringArrayContains(_id, s_UtcAliases, StringComparison.OrdinalIgnoreCase))
+            {
+                _standardDisplayName = GetUtcStandardDisplayName();
+                _daylightDisplayName = _standardDisplayName;
+                _displayName = GetUtcFullDisplayName(_id, _standardDisplayName);
+                _baseUtcOffset = TimeSpan.Zero;
+                _adjustmentRules = Array.Empty<AdjustmentRule>();
+                return;
             }
 
             // Set fallback values using abbreviations, base offset, and id


### PR DESCRIPTION
Avoid ignoring timezone data when timezone ID is set to UTC

In .NET Core 3.1 and .NET 5.0, we take into account timezone data regardless of the timezone ID. This was changed by #48931 in .NET 6.0. this creates a problem in some environments (e.g. Docker) when the '/etc/localtime' symlink is not set up as expected. I find the previous behavior more straight-forward and I'm not sure this change was intentional.