### PR TITLE
Documentation signature parser tests and fixes for NativeAOT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/DocumentationSignatureGenerator.PartVisitor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/DocumentationSignatureGenerator.PartVisitor.cs
@@ -162,7 +162,7 @@ namespace ILCompiler.Logging
             protected override void AppendNameForInstantiatedType(StringBuilder builder, DefType type)
             {
                 int containingArity = 0;
-                TypeDesc containingType = InstantiateContainingType(type);
+                DefType containingType = InstantiateContainingType(type);
                 if (containingType != null)
                 {
                     AppendName(builder, containingType);
@@ -221,16 +221,18 @@ namespace ILCompiler.Logging
             }
 #endif
 
-            private static TypeDesc InstantiateContainingType(DefType type)
+            private static DefType InstantiateContainingType(DefType type)
             {
                 DefType containingType = type.ContainingType;
                 if (containingType is null)
                     return null;
 
-                if (!containingType.HasInstantiation)
+                // If the type doesn't follow C# scheme where nested types inherit generic parameters from their container type
+                // return the container type as-is.
+                if (!containingType.HasInstantiation || containingType.Instantiation.Length > type.Instantiation.Length)
                     return containingType;
 
-                return containingType.InstantiateAsOpen().InstantiateSignature(type.Instantiation, default(Instantiation));
+                return (DefType)containingType.InstantiateAsOpen().InstantiateSignature(type.Instantiation, default);
             }
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/DocumentationSignatureParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/DocumentationSignatureParser.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 
 using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.Logging
 {
@@ -210,21 +211,17 @@ namespace ILCompiler.Logging
                 index = startIndex;
             }
 
-#if false
             if (memberTypes.HasFlag(MemberType.Property))
             {
                 GetMatchingProperties(id, ref index, containingType, memberName, results, acceptName);
                 endIndex = index;
                 index = startIndex;
             }
-#endif
 
             index = endIndex;
 
-#if false
             if (memberTypes.HasFlag(MemberType.Event))
                 GetMatchingEvents(containingType, memberName, results);
-#endif
 
             if (memberTypes.HasFlag(MemberType.Field))
                 GetMatchingFields(containingType, memberName, results);
@@ -536,7 +533,7 @@ namespace ILCompiler.Logging
                 string namepart;
                 if (indexOfLastDot > 0 && indexOfLastDot < name.Length - 1)
                 {
-                    namespacepart = name.Substring(indexOfLastDot - 1);
+                    namespacepart = name.Substring(0, indexOfLastDot);
                     namepart = name.Substring(indexOfLastDot + 1);
                 }
                 else
@@ -631,10 +628,9 @@ namespace ILCompiler.Logging
             index = endIndex;
         }
 
-#if false
-        static void GetMatchingProperties(string id, ref int index, TypeDesc type, string memberName, List<TypeSystemEntity> results, bool acceptName = false)
+        private static void GetMatchingProperties(string id, ref int index, TypeDesc typeDesc, string memberName, List<TypeSystemEntity> results, bool acceptName = false)
         {
-            if (type == null)
+            if (typeDesc is not EcmaType type)
                 return;
 
             int startIndex = index;
@@ -643,11 +639,14 @@ namespace ILCompiler.Logging
             List<string> parameters = null;
             // Unlike Roslyn, we don't need to decode property names because we are working
             // directly with IL.
-            foreach (var property in type.Properties)
+            foreach (var propertyHandle in type.MetadataReader.GetTypeDefinition(type.Handle).GetProperties())
             {
+                var p = new PropertyPseudoDesc(type, propertyHandle);
+
                 index = startIndex;
-                if (property.Name != memberName)
+                if (p.Name != memberName)
                     continue;
+
                 if (PeekNextChar(id, index) == '(')
                 {
                     if (parameters == null)
@@ -658,23 +657,22 @@ namespace ILCompiler.Logging
                     {
                         parameters.Clear();
                     }
-                    if (!ParseParameterList(id, ref index, property.DeclaringType, parameters))
+                    if (!ParseParameterList(id, ref index, p.OwningType, parameters))
                         continue;
-                    if (!AllParametersMatch(property.Parameters, parameters))
+                    if (!AllParametersMatch(p.Signature, parameters))
                         continue;
                 }
                 else
                 {
-                    if (!acceptName && property.Parameters.Count != 0)
+                    if (!acceptName && p.Signature.Length != 0)
                         continue;
                 }
-                results.Add(property);
+                results.Add(p);
                 endIndex = index;
             }
 
             index = endIndex;
         }
-#endif
 
         private static void GetMatchingFields(TypeDesc type, string memberName, List<TypeSystemEntity> results)
         {
@@ -688,19 +686,19 @@ namespace ILCompiler.Logging
             }
         }
 
