### PR TITLE
Fix handling of conv_i in the interpreter

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -723,9 +723,12 @@ namespace ILCompiler
                                 switch (opcode)
                                 {
                                     case ILOpcode.conv_u:
+                                    case ILOpcode.conv_i:
                                         stack.Push(StackValueKind.NativeInt,
                                             context.Target.PointerSize == 8 ? ValueTypeValue.FromInt64(val) : ValueTypeValue.FromInt32((int)val));
                                         break;
+                                    default:
+                                        return Status.Fail(methodIL.OwningMethod, opcode);
                                 }
                             }
                             else if (popped.ValueKind == StackValueKind.Float)


### PR DESCRIPTION
The missing `default` case was causing a stack imbalance (that we later detect so it doesn't actually harm anything). But better to `Status.Fail` than throw and catch.

Cc @dotnet/ilc-contrib 