### PR TITLE
Add AVX2 support to IndexOfAnyValues

### DIFF
--- a/src/libraries/System.Memory/tests/Span/IndexOfAnyValues.cs
+++ b/src/libraries/System.Memory/tests/Span/IndexOfAnyValues.cs
@@ -360,7 +360,7 @@ namespace System.SpanTests
         private static class IndexOfAnyValuesTestHelper
         {
             private const int MaxNeedleLength = 10;
-            private const int MaxHaystackLength = 40;
+            private const int MaxHaystackLength = 100;
 
             private static readonly char[] s_randomAsciiChars;
             private static readonly char[] s_randomLatin1Chars;

--- a/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/IndexOfAnyAsciiSearcher.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -171,28 +172,83 @@ namespace System.Buffers
 
             if (searchSpaceLength > 2 * Vector128<short>.Count)
             {
-                // Process the input in chunks of 16 characters (2 * Vector128<short>).
-                // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
-                // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
-                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                // Let the fallback below handle it instead. This is why the condition is
-                // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - (2 * Vector128<short>.Count));
-
-                do
+                if (Avx2.IsSupported)
                 {
-                    Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
-                    Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
+                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
 
-                    Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
-                    if (result != Vector128<byte>.Zero)
+                    if (searchSpaceLength > 2 * Vector256<short>.Count)
                     {
-                        return ComputeFirstIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        // Process the input in chunks of 32 characters (2 * Vector256<short>).
+                        // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector256<byte>.
+                        // As packing two Vector256<short>s into a Vector256<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                        // Let the fallback below handle it instead. This is why the condition is
+                        // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                        ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - (2 * Vector256<short>.Count));
+
+                        do
+                        {
+                            Vector256<short> source0 = Vector256.LoadUnsafe(ref currentSearchSpace);
+                            Vector256<short> source1 = Vector256.LoadUnsafe(ref currentSearchSpace, (nuint)Vector256<short>.Count);
+
+                            Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
+                            if (result != Vector256<byte>.Zero)
+                            {
+                                return ComputeFirstIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                            }
+
+                            currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 2 * Vector256<short>.Count);
+                        }
+                        while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref twoVectorsAwayFromEnd));
                     }
 
-                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 2 * Vector128<short>.Count);
+                    // We have 1-32 characters remaining. Process the first and last vector in the search space.
+                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                    Debug.Assert(searchSpaceLength >= Vector256<short>.Count, "We expect that the input is long enough for us to load a whole vector.");
+                    {
+                        ref short oneVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<short>.Count);
+
+                        ref short firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAwayFromEnd)
+                            ? ref oneVectorAwayFromEnd
+                            : ref currentSearchSpace;
+
+                        Vector256<short> source0 = Vector256.LoadUnsafe(ref firstVector);
+                        Vector256<short> source1 = Vector256.LoadUnsafe(ref oneVectorAwayFromEnd);
+
+                        Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
+                        if (result != Vector256<byte>.Zero)
+                        {
+                            return ComputeFirstIndexOverlapped<short, TNegator>(ref searchSpace, ref firstVector, ref oneVectorAwayFromEnd, result);
+                        }
+                    }
+
+                    return -1;
                 }
-                while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref twoVectorsAwayFromEnd));
+                else
+                {
+                    // Process the input in chunks of 16 characters (2 * Vector128<short>).
+                    // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
+                    // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                    ref short twoVectorsAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - (2 * Vector128<short>.Count));
+
+                    do
+                    {
+                        Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
+                        Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
+
+                        Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
+                        if (result != Vector128<byte>.Zero)
+                        {
+                            return ComputeFirstIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        }
+
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, 2 * Vector128<short>.Count);
+                    }
+                    while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref twoVectorsAwayFromEnd));
+                }
             }
 
             // We have 1-16 characters remaining. Process the first and last vector in the search space.
