### PR TITLE
Map correct fmt for mov instruction

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4010,6 +4010,15 @@ void emitter::emitIns(instruction ins, emitAttr attr)
 //
 emitter::insFormat emitter::emitMapFmtForIns(insFormat fmt, instruction ins)
 {
+    if (IsMovInstruction(ins))
+    {
+        // A `mov` instruction is always "write"
+        // and not "read/write".
+        if (fmt == IF_RRW_ARD)
+        {
+            return IF_RWR_ARD;
+        }
+    }
     switch (ins)
     {
         case INS_rol_N:
@@ -4034,7 +4043,6 @@ emitter::insFormat emitter::emitMapFmtForIns(insFormat fmt, instruction ins)
                     unreached();
             }
         }
-
         default:
             return fmt;
     }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4010,15 +4010,6 @@ void emitter::emitIns(instruction ins, emitAttr attr)
 //
 emitter::insFormat emitter::emitMapFmtForIns(insFormat fmt, instruction ins)
 {
-    if (IsMovInstruction(ins))
-    {
-        // A `mov` instruction is always "write"
-        // and not "read/write".
-        if (fmt == IF_RRW_ARD)
-        {
-            return IF_RWR_ARD;
-        }
-    }
     switch (ins)
     {
         case INS_rol_N:
@@ -4044,6 +4035,15 @@ emitter::insFormat emitter::emitMapFmtForIns(insFormat fmt, instruction ins)
             }
         }
         default:
+            if (IsMovInstruction(ins))
+            {
+                // A `mov` instruction is always "write"
+                // and not "read/write".
+                if (fmt == IF_RRW_ARD)
+                {
+                    return IF_RWR_ARD;
+                }
+            }
             return fmt;
     }
 }


### PR DESCRIPTION
With #78879, we most likely exposed a problem in emitter, where `mov` would never go through `emitIns_R_A`. 

I surveyed all the places that calls `emitHandleMemOp()` and hence `emitMapFmtForIns()` and the only place where `mov` can now end up to pass through `emitIns_R_A()` with wrong fmt. The format that would pass is `IF_RRW_ARD` (read/write) but it should be `IF_RWR_ARD` (since `mov` just writes to the register). The fix is to add a check in `emitMapFmtForIns()` to convert to right format.

Fixes: #79132