### PR TITLE
Internal.Console.Write uses unicode encoding for iOS

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.iOS.cs
@@ -10,20 +10,18 @@ namespace Internal
     {
         public static unsafe void Write(string s)
         {
-            byte[] bytes = Encoding.Unicode.GetBytes(s);
-            fixed (byte* pBytes = bytes)
+            fixed (char* ptr = s)
             {
-                Interop.Sys.Log(pBytes, bytes.Length);
+                Interop.Sys.Log((byte*)ptr, s.Length * 2);
             }
         }
         public static partial class Error
         {
             public static unsafe void Write(string s)
             {
-                byte[] bytes = Encoding.Unicode.GetBytes(s);
-                fixed (byte* pBytes = bytes)
+                fixed (char* ptr = s)
                 {
-                    Interop.Sys.LogError(pBytes, bytes.Length);
+                    Interop.Sys.Log((byte*)ptr, s.Length * 2);
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.iOS.cs
@@ -21,7 +21,7 @@ namespace Internal
             {
                 fixed (char* ptr = s)
                 {
-                    Interop.Sys.Log((byte*)ptr, s.Length * 2);
+                    Interop.Sys.LogError((byte*)ptr, s.Length * 2);
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.iOS.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+
+namespace Internal
+{
+    public static partial class Console
+    {
+        public static unsafe void Write(string s)
+        {
+            byte[] bytes = Encoding.Unicode.GetBytes(s);
+            fixed (byte* pBytes = bytes)
+            {
+                Interop.Sys.Log(pBytes, bytes.Length);
+            }
+        }
+        public static partial class Error
+        {
+            public static unsafe void Write(string s)
+            {
+                byte[] bytes = Encoding.Unicode.GetBytes(s);
+                fixed (byte* pBytes = bytes)
+                {
+                    Interop.Sys.LogError(pBytes, bytes.Length);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2235,9 +2235,9 @@
     <Compile Include="$(CommonPath)System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Unix.cs" Condition="'$(TargetsAndroid)' != 'true' and '$(TargetsiOS)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Unix.cs" Condition="'$(TargetsAndroid)' != 'true' and '$(IsiOSLike)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Android.cs" Condition="'$(TargetsAndroid)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.iOS.cs" Condition="'$(TargetsiOS)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.iOS.cs" Condition="'$(IsiOSLike)' == 'true'" />
     <Compile Include="$(CommonPath)Interop\Android\Interop.Logcat.cs" Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsLinuxBionic)' == 'true'">
       <Link>Common\Interop\Android\Interop.Logcat.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2235,8 +2235,9 @@
     <Compile Include="$(CommonPath)System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Unix.cs" Condition="'$(TargetsAndroid)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Unix.cs" Condition="'$(TargetsAndroid)' != 'true' and '$(TargetsiOS)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Android.cs" Condition="'$(TargetsAndroid)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.iOS.cs" Condition="'$(TargetsiOS)' == 'true'" />
     <Compile Include="$(CommonPath)Interop\Android\Interop.Logcat.cs" Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsLinuxBionic)' == 'true'">
       <Link>Common\Interop\Android\Interop.Logcat.cs</Link>
     </Compile>


### PR DESCRIPTION
Fix encoding between `Internal.Console.Write` and `SystemNative_Log` for iOS to be `UTF16`.