@@ -226,28 +282,83 @@ namespace System.Buffers
 
             if (searchSpaceLength > 2 * Vector128<short>.Count)
             {
-                // Process the input in chunks of 16 characters (2 * Vector128<short>).
-                // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
-                // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
-                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                // Let the fallback below handle it instead. This is why the condition is
-                // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                ref short twoVectorsAfterStart = ref Unsafe.Add(ref searchSpace, 2 * Vector128<short>.Count);
-
-                do
+                if (Avx2.IsSupported)
                 {
-                    currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, 2 * Vector128<short>.Count);
+                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
 
-                    Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
-                    Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
-
-                    Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
-                    if (result != Vector128<byte>.Zero)
+                    if (searchSpaceLength > 2 * Vector256<short>.Count)
                     {
-                        return ComputeLastIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        // Process the input in chunks of 32 characters (2 * Vector256<short>).
+                        // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector256<byte>.
+                        // As packing two Vector256<short>s into a Vector256<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                        // Let the fallback below handle it instead. This is why the condition is
+                        // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                        ref short twoVectorsAfterStart = ref Unsafe.Add(ref searchSpace, 2 * Vector256<short>.Count);
+
+                        do
+                        {
+                            currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, 2 * Vector256<short>.Count);
+
+                            Vector256<short> source0 = Vector256.LoadUnsafe(ref currentSearchSpace);
+                            Vector256<short> source1 = Vector256.LoadUnsafe(ref currentSearchSpace, (nuint)Vector256<short>.Count);
+
+                            Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
+                            if (result != Vector256<byte>.Zero)
+                            {
+                                return ComputeLastIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                            }
+                        }
+                        while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref twoVectorsAfterStart));
                     }
+
+                    // We have 1-32 characters remaining. Process the first and last vector in the search space.
+                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                    Debug.Assert(searchSpaceLength >= Vector256<short>.Count, "We expect that the input is long enough for us to load a whole vector.");
+                    {
+                        ref short oneVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<short>.Count);
+
+                        ref short secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref oneVectorAfterStart)
+                            ? ref Unsafe.Subtract(ref currentSearchSpace, Vector256<short>.Count)
+                            : ref searchSpace;
+
+                        Vector256<short> source0 = Vector256.LoadUnsafe(ref searchSpace);
+                        Vector256<short> source1 = Vector256.LoadUnsafe(ref secondVector);
+
+                        Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap256);
+                        if (result != Vector256<byte>.Zero)
+                        {
+                            return ComputeLastIndexOverlapped<short, TNegator>(ref searchSpace, ref secondVector, result);
+                        }
+                    }
+
+                    return -1;
                 }
-                while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref twoVectorsAfterStart));
+                else
+                {
+                    // Process the input in chunks of 16 characters (2 * Vector128<short>).
+                    // We're mainly interested in a single byte of each character, and the core lookup operates on a Vector128<byte>.
+                    // As packing two Vector128<short>s into a Vector128<byte> is cheap compared to the lookup, we can effectively double the throughput.
+                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                    ref short twoVectorsAfterStart = ref Unsafe.Add(ref searchSpace, 2 * Vector128<short>.Count);
+
+                    do
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, 2 * Vector128<short>.Count);
+
+                        Vector128<short> source0 = Vector128.LoadUnsafe(ref currentSearchSpace);
+                        Vector128<short> source1 = Vector128.LoadUnsafe(ref currentSearchSpace, (nuint)Vector128<short>.Count);
+
+                        Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source0, source1, bitmap);
+                        if (result != Vector128<byte>.Zero)
+                        {
+                            return ComputeLastIndex<short, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        }
+                    }
+                    while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref twoVectorsAfterStart));
+                }
             }
 
             // We have 1-16 characters remaining. Process the first and last vector in the search space.
@@ -281,32 +392,85 @@ namespace System.Buffers
 
             if (searchSpaceLength > Vector128<byte>.Count)
             {
-                // Process the input in chunks of 16 bytes.
-                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                // Let the fallback below handle it instead. This is why the condition is
-                // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
-
-                do
+                if (Avx2.IsSupported)
                 {
-                    Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
 
-                    Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source, bitmap);
-                    if (result != Vector128<byte>.Zero)
+                    if (searchSpaceLength > Vector256<byte>.Count)
                     {
-                        return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        // Process the input in chunks of 32 bytes.
+                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                        // Let the fallback below handle it instead. This is why the condition is
+                        // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                        ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<byte>.Count);
+
+                        do
+                        {
+                            Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
+
+                            Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source, bitmap256);
+                            if (result != Vector256<byte>.Zero)
+                            {
+                                return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                            }
+
+                            currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<byte>.Count);
+                        }
+                        while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
                     }
 
-                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<byte>.Count);
+                    // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
+                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                    Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
+                    {
+                        ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
+
+                        ref byte firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAwayFromEnd)
+                            ? ref halfVectorAwayFromEnd
+                            : ref currentSearchSpace;
+
+                        Vector128<byte> source0 = Vector128.LoadUnsafe(ref firstVector);
+                        Vector128<byte> source1 = Vector128.LoadUnsafe(ref halfVectorAwayFromEnd);
+                        Vector256<byte> source = Vector256.Create(source0, source1);
+
+                        Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source, bitmap256);
+                        if (result != Vector256<byte>.Zero)
+                        {
+                            return ComputeFirstIndexOverlapped<byte, TNegator>(ref searchSpace, ref firstVector, ref halfVectorAwayFromEnd, result);
+                        }
+                    }
+
+                    return -1;
                 }
