### PR TITLE
Take EventListener.EventListenersLock in EventPipeEventDispatcher.SendCommand

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventDispatcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventDispatcher.cs
@@ -46,20 +46,23 @@ namespace System.Diagnostics.Tracing
 
         internal void SendCommand(EventListener eventListener, EventCommand command, bool enable, EventLevel level, EventKeywords matchAnyKeywords)
         {
-            if (command == EventCommand.Update && enable)
+            lock (EventListener.EventListenersLock)
             {
-                lock (m_dispatchControlLock)
+                if (command == EventCommand.Update && enable)
                 {
-                    // Add the new subscription.  This will overwrite an existing subscription for the listener if one exists.
-                    m_subscriptions[eventListener] = new EventListenerSubscription(matchAnyKeywords, level);
+                    lock (m_dispatchControlLock)
+                    {
+                        // Add the new subscription.  This will overwrite an existing subscription for the listener if one exists.
+                        m_subscriptions[eventListener] = new EventListenerSubscription(matchAnyKeywords, level);
 
-                    // Commit the configuration change.
-                    CommitDispatchConfiguration();
+                        // Commit the configuration change.
+                        CommitDispatchConfiguration();
+                    }
                 }
-            }
-            else if (command == EventCommand.Update && !enable)
-            {
-                RemoveEventListener(eventListener);
+                else if (command == EventCommand.Update && !enable)
+                {
+                    RemoveEventListener(eventListener);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #78233

If an `EventListener` calls `EnableEvents` on `NativeRuntimeEventSource` outside of the `OnEventSourceCreated` callback we do not take `EventListener.EventListenersLock` before `m_dispatchControlLock` in `EventPipeEventDispatcher.SendCommand`, which can lead to a deadlock.