### PR TITLE
Use tokens for validation of Kept members in linker tests for NativeAOT

### DIFF
--- a/src/coreclr/tools/Common/Compiler/EventPseudoDesc.cs
+++ b/src/coreclr/tools/Common/Compiler/EventPseudoDesc.cs
@@ -71,6 +71,14 @@ namespace ILCompiler
             }
         }
 
+        public EventDefinitionHandle Handle
+        {
+            get
+            {
+                return _handle;
+            }
+        }
+
         public EventPseudoDesc(EcmaType type, EventDefinitionHandle handle)
         {
             _type = type;

--- a/src/coreclr/tools/Common/Compiler/PropertyPseudoDesc.cs
+++ b/src/coreclr/tools/Common/Compiler/PropertyPseudoDesc.cs
@@ -66,6 +66,14 @@ namespace ILCompiler
             }
         }
 
+        public PropertyDefinitionHandle Handle
+        {
+            get
+            {
+                return _handle;
+            }
+        }
+
         public PropertyPseudoDesc(EcmaType type, PropertyDefinitionHandle handle)
         {
             _type = type;

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using FluentAssertions;
+using ILCompiler;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Mono.Cecil;
@@ -20,16 +23,64 @@ namespace Mono.Linker.Tests.TestCasesRunner
 {
 	public class AssemblyChecker
 	{
+		internal readonly struct AssemblyQualifiedToken : IEquatable<AssemblyQualifiedToken>
+		{
+			public string? AssemblyName { get; }
+			public int Token { get; }
+
+			public AssemblyQualifiedToken (string? assemblyName, int token) => (AssemblyName, Token) = (assemblyName, token);
+
+			public AssemblyQualifiedToken (TypeSystemEntity entity) =>
+				(AssemblyName, Token) = entity switch {
+					EcmaType type => (type.Module.Assembly.GetName ().Name, MetadataTokens.GetToken (type.Handle)),
+					EcmaMethod method => (method.Module.Assembly.GetName ().Name, MetadataTokens.GetToken (method.Handle)),
+					PropertyPseudoDesc property => (((EcmaType)property.OwningType).Module.Assembly.GetName ().Name, MetadataTokens.GetToken (property.Handle)),
+					EventPseudoDesc @event => (((EcmaType)@event.OwningType).Module.Assembly.GetName ().Name, MetadataTokens.GetToken (@event.Handle)),
+					_ => (null, 0)
+				};
+
+			public AssemblyQualifiedToken (IMemberDefinition member) =>
+				(AssemblyName, Token) = member switch {
+					TypeDefinition type => (type.Module.Assembly.Name.Name, type.MetadataToken.ToInt32 ()),
+					MethodDefinition method => (method.Module.Assembly.Name.Name, method.MetadataToken.ToInt32 ()),
+					PropertyDefinition property => (property.Module.Assembly.Name.Name, property.MetadataToken.ToInt32 ()),
+					EventDefinition @event => (@event.Module.Assembly.Name.Name, @event.MetadataToken.ToInt32 ()),
+					_ => (null, 0)
+				};
+
+			public override int GetHashCode () => AssemblyName == null ? 0 : AssemblyName.GetHashCode () ^ Token.GetHashCode ();
+			public override string ToString () => $"{AssemblyName}: {Token}";
+			public bool Equals (AssemblyQualifiedToken other) =>
+				string.CompareOrdinal (AssemblyName, other.AssemblyName) == 0 && Token == other.Token;
+			public override bool Equals ([NotNullWhen (true)] object? obj) => ((AssemblyQualifiedToken?) obj)?.Equals (this) == true;
+
+			public bool IsNil => AssemblyName == null;
+		}
+
+		private static AssemblyQualifiedToken GetToken (TypeDefinition typeDefinition)
+			=> new AssemblyQualifiedToken (typeDefinition.Module.Assembly.Name.Name, typeDefinition.MetadataToken.ToInt32 ());
+
 		private readonly BaseAssemblyResolver originalsResolver;
 		private readonly ReaderParameters originalReaderParameters;
 		private readonly AssemblyDefinition originalAssembly;
 		private readonly ILCompilerTestCaseResult testResult;
 
-		private readonly Dictionary<string, TypeSystemEntity> linkedMembers;
+		private readonly Dictionary<AssemblyQualifiedToken, TypeSystemEntity> linkedMembers;
 		private readonly HashSet<string> verifiedGeneratedFields = new HashSet<string> ();
 		private readonly HashSet<string> verifiedEventMethods = new HashSet<string> ();
 		private readonly HashSet<string> verifiedGeneratedTypes = new HashSet<string> ();
 		private bool checkNames;
+
+		// Note: It's enough to exclude the type name, all of its members will also be excluded then
+		private static readonly HashSet<string> ExcludeDisplayNames = new () {
+				// Ignore compiler injected attributes to describe language version
+				"Microsoft.CodeAnalysis.EmbeddedAttribute",
+				"System.Runtime.CompilerServices.RefSafetyRulesAttribute",
+
+				// Ignore NativeAOT injected members
+				"<Module>.StartupCodeMain(Int32,IntPtr)",
+				"<Module>.MainMethodWrapper()"
+			};
 
 		public AssemblyChecker (
 			BaseAssemblyResolver originalsResolver,
@@ -41,7 +92,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			this.originalReaderParameters = originalReaderParameters;
 			this.originalAssembly = original;
 			this.testResult = testResult;
-			this.linkedMembers = new (StringComparer.Ordinal);
+			this.linkedMembers = new ();
 
 			checkNames = original.MainModule.GetTypeReferences ().Any (attr =>
 				attr.Name == nameof (RemovedNameValueAttribute));
@@ -68,32 +119,22 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			PopulateLinkedMembers ();
 
-			// Workaround for compiler injected attribute to describe the language version
-			linkedMembers.Remove ("Microsoft.CodeAnalysis.EmbeddedAttribute.EmbeddedAttribute()");
-			linkedMembers.Remove ("System.Runtime.CompilerServices.RefSafetyRulesAttribute.Version");
-			linkedMembers.Remove ("System.Runtime.CompilerServices.RefSafetyRulesAttribute.RefSafetyRulesAttribute(Int32)");
-
-			// Workaround for NativeAOT injected members
-			linkedMembers.Remove ("<Module>.StartupCodeMain(Int32,IntPtr)");
-			linkedMembers.Remove ("<Module>.MainMethodWrapper()");
-
-			// Workaround for compiler injected attribute to describe the language version
-			verifiedGeneratedTypes.Add ("Microsoft.CodeAnalysis.EmbeddedAttribute");
-			verifiedGeneratedTypes.Add ("System.Runtime.CompilerServices.RefSafetyRulesAttribute");
-
 			var membersToAssert = originalAssembly.MainModule.Types;
 			foreach (var originalMember in membersToAssert) {
 				if (originalMember is TypeDefinition td) {
+					AssemblyQualifiedToken token = GetToken (td);
+
 					if (td.Name == "<Module>") {
-						linkedMembers.Remove (td.Name);
+						linkedMembers.Remove (token);
 						continue;
 					}
 
 					linkedMembers.TryGetValue (
-						NameUtils.GetExpectedOriginDisplayName (originalMember),
+						token,
 						out TypeSystemEntity? linkedMember);
+
 					VerifyTypeDefinition (td, linkedMember as TypeDesc);
-					linkedMembers.Remove (td.FullName);
+					linkedMembers.Remove (token);
 
 					continue;
 				}
@@ -104,7 +145,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			// Filter out all members which are not from the main assembly
 			// The Kept attributes are "optional" for non-main assemblies
 			string mainModuleName = originalAssembly.Name.Name;
-			List<string> externalMembers = linkedMembers.Where (m => GetModuleName (m.Value) != mainModuleName).Select (m => m.Key).ToList ();
+			List<AssemblyQualifiedToken> externalMembers = linkedMembers.Where (m => GetModuleName (m.Value) != mainModuleName).Select (m => m.Key).ToList ();
 			foreach (var externalMember in externalMembers) {
 				linkedMembers.Remove (externalMember);
 			}
@@ -113,7 +154,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				Assert.True (
 					false,
 					"Linked output includes unexpected member:\n  " +
-					string.Join ("\n  ", linkedMembers.Keys));
+					string.Join ("\n  ", linkedMembers.Values.Select (e => e.GetDisplayName())));
 		}
 
 		private void PopulateLinkedMembers ()
@@ -130,7 +171,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			{
 				MethodDesc methodDef = method.GetTypicalMethodDefinition ();
 
-				if (!ShouldIncludeType (methodDef.OwningType))
+				if (!ShouldIncludeMethod (methodDef))
 					return;
 
 				if (!AddMember (methodDef))
@@ -138,6 +179,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 				if (methodDef.OwningType is { } owningType)
 					AddType (owningType);
+
+				if (methodDef.GetPropertyForAccessor () is { } property)
+					AddProperty (property);
+
+				if (methodDef.GetEventForAccessor () is { } @event)
+					AddEvent (@event);
 			}
 
 			void AddType (TypeDesc type)
@@ -155,19 +202,35 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				}
 			}
 
-			bool AddMember (TypeSystemEntity entity)
+			void AddProperty (PropertyPseudoDesc property)
 			{
-				if (NameUtils.GetActualOriginDisplayName (entity) is string fullName &&
-					!linkedMembers.ContainsKey (fullName)) {
+				if (!ShouldIncludeProperty (property))
+					return;
 
-					linkedMembers.Add (fullName, entity);
-					return true;
-				}
+				if (!AddMember (property))
+					return;
 
-				return false;
+				if (property.OwningType is { } owningType)
+					AddType (owningType);
 			}
 
-			bool ShouldIncludeType (TypeDesc type)
+			void AddEvent (EventPseudoDesc @event)
+			{
+				if (!ShouldIncludeEvent (@event))
+					return;
+
+				if (!AddMember (@event))
+					return;
+
+				if (@event.OwningType is { } owningType)
+					AddType (owningType);
+			}
+
+			bool AddMember (TypeSystemEntity entity) => linkedMembers.TryAdd (new AssemblyQualifiedToken (entity), entity);
+
+			static bool ShouldIncludeEntityByDisplayName (TypeSystemEntity entity) => !ExcludeDisplayNames.Contains (entity.GetDisplayName ());
+
+			static bool ShouldIncludeType (TypeDesc type)
 			{
 				if (type is MetadataType metadataType) {
 					if (metadataType.ContainingType is { } containingType) {
@@ -183,11 +246,18 @@ namespace Mono.Linker.Tests.TestCasesRunner
 					if (metadataType.Namespace.StartsWith ("System"))
 						return false;
 
-					return true;
+
+					return ShouldIncludeEntityByDisplayName (type);
 				}
 
 				return false;
 			}
+
+			static bool ShouldIncludeMethod (MethodDesc method) => ShouldIncludeType (method.OwningType) && ShouldIncludeEntityByDisplayName (method);
+
+			static bool ShouldIncludeProperty (PropertyPseudoDesc property) => ShouldIncludeType (property.OwningType) && ShouldIncludeEntityByDisplayName (property);
+
+			static bool ShouldIncludeEvent (EventPseudoDesc @event) => ShouldIncludeType (@event.OwningType) && ShouldIncludeEntityByDisplayName (@event);
 		}
 
 		private static string? GetModuleName (TypeSystemEntity entity)
@@ -253,6 +323,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			checkNames = prev;
 
 			if (original.HasAttribute (nameof (CreatedMemberAttribute))) {
+				// For now always fail on this attribute since we don't know how to validate it
+				throw new NotSupportedException ("CreatedMemberAttribute is not yet supported by the test infra");
+#if false
 				foreach (var attr in original.CustomAttributes.Where (l => l.AttributeType.Name == nameof (CreatedMemberAttribute))) {
 					var newName = original.FullName + "::" + attr.ConstructorArguments[0].Value.ToString ();
 
@@ -262,6 +335,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 					linkedMembers.Remove (linkedMemberName);
 				}
+#endif
 			}
 		}
 
