### PR TITLE
Fix NonCryptoHashTestDriver.AssertEqualHashNumber for big endian

### DIFF
--- a/src/libraries/System.IO.Hashing/tests/NonCryptoHashTestDriver.cs
+++ b/src/libraries/System.IO.Hashing/tests/NonCryptoHashTestDriver.cs
@@ -297,7 +297,7 @@ namespace System.IO.Hashing.Tests
 
         protected static void AssertEqualHashNumber(string hex, uint hash, bool littleEndian = false)
         {
-            if (littleEndian == BitConverter.IsLittleEndian)
+            if (littleEndian)
             {
                 hash = BinaryPrimitives.ReverseEndianness(hash);
             }
@@ -306,7 +306,7 @@ namespace System.IO.Hashing.Tests
 
         protected static void AssertEqualHashNumber(string hex, ulong hash, bool littleEndian = false)
         {
-            if (littleEndian == BitConverter.IsLittleEndian)
+            if (littleEndian)
             {
                 hash = BinaryPrimitives.ReverseEndianness(hash);
             }


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/pull/78075#issuecomment-1325487302
cc: @uweigand, @akoeplinger 