### PR TITLE
Fix XxHash3/XxHash128 DeriveSecretFromSeed scalar fallback on big endian

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs
@@ -501,8 +501,8 @@ namespace System.IO.Hashing
                 {
                     for (int i = 0; i < SecretLengthBytes; i += sizeof(ulong) * 2)
                     {
-                        Unsafe.WriteUnaligned(destinationSecret + i, Unsafe.ReadUnaligned<ulong>(defaultSecret + i) + seed);
-                        Unsafe.WriteUnaligned(destinationSecret + i + 8, Unsafe.ReadUnaligned<ulong>(defaultSecret + i + 8) - seed);
+                        WriteUInt64LE(destinationSecret + i, ReadUInt64LE(defaultSecret + i) + seed);
+                        WriteUInt64LE(destinationSecret + i + 8, ReadUInt64LE(defaultSecret + i + 8) - seed);
                     }
                 }
             }
@@ -790,6 +790,16 @@ namespace System.IO.Hashing
             BitConverter.IsLittleEndian ?
                 Unsafe.ReadUnaligned<ulong>(data) :
                 BinaryPrimitives.ReverseEndianness(Unsafe.ReadUnaligned<ulong>(data));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WriteUInt64LE(byte* data, ulong value)
+        {
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = BinaryPrimitives.ReverseEndianness(value);
+            }
+            Unsafe.WriteUnaligned(data, value);
+        }
 
         [StructLayout(LayoutKind.Auto)]
         public struct State


### PR DESCRIPTION
This is a backport of #78084 to fix a regression on big-endian platform (see this [comment](https://github.com/dotnet/runtime/pull/77944#issuecomment-1335825663))