### PR TITLE
Extend regex [x, x+64) char class optimization to [x, x+32)

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4626,10 +4626,10 @@ namespace System.Text.RegularExpressions.Generator
                 }
 
                 // To determine whether a character is in the set, we subtract the lowest char; this subtraction happens before
-                // the result is zero-extended to uint, meaning that `charMinusLowUInt32` will always have upper 16 bits equal to 0.
+                // the result is zero-extended to uint, meaning that `charMinusLowUInt64` will always have upper 32 bits equal to 0.
                 // We then left shift the constant with this offset, and apply a bitmask that has the highest bit set (the sign bit)
-                // if and only if `chExpr` is in the [low, low + 32) range. Then we only need to check whether this final result is
-                // less than 0: this will only be the case if both `charMinusLowUInt32` was in fact the index of a set bit in the constant,
+                // if and only if `chExpr` is in the [low, low + 64) range. Then we only need to check whether this final result is
+                // less than 0: this will only be the case if both `charMinusLowUInt64` was in fact the index of a set bit in the constant,
                 // and also `chExpr` was in the allowed range (this ensures that false positive bit shifts are ignored).
                 negate ^= negatedClass;
                 return $"((long)((0x{bitmap:X}UL << (int)(charMinusLowUInt64 = (uint){chExpr} - {Literal((char)analysis.LowerBoundInclusiveIfOnlyRanges)})) & (charMinusLowUInt64 - 64)) {(negate ? ">=" : "<")} 0)";

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -4570,16 +4570,47 @@ namespace System.Text.RegularExpressions.Generator
             // Analyze the character set more to determine what code to generate.
             RegexCharClass.CharClassAnalysisResults analysis = RegexCharClass.Analyze(charClass);
 
-            // Next, handle sets where the high - low + 1 range is <= 64.  In that case, we can emit
-            // a branchless lookup in a ulong that does not rely on loading any objects (e.g. the string-based
-            // lookup we use later).  This nicely handles common sets like [0-9A-Fa-f], [0-9a-f], [A-Za-z], etc.
-            // Note that unlike RegexCompiler, the source generator doesn't know whether the code is going to be
-            // run in a 32-bit or 64-bit process: in a 64-bit process, this is an optimization, but in a 32-bit process,
-            // it's a deoptimization.  In general we optimize for 64-bit perf, so this code remains; it complicates
-            // the code too much to try to include both this and a fallback for the check.
+            // Next, handle sets where the high - low + 1 range is <= 32.  In that case, we can emit
+            // a branchless lookup in a uint that does not rely on loading any objects (e.g. the string-based
+            // lookup we use later).  This nicely handles common sets like [\t\r\n ].
+            if (analysis.OnlyRanges && (analysis.UpperBoundExclusiveIfOnlyRanges - analysis.LowerBoundInclusiveIfOnlyRanges) <= 32)
+            {
+                additionalDeclarations.Add("uint charMinusLowUInt32;");
+
+                // Create the 32-bit value with 1s at indices corresponding to every character in the set,
+                // where the bit is computed to be the char value minus the lower bound starting from
+                // most significant bit downwards.
+                bool negatedClass = RegexCharClass.IsNegated(charClass);
+                uint bitmap = 0;
+                for (int i = analysis.LowerBoundInclusiveIfOnlyRanges; i < analysis.UpperBoundExclusiveIfOnlyRanges; i++)
+                {
+                    if (RegexCharClass.CharInClass((char)i, charClass) ^ negatedClass)
+                    {
+                        bitmap |= 1u << (31 - (i - analysis.LowerBoundInclusiveIfOnlyRanges));
+                    }
+                }
+
+                // To determine whether a character is in the set, we subtract the lowest char; this subtraction happens before the result is
+                // zero-extended to uint, meaning that `charMinusLowUInt32` will always have upper 16 bits equal to 0.
+                // We then left shift the constant with this offset, and apply a bitmask that has the highest
+                // bit set (the sign bit) if and only if `chExpr` is in the [low, low + 32) range.
+                // Then we only need to check whether this final result is less than 0: this will only be
+                // the case if both `charMinusLowUInt32` was in fact the index of a set bit in the constant, and also
+                // `chExpr` was in the allowed range (this ensures that false positive bit shifts are ignored).
+                negate ^= negatedClass;
+                return $"((int)((0x{bitmap:X}U << (short)(charMinusLowUInt32 = (ushort)({chExpr} - {Literal((char)analysis.LowerBoundInclusiveIfOnlyRanges)}))) & (charMinusLowUInt32 - 32)) {(negate ? ">=" : "<")} 0)";
+            }
+
+            // Next, handle sets where the high - low + 1 range is <= 64.  As with the 32-bit case above, we can emit
+            // a branchless lookup in a ulong that does not rely on loading any objects (e.g. the string-based lookup
+            // we use later). Note that unlike RegexCompiler, the source generator doesn't know whether the code is going
+            // to be run in a 32-bit or 64-bit process: in a 64-bit process, this is an optimization, but in a 32-bit process,
+            // it's a deoptimization.  In general we optimize for 64-bit perf, so this code remains; it complicates the code
+            // too much to try to include both this and a fallback for the check. This, however, is why we do the 32-bit
+            // version and check first, as that variant performs equally well on both 32-bit and 64-bit systems.
             if (analysis.OnlyRanges && (analysis.UpperBoundExclusiveIfOnlyRanges - analysis.LowerBoundInclusiveIfOnlyRanges) <= 64)
             {
-                additionalDeclarations.Add("ulong charMinusLow;");
+                additionalDeclarations.Add("ulong charMinusLowUInt64;");
 
                 // Create the 64-bit value with 1s at indices corresponding to every character in the set,
                 // where the bit is computed to be the char value minus the lower bound starting from
@@ -4590,20 +4621,18 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     if (RegexCharClass.CharInClass((char)i, charClass) ^ negatedClass)
                     {
-                        bitmap |= (1ul << (63 - (i - analysis.LowerBoundInclusiveIfOnlyRanges)));
+                        bitmap |= 1ul << (63 - (i - analysis.LowerBoundInclusiveIfOnlyRanges));
                     }
                 }
 
