### PR TITLE
[.NET 7] Fix spurious OOMs after upgrading to 7

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -21711,7 +21711,10 @@ void gc_heap::gc1()
 #endif //BACKGROUND_GC
 #endif //MULTIPLE_HEAPS
 #ifdef USE_REGIONS
-    last_gc_before_oom = FALSE;
+    if (!(settings.concurrent))
+    {
+        last_gc_before_oom = FALSE;
+    }
 #endif //USE_REGIONS
 }
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -21711,7 +21711,7 @@ void gc_heap::gc1()
 #endif //BACKGROUND_GC
 #endif //MULTIPLE_HEAPS
 #ifdef USE_REGIONS
-    if (!(settings.concurrent))
+    if (!(settings.concurrent) && (settings.condemned_generation == max_generation))
     {
         last_gc_before_oom = FALSE;
     }


### PR DESCRIPTION

# Description
This is fixing the issue (https://github.com/dotnet/runtime/issues/78959) where customers are noticing spurious OOMs within their applications after upgrading to 7. 

This is porting two PRs into 7:
https://github.com/dotnet/runtime/pull/77478
https://github.com/dotnet/runtime/pull/78973

Problem was that a BGC was in progress when the full GC was requested by setting the last_gc_before_oom flag, and at the end of the BGC we turned off the last_gc_before_oom flag.

Fix is simply not to turn off the flag in the case of BGC. This is a slightly incomplete fix hence the next PR (#78973) was required

# Customer Impact

Reported by multiple customers where they are noticing OOMs after upgrading to .NET 7. Two customers have tried the private fix and confirmed it fixes the issue. 

# Regression

This is a regression from the 6.0.x version since the bug exists in Regions code. 

# Testing

Validated by at least two customers who had reported the issue. 
