### PR TITLE
initial support for '@' symbol in message template

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -250,8 +250,7 @@ namespace {lc.Namespace}
                 {
                     // this is related to https://github.com/serilog/serilog-extensions-logging/issues/197
                     string name = p.CodeName;
-
-                    if (lm.TemplateMap.ContainsKey(p.Name))
+                    if (lm.TemplateMap.ContainsKey(name))
                     {
                         // take the letter casing from the template
                         name = lm.TemplateMap[name];

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Extensions.Logging.Generators
                     for (int i = 0; i < lm.TemplateList.Count; i++)
                     {
                         string t = lm.TemplateList[i];
-                        if (!t.Equals(lm.TemplateParameters[i].Name, StringComparison.OrdinalIgnoreCase) && !t.Equals(lm.TemplateParameters[i].CodeName, StringComparison.OrdinalIgnoreCase))
+                        var (template, parameter) = SanitizeAtSign(t, lm.TemplateParameters[i].CodeName);
+                        if (!template.Equals(parameter, StringComparison.OrdinalIgnoreCase))
                         {
                             // order doesn't match, can't use LoggerMessage.Define
                             return false;
@@ -217,7 +218,8 @@ namespace {lc.Namespace}
                     int index = 0;
                     foreach (LoggerParameter p in lm.TemplateParameters)
                     {
-                        if (t.Key.Equals(p.Name, StringComparison.OrdinalIgnoreCase))
+                        var (key, parameter) = SanitizeAtSign(t.Key, p.Name);
+                        if (key.Equals(parameter, StringComparison.OrdinalIgnoreCase))
                         {
                             break;
                         }
@@ -609,5 +611,11 @@ internal static class __LoggerMessageGenerator
 
         private static string ProtectAtSymbol(string value) =>
             ContainsAtSymbol(value) ? value : $"_{value}";
+
+        private static (string template, string parameter) SanitizeAtSign(string template, string parameter)
+        {
+            static string SanitizeSingle(string input) => input.Length > 0 && input[0] == '@' ? input.Substring(1) : input;
+            return (SanitizeSingle(template), SanitizeSingle(parameter));
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -248,13 +248,10 @@ namespace {lc.Namespace}
                 int index = 0;
                 foreach (LoggerParameter p in lm.TemplateParameters)
                 {
-                    string name = p.Name;
-                    if(ContainsAtSymbol(p.CodeName))
-                    {
-                        // this is related to https://github.com/serilog/serilog-extensions-logging/issues/197
-                        name = p.CodeName;
-                    }
-                    if (lm.TemplateMap.ContainsKey(name))
+                    // this is related to https://github.com/serilog/serilog-extensions-logging/issues/197
+                    string name = p.CodeName;
+
+                    if (lm.TemplateMap.ContainsKey(p.Name))
                     {
                         // take the letter casing from the template
                         name = lm.TemplateMap[name];
@@ -608,17 +605,10 @@ internal static class __LoggerMessageGenerator
 
             return sb.ToString();
         }
-        private static bool ContainsAtSymbol(string value)=> value.Length > 0 && value[0] == '@';
-        private static string ProtectAtSymbol(string value)
-        {
-            if(ContainsAtSymbol(value))
-            {
-                return value;
-            }
-            else
-            {
-                return $"_{value}";
-            }
-        }
+
+        private static bool ContainsAtSymbol(string value) => value.Length > 0 && value[0] == '@';
+
+        private static string ProtectAtSymbol(string value) =>
+            ContainsAtSymbol(value) ? value : $"_{value}";
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.Logging.Generators
                     for (int i = 0; i < lm.TemplateList.Count; i++)
                     {
                         string t = lm.TemplateList[i];
-                        if (!t.Equals(lm.TemplateParameters[i].Name, StringComparison.OrdinalIgnoreCase))
+                        if (!t.Equals(lm.TemplateParameters[i].Name, StringComparison.OrdinalIgnoreCase) && !t.Equals(lm.TemplateParameters[i].CodeName, StringComparison.OrdinalIgnoreCase))
                         {
                             // order doesn't match, can't use LoggerMessage.Define
                             return false;
@@ -198,7 +198,7 @@ namespace {lc.Namespace}
             {
                 foreach (LoggerParameter p in lm.TemplateParameters)
                 {
-                    _builder.AppendLine($"            {nestedIndentation}private readonly {p.Type} _{p.Name};");
+                    _builder.AppendLine($"            {nestedIndentation}private readonly {p.Type} _{p.CodeName};");
                 }
             }
 
@@ -206,7 +206,7 @@ namespace {lc.Namespace}
             {
                 foreach (LoggerParameter p in lm.TemplateParameters)
                 {
-                    _builder.AppendLine($"                {nestedIndentation}this._{p.Name} = {p.CodeName};");
+                    _builder.AppendLine($"                {nestedIndentation}this._{p.CodeName} = {p.CodeName};");
                 }
             }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Extensions.Logging.Generators
                                             {
                                                 Diag(DiagnosticDescriptors.ArgumentHasNoCorrespondingTemplate, paramSymbol.Locations[0], paramName);
                                             }
-                                            else if (lp.IsTemplateParameter && !lm.TemplateMap.ContainsKey(paramName) && !lm.TemplateMap.ContainsKey(lp.CodeName))
+                                            else if (lp.IsTemplateParameter && !lm.TemplateMap.ContainsKey(paramName) && !lm.TemplateMap.ContainsKey($"@{paramName}") && !lm.TemplateMap.ContainsKey(lp.CodeName))
                                             {
                                                 Diag(DiagnosticDescriptors.ArgumentHasNoCorrespondingTemplate, paramSymbol.Locations[0], paramName);
                                             }
@@ -419,7 +419,9 @@ namespace Microsoft.Extensions.Logging.Generators
                                                 bool found = false;
                                                 foreach (LoggerParameter p in lm.AllParameters)
                                                 {
-                                                    if (t.Key.Equals(p.Name, StringComparison.OrdinalIgnoreCase) || t.Key.Equals(p.CodeName, StringComparison.OrdinalIgnoreCase))
+                                                    if (t.Key.Equals(p.Name, StringComparison.OrdinalIgnoreCase) ||
+                                                        t.Key.Equals(p.CodeName, StringComparison.OrdinalIgnoreCase) ||
+                                                        t.Key[0] == '@' && t.Key.Substring(1).Equals(p.CodeName, StringComparison.OrdinalIgnoreCase))
                                                     {
                                                         found = true;
                                                         break;

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -351,11 +351,11 @@ namespace Microsoft.Extensions.Logging.Generators
                                                 Diag(DiagnosticDescriptors.ShouldntMentionLogLevelInMessage, paramSymbol.Locations[0], paramName);
                                                 forceAsTemplateParams = true;
                                             }
-                                            else if (lp.IsLogLevel && level != null && !lm.TemplateMap.ContainsKey(paramName))
+                                            else if (lp.IsLogLevel && level != null && !lm.TemplateMap.ContainsKey(paramName) && !lm.TemplateMap.ContainsKey(lp.CodeName))
                                             {
                                                 Diag(DiagnosticDescriptors.ArgumentHasNoCorrespondingTemplate, paramSymbol.Locations[0], paramName);
                                             }
-                                            else if (lp.IsTemplateParameter && !lm.TemplateMap.ContainsKey(paramName))
+                                            else if (lp.IsTemplateParameter && !lm.TemplateMap.ContainsKey(paramName) && !lm.TemplateMap.ContainsKey(lp.CodeName))
                                             {
                                                 Diag(DiagnosticDescriptors.ArgumentHasNoCorrespondingTemplate, paramSymbol.Locations[0], paramName);
                                             }
@@ -419,7 +419,7 @@ namespace Microsoft.Extensions.Logging.Generators
                                                 bool found = false;
                                                 foreach (LoggerParameter p in lm.AllParameters)
                                                 {
-                                                    if (t.Key.Equals(p.Name, StringComparison.OrdinalIgnoreCase))
+                                                    if (t.Key.Equals(p.Name, StringComparison.OrdinalIgnoreCase) || t.Key.Equals(p.CodeName, StringComparison.OrdinalIgnoreCase))
                                                     {
                                                         found = true;
                                                         break;

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -783,6 +783,41 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
             Assert.Equal(1, generatedSources.Length);
             Assert.Equal(21, generatedSources[0].SourceText.Lines.Count);
         }
+        [Theory]
+        [InlineData("{request}", "request")]
+        [InlineData("{request}", "@request")]
+        [InlineData("{@request}", "request")]
+        [InlineData("{@request}", "@request")]
+        public async Task AtSymbolArgument(string stringTemplate, string parameterName)
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@$"
+                partial class C
+                {{
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = ""{stringTemplate}"")]
+                    static partial void M1(ILogger logger, string {parameterName});
+                }}
+            ");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Theory]
+        [InlineData("{request}", "request")]
+        [InlineData("{request}", "@request")]
+        [InlineData("{@request}", "request")]
+        [InlineData("{@request}", "@request")]
+        public async Task AtSymbolArgumentOutOfOrder(string stringTemplate, string parameterName)
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@$"
+                partial class C
+                {{
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = ""{stringTemplate} {{a1}}"")]
+                    static partial void M1(ILogger logger,string a1, string {parameterName});
+                }}
+            ");
+
+            Assert.Empty(diagnostics);
+        }
 
         private static async Task<IReadOnlyList<Diagnostic>> RunGenerator(
             string code,

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/AtSymbolTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/AtSymbolTestExtensions.cs
@@ -10,5 +10,11 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 
         [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "M1 {@myevent}")]
         internal static partial void M1(ILogger logger, string @myevent);
+
+        [LoggerMessage(Message = "Force use of Struct, {@myevent} {otherevent}", EventId = 2)]
+        public static partial void UseAtSymbol3(this ILogger logger,  LogLevel level, string @myevent, int otherevent);
+
+        [LoggerMessage(Message = "Force use of Struct with error, {@myevent} {otherevent}", EventId = 3)]
+        public static partial void UseAtSymbol4(this ILogger logger,  LogLevel level, string @myevent, int otherevent, System.Exception ex);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/AtSymbolTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/AtSymbolTestExtensions.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
         [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "M0 {event}")]
         internal static partial void M0(ILogger logger, string @event);
 
-        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "M1 {@myevent}")]
-        internal static partial void M1(ILogger logger, string @myevent);
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "M1 {@myevent1}")]
+        internal static partial void M1(ILogger logger, string @myevent1);
 
-        [LoggerMessage(Message = "Force use of Struct, {@myevent} {otherevent}", EventId = 2)]
-        public static partial void UseAtSymbol3(this ILogger logger,  LogLevel level, string @myevent, int otherevent);
+        [LoggerMessage(Message = "Force use of Struct, {@myevent2} {otherevent}", EventId = 2)]
+        public static partial void UseAtSymbol3(this ILogger logger,  LogLevel level, string @myevent2, int otherevent);
 
-        [LoggerMessage(Message = "Force use of Struct with error, {@myevent} {otherevent}", EventId = 3)]
-        public static partial void UseAtSymbol4(this ILogger logger,  LogLevel level, string @myevent, int otherevent, System.Exception ex);
+        [LoggerMessage(Message = "Force use of Struct with error, {@myevent3} {otherevent}", EventId = 3)]
+        public static partial void UseAtSymbol4(this ILogger logger,  LogLevel level, string @myevent3, int otherevent, System.Exception ex);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/AtSymbolTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/TestClasses/AtSymbolTestExtensions.cs
@@ -7,5 +7,8 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
     {
         [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "M0 {event}")]
         internal static partial void M0(ILogger logger, string @event);
+
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "M1 {@myevent}")]
+        internal static partial void M1(ILogger logger, string @myevent);
     }
 }


### PR DESCRIPTION
With this change, users will be able to create message templates containing '@' symbol.
This allows initial compatibility with https://messagetemplates.org/ and with serilog sink.
This issue [#197 ](https://github.com/serilog/serilog-extensions-logging/issues/197) can be resolved (it was closed without a proper solution).

@maryamariyan fixed an issue not related with templating, she added support for reseverd keyword parameters by prefixing them with '@' symbol (#64779)

I made those changes, tried to not break things and tried to not add performance issues. Please let me know if there's anything I have to change to allow this PR to be accepted.