### PR TITLE
JIT: Avoid containing small memory operands in GT_SELECT nodes

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5614,28 +5614,37 @@ void Lowering::ContainCheckSelect(GenTreeOp* select)
     // op1 and op2 are emitted as two separate instructions due to the
     // conditional nature of cmov, so both operands can be contained memory
     // operands.
-    if (IsContainableMemoryOp(op1))
+    unsigned operSize = genTypeSize(select);
+    assert((operSize == 4) || (operSize == TARGET_POINTER_SIZE));
+
+    if (genTypeSize(op1) == operSize)
     {
-        if (IsSafeToContainMem(select, op1))
+        if (IsContainableMemoryOp(op1))
         {
-            MakeSrcContained(select, op1);
+            if (IsSafeToContainMem(select, op1))
+            {
+                MakeSrcContained(select, op1);
+            }
         }
-    }
-    else if (IsSafeToContainMem(select, op1))
-    {
-        MakeSrcRegOptional(select, op1);
+        else if (IsSafeToContainMem(select, op1))
+        {
+            MakeSrcRegOptional(select, op1);
+        }
     }
 
-    if (IsContainableMemoryOp(op2))
+    if (genTypeSize(op2) == operSize)
     {
-        if (IsSafeToContainMem(select, op2))
+        if (IsContainableMemoryOp(op2))
         {
-            MakeSrcContained(select, op2);
+            if (IsSafeToContainMem(select, op2))
+            {
+                MakeSrcContained(select, op2);
+            }
         }
-    }
-    else if (IsSafeToContainMem(select, op2))
-    {
-        MakeSrcRegOptional(select, op2);
+        else if (IsSafeToContainMem(select, op2))
+        {
+            MakeSrcRegOptional(select, op2);
+        }
     }
 }
 


### PR DESCRIPTION
The containment I added is missing a check for operand size causing us to contain small memory loads in `GT_SELECT` nodes. This misses required normalization.

Fix #79290

Diff for the affected method:
```diff
@@ -100,9 +97,10 @@ G_M4770_IG04:
        xor      ecx, ecx
        test     r14d, r14d
        setne    cl
-       xor      r15d, r15d
+       movsx    r15, word  ptr [rsp+7AH]
+       xor      r12d, r12d
        test     ecx, ecx
-       cmovne   r15d, dword ptr [rsp+7AH]
+       cmove    r15d, r12d
        mov      rbp, gword ptr [rsi+08H]
        mov      r12d, dword ptr [rbp+08H]
        mov      r13d, r12d
@@ -113,7 +111,7 @@ G_M4770_IG04:
 
        mov      rcx, rdx
        call     [System.Diagnostics.Debug:Fail(System.String,System.String)]
-						;; size=79 bbWeight=0.50 PerfScore 9.75
+                                                ;; size=83 bbWeight=0.50 PerfScore 10.38
```