### PR TITLE
Fix creating incorrect options in the repro package

### DIFF
--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -109,7 +109,7 @@ namespace System.CommandLine
             throw new CommandLineException($"Target architecture '{token}' is not supported");
         }
 
-        public static void MakeReproPackage(string makeReproPath, string outputFilePath, string[] args, ParseResult res, IEnumerable<string> inputOptions)
+        public static void MakeReproPackage(string makeReproPath, string outputFilePath, string[] args, ParseResult res, IEnumerable<string> inputOptions, IEnumerable<string> outputOptions = null)
         {
             Directory.CreateDirectory(makeReproPath);
 
@@ -169,6 +169,8 @@ namespace System.CommandLine
 
                 HashSet<string> inputOptionNames = new HashSet<string>(inputOptions);
                 Dictionary<string, string> inputToReproPackageFileName = new();
+                HashSet<string> outputOptionNames = outputOptions == null ? new HashSet<string>() : new HashSet<string>(outputOptions);
+                Dictionary<string, string> outputToReproPackageFileName = new();
 
                 List<string> rspFile = new List<string>();
                 foreach (var option in res.CommandResult.Command.Options)
@@ -192,24 +194,43 @@ namespace System.CommandLine
                                 Dictionary<string, string> dictionary = new();
                                 foreach (string optInList in values)
                                 {
-                                    AppendExpandedPaths(dictionary, optInList, false);
+                                    if (string.IsNullOrEmpty(optInList))
+                                        continue;
+
+                                    if (CheckOptionValueForAssemblyName(option.Name, optInList))
+                                        rspFile.Add($"--{option.Name}:{optInList}");
+                                    else
+                                        AppendExpandedPaths(dictionary, optInList, false);
                                 }
                                 foreach (string inputFile in dictionary.Values)
                                 {
-                                    rspFile.Add($"--{option.Name}:{ConvertFromInputPathToReproPackagePath(inputFile)}");
+                                    rspFile.Add($"--{option.Name}:{ConvertFromOriginalPathToReproPackagePath(input: true, inputFile)}");
                                 }
                             }
                             else
                             {
                                 foreach (string optInList in values)
                                 {
-                                    rspFile.Add($"--{option.Name}:{optInList}");
+                                    if (!string.IsNullOrEmpty(optInList))
+                                        rspFile.Add($"--{option.Name}:{optInList}");
                                 }
                             }
                         }
                         else
                         {
-                            rspFile.Add($"--{option.Name}:{val}");
+                            if (val is string stringVal && !string.IsNullOrEmpty(stringVal))
+                            {
+                                if (outputOptionNames.Contains(option.Name))
+                                {
+                                    // if output option is used, overwrite the path to the repro package
+                                    stringVal = ConvertFromOriginalPathToReproPackagePath(input: false, stringVal);
+                                }
+                                rspFile.Add($"--{option.Name}:{stringVal}");
+                            }
+                            else
+                            {
+                                rspFile.Add($"--{option.Name}:{val}");
+                            }
                         }
                     }
                 }
@@ -224,12 +245,12 @@ namespace System.CommandLine
 
                         foreach (string optInList in values)
                         {
-                            rspFile.Add($"{ConvertFromInputPathToReproPackagePath((string)optInList)}");
+                            rspFile.Add($"{ConvertFromOriginalPathToReproPackagePath(input: true, optInList)}");
                         }
                     }
                     else
                     {
-                        rspFile.Add($"{ConvertFromInputPathToReproPackagePath((string)val)}");
+                        rspFile.Add($"{ConvertFromOriginalPathToReproPackagePath(input: true, (string)val)}");
                     }
                 }
 
@@ -240,26 +261,44 @@ namespace System.CommandLine
                         writer.WriteLine(s);
                 }
 
