### PR TITLE
Allow Base64Decoder to ignore space chars, add IsValid methods and tests

### DIFF
--- a/src/libraries/System.Memory/tests/Base64/Base64TestBase.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64TestBase.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Buffers.Text.Tests
+{
+    public class Base64TestBase
+    {
+        public static IEnumerable<object[]> ValidBase64Strings_WithCharsThatMustBeIgnored()
+        {
+            // Create a Base64 string
+            string text = "a b c";
+            byte[] utf8Bytes = Encoding.UTF8.GetBytes(text);
+            string base64Utf8String = Convert.ToBase64String(utf8Bytes);
+
+            // Split the base64 string in half
+            int stringLength = base64Utf8String.Length / 2;
+            string firstSegment = base64Utf8String.Substring(0, stringLength);
+            string secondSegment = base64Utf8String.Substring(stringLength, stringLength);
+
+            // Insert ignored chars between the base 64 string
+            // One will have 1 char, another will have 3
+
+            // Line feed
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(9), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(9), 3), utf8Bytes };
+
+            // Horizontal tab
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(10), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(10), 3), utf8Bytes };
+
+            // Carriage return
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(13), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(13), 3), utf8Bytes };
+
+            // Space
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(32), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedInTheMiddle(Convert.ToChar(32), 3), utf8Bytes };
+
+            string GetBase64StringWithPassedCharInsertedInTheMiddle(char charToInsert, int numberOfTimesToInsert) => $"{firstSegment}{new string(charToInsert, numberOfTimesToInsert)}{secondSegment}";
+
+            // Insert ignored chars at the start of the base 64 string
+            // One will have 1 char, another will have 3
+
+            // Line feed
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(9), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(9), 3), utf8Bytes };
+
+            // Horizontal tab
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(10), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(10), 3), utf8Bytes };
+
+            // Carriage return
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(13), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(13), 3), utf8Bytes };
+
+            // Space
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(32), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheStart(Convert.ToChar(32), 3), utf8Bytes };
+
+            string GetBase64StringWithPassedCharInsertedAtTheStart(char charToInsert, int numberOfTimesToInsert) => $"{new string(charToInsert, numberOfTimesToInsert)}{firstSegment}{secondSegment}";
+
+            // Insert ignored chars at the end of the base 64 string
+            // One will have 1 char, another will have 3
+
+            // Line feed
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(9), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(9), 3), utf8Bytes };
+
+            // Horizontal tab
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(10), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(10), 3), utf8Bytes };
+
+            // Carriage return
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(13), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(13), 3), utf8Bytes };
+
+            // Space
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(32), 1), utf8Bytes };
+            yield return new object[] { GetBase64StringWithPassedCharInsertedAtTheEnd(Convert.ToChar(32), 3), utf8Bytes };
+
+            string GetBase64StringWithPassedCharInsertedAtTheEnd(char charToInsert, int numberOfTimesToInsert) => $"{firstSegment}{secondSegment}{new string(charToInsert, numberOfTimesToInsert)}";
+        }
+
+        public static IEnumerable<object[]> StringsOnlyWithCharsToBeIgnored()
+        {
+            // One will have 1 char, another will have 3
+
+            // Line feed
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(9), 1) };
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(9), 3) };
+
+            // Horizontal tab
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(10), 1) };
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(10), 3) };
+
+            // Carriage return
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(13), 1) };
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(13), 3) };
+
+            // Space
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(32), 1) };
+            yield return new object[] { GetRepeatedChar(Convert.ToChar(32), 3) };
+
+            string GetRepeatedChar(char charToInsert, int numberOfTimesToInsert) => new string(charToInsert, numberOfTimesToInsert);
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64TestHelper.cs
@@ -44,6 +44,20 @@ namespace System.Buffers.Text.Tests
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
 
