### PR TITLE
fix SslStream.IsMutuallyAuthenticated with cached credentials

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
@@ -301,7 +301,6 @@ namespace System.Net
         public static bool QueryContextAttributes_SECPKG_ATTR_LOCAL_CERT_CONTEXT(ISSPIInterface secModule, SafeDeleteContext securityContext, out SafeFreeCertContext? certContext)
             => QueryCertContextAttribute(secModule, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_LOCAL_CERT_CONTEXT, out certContext);
 
-
         public static bool QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CHAIN(ISSPIInterface secModule, SafeDeleteContext securityContext, out SafeFreeCertContext? certContext)
             => QueryCertContextAttribute(secModule, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_REMOTE_CERT_CHAIN, out certContext);
 

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
@@ -298,6 +298,10 @@ namespace System.Net
         public static bool QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CONTEXT(ISSPIInterface secModule, SafeDeleteContext securityContext, out SafeFreeCertContext? certContext)
             => QueryCertContextAttribute(secModule, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_REMOTE_CERT_CONTEXT, out certContext);
 
+        public static bool QueryContextAttributes_SECPKG_ATTR_LOCAL_CERT_CONTEXT(ISSPIInterface secModule, SafeDeleteContext securityContext, out SafeFreeCertContext? certContext)
+            => QueryCertContextAttribute(secModule, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_LOCAL_CERT_CONTEXT, out certContext);
+
+
         public static bool QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CHAIN(ISSPIInterface secModule, SafeDeleteContext securityContext, out SafeFreeCertContext? certContext)
             => QueryCertContextAttribute(secModule, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_REMOTE_CERT_CHAIN, out certContext);
 

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
@@ -91,6 +91,10 @@ namespace System.Net
             return cert;
         }
 
+        // This is only called when we selected local client certificate.
+        // Currently this is only when Java crypto asked for it.
+        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+
         //
         // Used only by client SSL code, never returns null.
         //

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -102,6 +102,10 @@ namespace System.Net
             return result;
         }
 
+        // This is only called when we selected local client certificate.
+        // Currently this is only when Apple crypto asked for it.
+        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+
         //
         // Used only by client SSL code, never returns null.
         //

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -95,6 +95,10 @@ namespace System.Net
             return result;
         }
 
+        // This is only called when we selected local client certificate.
+        // Currently this is only when OpenSSL needs it becaseu peer asked.
+        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+
         //
         // Used only by client SSL code, never returns null.
         //

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -96,7 +96,7 @@ namespace System.Net
         }
 
         // This is only called when we selected local client certificate.
-        // Currently this is only when OpenSSL needs it becaseu peer asked.
+        // Currently this is only when OpenSSL needs it because peer asked.
         internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
 
         //

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -89,6 +89,21 @@ namespace System.Net
             return result;
         }
 
+        // Check that local certificate was used by schannel.
+        internal static bool IsLocalCertificateUsed(SafeDeleteContext securityContext)
+        {
+            SafeFreeCertContext? localContext;
+            SSPIWrapper.QueryContextAttributes_SECPKG_ATTR_LOCAL_CERT_CONTEXT(GlobalSSPI.SSPISecureChannel, securityContext, out localContext);
+            if (localContext != null)
+            {
+                bool result = !localContext.IsInvalid;
+                localContext?.Dispose();
+                return result;
+            }
+
+            return false;
+        }
+
         //
         // Used only by client SSL code, never returns null.
         //

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -92,16 +92,23 @@ namespace System.Net
         // Check that local certificate was used by schannel.
         internal static bool IsLocalCertificateUsed(SafeDeleteContext securityContext)
         {
-            SafeFreeCertContext? localContext;
-            SSPIWrapper.QueryContextAttributes_SECPKG_ATTR_LOCAL_CERT_CONTEXT(GlobalSSPI.SSPISecureChannel, securityContext, out localContext);
-            if (localContext != null)
+            SafeFreeCertContext? localContext = null;
+            try
             {
-                bool result = !localContext.IsInvalid;
+                if (SSPIWrapper.QueryContextAttributes_SECPKG_ATTR_LOCAL_CERT_CONTEXT(GlobalSSPI.SSPISecureChannel, securityContext, out localContext) &&
+                    localContext != null)
+                {
+                    return !localContext.IsInvalid;
+                }
+            }
+            finally
+            {
                 localContext?.Dispose();
-                return result;
             }
 
-            return false;
+            // Some older Windows do not support that. This is only called when client certificate was provided
+            // so assume it was for a reason.
+            return true;
         }
 
         //

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -518,7 +518,6 @@ namespace System.Net.Security
             bool cachedCred = false;                   // this is a return result from this method.
 
             X509Certificate2? selectedCert = SelectClientCertificate(out sessionRestartAttempt);