-                while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
+                else
+                {
+                    // Process the input in chunks of 16 bytes.
+                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                    ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
+
+                    do
+                    {
+                        Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+
+                        Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source, bitmap);
+                        if (result != Vector128<byte>.Zero)
+                        {
+                            return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        }
+
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<byte>.Count);
+                    }
+                    while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
+                }
             }
 
             // We have 1-16 bytes remaining. Process the first and last half vectors in the search space.
             // They may overlap, but we'll handle that in the index calculation if we do get a match.
             Debug.Assert(searchSpaceLength >= sizeof(ulong), "We expect that the input is long enough for us to load a ulong.");
             {
-                ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count / 2);
+                ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - sizeof(ulong));
 
                 ref byte firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAwayFromEnd)
                     ? ref halfVectorAwayFromEnd
@@ -334,35 +498,88 @@ namespace System.Buffers
 
             if (searchSpaceLength > Vector128<byte>.Count)
             {
-                // Process the input in chunks of 16 bytes.
-                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                // Let the fallback below handle it instead. This is why the condition is
-                // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
-
-                do
+                if (Avx2.IsSupported)
                 {
-                    currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count);
+                    Vector256<byte> bitmap256 = Vector256.Create(bitmap, bitmap);
 
-                    Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
-
-                    Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source, bitmap);
-                    if (result != Vector128<byte>.Zero)
+                    if (searchSpaceLength > Vector256<byte>.Count)
                     {
-                        return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        // Process the input in chunks of 32 bytes.
+                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                        // Let the fallback below handle it instead. This is why the condition is
+                        // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                        ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<byte>.Count);
+
+                        do
+                        {
+                            currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<byte>.Count);
+
+                            Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
+
+                            Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source, bitmap256);
+                            if (result != Vector256<byte>.Zero)
+                            {
+                                return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                            }
+                        }
+                        while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
                     }
+
+                    // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
+                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                    Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
+                    {
+                        ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+
+                        ref byte secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAfterStart)
+                            ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count)
+                            : ref searchSpace;
+
+                        Vector128<byte> source0 = Vector128.LoadUnsafe(ref searchSpace);
+                        Vector128<byte> source1 = Vector128.LoadUnsafe(ref secondVector);
+                        Vector256<byte> source = Vector256.Create(source0, source1);
+
+                        Vector256<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source, bitmap256);
+                        if (result != Vector256<byte>.Zero)
+                        {
+                            return ComputeLastIndexOverlapped<byte, TNegator>(ref searchSpace, ref secondVector, result);
+                        }
+                    }
+
+                    return -1;
                 }
-                while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
+                else
+                {
+                    // Process the input in chunks of 16 bytes.
+                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                    ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+
+                    do
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count);
+
+                        Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+
+                        Vector128<byte> result = IndexOfAnyLookup<TNegator, TOptimizations>(source, bitmap);
+                        if (result != Vector128<byte>.Zero)
+                        {
+                            return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        }
+                    }
+                    while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
+                }
             }
 
             // We have 1-16 bytes remaining. Process the first and last half vectors in the search space.
             // They may overlap, but we'll handle that in the index calculation if we do get a match.
             Debug.Assert(searchSpaceLength >= sizeof(ulong), "We expect that the input is long enough for us to load a ulong.");
             {
-                ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count / 2);
+                ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, sizeof(ulong));
 
                 ref byte secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAfterStart)
-                    ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<short>.Count)
+                    ? ref Unsafe.Subtract(ref currentSearchSpace, sizeof(ulong))
                     : ref searchSpace;
 
                 ulong source0 = Unsafe.ReadUnaligned<ulong>(ref searchSpace);
@@ -386,32 +603,86 @@ namespace System.Buffers
 
             if (searchSpaceLength > Vector128<byte>.Count)
             {
-                // Process the input in chunks of 16 bytes.
-                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                // Let the fallback below handle it instead. This is why the condition is
-                // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
-                ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
-
-                do
+                if (Avx2.IsSupported)
                 {
-                    Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+                    Vector256<byte> bitmap256_0 = Vector256.Create(bitmap0, bitmap0);
+                    Vector256<byte> bitmap256_1 = Vector256.Create(bitmap1, bitmap1);
 
-                    Vector128<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap0, bitmap1);
-                    if (result != Vector128<byte>.Zero)
+                    if (searchSpaceLength > Vector256<byte>.Count)
                     {
-                        return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        // Process the input in chunks of 32 bytes.
+                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                        // Let the fallback below handle it instead. This is why the condition is
+                        // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                        ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector256<byte>.Count);
+
+                        do
+                        {
+                            Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
+
+                            Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
+                            if (result != Vector256<byte>.Zero)
+                            {
+                                return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                            }
+
+                            currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector256<byte>.Count);
+                        }
+                        while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
                     }
 
