### PR TITLE
Speed up data dehydration

### DIFF
--- a/src/coreclr/tools/Common/Internal/Runtime/DehydratedData.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/DehydratedData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -59,6 +60,7 @@ namespace Internal.Runtime
             return 1 + numExtraBytes;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe byte* Decode(byte* pB, out int command, out int payload)
         {
             byte b = *pB;


### PR DESCRIPTION
Now that we switched everything we wanted to switch to dehydrated data, I redid startup measurements.

I used a 30 MB app that doesn't actually do anything useful with those megabytes and just exits (to get a lot of dehydrated data into the startup path).

On Windows:

(The measurements were frustratingly noisy within a range that spans 10 ms.)

Without dehydration, the app exits in ~27 ms.
With dehydration, the app exits in ~37 ms.
With the fixes in this PR and dehydration, it exits in ~34 ms.

On Linux, the difference between not dehydrated and dehydrated is ~8 ms -> ~12 ms. I didn't re-measure with this PR. Possibly shaved off a millisecond.

Cc @dotnet/ilc-contrib 