### PR TITLE
[Release/7.0] Don't emit manifest for NativeRuntimeEventSource (#78213)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2807,8 +2807,13 @@ namespace System.Diagnostics.Tracing
         // Today, we only send the manifest to ETW, custom listeners don't get it.
         private unsafe void SendManifest(byte[]? rawManifest)
         {
-            if (rawManifest == null)
+            if (rawManifest == null
+                // Don't send the manifest for NativeRuntimeEventSource, it is conceptually
+                // an extension of the native coreclr provider
+                || m_name.Equals("Microsoft-Windows-DotNETRuntime"))
+            {
                 return;
+            }
 
             Debug.Assert(!SelfDescribingEvents);
 


### PR DESCRIPTION
Port #78213 to 7.0

## Customer Impact

When starting an ETW session on a machine with lots of .net processes every 6.0 and newer process will emit a very large manifest event for NativeRuntimeEventSource (~50kb per process). This causes an event storm and will overflow buffers leading to dropped events. See #77014 for a customer impacted.

Historically we have never emitted the manifest for the `Microsoft-Windows-DotNETRuntime*` providers, consumers need to hardcode each event, or use a library such as TraceEvent that parses it for you. In 6.0 we added the ability for managed BCL code to emit events from the `Microsoft-Windows-DotNETRuntime` provider by adding events to NativeRuntimeEventSource, previously it would not have any events declared and only existed to forward events to in process EventListeners. Making NativeRuntimeEventSource have events unintentionally caused us to start emitting the manifest.

## Regression?

Yes

## Testing

Manual testing that the manifest is not emitted with this change

## Risk

Low