@@ -286,27 +360,37 @@ namespace Mono.Linker.Tests.TestCasesRunner
 #endif
 
 			foreach (var td in original.NestedTypes) {
-				string originalFullName = NameUtils.GetExpectedOriginDisplayName (td);
+				AssemblyQualifiedToken token = GetToken (td);
 				linkedMembers.TryGetValue (
-					originalFullName,
+					token,
 					out TypeSystemEntity? linkedMember);
 
 				VerifyTypeDefinition (td, linkedMember as TypeDesc);
-				linkedMembers.Remove (originalFullName);
+				linkedMembers.Remove (token);
 			}
 
-#if false
 			//// Need to check properties before fields so that the KeptBackingFieldAttribute is handled correctly
 			foreach (var p in original.Properties) {
-				VerifyProperty (p, linked.Properties.FirstOrDefault (l => p.Name == l.Name), linked);
-				linkedMembers.Remove (p.FullName);
+				AssemblyQualifiedToken token = new AssemblyQualifiedToken (p);
+
+				linkedMembers.TryGetValue (
+					token,
+					out TypeSystemEntity? linkedMember);
+				VerifyProperty (p, linkedMember as PropertyPseudoDesc, linked);
+				linkedMembers.Remove (token);
 			}
 			// Need to check events before fields so that the KeptBackingFieldAttribute is handled correctly
 			foreach (var e in original.Events) {
-				VerifyEvent (e, linked.Events.FirstOrDefault (l => e.Name == l.Name), linked);
-				linkedMembers.Remove (e.FullName);
+				AssemblyQualifiedToken token = new AssemblyQualifiedToken (e);
+
+				linkedMembers.TryGetValue (
+					token,
+					out TypeSystemEntity? linkedMember);
+				VerifyEvent (e, linkedMember as EventPseudoDesc, linked);
+				linkedMembers.Remove (token);
 			}
 
