### PR TITLE
Do not override content root with default

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
@@ -88,7 +88,12 @@ namespace Microsoft.Extensions.Hosting
 
             if (!settings.DisableDefaults)
             {
-                HostingHostBuilderExtensions.ApplyDefaultHostConfiguration(Configuration, settings.Args);
+                if (settings.ContentRootPath is null && Configuration[HostDefaults.ContentRootKey] is null)
+                {
+                    HostingHostBuilderExtensions.SetDefaultContentRoot(Configuration);
+                }
+
+                HostingHostBuilderExtensions.AddDefaultHostConfigurationSources(Configuration, settings.Args);
             }
 
             // HostApplicationBuilderSettings override all other config sources.

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Extensions.Hosting
                           .UseServiceProviderFactory(context => new DefaultServiceProviderFactory(CreateDefaultServiceProviderOptions(context)));
         }
 
-        internal static void ApplyDefaultHostConfiguration(IConfigurationBuilder hostConfigBuilder, string[]? args)
+        internal static void SetDefaultContentRoot(IConfigurationBuilder hostConfigBuilder)
         {
             // If we're running anywhere other than C:\Windows\system32, we default to using the CWD for the ContentRoot.
             // However, since many things like Windows services and MSIX installers have C:\Windows\system32 as there CWD which is not likely
@@ -219,12 +219,21 @@ namespace Microsoft.Extensions.Hosting
                     new KeyValuePair<string, string?>(HostDefaults.ContentRootKey, cwd),
                 });
             }
+        }
 
+        internal static void AddDefaultHostConfigurationSources(IConfigurationBuilder hostConfigBuilder, string[]? args)
+        {
             hostConfigBuilder.AddEnvironmentVariables(prefix: "DOTNET_");
             if (args is { Length: > 0 })
             {
                 hostConfigBuilder.AddCommandLine(args);
             }
+        }
+
+        private static void ApplyDefaultHostConfiguration(IConfigurationBuilder hostConfigBuilder, string[]? args)
+        {
+            SetDefaultContentRoot(hostConfigBuilder);
+            AddDefaultHostConfigurationSources(hostConfigBuilder, args);
         }
 
         internal static void ApplyDefaultAppConfiguration(HostBuilderContext hostingContext, IConfigurationBuilder appConfigBuilder, string[]? args)

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -201,6 +201,12 @@ namespace Microsoft.Extensions.Hosting
                           .UseServiceProviderFactory(context => new DefaultServiceProviderFactory(CreateDefaultServiceProviderOptions(context)));
         }
 
+        private static void ApplyDefaultHostConfiguration(IConfigurationBuilder hostConfigBuilder, string[]? args)
+        {
+            SetDefaultContentRoot(hostConfigBuilder);
+            AddDefaultHostConfigurationSources(hostConfigBuilder, args);
+        }
+
         internal static void SetDefaultContentRoot(IConfigurationBuilder hostConfigBuilder)
         {
             // If we're running anywhere other than C:\Windows\system32, we default to using the CWD for the ContentRoot.
@@ -228,12 +234,6 @@ namespace Microsoft.Extensions.Hosting
             {
                 hostConfigBuilder.AddCommandLine(args);
             }
-        }
-
-        private static void ApplyDefaultHostConfiguration(IConfigurationBuilder hostConfigBuilder, string[]? args)
-        {
-            SetDefaultContentRoot(hostConfigBuilder);
-            AddDefaultHostConfigurationSources(hostConfigBuilder, args);
         }
 
         internal static void ApplyDefaultAppConfiguration(HostBuilderContext hostingContext, IConfigurationBuilder appConfigBuilder, string[]? args)

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
@@ -229,34 +229,46 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
         }
 
-        [Fact]
-        public void ConfigurationSettingCanInfluenceEnvironment()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ConfigurationSettingCanInfluenceEnvironment(bool disableDefaults)
         {
+            var tempPath = Path.GetTempPath();
+
             using var config = new ConfigurationManager();
 
             config.AddInMemoryCollection(new KeyValuePair<string, string>[]
             {
                 new(HostDefaults.ApplicationKey, "AppA" ),
                 new(HostDefaults.EnvironmentKey, "EnvA" ),
+                new(HostDefaults.ContentRootKey, tempPath)
             });
 
             var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
             {
-                DisableDefaults = true,
+                DisableDefaults = disableDefaults,
                 Configuration = config,
             });
 
             Assert.Equal("AppA", builder.Configuration[HostDefaults.ApplicationKey]);
             Assert.Equal("EnvA", builder.Configuration[HostDefaults.EnvironmentKey]);
+            Assert.Equal(tempPath, builder.Configuration[HostDefaults.ContentRootKey]);
 
             Assert.Equal("AppA", builder.Environment.ApplicationName);
             Assert.Equal("EnvA", builder.Environment.EnvironmentName);
+            Assert.Equal(tempPath, builder.Environment.ContentRootPath);
+            var fileProviderFromBuilder = Assert.IsType<PhysicalFileProvider>(builder.Environment.ContentRootFileProvider);
+            Assert.Equal(tempPath, fileProviderFromBuilder.Root);
 
             using IHost host = builder.Build();
 
             var hostEnvironmentFromServices = host.Services.GetRequiredService<IHostEnvironment>();
             Assert.Equal("AppA", hostEnvironmentFromServices.ApplicationName);
             Assert.Equal("EnvA", hostEnvironmentFromServices.EnvironmentName);
+            Assert.Equal(tempPath, hostEnvironmentFromServices.ContentRootPath);
+            var fileProviderFromServices = Assert.IsType<PhysicalFileProvider>(hostEnvironmentFromServices.ContentRootFileProvider);
+            Assert.Equal(tempPath, fileProviderFromServices.Root);
         }
 
         [Fact]


### PR DESCRIPTION
This fixes #78583 which is a regression between .NET 6 and .NET 7 where the impact is that `ASPNETCORE_CONTENTROOT` always gets ignored.

The issue was customer reported. There is a workaround of using the `DOTNET_CONTENTROOT` or even just `CONTENTROOT` environment variables instead, but the `ASPNETCORE_` environment variable prefix is common. I plan to backport this for .NET 7 servicing.

This issue is caused by `HostApplicationBuilder` overriding the content root configuration passed in by ASP.NET Core's `WebApplicationBuilder` via `HostApplicationBuilderSettings.Configuration` with the CWD. This fix changes the `HostApplicationBuilder` to only configure the default content root to be CWD if it has not already been configured manually.