### PR TITLE
measure the perf impact of deduplicating IsCompleted call in GetConsumingEnumerable

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -1639,16 +1639,9 @@ namespace System.Collections.Concurrent
             }
 
             using CancellationTokenSource linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _consumersCancellationTokenSource.Token);
-            while (true)
+            while (TryTakeWithNoTimeValidation(out T? item, Timeout.Infinite, cancellationToken, linkedTokenSource))
             {
-                if (TryTakeWithNoTimeValidation(out T? item, Timeout.Infinite, cancellationToken, linkedTokenSource))
-                {
-                    yield return item;
-                }
-                else
-                {
-                    break;
-                }
+                yield return item;
             }
         }
 

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -1633,12 +1633,21 @@ namespace System.Collections.Concurrent
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
         public IEnumerable<T> GetConsumingEnumerable(CancellationToken cancellationToken)
         {
+            if (IsCompleted)
+            {
+                yield break;
+            }
+
             using CancellationTokenSource linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _consumersCancellationTokenSource.Token);
-            while (!IsCompleted)
+            while (true)
             {
                 if (TryTakeWithNoTimeValidation(out T? item, Timeout.Infinite, cancellationToken, linkedTokenSource))
                 {
                     yield return item;
+                }
+                else
+                {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Fixes #69320

@theodorzoulias sorry I totally forgot about this issue.

I tried your own solution, here is the benchmark code https://github.com/dotnet/performance/compare/main...pedrobsaila:performance:69320 and here are the results (let me know if something should be adjusted in the optimization or benchmark code) :

* AddRemoveFromSameThreads with optimization :
```
[2022/11/27 13:08:48][INFO] // * Summary *
[2022/11/27 13:08:48][INFO]
[2022/11/27 13:08:48][INFO] BenchmarkDotNet=v0.13.2.2009-nightly, OS=Windows 11 (10.0.22621.819)
[2022/11/27 13:08:48][INFO] 12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
[2022/11/27 13:08:48][INFO] .NET SDK=8.0.100-alpha.1.22575.20
[2022/11/27 13:08:48][INFO]   [Host]     : .NET 8.0.0 (8.0.22.55902), X64 RyuJIT AVX2
[2022/11/27 13:08:48][INFO]   Job-KRRVNP : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
[2022/11/27 13:08:48][INFO]
[2022/11/27 13:08:48][INFO] PowerPlanMode=00000000-0000-0000-0000-000000000000  Toolchain=CoreRun  InvocationCount=1
[2022/11/27 13:08:48][INFO] IterationTime=250.0000 ms  MaxIterationCount=20  MaxWarmupIterationCount=10
[2022/11/27 13:08:48][INFO] MinIterationCount=15  MinWarmupIterationCount=6  UnrollFactor=1
[2022/11/27 13:08:48][INFO] WarmupCount=-1
[2022/11/27 13:08:48][INFO]
[2022/11/27 13:08:48][INFO] |             Method |    Size |    Mean |    Error |   StdDev |  Median |      Min |     Max |       Gen0 | Allocated |
[2022/11/27 13:08:48][INFO] |------------------- |-------- |--------:|---------:|---------:|--------:|---------:|--------:|-----------:|----------:|
[2022/11/27 13:08:48][INFO] | BlockingCollection | 2000000 | 1.072 s | 0.0812 s | 0.0935 s | 1.069 s | 0.8641 s | 1.248 s | 40000.0000 | 488.29 MB |
```
* AddRemoveFromSameThreads with main code :
```
[2022/11/27 13:37:16][INFO] // * Summary *
[2022/11/27 13:37:16][INFO]
[2022/11/27 13:37:16][INFO] BenchmarkDotNet=v0.13.2.2009-nightly, OS=Windows 11 (10.0.22621.819)
[2022/11/27 13:37:16][INFO] 12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
[2022/11/27 13:37:16][INFO] .NET SDK=8.0.100-alpha.1.22575.20
[2022/11/27 13:37:16][INFO]   [Host]     : .NET 8.0.0 (8.0.22.55902), X64 RyuJIT AVX2
[2022/11/27 13:37:16][INFO]   Job-MUKWDB : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
[2022/11/27 13:37:16][INFO]
[2022/11/27 13:37:16][INFO] PowerPlanMode=00000000-0000-0000-0000-000000000000  Toolchain=CoreRun  InvocationCount=1
[2022/11/27 13:37:16][INFO] IterationTime=250.0000 ms  MaxIterationCount=20  MaxWarmupIterationCount=10
[2022/11/27 13:37:16][INFO] MinIterationCount=15  MinWarmupIterationCount=6  UnrollFactor=1
[2022/11/27 13:37:16][INFO] WarmupCount=-1
[2022/11/27 13:37:16][INFO]
[2022/11/27 13:37:16][INFO] |             Method |    Size |    Mean |    Error |   StdDev |  Median |      Min |     Max |       Gen0 | Allocated |
[2022/11/27 13:37:16][INFO] |------------------- |-------- |--------:|---------:|---------:|--------:|---------:|--------:|-----------:|----------:|
[2022/11/27 13:37:16][INFO] | BlockingCollection | 2000000 | 1.062 s | 0.1468 s | 0.1691 s | 1.089 s | 0.7242 s | 1.329 s | 40000.0000 | 488.28 MB |
```

* AddRemoveFromDifferentThreads with optimization :
```
[2022/11/27 13:28:13][INFO] // * Summary *
[2022/11/27 13:28:13][INFO]
[2022/11/27 13:28:13][INFO] BenchmarkDotNet=v0.13.2.2009-nightly, OS=Windows 11 (10.0.22621.819)
[2022/11/27 13:28:13][INFO] 12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
[2022/11/27 13:28:13][INFO] .NET SDK=8.0.100-alpha.1.22575.20
[2022/11/27 13:28:13][INFO]   [Host]     : .NET 8.0.0 (8.0.22.55902), X64 RyuJIT AVX2
[2022/11/27 13:28:13][INFO]   Job-DSIODT : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
[2022/11/27 13:28:13][INFO]
[2022/11/27 13:28:13][INFO] PowerPlanMode=00000000-0000-0000-0000-000000000000  Toolchain=CoreRun  InvocationCount=1
[2022/11/27 13:28:13][INFO] IterationTime=250.0000 ms  MaxIterationCount=20  MaxWarmupIterationCount=10
[2022/11/27 13:28:13][INFO] MinIterationCount=15  MinWarmupIterationCount=6  UnrollFactor=1
[2022/11/27 13:28:13][INFO] WarmupCount=-1
[2022/11/27 13:28:13][INFO]
[2022/11/27 13:28:13][INFO] |             Method |    Size |     Mean |    Error |   StdDev |   Median |      Min |      Max | Allocated |
[2022/11/27 13:28:13][INFO] |------------------- |-------- |---------:|---------:|---------:|---------:|---------:|---------:|----------:|
[2022/11/27 13:28:13][INFO] | BlockingCollection | 2000000 | 400.1 ms | 58.87 ms | 67.80 ms | 388.2 ms | 292.8 ms | 509.7 ms |  33.22 KB |
```
* AddRemoveFromDifferentThreads with main code :
```
[2022/11/27 13:33:26][INFO] // * Summary *
[2022/11/27 13:33:26][INFO]
[2022/11/27 13:33:26][INFO] BenchmarkDotNet=v0.13.2.2009-nightly, OS=Windows 11 (10.0.22621.819)
[2022/11/27 13:33:26][INFO] 12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
[2022/11/27 13:33:26][INFO] .NET SDK=8.0.100-alpha.1.22575.20
[2022/11/27 13:33:26][INFO]   [Host]     : .NET 8.0.0 (8.0.22.55902), X64 RyuJIT AVX2
[2022/11/27 13:33:26][INFO]   Job-NCVXOG : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT AVX2
[2022/11/27 13:33:26][INFO]
[2022/11/27 13:33:26][INFO] PowerPlanMode=00000000-0000-0000-0000-000000000000  Toolchain=CoreRun  InvocationCount=1
[2022/11/27 13:33:26][INFO] IterationTime=250.0000 ms  MaxIterationCount=20  MaxWarmupIterationCount=10
[2022/11/27 13:33:26][INFO] MinIterationCount=15  MinWarmupIterationCount=6  UnrollFactor=1
[2022/11/27 13:33:26][INFO] WarmupCount=-1
[2022/11/27 13:33:26][INFO]
[2022/11/27 13:33:26][INFO] |             Method |    Size |     Mean |    Error |   StdDev |   Median |      Min |      Max | Allocated |
[2022/11/27 13:33:26][INFO] |------------------- |-------- |---------:|---------:|---------:|---------:|---------:|---------:|----------:|
[2022/11/27 13:33:26][INFO] | BlockingCollection | 2000000 | 415.7 ms | 27.82 ms | 32.03 ms | 410.6 ms | 354.3 ms | 469.0 ms | 257.97 KB |
```

