### PR TITLE
Fix a NonBacktracking subsumption checking rule for XY|X??Y

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -665,9 +665,9 @@ namespace System.Text.RegularExpressions.Symbolic
                 // This structure arises from a folding rule in TryFold
                 if (left._kind == SymbolicRegexNodeKind.Concat && right._kind == SymbolicRegexNodeKind.Concat)
                 {
-                    Debug.Assert(right._left is not null && right._right is not null);
+                    Debug.Assert(left._left is not null && right._left is not null && right._right is not null);
                     SymbolicRegexNode<TSet> rl = right._left;
-                    if (rl._kind == SymbolicRegexNodeKind.Loop && rl._lower == 0 && rl._upper == 1 && rl.IsLazy)
+                    if (left._left.IsNullable && rl._kind == SymbolicRegexNodeKind.Loop && rl._lower == 0 && rl._upper == 1 && rl.IsLazy)
                     {
                         Debug.Assert(rl._left is not null);
                         if (TrySkipPrefix(left, rl._left, out SymbolicRegexNode<TSet>? tail))

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -945,6 +945,9 @@ namespace System.Text.RegularExpressions.Tests
                 //mixed lazy and eager counting
                 yield return ("z(a{0,5}|a{0,10}?)", "xyzaaaaaaaaaxyz", options, 0, 15, true, "zaaaaa");
             }
+
+            // Test for a bug in NonBacktracking's subsumption rule for XY subsuming X??Y, which didn't check that X is nullable
+            yield return (@"XY|X??Y", "Y", RegexOptions.None, 0, 1, true, "Y");
         }
 
         [OuterLoop("Takes several seconds to run")]


### PR DESCRIPTION
This PR fixes https://github.com/dotnet/runtime/issues/79110. The subsumption rule in question targets patterns of the form XY|X??Y, where X and Y are regexes. The subsumption only holds when X is nullable, i.e., matches on an empty string. The check is done for the right side, where X is directly known, before the rule attempts to find the prefix on the left side.