### PR TITLE
[release/7.0][wasm] Add RollForward=Major for WasmAppHost .

### DIFF
--- a/src/mono/wasm/host/WasmAppHost.csproj
+++ b/src/mono/wasm/host/WasmAppHost.csproj
@@ -6,6 +6,7 @@
     <NoWarn>$(NoWarn),CA2007</NoWarn>
     <Nullable>enable</Nullable>
     <UseAppHost>false</UseAppHost>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/wasm/host/WasmAppHost.csproj
+++ b/src/mono/wasm/host/WasmAppHost.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn),CA2007</NoWarn>
     <Nullable>enable</Nullable>
     <UseAppHost>false</UseAppHost>
-    <RollForward>LatestMajor</RollForward>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Customer impact

`WasmAppHost` is used to run apps created with wasm templates. This fix allows such projects that target `net7.0` to be run with `8.0` SDK.

Fixes https://github.com/dotnet/runtime/issues/79313

## Testing

Unit tests, and manual testing.

## Risk

Low.