### PR TITLE
Add ProductVersionSuffix to workload manifest names

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -94,6 +94,7 @@
       <ProductBandVersion Condition="'$(ProductBandVersion)' == ''">$(MajorVersion).$(MinorVersion)</ProductBandVersion>
       <ProductionVersion Condition="'$(ProductionVersion)' == ''">$(ProductBandVersion).$(PatchVersion)</ProductionVersion>
       <ProductVersion>$(ProductionVersion)$(ProductVersionSuffix)</ProductVersion>
+      <SdkBandVersion>$(SdkBandVersion)$(ProductVersionSuffix)</SdkBandVersion>
 
       <SharedFrameworkNugetVersion>$(ProductVersion)</SharedFrameworkNugetVersion>
       <NuGetVersion>$(SharedFrameworkNugetVersion)</NuGetVersion>

--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -11,6 +11,7 @@
     <_SdkWithNoWorkloadStampPath>$([MSBuild]::NormalizePath($(_SdkWithNoWorkloadPath), '.version-$(SdkVersionForWorkloadTesting).stamp'))</_SdkWithNoWorkloadStampPath>
     <InstallWorkloadUsingArtifactsDependsOn>
       $(InstallWorkloadUsingArtifactsDependsOn);
+      GetProductVersions;
       _SetPackageVersionForWorkloadsTesting;
       _GetNuGetsToBuild;
       _PreparePackagesForWorkloadInstall;

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Manifest.pkgproj
@@ -5,7 +5,7 @@
     <PackageDescription>Internal toolchain package not meant for direct consumption. Please do not reference directly.</PackageDescription>
   </PropertyGroup>
 
-  <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">
+  <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" DependsOnTargets="GetProductVersions" Returns="@(PackageFile)">
     <!-- Override the id to include the sdk band as per the workload installer spec -->
     <PropertyGroup>
       <Id>Microsoft.NET.Workload.Mono.ToolChain.Manifest-$(SdkBandVersion)</Id>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest.pkgproj
@@ -5,7 +5,7 @@
     <PackageDescription>Internal toolchain package not meant for direct consumption. Please do not reference directly.</PackageDescription>
   </PropertyGroup>
 
-  <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">
+  <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" DependsOnTargets="GetProductVersions" Returns="@(PackageFile)">
     <!-- Override the id to include the sdk band as per the workload installer spec -->
     <PropertyGroup>
       <Id>Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest-$(SdkBandVersion)</Id>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest.pkgproj
@@ -5,7 +5,7 @@
     <PackageDescription>Internal toolchain package not meant for direct consumption. Please do not reference directly.</PackageDescription>
   </PropertyGroup>
 
-  <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">
+  <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" DependsOnTargets="GetProductVersions" Returns="@(PackageFile)">
     <!-- Override the id to include the sdk band as per the workload installer spec -->
     <PropertyGroup>
       <Id>Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(SdkBandVersion)</Id>


### PR DESCRIPTION
This change adds a prerelease label to workload manifests so that they can sit beside official ones in the dotnet sdk. For example, `Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-8.0.100-alpha.1` could install alongside `Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-8.0.100` and not cause conflicts.

Fixes https://github.com/dotnet/runtime/issues/79086