### PR TITLE
Simplify MethodCell

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -88,20 +88,6 @@ namespace Internal.Runtime.TypeLoader
             return true;
         }
 
-        internal static bool RetrieveExactFunctionPointerIfPossible(MethodDesc method, out IntPtr result)
-        {
-            result = IntPtr.Zero;
-
-            if (!method.IsNonSharableMethod || !CheckAllHandlesValidForMethod(method))
-                return false;
-
-            RuntimeTypeHandle[] genMethodArgs = method.Instantiation.Length > 0 ? new RuntimeTypeHandle[method.Instantiation.Length] : Empty<RuntimeTypeHandle>.Array;
-            for (int i = 0; i < method.Instantiation.Length; i++)
-                genMethodArgs[i] = method.Instantiation[i].RuntimeTypeHandle;
-
-            return TypeLoaderEnvironment.Instance.TryLookupExactMethodPointerForComponents(method.OwningType.RuntimeTypeHandle, method.NameAndSignature, genMethodArgs, out result);
-        }
-
         internal static bool RetrieveMethodDictionaryIfPossible(InstantiatedMethod method)
         {
             if (method.RuntimeMethodDictionary != IntPtr.Zero)

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
@@ -155,28 +155,6 @@ namespace Internal.Runtime.TypeLoader
             return new MethodNameAndSignature(methodName, methodSig);
         }
 
-        internal static bool IsStaticMethodSignature(RuntimeSignature methodSig)
-        {
-            if (methodSig.IsNativeLayoutSignature)
-            {
-                NativeReader reader = GetNativeLayoutInfoReader(methodSig);
-                NativeParser parser = new NativeParser(reader, methodSig.NativeLayoutOffset);
-
-                MethodCallingConvention callingConvention = (MethodCallingConvention)parser.GetUnsigned();
-                return callingConvention.HasFlag(MethodCallingConvention.Static);
-            }
-            else
-            {
-                ModuleInfo module = methodSig.GetModuleInfo();
-                NativeFormatModuleInfo nativeFormatModule = (NativeFormatModuleInfo)module;
-                var metadataReader = nativeFormatModule.MetadataReader;
-                var methodHandle = methodSig.Token.AsHandle().ToMethodHandle(metadataReader);
-
-                var method = methodHandle.GetMethod(metadataReader);
-                return (method.Flags & MethodAttributes.Static) != 0;
-            }
-        }
-
         #region Private Helpers
 
         private bool TryGetTypeFromSimpleTypeSignature(ref NativeParser parser, NativeFormatModuleInfo moduleHandle, out RuntimeTypeHandle typeHandle)


### PR DESCRIPTION
Even if my life depended on it, I would not be able to explain how/why `MethodCell` works and which code paths in it we would take at runtime. This pretty much restores `MethodCell` to how it looked like before the universal shared code RI in .NET Native.

Cc @dotnet/ilc-contrib 