+        public static bool IsByteToBeIgnored(byte charByte)
+        {
+            switch (charByte)
+            {
+                case 9: // Line feed
+                case 10: // Horizontal tab
+                case 13: // Carriage return
+                case 32: // Space
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         public const byte EncodingPad = (byte)'=';      // '=', for padding
         public const sbyte InvalidByte = -1;            // Designating -1 for invalid bytes in the decoding map
 

--- a/src/libraries/System.Memory/tests/Base64/Base64ValidationUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64ValidationUnitTests.cs
@@ -1,0 +1,192 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public class Base64ValidationUnitTests : Base64TestBase
+    {
+        [Fact]
+        public void BasicValidationBytes()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes;
+                do
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                } while (numBytes % 4 != 0);    // ensure we have a valid length
+
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitializeDecodableBytes(source, numBytes);
+
+                Assert.True(Base64.IsValid(source));
+                Assert.True(Base64.IsValid(source, out int decodedLength));
+                Assert.True(decodedLength > 0);
+            }
+        }
+
+        [Fact]
+        public void BasicValidationChars()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes;
+                do
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                } while (numBytes % 4 != 0);    // ensure we have a valid length
+
+                Span<byte> source = new byte[numBytes];
+                Base64TestHelper.InitializeDecodableBytes(source, numBytes);
+                Span<char> chars = source
+                    .ToArray()
+                    .Select(Convert.ToChar)
+                    .ToArray()
+                    .AsSpan();
+
+                Assert.True(Base64.IsValid(chars));
+                Assert.True(Base64.IsValid(chars, out int decodedLength));
+                Assert.True(decodedLength > 0);
+            }
+        }
+
+        [Fact]
+        public void BasicValidationInvalidInputLengthBytes()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes;
+                do
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                } while (numBytes % 4 == 0);    // ensure we have a invalid length
+
+                Span<byte> source = new byte[numBytes];
+
+                Assert.False(Base64.IsValid(source));
+                Assert.False(Base64.IsValid(source, out int decodedLength));
+                Assert.Equal(0, decodedLength);
+            }
+        }
+
+        [Fact]
+        public void BasicValidationInvalidInputLengthChars()
+        {
+            var rnd = new Random(42);
+            for (int i = 0; i < 10; i++)
+            {
+                int numBytes;
+                do
+                {
+                    numBytes = rnd.Next(100, 1000 * 1000);
+                } while (numBytes % 4 == 0);    // ensure we have a invalid length
+
+                Span<char> source = new char[numBytes];
+
+                Assert.False(Base64.IsValid(source));
+                Assert.False(Base64.IsValid(source, out int decodedLength));
+                Assert.Equal(0, decodedLength);
+            }
+        }
+
+        [Fact]
+        public void ValidateEmptySpanBytes()
+        {
+            Span<byte> source = Span<byte>.Empty;
+
+            Assert.True(Base64.IsValid(source));
+            Assert.True(Base64.IsValid(source, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Fact]
+        public void ValidateEmptySpanChars()
+        {
+            Span<char> source = Span<char>.Empty;
+
+            Assert.True(Base64.IsValid(source));
+            Assert.True(Base64.IsValid(source, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Fact]
+        public void ValidateGuidBytes()
+        {
+            Span<byte> source = new byte[24];
+            Span<byte> decodedBytes = Guid.NewGuid().ToByteArray();
+            Base64.EncodeToUtf8(decodedBytes, source, out int _, out int _);
+
+            Assert.True(Base64.IsValid(source));
+            Assert.True(Base64.IsValid(source, out int decodedLength));
+            Assert.True(decodedLength > 0);
+        }
+
+        [Fact]
+        public void ValidateGuidChars()
+        {
+            Span<byte> source = new byte[24];
+            Span<byte> decodedBytes = Guid.NewGuid().ToByteArray();
+            Base64.EncodeToUtf8(decodedBytes, source, out int _, out int _);
+            Span<char> chars = source
+                .ToArray()
+                .Select(Convert.ToChar)
+                .ToArray()
+                .AsSpan();
+
+            Assert.True(Base64.IsValid(chars));
+            Assert.True(Base64.IsValid(chars, out int decodedLength));
+            Assert.True(decodedLength > 0);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidBase64Strings_WithCharsThatMustBeIgnored))]
+        public void ValidateBytesIgnoresCharsToBeIgnoredBytes(string utf8WithByteToBeIgnored, byte[] expectedBytes)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(expectedBytes.Length, decodedLength);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidBase64Strings_WithCharsThatMustBeIgnored))]
+        public void ValidateBytesIgnoresCharsToBeIgnoredChars(string utf8WithByteToBeIgnored, byte[] expectedBytes)
+        {
+            ReadOnlySpan<char> utf8BytesWithByteToBeIgnored = utf8WithByteToBeIgnored.ToArray();
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(expectedBytes.Length, decodedLength);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringsOnlyWithCharsToBeIgnored))]
+        public void ValidateWithOnlyCharsToBeIgnoredBytes(string utf8WithByteToBeIgnored)
+        {
+            byte[] utf8BytesWithByteToBeIgnored = UTF8Encoding.UTF8.GetBytes(utf8WithByteToBeIgnored);
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringsOnlyWithCharsToBeIgnored))]
+        public void ValidateWithOnlyCharsToBeIgnoredChars(string utf8WithByteToBeIgnored)
+        {
+            ReadOnlySpan<char> utf8BytesWithByteToBeIgnored = utf8WithByteToBeIgnored.ToArray();
+
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored));
+            Assert.True(Base64.IsValid(utf8BytesWithByteToBeIgnored, out int decodedLength));
+            Assert.Equal(0, decodedLength);
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -270,6 +270,8 @@
     <Compile Include="Base64\Base64DecoderUnitTests.cs" />
     <Compile Include="Base64\Base64EncoderUnitTests.cs" />
     <Compile Include="Base64\Base64TestHelper.cs" />
