### PR TITLE
Allow inlining in some over-bugdet cases

### DIFF
--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1462,7 +1462,7 @@ bool ExtendedDefaultPolicy::BudgetCheck() const
     //
     INT64 codeSize = (INT64)m_CodeSize;
 
-    // We assume each foldable branch reduces total IL size by 32 bytes, it's
+    // We assume each foldable branch reduces total IL size by 35 bytes, it's
     // a pretty conservative guess, e.g. the following branch:
     //
     //  if (typeof(TKey) == typeof(byte))
@@ -1470,23 +1470,19 @@ bool ExtendedDefaultPolicy::BudgetCheck() const
     //
     // is recognized as foldable and removes 52 bytes of IL if TKey is not byte.
     //
-    codeSize -= (INT64)m_FoldableBranch * 32;
+    codeSize -= (INT64)m_FoldableBranch * 35;
 
     // Foldable switches are usually able to fold more than foldable branches
     //
-    codeSize -= (INT64)m_FoldableSwitch * 64;
-
-    // Don't report negative number
-    //
-    codeSize = codeSize < 0 ? 0 : codeSize;
+    codeSize -= (INT64)m_FoldableSwitch * 70;
 
     // Assume we can't fold more than 70% of IL
     //
-    codeSize = max((INT64)(m_CodeSize * 0.3), codeSize);
+    codeSize = codeSize < (INT64)(m_CodeSize * 0.3) ? (INT64)(m_CodeSize * 0.3) : codeSize;
 
     // In future, we plan to introduce a more precise IL scan phase to know exactly
     // what we can elide if we inline given callee.
-
+    //
     return m_RootCompiler->m_inlineStrategy->BudgetCheck((unsigned)codeSize);
 }
 

--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1449,22 +1449,24 @@ void ExtendedDefaultPolicy::NoteDouble(InlineObservation obs, double value)
 bool ExtendedDefaultPolicy::BudgetCheck() const
 {
     // First, use a more conservative DefaultPolicy::BudgetCheck
-    // if it's fine with inlining the callee - we're good as is.
+    // if it's fine with inlining the current callee - we're good as is.
     if (!DefaultPolicy::BudgetCheck())
     {
         return false;
     }
 
-    // ExtendedDefaultPolicy has a better understanding on how many branches are foldable
-    // so we can roughly predict the final IL size JIT will have to emit (all foldable
-    // branches will be eliminated early in the importer)
+    // ExtendedDefaultPolicy has a better understanding on how many branches
+    // are foldable so we can roughly predict the final IL size JIT will have
+    // to work with (all foldable branches will be eliminated early in the
+    // importer so they won't affect the time it takes to compile the callee)
     //
     INT64 codeSize = (INT64)m_CodeSize;
 
-    // We assume each foldable branch reduces total IL size by 32 bytes, it's a pretty conservative
-    // guess, e.g. the following pattern:
+    // We assume each foldable branch reduces total IL size by 32 bytes, it's
+    // a pretty conservative guess, e.g. the following branch:
     //
-    //  if (typeof(TKey) == typeof(byte)) return (byte)(object)left < (byte)(object)right;
+    //  if (typeof(TKey) == typeof(byte))
+    //      return (byte)(object)left < (byte)(object)right;
     //
     // is recognized as foldable and removes 52 bytes of IL if TKey is not byte.
     //
@@ -1482,8 +1484,8 @@ bool ExtendedDefaultPolicy::BudgetCheck() const
     //
     codeSize = max((INT64)(m_CodeSize * 0.3), codeSize);
 
-    // In future, we plan to introduce a more precise IL scan phase to know exactly what we can elide
-    // if we inline given callee.
+    // In future, we plan to introduce a more precise IL scan phase to know exactly
+    // what we can elide if we inline given callee.
 
     return m_RootCompiler->m_inlineStrategy->BudgetCheck((unsigned)codeSize);
 }