+#if false
 			// Need to check delegate cache fields before the normal field check
 			VerifyDelegateBackingFields (original, linked);
 
@@ -322,13 +406,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				if (verifiedEventMethods.Contains (m.FullName))
 					continue;
 
-				string originalFullName = NameUtils.GetExpectedOriginDisplayName (m);
+				AssemblyQualifiedToken token = new (m);
 				linkedMembers.TryGetValue (
-					originalFullName,
+					token,
 					out TypeSystemEntity? linkedMember);
 
 				VerifyMethod (m, linkedMember as MethodDesc);
-				linkedMembers.Remove (originalFullName);
+				linkedMembers.Remove (token);
 			}
 		}
 
@@ -390,7 +474,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			return builder.ToString ();
 		}
 
-		private void VerifyField (FieldDefinition src, FieldDefinition? linked)
+		private void VerifyField (FieldDefinition src, FieldDesc? linked)
 		{
 			bool expectedKept = ShouldBeKept (src);
 
@@ -404,48 +488,61 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			VerifyFieldKept (src, linked);
 		}
 
-		private void VerifyFieldKept (FieldDefinition src, FieldDefinition? linked)
+		private static void VerifyFieldKept (FieldDefinition src, FieldDesc? linked)
 		{
 			if (linked == null) {
 				Assert.True (false, $"Field `{src}' should have been kept");
 				return;
 			}
 
+
+			if (src.HasConstant)
+				throw new NotImplementedException ("Constant value for a field is not yet supported by the test infra.");
+#if false
 			if (!Equals (src.Constant, linked.Constant)) {
 				Assert.True (false, $"Field '{src}' value doesn's match. Expected {src.Constant}, actual {linked.Constant}");
 			}
+#endif
 
+#if false
 			VerifyPseudoAttributes (src, linked);
 			VerifyCustomAttributes (src, linked);
+#endif
 		}
 
