### PR TITLE
[wasm] Supply `-s INITIAL_MEMORY` to emcc in wasm.proj

### DIFF
--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -158,8 +158,10 @@
     <PropertyGroup>
       <_EmccExportedRuntimeMethods>&quot;[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]&quot;</_EmccExportedRuntimeMethods>
       <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
+      <EmccInitialHeapSize>536870912</EmccInitialHeapSize>
     </PropertyGroup>
     <ItemGroup>
+      <_EmccLinkFlags Include="-s INITIAL_MEMORY=$(EmccInitialHeapSize)" />
       <_EmccCommonFlags Condition="'$(WasmEnableSIMD)' == 'true'" Include="-msimd128" />
       <_EmccCommonFlags Condition="'$(MonoWasmThreads)' == 'true'" Include="-s USE_PTHREADS=1" />
       <_EmccLinkFlags Condition="'$(MonoWasmThreads)' == 'true'" Include="-Wno-pthreads-mem-growth" />


### PR DESCRIPTION
Currently, the `-s INITIAL_MEMORY` is supplied only in the `WasmApp.Native.targets`. 
This means that just by running native relink on project changes initial memory from emscripten's default ~16MB to ~512MB.

Open question is whether 512MB is a good default value.