### PR TITLE
Speeds up linker tests in NativeAOT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
@@ -168,6 +168,10 @@ namespace ILCompiler
 
             public void DetectCycle(TypeSystemEntity owner, TypeSystemEntity referent)
             {
+                // This allows to disable cycle detection completely (typically for perf reasons as the algorithm is pretty slow)
+                if (_cutoffPoint < 0)
+                    return;
+
                 // Not clear if generic recursion through fields is a thing
                 if (referent is FieldDesc)
                 {

--- a/src/coreclr/tools/aot/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupIlcFrameworkCompilationAttribute.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupIlcFrameworkCompilationAttribute.cs
@@ -11,7 +11,7 @@ namespace Mono.Linker.Tests.Cases.Expectations.Metadata
 	/// Adding this attribute modifies the runner to compile all framework assemblies as well.
 	/// </summary>
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
-	public class SetupIlcFrameworkCompilationAttribute : BaseMetadataAttribute
+	public class SetupIlcWholeProgramAnalysisAttribute : BaseMetadataAttribute
 	{
 	}
 }

--- a/src/coreclr/tools/aot/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupIlcFrameworkCompilationAttribute.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests.Cases.Expectations/Metadata/SetupIlcFrameworkCompilationAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Metadata
+{
+	/// <summary>
+	/// In ILC/AOT tests by default only compile the test itself (and its compiled dependencies) through the ILC compiler
+	/// this means that by default none of the framework assemblies are compiled.
+	/// Adding this attribute modifies the runner to compile all framework assemblies as well.
+	/// </summary>
+	[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
+	public class SetupIlcFrameworkCompilationAttribute : BaseMetadataAttribute
+	{
+	}
+}

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerOptions.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerOptions.cs
@@ -13,5 +13,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public List<string> TrimAssemblies = new List<string> ();
 		public List<string> AdditionalRootAssemblies = new List<string> ();
 		public Dictionary<string, bool> FeatureSwitches = new Dictionary<string, bool> ();
+		public bool FrameworkCompilation;
 	}
 }

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerOptionsBuilder.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerOptionsBuilder.cs
@@ -44,6 +44,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			Options.FeatureSwitches.Add ("System.Linq.Expressions.CanCompileToIL", false);
 			Options.FeatureSwitches.Add ("System.Linq.Expressions.CanEmitObjectArrayDelegate", false);
 			Options.FeatureSwitches.Add ("System.Linq.Expressions.CanCreateArbitraryDelegates", false);
+			Options.FeatureSwitches.Add ("System.Diagnostics.Debugger.IsSupported", false);
+			Options.FeatureSwitches.Add ("System.Text.Encoding.EnableUnsafeUTF7Encoding", false);
+			Options.FeatureSwitches.Add ("System.Diagnostics.Tracing.EventSource.IsSupported", false);
+			Options.FeatureSwitches.Add ("System.Globalization.Invariant", true);
+			Options.FeatureSwitches.Add ("System.Resources.UseSystemResourceKeys", true);
+
+			Options.FrameworkCompilation = false;
 		}
 
 		public virtual void AddSearchDirectory (NPath directory)
@@ -224,6 +231,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			// we keep the information in flag + values format for as long as we can so that this information doesn't have to be parsed out of a single string
 			foreach (var additionalArgument in options.AdditionalArguments)
 				AddAdditionalArgument (additionalArgument.Key, additionalArgument.Value);
+
+			if (options.IlcFrameworkCompilation)
+				Options.FrameworkCompilation = true;
 		}
 
 		private static void AppendExpandedPaths (Dictionary<string, string> dictionary, string pattern)

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerTestPInvokePolicy.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerTestPInvokePolicy.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.IL;
+using Internal.TypeSystem;
+
+namespace Mono.Linker.Tests.TestCasesRunner
+{
+	internal sealed class ILCompilerTestPInvokePolicy : PInvokeILEmitterConfiguration
+	{
+		public override bool GenerateDirectCall (MethodDesc method, out string? externName)
+		{
+			externName = null;
+			return false;
+		}
+	}
+}

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerTestPInvokePolicy.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/ILCompilerTestPInvokePolicy.cs
@@ -10,8 +10,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 	{
 		public override bool GenerateDirectCall (MethodDesc method, out string? externName)
 		{
-			externName = null;
-			return false;
+			externName = method.Name;
+			return true;
 		}
 	}
 }

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/TestCaseLinkerOptions.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/TestCaseLinkerOptions.cs
@@ -25,6 +25,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public bool StripSubstitutions;
 		public bool StripLinkAttributes;
 
+		public bool IlcFrameworkCompilation;
+
 		public List<KeyValuePair<string, string[]>> AdditionalArguments = new List<KeyValuePair<string, string[]>> ();
 
 		public List<string> Descriptors = new List<string> ();

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadataProvider.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadataProvider.cs
@@ -35,6 +35,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				StripDescriptors = GetOptionAttributeValue (nameof (StripDescriptorsAttribute), true),
 				StripSubstitutions = GetOptionAttributeValue (nameof (StripSubstitutionsAttribute), true),
 				StripLinkAttributes = GetOptionAttributeValue (nameof (StripLinkAttributesAttribute), true),
+				IlcFrameworkCompilation = _testCaseTypeDefinition.HasAttribute (nameof (SetupIlcFrameworkCompilationAttribute)),
 			};
 
 			foreach (var assemblyAction in _testCaseTypeDefinition.CustomAttributes.Where (attr => attr.AttributeType.Name == nameof (SetupLinkerActionAttribute))) {

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadataProvider.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadataProvider.cs
@@ -35,7 +35,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				StripDescriptors = GetOptionAttributeValue (nameof (StripDescriptorsAttribute), true),
 				StripSubstitutions = GetOptionAttributeValue (nameof (StripSubstitutionsAttribute), true),
 				StripLinkAttributes = GetOptionAttributeValue (nameof (StripLinkAttributesAttribute), true),
-				IlcFrameworkCompilation = _testCaseTypeDefinition.HasAttribute (nameof (SetupIlcFrameworkCompilationAttribute)),
+				IlcFrameworkCompilation = _testCaseTypeDefinition.HasAttribute (nameof (SetupIlcWholeProgramAnalysisAttribute)),
 			};
 
 			foreach (var assemblyAction in _testCaseTypeDefinition.CustomAttributes.Where (attr => attr.AttributeType.Name == nameof (SetupLinkerActionAttribute))) {


### PR DESCRIPTION
The main gain is from disable cycle detection in generic instantiations. None of the tests rely on this functionality and it is only useful if we had a cycle in the test - which we don't for now. It's perf cost especially in Debug builds is substantial (in some tests it completely dominates everything).

This adds the ability for a test to choose if the framework should be compiled or not. By default it's not. Compiling framework makes the test slower (about 10x for small tests), but for some functionality it might be necessary (for example Linq Expression special behaviors will need this).

Also disables additional feature switches to make the framework "Smaller".