### PR TITLE
Disable ClientConnectAsync_Cancel_With_InfiniteTimeout test frequently failing in CI

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -697,6 +697,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69101")]
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix implementation doesn't rely on a timeout and cancellation token when connecting
         public async Task ClientConnectAsync_Cancel_With_InfiniteTimeout()


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/69101