-		private void VerifyProperty (PropertyDefinition src, PropertyDefinition? linked, TypeDefinition linkedType)
+		private void VerifyProperty (PropertyDefinition src, PropertyPseudoDesc? linked, TypeDesc linkedType)
 		{
 			VerifyMemberBackingField (src, linkedType);
 
 			bool expectedKept = ShouldBeKept (src);
 
 			if (!expectedKept) {
-				if (linked != null)
+				if (linked is not null)
 					Assert.True (false, $"Property `{src}' should have been removed");
 
 				return;
 			}
 
-			if (linked == null) {
+			if (linked is null) {
 				Assert.True (false, $"Property `{src}' should have been kept");
 				return;
 			}
 
+			if (src.HasConstant)
+				throw new NotSupportedException ("Constant value for a property is not yet supported by the test infra.");
+#if false
 			if (src.Constant != linked.Constant) {
 				Assert.True (false, $"Property '{src}' value doesn's match. Expected {src.Constant}, actual {linked.Constant}");
 			}
+#endif
 
+#if false
 			VerifyPseudoAttributes (src, linked);
 			VerifyCustomAttributes (src, linked);
+#endif
 		}
 
-		private void VerifyEvent (EventDefinition src, EventDefinition? linked, TypeDefinition linkedType)
+		private void VerifyEvent (EventDefinition src, EventPseudoDesc? linked, TypeDesc linkedType)
 		{
 			VerifyMemberBackingField (src, linkedType);
 
@@ -464,19 +561,21 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			}
 
 			if (src.CustomAttributes.Any (attr => attr.AttributeType.Name == nameof (KeptEventAddMethodAttribute))) {
-				//VerifyMethodInternal (src.AddMethod, linked.AddMethod, true);
+				VerifyMethodInternal (src.AddMethod, linked.AddMethod, true);
 				verifiedEventMethods.Add (src.AddMethod.FullName);
-				linkedMembers.Remove (src.AddMethod.FullName);
+				linkedMembers.Remove (new AssemblyQualifiedToken(src.AddMethod));
 			}
 
 			if (src.CustomAttributes.Any (attr => attr.AttributeType.Name == nameof (KeptEventRemoveMethodAttribute))) {
-				//VerifyMethodInternal (src.RemoveMethod, linked.RemoveMethod, true);
+				VerifyMethodInternal (src.RemoveMethod, linked.RemoveMethod, true);
 				verifiedEventMethods.Add (src.RemoveMethod.FullName);
-				linkedMembers.Remove (src.RemoveMethod.FullName);
+				linkedMembers.Remove (new AssemblyQualifiedToken(src.RemoveMethod));
 			}
 
+#if false
 			VerifyPseudoAttributes (src, linked);
 			VerifyCustomAttributes (src, linked);
+#endif
 		}
 
 		private void VerifyMethod (MethodDefinition src, MethodDesc? linked)
