### PR TITLE
improve symlink handling in Ping

### DIFF
--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -40,12 +40,15 @@ namespace System.Net.NetworkInformation
         {
             if (pingBinary != null)
             {
-                string? linkedName = Interop.Sys.ReadLink(pingBinary);
-
-                // If pingBinary is not link linkedName will be null
-                if (linkedName != null && linkedName.EndsWith("busybox", StringComparison.Ordinal))
+                FileInfo info = new FileInfo(pingBinary);
+                // This is Windows way how to say it is symlink
+                if (info?.Attributes.HasFlag(FileAttributes.ReparsePoint) == true)
                 {
-                    return true;
+                    System.IO.FileSystemInfo? linkInfo = File.ResolveLinkTarget(pingBinary, returnFinalTarget: true);
+                    if (linkInfo?.Name.EndsWith("busybox", StringComparison.Ordinal) == true)
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -41,7 +41,7 @@ namespace System.Net.NetworkInformation
             if (pingBinary != null)
             {
                 FileInfo info = new FileInfo(pingBinary);
-                // This is Windows way how to say it is symlink
+                // Workaround until there is a better API to determine symlink: https://github.com/dotnet/runtime/issues/53577
                 if (info?.Attributes.HasFlag(FileAttributes.ReparsePoint) == true)
                 {
                     System.IO.FileSystemInfo? linkInfo = File.ResolveLinkTarget(pingBinary, returnFinalTarget: true);

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -40,15 +40,10 @@ namespace System.Net.NetworkInformation
         {
             if (pingBinary != null)
             {
-                FileInfo info = new FileInfo(pingBinary);
-                // Workaround until there is a better API to determine symlink: https://github.com/dotnet/runtime/issues/53577
-                if (info?.Attributes.HasFlag(FileAttributes.ReparsePoint) == true)
+                System.IO.FileSystemInfo? linkInfo = File.ResolveLinkTarget(pingBinary, returnFinalTarget: true);
+                if (linkInfo?.Name.EndsWith("busybox", StringComparison.Ordinal) == true)
                 {
-                    System.IO.FileSystemInfo? linkInfo = File.ResolveLinkTarget(pingBinary, returnFinalTarget: true);
-                    if (linkInfo?.Name.EndsWith("busybox", StringComparison.Ordinal) == true)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
 

--- a/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
@@ -56,8 +56,6 @@
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Close.cs"
              Link="Common\Interop\Unix\System.Native\Interop.Close.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ReadLink.cs"
-             Link="Common\Interop\Unix\System.Native\Interop.ReadLink.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Socket.cs"
              Link="Common\Interop\Unix\System.Native\Interop.Socket.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs"


### PR DESCRIPTION
This avoids internal direct use of `readlink` and uses public API to deal with weird errors and multiple links. Since this is only done once I also added check if a path is link before trying to resolve it. The `linkInfo` can still be null of the "ping" entry exist but either points to nowhere or it loops. 

fixes #73812 