### PR TITLE
Added byref to native int CAST on import

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2900,6 +2900,10 @@ GenTree* Compiler::impImplicitIorI4Cast(GenTree* tree, var_types dstTyp)
             tree = gtNewCastNode(TYP_INT, tree, false, TYP_INT);
         }
 #endif // TARGET_64BIT
+        else if ((wantedType == TYP_I_IMPL) && (currType == TYP_BYREF))
+        {
+            tree = gtNewCastNode(TYP_I_IMPL, tree, false, TYP_I_IMPL);
+        }
     }
 
     return tree;


### PR DESCRIPTION
**Description**

Should resolve: https://github.com/dotnet/runtime/issues/78944

For a while now, the JIT has accepted the implicit conversion `byref` -> `native int` for IL, even though the IL spec says that it is illegal. However, an assertion was coming up in https://github.com/dotnet/runtime/issues/78944.

Example IL:
```MSIL
.method public static native int byrefsubi4(class ctest& V_1, int32 V_2)
{
ldarg 0
ldarg 1
sub
ret
}
```

It probably would not be a good idea to error with a BADCODE for this implicit conversion as there are probably lots of cases where the IL is shaped like this. Therefore, the right fix is to insert a `CAST` to handle the implicit conversion for `byref` -> `native int` correctly, as morph will see the `CAST` and create a throw-away GC info variable.

Old IR after Import:
```
               [000003] -----------                         *  RETURN    int   
               [000002] -----------                         \--*  SUB       byref 
               [000000] -----------                            +--*  LCL_VAR   byref  V00 arg0         
               [000001] -----------                            \--*  LCL_VAR   int    V01 arg1   
```

New IR after Import:
```
               [000004] -----------                         *  RETURN    int   
               [000003] -----------                         \--*  CAST      int <- byref
               [000002] -----------                            \--*  SUB       byref 
               [000000] -----------                               +--*  LCL_VAR   byref  V00 arg0         
               [000001] -----------                               \--*  LCL_VAR   int    V01 arg1 
```