-                // To determine whether a character is in the set, we subtract the lowest char (casting to
-                // uint to account for any smaller values); this subtraction happens before the result is
-                // zero-extended to ulong, meaning that `charMinusLow` will always have upper 32 bits equal to 0.
-                // We then left shift the constant with this offset, and apply a bitmask that has the highest
-                // bit set (the sign bit) if and only if `chExpr` is in the [low, low + 64) range.
-                // Then we only need to check whether this final result is less than 0: this will only be
-                // the case if both `charMinusLow` was in fact the index of a set bit in the constant, and also
-                // `chExpr` was in the allowed range (this ensures that false positive bit shifts are ignored).
+                // To determine whether a character is in the set, we subtract the lowest char; this subtraction happens before
+                // the result is zero-extended to uint, meaning that `charMinusLowUInt32` will always have upper 16 bits equal to 0.
+                // We then left shift the constant with this offset, and apply a bitmask that has the highest bit set (the sign bit)
+                // if and only if `chExpr` is in the [low, low + 32) range. Then we only need to check whether this final result is
+                // less than 0: this will only be the case if both `charMinusLowUInt32` was in fact the index of a set bit in the constant,
+                // and also `chExpr` was in the allowed range (this ensures that false positive bit shifts are ignored).
                 negate ^= negatedClass;
-                return $"((long)((0x{bitmap:X}UL << (int)(charMinusLow = (uint){chExpr} - {Literal((char)analysis.LowerBoundInclusiveIfOnlyRanges)})) & (charMinusLow - 64)) {(negate ? ">=" : "<")} 0)";
+                return $"((long)((0x{bitmap:X}UL << (int)(charMinusLowUInt64 = (uint){chExpr} - {Literal((char)analysis.LowerBoundInclusiveIfOnlyRanges)})) & (charMinusLowUInt64 - 64)) {(negate ? ">=" : "<")} 0)";
             }
 
             // All options after this point require a ch local.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1757,7 +1757,7 @@ namespace System.Text.RegularExpressions
                 Label body = DefineLabel();
                 Label charactersMatched = DefineLabel();
                 LocalBuilder backreferenceCharacter = _ilg!.DeclareLocal(typeof(char));
-                LocalBuilder currentCharacter = _ilg!.DeclareLocal(typeof(char));
+                LocalBuilder currentCharacter = _ilg.DeclareLocal(typeof(char));
 
                 // for (int i = 0; ...)
                 Ldc(0);
@@ -5481,11 +5481,67 @@ namespace System.Text.RegularExpressions
             // Analyze the character set more to determine what code to generate.
             RegexCharClass.CharClassAnalysisResults analysis = RegexCharClass.Analyze(charClass);
 
