### PR TITLE
Put back setting of field in DirectorySearcher.FindAll

### DIFF
--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
@@ -607,6 +607,8 @@ namespace System.DirectoryServices
 
         private SearchResultCollection FindAll(bool findMoreThanOne)
         {
+            searchResult = null;
+
             DirectoryEntry clonedRoot = SearchRoot!.CloneBrowsable();
 
             UnsafeNativeMethods.IAds adsObject = clonedRoot.AdsObject;
@@ -650,7 +652,9 @@ namespace System.DirectoryServices
                 properties = Array.Empty<string>();
             }
 
-            return new SearchResultCollection(clonedRoot, resultsHandle, properties, this);
+            SearchResultCollection result = new SearchResultCollection(clonedRoot, resultsHandle, properties, this);
+            searchResult = result;
+            return result;
         }
 
         private unsafe void SetSearchPreferences(UnsafeNativeMethods.IDirectorySearch adsSearch, bool findMoreThanOne)


### PR DESCRIPTION
This was removed accidentally due to erroneously thinking it was a local rather than a field.
Reverts most of https://github.com/dotnet/corefx/pull/40321
Fixes https://github.com/dotnet/runtime/issues/79066