--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1337,6 +1337,7 @@ void ExtendedDefaultPolicy::NoteBool(InlineObservation obs, bool value)
 
         case InlineObservation::CALLEE_END_OPCODE_SCAN:
         {
+            // Based on DefaultPolicy with a few modifications around overBudget inlining
             if (m_StateMachine != nullptr)
             {
                 m_StateMachine->End();

--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1335,6 +1335,63 @@ void ExtendedDefaultPolicy::NoteBool(InlineObservation obs, bool value)
             m_IsCallsiteInNoReturnRegion = value;
             break;
 
+        case InlineObservation::CALLEE_END_OPCODE_SCAN:
+        {
+            if (m_StateMachine != nullptr)
+            {
+                m_StateMachine->End();
+            }
+
+            // This heuristic is copied from DefaultPolicy for compatibility
+            if (((m_InstructionCount - m_LoadStoreCount) < 4) ||
+                (((double)m_LoadStoreCount / (double)m_InstructionCount) > .90))
+            {
+                m_MethodIsMostlyLoadStore = true;
+            }
+
+            bool overBudget = !m_IsPrejitRoot && m_RootCompiler->m_inlineStrategy->BudgetCheck(m_CodeSize);
+            if (overBudget && m_IsForceInline)
+            {
+                if (m_CallsiteDepth == 1)
+                {
+                    // Unconditionally allow inlining for top-level force-inlines
+                    // (compatibility with DefaultPolicy)
+                    overBudget = false;
+                }
+                else
+                {
+                    // For this case we want to take number of foldable branches into account: the more the foldable
+                    // branches we found
+                    // the less work JIT will need to do because those will be elided early in the importer.
+                    // TODO: the current design validates time budget after full prescan while we could save JIT TP by
+                    // only doing a partial prescan.
+                    assert(m_CallsiteDepth > 1);
+
+                    // Calculate the benefits, we take into account:
+                    //  FoldableBranches
+                    //  FoldableSwitches (we usually elide more than in case of FoldableBranch, hence, multiply by 2)
+                    double pros = m_FoldableBranch + m_FoldableSwitch * 2.0;
+
+                    // We ran out of time budget so have to be quite conservative
+                    double cons = m_CallsiteDepth *
+                                  (2.0 + min(1.0, (double)m_RootCompiler->lvaCount / JitConfig.JitMaxLocalsToTrack()));
+
+                    JITDUMP("Considering over-budget inlining - pros:%g, cons:%g\n", pros, cons);
+
+                    if (pros > cons)
+                    {
+                        overBudget = false;
+                    }
+                }
+            }
+
+            if (overBudget)
+            {
+                SetFailure(InlineObservation::CALLSITE_OVER_BUDGET);
+            }
+            break;
+        }
+
         default:
             DefaultPolicy::NoteBool(obs, value);
             break;

--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -1440,16 +1440,21 @@ void ExtendedDefaultPolicy::NoteDouble(InlineObservation obs, double value)
     m_ProfileFrequency = value;
 }
 
+//------------------------------------------------------------------------
+// BudgetCheck: see if this inline would exceed the current budget
+//
+// Returns:
+//   True if inline would exceed the budget.
+//
 bool ExtendedDefaultPolicy::BudgetCheck() const
 {
-    // Only relevant if we're actually inlining.
     if (m_IsPrejitRoot)
     {
+        // Only relevant if we're actually inlining.
         return false;
     }
 
-    // The strategy tracks the amout of inlining done so far,
-    // so it performs the actual check.
+    // The strategy tracks the amout of inlining done so far, so it performs the actual check.
     const bool overBudget = m_RootCompiler->m_inlineStrategy->BudgetCheck(m_CodeSize);
 
     if (overBudget)
@@ -1474,20 +1479,17 @@ bool ExtendedDefaultPolicy::BudgetCheck() const
             // Analyze potential benefits, we take into account:
             //  FoldableBranches
             //  FoldableSwitches (we usually elide more than in case of FoldableBranch, hence, multiply by 2)
-            double pros = m_FoldableBranch + m_FoldableSwitch * 2.0;
+            const double pros = m_FoldableBranch + m_FoldableSwitch * 2.0;
 
             // We ran out of time budget so have to be quite conservative
-            double cons =
+            const double cons =
                 m_CallsiteDepth * (2.0 + min(1.0, (double)m_RootCompiler->lvaCount / JitConfig.JitMaxLocalsToTrack()));
 
             JITDUMP("Considering over-budget inlining for forceinline - pros:%g, cons:%g\n", pros, cons);
 
-            if (pros > cons)
-            {
-                return false;
-            }
-            return true;
+            return pros < cons;
         }
+        return true;
     }
     return false;
 }

