### PR TITLE
Experiment with inlining dispatch VSDs

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1273,9 +1273,9 @@ float emitter::insEvaluateExecutionCost(instrDesc* id)
 void emitter::perfScoreUnhandledInstruction(instrDesc* id, insExecutionCharacteristics* pResult)
 {
 #ifdef DEBUG
-    printf("PerfScore: unhandled instruction: %s, format %s", codeGen->genInsDisplayName(id),
-           emitIfName(id->idInsFmt()));
-    assert(!"PerfScore: unhandled instruction");
+    //printf("PerfScore: unhandled instruction: %s, format %s", codeGen->genInsDisplayName(id),
+    //       emitIfName(id->idInsFmt()));
+    //assert(!"PerfScore: unhandled instruction");
 #endif
     pResult->insThroughput = PERFSCORE_THROUGHPUT_1C;
     pResult->insLatency    = PERFSCORE_LATENCY_1C;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6965,7 +6965,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #endif
             insGroup* tgt = jmp->idAddr()->iiaIGlabel;
 
-            if (jmp->idjTemp.idjAddr == nullptr)
+            if (jmp->idjTemp.idjAddr == nullptr || jmp->idAddr()->iiaHasInstrCount())
             {
                 continue;
             }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8573,9 +8573,6 @@ void emitter::emitIns_J(instruction ins,
     }
     else
     {
-        /* Only allow non-label jmps in prolog */
-        assert(emitPrologIG);
-        assert(emitPrologIG == emitCurIG);
         assert(instrCount != 0);
     }
 

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -1989,7 +1989,6 @@ PCODE VirtualCallStubManager::ResolveWorker(StubCallSite* pCallSite,
                     {
                         void* orig = InterlockedCompareExchangeT(indirCell + 32, (void*)objectType, nullptr);
                         _ASSERTE(orig == nullptr);
-
                         //printf("Patched %p to target %p object type %p\n", indirCell, (void*)target, (void*)objectType);
 
                         MethodDesc *pMD = MethodTable::GetMethodDescForSlotAddress(target);


### PR DESCRIPTION
This is an experiment to inline dispatch VSDs in the JIT's codegen. Probably not that useful given long term plans to enable PGO by default.

For:
<details>
<summary>benchmark</summary>

```csharp
public class Benchmark
{
    [Benchmark]
    public long Mono()
    {
        IFace c = Get();

        long sum = 0;
        for (int i = 0; i < 1000000; i++)
            sum += c.Foo();

        return sum;
    }

    [Benchmark]
    public long Bimorphic()
    {
        IFace c = Get();

        long sum = 0;
        for (int i = 0; i < 1000000; i++)
            c = c.Bar();

        return sum;
    }

    [Benchmark]
    public long MonoThenMono()
    {
        IFace c = Get();

        long sum = 0;
        for (int j = 0; j < 2; j++)
        {
            for (int i = 0; i < 1000000; i++)
                sum += c.Foo();

            c = c.Bar();
        }

        return sum;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    private IFace Get()
    {
        C first = new C();
        C2 second = new C2();

        first.Other = second;
        second.Other = first;
        return first;
    }

    public interface IFace
    {
        long Foo();
        IFace Bar();
    }

    public class C : IFace
    {
        public C2 Other;
        public long Foo() => 15;
        public IFace Bar() => Other;

    }

    public class C2 : IFace
    {
        public C Other;

        public long Foo() => 15;
        public IFace Bar() => Other;
    }
}
```
</details>
</summary>

The results on my 5950X are:

|       Method |        Job |             Toolchain |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD |
|------------- |----------- |---------------------- |---------:|----------:|----------:|---------:|------:|--------:|
|         Mono | Job-QUUFXI |     \cmov\corerun.exe | 1.705 ms | 0.0646 ms | 0.1904 ms | 1.771 ms |  1.06 |    0.13 |
|         Mono | Job-PRAHNO |     \main\corerun.exe | 1.609 ms | 0.0321 ms | 0.0762 ms | 1.628 ms |  1.00 |    0.00 |
|         Mono | Job-JZCWQI |  \onejump\corerun.exe | 1.534 ms | 0.0069 ms | 0.0064 ms | 1.535 ms |  0.94 |    0.04 |
|         Mono | Job-SWFTQQ | \twojumps\corerun.exe | 1.491 ms | 0.0024 ms | 0.0022 ms | 1.491 ms |  0.92 |    0.04 |
|              |            |                       |          |           |           |          |       |         |
|    Bimorphic | Job-QUUFXI |     \cmov\corerun.exe | 1.605 ms | 0.0062 ms | 0.0055 ms | 1.603 ms |  0.19 |    0.00 |
|    Bimorphic | Job-PRAHNO |     \main\corerun.exe | 8.622 ms | 0.0132 ms | 0.0117 ms | 8.620 ms |  1.00 |    0.00 |
|    Bimorphic | Job-JZCWQI |  \onejump\corerun.exe | 1.647 ms | 0.0107 ms | 0.0100 ms | 1.645 ms |  0.19 |    0.00 |
|    Bimorphic | Job-SWFTQQ | \twojumps\corerun.exe | 1.501 ms | 0.0036 ms | 0.0030 ms | 1.501 ms |  0.17 |    0.00 |
|              |            |                       |          |           |           |          |       |         |
| MonoThenMono | Job-QUUFXI |     \cmov\corerun.exe | 3.656 ms | 0.0164 ms | 0.0145 ms | 3.660 ms |  0.89 |    0.01 |
| MonoThenMono | Job-PRAHNO |     \main\corerun.exe | 4.102 ms | 0.0472 ms | 0.0442 ms | 4.107 ms |  1.00 |    0.00 |
| MonoThenMono | Job-JZCWQI |  \onejump\corerun.exe | 3.673 ms | 0.0616 ms | 0.0576 ms | 3.644 ms |  0.90 |    0.02 |
| MonoThenMono | Job-SWFTQQ | \twojumps\corerun.exe | 3.418 ms | 0.0060 ms | 0.0056 ms | 3.416 ms |  0.83 |    0.01 |

`main` is
```asm
mov r11, indirCell
call [r11]
```

`cmov` is
```asm
mov r11, indirCell
mov rax, [r11 + 0x100] // method table for guess
cmp rax, [rcx]
mov rax, [r11 + 0x200] // target for guess
cmovne rax, [r11]
call rax
```

`onejump` is
```asm
mov r11, indirCell
mov rax, [r11 + 0x100]
cmp rax, [rcx]
je equal

call [r11]
jmp after

equal:
call [r11 + 0x200]

after:
```

`twojumps` is
```asm
mov r11, indirCell
mov rax, [r11 + 0x100]
cmp rax, [rcx]
jne notEqual

call [r11+0x200]
jmp after

notEqual:
call [r11]

after:
```

The expansion is quite costly in terms of code size.