### PR TITLE
add SEC_E_CONTEXT_EXPIRED to avoid throwing InternalException

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
@@ -33,6 +33,7 @@ internal static partial class Interop
         MessageAltered = unchecked((int)0x8009030F),
         OutOfSequence = unchecked((int)0x80090310),
         NoAuthenticatingAuthority = unchecked((int)0x80090311),
+        ContextExpiredError = unchecked((int)0x80090317),
         IncompleteMessage = unchecked((int)0x80090318),
         IncompleteCredentials = unchecked((int)0x80090320),
         BufferNotEnough = unchecked((int)0x80090321),

--- a/src/libraries/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
@@ -9,7 +9,7 @@ namespace System.Net
 {
     internal static class SecurityStatusAdapterPal
     {
-        private const int StatusDictionarySize = 44;
+        private const int StatusDictionarySize = 45;
 
 #if DEBUG
         static SecurityStatusAdapterPal()
@@ -31,6 +31,7 @@ namespace System.Net
             { Interop.SECURITY_STATUS.CompAndContinue, SecurityStatusPalErrorCode.CompAndContinue },
             { Interop.SECURITY_STATUS.CompleteNeeded, SecurityStatusPalErrorCode.CompleteNeeded },
             { Interop.SECURITY_STATUS.ContextExpired, SecurityStatusPalErrorCode.ContextExpired },
+            { Interop.SECURITY_STATUS.ContextExpiredError, SecurityStatusPalErrorCode.ContextExpiredError },
             { Interop.SECURITY_STATUS.ContinueNeeded, SecurityStatusPalErrorCode.ContinueNeeded },
             { Interop.SECURITY_STATUS.CredentialsNeeded, SecurityStatusPalErrorCode.CredentialsNeeded },
             { Interop.SECURITY_STATUS.DecryptFailure, SecurityStatusPalErrorCode.DecryptFailure },

--- a/src/libraries/Common/src/System/Net/SecurityStatusPal.cs
+++ b/src/libraries/Common/src/System/Net/SecurityStatusPal.cs
@@ -71,6 +71,7 @@ namespace System.Net
         DowngradeDetected,
         ApplicationProtocolMismatch,
         NoRenegotiation,
-        KeySetDoesNotExist
+        KeySetDoesNotExist,
+        ContextExpiredError
     }
 }


### PR DESCRIPTION
contributes to #66188
In the linked issue we would throw internal exception because we don't have mapping for the error.

This is not fix for the underlying issue - since there is no clear repro at the moment. 
At least, it would bubble up as Win32Exception as other Schannel errors. 