### PR TITLE
improve SslStream exception after disposal

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -338,7 +338,7 @@ namespace System.Net.Security
             {
                 if (reAuthenticationData == null)
                 {
-                    _nestedAuth = (int)StreamUse.InUse;
+                    _nestedAuth = (int)StreamUse.NotInUse;
                     _isRenego = false;
                 }
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -175,7 +175,7 @@ namespace System.Net.Security
             }
 
             // Write is different since we do not do anything special in Dispose
-            if (Interlocked.Exchange(ref _nestedWrite, (int)StreamUse.InUse) == (int)StreamUse.NotInUse)
+            if (Interlocked.Exchange(ref _nestedWrite, (int)StreamUse.InUse) != (int)StreamUse.NotInUse)
             {
                 _nestedRead = (int)StreamUse.NotInUse;
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "write"));

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -170,12 +170,10 @@ namespace System.Net.Security
             }
         }
 
-        private enum StreamUse
-        {
-            NotInUse = 0,
-            InUse = 1,
-            Disposed = 2,
-        };
+        // used to track ussage in _nested* variables bellow
+        private const int StreamNotInUse = 0;
+        private const int StreamInUse = 1;
+        private const int StreamDisposed = 2;
 
         private int _nestedWrite;
         private int _nestedRead;
@@ -710,7 +708,7 @@ namespace System.Net.Security
         public override int ReadByte()
         {
             ThrowIfExceptionalOrNotAuthenticated();
-            if (Interlocked.Exchange(ref _nestedRead, (int)StreamUse.InUse) == (int)StreamUse.InUse)
+            if (Interlocked.Exchange(ref _nestedRead, StreamInUse) == StreamInUse)
             {
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "read"));
             }
@@ -731,7 +729,7 @@ namespace System.Net.Security
                 // Regardless of whether we were able to read a byte from the buffer,
                 // reset the read tracking.  If we weren't able to read a byte, the
                 // subsequent call to Read will set the flag again.
-                _nestedRead = (int)StreamUse.NotInUse;
+                _nestedRead = StreamNotInUse;
             }
 
             // Otherwise, fall back to reading a byte via Read, the same way Stream.ReadByte does.

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -170,6 +170,13 @@ namespace System.Net.Security
             }
         }
 
+        private enum StreamUse
+        {
+            NotInUse = 0,
+            InUse = 1,
+            Disposed = 2,
+        };
+
         private int _nestedWrite;
         private int _nestedRead;
 
@@ -703,7 +710,7 @@ namespace System.Net.Security
         public override int ReadByte()
         {
             ThrowIfExceptionalOrNotAuthenticated();
-            if (Interlocked.Exchange(ref _nestedRead, 1) == 1)
+            if (Interlocked.Exchange(ref _nestedRead, (int)StreamUse.InUse) == (int)StreamUse.InUse)
             {
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "read"));
             }
@@ -724,7 +731,7 @@ namespace System.Net.Security
                 // Regardless of whether we were able to read a byte from the buffer,
                 // reset the read tracking.  If we weren't able to read a byte, the
                 // subsequent call to Read will set the flag again.
-                _nestedRead = 0;
+                _nestedRead = (int)StreamUse.NotInUse;
             }
 
             // Otherwise, fall back to reading a byte via Read, the same way Stream.ReadByte does.

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -51,10 +51,10 @@ namespace System.Net.Security.Tests
             return true;
         }
 
-        public static (SslStream ClientStream, SslStream ServerStream) GetConnectedSslStreams()
+        public static (SslStream ClientStream, SslStream ServerStream) GetConnectedSslStreams(bool leaveInnerStreamOpen = false)
         {
             (Stream clientStream, Stream serverStream) = GetConnectedStreams();
-            return (new SslStream(clientStream), new SslStream(serverStream));
+            return (new SslStream(clientStream, leaveInnerStreamOpen), new SslStream(serverStream, leaveInnerStreamOpen));
         }
 
         public static (Stream ClientStream, Stream ServerStream) GetConnectedStreams()


### PR DESCRIPTION
As noted in #78586, `CloseInternal` (e.g. Disose) can set  `_nestedRead` to 1 and then we can throw misleading exception on next Read(Async). There are some checks in place but this seems to be race condition - I was not able to write reliable functional test for it. 
This change basically splits the value so we can reliably determine when it was set by disposal. 

Note that repro provided by @mikeharder still fails occasionally. That means that either `HttpClient` or `Azure.Core.Pipeline` does concurrent reads and that is not permitted by `SslStream`. 
Investigating that is separate from the misleading exception. 

closes #32577


 