@@ -497,7 +596,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			VerifyMethodKept (src, linked);
 		}
 
-		private void VerifyMemberBackingField (IMemberDefinition src, TypeDefinition linkedType)
+		private void VerifyMemberBackingField (IMemberDefinition src, TypeDesc? linkedType)
 		{
 			var keptBackingFieldAttribute = src.CustomAttributes.FirstOrDefault (attr => attr.AttributeType.Name == nameof (KeptBackingFieldAttribute));
 			if (keptBackingFieldAttribute == null)
@@ -521,9 +620,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				return;
 			}
 
-			VerifyFieldKept (srcField, linkedType?.Fields.FirstOrDefault (l => srcField.Name == l.Name));
+			VerifyFieldKept (srcField, linkedType?.GetFields ()?.FirstOrDefault (l => srcField.Name == l.Name));
 			verifiedGeneratedFields.Add (srcField.FullName);
-			linkedMembers.Remove (srcField.FullName);
+			linkedMembers.Remove (new AssemblyQualifiedToken (srcField));
 		}
 
 		protected virtual void VerifyMethodKept (MethodDefinition src, MethodDesc? linked)
@@ -825,6 +924,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			linkedAttrs.Should ().BeEquivalentTo (expectedAttrs, $"Security attributes on `{src}' are not matching");
 		}
 
+#if false
 		protected virtual void VerifyArrayInitializers (MethodDefinition src, MethodDefinition linked)
 		{
 			var expectedIndices = GetCustomAttributeCtorValues<object> (src, nameof (KeptInitializerData))
@@ -883,12 +983,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		{
 			VerifyFieldKept (src, linked);
 			verifiedGeneratedFields.Add (linked!.FullName);
-			linkedMembers.Remove (linked.FullName);
+			linkedMembers.Remove (new (linked));
 			//VerifyTypeDefinitionKept (src.FieldType.Resolve (), linked.FieldType.Resolve ());
-			linkedMembers.Remove (linked.FieldType.FullName);
-			linkedMembers.Remove (linked.DeclaringType.FullName);
+			linkedMembers.Remove (new (linked.FieldType.Resolve ()));
+			linkedMembers.Remove (new (linked.DeclaringType.Resolve ()));
 			verifiedGeneratedTypes.Add (linked.DeclaringType.FullName);
 		}
+#endif
 
 		private static bool IsLdtokenOnPrivateImplementationDetails (TypeDefinition privateImplementationDetails, Instruction instruction)
 		{
@@ -957,6 +1058,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				.Select (attr => attr.AttributeType.ToString ());
 		}
 
+#if false
 		private void VerifyFixedBufferFields (TypeDefinition src, TypeDefinition linked)
 		{
 			var fields = src.Fields.Where (f => f.CustomAttributes.Any (attr => attr.AttributeType.Name == nameof (KeptFixedBufferAttribute)));
@@ -987,7 +1089,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				var linkedField = linkedCompilerGeneratedBufferType?.Fields.FirstOrDefault ();
 				VerifyFieldKept (originalElementField, linkedField);
 				verifiedGeneratedFields.Add (originalElementField.FullName);
-				linkedMembers.Remove (linkedField!.FullName);
+				linkedMembers.Remove (new (linkedField!));
 
 				//VerifyTypeDefinitionKept (originalCompilerGeneratedBufferType, linkedCompilerGeneratedBufferType);
 				verifiedGeneratedTypes.Add (originalCompilerGeneratedBufferType.FullName);
@@ -1010,9 +1112,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				var linkedField = linked?.Fields.FirstOrDefault (l => l.Name == srcField.Name);
 				VerifyFieldKept (srcField, linkedField);
 				verifiedGeneratedFields.Add (srcField.FullName);
-				linkedMembers.Remove (srcField.FullName);
+				linkedMembers.Remove (new (srcField));
 			}
 		}
