### PR TITLE
Add condition to backport.yml

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   backport:
+    if: ${{ contains(github.event.comment.body, '/backport to') }}
     uses: dotnet/arcade/.github/workflows/backport-base.yml@main
     with:
       pr_description_template: |


### PR DESCRIPTION
GitHub sent me an email that they couldn't fetch the backport-base.yml from the arcade repo (looks like some kind of infrastructure issue) but it shouldn't even do that if my comment didn't have the backport magic word.