### PR TITLE
[Android] Fix path to `ping` on Android API 21-27

### DIFF
--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -9,8 +9,8 @@ namespace System.Net.NetworkInformation
 {
     internal static class UnixCommandLinePing
     {
-        // Ubuntu has ping under /bin, OSX under /sbin, ArchLinux under /usr/bin.
-        private static readonly string[] s_binFolders = { "/bin/", "/sbin/", "/usr/bin/" };
+        // Ubuntu has ping under /bin, OSX under /sbin, ArchLinux under /usr/bin, Android under /system/bin.
+        private static readonly string[] s_binFolders = { "/bin/", "/sbin/", "/usr/bin/", "/system/bin" };
         private const string s_ipv4PingFile = "ping";
         private const string s_ipv6PingFile = "ping6";
 


### PR DESCRIPTION
The path to the `ping` binary on Android is `/system/bin/ping`. Newer Androids (API 28+) have a symlink for `/bin -> /system/bin`, so our CI that runs tests on API 29 didn't catch it.

Ref #78990

/cc @wfurt @steveisok 