### PR TITLE
Generate diagnosable failfast in GVM resolution

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
@@ -72,13 +72,13 @@ namespace Internal.Runtime.TypeLoader
                         var sb = new System.Text.StringBuilder();
                         sb.AppendLine("Generic virtual method pointer lookup failure.");
                         sb.AppendLine();
-                        sb.AppendLine("Declaring type handle: " + declaringType.LowLevelToStringRawEETypeAddress());
-                        sb.AppendLine("Target type handle: " + targetHandle.LowLevelToStringRawEETypeAddress());
+                        sb.AppendLine("Declaring type handle: " + RuntimeAugments.GetLastResortString(declaringType));
+                        sb.AppendLine("Target type handle: " + RuntimeAugments.GetLastResortString(targetHandle));
                         sb.AppendLine("Method name: " + methodNameAndSignature.Name);
                         sb.AppendLine("Instantiation:");
                         for (int i = 0; i < genericArguments.Length; i++)
                         {
-                            sb.AppendLine("  Argument " + i.LowLevelToString() + ": " + genericArguments[i].LowLevelToStringRawEETypeAddress());
+                            sb.AppendLine("  Argument " + i.LowLevelToString() + ": " + RuntimeAugments.GetLastResortString(genericArguments[i]));
                         }
 
                         Environment.FailFast(sb.ToString());
@@ -616,13 +616,13 @@ namespace Internal.Runtime.TypeLoader
                         var sb = new System.Text.StringBuilder();
                         sb.AppendLine("Generic virtual method pointer lookup failure.");
                         sb.AppendLine();
-                        sb.AppendLine("Declaring type handle: " + declaringType.LowLevelToStringRawEETypeAddress());
-                        sb.AppendLine("Target type handle: " + targetTypeHandle.LowLevelToStringRawEETypeAddress());
+                        sb.AppendLine("Declaring type handle: " + RuntimeAugments.GetLastResortString(declaringType));
+                        sb.AppendLine("Target type handle: " + RuntimeAugments.GetLastResortString(targetTypeHandle));
                         sb.AppendLine("Method name: " + targetMethodNameAndSignature.Name);
                         sb.AppendLine("Instantiation:");
                         for (int i = 0; i < genericArguments.Length; i++)
                         {
-                            sb.AppendLine("  Argument " + i.LowLevelToString() + ": " + genericArguments[i].LowLevelToStringRawEETypeAddress());
+                            sb.AppendLine("  Argument " + i.LowLevelToString() + ": " + RuntimeAugments.GetLastResortString(genericArguments[i]));
                         }
 
                         Environment.FailFast(sb.ToString());


### PR DESCRIPTION
If the program hits the conditions in #77070, generate a failfast message that makes it possible to create a workaround.

Instead of:

```
Process terminated. Generic virtual method pointer lookup failure.

Declaring type handle: MethodTable:0x00007FF66E8587B8
Target type handle: MethodTable:0x00007FF66E858810
Method name: Serialize
Instantiation:
  Argument 00000000: MethodTable:0x00007FF66E85DA08
```

Generate:

```
Process terminated. Generic virtual method pointer lookup failure.

Declaring type handle: EETypeRva:0x005438B8(MemoryPackFormatter2`1[MemPackObject])
Target type handle: EETypeRva:0x00543910(MemoryPackableFormatter2`1[MemPackObject])
Method name: Serialize
Instantiation:
  Argument 00000000: EETypeRva:0x00529B38(System.Buffers.ArrayBufferWriter`1[System.Byte])
```

The workaround is then:

```xml
<Directives>
  <Application>
    <Assembly Name="repro">
      <Type Name="MemoryPackableFormatter2`1[[MemPackObject]]">
        <Method Name="Serialize" Dynamic="Required All">
          <GenericArgument Name="System.Buffers.ArrayBufferWriter`1[[System.Byte, mscorlib]],System.Memory" />
        </Method>
      </Type>
    </Assembly>
  </Application>
</Directives>
```

Cc @dotnet/ilc-contrib expedited code review would be appreciated. I'd like service this into the January update.