### PR TITLE
Disable Allow_Connection_UnderDifferentUsers_ForClientReading on mono

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
@@ -210,6 +210,7 @@ namespace System.IO.Pipes.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/79180", TestRuntimes.Mono)]
         [ConditionalTheory(nameof(IsSupportedWindowsVersionAndPrivilegedProcess))]
         [InlineData(false)]
         [InlineData(true)]


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/79180