### PR TITLE
[mono][aot] Fix infinite recursion in the AOT dwarf emitter.

### DIFF
--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -939,6 +939,11 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 	if (die)
 		return die;
 
+	if (m_class_is_ginst (klass) && !vtype) {
+		/* This could lead to recursion */
+		return NULL;
+	}
+
 	if (!((m_class_get_byval_arg (klass)->type == MONO_TYPE_CLASS) || (m_class_get_byval_arg (klass)->type == MONO_TYPE_OBJECT) || m_class_get_byval_arg (klass)->type == MONO_TYPE_GENERICINST || m_class_is_enumtype (klass) || (m_class_get_byval_arg (klass)->type == MONO_TYPE_VALUETYPE && vtype) ||
 		(m_class_get_byval_arg (klass)->type >= MONO_TYPE_BOOLEAN && m_class_get_byval_arg (klass)->type <= MONO_TYPE_R8 && !vtype)))
 		return NULL;
@@ -1174,6 +1179,8 @@ get_type_die (MonoDwarfWriter *w, MonoType *t)
 		case MONO_TYPE_GENERICINST:
 			if (!MONO_TYPE_ISSTRUCT (t)) {
 				tdie = (const char *)g_hash_table_lookup (w->class_to_reference_die, klass);
+				if (!tdie)
+					tdie = ".LDIE_OBJECT";
 			} else {
 				tdie = ".LDIE_I4";
 			}


### PR DESCRIPTION
The recursion would happen if a gshared type would contain a recursive reference to it. It was triggered by the JsonTypeInfo:JsonTypeInfo<Queue<T>> field added by #78646.

Fixes https://github.com/dotnet/runtime/issues/79279.