### PR TITLE
Delete DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER workarounds

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -416,12 +416,6 @@ function MSBuild {
       export NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
       Write-PipelineSetVariable -name "NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS" -value "20"
       Write-PipelineSetVariable -name "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS" -value "20"
-
-      # https://github.com/dotnet/arcade/issues/11369 - disable new MSBuild server feature on linux
-      # This feature is new and can result in build failures from connection timeout errors.
-      export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
-      Write-PipelineSetVariable -name "DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER" -value "1"
-
     fi
 
     local toolset_dir="${_InitializeToolset%/*}"

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -90,7 +90,6 @@ jobs:
         sudo apt-get update &&
         sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates &&
         $(HelixPreCommandsWasmOnLinux) &&
-        export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1 &&
         export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)"
         || export PERF_PREREQS_INSTALL_FAILED=1;
         test "x$PERF_PREREQS_INSTALL_FAILED" = "x1" && echo "** Error: Failed to install prerequites **"

--- a/eng/testing/performance/microbenchmarks.proj
+++ b/eng/testing/performance/microbenchmarks.proj
@@ -34,8 +34,7 @@
     <Python>python3</Python>
     <CoreRun>$(BaseDirectory)/Core_Root/corerun</CoreRun>
     <BaselineCoreRun>$(BaseDirectory)/Baseline_Core_Root/corerun</BaselineCoreRun>
-    <!-- Set DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1 as a workaround for https://github.com/dotnet/runtime/issues/74328 -->
-    <HelixPreCommands>$(HelixPreCommands);chmod +x $(PerformanceDirectory)/tools/machine-setup.sh;. $(PerformanceDirectory)/tools/machine-setup.sh;export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1</HelixPreCommands>
+    <HelixPreCommands>$(HelixPreCommands);chmod +x $(PerformanceDirectory)/tools/machine-setup.sh;. $(PerformanceDirectory)/tools/machine-setup.sh</HelixPreCommands>
     <ArtifactsDirectory>$HELIX_WORKITEM_ROOT/artifacts/BenchmarkDotNet.Artifacts</ArtifactsDirectory>
     <BaselineArtifactsDirectory>$HELIX_WORKITEM_ROOT/artifacts/BenchmarkDotNet.Artifacts_Baseline</BaselineArtifactsDirectory>
     <ResultsComparer>$(PerformanceDirectory)/src/tools/ResultsComparer/ResultsComparer.csproj</ResultsComparer>

--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -74,16 +74,12 @@
     <SetScriptCommands Condition="'$(JSEngine)' != ''" Include="export JS_ENGINE=--engine=$(JSEngine)" />
     <SetScriptCommands Condition="'$(JSEngineArgs)' != ''" Include="export JS_ENGINE_ARGS=$(JSEngineArgs)" />
     <SetScriptCommands Condition="'$(_WasmMainJSFileName)' != ''" Include="export MAIN_JS=--js-file=$(_WasmMainJSFileName)" />
-    <!-- Workaround for https://github.com/dotnet/runtime/issues/74328 -->
-    <SetScriptCommands Condition="'$(BuildAOTTestsOnHelix)' == 'true'" Include="export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <SetScriptCommands Condition="'$(Scenario)' != '' and '$(ContinuousIntegrationBuild)' != 'true'" Include="set &quot;SCENARIO=$(Scenario)&quot;" />
     <SetScriptCommands Condition="'$(JSEngine)' != ''" Include="set &quot;JS_ENGINE=--engine^=$(JSEngine)&quot;" />
     <SetScriptCommands Condition="'$(JSEngineArgs)' != ''" Include="set &quot;JS_ENGINE_ARGS=$(JSEngineArgs)&quot;" />
     <SetScriptCommands Condition="'$(_WasmMainJSFileName)' != ''" Include="set &quot;MAIN_JS=--js-file^=$(_WasmMainJSFileName)&quot;" />
-    <!-- Workaround for https://github.com/dotnet/runtime/issues/74328 -->
-    <SetScriptCommands Condition="'$(BuildAOTTestsOnHelix)' == 'true'" Include="set DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/installer/tests/TestUtils/DotNetCli.cs
+++ b/src/installer/tests/TestUtils/DotNetCli.cs
@@ -53,7 +53,6 @@ namespace Microsoft.DotNet.Cli.Build
             newArgs.Insert(0, command);
 
             return Command.Create(DotnetExecutablePath, newArgs)
-                .EnvironmentVariable("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER", "1") // https://github.com/dotnet/runtime/issues/74328
                 .EnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1")
                 .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0"); // Avoid looking at machine state by default
         }

--- a/src/mono/wasm/Wasm.Build.Tests/BuildEnvironment.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildEnvironment.cs
@@ -113,12 +113,6 @@ namespace Wasm.Build.Tests
             // helps with debugging
             EnvVars["WasmNativeStrip"] = "false";
 
-            // Works around an issue in msbuild due to which
-            // second, and subsequent builds fail without any details
-            // in the logs
-            EnvVars["DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER"] = "1";
-            DefaultBuildArgs += " /nr:false";
-
             DotNet = Path.Combine(sdkForWorkloadPath!, "dotnet");
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 DotNet += ".exe";

--- a/src/mono/wasm/Wasm.Build.Tests/DotNetCommand.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/DotNetCommand.cs
@@ -16,8 +16,6 @@ namespace Wasm.Build.Tests
             _useDefaultArgs = useDefaultArgs;
             if (useDefaultArgs)
                 WithEnvironmentVariables(buildEnv.EnvVars);
-            // workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
-            WithEnvironmentVariable("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER", "1");
         }
 
         protected override string GetFullArgs(params string[] args)

--- a/src/mono/wasm/Wasm.Build.Tests/RunCommand.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/RunCommand.cs
@@ -15,7 +15,5 @@ public class RunCommand : DotNetCommand
         WithEnvironmentVariable("DOTNET_INSTALL_DIR", Path.GetDirectoryName(buildEnv.DotNet)!);
         WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0");
         WithEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1");
-        // workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
-        WithEnvironmentVariable("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER", "1");
     }
 }


### PR DESCRIPTION
This workaround is no longer needed with .NET SDK 7 GA