### PR TITLE
[release/7.0][workloads] Automatically calculate the net6 patch version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>2</PatchVersion>
     <SdkBandVersion>7.0.100</SdkBandVersion>
-    <PackageVersionNet6>6.0.13</PackageVersionNet6>
+    <PackageVersionNet6>6.0.$([MSBuild]::Add($(PatchVersion), 11))</PackageVersionNet6>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>


### PR DESCRIPTION
Automatically calculate the net6 patch version based on the net7 patch version. This is to prevent any instance where we forget to bump it manually.