### PR TITLE
Fix issue with last_gc_before_oom flag being reset by intervening gen 1 GC.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -21785,7 +21785,7 @@ void gc_heap::gc1()
 #endif //BACKGROUND_GC
 #endif //MULTIPLE_HEAPS
 #ifdef USE_REGIONS
-    if (!(settings.concurrent))
+    if (!(settings.concurrent) && (settings.condemned_generation == max_generation))
     {
         last_gc_before_oom = FALSE;
     }


### PR DESCRIPTION
This is a refinement suggested by Maoni for earlier PR #77478 - the last_gc_before_oom flag should also not be reset by an intervening gen 1 GC.

This was noticed by Maoni due to a customer issue with spurious OOM exceptions with .NET Core 7.
