### PR TITLE
Disable struct promotion for structs with SIMD12 fields

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1823,6 +1823,14 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
 
         noway_assert(fieldInfo.fldOffset < structSize);
 
+#ifdef FEATURE_SIMD
+        if ((fieldInfo.fldType == TYP_SIMD12) && ((structSize - fieldInfo.fldOffset) < genTypeSize(TYP_SIMD16)))
+        {
+            // Conservatively disable promotion if we can't load a SIMD12 field via 16-bytes load
+            return false;
+        }
+#endif
+
         if (fieldInfo.fldSize == 0)
         {
             // Not a scalar type.

--- a/src/tests/JIT/Regression/JitBlue/Runtime_79118/Runtime_79118.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_79118/Runtime_79118.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+readonly struct Ray
+{
+    public readonly Vector3 Origin;
+    public readonly Vector3 Direction;
+
+    public Ray(Vector3 origin, Vector3 direction)
+    {
+        Origin = origin;
+        Direction = direction;
+    }
+}
+
+class Runtime_79118
+{
+    static IEnumerable<object> hittables;
+
+    static Runtime_79118()
+    {
+        var list = new List<object>();
+        list.Add(new object());
+        hittables = list;
+    }
+
+    static int Main()
+    {
+        Ray r = GetRay();
+        traceRay(r);
+        return 100;
+    }
+
+    static Ray GetRay()
+    {
+        return new Ray(Vector3.Zero, -Vector3.UnitY);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | 
+                MethodImplOptions.AggressiveOptimization)]
+    static Vector3 traceRay(Ray r)
+    {
+        foreach (object h in hittables)
+        {
+            TestHit(r);
+            return Vector3.One;
+        }
+        return Vector3.Zero;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestHit(Ray ray)
+    {
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_79118/Runtime_79118.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_79118/Runtime_79118.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/79118 bug (see https://github.com/dotnet/runtime/issues/79118#issuecomment-1335155214)
