### PR TITLE
Align version option in System.CommandLine usages

### DIFF
--- a/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
+++ b/src/coreclr/tools/ILVerify/ILVerifyRootCommand.cs
@@ -33,7 +33,7 @@ namespace ILVerify
         public Option<bool> Statistics { get; } =
             new(new[] { "--statistics" }, "Print verification statistics");
         public Option<bool> Verbose { get; } =
-            new(new[] { "--verbose", "-v" }, "Verbose output");
+            new(new[] { "--verbose" }, "Verbose output");
         public Option<bool> Tokens { get; } =
             new(new[] { "--tokens", "-t" }, "Include metadata tokens in error messages");
 

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -456,7 +456,7 @@ namespace ILVerify
         private static int Main(string[] args) =>
             new CommandLineBuilder(new ILVerifyRootCommand())
                 .UseTokenReplacer(Helpers.TryReadResponseFile)
-                .UseVersionOption()
+                .UseVersionOption("--version", "-v")
                 .UseHelp()
                 .UseParseErrorReporting()
                 .Build()

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -24,9 +24,9 @@ namespace ILCompiler
         public Option<bool> Optimize { get; } =
             new(new[] { "--optimize", "-O" }, "Enable optimizations");
         public Option<bool> OptimizeSpace { get; } =
-            new(new[] { "--optimize-space", "-Os" }, "Enable optimizations, favor code space");
+            new(new[] { "--optimize-space", "--Os" }, "Enable optimizations, favor code space");
         public Option<bool> OptimizeTime { get; } =
-            new(new[] { "--optimize-time", "-Ot" }, "Enable optimizations, favor code speed");
+            new(new[] { "--optimize-time", "--Ot" }, "Enable optimizations, favor code speed");
         public Option<string[]> MibcFilePaths { get; } =
             new(new[] { "--mibc", "-m" }, Array.Empty<string>, "Mibc file(s) for profile guided optimization");
         public Option<bool> EnableDebugInfo { get; } =

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -657,7 +657,7 @@ namespace ILCompiler
         private static int Main(string[] args) =>
             new CommandLineBuilder(new ILCompilerRootCommand(args))
                 .UseTokenReplacer(Helpers.TryReadResponseFile)
-                .UseVersionOption("-v")
+                .UseVersionOption("--version", "-v")
                 .UseHelp(context => context.HelpBuilder.CustomizeLayout(ILCompilerRootCommand.GetExtendedHelp))
                 .UseParseErrorReporting()
                 .Build()

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -32,11 +32,11 @@ namespace ILCompiler
         public Option<bool> Optimize { get; } =
             new(new[] { "--optimize", "-O" }, SR.EnableOptimizationsOption);
         public Option<bool> OptimizeDisabled { get; } =
-            new(new[] { "--optimize-disabled", "-Od" }, SR.DisableOptimizationsOption);
+            new(new[] { "--optimize-disabled", "--Od" }, SR.DisableOptimizationsOption);
         public Option<bool> OptimizeSpace { get; } =
-            new(new[] { "--optimize-space", "-Os" }, SR.OptimizeSpaceOption);
+            new(new[] { "--optimize-space", "--Os" }, SR.OptimizeSpaceOption);
         public Option<bool> OptimizeTime { get; } =
-            new(new[] { "--optimize-time", "-Ot" }, SR.OptimizeSpeedOption);
+            new(new[] { "--optimize-time", "--Ot" }, SR.OptimizeSpeedOption);
         public Option<bool> InputBubble { get; } =
             new(new[] { "--inputbubble" }, SR.InputBubbleOption);
         public Option<Dictionary<string, string>> InputBubbleReferenceFilePaths { get; } =

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -891,7 +891,7 @@ namespace ILCompiler
         private static int Main(string[] args) =>
             new CommandLineBuilder(new Crossgen2RootCommand(args))
                 .UseTokenReplacer(Helpers.TryReadResponseFile)
