### PR TITLE
Wait for serverTask before asserting IsCompletedSuccessfully

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
@@ -197,7 +197,7 @@ namespace System.IO.Pipes.Tests
                 {
                     // When CurrentUserOnly is only on client side and asks for ReadOnly access, the connection is not rejected
                     // but we get the UnauthorizedAccessException on the client regardless.
-                    serverTask.Wait(10_000);
+                    Assert.True(serverTask.Wait(TimeSpan.FromSeconds(10)));
                     Assert.True(serverTask.IsCompletedSuccessfully);
                 }
                 else

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
@@ -197,6 +197,7 @@ namespace System.IO.Pipes.Tests
                 {
                     // When CurrentUserOnly is only on client side and asks for ReadOnly access, the connection is not rejected
                     // but we get the UnauthorizedAccessException on the client regardless.
+                    serverTask.Wait(10_000);
                     Assert.True(serverTask.IsCompletedSuccessfully);
                 }
                 else


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/79052.


Most likely `serverTask` not always finishes on time, so adding `Wait(10_000)` before checking the property.
That's what we do on the `else` branch.

https://github.com/dotnet/runtime/blob/555369171d198c49d45051e61dee2797ab0561fb/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs#L196-L206