-
             try
             {
                 // Try to locate cached creds first.
@@ -977,6 +976,12 @@ namespace System.Net.Security
                 }
 
                 _remoteCertificate = certificate;
+                if (_selectedClientCertificate != null && !CertificateValidationPal.IsLocalCertificateUsed(_securityContext!))
+                {
+                    // We may slect client cert but it may not be used.
+                    // This is primarily issue on Windows with credential caching
+                    _selectedClientCertificate = null;
+                }
 
                 if (_remoteCertificate == null)
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
@@ -4,9 +4,11 @@
 using System.IO;
 using System.Threading.Tasks;
 using System.Net.Test.Common;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
 using Xunit;
+using System.Runtime.InteropServices;
 
 namespace System.Net.Security.Tests
 {
@@ -16,11 +18,13 @@ namespace System.Net.Security.Tests
     {
         private readonly X509Certificate2 _clientCertificate;
         private readonly X509Certificate2 _serverCertificate;
+        private readonly X509Certificate2 _selfSignedCertificate;
 
         public SslStreamMutualAuthenticationTest()
         {
             _serverCertificate = Configuration.Certificates.GetServerCertificate();
             _clientCertificate = Configuration.Certificates.GetClientCertificate();
+            _selfSignedCertificate = Configuration.Certificates.GetSelfSignedServerCertificate();
         }
 
         public void Dispose()
@@ -77,6 +81,45 @@ namespace System.Net.Security.Tests
                         Assert.False(server.IsMutuallyAuthenticated, "server.IsMutuallyAuthenticated");
                     }
                 }
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
+        public async Task SslStream_CachedCredentials_IsMutuallyAuthenticatedCorrect(
+           SslProtocols protocol)
+        {
+            var clientOptions = new SslClientAuthenticationOptions
+            {
+                ClientCertificates = new X509CertificateCollection() { _clientCertificate },
+                RemoteCertificateValidationCallback = delegate { return true; },
+                TargetHost = Guid.NewGuid().ToString("N")
+            };
+
+            for (int i = 0; i < 5; i++)
+            {
+                (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+                using (client)
+                using (server)
+                {
+                    bool expectMutualAuthentication = (i % 2) == 0;
+
+                    var serverOptions = new SslServerAuthenticationOptions
+                    {
+                        ClientCertificateRequired = expectMutualAuthentication,
+                        ServerCertificate = expectMutualAuthentication ? _serverCertificate : _selfSignedCertificate,
+                        RemoteCertificateValidationCallback = delegate { return true; },
+                        EnabledSslProtocols = protocol
+                    };
+
+                    await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                        client.AuthenticateAsClientAsync(clientOptions),
+                        server.AuthenticateAsServerAsync(serverOptions));
+
+                    // mutual authentication should only be set if server required client cert
+                    Assert.Equal(expectMutualAuthentication, server.IsMutuallyAuthenticated);
+                    Assert.Equal(expectMutualAuthentication, client.IsMutuallyAuthenticated);
+                };
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
@@ -84,8 +84,9 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         [ClassData(typeof(SslProtocolSupport.SupportedSslProtocolsTestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/65563", TestPlatforms.Android)]
         public async Task SslStream_CachedCredentials_IsMutuallyAuthenticatedCorrect(
            SslProtocols protocol)
         {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
@@ -92,6 +92,7 @@ namespace System.Net.Security.Tests
             var clientOptions = new SslClientAuthenticationOptions
             {
                 ClientCertificates = new X509CertificateCollection() { _clientCertificate },
+                EnabledSslProtocols = protocol,
                 RemoteCertificateValidationCallback = delegate { return true; },
                 TargetHost = Guid.NewGuid().ToString("N")
             };


### PR DESCRIPTION
fixes #65563

We can query Schannel after handshake is done to see if certificate was used. This is no-op for test of the platforms at the moment.
The test is essentially repro @rzikm put together during investigation. 

not 100% about android. cc: @simonrozsival  