-                .UseVersionOption("-v")
+                .UseVersionOption("--version", "-v")
                 .UseHelp(context => context.HelpBuilder.CustomizeLayout(Crossgen2RootCommand.GetExtendedHelp))
                 .UseParseErrorReporting()
                 .Build()

--- a/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
+++ b/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         private Option<bool> _includeReadyToRun { get; } =
             new("--includeReadyToRun", "Include ReadyToRun methods in the trace file");
         private Option<Verbosity> _verbosity { get; } =
-            new(new[] { "--verbose", "-v" }, () => Verbosity.normal, "Adjust verbosity level. Supported levels are minimal, normal, detailed, and diagnostic");
+            new(new[] { "--verbose" }, () => Verbosity.normal, "Adjust verbosity level. Supported levels are minimal, normal, detailed, and diagnostic");
         private Option<bool> _isSorted { get; } =
             new("--sorted", "Generate sorted output.");
         private Option<bool> _showTimestamp { get; } =

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         private static int Main(string[] args) =>
             new CommandLineBuilder(new PgoRootCommand(args))
                 .UseTokenReplacer(Helpers.TryReadResponseFile)
-                .UseVersionOption("-v")
+                .UseVersionOption("--version", "-v")
                 .UseHelp(context => context.HelpBuilder.CustomizeLayout(PgoRootCommand.GetExtendedHelp))
                 .UseParseErrorReporting()
                 .Build()

--- a/src/coreclr/tools/r2rdump/Program.cs
+++ b/src/coreclr/tools/r2rdump/Program.cs
@@ -499,6 +499,7 @@ namespace R2RDump
         public static int Main(string[] args) =>
             new CommandLineBuilder(new R2RDumpRootCommand())
                 .UseTokenReplacer(Helpers.TryReadResponseFile)
+                .UseVersionOption("--version", "-v")
                 .UseHelp()
                 .UseParseErrorReporting()
                 .Build()

--- a/src/coreclr/tools/r2rdump/R2RDumpRootCommand.cs
+++ b/src/coreclr/tools/r2rdump/R2RDumpRootCommand.cs
@@ -49,7 +49,7 @@ namespace R2RDump
         public Option<bool> HideTransitions { get; } =
             new(new[] { "--hide-transitions", "--ht" }, "Don't include GC transitions in disassembly output");
         public Option<bool> Verbose { get; } =
-            new(new[] { "--verbose", "-v" }, "Dump disassembly, unwindInfo, gcInfo and sectionContents");
+            new(new[] { "--verbose" }, "Dump disassembly, unwindInfo, gcInfo and sectionContents");
         public Option<bool> Diff { get; } =
             new(new[] { "--diff" }, "Compare two R2R images");
         public Option<bool> DiffHideSameDisasm { get; } =

--- a/src/coreclr/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/tools/r2rtest/CommandLineOptions.cs
@@ -301,14 +301,13 @@ namespace R2RTest
         public Option<DirectoryInfo> AspNetPath { get; } =
             new Option<DirectoryInfo>(new[] { "--asp-net-path", "-asp" }, "Path to SERP's ASP.NET Core folder").AcceptExistingOnly();
 
-        static int Main(string[] args)
-        {
-            return new CommandLineBuilder(new R2RTestRootCommand())
+        private static int Main(string[] args) =>
+            new CommandLineBuilder(new R2RTestRootCommand())
+                .UseVersionOption("--version", "-v")
                 .UseHelp()
                 .UseParseErrorReporting()
                 .Build()
                 .Invoke(args);
-        }
     }
 
     public partial class BuildOptions


### PR DESCRIPTION
I was under the (wrong) impression that the overload of `UseVersionOption` which accepts aliases implicitly includes `--version`. Argument `--version` is not recognized in tools where we are explicitly passing `"-v"` to `UseVersionOption`. 

This PR aligns all tools to use the same style for version.