### PR TITLE
[wasm] Catch error from loading "node:crypto" module

### DIFF
--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -209,7 +209,9 @@ export async function init_polyfills_async(): Promise<void> {
             }
             
             if (!nodeCrypto) {
-                nodeCrypto.randomBytes = () => { throw new Error("Using node without crypto support. To enable current operation, either provide polyfill for 'globalThis.crypto.getRandomValues' or enable 'node:crypto' module."); };
+                globalThis.crypto.getRandomValues = () => { 
+                    throw new Error("Using node without crypto support. To enable current operation, either provide polyfill for 'globalThis.crypto.getRandomValues' or enable 'node:crypto' module."); 
+                };
             } else if (nodeCrypto.webcrypto) {
                 globalThis.crypto = nodeCrypto.webcrypto;
             } else if (nodeCrypto.randomBytes) {

--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -201,15 +201,19 @@ export async function init_polyfills_async(): Promise<void> {
             globalThis.crypto = <any>{};
         }
         if (!globalThis.crypto.getRandomValues) {
-            const nodeCrypto = INTERNAL.require("node:crypto");
-            if (nodeCrypto.webcrypto) {
-                globalThis.crypto = nodeCrypto.webcrypto;
-            } else if (nodeCrypto.randomBytes) {
-                globalThis.crypto.getRandomValues = (buffer: TypedArray) => {
-                    if (buffer) {
-                        buffer.set(nodeCrypto.randomBytes(buffer.length));
-                    }
-                };
+            try {
+                const nodeCrypto = INTERNAL.require("node:crypto");
+                if (nodeCrypto.webcrypto) {
+                    globalThis.crypto = nodeCrypto.webcrypto;
+                } else if (nodeCrypto.randomBytes) {
+                    globalThis.crypto.getRandomValues = (buffer: TypedArray) => {
+                        if (buffer) {
+                            buffer.set(nodeCrypto.randomBytes(buffer.length));
+                        }
+                    };
+                }
+            } catch (err: any) {
+                // Noop as node can be delivered without "node:crypto", but it's possible that we won't need it.
             }
         }
     }


### PR DESCRIPTION
According to ["node:crypto" documentation](https://nodejs.org/api/crypto.html#determining-if-crypto-support-is-unavailable), there can be build of node without this module. We silently ignore the error with loading the module until some API requiring it is called.

This restores the behavior before https://github.com/dotnet/runtime/pull/78696