### PR TITLE
A gentle reminder that TraceGC is turned off

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -45178,6 +45178,9 @@ HRESULT GCHeap::Init(size_t hn)
 //System wide initialization
 HRESULT GCHeap::Initialize()
 {
+#ifndef TRACE_GC
+    STRESS_LOG_VA (1, (ThreadStressLog::gcLoggingIsOffMsg()));
+#endif
     HRESULT hr = S_OK;
 
     qpf = (uint64_t)GCToOSInterface::QueryPerformanceFrequency();

--- a/src/coreclr/inc/gcmsg.inl
+++ b/src/coreclr/inc/gcmsg.inl
@@ -130,3 +130,9 @@
         STATIC_CONTRACT_LEAF;
         return "Relocating reference *(%p) from %p to %p";
     }
+
+    static const char* gcLoggingIsOffMsg()
+    {
+        STATIC_CONTRACT_LEAF;
+        return "TraceGC is not turned on";
+    }

--- a/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
+++ b/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin.cpp
@@ -151,6 +151,7 @@ d(IS_DESIRED_NEW_ALLOCATION,    ThreadStressLog::gcDesiredNewAllocationMsg())   
 d(IS_MAKE_UNUSED_ARRAY,         ThreadStressLog::gcMakeUnusedArrayMsg())                                                    \
 d(IS_START_BGC_THREAD,          ThreadStressLog::gcStartBgcThread())                                                        \
 d(IS_RELOCATE_REFERENCE,        ThreadStressLog::gcRelocateReferenceMsg())                                                  \
+d(IS_LOGGING_OFF,               ThreadStressLog::gcLoggingIsOffMsg())                                                       \
 d(IS_UNINTERESTING,             "")
 
 enum InterestingStringId : unsigned char
@@ -385,6 +386,9 @@ bool FilterMessage(StressLog::StressLogHeader* hdr, ThreadStressLog* tsl, uint32
         }
         break;
     }
+
+    case    IS_LOGGING_OFF:
+        return true;
 
     case    IS_GCSTART:
     {


### PR DESCRIPTION
Let's help ourselves not to waste time figuring out why we don't have the logging just because we forgot to turn it on!

With this change - the stress log analyzer will show that fact right away so I don't have to wonder why.