### PR TITLE
Try loading build time ICU version.

### DIFF
--- a/src/native/libs/System.Globalization.Native/pal_icushim.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim.c
@@ -317,6 +317,12 @@ static int FindLibWithMajorVersion(const char* versionPrefix, char* symbolName, 
     // ICU packaging documentation (http://userguide.icu-project.org/packaging)
     // describes applications link against the major (e.g. libicuuc.so.54).
 
+    // Select the version of ICU present at build time
+    if (OpenICULibraries(U_ICU_VERSION_MAJOR_NUM, -1, -1, versionPrefix, symbolName, symbolVersion))
+    {
+        return true;
+    }
+
     // Select the highest supported version of ICU present on the local machine
     for (int i = MaxICUVersion; i >= MinICUVersion; i--)
     {


### PR DESCRIPTION
Calling dlopen() function multiple times from an unknown max version to find the ICU library makes performance degradation under heavy IO contention. 
To avoid this situation, try loading first with the ICU version used at build time.

In our tests, it took up to 100ms under heavy IO contention.