-            // Next, handle sets where the high - low + 1 range is <= 64.  In that case, we can emit
+            // Next, handle sets where the high - low + 1 range is <= 32.  In that case, we can emit
+            // a branchless lookup in a uint that does not rely on loading any objects (e.g. the string-based
+            // lookup we use later).  This nicely handles common sets like [\t\r\n ].
+            if (analysis.OnlyRanges && (analysis.UpperBoundExclusiveIfOnlyRanges - analysis.LowerBoundInclusiveIfOnlyRanges) <= 32)
+            {
+                // Create the 32-bit value with 1s at indices corresponding to every character in the set,
+                // where the bit is computed to be the char value minus the lower bound starting from
+                // most significant bit downwards.
+                uint bitmap = 0;
+                bool negatedClass = RegexCharClass.IsNegated(charClass);
+                for (int i = analysis.LowerBoundInclusiveIfOnlyRanges; i < analysis.UpperBoundExclusiveIfOnlyRanges; i++)
+                {
+                    if (RegexCharClass.CharInClass((char)i, charClass) ^ negatedClass)
+                    {
+                        bitmap |= 1u << (31 - (i - analysis.LowerBoundInclusiveIfOnlyRanges));
+                    }
+                }
+
+                // To determine whether a character is in the set, we subtract the lowest char; this subtraction happens before
+                // the result is zero-extended to uint, meaning that `charMinusLow` will always have upper 16 bits equal to 0.
+                // We then left shift the constant with this offset, and apply a bitmask that has the highest bit set (the sign bit)
+                // if and only if `ch` is in the [low, low + 32) range. Then we only need to check whether this final result is
+                // less than 0: this will only be the case if both `charMinusLow` was in fact the index of a set bit in the constant,
+                // and also `ch` was in the allowed range (this ensures that false positive bit shifts are ignored).
+
+                // uint charMinusLow = (ushort)(ch - lowInclusive);
+                LocalBuilder charMinusLow = _ilg!.DeclareLocal(typeof(uint));
+                Ldloc(tempLocal);
+                Ldc(analysis.LowerBoundInclusiveIfOnlyRanges);
+                Sub();
+                _ilg.Emit(OpCodes.Conv_U2);
+                Stloc(charMinusLow);
+
+                // uint shift = bitmap << (short)charMinusLow;
+                _ilg.Emit(OpCodes.Ldc_I4, bitmap);
+                Ldloc(charMinusLow);
+                _ilg.Emit(OpCodes.Conv_I2);
+                Ldc(31);
+                And();
+                Shl();
+
+                // uint mask = charMinusLow - 32;
+                Ldloc(charMinusLow);
+                Ldc(32);
+                _ilg.Emit(OpCodes.Conv_I4);
+                Sub();
+
+                // (int)(shift & mask) < 0 // or >= for a negated character class
+                And();
+                Ldc(0);
+                _ilg.Emit(OpCodes.Conv_I4);
+                _ilg.Emit(OpCodes.Clt);
+                NegateIf(negatedClass);
+
+                return;
+            }
+
+            // Next, handle sets where the high - low + 1 range is <= 64.  As with the 32-bit case above, we can emit
             // a branchless lookup in a ulong that does not rely on loading any objects (e.g. the string-based
-            // lookup we use later).  This nicely handles sets made up of a subset of ASCII letters, for example.
-            // We skip this on 32-bit, as otherwise using 64-bit numbers in this manner is a deoptimization
-            // when compared to the subsequent fallbacks.
+            // lookup we use later).  We skip this on 32-bit, as otherwise using 64-bit numbers in this manner is
+            // a deoptimization when compared to the subsequent fallbacks.
             if (IntPtr.Size == 8 && analysis.OnlyRanges && (analysis.UpperBoundExclusiveIfOnlyRanges - analysis.LowerBoundInclusiveIfOnlyRanges) <= 64)
             {
                 // Create the 64-bit value with 1s at indices corresponding to every character in the set,
@@ -5497,7 +5553,7 @@ namespace System.Text.RegularExpressions
                 {
                     if (RegexCharClass.CharInClass((char)i, charClass) ^ negatedClass)
                     {
-                        bitmap |= (1ul << (63 - (i - analysis.LowerBoundInclusiveIfOnlyRanges)));
+                        bitmap |= 1ul << (63 - (i - analysis.LowerBoundInclusiveIfOnlyRanges));
                     }
                 }
 
@@ -5515,13 +5571,13 @@ namespace System.Text.RegularExpressions
                 Ldloc(tempLocal);
                 Ldc(analysis.LowerBoundInclusiveIfOnlyRanges);
                 Sub();
-                _ilg!.Emit(OpCodes.Conv_U8);
+                _ilg.Emit(OpCodes.Conv_U8);
                 Stloc(charMinusLow);
 
                 // ulong shift = bitmap << (int)charMinusLow;
                 LdcI8((long)bitmap);
                 Ldloc(charMinusLow);
-                _ilg!.Emit(OpCodes.Conv_I4);
+                _ilg.Emit(OpCodes.Conv_I4);
                 Ldc(63);
                 And();
                 Shl();
@@ -5529,14 +5585,14 @@ namespace System.Text.RegularExpressions
                 // ulong mask = charMinusLow - 64;
                 Ldloc(charMinusLow);
                 Ldc(64);
-                _ilg!.Emit(OpCodes.Conv_I8);
+                _ilg.Emit(OpCodes.Conv_I8);
                 Sub();
 
                 // (long)(shift & mask) < 0 // or >= for a negated character class
                 And();
                 Ldc(0);
-                _ilg!.Emit(OpCodes.Conv_I8);
-                _ilg!.Emit(OpCodes.Clt);
+                _ilg.Emit(OpCodes.Conv_I8);
+                _ilg.Emit(OpCodes.Clt);
                 NegateIf(negatedClass);
 
                 return;


### PR DESCRIPTION
Regex currently optimizes set lookups when all of the characters in the range-based character class are within 64 of each other; in that case, it builds a 64-bit bitmap in a ulong and does bit manipulation to compute in a branchless manner whether the target character is in the set. However, because this manipulates 64-bit values, RegexCompiler avoids this optimization when in a 32-bit process, and the source generator generates the code anyway, with a 32-bit process suffering slightly. This PR adds a 32-bit variation of the scheme, such that if all of the characters fall within 32 of each other, it's used.