### PR TITLE
Remove staged build param

### DIFF
--- a/eng/pipelines/common/build-coreclr-and-libraries-job.yml
+++ b/eng/pipelines/common/build-coreclr-and-libraries-job.yml
@@ -9,7 +9,6 @@ parameters:
   crossBuild: false
   timeoutInMinutes: ''
   signBinaries: false
-  stagedBuild: false
   variables: {}
   pool: ''
   platform: ''
@@ -28,7 +27,6 @@ jobs:
     crossBuild: ${{ parameters.crossBuild }}
     timeoutInminutes: ${{ parameters.timeoutInMinutes }}
     signBinaries: ${{ parameters.signBinaries }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     variables: ${{ parameters.variables }}
     pool: ${{ parameters.pool }}
 

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -16,7 +16,6 @@ parameters:
   # helixQueuesTemplate is a yaml template which will be expanded in order to set up the helix queues
   # for the given platform and helixQueueGroup.
   helixQueuesTemplate: ''
-  stagedBuild: false
   container: ''
   shouldContinueOnError: false
   jobParameters: {}
@@ -39,7 +38,6 @@ jobs:
       container: Linux_arm
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -60,7 +58,6 @@ jobs:
       container: Linux_armv6
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -87,7 +84,6 @@ jobs:
           registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -110,7 +106,6 @@ jobs:
       container: Linux_musl_x64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -132,7 +127,6 @@ jobs:
       container: Linux_musl_arm
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -155,7 +149,6 @@ jobs:
       container: Linux_musl_arm64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -181,7 +174,6 @@ jobs:
         # We build on Linux, but the test queue runs Windows, so
         # we need to override the test script generation
         runScriptWindowsCmd: true
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -203,7 +195,6 @@ jobs:
       container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -229,7 +220,6 @@ jobs:
           registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -250,7 +240,6 @@ jobs:
       container: Linux_x86
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -275,7 +264,6 @@ jobs:
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         isSourceBuild: true
@@ -300,7 +288,6 @@ jobs:
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         isSourceBuild: true
@@ -323,7 +310,6 @@ jobs:
       container: SourceBuild_Linux_x64
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         isSourceBuild: true
@@ -346,7 +332,6 @@ jobs:
       container: Linux_s390x
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -368,7 +353,6 @@ jobs:
       container: Linux_ppc64le
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -391,7 +375,6 @@ jobs:
       jobParameters:
         hostedOs: Linux
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -412,7 +395,6 @@ jobs:
       jobParameters:
         hostedOs: Linux
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -432,7 +414,6 @@ jobs:
       jobParameters:
         hostedOs: windows
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -472,7 +453,6 @@ jobs:
       container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -493,7 +473,6 @@ jobs:
       container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -514,7 +493,6 @@ jobs:
       container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -535,7 +513,6 @@ jobs:
       container: Linux_bionic
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -555,7 +532,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -575,7 +551,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -595,7 +570,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -615,7 +589,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -635,7 +608,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -655,7 +627,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -675,7 +646,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -695,7 +665,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -715,7 +684,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         managedTestBuildOsGroup: OSX
@@ -736,7 +704,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: mono
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -756,7 +723,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -777,7 +743,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -798,7 +763,6 @@ jobs:
       container: Tizen_armel
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
@@ -820,7 +784,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -840,7 +803,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -859,7 +821,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
@@ -879,7 +840,6 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
@@ -7,7 +7,6 @@ parameters:
   testGroup: ''
   liveLibrariesBuildConfig: ''
   helixQueues: ''
-  stagedBuild: false
   displayNameArgs: ''
   runtimeVariant: ''
   variables: {}

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -10,7 +10,6 @@ parameters:
   liveLibrariesBuildConfig: ''
   compositeBuildMode: false
   helixQueues: ''
-  stagedBuild: false
   displayNameArgs: ''
   runInUnloadableContext: false
   runtimeVariant: 'monointerpreter'

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -7,7 +7,6 @@ parameters:
   testGroup: ''
   displayNameArgs: ''
   condition: true
-  stagedBuild: false
   variables: {}
   pool: ''
   runtimeFlavor: 'coreclr'
@@ -35,7 +34,6 @@ jobs:
     container: ${{ parameters.container }}
     runtimeVariant: ${{ parameters.runtimeVariant }}
     testGroup: ${{ parameters.testGroup }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     pool: ${{ parameters.pool }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
 

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -59,19 +59,19 @@ jobs:
         - '${{ parameters.runtimeFlavor }}_common_test_build_p0_AnyOS_AnyCPU_${{parameters.buildConfig }}'
       - ${{ if notIn(parameters.testGroup, 'innerloop', 'clrinterpreter') }}:
         - '${{ parameters.runtimeFlavor }}_common_test_build_p1_AnyOS_AnyCPU_${{parameters.buildConfig }}'
-        - ${{ if or( eq(parameters.runtimeVariant, 'minijit'), eq(parameters.runtimeVariant, 'monointerpreter'), eq(parameters.runtimeVariant, 'llvmaot'), eq(parameters.runtimeVariant, 'llvmfullaot'))  }}:
-          # This is needed for creating a CORE_ROOT in the current design.
-          - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', '', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        - ${{ if or( eq(parameters.runtimeVariant, 'minijit'), eq(parameters.runtimeVariant, 'monointerpreter')) }} :
-          # minijit and mono interpreter runtimevariants do not require any special build of the runtime
-          - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, '', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        - ${{ if not(or(eq(parameters.runtimeVariant, 'minijit'), eq(parameters.runtimeVariant, 'monointerpreter')))  }}:
-          - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
-            - ${{ format('{0}_llvmaot_product_build_{1}{2}_{3}_{4}', parameters.runtimeFlavor, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-          - ${{ if ne(parameters.runtimeVariant, 'llvmfullaot') }}:
-            - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
-          - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
+      - ${{ if or( eq(parameters.runtimeVariant, 'minijit'), eq(parameters.runtimeVariant, 'monointerpreter'), eq(parameters.runtimeVariant, 'llvmaot'), eq(parameters.runtimeVariant, 'llvmfullaot'))  }}:
+        # This is needed for creating a CORE_ROOT in the current design.
+        - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', '', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+      - ${{ if or( eq(parameters.runtimeVariant, 'minijit'), eq(parameters.runtimeVariant, 'monointerpreter')) }} :
+        # minijit and mono interpreter runtimevariants do not require any special build of the runtime
+        - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, '', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+      - ${{ if not(or(eq(parameters.runtimeVariant, 'minijit'), eq(parameters.runtimeVariant, 'monointerpreter')))  }}:
+        - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
+          - ${{ format('{0}_llvmaot_product_build_{1}{2}_{3}_{4}', parameters.runtimeFlavor, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+        - ${{ if ne(parameters.runtimeVariant, 'llvmfullaot') }}:
+          - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+      - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
+        - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
       # SuperPMI collection needs to run mcs.exe on the AzDO machine. Assume that's an x64 machine, and download an x64 product build if needed.
       - ${{ if and(eq(parameters.SuperPmiCollect, true), ne(parameters.archType, 'x64')) }}:
           - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', '', parameters.osGroup, parameters.osSubgroup, 'x64', parameters.buildConfig) }}

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -12,7 +12,6 @@ parameters:
   useCodeFlowEnforcement: ''
   helixQueues: ''
   condition: true
-  stagedBuild: false
   displayNameArgs: ''
   runInUnloadableContext: false
   tieringTest: false
@@ -40,7 +39,6 @@ jobs:
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
     crossBuild: ${{ parameters.crossBuild }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     liveLibrariesBuildConfig: ${{ parameters.liveLibrariesBuildConfig }}
     helixType: 'build/tests/'
     runtimeVariant: ${{ parameters.runtimeVariant }}
@@ -61,7 +59,6 @@ jobs:
         - '${{ parameters.runtimeFlavor }}_common_test_build_p0_AnyOS_AnyCPU_${{parameters.buildConfig }}'
       - ${{ if notIn(parameters.testGroup, 'innerloop', 'clrinterpreter') }}:
         - '${{ parameters.runtimeFlavor }}_common_test_build_p1_AnyOS_AnyCPU_${{parameters.buildConfig }}'
-      - ${{ if ne(parameters.stagedBuild, true) }}:
         - ${{ if or( eq(parameters.runtimeVariant, 'minijit'), eq(parameters.runtimeVariant, 'monointerpreter'), eq(parameters.runtimeVariant, 'llvmaot'), eq(parameters.runtimeVariant, 'llvmfullaot'))  }}:
           # This is needed for creating a CORE_ROOT in the current design.
           - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', '', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -7,7 +7,6 @@ parameters:
   helixType: '(unspecified)'
   container: ''
   crossBuild: false
-  stagedBuild: false
   strategy: ''
   pool: ''
 

--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -7,7 +7,6 @@ parameters:
   osSubgroup: ''
   condition: true
   pool: ''
-  stagedBuild: false
   timeoutInMinutes: ''
   variables: {}
   dependOnEvaluatePaths: false
@@ -24,7 +23,6 @@ jobs:
     condition: ${{ parameters.condition }}
     helixType: 'build/product/'
     enableMicrobuild: true
-    stagedBuild: ${{ parameters.stagedBuild }}
     pool: ${{ parameters.pool }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
 

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -16,7 +16,6 @@ parameters:
   pool: ''
   runtimeVariant: ''
   signBinaries: false
-  stagedBuild: false
   testGroup: ''
   timeoutInMinutes: ''
   variables: {}
@@ -34,7 +33,6 @@ jobs:
     testGroup: ${{ parameters.testGroup }}
     helixType: 'build/product/'
     enableMicrobuild: true
-    stagedBuild: ${{ parameters.stagedBuild }}
     pool: ${{ parameters.pool }}
     condition: ${{ parameters.condition }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}

--- a/eng/pipelines/coreclr/templates/crossdac-pack.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-pack.yml
@@ -10,7 +10,6 @@ parameters:
   platform: ''
   pool: ''
   runtimeVariant: ''
-  stagedBuild: false
   testGroup: ''
   timeoutInMinutes: ''
   variables: {}
@@ -27,7 +26,6 @@ jobs:
     osSubgroup: ${{ parameters.osSubgroup }}
     pool: ${{ parameters.pool }}
     runtimeVariant: ${{ parameters.runtimeVariant }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
 

--- a/eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen2-comparison-build-job.yml
@@ -8,7 +8,6 @@ parameters:
   runtimeVariant: ''
   crossBuild: false
   dependOnEvaluatePaths: false
-  stagedBuild: false
   variables: {}
   pool: ''
 
@@ -31,7 +30,6 @@ jobs:
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}
     osSubgroup: ${{ parameters.osSubgroup }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     runtimeVariant: ${{ parameters.runtimeVariant }}
     liveLibrariesBuildConfig: ${{ parameters.liveLibrariesBuildConfig }}
     helixType: 'test/crossgen-comparison/'

--- a/eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
+++ b/eng/pipelines/coreclr/templates/crossgen2-comparison-job.yml
@@ -8,7 +8,6 @@ parameters:
   runtimeVariant: ''
   crossBuild: false
   dependOnEvaluatePaths: false
-  stagedBuild: false
   variables: {}
   pool: ''
   targetarch: ''
@@ -33,7 +32,6 @@ jobs:
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}
     osSubgroup: ${{ parameters.osSubgroup }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     runtimeVariant: ${{ parameters.runtimeVariant }}
     liveLibrariesBuildConfig: ${{ parameters.liveLibrariesBuildConfig }}
     helixType: 'test/crossgen-comparison/'

--- a/eng/pipelines/coreclr/templates/format-job.yml
+++ b/eng/pipelines/coreclr/templates/format-job.yml
@@ -7,7 +7,6 @@ parameters:
   crossBuild: false
   dependOnEvaluatePaths: false
   timeoutInMinutes: ''
-  stagedBuild: false
   variables: {}
   pool: ''
   condition: true
@@ -23,7 +22,6 @@ jobs:
     container: ${{ parameters.container }}
     crossBuild: ${{ parameters.crossBuild }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     name: ${{ format('format_{0}{1}_{2}', parameters.osGroup, parameters.osSubgroup, parameters.archType) }}
     displayName: ${{ format('Formatting {0}{1} {2}', parameters.osGroup, parameters.osSubgroup, parameters.archType) }}

--- a/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
@@ -9,7 +9,6 @@ parameters:
   testGroup: ''
   crossBuild: false
   liveLibrariesBuildConfig: ''
-  stagedBuild: false
   strategy: ''
   pool: ''
 
@@ -36,7 +35,6 @@ jobs:
     helixType: ${{ parameters.helixType }}
     container: ${{ parameters.container }}
     crossBuild: ${{ parameters.crossBuild }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     strategy: ${{ parameters.strategy }}
     pool: ${{ parameters.pool }}
     pgoType: ${{ parameters.pgoType }}

--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -50,7 +50,6 @@ jobs:
     testGroup: ${{ parameters.testGroup }}
     helixType: 'build/product/'
     enableMicrobuild: true
-    stagedBuild: ${{ parameters.stagedBuild }}
     pool: ${{ parameters.pool }}
 
     ${{ if eq(parameters.runOnlyIfDependenciesSucceeded, true) }}:

--- a/eng/pipelines/mono/templates/workloads-build.yml
+++ b/eng/pipelines/mono/templates/workloads-build.yml
@@ -10,7 +10,6 @@ parameters:
   platform: ''
   pool: ''
   runtimeVariant: ''
-  stagedBuild: false
   testGroup: ''
   timeoutInMinutes: ''
   variables: {}
@@ -27,7 +26,6 @@ jobs:
     osSubgroup: ${{ parameters.osSubgroup }}
     pool: ${{ parameters.pool }}
     runtimeVariant: ${{ parameters.runtimeVariant }}
-    stagedBuild: ${{ parameters.stagedBuild }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
 


### PR DESCRIPTION
Within dotnet/runtime, `stagedBuild` as a pipeline parameter is currently leveraged only at https://github.com/dotnet/runtime/blob/41f57b7862dca221687a6cb638c35e33ee8e25db/eng/pipelines/common/templates/runtimes/run-test-job.yml#L64 Throughout our pipelines, it is only false or unset, and so the condition is always true.

It seems like `stagedBuild` is a leftover parameter from coreclr, so this PR aims to remove it altogether as it no longer provides value, making pipelines slightly cleaner :)