+    <Compile Include="Base64\Base64TestBase.cs" />
+    <Compile Include="Base64\Base64ValidationUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs"

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -124,6 +124,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Base64.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Base64Encoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Base64Decoder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Base64Validator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\FormattingHelpers.CountDigits.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Formatter\FormattingHelpers.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Validator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Validator.cs
@@ -1,0 +1,192 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Buffers.Text
+{
+    public static partial class Base64
+    {
+        /// <summary>
+        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
+        /// </summary>
+        /// <param name="base64Text">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
+        /// <returns>true if <paramref name="base64Text"/> is decodable; otherwise, false.</returns>
+        public static bool IsValid(ReadOnlySpan<char> base64Text) => IsValid(base64Text, out int _);
+
+        /// <summary>
+        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
+        /// </summary>
+        /// <param name="base64Text">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
+        /// <param name="decodedLength">The maximum length (in bytes) if you were to decode the base 64 encoded text <paramref name="base64Text"/> within a byte span.</param>
+        /// <returns>true if <paramref name="base64Text"/> is decodable; otherwise, false.</returns>
+        public static unsafe bool IsValid(ReadOnlySpan<char> base64Text, out int decodedLength)
+        {
+            if (base64Text.IsEmpty)
+            {
+                decodedLength = 0;
+                return true;
+            }
+
+            // Check for invalid chars
+            int indexOfFirstNonBase64 = base64Text.IndexOfAnyExcept(ValidBase64CharsSortedAsc);
+            if (indexOfFirstNonBase64 > -1)
+            {
+                decodedLength = 0;
+                return false;
+            }
+
+            int length = base64Text.Length;
+            int paddingCount = 0;
+
+            // Check if there are chars that need to be ignored while determining the length
+            if (base64Text.IndexOfAny(CharsToIgnore) > -1)
+            {
+                fixed (char* srcChars = &MemoryMarshal.GetReference(base64Text))
+                {
+                    int numberOfCharsToIgnore = 0;
+                    char* src = srcChars;
+
+                    for (int i = 0; i < base64Text.Length; i++)
+                    {
+                        char charToValidate = *src++;
+                        if (IsCharToBeIgnored(charToValidate))
+                        {
+                            numberOfCharsToIgnore++;
+                        }
+                        // 61 = '=' (padding)
+                        else if (charToValidate == 61)
+                        {
+                            paddingCount++;
+                        }
+                    }
+
+                    length -= numberOfCharsToIgnore;
+                }
+            }
+
+            if (length % 4 != 0)
+            {
+                decodedLength = 0;
+                return false;
+            }
+
+            // Remove padding to get exact length
+            decodedLength = (length / 4 * 3) - paddingCount;
+            return true;
+        }
+
+        /// <summary>
+        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
+        /// </summary>
+        /// <param name="base64TextUtf8">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
+        /// <returns>true if <paramref name="base64TextUtf8"/> is decodable; otherwise, false.</returns>
+        public static bool IsValid(ReadOnlySpan<byte> base64TextUtf8) => IsValid(base64TextUtf8, out int _);
+
+        /// <summary>
+        /// Validates the span of UTF-8 encoded text represented as base64 into binary data.
+        /// </summary>
+        /// <param name="base64TextUtf8">The input span which contains UTF-8 encoded text in base64 that needs to be validated.</param>
+        /// <param name="decodedLength">The maximum length (in bytes) if you were to decode the base 64 encoded text <paramref name="base64TextUtf8"/> within a byte span.</param>
+        /// <returns>true if <paramref name="base64TextUtf8"/> is decodable; otherwise, false.</returns>
+        public static unsafe bool IsValid(ReadOnlySpan<byte> base64TextUtf8, out int decodedLength)
+        {
+            if (base64TextUtf8.IsEmpty)
+            {
+                decodedLength = 0;
+                return true;
+            }
+
+            // Check for invalid chars
+            int indexOfFirstNonBase64 = base64TextUtf8.IndexOfAnyExcept(ValidBase64BytesSortedAsc);
+            if (indexOfFirstNonBase64 > -1)
+            {
+                decodedLength = 0;
+                return false;
+            }
+
+            int length = base64TextUtf8.Length;
+            int paddingCount = 0;
+
+            // Check if there are chars that need to be ignored while determining the length
+            if (base64TextUtf8.IndexOfAny(BytesToIgnore) > -1)
+            {
+                fixed (byte* srcBytes = &MemoryMarshal.GetReference(base64TextUtf8))
+                {
+                    int numberOfBytesToIgnore = 0;
+                    byte* src = srcBytes;
+
+                    for (int i = 0; i < base64TextUtf8.Length; i++)
+                    {
+                        byte byteToValidate = *src++;
+                        if (IsByteToBeIgnored(byteToValidate))
+                        {
+                            numberOfBytesToIgnore++;
+                        }
+                        // 61 = '=' (padding)
+                        else if (byteToValidate == 61)
+                        {
+                            paddingCount++;
+                        }
+                    }
+
+                    length -= numberOfBytesToIgnore;
+                }
+            }
+
+            if (length % 4 != 0)
+            {
+                decodedLength = 0;
+                return false;
+            }
+
+            // Remove padding to get exact length
+            decodedLength = (length / 4 * 3) - paddingCount;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsCharToBeIgnored(char aChar)
+        {
+            switch (aChar)
+            {
+                case '\n': // Line feed
+                case '\t': // Horizontal tab
+                case '\r': // Carriage return
+                case ' ':  // Space
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static ReadOnlySpan<byte> ValidBase64BytesSortedAsc => new byte[] {
+            9, 10, 13, 32, 43, 47,                   //Line feed, Horizontal tab, Carriage return, Space, +, /
+            48, 49, 50, 51, 52, 53, 54, 55, 56, 57,  //0..9,
+            61,                                      //=
+            65, 66, 67, 68, 69, 70, 71, 72,          //A..H
+            73, 74, 75, 76, 77, 78, 79, 80,          //I..P
+            81, 82, 83, 84, 85, 86, 87, 88,          //Q..X
+            89, 90, 97, 98, 99, 100, 101, 102,       //Y..Z, a..f
+            103, 104, 105, 106, 107, 108, 109, 110,  //g..n
+            111, 112, 113, 114, 115, 116, 117, 118,  //o..v
+            119, 120, 121, 122,                      //w..z
+        };
+
+        private static ReadOnlySpan<char> ValidBase64CharsSortedAsc => new char[] {
+            '\n', '\t', '\r', ' ', '+', '/',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            '=',
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+            'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+            'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+            'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+            'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+            'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+            'w', 'x', 'y', 'z',
+        };
+
+        private static ReadOnlySpan<char> CharsToIgnore => new char[] { '\n', '\t', '\r', ' ' };
+    }
+}

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7109,6 +7109,10 @@ namespace System.Buffers.Text
         public static System.Buffers.OperationStatus EncodeToUtf8InPlace(System.Span<byte> buffer, int dataLength, out int bytesWritten) { throw null; }
         public static int GetMaxDecodedFromUtf8Length(int length) { throw null; }
         public static int GetMaxEncodedToUtf8Length(int length) { throw null; }
+        public static bool IsValid(System.ReadOnlySpan<char> base64Text) { throw null; }
+        public static bool IsValid(System.ReadOnlySpan<char> base64Text, out int decodedLength) { throw null; }
+        public static bool IsValid(System.ReadOnlySpan<byte> base64TextUtf8) { throw null; }
+        public static bool IsValid(System.ReadOnlySpan<byte> base64TextUtf8, out int decodedLength) { throw null; }
     }
 }
 namespace System.CodeDom.Compiler


### PR DESCRIPTION
Implementation of api-approved issue: https://github.com/dotnet/runtime/issues/76020