### PR TITLE
Speed up `Matrix4x4.CreateScale`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -1202,10 +1202,13 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(float xScale, float yScale, float zScale)
         {
-            Matrix4x4 result = Identity;
+            Matrix4x4 result = default;
+
             result.M11 = xScale;
             result.M22 = yScale;
             result.M33 = zScale;
+            result.M44 = 1;
+
             return result;
         }
 
@@ -1217,7 +1220,7 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(float xScale, float yScale, float zScale, Vector3 centerPoint)
         {
-            Matrix4x4 result = Identity;
+            Matrix4x4 result = default;
 
             float tx = centerPoint.X * (1 - xScale);
             float ty = centerPoint.Y * (1 - yScale);
@@ -1226,9 +1229,12 @@ namespace System.Numerics
             result.M11 = xScale;
             result.M22 = yScale;
             result.M33 = zScale;
+            result.M44 = 1;
+
             result.M41 = tx;
             result.M42 = ty;
             result.M43 = tz;
+
             return result;
         }
 
@@ -1237,10 +1243,13 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(Vector3 scales)
         {
-            Matrix4x4 result = Identity;
+            Matrix4x4 result = default;
+
             result.M11 = scales.X;
             result.M22 = scales.Y;
             result.M33 = scales.Z;
+            result.M44 = 1;
+
             return result;
         }
 
@@ -1250,18 +1259,19 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(Vector3 scales, Vector3 centerPoint)
         {
-            Matrix4x4 result = Identity;
+            Matrix4x4 result = default;
 
-            float tx = centerPoint.X * (1 - scales.X);
-            float ty = centerPoint.Y * (1 - scales.Y);
-            float tz = centerPoint.Z * (1 - scales.Z);
+            Vector3 t = centerPoint * (Vector3.One - scales);
 
             result.M11 = scales.X;
             result.M22 = scales.Y;
             result.M33 = scales.Z;
-            result.M41 = tx;
-            result.M42 = ty;
-            result.M43 = tz;
+            result.M44 = 1;
+
+            result.M41 = t.X;
+            result.M42 = t.Y;
+            result.M43 = t.Z;
+
             return result;
         }
 
@@ -1270,11 +1280,12 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(float scale)
         {
-            Matrix4x4 result = Identity;
+            Matrix4x4 result = default;
 
             result.M11 = scale;
             result.M22 = scale;
             result.M33 = scale;
+            result.M44 = 1;
 
             return result;
         }
@@ -1285,19 +1296,18 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(float scale, Vector3 centerPoint)
         {
-            Matrix4x4 result = Identity;
+            Matrix4x4 result = default;
 
-            float tx = centerPoint.X * (1 - scale);
-            float ty = centerPoint.Y * (1 - scale);
-            float tz = centerPoint.Z * (1 - scale);
+            Vector3 t = centerPoint * (Vector3.One - new Vector3(scale));
 
             result.M11 = scale;
             result.M22 = scale;
             result.M33 = scale;
+            result.M44 = 1;
 
-            result.M41 = tx;
-            result.M42 = ty;
-            result.M43 = tz;
+            result.M41 = t.X;
+            result.M42 = t.Y;
+            result.M43 = t.Z;
 
             return result;
         }


### PR DESCRIPTION
In #76491 the Jit became a little more eager to optimize code using vectors as a whole. Unfortunately, this regressed `Matrix4x4.CreateScale` on some platforms because code for it is written in a way that favors promotion over whole-register access.

This change fixes the regression by using style that is more in line with what the Jit expects of vectors. It also optimizes related overloads by avoiding the relatively expensive `get_Identity` property call (that is not even inlined due to loading a value type field).

Linux x64 benchmark results:

|                                      Method |        Job |    Toolchain |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio | RatioSD | Allocated | Alloc Ratio |
|-------------------------------------------- |----------- |------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
|              CreateScaleFromVectorBenchmark | Job-AFMBXB | Root/corerun | 12.575 ns | 0.1031 ns | 0.0861 ns | 12.555 ns | 12.452 ns | 12.770 ns |  0.74 |    0.01 |         - |          NA |
|              CreateScaleFromVectorBenchmark | Job-KPUHXS | /crb/corerun | 16.988 ns | 0.1283 ns | 0.1138 ns | 16.959 ns | 16.789 ns | 17.189 ns |  1.00 |    0.00 |         - |          NA |
|                                             |            |              |           |           |           |           |           |           |       |         |           |             |
|    CreateScaleFromVectorWithCenterBenchmark | Job-AFMBXB | Root/corerun |  9.548 ns | 0.0628 ns | 0.0588 ns |  9.529 ns |  9.476 ns |  9.663 ns |  0.44 |    0.02 |         - |          NA |
|    CreateScaleFromVectorWithCenterBenchmark | Job-KPUHXS | /crb/corerun | 21.963 ns | 0.9062 ns | 1.0435 ns | 21.291 ns | 21.155 ns | 24.310 ns |  1.00 |    0.00 |         - |          NA |
|                                             |            |              |           |           |           |           |           |           |       |         |           |             |
|              CreateScaleFromScalarBenchmark | Job-AFMBXB | Root/corerun |  9.321 ns | 0.0701 ns | 0.0655 ns |  9.329 ns |  9.207 ns |  9.442 ns |  0.54 |    0.00 |         - |          NA |
|              CreateScaleFromScalarBenchmark | Job-KPUHXS | /crb/corerun | 17.138 ns | 0.0886 ns | 0.0828 ns | 17.154 ns | 16.954 ns | 17.255 ns |  1.00 |    0.00 |         - |          NA |
|                                             |            |              |           |           |           |           |           |           |       |         |           |             |
|    CreateScaleFromScalarWithCenterBenchmark | Job-AFMBXB | Root/corerun | 12.807 ns | 0.1044 ns | 0.0977 ns | 12.789 ns | 12.689 ns | 12.999 ns |  0.74 |    0.01 |         - |          NA |
|    CreateScaleFromScalarWithCenterBenchmark | Job-KPUHXS | /crb/corerun | 17.203 ns | 0.0963 ns | 0.0901 ns | 17.216 ns | 16.980 ns | 17.342 ns |  1.00 |    0.00 |         - |          NA |
|                                             |            |              |           |           |           |           |           |
|           CreateScaleFromScalarXYZBenchmark | Job-AFMBXB | Root/corerun |  9.454 ns | 0.0688 ns | 0.0609 ns |  9.433 ns |  9.389 ns |  9.577 ns |  0.46 |    0.00 |         - |          NA |
|           CreateScaleFromScalarXYZBenchmark | Job-KPUHXS | /crb/corerun | 20.481 ns | 0.1567 ns | 0.1466 ns | 20.431 ns | 20.296 ns | 20.769 ns |  1.00 |    0.00 |         - |          NA |
|                                             |            |              |           |           |           |           |           |           |       |         |           |             |
| CreateScaleFromScalarXYZWithCenterBenchmark | Job-AFMBXB | Root/corerun |  9.434 ns | 0.0380 ns | 0.0297 ns |  9.438 ns |  9.384 ns |  9.477 ns |  0.55 |    0.00 |         - |          NA |
| CreateScaleFromScalarXYZWithCenterBenchmark | Job-KPUHXS | /crb/corerun | 17.160 ns | 0.1791 ns | 0.1588 ns | 17.171 ns | 16.901 ns | 17.433 ns |  1.00 |    0.00 |         - |          NA |

Where `Root/corerun` is this change and `/crb/corerun` is `main`.

Fixes #78977.