### PR TITLE
Fix malformed XML documentation

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Logging.Console
         }
 
         /// <summary>
-        /// Name of the log message formatter to use. Defaults to "simple" />.
+        /// Name of the log message formatter to use. Defaults to <c>simple</c>.
         /// </summary>
         public string? FormatterName { get; set; }
 


### PR DESCRIPTION
Fix malformed XML documentation on `ConsoleLoggerOptions.FormatterName`.

I wrapped the value in `<c>` tags to be consistent with the other properties.
