### PR TITLE
Don't gitignore linker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,9 +342,6 @@ jit32
 # performance testing sandbox
 sandbox
 
-#IL linker for testing
-linker
-
 # Symbolic link for the shared portion of CoreLib to make grep/findstr work for runtime devs
 #
 # On Windows, make your own by running these commands from the repo root:


### PR DESCRIPTION
Files under [eng/testing/linker](https://github.com/dotnet/runtime/tree/main/eng/testing/linker) should not be ignored.

This was making it hard to understand how the trimmingTests targets were imported while fixing issues in https://github.com/dotnet/runtime/pull/78020, because the ignored files weren't showing up in VS code's search.