+#endif
 
 		private void VerifyGenericParameters (IGenericParameterProvider src, IGenericParameterProvider linked)
 		{

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -34,8 +34,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				(AssemblyName, Token) = entity switch {
 					EcmaType type => (type.Module.Assembly.GetName ().Name, MetadataTokens.GetToken (type.Handle)),
 					EcmaMethod method => (method.Module.Assembly.GetName ().Name, MetadataTokens.GetToken (method.Handle)),
-					PropertyPseudoDesc property => (((EcmaType)property.OwningType).Module.Assembly.GetName ().Name, MetadataTokens.GetToken (property.Handle)),
-					EventPseudoDesc @event => (((EcmaType)@event.OwningType).Module.Assembly.GetName ().Name, MetadataTokens.GetToken (@event.Handle)),
+					PropertyPseudoDesc property => (((EcmaType) property.OwningType).Module.Assembly.GetName ().Name, MetadataTokens.GetToken (property.Handle)),
+					EventPseudoDesc @event => (((EcmaType) @event.OwningType).Module.Assembly.GetName ().Name, MetadataTokens.GetToken (@event.Handle)),
 					_ => (null, 0)
 				};
 
@@ -154,7 +154,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				Assert.True (
 					false,
 					"Linked output includes unexpected member:\n  " +
-					string.Join ("\n  ", linkedMembers.Values.Select (e => e.GetDisplayName())));
+					string.Join ("\n  ", linkedMembers.Values.Select (e => e.GetDisplayName ())));
 		}
 
 		private void PopulateLinkedMembers ()
@@ -563,13 +563,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			if (src.CustomAttributes.Any (attr => attr.AttributeType.Name == nameof (KeptEventAddMethodAttribute))) {
 				VerifyMethodInternal (src.AddMethod, linked.AddMethod, true);
 				verifiedEventMethods.Add (src.AddMethod.FullName);
-				linkedMembers.Remove (new AssemblyQualifiedToken(src.AddMethod));
+				linkedMembers.Remove (new AssemblyQualifiedToken (src.AddMethod));
 			}
 
 			if (src.CustomAttributes.Any (attr => attr.AttributeType.Name == nameof (KeptEventRemoveMethodAttribute))) {
 				VerifyMethodInternal (src.RemoveMethod, linked.RemoveMethod, true);
 				verifiedEventMethods.Add (src.RemoveMethod.FullName);
-				linkedMembers.Remove (new AssemblyQualifiedToken(src.RemoveMethod));
+				linkedMembers.Remove (new AssemblyQualifiedToken (src.RemoveMethod));
 			}
 
 #if false


### PR DESCRIPTION
Switches from using display names (which are currently not consistent between linker/AOT) to tokens. This is possible for NativeAOT because the analysis reports type system entities as read from the input assembly, and thus we can directly compare them to the input assembly read via Cecil.

(Note that this is not possible in linker version of this infra, because the linked members are read from the output assembly which has different token numbers).

This also enables validation of properties and events.

@MichalStrehovsky could you please approve the changes to the pseudo descriptors - exposing handles?