### PR TITLE
CallSiteRuntimeResolver. VisitFactory method implements adding IsInstanceOfType check

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -174,9 +174,15 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return array;
         }
 
-        protected override object VisitFactory(FactoryCallSite factoryCallSite, RuntimeResolverContext context)
+        protected override object? VisitFactory(FactoryCallSite factoryCallSite, RuntimeResolverContext context)
         {
-            return factoryCallSite.Factory(context.Scope);
+            object? value = factoryCallSite.Factory(context.Scope);
+            Type serviceType = factoryCallSite.ServiceType;
+            if (value != null && !serviceType.IsInstanceOfType(value))
+            {
+                throw new ArgumentException(SR.Format(SR.ConstantCantBeConvertedToServiceType, value.GetType(), serviceType));
+            }
+            return value;
         }
     }
 


### PR DESCRIPTION
```C#
var provider = new ServiceCollection()
    .AddSingleton(typeof(IHostedService), provider => new StringWriter())
    .BuildServiceProvider();
var hostedService = provider.GetService(typeof(IHostedService));
```

Using the above code, you will get an instance without any inheritance or implementation relationship.
I think we should throw an exception instead of getting an instance, which may cause problems in some cases.