### PR TITLE
[wasm] Fix debugger tests run on CI/Windows

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj
@@ -54,7 +54,7 @@
           BeforeTargets="CopyTestZipForHelix"
           DependsOnTargets="_GenerateRunSettingsFile">
 
-    <Exec Command="$(DotNetTool) test --no-build -s $(RunSettingsFilePath) -t --nologo -v:q" ConsoleToMSBuild="true">
+    <Exec Command="&quot;$(DotNetTool)&quot; test --no-build -s $(RunSettingsFilePath) -t --nologo -v:q" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" ItemName="_ListOfTestsLines" />
     </Exec>
 


### PR DESCRIPTION
This broke recently, and can be see on a [rolling build](https://dev.azure.com/dnceng-public/public/_build/results?buildId=98671&view=logs&j=1567862a-6a9e-5016-9353-cc84f1411dc4&t=ce4bdad4-0de6-5895-a84e-38de413a28c1&l=3254):

```
  'C:\Program' is not recognized as an internal or external command,
  operable program or batch file.
D:\a\_work\1\s\src\mono\wasm\debugger\DebuggerTestSuite\DebuggerTestSuite.csproj(57,5): error MSB3073: The command "C:\Program Files\dotnet\dotnet.exe test --no-build -s D:\a\_work\1\s\artifacts\bin\DebuggerTestSuite\x64\Debug\.runsettings -t --nologo -v:q" exited with code 9009.
```

- this is breaking because we are running `src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestSuite.csproj` `<Exec Command="$(DotNetTool) test ..." />`

  - and `DotNetTool` here is `c:\Program Files\dotnet\dotnet.exe`, and the shell command breaks because of the space.
  - this broke because recently we moved to building with `7.0.100`. And when the version used for building matches the version installed on the system, the system dotnet is used.
    - but when it doesn't, it gets installed in `</repo/checkout>/.dotnet/dotnet`
    - So, because of the recent update the path changed to `C:\Program files`, and broke the command. - The fix is to simply quote the path.