### PR TITLE
[JIT] Allow new temp assignment whose dstTyp is TYP_I_IMPL and valTyp is TYP_BYREF

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15683,6 +15683,10 @@ GenTree* Compiler::gtNewTempAssign(
         {
             ok = true;
         }
+        else if ((dstTyp == TYP_I_IMPL) && varTypeIsGC(valTyp))
+        {
+            ok = true;
+        }
         // - TYP_BYREF = TYP_REF when object stack allocation is enabled
         else if (JitConfig.JitObjectStackAllocation() && (dstTyp == TYP_BYREF) && (valTyp == TYP_REF))
         {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15683,7 +15683,8 @@ GenTree* Compiler::gtNewTempAssign(
         {
             ok = true;
         }
-        else if ((dstTyp == TYP_I_IMPL) && varTypeIsGC(valTyp))
+        // - TYP_I_IMPL = TYP_BYREF
+        else if ((dstTyp == TYP_I_IMPL) && (valTyp == TYP_BYREF))
         {
             ok = true;
         }


### PR DESCRIPTION
**Description**

Should resolve: https://github.com/dotnet/runtime/issues/78944

I have two other PRs that tried to resolve this issue as well:

- https://github.com/dotnet/runtime/pull/78999

- https://github.com/dotnet/runtime/pull/79113

When creating a temp assignment, we would assert if the new temp assignment looked like this `ASG(VAR{i_impl}, NODE{byref})`. This PR now allows these types when creating a new temp assignment, assuming that `ASG(VAR{i_impl}, NODE{byref})` is considered legal IR.

I believe that IR is legal, because consider this example:
```csharp
struct ctest { }
unsafe static IntPtr byrefsubi4(ref ctest V_1, int V_2)
{
    return (nint)Unsafe.AsPointer(ref Unsafe.SubtractByteOffset(ref V_1, V_2));
}
```

After global morph, the IR looks like this:
```
               [000005] -A---+-----                         *  RETURN    long  
               [000010] -A---+-----                         \--*  COMMA     long  
               [000007] -A---+-----                            +--*  ASG       long  
               [000006] D----+-N---                            |  +--*  LCL_VAR   long   V03 tmp1         
               [000003] -----+-----                            |  \--*  SUB       byref 
               [000000] -----+-----                            |     +--*  LCL_VAR   byref  V00 arg0         
               [000002] -----+-----                            |     \--*  CAST      long <- int
               [000001] -----+-----                            |        \--*  LCL_VAR   int    V01 arg1         
               [000008] -----+-----                            \--*  LCL_VAR   long   V03 tmp1
```
Notice the `ASG(VAR{long}, NODE{byref})` - so it seems like we allow this today.
In this case, the above IR's `tmp1` is created when creating a temp for cast-away gc info:
```cpp
    else if (varTypeIsGC(srcType) != varTypeIsGC(dstType))
    {
        // We are casting away GC information.  we would like to just
        // change the type to int, however this gives the emitter fits because
        // it believes the variable is a GC variable at the beginning of the
        // instruction group, but is not turned non-gc by the code generator
        // we fix this by copying the GC pointer to a non-gc pointer temp.
        noway_assert(!varTypeIsGC(dstType) && "How can we have a cast to a GCRef here?");

        // We generate an assignment to an int and then do the cast from an int. With this we avoid
        // the gc problem and we allow casts to bytes, longs,  etc...
        unsigned lclNum = lvaGrabTemp(true DEBUGARG("Cast away GC"));
        oper->gtType    = TYP_I_IMPL;
        GenTree* asg    = gtNewTempAssign(lclNum, oper);
        oper->gtType    = srcType;
```

The reason why this case does not assert is because we change oper type right before `gtNewTempAssign` which is `oper->gtType = TYP_I_IMPL`. And then right after it, we set it back so its `srcType`. So that explains why the assert didn't happen here.