### PR TITLE
[wasm] Fix chrome downloads to unbreak CI

### DIFF
--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -22,6 +22,35 @@
     <FirefoxStampFile>$([MSBuild]::NormalizePath($(FirefoxDir), '.install-firefox-$(FirefoxRevision).stamp'))</FirefoxStampFile>
   </PropertyGroup>
 
+  <!--
+    We use https://omahaproxy.appspot.com/all.json to get details about the
+    latest stable chrome versions. The `branch_base_position` field in that is
+    used to locate closest snapshots that can be installed for testing.
+
+    But this `branch_base_position` seems to be incorrect sometimes, and can
+    cause failures like:
+
+      `Could not find a chrome snapshot folder under
+      https://storage.googleapis.com/chromium-browser-snapshots/Win_x64, for
+      branch positions 1202 to 1232, for version 107.0.5304.122`
+
+    For now, use the last branch position from the last working stable
+    version - `107.0.5304.110`, till we find a better way to do this.
+
+    Refer to `GetChromeVersions` task in `src/tasks` to see how we find
+    these snapshot urls.
+  -->
+  <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('linux'))">
+    <ChromeVersion>107.0.5304.110</ChromeVersion>
+    <ChromeRevision>1047731</ChromeRevision>
+    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1047731</_ChromeBaseSnapshotUrl>
+  </PropertyGroup>
+  <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('windows'))">
+    <ChromeVersion>107.0.5304.107</ChromeVersion>
+    <ChromeRevision>1047731</ChromeRevision>
+    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1047737</_ChromeBaseSnapshotUrl>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(BrowserHost)' != 'windows'">
     <FirefoxRevision>97.0.1</FirefoxRevision>
     <FirefoxUrl>https://ftp.mozilla.org/pub/firefox/releases/$(FirefoxRevision)/linux-x86_64/en-US/firefox-$(FirefoxRevision).tar.bz2</FirefoxUrl>

--- a/eng/testing/wasm-provisioning.targets
+++ b/eng/testing/wasm-provisioning.targets
@@ -99,7 +99,19 @@
              TaskName="Microsoft.WebAssembly.Build.Tasks.GetChromeVersions" />
 
   <Target Name="GetChromeVersion" AfterTargets="Build" Condition="'$(InstallChromeForTests)' == 'true'">
+    <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('linux'))">
+      <ChromeVersion>107.0.5304.110</ChromeVersion>
+      <ChromeRevision>1047731</ChromeRevision>
+      <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1047731</_ChromeBaseSnapshotUrl>
+    </PropertyGroup>
+    <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('windows'))">
+      <ChromeVersion>107.0.5304.107</ChromeVersion>
+      <ChromeRevision>1047731</ChromeRevision>
+      <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1047737</_ChromeBaseSnapshotUrl>
+    </PropertyGroup>
+
     <GetChromeVersions
+                Condition="'$(ChromeVersion)' == ''"
                 OSIdentifier="$(ChromeOSIdentifier)"
                 OSPrefix="$(_ChromeOSPrefix)"
                 Channel="$(ChromeChannel)"

--- a/eng/testing/wasm-provisioning.targets
+++ b/eng/testing/wasm-provisioning.targets
@@ -99,17 +99,6 @@
              TaskName="Microsoft.WebAssembly.Build.Tasks.GetChromeVersions" />
 
   <Target Name="GetChromeVersion" AfterTargets="Build" Condition="'$(InstallChromeForTests)' == 'true'">
-    <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('linux'))">
-      <ChromeVersion>107.0.5304.110</ChromeVersion>
-      <ChromeRevision>1047731</ChromeRevision>
-      <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1047731</_ChromeBaseSnapshotUrl>
-    </PropertyGroup>
-    <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('windows'))">
-      <ChromeVersion>107.0.5304.107</ChromeVersion>
-      <ChromeRevision>1047731</ChromeRevision>
-      <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1047737</_ChromeBaseSnapshotUrl>
-    </PropertyGroup>
-
     <GetChromeVersions
                 Condition="'$(ChromeVersion)' == ''"
                 OSIdentifier="$(ChromeOSIdentifier)"


### PR DESCRIPTION
CI is failing to install snapshots for latest chrome stable with:

`Could not find a chrome snapshot folder under
https://storage.googleapis.com/chromium-browser-snapshots/Win_x64, for branch positions 1202 to 1232, for version 107.0.5304.122`

This is because we use `branch_base_position` from https://omahaproxy.appspot.com/all.json but that seems to be incorrect sometimes.

Looking at other projects trying to find the snapshot urls, they depend on more than one way for this.

- for example - playwright installs the debs on linux for *stable* chrome, but tries to find snapshot for other channels.
- https://chromiumdash.appspot.com/branches - this seems to have the correct branch position but the data is in a html table.
- chromedriver snapshots are easier to find directly by version number, but not for chrome

For now, use the last branch position from the last working stable version - `107.0.5304.110`, till we find a better way to do this.