### PR TITLE
[release/7.0] Bump 6.0 workload

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>2</PatchVersion>
     <SdkBandVersion>7.0.100</SdkBandVersion>
-    <PackageVersionNet6>6.0.12</PackageVersionNet6>
+    <PackageVersionNet6>6.0.13</PackageVersionNet6>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>


### PR DESCRIPTION
Bump the 6.0.x version to 6.0.13 for servicing. Without this the 7.0.1xx sdks will not get the latest 6.0.13 runtimes for maui/wasm
