### PR TITLE
Disable APICompat assembly validation in source build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -49,6 +49,8 @@
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnableNgenOptimization=false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:AdditionalRuntimeIdentifierParent=$(BaseOS)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:EnablePackageValidation=false</InnerBuildArgs>
+      <!-- Re-enable for source-build when 8.0 Preview 1 shipped. See https://github.com/dotnet/installer/pull/14991 for more information. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ApiCompatValidateAssemblies=false</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) /p:PrimaryRuntimeFlavor=Mono /p:RuntimeFlavor=Mono</InnerBuildArgs>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
The APICompat tooling was recently updated and the CoreLib projects and ApiCompat.proj depend on the new features. As source-build in main builds with a 7.0.100 toolchain instead of live built components, disable APICompat for now in source-build.

Unblocks https://github.com/dotnet/installer/pull/14991