### PR TITLE
Do not overallocate SocketAddress.Buffer

### DIFF
--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -175,6 +175,7 @@ namespace System.Net.Internals
             return new IPEndPoint(GetIPAddress(), GetPort());
         }
 
+#if !SYSTEM_NET_PRIMITIVES_DLL && WINDOWS
         // For ReceiveFrom we need to pin address size, using reserved Buffer space.
         internal void CopyAddressSizeIntoBuffer()
         {
@@ -190,6 +191,7 @@ namespace System.Net.Internals
         {
             return Buffer.Length - 4;
         }
+#endif
 
         public override bool Equals(object? comparand) =>
             comparand is SocketAddress other &&

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -95,7 +95,7 @@ namespace System.Net.Internals
 #if !SYSTEM_NET_PRIMITIVES_DLL && WINDOWS
             // WSARecvFrom needs a pinned pointer to the 32bit socket address size: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsarecvfrom
             // Allocate IntPtr.Size extra bytes at the end of Buffer ensuring IntPtr.Size alignment, so we don't need to pin anything else.
-            // The following forumla will extend 'size' to the alignment boundary then add IntPtr.Size more bytes.
+            // The following formula will extend 'size' to the alignment boundary then add IntPtr.Size more bytes.
             size = (size + IntPtr.Size -  1) / IntPtr.Size * IntPtr.Size + IntPtr.Size;
 #endif
             Buffer = new byte[size];

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -93,10 +93,10 @@ namespace System.Net.Internals
 
             InternalSize = size;
 #if !SYSTEM_NET_PRIMITIVES_DLL && WINDOWS
-            // WSARecvFrom needs a pinned pointer to the 32bit socket address size.
-            // Allocate extra bytes at the end of Buffer with a 4-byte alignment, so we don't need to pin anything else.
-            // The following forumla ensures addition of the minimum necessary extra padding,
-            // eg. size=16 will be extended to 20, while size=17 will be extended to 24
+            // WSARecvFrom needs a pinned pointer to the 32bit socket address size: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsarecvfrom
+            // Allocate sizeof(int) extra bytes at the end of Buffer ensuring sizeof(int) alignment for the LPINT lpFromlen pointer, so we don't need to pin anything else.
+            // The following forumla will extend 'size' to the 4-byte alignment boundary then add 4 more bytes.
+            // eg. size=16 will be extended to 20, while size=17 will be extended to 24.
             const int PtrSize = sizeof(int);
             size = (size + PtrSize -  1) / PtrSize * PtrSize + PtrSize;
 #endif

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -94,11 +94,9 @@ namespace System.Net.Internals
             InternalSize = size;
 #if !SYSTEM_NET_PRIMITIVES_DLL && WINDOWS
             // WSARecvFrom needs a pinned pointer to the 32bit socket address size: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsarecvfrom
-            // Allocate sizeof(int) extra bytes at the end of Buffer ensuring sizeof(int) alignment for the LPINT lpFromlen pointer, so we don't need to pin anything else.
-            // The following forumla will extend 'size' to the 4-byte alignment boundary then add 4 more bytes.
-            // eg. size=16 will be extended to 20, while size=17 will be extended to 24.
-            const int PtrSize = sizeof(int);
-            size = (size + PtrSize -  1) / PtrSize * PtrSize + PtrSize;
+            // Allocate IntPtr.Size extra bytes at the end of Buffer ensuring IntPtr.Size alignment, so we don't need to pin anything else.
+            // The following forumla will extend 'size' to the alignment boundary then add IntPtr.Size more bytes.
+            size = (size + IntPtr.Size -  1) / IntPtr.Size * IntPtr.Size + IntPtr.Size;
 #endif
             Buffer = new byte[size];
 
@@ -193,7 +191,7 @@ namespace System.Net.Internals
         // Can be called after the above method did work.
         internal int GetAddressSizeOffset()
         {
-            return Buffer.Length - sizeof(int);
+            return Buffer.Length - IntPtr.Size;
         }
 #endif
 

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -93,8 +93,9 @@ namespace System.Net.Internals
 
             InternalSize = size;
 #if !SYSTEM_NET_PRIMITIVES_DLL && WINDOWS
-            // WSARecvFrom needs a pinned pointer to the size. Allocate 4 extra bytes for it, so we don't need to pin another buffer.
-            size += 4;
+            // WSARecvFrom needs a pinned pointer to the 32bit socket address size.
+            // Allocate extra bytes at the end of Buffer, so we don't need to pin anything else.
+            size += sizeof(int);
 #endif
             Buffer = new byte[size];
 
@@ -189,7 +190,7 @@ namespace System.Net.Internals
         // Can be called after the above method did work.
         internal int GetAddressSizeOffset()
         {
-            return Buffer.Length - 4;
+            return Buffer.Length - sizeof(int);
         }
 #endif
 

--- a/src/libraries/Common/src/System/Net/SocketAddress.cs
+++ b/src/libraries/Common/src/System/Net/SocketAddress.cs
@@ -94,8 +94,11 @@ namespace System.Net.Internals
             InternalSize = size;
 #if !SYSTEM_NET_PRIMITIVES_DLL && WINDOWS
             // WSARecvFrom needs a pinned pointer to the 32bit socket address size.
-            // Allocate extra bytes at the end of Buffer, so we don't need to pin anything else.
-            size += sizeof(int);
+            // Allocate extra bytes at the end of Buffer with a 4-byte alignment, so we don't need to pin anything else.
+            // The following forumla ensures addition of the minimum necessary extra padding,
+            // eg. size=16 will be extended to 20, while size=17 will be extended to 24
+            const int PtrSize = sizeof(int);
+            size = (size + PtrSize -  1) / PtrSize * PtrSize + PtrSize;
 #endif
             Buffer = new byte[size];
 


### PR DESCRIPTION
We build [SocketAddress.cs](https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Net/SocketAddress.cs) in two modes: to get the public type in System.Net.Primitives and - independently - as a System.Net.Sockets internal, so we can access internal members, and work withe the extra bytes allocated at the end of `SocketAddress.Buffer` for WSARecvFrom which needs a pinned pointer to the socket address size. This duplication was a refactoring technique when Framework code was ported to Core where System.Net.Sockets and System.Net.Primtives live in separate dll-s and socket code cannot access SocketAddress internals.

There seem to be two obvious problems:
1. Extra bytes are allocated in both compilation modes penalizing the public `SocketAddress` everywhere, including Unix platforms
2. The formula to calculate the number of bytes to be allocated is inherited from early .NET Framework days, and seems to be wrong, or at least overly defensive:

https://github.com/dotnet/runtime/blob/4f53c2f7e62df44f07cf410df8a0d439f42a0a71/src/libraries/Common/src/System/Net/SocketAddress.cs#L95

This **allocates 32 bytes for a 16-byte IPv4 address** for both `SocketAddress` and `Internals.SocketAddress` on a 64bit machine. ~The intention of the formula was probably to make sure that `lpFromlen`'s buffer is 4-byte aligned (assuming 32 bit), but I don't see any signs in [WSARecvFrom docs](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsarecvfrom) that there is a need for any alignment.~ Edit: updated the code reintroducing alignment (though with a "smarter" formula), see discussion.