### PR TITLE
Move the rearrange_uoh_segments call earlier so that distribute_free_regions can take them into account

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -21750,6 +21750,7 @@ void gc_heap::gc1()
 
     if (!(settings.concurrent))
     {
+        rearrange_uoh_segments();
 #ifdef USE_REGIONS
         initGCShadow();
         distribute_free_regions();
@@ -21771,7 +21772,6 @@ void gc_heap::gc1()
         }
 #endif //USE_REGIONS
 
-        rearrange_uoh_segments();
         update_end_ngc_time();
         update_end_gc_time_per_heap();
         add_to_history_per_heap();


### PR DESCRIPTION
This is a work in progress, it is known to fix the symptom of #78679. 

Besides that, I haven't run any tests on it yet.