-                    currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<byte>.Count);
+                    // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
+                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                    Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
+                    {
+                        ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
+
+                        ref byte firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAwayFromEnd)
+                            ? ref halfVectorAwayFromEnd
+                            : ref currentSearchSpace;
+
+                        Vector128<byte> source0 = Vector128.LoadUnsafe(ref firstVector);
+                        Vector128<byte> source1 = Vector128.LoadUnsafe(ref halfVectorAwayFromEnd);
+                        Vector256<byte> source = Vector256.Create(source0, source1);
+
+                        Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
+                        if (result != Vector256<byte>.Zero)
+                        {
+                            return ComputeFirstIndexOverlapped<byte, TNegator>(ref searchSpace, ref firstVector, ref halfVectorAwayFromEnd, result);
+                        }
+                    }
+
+                    return -1;
                 }
-                while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
+                else
+                {
+                    // Process the input in chunks of 16 bytes.
+                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressLessThan" is used instead of "!IsAddressGreaterThan".
+                    ref byte vectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count);
+
+                    do
+                    {
+                        Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+
+                        Vector128<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap0, bitmap1);
+                        if (result != Vector128<byte>.Zero)
+                        {
+                            return ComputeFirstIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        }
+
+                        currentSearchSpace = ref Unsafe.Add(ref currentSearchSpace, Vector128<byte>.Count);
+                    }
+                    while (Unsafe.IsAddressLessThan(ref currentSearchSpace, ref vectorAwayFromEnd));
+                }
             }
 
             // We have 1-16 bytes remaining. Process the first and last half vectors in the search space.
             // They may overlap, but we'll handle that in the index calculation if we do get a match.
             Debug.Assert(searchSpaceLength >= sizeof(ulong), "We expect that the input is long enough for us to load a ulong.");
             {
-                ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - Vector128<byte>.Count / 2);
+                ref byte halfVectorAwayFromEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength - sizeof(ulong));
 
                 ref byte firstVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAwayFromEnd)
                     ? ref halfVectorAwayFromEnd
@@ -438,35 +709,89 @@ namespace System.Buffers
 
             if (searchSpaceLength > Vector128<byte>.Count)
             {
-                // Process the input in chunks of 16 bytes.
-                // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
-                // Let the fallback below handle it instead. This is why the condition is
-                // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
-                ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
-
-                do
+                if (Avx2.IsSupported)
                 {
-                    currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count);
+                    Vector256<byte> bitmap256_0 = Vector256.Create(bitmap0, bitmap0);
+                    Vector256<byte> bitmap256_1 = Vector256.Create(bitmap1, bitmap1);
 
-                    Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
-
-                    Vector128<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap0, bitmap1);
-                    if (result != Vector128<byte>.Zero)
+                    if (searchSpaceLength > Vector256<byte>.Count)
                     {
-                        return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        // Process the input in chunks of 32 bytes.
+                        // If the input length is a multiple of 32, don't consume the last 32 characters in this loop.
+                        // Let the fallback below handle it instead. This is why the condition is
+                        // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                        ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector256<byte>.Count);
+
+                        do
+                        {
+                            currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector256<byte>.Count);
+
+                            Vector256<byte> source = Vector256.LoadUnsafe(ref currentSearchSpace);
+
+                            Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
+                            if (result != Vector256<byte>.Zero)
+                            {
+                                return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                            }
+                        }
+                        while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
                     }
+
+                    // We have 1-32 bytes remaining. Process the first and last half vectors in the search space.
+                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                    Debug.Assert(searchSpaceLength >= Vector128<byte>.Count, "We expect that the input is long enough for us to load a Vector128.");
+                    {
+                        ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+
+                        ref byte secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAfterStart)
+                            ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count)
+                            : ref searchSpace;
+
+                        Vector128<byte> source0 = Vector128.LoadUnsafe(ref searchSpace);
+                        Vector128<byte> source1 = Vector128.LoadUnsafe(ref secondVector);
+                        Vector256<byte> source = Vector256.Create(source0, source1);
+
+                        Vector256<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap256_0, bitmap256_1);
+                        if (result != Vector256<byte>.Zero)
+                        {
+                            return ComputeLastIndexOverlapped<byte, TNegator>(ref searchSpace, ref secondVector, result);
+                        }
+                    }
+
+                    return -1;
                 }