-                string ConvertFromInputPathToReproPackagePath(string inputPath)
+                string ConvertFromOriginalPathToReproPackagePath(bool input, string originalPath)
                 {
-                    if (inputToReproPackageFileName.TryGetValue(inputPath, out string reproPackagePath))
+                    var originalToReproPackageFileName = input ? inputToReproPackageFileName : outputToReproPackageFileName;
+                    if (originalToReproPackageFileName.TryGetValue(originalPath, out string reproPackagePath))
                     {
                         return reproPackagePath;
                     }
 
                     try
                     {
-                        string inputFileDir = inputToReproPackageFileName.Count.ToString();
-                        reproPackagePath = Path.Combine(inputFileDir, Path.GetFileName(inputPath));
-                        archive.CreateEntryFromFile(inputPath, reproPackagePath);
-                        inputToReproPackageFileName.Add(inputPath, reproPackagePath);
+                        string prefix = input ? string.Empty : "out_"; // prefix output directories for clarity
+                        string reproFileDir = prefix + originalToReproPackageFileName.Count.ToString() + Path.DirectorySeparatorChar;
+                        reproPackagePath = Path.Combine(reproFileDir, Path.GetFileName(originalPath));
+                        if (!input)
+                            archive.CreateEntry(reproFileDir); // for outputs just create output directory
+                        else
+                            archive.CreateEntryFromFile(originalPath, reproPackagePath);
+                        originalToReproPackageFileName.Add(originalPath, reproPackagePath);
 
                         return reproPackagePath;
                     }
                     catch
                     {
-                        return inputPath;
+                        return originalPath;
                     }
+                }
+
+                bool CheckOptionValueForAssemblyName(string optionName, string optionValue)
+                {
+                    // For the options accepting both assembly names and assembly paths as parameters,
+                    // we try to detect if the option value is an assembly name.
+                    // Since there is no predefined pattern to do this, we will simply verify that the value
+                    // does not exist as a file, and that is in the current directory (making sure it is not a wrong path).
+                    var optionsAcceptingAssemblyNames = new List<string> { "root", "conditionalroot", "trim" };
+                    if (!optionsAcceptingAssemblyNames.Contains(optionName))
+                        return false;
+                    else
+                        return Path.GetDirectoryName(optionValue) == string.Empty && !File.Exists(optionValue);
                 }
             }
         }

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -194,12 +194,7 @@ namespace System.CommandLine
                                 Dictionary<string, string> dictionary = new();
                                 foreach (string optInList in values)
                                 {
-                                    if (string.IsNullOrEmpty(optInList))
-                                        continue;
-
-                                    if (CheckOptionValueForAssemblyName(option.Name, optInList))
-                                        rspFile.Add($"--{option.Name}:{optInList}");
-                                    else
+                                    if (!string.IsNullOrEmpty(optInList))
                                         AppendExpandedPaths(dictionary, optInList, false);
                                 }
                                 foreach (string inputFile in dictionary.Values)
@@ -286,19 +281,6 @@ namespace System.CommandLine
                     {
                         return originalPath;
                     }
-                }
-
-                bool CheckOptionValueForAssemblyName(string optionName, string optionValue)
-                {
-                    // For the options accepting both assembly names and assembly paths as parameters,
-                    // we try to detect if the option value is an assembly name.
-                    // Since there is no predefined pattern to do this, we will simply verify that the value
-                    // does not exist as a file, and that is in the current directory (making sure it is not a wrong path).
-                    var optionsAcceptingAssemblyNames = new List<string> { "root", "conditionalroot", "trim" };
-                    if (!optionsAcceptingAssemblyNames.Contains(optionName))
-                        return false;
-                    else
-                        return Path.GetDirectoryName(optionValue) == string.Empty && !File.Exists(optionValue);
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -262,7 +262,7 @@ namespace ILCompiler
                         // + a rsp file that should work to directly run out of the zip file
 
                         Helpers.MakeReproPackage(makeReproPath, context.ParseResult.GetValue(OutputFilePath), args, context.ParseResult,
-                            inputOptions : new[] { "r", "reference", "m", "mibc", "rdxml", "directpinvokelist", "descriptor", "root", "conditionalroot", "trim" },
+                            inputOptions : new[] { "r", "reference", "m", "mibc", "rdxml", "directpinvokelist", "descriptor" },
                             outputOptions : new[] { "o", "out", "exportsfile" });
                     }
 

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -261,8 +261,9 @@ namespace ILCompiler
                         // + the original command line arguments
                         // + a rsp file that should work to directly run out of the zip file
 
-                        Helpers.MakeReproPackage(makeReproPath, context.ParseResult.GetValue(OutputFilePath), args,
-                            context.ParseResult, new[] { "r", "reference", "m", "mibc", "rdxml", "directpinvokelist", "descriptor" });
+                        Helpers.MakeReproPackage(makeReproPath, context.ParseResult.GetValue(OutputFilePath), args, context.ParseResult,
+                            inputOptions : new[] { "r", "reference", "m", "mibc", "rdxml", "directpinvokelist", "descriptor", "root", "conditionalroot", "trim" },
+                            outputOptions : new[] { "o", "out", "exportsfile" });
                     }
 
                     context.ExitCode = new Program(this).Run();


### PR DESCRIPTION
As proposed in #79032 this PR implements suggested improvements (2) and (3):

2. Options with missing values are not emitted
3. Output options: `-o`, `--out`, `--exportsfile` are now being processed and for them: 

- adequate output directories are created within the repro package
- the paths are converted into the relative path to the repro package
