### PR TITLE
Fix `IMetaDataImport::GetCustomAttributeByName` generic attributes

### DIFF
--- a/src/coreclr/md/inc/metamodel.h
+++ b/src/coreclr/md/inc/metamodel.h
@@ -1390,7 +1390,9 @@ public:
 
         pSig += CorSigUncompressData(pSig, &data);
 
-        while (pSig < pEnd && CorIsModifierElementType((CorElementType) data))
+        while (pSig < pEnd
+            && (CorIsModifierElementType((CorElementType) data)
+                || data == ELEMENT_TYPE_GENERICINST))
         {
             pSig += CorSigUncompressData(pSig, &data);
         }


### PR DESCRIPTION
The current logic doesn't handle the case where
a `TypeSpec` can be a generic attribute. Since C#
now supports generic attributes, this is a deficiency
that can be observed by diagnostics tooling using
`IMetaDataImport`.

The `TypeSpec` specification is defined in II.23.2.14 of
ECMA-335. Practically, CustomAttributes only support
`TypeDef`, `TypeRef` and `TypeSpec` with GENERICINST.
This means the check could be more targeted if desired.

```
TypeSpecBlob ::= 
   PTR CustomMod* VOID 
  | PTR CustomMod* Type 
  | FNPTR MethodDefSig 
  | FNPTR MethodRefSig 
  | ARRAY Type ArrayShape 
  | SZARRAY CustomMod* Type 
  | GENERICINST (CLASS | VALUETYPE) TypeDefOrRefOrSpecEncoded GenArgCount Type 
Type*
```