-                while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
+                else
+                {
+                    // Process the input in chunks of 16 bytes.
+                    // If the input length is a multiple of 16, don't consume the last 16 characters in this loop.
+                    // Let the fallback below handle it instead. This is why the condition is
+                    // ">" instead of ">=" above, and why "IsAddressGreaterThan" is used instead of "!IsAddressLessThan".
+                    ref byte vectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count);
+
+                    do
+                    {
+                        currentSearchSpace = ref Unsafe.Subtract(ref currentSearchSpace, Vector128<byte>.Count);
+
+                        Vector128<byte> source = Vector128.LoadUnsafe(ref currentSearchSpace);
+
+                        Vector128<byte> result = IndexOfAnyLookup<TNegator>(source, bitmap0, bitmap1);
+                        if (result != Vector128<byte>.Zero)
+                        {
+                            return ComputeLastIndex<byte, TNegator>(ref searchSpace, ref currentSearchSpace, result);
+                        }
+                    }
+                    while (Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref vectorAfterStart));
+                }
             }
 
             // We have 1-16 bytes remaining. Process the first and last half vectors in the search space.
             // They may overlap, but we'll handle that in the index calculation if we do get a match.
             Debug.Assert(searchSpaceLength >= sizeof(ulong), "We expect that the input is long enough for us to load a ulong.");
             {
-                ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, Vector128<byte>.Count / 2);
+                ref byte halfVectorAfterStart = ref Unsafe.Add(ref searchSpace, sizeof(ulong));
 
                 ref byte secondVector = ref Unsafe.IsAddressGreaterThan(ref currentSearchSpace, ref halfVectorAfterStart)
-                    ? ref Unsafe.Subtract(ref currentSearchSpace, Vector128<short>.Count)
+                    ? ref Unsafe.Subtract(ref currentSearchSpace, sizeof(ulong))
                     : ref searchSpace;
 
                 ulong source0 = Unsafe.ReadUnaligned<ulong>(ref searchSpace);
