### PR TITLE
Move AT_EXECFN to fallback for /proc/self/exe

### DIFF
--- a/src/native/minipal/getexepath.h
+++ b/src/native/minipal/getexepath.h
@@ -97,6 +97,8 @@ static inline char* minipal_getexepath(void)
         return realpath(exePath, NULL);
     }
 #endif // HAVE_GETAUXVAL && defined(AT_EXECFN)
+
+    return NULL;
 #endif // defined(__APPLE__)
 }
 

--- a/src/native/minipal/getexepath.h
+++ b/src/native/minipal/getexepath.h
@@ -75,13 +75,6 @@ static inline char* minipal_getexepath(void)
     // This is a packaging convention that our tooling should enforce.
     return strdup("/managed");
 #else
-#if HAVE_GETAUXVAL && defined(AT_EXECFN)
-    const char* path = (const char *)(getauxval(AT_EXECFN));
-    if (path && !errno)
-    {
-        return realpath(path, NULL);
-    }
-#endif // HAVE_GETAUXVAL && defined(AT_EXECFN)
 #ifdef __linux__
     const char* symlinkEntrypointExecutable = "/proc/self/exe";
 #else
@@ -89,7 +82,21 @@ static inline char* minipal_getexepath(void)
 #endif
 
     // Resolve the symlink to the executable from /proc
-    return realpath(symlinkEntrypointExecutable, NULL);
+    char* path = realpath(symlinkEntrypointExecutable, NULL);
+    if (path)
+    {
+        return path;
+    }
+
+#if HAVE_GETAUXVAL && defined(AT_EXECFN)
+    // fallback to AT_EXECFN, which does not work properly in rare cases
+    // when .NET process is set as interpreter (shebang).
+    const char* exePath = (const char *)(getauxval(AT_EXECFN));
+    if (exePath && !errno)
+    {
+        return realpath(exePath, NULL);
+    }
+#endif // HAVE_GETAUXVAL && defined(AT_EXECFN)
 #endif // defined(__APPLE__)
 }
 


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/66874, the missing header was added which enabled the fast (aux vector) path on Linux.

The issue with `AT_EXECFN` is that it returns the path which was passed to the process via [`namei`](https://github.com/torvalds/linux/blob/master/fs/namei.c). This breaks the scenario where the .NET process is used as interpreter (namely PowerShell's `#!/bin/pwsh`) and returns the path of script containing the shebang link to the interpreter rather than the interpreter's path. In other words, `AT_EXCFN` implementation != `/proc/self/exe`. In all the usages of `minipal_getexepath()` in runtime repo, we need the behavior of latter on Linux.

<del>The fix is to remove the usage of `AT_EXCFN` and rely solely on `/proc/self/exe` for Linux (which we were accidentally using in .NET 6 due to the missing header).</del>

The fix is to flip the order so `AT_EXCFN` is used as a fallback to `/proc/self/exe`.

Fixes #78941 (we will probably need to backport this to .NET 7)