--- a/src/coreclr/jit/inlinepolicy.h
+++ b/src/coreclr/jit/inlinepolicy.h
@@ -127,6 +127,11 @@ public:
     void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) override;
     bool BudgetCheck() const override;
 
+    virtual unsigned EstimatedTotalILSize() const
+    {
+        return m_CodeSize;
+    }
+
     // Policy policies
     bool PropagateNeverToRuntime() const override;
 
@@ -228,7 +233,7 @@ public:
 
     double DetermineMultiplier() override;
 
-    bool BudgetCheck() const override;
+    unsigned EstimatedTotalILSize() const override;
 
     bool RequiresPreciseScan() override
     {

--- a/src/coreclr/jit/inlinepolicy.h
+++ b/src/coreclr/jit/inlinepolicy.h
@@ -228,6 +228,8 @@ public:
 
     double DetermineMultiplier() override;
 
+    bool BudgetCheck() const override;
+
     bool RequiresPreciseScan() override
     {
         return true;


### PR DESCRIPTION
This PR reduces number of not inlined methods with `[AggressiveInlining]` attribute in cases where it's profitable.

Closes https://github.com/dotnet/runtime/issues/78648
Closes https://github.com/dotnet/runtime/issues/43761
Closes https://github.com/dotnet/runtime/issues/51587
Closes https://github.com/dotnet/runtime/issues/41692
(I've verified that this PR fixes all codegen issues in the snippets in those issues ^)


The current inliner is quite conservative around the time budget it uses for a call graph, [here is how it looks like](https://github.com/dotnet/runtime/blob/4f53c2f7e62df44f07cf410df8a0d439f42a0a71/src/coreclr/jit/inline.cpp#L1054-L1076).
The following sample demonstrates why it's not perfect:
```csharp
[MethodImpl(MethodImplOptions.AggressiveInlining)]
static bool LessThan<TKey>(TKey left, TKey right)
{
    if (typeof(TKey) == typeof(byte)) return (byte)(object)left < (byte)(object)right;
    if (typeof(TKey) == typeof(sbyte)) return (sbyte)(object)left < (sbyte)(object)right;
    if (typeof(TKey) == typeof(ushort)) return (ushort)(object)left < (ushort)(object)right;
    if (typeof(TKey) == typeof(short)) return (short)(object)left < (short)(object)right;
    if (typeof(TKey) == typeof(uint)) return (uint)(object)left < (uint)(object)right;
    if (typeof(TKey) == typeof(int)) return (int)(object)left < (int)(object)right;
    if (typeof(TKey) == typeof(ulong)) return (ulong)(object)left < (ulong)(object)right;
    if (typeof(TKey) == typeof(long)) return (long)(object)left < (long)(object)right;
    return false;
}

[MethodImpl(MethodImplOptions.AggressiveInlining)]
static bool LessThanWrapper<TKey>(TKey left, TKey right) =>
    LessThan(left, right);

public static void Main()
{
    LessThanWrapper(1, 2);
}
```
Codegen for Main:
```asm
; Method Program:Main()
G_M000_IG01:                
       4883EC28             sub      rsp, 40
G_M000_IG02:                
       B901000000           mov      ecx, 1
       BA02000000           mov      edx, 2
       FF15BCF82C00         call     [Program:LessThan[int](int,int):bool]
       90                   nop      
G_M000_IG03:               
       4883C428             add      rsp, 40
       C3                   ret      
; Total bytes of code: 26
```
As you can see, it's not inlined due to "exceeds the time budget" reason despite being marked as AggressiveInlining. While in reality the method doesn't have a lot of work for JIT to do - 95% of it is stripped during import.

So it seems to me that we should allow overbudget for forceinline callees with foldable branches inside.

jit-diff (`-f -pmi`) from this change:
```
PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies [invoking .cctors] for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 54786092
Total bytes of diff: 54783678
Total bytes of delta: -2414 (-0.00 % of base)

Top method regressions (percentages):
         197 (160.16% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.ErrorFacts:CreateCategoriesMap():System.Collections.Immutable.ImmutableDictionary`2[int,System.String]
         197 (160.16% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.ErrorFacts:CreateHelpLinks():System.Collections.Immutable.ImmutableDictionary`2[int,System.String]
         197 (160.16% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.ErrorFactory:CreateCategoriesMap():System.Collections.Immutable.ImmutableDictionary`2[int,System.String]
         197 (160.16% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.ErrorFactory:CreateHelpLinks():System.Collections.Immutable.ImmutableDictionary`2[int,System.String]
         180 (28.80% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference+<>c:<GetAnalyzerTypeNameMap>b__30_9(System.Linq.IGrouping`2[System.String,System.String]):System.Collections.Immutable.ImmutableHashSet`1[System.String]:this
          81 (18.93% of base) : System.Net.Sockets.dasm - System.Net.Sockets.Socket:ReceiveAsync(System.ArraySegment`1[ubyte]):System.Threading.Tasks.Task`1[int]:this
          81 (18.93% of base) : System.Net.Sockets.dasm - System.Net.Sockets.Socket:SendAsync(System.ArraySegment`1[ubyte]):System.Threading.Tasks.Task`1[int]:this
          81 (18.79% of base) : System.Net.Sockets.dasm - System.Net.Sockets.Socket:ReceiveAsync(System.ArraySegment`1[ubyte],int):System.Threading.Tasks.Task`1[int]:this
          81 (18.79% of base) : System.Net.Sockets.dasm - System.Net.Sockets.SocketTaskExtensions:ReceiveAsync(System.Net.Sockets.Socket,System.ArraySegment`1[ubyte],int):System.Threading.Tasks.Task`1[int]
          85 (18.01% of base) : System.Net.Sockets.dasm - System.Net.Sockets.UdpClient:BeginSend(ubyte[],int,System.AsyncCallback,System.Object):System.IAsyncResult:this
          81 (17.46% of base) : System.Net.Sockets.dasm - System.Net.Sockets.Socket:SendToAsync(System.ArraySegment`1[ubyte],System.Net.EndPoint):System.Threading.Tasks.Task`1[int]:this
          61 (16.90% of base) : System.Memory.dasm - System.Buffers.ReadOnlySequence`1+<>c[double]:<ToString>b__33_0(System.Span`1[ushort],System.Buffers.ReadOnlySequence`1[ushort]):this
          61 (16.90% of base) : System.Memory.dasm - System.Buffers.ReadOnlySequence`1+<>c[int]:<ToString>b__33_0(System.Span`1[ushort],System.Buffers.ReadOnlySequence`1[ushort]):this
          61 (16.90% of base) : System.Memory.dasm - System.Buffers.ReadOnlySequence`1+<>c[long]:<ToString>b__33_0(System.Span`1[ushort],System.Buffers.ReadOnlySequence`1[ushort]):this
          61 (16.90% of base) : System.Memory.dasm - System.Buffers.ReadOnlySequence`1+<>c[short]:<ToString>b__33_0(System.Span`1[ushort],System.Buffers.ReadOnlySequence`1[ushort]):this
          61 (16.90% of base) : System.Memory.dasm - System.Buffers.ReadOnlySequence`1+<>c[System.__Canon]:<ToString>b__33_0(System.Span`1[ushort],System.Buffers.ReadOnlySequence`1[ushort]):this
          61 (16.90% of base) : System.Memory.dasm - System.Buffers.ReadOnlySequence`1+<>c[System.Nullable`1[int]]:<ToString>b__33_0(System.Span`1[ushort],System.Buffers.ReadOnlySequence`1[ushort]):this
          61 (16.90% of base) : System.Memory.dasm - System.Buffers.ReadOnlySequence`1+<>c[System.Numerics.Vector`1[float]]:<ToString>b__33_0(System.Span`1[ushort],System.Buffers.ReadOnlySequence`1[ushort]):this
          61 (16.90% of base) : System.Memory.dasm - System.Buffers.ReadOnlySequence`1+<>c[ubyte]:<ToString>b__33_0(System.Span`1[ushort],System.Buffers.ReadOnlySequence`1[ushort]):this
          60 (14.05% of base) : System.Security.Cryptography.Xml.dasm - System.Security.Cryptography.Xml.RSAPKCS1SHA1SignatureDescription:.ctor():this
          60 (14.05% of base) : System.Security.Cryptography.Xml.dasm - System.Security.Cryptography.Xml.RSAPKCS1SHA256SignatureDescription:.ctor():this
          60 (14.05% of base) : System.Security.Cryptography.Xml.dasm - System.Security.Cryptography.Xml.RSAPKCS1SHA384SignatureDescription:.ctor():this
          60 (14.05% of base) : System.Security.Cryptography.Xml.dasm - System.Security.Cryptography.Xml.RSAPKCS1SHA512SignatureDescription:.ctor():this
          45 ( 8.64% of base) : System.Net.Sockets.dasm - System.Net.Sockets.Socket:ReceiveMessageFromAsync(System.ArraySegment`1[ubyte],System.Net.EndPoint):System.Threading.Tasks.Task`1[System.Net.Sockets.SocketReceiveMessageFromResult]:this
          76 ( 7.87% of base) : System.Text.Json.dasm - System.Text.Json.Utf8JsonWriter:WritePropertyName(System.Decimal):this
          70 ( 7.28% of base) : System.Text.Json.dasm - System.Text.Json.Utf8JsonWriter:WritePropertyName(System.Guid):this
          70 ( 6.90% of base) : System.Text.Json.dasm - System.Text.Json.Utf8JsonWriter:WritePropertyName(double):this
          28 ( 5.67% of base) : System.Net.Sockets.dasm - System.Net.Sockets.Socket:ReceiveFromAsync(System.ArraySegment`1[ubyte],System.Net.EndPoint):System.Threading.Tasks.Task`1[System.Net.Sockets.SocketReceiveFromResult]:this
         227 ( 5.14% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.SyntaxAndDeclarationManager:CreateState(System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.SyntaxTree],System.String,Microsoft.CodeAnalysis.SourceReferenceResolver,Microsoft.CodeAnalysis.CommonMessageProvider,bool):Microsoft.CodeAnalysis.CSharp.SyntaxAndDeclarationManager+State
          44 ( 5.03% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.MetadataReaderExtensions:IsTheObjectClass(System.Reflection.Metadata.MetadataReader,System.Reflection.Metadata.TypeDefinition):bool
          38 ( 4.48% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.CodeGen.CodeGenerator:EmitStaticFieldLoad(Microsoft.CodeAnalysis.VisualBasic.Symbols.FieldSymbol,bool,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode):this
          38 ( 4.24% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToDate(System.String):System.DateTime
          38 ( 4.24% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToDateTime(System.String):System.DateTime
          38 ( 4.24% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToGYearMonth(System.String):System.DateTime
          38 ( 4.24% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToTime(System.String):System.DateTime
          38 ( 4.19% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToDateOffset(System.String):System.DateTimeOffset
          38 ( 4.19% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToDateTimeOffset(System.String):System.DateTimeOffset
          38 ( 4.19% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToGYearMonthOffset(System.String):System.DateTimeOffset
          38 ( 4.19% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToTimeOffset(System.String):System.DateTimeOffset
          38 ( 4.07% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToGDay(System.String):System.DateTime
          38 ( 4.07% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToGMonthDay(System.String):System.DateTime
          38 ( 4.07% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToGYear(System.String):System.DateTime
          38 ( 4.03% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToGDayOffset(System.String):System.DateTimeOffset
          38 ( 4.03% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToGMonthDayOffset(System.String):System.DateTimeOffset
          38 ( 4.03% of base) : System.Private.Xml.dasm - System.Xml.Schema.XmlBaseConverter:StringToGYearOffset(System.String):System.DateTimeOffset
          20 ( 2.64% of base) : System.Security.Cryptography.dasm - System.Security.Cryptography.AesCng:CreateDecryptor(ubyte[],ubyte[]):System.Security.Cryptography.ICryptoTransform:this
          20 ( 2.64% of base) : System.Security.Cryptography.dasm - System.Security.Cryptography.TripleDESCng:CreateDecryptor(ubyte[],ubyte[]):System.Security.Cryptography.ICryptoTransform:this
          17 ( 2.24% of base) : System.Security.Cryptography.dasm - System.Security.Cryptography.AesCng:CreateEncryptor(ubyte[],ubyte[]):System.Security.Cryptography.ICryptoTransform:this
          17 ( 2.24% of base) : System.Security.Cryptography.dasm - System.Security.Cryptography.TripleDESCng:CreateEncryptor(ubyte[],ubyte[]):System.Security.Cryptography.ICryptoTransform:this
          16 ( 2.10% of base) : System.Private.CoreLib.dasm - System.Int128:TryFormat(System.Span`1[ushort],byref,System.ReadOnlySpan`1[ushort],System.IFormatProvider):bool:this
          25 ( 1.70% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference:GetFullyQualifiedTypeName(System.Reflection.Metadata.TypeDefinition,Microsoft.CodeAnalysis.PEModule):System.String
           1 ( 0.07% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlnsAttribute(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax,System.String,System.String,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundXmlAttribute:this

Top method improvements (percentages):
        -103 (-100.00% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.SmallDictionary`2[System.__Canon,int]:RightComplex(Microsoft.CodeAnalysis.SmallDictionary`2+AvlNode[System.__Canon,int]):Microsoft.CodeAnalysis.SmallDictionary`2+AvlNode[System.__Canon,int] (1 base, 0 diff methods)
        -138 (-82.63% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Counter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float]):this
        -138 (-82.63% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Histogram`1[System.Numerics.Vector`1[float]]:Record(System.Numerics.Vector`1[float]):this
        -138 (-82.63% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.UpDownCounter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float]):this
        -128 (-71.11% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Counter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -128 (-71.11% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Histogram`1[System.Numerics.Vector`1[float]]:Record(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -128 (-71.11% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.UpDownCounter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -171 (-70.95% of base) : System.Linq.dasm - System.Linq.Enumerable:Order[int](System.Collections.Generic.IEnumerable`1[int]):System.Linq.IOrderedEnumerable`1[int]
        -171 (-70.95% of base) : System.Linq.dasm - System.Linq.Enumerable:Order[long](System.Collections.Generic.IEnumerable`1[long]):System.Linq.IOrderedEnumerable`1[long]
        -171 (-70.95% of base) : System.Linq.dasm - System.Linq.Enumerable:Order[short](System.Collections.Generic.IEnumerable`1[short]):System.Linq.IOrderedEnumerable`1[short]
        -171 (-70.95% of base) : System.Linq.dasm - System.Linq.Enumerable:Order[ubyte](System.Collections.Generic.IEnumerable`1[ubyte]):System.Linq.IOrderedEnumerable`1[ubyte]
        -171 (-70.95% of base) : System.Linq.dasm - System.Linq.Enumerable:OrderDescending[int](System.Collections.Generic.IEnumerable`1[int]):System.Linq.IOrderedEnumerable`1[int]
        -171 (-70.95% of base) : System.Linq.dasm - System.Linq.Enumerable:OrderDescending[long](System.Collections.Generic.IEnumerable`1[long]):System.Linq.IOrderedEnumerable`1[long]
        -171 (-70.95% of base) : System.Linq.dasm - System.Linq.Enumerable:OrderDescending[short](System.Collections.Generic.IEnumerable`1[short]):System.Linq.IOrderedEnumerable`1[short]
        -171 (-70.95% of base) : System.Linq.dasm - System.Linq.Enumerable:OrderDescending[ubyte](System.Collections.Generic.IEnumerable`1[ubyte]):System.Linq.IOrderedEnumerable`1[ubyte]
        -194 (-68.07% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Counter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float],byref):this
        -194 (-68.07% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Histogram`1[System.Numerics.Vector`1[float]]:Record(System.Numerics.Vector`1[float],byref):this
        -194 (-68.07% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.UpDownCounter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float],byref):this
        -137 (-59.57% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Counter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -137 (-59.57% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Histogram`1[System.Numerics.Vector`1[float]]:Record(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -137 (-59.57% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.UpDownCounter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -165 (-57.69% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Counter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -165 (-57.69% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.Histogram`1[System.Numerics.Vector`1[float]]:Record(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -165 (-57.69% of base) : System.Diagnostics.DiagnosticSource.dasm - System.Diagnostics.Metrics.UpDownCounter`1[System.Numerics.Vector`1[float]]:Add(System.Numerics.Vector`1[float],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object],System.Collections.Generic.KeyValuePair`2[System.String,System.Object]):this
        -190 (-47.98% of base) : System.Private.CoreLib.dasm - System.MemoryExtensions:LastIndexOfAnyExcept[System.Numerics.Vector`1[float]](System.Span`1[System.Numerics.Vector`1[float]],System.Numerics.Vector`1[float]):int
        -192 (-47.76% of base) : System.Private.CoreLib.dasm - System.MemoryExtensions:IndexOfAnyExcept[System.Numerics.Vector`1[float]](System.Span`1[System.Numerics.Vector`1[float]],System.Numerics.Vector`1[float]):int
        -306 (-45.81% of base) : System.Private.CoreLib.dasm - System.MemoryExtensions:LastIndexOfAnyExcept[System.Numerics.Vector`1[float]](System.Span`1[System.Numerics.Vector`1[float]],System.Numerics.Vector`1[float],System.Numerics.Vector`1[float]):int
        -307 (-45.41% of base) : System.Private.CoreLib.dasm - System.MemoryExtensions:IndexOfAnyExcept[System.Numerics.Vector`1[float]](System.Span`1[System.Numerics.Vector`1[float]],System.Numerics.Vector`1[float],System.Numerics.Vector`1[float]):int
        -147 (-38.38% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.ValueTuple`2[System.Numerics.Vector`1[float],System.Nullable`1[int]]:op_Equality(Roslyn.Utilities.ValueTuple`2[System.Numerics.Vector`1[float],System.Nullable`1[int]],Roslyn.Utilities.ValueTuple`2[System.Numerics.Vector`1[float],System.Nullable`1[int]]):bool
        -147 (-37.60% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.ValueTuple`2[System.Numerics.Vector`1[float],System.Nullable`1[int]]:op_Inequality(Roslyn.Utilities.ValueTuple`2[System.Numerics.Vector`1[float],System.Nullable`1[int]],Roslyn.Utilities.ValueTuple`2[System.Numerics.Vector`1[float],System.Nullable`1[int]]):bool
        -134 (-27.07% of base) : CommandLine.dasm - CSharpx.MaybeExtensions:ToMaybe[System.Numerics.Vector`1[float]](System.Numerics.Vector`1[float]):CSharpx.Maybe`1[System.Numerics.Vector`1[float]]
        -134 (-25.57% of base) : System.Collections.Immutable.dasm - System.Collections.Frozen.ValueTypeDefaultComparerFrozenSet`1+GSW[System.Numerics.Vector`1[float]]:FindItemIndex(System.Numerics.Vector`1[float]):int:this
         -59 (-24.48% of base) : System.Linq.dasm - System.Linq.Enumerable:Order[double](System.Collections.Generic.IEnumerable`1[double]):System.Linq.IOrderedEnumerable`1[double]
         -59 (-24.48% of base) : System.Linq.dasm - System.Linq.Enumerable:Order[System.Nullable`1[int]](System.Collections.Generic.IEnumerable`1[System.Nullable`1[int]]):System.Linq.IOrderedEnumerable`1[System.Nullable`1[int]]
         -59 (-24.48% of base) : System.Linq.dasm - System.Linq.Enumerable:Order[System.Numerics.Vector`1[float]](System.Collections.Generic.IEnumerable`1[System.Numerics.Vector`1[float]]):System.Linq.IOrderedEnumerable`1[System.Numerics.Vector`1[float]]
         -59 (-24.48% of base) : System.Linq.dasm - System.Linq.Enumerable:OrderDescending[double](System.Collections.Generic.IEnumerable`1[double]):System.Linq.IOrderedEnumerable`1[double]
         -59 (-24.48% of base) : System.Linq.dasm - System.Linq.Enumerable:OrderDescending[System.Nullable`1[int]](System.Collections.Generic.IEnumerable`1[System.Nullable`1[int]]):System.Linq.IOrderedEnumerable`1[System.Nullable`1[int]]
         -59 (-24.48% of base) : System.Linq.dasm - System.Linq.Enumerable:OrderDescending[System.Numerics.Vector`1[float]](System.Collections.Generic.IEnumerable`1[System.Numerics.Vector`1[float]]):System.Linq.IOrderedEnumerable`1[System.Numerics.Vector`1[float]]
         -36 (-22.64% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Divide[long](System.Numerics.Vector`1[long],long):System.Numerics.Vector`1[long]
         -16 (-17.98% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Divide[int](System.Numerics.Vector`1[int],int):System.Numerics.Vector`1[int]
         -17 (-14.78% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Divide[short](System.Numerics.Vector`1[short],System.Numerics.Vector`1[short]):System.Numerics.Vector`1[short]
         -13 (-13.98% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Divide[short](System.Numerics.Vector`1[short],short):System.Numerics.Vector`1[short]
         -27 (-13.78% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Divide[long](System.Numerics.Vector`1[long],System.Numerics.Vector`1[long]):System.Numerics.Vector`1[long]
         -13 (-12.26% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Divide[int](System.Numerics.Vector`1[int],System.Numerics.Vector`1[int]):System.Numerics.Vector`1[int]
          -9 (-9.89% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Divide[ubyte](System.Numerics.Vector`1[ubyte],ubyte):System.Numerics.Vector`1[ubyte]
          -9 (-8.11% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Divide[ubyte](System.Numerics.Vector`1[ubyte],System.Numerics.Vector`1[ubyte]):System.Numerics.Vector`1[ubyte]
         -14 (-1.54% of base) : System.Net.Sockets.dasm - System.Net.Sockets.UdpClient:BeginSend(ubyte[],int,System.String,int,System.AsyncCallback,System.Object):System.IAsyncResult:this
         -24 (-1.09% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree+ConditionalSymbolsMap+ConditionalSymbolsMapBuilder:ProcessCommandLinePreprocessorSymbols(System.Collections.Immutable.ImmutableDictionary`2[System.String,Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.CConst]):this

100 total methods with Code Size differences (48 improved, 52 regressed), 341155 unchanged.
```
Some examples:
1. [System.Linq.Enumerable:OrderDescending[int]](https://www.diffchecker.com/KDTl0ZPE) - [TypeIsImplicitlyStable](https://github.com/dotnet/runtime/blob/4f53c2f7e62df44f07cf410df8a0d439f42a0a71/src/libraries/System.Linq/src/System/Linq/OrderBy.cs#L142-L150) was not inlined previously.
2. [System.Numerics.Vector:Divide[int]](https://www.diffchecker.com/8f0ARhUw) - `Vector<T>(Vector, T)` used to be extremely slow because of that, see https://github.com/dotnet/runtime/issues/43761
3. [CSharpx.MaybeExtensions:ToMaybe[System.Numerics.Vector'1[float]]](https://www.diffchecker.com/iAJwPKoN) - ouch, it turns out `Vector<T>.IsSupported` is not a jit intrinsic - [see here](https://github.com/dotnet/runtime/blob/77de7840c7ad806cd5ad5dc9555ad3d3bed2a6e5/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs#L160-L175).

Size-regressions (look to be perf improvements):
1. [System.Net.Sockets.Socket:ReceiveAsync](https://www.diffchecker.com/uaHe4Yus) - Task.FromResult was inlined (it's marked as AggressiveInlining).
2. [System.Xml.Schema.XmlBaseConverter:StringToDate(System.String)](https://www.diffchecker.com/B2PyC4xM) - DateTime::Kind is marked as AggressiveInlining
5. [System.Int128:TryFormat(...)](https://www.diffchecker.com/ofhgIda2) - BitOperations.log2 was not inlined previously.
6. [System.Security.Cryptography.Xml.RSAPKCS1SHA1SignatureDescription:.ctor():this](https://www.diffchecker.com/ANKULW67)
7. Five Microsoft.CodeAnalysis.* are questionable inline decisions (e.g. [this](https://www.diffchecker.com/DPB4px7s)), inliner recognized 2 foldable branches where in fact it's 0 of them, hopefully, we'll have a more precise analysis in future. 
8. [System.Text.Json.Utf8JsonWriter:WritePropertyName(double):this](https://www.diffchecker.com/JLv9aw7m) - Memory.get_Span is inlined (it's marked with AggressiveInlining)

Might also help @stephentoub in https://github.com/dotnet/runtime/pull/78580