@@ -559,6 +884,54 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector256<byte> IndexOfAnyLookup<TNegator, TOptimizations>(Vector256<short> source0, Vector256<short> source1, Vector256<byte> bitmapLookup)
+            where TNegator : struct, INegator
+            where TOptimizations : struct, IOptimizations
+        {
+            // See comments in IndexOfAnyLookup(Vector128<byte>) above for more details.
+            Vector256<byte> source = Avx2.PackUnsignedSaturate(source0, source1);
+            Vector256<byte> result = IndexOfAnyLookupCore(source, bitmapLookup);
+
+            if (TOptimizations.NeedleContainsZero)
+            {
+                Vector256<short> ascii0 = Vector256.LessThan(source0.AsUInt16(), Vector256.Create((ushort)128)).AsInt16();
+                Vector256<short> ascii1 = Vector256.LessThan(source1.AsUInt16(), Vector256.Create((ushort)128)).AsInt16();
+                Vector256<byte> ascii = Avx2.PackSignedSaturate(ascii0, ascii1).AsByte();
+                result &= ascii;
+            }
+
+            return TNegator.NegateIfNeeded(result);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector256<byte> IndexOfAnyLookup<TNegator, TOptimizations>(Vector256<byte> source, Vector256<byte> bitmapLookup)
+            where TNegator : struct, INegator
+            where TOptimizations : struct, IOptimizations
+        {
+            // See comments in IndexOfAnyLookup(Vector128<byte>) above for more details.
+            Vector256<byte> result = IndexOfAnyLookupCore(source, bitmapLookup);
+
+            if (TOptimizations.NeedleContainsZero)
+            {
+                Vector256<byte> ascii = Vector256.LessThan(source, Vector256.Create((byte)128));
+                result &= ascii;
+            }
+
+            return TNegator.NegateIfNeeded(result);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector256<byte> IndexOfAnyLookupCore(Vector256<byte> source, Vector256<byte> bitmapLookup)
+        {
+            // See comments in IndexOfAnyLookupCore(Vector128<byte>) above for more details.
+            Vector256<byte> highNibbles = Vector256.ShiftRightLogical(source.AsInt32(), 4).AsByte() & Vector256.Create((byte)0xF);
+            Vector256<byte> bitMask = Avx2.Shuffle(bitmapLookup, source);
+            Vector256<byte> bitPositions = Avx2.Shuffle(Vector256.Create(0x8040201008040201).AsByte(), highNibbles);
+            Vector256<byte> result = bitMask & bitPositions;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<byte> IndexOfAnyLookup<TNegator>(Vector128<byte> source, Vector128<byte> bitmapLookup0, Vector128<byte> bitmapLookup1)
             where TNegator : struct, INegator
         {
@@ -572,10 +945,32 @@ namespace System.Buffers
 
             Vector128<byte> bitmask = Shuffle(Vector128.Create(0x8040201008040201).AsByte(), highNibbles);
 
-            Vector128<byte> mask = Vector128.LessThan(highNibbles, Vector128.Create((byte)0x8));
-            Vector128<byte> bitsets = Vector128.ConditionalSelect(mask, row0, row1);
+            Vector128<byte> mask = Vector128.GreaterThan(highNibbles.AsSByte(), Vector128.Create((sbyte)0x7)).AsByte();
+            Vector128<byte> bitsets = Vector128.ConditionalSelect(mask, row1, row0);
 
             Vector128<byte> result = Vector128.Equals(bitsets & bitmask, bitmask);
+
+            return TNegator.NegateIfNeeded(result);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector256<byte> IndexOfAnyLookup<TNegator>(Vector256<byte> source, Vector256<byte> bitmapLookup0, Vector256<byte> bitmapLookup1)
+            where TNegator : struct, INegator
+        {
+            // http://0x80.pl/articles/simd-byte-lookup.html#universal-algorithm
+
+            Vector256<byte> lowNibbles = source & Vector256.Create((byte)0xF);
+            Vector256<byte> highNibbles = Vector256.ShiftRightLogical(source.AsInt32(), 4).AsByte() & Vector256.Create((byte)0xF);
+
+            Vector256<byte> row0 = Avx2.Shuffle(bitmapLookup0, lowNibbles);
+            Vector256<byte> row1 = Avx2.Shuffle(bitmapLookup1, lowNibbles);
+
+            Vector256<byte> bitmask = Avx2.Shuffle(Vector256.Create(0x8040201008040201).AsByte(), highNibbles);
+
+            Vector256<byte> mask = Vector256.GreaterThan(highNibbles.AsSByte(), Vector256.Create((sbyte)0x7)).AsByte();
+            Vector256<byte> bitsets = Vector256.ConditionalSelect(mask, row1, row0);
+
+            Vector256<byte> result = Vector256.Equals(bitsets & bitmask, bitmask);
 
             return TNegator.NegateIfNeeded(result);
         }
@@ -639,18 +1034,105 @@ namespace System.Buffers
             return offsetInVector - Vector128<short>.Count + (int)(Unsafe.ByteOffset(ref searchSpace, ref secondVector) / sizeof(T));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int ComputeFirstIndex<T, TNegator>(ref T searchSpace, ref T current, Vector256<byte> result)
+            where TNegator : struct, INegator
+        {
+            uint mask = TNegator.ExtractMask(result);
+            if (typeof(T) == typeof(short))
+            {
+                mask = FixUpPackedVector256Mask(mask);
+            }
+
+            int offsetInVector = BitOperations.TrailingZeroCount(mask);
+            return offsetInVector + (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / sizeof(T));
+        }
+
+#pragma warning disable IDE0060 // https://github.com/dotnet/roslyn-analyzers/issues/6228
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int ComputeFirstIndexOverlapped<T, TNegator>(ref T searchSpace, ref T current0, ref T current1, Vector256<byte> result)
+            where TNegator : struct, INegator
+        {
+            uint mask = TNegator.ExtractMask(result);
+            if (typeof(T) == typeof(short))
+            {
+                mask = FixUpPackedVector256Mask(mask);
+            }
+
+            int offsetInVector = BitOperations.TrailingZeroCount(mask);
+            if (offsetInVector >= Vector256<short>.Count)
+            {
+                // We matched within the second vector
+                current0 = ref current1;
+                offsetInVector -= Vector256<short>.Count;
+            }
+            return offsetInVector + (int)(Unsafe.ByteOffset(ref searchSpace, ref current0) / sizeof(T));
+        }
+#pragma warning restore IDE0060 // https://github.com/dotnet/roslyn-analyzers/issues/6228
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int ComputeLastIndex<T, TNegator>(ref T searchSpace, ref T current, Vector256<byte> result)
+            where TNegator : struct, INegator
+        {
+            uint mask = TNegator.ExtractMask(result);
+            if (typeof(T) == typeof(short))
+            {
+                mask = FixUpPackedVector256Mask(mask);
+            }
+
+            int offsetInVector = 31 - BitOperations.LeadingZeroCount(mask);
+            return offsetInVector + (int)(Unsafe.ByteOffset(ref searchSpace, ref current) / sizeof(T));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int ComputeLastIndexOverlapped<T, TNegator>(ref T searchSpace, ref T secondVector, Vector256<byte> result)
+            where TNegator : struct, INegator
+        {
+            uint mask = TNegator.ExtractMask(result);
+            if (typeof(T) == typeof(short))
+            {
+                mask = FixUpPackedVector256Mask(mask);
+            }
+
+            int offsetInVector = 31 - BitOperations.LeadingZeroCount(mask);
+            if (offsetInVector < Vector256<short>.Count)
+            {
+                return offsetInVector;
+            }
+
+            // We matched within the second vector
+            return offsetInVector - Vector256<short>.Count + (int)(Unsafe.ByteOffset(ref searchSpace, ref secondVector) / sizeof(T));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint FixUpPackedVector256Mask(uint mask)
+        {
+            Debug.Assert(Avx2.IsSupported);
+            // Avx2.PackUnsignedSaturate(Vector256.Create((short)1), Vector256.Create((short)2)) will result in
+            // 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2
+            // We want to swap the X and Y bits
+            // 1, 1, 1, 1, 1, 1, 1, 1, X, X, X, X, X, X, X, X, Y, Y, Y, Y, Y, Y, Y, Y, 2, 2, 2, 2, 2, 2, 2, 2
+            const uint CorrectPositionsMask = 0xFF0000FF;
+
+            return (mask & CorrectPositionsMask) | BinaryPrimitives.ReverseEndianness(mask & ~CorrectPositionsMask);
+        }
+
         internal interface INegator
         {
             static abstract bool NegateIfNeeded(bool result);
             static abstract Vector128<byte> NegateIfNeeded(Vector128<byte> result);
+            static abstract Vector256<byte> NegateIfNeeded(Vector256<byte> result);
             static abstract uint ExtractMask(Vector128<byte> result);
+            static abstract uint ExtractMask(Vector256<byte> result);
         }
 
         internal readonly struct DontNegate : INegator
         {
             public static bool NegateIfNeeded(bool result) => result;
             public static Vector128<byte> NegateIfNeeded(Vector128<byte> result) => result;
+            public static Vector256<byte> NegateIfNeeded(Vector256<byte> result) => result;
             public static uint ExtractMask(Vector128<byte> result) => ~Vector128.Equals(result, Vector128<byte>.Zero).ExtractMostSignificantBits();
+            public static uint ExtractMask(Vector256<byte> result) => ~Vector256.Equals(result, Vector256<byte>.Zero).ExtractMostSignificantBits();
         }
 
         internal readonly struct Negate : INegator
@@ -659,7 +1141,9 @@ namespace System.Buffers
             // This is intentionally testing for equality with 0 instead of "~result".
             // We want to know if any character didn't match, as that means it should be treated as a match for the -Except method.
             public static Vector128<byte> NegateIfNeeded(Vector128<byte> result) => Vector128.Equals(result, Vector128<byte>.Zero);
+            public static Vector256<byte> NegateIfNeeded(Vector256<byte> result) => Vector256.Equals(result, Vector256<byte>.Zero);
             public static uint ExtractMask(Vector128<byte> result) => result.ExtractMostSignificantBits();
+            public static uint ExtractMask(Vector256<byte> result) => result.ExtractMostSignificantBits();
         }
 
         internal interface IOptimizations


### PR DESCRIPTION
## Easier to review while [ignoring whitespace](https://github.com/dotnet/runtime/pull/78863/files?w=1)

This change makes `IndexOfAnyValues` noticeably faster than a regular `IndexOf(char)` without #78861 :)

|              Method | Toolchain | Length |         Mean |      Error | Ratio |
|-------------------- |---------- |------- |-------------:|-----------:|------:|
| IndexOfAnyAsciiChar |      main |      1 |     2.270 ns |  0.0145 ns |  1.00 |
| IndexOfAnyAsciiChar |        pr |      1 |     2.279 ns |  0.0204 ns |  1.00 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiByte |      main |      1 |     1.787 ns |  0.0053 ns |  1.00 |
| IndexOfAnyAsciiByte |        pr |      1 |     1.788 ns |  0.0083 ns |  1.00 |
|                     |           |        |              |            |       |
|      IndexOfAnyByte |      main |      1 |     1.789 ns |  0.0050 ns |  1.00 |
|      IndexOfAnyByte |        pr |      1 |     1.790 ns |  0.0051 ns |  1.00 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiChar |      main |     16 |     2.784 ns |  0.0247 ns |  1.00 |
| IndexOfAnyAsciiChar |        pr |     16 |     2.782 ns |  0.0252 ns |  1.00 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiByte |      main |     16 |     2.696 ns |  0.0117 ns |  1.00 |
| IndexOfAnyAsciiByte |        pr |     16 |     2.364 ns |  0.0084 ns |  0.88 |
|                     |           |        |              |            |       |
|      IndexOfAnyByte |      main |     16 |     3.887 ns |  0.0196 ns |  1.00 |
|      IndexOfAnyByte |        pr |     16 |     3.488 ns |  0.0214 ns |  0.90 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiChar |      main |     17 |     3.348 ns |  0.0125 ns |  1.00 |
| IndexOfAnyAsciiChar |        pr |     17 |     3.103 ns |  0.0639 ns |  0.94 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiByte |      main |     17 |     3.122 ns |  0.0109 ns |  1.00 |
| IndexOfAnyAsciiByte |        pr |     17 |     3.061 ns |  0.0124 ns |  0.98 |
|                     |           |        |              |            |       |
|      IndexOfAnyByte |      main |     17 |     5.465 ns |  0.0762 ns |  1.00 |
|      IndexOfAnyByte |        pr |     17 |     4.102 ns |  0.0258 ns |  0.75 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiChar |      main |     32 |     3.381 ns |  0.0098 ns |  1.00 |
| IndexOfAnyAsciiChar |        pr |     32 |     3.042 ns |  0.0095 ns |  0.90 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiByte |      main |     32 |     3.261 ns |  0.0063 ns |  1.00 |
| IndexOfAnyAsciiByte |        pr |     32 |     3.074 ns |  0.0138 ns |  0.94 |
|                     |           |        |              |            |       |
|      IndexOfAnyByte |      main |     32 |     5.538 ns |  0.0131 ns |  1.00 |
|      IndexOfAnyByte |        pr |     32 |     4.149 ns |  0.0197 ns |  0.75 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiChar |      main |   1000 |    60.429 ns |  0.2208 ns |  1.00 |
| IndexOfAnyAsciiChar |        pr |   1000 |    34.636 ns |  0.1453 ns |  0.57 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiByte |      main |   1000 |    49.191 ns |  0.1576 ns |  1.00 |
| IndexOfAnyAsciiByte |        pr |   1000 |    34.826 ns |  0.4630 ns |  0.71 |
|                     |           |        |              |            |       |
|      IndexOfAnyByte |      main |   1000 |    83.976 ns |  0.2974 ns |  1.00 |
|      IndexOfAnyByte |        pr |   1000 |    45.647 ns |  0.1477 ns |  0.54 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiChar |      main | 100000 | 5,865.958 ns | 23.1353 ns |  1.00 |
| IndexOfAnyAsciiChar |        pr | 100000 | 3,880.814 ns | 35.5076 ns |  0.66 |
|                     |           |        |              |            |       |
| IndexOfAnyAsciiByte |      main | 100000 | 4,753.754 ns | 15.7070 ns |  1.00 |
| IndexOfAnyAsciiByte |        pr | 100000 | 3,215.513 ns | 10.5250 ns |  0.68 |
|                     |           |        |              |            |       |
|      IndexOfAnyByte |      main | 100000 | 7,691.448 ns | 38.5081 ns |  1.00 |
|      IndexOfAnyByte |        pr | 100000 | 4,488.097 ns | 41.8751 ns |  0.58 |


Chars
|                 Method | Length |     Mean |     Error |    StdDev |
|----------------------- |------- |---------:|----------:|----------:|
|    IndexOfAnyAsciiChar | 100000 | 3.936 us | 0.0525 us | 0.0491 us |
|                IndexOf | 100000 | 4.925 us | 0.0186 us | 0.0174 us |
|      IndexOfAny2Values | 100000 | 5.754 us | 0.0196 us | 0.0174 us |
|      IndexOfAny3Values | 100000 | 6.161 us | 0.0257 us | 0.0228 us |
|      IndexOfAny4Values | 100000 | 7.011 us | 0.0162 us | 0.0135 us |
|      IndexOfAny5Values | 100000 | 7.743 us | 0.0363 us | 0.0303 us |
| IndexOfAnyInRange_Char | 100000 | 5.196 us | 0.0143 us | 0.0120 us |

Bytes
|                 Method | Length |     Mean |     Error |    StdDev |
|----------------------- |------- |---------:|----------:|----------:|
|    IndexOfAnyAsciiByte | 100000 | 3.189 us | 0.0171 us | 0.0151 us |
|         IndexOfAnyByte | 100000 | 4.484 us | 0.0259 us | 0.0229 us |
|                IndexOf | 100000 | 1.971 us | 0.0186 us | 0.0174 us |
|      IndexOfAny2Values | 100000 | 2.233 us | 0.0093 us | 0.0078 us |
|      IndexOfAny3Values | 100000 | 2.628 us | 0.0081 us | 0.0076 us |
|      IndexOfAny4Values | 100000 | 2.929 us | 0.0155 us | 0.0145 us |
|      IndexOfAny5Values | 100000 | 3.270 us | 0.0102 us | 0.0090 us |
| IndexOfAnyInRange_Byte | 100000 | 2.187 us | 0.0090 us | 0.0084 us |