-#if false
-        static void GetMatchingEvents(TypeDesc type, string memberName, List<TypeSystemEntity> results)
+        private static void GetMatchingEvents(TypeDesc typeDesc, string memberName, List<TypeSystemEntity> results)
         {
-            if (type == null)
+            if (typeDesc is not EcmaType type)
                 return;
-            foreach (var evt in type.Events)
+
+            foreach (var eventHandle in type.MetadataReader.GetTypeDefinition(type.Handle).GetEvents())
             {
-                if (evt.Name != memberName)
+                var e = new EventPseudoDesc(type, eventHandle);
+                if (e.Name != memberName)
                     continue;
-                results.Add(evt);
+                results.Add(e);
             }
         }
-#endif
 
         private static bool AllParametersMatch(MethodSignature methodParameters, List<string> expectedParameters)
         {
@@ -710,6 +708,20 @@ namespace ILCompiler.Logging
             for (int i = 0; i < expectedParameters.Count; i++)
             {
                 if (GetSignaturePart(methodParameters[i]) != expectedParameters[i])
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static bool AllParametersMatch(PropertySignature propertyParameters, List<string> expectedParameters)
+        {
+            if (propertyParameters.Length != expectedParameters.Count)
+                return false;
+
+            for (int i = 0; i < expectedParameters.Count; i++)
+            {
+                if (GetSignaturePart(propertyParameters[i]) != expectedParameters[i])
                     return false;
             }
 

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Mono.Linker.Tests.Extensions;
 using Mono.Linker.Tests.TestCasesRunner;
 
@@ -15,17 +16,22 @@ namespace Mono.Linker.Tests.TestCases
 
 		public static IEnumerable<object[]> DataFlow ()
 		{
-			return TestNamesBySuiteName ("DataFlow");
+			return TestNamesBySuiteName ();
+		}
+
+		public static IEnumerable<object[]> DynamicDependencies ()
+		{
+			return TestNamesBySuiteName ();
 		}
 
 		public static IEnumerable<object[]> Repro ()
 		{
-			return TestNamesBySuiteName ("Repro");
+			return TestNamesBySuiteName ();
 		}
 
 		public static IEnumerable<object[]> RequiresCapability ()
 		{
-			return TestNamesBySuiteName ("RequiresCapability");
+			return TestNamesBySuiteName ();
 		}
 
 		public static TestCaseCollector CreateCollector ()
@@ -57,7 +63,7 @@ namespace Mono.Linker.Tests.TestCases
 			return AllCases ().FirstOrDefault (c => c.Name == name);
 		}
 
-		private static IEnumerable<object[]> TestNamesBySuiteName (string suiteName)
+		private static IEnumerable<object[]> TestNamesBySuiteName ([CallerMemberName] string suiteName = "")
 		{
 			return AllCases ()
 				.Where (c => c.TestSuiteDirectory.FileName == suiteName)

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestDatabase.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestDatabase.cs
@@ -19,11 +19,6 @@ namespace Mono.Linker.Tests.TestCases
 			return TestNamesBySuiteName ();
 		}
 
-		public static IEnumerable<object[]> DynamicDependencies ()
-		{
-			return TestNamesBySuiteName ();
-		}
-
 		public static IEnumerable<object[]> Repro ()
 		{
 			return TestNamesBySuiteName ();

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -18,6 +18,13 @@ namespace Mono.Linker.Tests.TestCases
 		}
 
 		[Theory]
+		[MemberData (nameof (TestDatabase.DynamicDependencies), MemberType = typeof (TestDatabase))]
+		public void DynamicDependencies (string t)
+		{
+			Run (t);
+		}
+
+		[Theory]
 		[MemberData (nameof (TestDatabase.Repro), MemberType = typeof (TestDatabase))]
 		public void Repro (string t)
 		{

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestSuites.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCases/TestSuites.cs
@@ -18,13 +18,6 @@ namespace Mono.Linker.Tests.TestCases
 		}
 
 		[Theory]
-		[MemberData (nameof (TestDatabase.DynamicDependencies), MemberType = typeof (TestDatabase))]
-		public void DynamicDependencies (string t)
-		{
-			Run (t);
-		}
-
-		[Theory]
 		[MemberData (nameof (TestDatabase.Repro), MemberType = typeof (TestDatabase))]
 		public void Repro (string t)
 		{

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerDriver.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerDriver.cs
@@ -16,7 +16,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 {
 	public class ILCompilerDriver
 	{
-		private const string DefaultSystemModule = "System.Private.CoreLib";
+		internal const string DefaultSystemModule = "System.Private.CoreLib";
 
 		public ILScanResults Trim (ILCompilerOptions options, ILogWriter logWriter)
 		{

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/MemberAssertionsCollector.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/MemberAssertionsCollector.cs
@@ -1,0 +1,196 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.Loader;
+using ILCompiler;
+using Internal.IL;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.TestCasesRunner
+{
+	public class MemberAssertionsCollector : IEnumerable<object[]>
+	{
+		public struct CustomAttribute
+		{
+			public MetadataType AttributeType;
+			public CustomAttributeValue<TypeDesc> Value;
+
+			public override string ToString () => AttributeType.ToString ();
+		}
+
+		public MemberAssertionsCollector(Type type)
+		{
+			this.type = type;
+			TypeSystemContext = CreateTypeSystemContext();
+		}
+
+		private CompilerTypeSystemContext TypeSystemContext;
+		private readonly Type type;
+
+		private CompilerTypeSystemContext CreateTypeSystemContext ()
+		{
+			ILCompilerDriver.ComputeDefaultOptions (out var targetOS, out var targetArchitecture);
+			var targetDetails = new TargetDetails (targetArchitecture, targetOS, TargetAbi.NativeAot);
+			CompilerTypeSystemContext typeSystemContext =
+				new CompilerTypeSystemContext (targetDetails, SharedGenericsMode.CanonicalReferenceTypes, DelegateFeature.All);
+			typeSystemContext.InputFilePaths = new Dictionary<string, string> () {
+				{ type.Assembly.GetName().Name!, type.Assembly.Location }
+			};
+			Dictionary<string, string> references = new Dictionary<string, string> ();
+			foreach (Assembly assembly in AssemblyLoadContext.Default.Assemblies) {
+				references.Add (assembly.GetName ().Name!, assembly.Location!);
+			}
+			typeSystemContext.ReferenceFilePaths = references;
+			typeSystemContext.SetSystemModule (typeSystemContext.GetModuleForSimpleName (ILCompilerDriver.DefaultSystemModule));
+
+			return typeSystemContext;
+		}
+
+		internal IEnumerable<(TypeSystemEntity member, CustomAttribute ca)> GetMemberAssertions (Type type)
+		{
+			var module = TypeSystemContext.GetModuleFromPath (type.Assembly.Location);
+			var t = module.GetType (type.Namespace, type.Name, throwIfNotFound: false);
+			if (t == null)
+				throw new InvalidOperationException ($"type {type} not found in {module}");
+			var results = new List<(TypeSystemEntity, CustomAttribute)> ();
+			CollectMemberAssertions (t, results);
+			return results;
+		}
+
+		public IEnumerable<object[]> GetMemberAssertionsData ()
+		{
+			return GetMemberAssertions (type).Select (v => new object[] { v.member, v.ca });
+		}
+
+		public IEnumerator<object[]> GetEnumerator () => GetMemberAssertionsData ().GetEnumerator ();
+		IEnumerator IEnumerable.GetEnumerator () => throw new NotImplementedException ();
+
+		private static bool IsMemberAssertion (MetadataType attributeType)
+		{
+			if (attributeType == null)
+				return false;
+
+			if (attributeType.Namespace != "Mono.Linker.Tests.Cases.Expectations.Assertions")
+				return false;
+
+			MetadataType t = attributeType;
+			while (t != null) {
+				if (t.Name == nameof (BaseMemberAssertionAttribute))
+					return true;
+
+				t = t.MetadataBaseType;
+			}
+
+			return false;
+		}
+
+		private static void CollectMemberAssertions (MetadataType metadataType, List<(TypeSystemEntity, CustomAttribute)> results)
+		{
+			if (metadataType is not EcmaType type)
+				return;
+
+			foreach (var ca in GetCustomAttributes (type)) {
+				if (!IsMemberAssertion (ca.AttributeType))
+					continue;
+				results.Add ((type, ca));
+			}
+
+			foreach (var md in type.GetMethods ()) {
+				if (md is not EcmaMethod m)
+					continue;
+
+				foreach (var ca in GetCustomAttributes(m)) {
+					if (!IsMemberAssertion (ca.AttributeType))
+						continue;
+					results.Add ((m, ca));
+				}
+			}
+
+			foreach (var fd in type.GetFields()) {
+				if (fd is not EcmaField f)
+					continue;
+
+				foreach (var ca in GetCustomAttributes(f)) {
+					if (!IsMemberAssertion (ca.AttributeType))
+						continue;
+					results.Add ((f, ca));
+				}
+			}
+
+			foreach (var propertyHandle in type.MetadataReader.GetTypeDefinition (type.Handle).GetProperties ()) {
+				var p = new PropertyPseudoDesc (type, propertyHandle);
+				foreach (var ca in GetCustomAttributes(type, p)) {
+					if (!IsMemberAssertion (ca.AttributeType))
+						continue;
+					results.Add ((p, ca));
+				}
+			}
+
+			foreach (var eventHandle in type.MetadataReader.GetTypeDefinition (type.Handle).GetEvents ()) {
+				var e = new EventPseudoDesc (type, eventHandle);
+				foreach (var ca in GetCustomAttributes(type, e)) {
+					if (!IsMemberAssertion (ca.AttributeType))
+						continue;
+					results.Add ((e, ca));
+				}
+			}
+
+			foreach (var nested in type.GetNestedTypes()) {
+				CollectMemberAssertions (nested, results);
+			}
+		}
+
+		private static IEnumerable<CustomAttribute> GetCustomAttributes (EcmaType type)
+		{
+			var metadataReader = type.MetadataReader;
+			return GetCustomAttributes (metadataReader.GetTypeDefinition (type.Handle).GetCustomAttributes (), metadataReader, type.EcmaModule);
+		}
+
+		private static IEnumerable<CustomAttribute> GetCustomAttributes (EcmaMethod method)
+		{
+			var metadataReader = method.MetadataReader;
+			return GetCustomAttributes (metadataReader.GetMethodDefinition (method.Handle).GetCustomAttributes (), metadataReader, method.Module);
+		}
+
+		private static IEnumerable<CustomAttribute> GetCustomAttributes (EcmaField field)
+		{
+			var metadataReader = field.MetadataReader;
+			return GetCustomAttributes (metadataReader.GetFieldDefinition (field.Handle).GetCustomAttributes (), metadataReader, field.Module);
+		}
+
+		private static IEnumerable<CustomAttribute> GetCustomAttributes (EcmaType type, PropertyPseudoDesc prop)
+		{
+			return GetCustomAttributes (prop.GetCustomAttributes, type.MetadataReader, type.EcmaModule);
+		}
+
+		private static IEnumerable<CustomAttribute> GetCustomAttributes (EcmaType type, EventPseudoDesc @event)
+		{
+			return GetCustomAttributes (@event.GetCustomAttributes, type.MetadataReader, type.EcmaModule);
+		}
+
+		private static IEnumerable<CustomAttribute> GetCustomAttributes(CustomAttributeHandleCollection attributeHandles, MetadataReader metadataReader, EcmaModule module)
+		{
+			foreach (var attributeHandle in attributeHandles) {
+				if (!metadataReader.GetAttributeTypeAndConstructor (attributeHandle, out var attributeType, out _))
+					continue;
+
+				if (module.GetType (attributeType) is not MetadataType attributeMetadataType)
+					continue;
+
+				yield return
+					new CustomAttribute () {
+						AttributeType = attributeMetadataType,
+						Value = metadataReader.GetCustomAttribute (attributeHandle).DecodeValue (new CustomAttributeTypeProvider (module))
+					};
+			}
+		}
+	}
+}

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
@@ -22,9 +22,6 @@ namespace Mono.Linker.Tests
 		[ClassData (typeof (MemberAssertions))]
 		public void TestSignatureParsing (TypeSystemEntity member, MemberAssertionsCollector.CustomAttribute customAttribute)
 		{
-			if (member.ToString ()!.Contains ("NG`1<A"))
-				Debug.WriteLine ("");
-
 			var attributeString = (string) customAttribute.Value.FixedArguments[0].Value!;
 			switch (customAttribute.AttributeType.Name) {
 			case nameof (ExpectExactlyResolvedDocumentationSignatureAttribute):

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/Tests/DocumentationSignatureParserTests.cs
@@ -1,0 +1,563 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using ILCompiler;
+using ILCompiler.Logging;
+using Internal.TypeSystem;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.TestCasesRunner;
+using Xunit;
+
+#pragma warning disable xUnit1013 // Public method should be marked as test
+
+namespace Mono.Linker.Tests
+{
+	public class DocumentationSignatureParserTests
+	{
+		[Theory]
+		[ClassData (typeof (MemberAssertions))]
+		public void TestSignatureParsing (TypeSystemEntity member, MemberAssertionsCollector.CustomAttribute customAttribute)
+		{
+			if (member.ToString ()!.Contains ("NG`1<A"))
+				Debug.WriteLine ("");
+
+			var attributeString = (string) customAttribute.Value.FixedArguments[0].Value!;
+			switch (customAttribute.AttributeType.Name) {
+			case nameof (ExpectExactlyResolvedDocumentationSignatureAttribute):
+				CheckUniqueParsedString (member, attributeString);
+				break;
+			case nameof (ExpectGeneratedDocumentationSignatureAttribute):
+				// CheckGeneratedString (member, attributeString);
+				break;
+			case nameof (ExpectResolvedDocumentationSignatureAttribute):
+				CheckParsedString (member, attributeString);
+				break;
+			case nameof (ExpectUnresolvedDocumentationSignatureAttribute):
+				CheckUnresolvedDocumentationSignature (member, attributeString);
+				break;
+			default:
+				throw new NotImplementedException ();
+			}
+		}
+
+		public class MemberAssertions : MemberAssertionsCollector
+		{
+			public MemberAssertions () : base (typeof (DocumentationSignatureParserTests))
+			{ }
+		}
+
+		private static void CheckUniqueParsedString (TypeSystemEntity member, string input)
+		{
+			var module = GetModule (member);
+			Assert.NotNull (module);
+			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module);
+			Assert.Single (parseResults);
+			TypeSystemEntity result = parseResults.First ();
+			switch (member) {
+			case PropertyPseudoDesc p:
+				var actualProperty = Assert.IsType<PropertyPseudoDesc> (result);
+				Assert.Equal (p.OwningType, actualProperty.OwningType);
+				Assert.Equal (p.Name, actualProperty.Name);
+				break;
+			case EventPseudoDesc e:
+				var actualEvent = Assert.IsType<EventPseudoDesc> (result);
+				Assert.Equal (e.OwningType, actualEvent.OwningType);
+				Assert.Equal (e.Name, actualEvent.Name);
+				break;
+			default:
+				Assert.Equal (member, parseResults.First ());
+				break;
+			}
+		}
+
+		// Currently NativeAOT has only a partial implementation of the generator since it doesn't need it for anything
+		// other than signature parsing (which uses the generator for certain parts).
+#if false
+		private static void CheckGeneratedString (TypeSystemEntity member, string expected)
+		{
+			var builder = new StringBuilder ();
+			DocumentationSignatureGenerator.PartVisitor.Instance.AppendName (builder, type);
+			Assert.Equal (expected, builder.ToString ());
+		}
+#endif
+
+		private static void CheckParsedString (TypeSystemEntity member, string input)
+		{
+			var module = GetModule (member);
+			Assert.NotNull (module);
+			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module);
+			Assert.Contains (member, parseResults);
+		}
+
+		private static void CheckUnresolvedDocumentationSignature (TypeSystemEntity member, string input)
+		{
+			var module = GetModule (member);
+			Assert.NotNull (module);
+			var parseResults = DocumentationSignatureParser.GetMembersForDocumentationSignature (input, module);
+			Assert.DoesNotContain (member, parseResults);
+		}
+
+		private static ModuleDesc? GetModule (TypeSystemEntity entity)
+		{
+			return entity switch {
+				MethodDesc method => (method.OwningType as MetadataType)?.Module,
+				FieldDesc field => (field.OwningType as MetadataType)?.Module,
+				MetadataType type => type.Module,
+				PropertyPseudoDesc property => property.OwningType.Module,
+				EventPseudoDesc @event => @event.OwningType.Module,
+				_ => throw new InvalidOperationException (),
+			};
+		}
+
+		// testcases
+
+		[ExpectGeneratedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.A")]
+		[ExpectExactlyResolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.A")]
+		public class A
+		{
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.#ctor")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.#ctor")]
+			public A ()
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.#ctor(System.Int32)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.#ctor(System.Int32)")]
+			public A (int a)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.#cctor")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.#cctor")]
+			static A ()
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32[])")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32[])")]
+			public static void M (int[] a)
+			{
+			}
+
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32,System.Int32,System.Int32)~System.Int32")]
+			public static int M (int a, int b, int c)
+			{
+				return 0;
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MRef(System.Int32@)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MRef(System.Int32@)")]
+			public static void MRef (ref int a)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MOut(System.Int32@)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MOut(System.Int32@)")]
+			public static void MOut (out int a)
+			{
+				a = 5;
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MIn(System.Int32@)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MIn(System.Int32@)")]
+			public static void MIn (in int a)
+			{
+			}
+
+			private static int i;
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MRefReturn")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MRefReturn")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MRefReturn~System.Int32@")]
+			public static ref int MRefReturn ()
+			{
+				return ref i;
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M")]
+			[ExpectResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M")] // binds to both.
+			[ExpectResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M()")] // binds to both.
+			public static void M ()
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M()")]
+			[ExpectResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M")]
+			[ExpectResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M()")]
+			public static void M (__arglist)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32[][])")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32[][])")]
+			public static void M (int[][] a)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32[][0:,0:,0:])")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32[][0:,0:,0:])")]
+			public static void M (int[,,][] a)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32[0:,0:])")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32[0:,0:])")]
+			public static void M (int[,] a)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Object)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Object)")]
+			public static void M (dynamic d)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32*)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32*)")]
+			public static unsafe void M (int* a)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M``1(Mono.Linker.Tests.DocumentationSignatureParserTests.S{Mono.Linker.Tests.DocumentationSignatureParserTests.G{Mono.Linker.Tests.DocumentationSignatureParserTests.A,``0}}**[0:,0:,0:][][][0:,0:]@)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M``1(Mono.Linker.Tests.DocumentationSignatureParserTests.S{Mono.Linker.Tests.DocumentationSignatureParserTests.G{Mono.Linker.Tests.DocumentationSignatureParserTests.A,``0}}**[0:,0:,0:][][][0:,0:]@)")]
+			public static unsafe void M<T> (ref S<G<A, T>>**[,][][][,,] a)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Collections.Generic.List{System.Int32[]})")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Collections.Generic.List{System.Int32[]})")]
+			public static void M (List<int[]> a)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32,)")]
+			//[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.M(System.Int32,)")]
+			// there's no way to reference this, since the parsing logic doesn't like it.
+			public static void M (int abo, __arglist)
+			{
+			}
+
+			[ExpectGeneratedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.A.Prop")]
+			[ExpectExactlyResolvedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.A.Prop")]
+			public int Prop { get; set; }
+
+			[ExpectGeneratedDocumentationSignature ("F:Mono.Linker.Tests.DocumentationSignatureParserTests.A.field")]
+			[ExpectExactlyResolvedDocumentationSignature ("F:Mono.Linker.Tests.DocumentationSignatureParserTests.A.field")]
+			public int field;
+
+
+			[ExpectGeneratedDocumentationSignature ("E:Mono.Linker.Tests.DocumentationSignatureParserTests.A.OnEvent")]
+			[ExpectExactlyResolvedDocumentationSignature ("E:Mono.Linker.Tests.DocumentationSignatureParserTests.A.OnEvent")]
+			public event EventHandler? OnEvent;
+
+			[ExpectGeneratedDocumentationSignature ("E:Mono.Linker.Tests.DocumentationSignatureParserTests.A.OnEventInt")]
+			[ExpectExactlyResolvedDocumentationSignature ("E:Mono.Linker.Tests.DocumentationSignatureParserTests.A.OnEventInt")]
+			public event Action<int>? OnEventInt;
+
+			[ExpectGeneratedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.A.Del")]
+			[ExpectExactlyResolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.A.Del")]
+			public delegate int Del (int a, int b);
+
+			[ExpectGeneratedDocumentationSignature ("E:Mono.Linker.Tests.DocumentationSignatureParserTests.A.OnEventDel")]
+			[ExpectExactlyResolvedDocumentationSignature ("E:Mono.Linker.Tests.DocumentationSignatureParserTests.A.OnEventDel")]
+			public event Del? OnEventDel;
+
+			// prevent warning about unused events
+			public void UseEvents ()
+			{
+				OnEventDel?.Invoke (1, 2);
+				OnEventInt?.Invoke (1);
+				OnEvent?.Invoke (null, new EventArgs ());
+			}
+
+			[ExpectGeneratedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.A.Item(System.Int32)")]
+			[ExpectExactlyResolvedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.A.Item(System.Int32)")]
+			public int this[int i] {
+				get => 0;
+				set { }
+			}
+
+			[ExpectGeneratedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.A.Item(System.String,System.Int32)")]
+			[ExpectExactlyResolvedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.A.Item(System.String,System.Int32)")]
+			public int this[string s, int i] {
+				get => 0;
+				set { }
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_Implicit(Mono.Linker.Tests.DocumentationSignatureParserTests.A)~System.Boolean")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_Implicit(Mono.Linker.Tests.DocumentationSignatureParserTests.A)~System.Boolean")]
+			public static implicit operator bool (A a) => false;
+
+			// C# will not generate a return type for this method, but we will.
+			// [ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_Implicit(Mono.Linker.Tests.DocumentationSignatureParserTests.A)~System.Boolean")]
+			// [ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_Implicit(Mono.Linker.Tests.DocumentationSignatureParserTests.A)~System.Boolean")]
+			//public static int op_Implicit (A a) => 0;
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_UnaryPlus(Mono.Linker.Tests.DocumentationSignatureParserTests.A)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_UnaryPlus(Mono.Linker.Tests.DocumentationSignatureParserTests.A)")]
+			public static A? operator + (A a) => null;
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_Addition(Mono.Linker.Tests.DocumentationSignatureParserTests.A,Mono.Linker.Tests.DocumentationSignatureParserTests.A)")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.op_Addition(Mono.Linker.Tests.DocumentationSignatureParserTests.A,Mono.Linker.Tests.DocumentationSignatureParserTests.A)")]
+			public static A? operator + (A left, A right) => null;
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MWithReturnType")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.A.MWithReturnType~System.Boolean")]
+			public static bool MWithReturnType () => false;
+		}
+
+		public struct S<T>
+		{
+		}
+
+		[ExpectGeneratedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.A`1")]
+		[ExpectExactlyResolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.A`1")]
+		public class A<T>
+		{
+			[ExpectGeneratedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.A`1.Item(`0)")]
+			[ExpectExactlyResolvedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.A`1.Item(`0)")]
+			public int this[T t] {
+				get => 0;
+				set { }
+			}
+		}
+
+		[ExpectExactlyResolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.B")]
+		[ExpectGeneratedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.B")]
+		public class B
+		{
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.B.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{Mono.Linker.Tests.DocumentationSignatureParserTests.A{Mono.Linker.Tests.DocumentationSignatureParserTests.B},System.Collections.Generic.List{Mono.Linker.Tests.DocumentationSignatureParserTests.A}})")]
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.B.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{Mono.Linker.Tests.DocumentationSignatureParserTests.A{Mono.Linker.Tests.DocumentationSignatureParserTests.B},System.Collections.Generic.List{Mono.Linker.Tests.DocumentationSignatureParserTests.A}})")]
+			public static void Method (G<A<B>, List<A>> l)
+			{
+			}
+		}
+
+		[ExpectGeneratedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2")]
+		[ExpectExactlyResolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2")]
+		public class G<T, U>
+		{
+			[ExpectGeneratedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.NG`1")]
+			[ExpectExactlyResolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.NG`1")]
+			public class NG<V>
+			{
+				[ExpectGeneratedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.NG`1.NG2`1")]
+				[ExpectExactlyResolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.NG`1.NG2`1")]
+				public class NG2<W>
+				{
+					[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.NG`1.NG2`1.Method``1(`0,`1,`2,`3,``0)")]
+					[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.NG`1.NG2`1.Method``1(`0,`1,`2,`3,``0)")]
+					public void Method<X> (T t, U u, V v, W w, X x)
+					{
+					}
+
+					[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.NG`1.NG2`1.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{`0,`1}.NG{`2}.NG2{`3})")]
+					[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.NG`1.NG2`1.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{`0,`1}.NG{`2}.NG2{`3})")]
+					public void Method (NG2<W> n)
+					{
+					}
+				}
+			}
+
+			[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{`0,`1})")]
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.G`2.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{`0,`1})")]
+			public void Method (G<T, U> g)
+			{
+			}
+		}
+
+		[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Method")]
+		[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Method")]
+		public static void Method ()
+		{
+		}
+
+		[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Method(System.Int32)")]
+		[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Method(System.Int32)")]
+		public static void Method (int i)
+		{
+		}
+
+		[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.IntMethod")]
+		[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.IntMethod")]
+		public static int IntMethod () => 0;
+
+		[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{Mono.Linker.Tests.DocumentationSignatureParserTests.A,Mono.Linker.Tests.DocumentationSignatureParserTests.A})")]
+		[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{Mono.Linker.Tests.DocumentationSignatureParserTests.A,Mono.Linker.Tests.DocumentationSignatureParserTests.A})")]
+		public static void Method (G<A, A> g)
+		{
+		}
+
+		[ExpectGeneratedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{Mono.Linker.Tests.DocumentationSignatureParserTests.A,Mono.Linker.Tests.DocumentationSignatureParserTests.A}.NG{Mono.Linker.Tests.DocumentationSignatureParserTests.A})")]
+		[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.G{Mono.Linker.Tests.DocumentationSignatureParserTests.A,Mono.Linker.Tests.DocumentationSignatureParserTests.A}.NG{Mono.Linker.Tests.DocumentationSignatureParserTests.A})")]
+		public static void Method (G<A, A>.NG<A> g)
+		{
+		}
+
+		public class Invalid
+		{
+			[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NoReturnType~")]
+			public static int NoReturnType () => 0;
+
+			[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NoParameters(,)")]
+			public static void NoParameters (int a, int b)
+			{
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NoClosingParen(")]
+			public static void NoClosingParen () { }
+
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Whitespace ")]
+			[ExpectUnresolvedDocumentationSignature (" T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Whitespace")]
+			[ExpectUnresolvedDocumentationSignature ("T: Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Whitespace")]
+			[ExpectUnresolvedDocumentationSignature ("T :Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Whitespace")]
+			[ExpectUnresolvedDocumentationSignature ("")]
+			[ExpectUnresolvedDocumentationSignature (" ")]
+			public class Whitespace
+			{
+				[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Whitespace.Method(System.Int32, System.Int32)")]
+				public static void Method (int a, int b)
+				{
+				}
+
+				[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Whitespace.Method(Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic{System.Int32, System.Int32})")]
+				public static void Method (Generic<int, int> g)
+				{
+				}
+			}
+
+			public class Generic<T, U>
+			{
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic{`1}")]
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic{T}")]
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic<T>")]
+			public class Generic<T>
+			{
+				[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic``1.MethodSyntaxForTypeParameter(`0)")]
+
+				public void MethodSyntaxForTypeParameter (T t)
+				{
+				}
+
+				[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic`1.MethodSyntaxForTypeGenericArgument(Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic{``0})")]
+				public void MethodSyntaxForTypeGenericArgument (Generic<T> g)
+				{
+				}
+
+				[ExpectUnresolvedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic`1.Item(``0)")]
+				public bool this[T t] {
+					get => false;
+					set { }
+				}
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.MethodWithGenericInstantiation(Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic`1)")]
+			public static void MethodWithGenericInstantiation (Generic<A> g)
+			{
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Method(System.Int32[:,:])")]
+			[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Method(System.Int32[0:,)")]
+			public static void Method (int[,] a)
+			{
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NonGenericMethod(``0)")]
+			public static void NonGenericMethod (int i)
+			{
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Item(`0)")]
+			[ExpectUnresolvedDocumentationSignature ("P:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Item(``0)")]
+			public int this[int i] {
+				get => 0;
+				set { }
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.MethodMissingArgumentTypeName(System.)")]
+			public static void MethodMissingArgumentTypeName (int i)
+			{
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.")]
+			public class NoType
+			{
+				[ExpectUnresolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid..Method")]
+				public static void Method ()
+				{
+				}
+			}
+
+			// prevent warning about unused events
+			public void UseEvents ()
+			{
+				OnEvent?.Invoke (null, new EventArgs ());
+				OnEventArgs?.Invoke (null, new EventArgs ());
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NoParameterType()")]
+			public static void NoParameterType (int i)
+			{
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NoParameterType(Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic{})")]
+			public static void NoGenericParameterType (Generic<A> g)
+			{
+			}
+
+			[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.TypeWithMethodGenericParameters``1")]
+			public class TypeWithMethodGenericParameters
+			{
+			}
+
+			public class GenericType<T, U>
+			{
+				[ExpectUnresolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.GenericType`2.TypeWithMethodGenericParameters``1")]
+				public class TypeWithMethodGenericParameters
+				{
+				}
+			}
+
+			// our parser won't match fields with `, unlike roslyn.
+			[ExpectUnresolvedDocumentationSignature ("F:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.field`gibberish")]
+			public int field;
+
+			[ExpectUnresolvedDocumentationSignature ("E:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.OnEvent`gibberish")]
+			public event EventHandler? OnEvent;
+
+			// the below work, but seem like they shouldn't. See https://github.com/dotnet/linker/issues/1214.
+
+			[ExpectExactlyResolvedDocumentationSignature ("TMono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NoColon")]
+			public class NoColon
+			{
+			}
+
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NoClosingParenWithParameters(System.Int32")]
+			public static void NoClosingParenWithParameters (int a)
+			{
+			}
+
+			[ExpectExactlyResolvedDocumentationSignature ("M:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NoClosingBrace(Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.Generic{Mono.Linker.Tests.DocumentationSignatureParserTests.A)")]
+			public static void NoClosingBrace (Generic<A> g)
+			{
+			}
+
+			[ExpectExactlyResolvedDocumentationSignature ("F:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.fieldArgs(gibberish")]
+			public int fieldArgs;
+
+			[ExpectExactlyResolvedDocumentationSignature ("E:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.OnEventArgs(gibberish")]
+			public event EventHandler? OnEventArgs;
+
+			[ExpectExactlyResolvedDocumentationSignature ("T:Mono.Linker.Tests.DocumentationSignatureParserTests.Invalid.NestedType{")]
+			public class NestedType
+			{
+			}
+		}
+	}
+}


### PR DESCRIPTION
Ports the `MemberAssertionsCollector` test infra from linker - changes to work on top of the ILC's type system.
Ports the DocumentationSignatureParser tests - changes to work with the different type system, but the tests themselves are untouched.

Fixes behavior bugs and differences in the AOT port of the parser/generator to pass the tests. This is now 100% identical to linker per the test.

