### PR TITLE
Use static sealed vtable for dynamically created types

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -487,11 +487,6 @@ namespace Internal.Runtime.TypeLoader
                         typeInfoParser.SkipInteger(); // Handled in type layout algorithm
                         break;
 
-                    case BagElementKind.SealedVTableEntries:
-                        TypeLoaderLogger.WriteLine("Found BagElementKind.SealedVTableEntries");
-                        state.NumSealedVTableEntries = typeInfoParser.GetUnsigned();
-                        break;
-
                     case BagElementKind.DictionaryLayout:
                         TypeLoaderLogger.WriteLine("Found BagElementKind.DictionaryLayout");
                         Debug.Assert(!isTemplateUniversalCanon, "Universal template nativelayout do not have DictionaryLayout");

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -45,7 +45,6 @@ namespace Internal.Runtime.TypeLoader
 
         public RuntimeTypeHandle HalfBakedRuntimeTypeHandle;
         public IntPtr HalfBakedDictionary;
-        public IntPtr HalfBakedSealedVTable;
 
         private bool _templateComputed;
         private bool _nativeLayoutTokenComputed;
@@ -344,7 +343,6 @@ namespace Internal.Runtime.TypeLoader
         public IntPtr GcStaticDesc;
         public IntPtr ThreadStaticDesc;
         public uint ThreadStaticOffset;
-        public uint NumSealedVTableEntries;
         public GenericVariance[] GenericVarianceFlags;
 
         // Sentinel static to allow us to initialize _instanceLayout to something

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
@@ -52,7 +52,7 @@ namespace Internal.NativeFormat
         ThreadStaticOffset          = 0x4a,
         FieldLayout                 = 0x4b,
         // unused                   = 0x4c,
-        SealedVTableEntries         = 0x4d,
+        // unused                   = 0x4d,
         ClassConstructorPointer     = 0x4e,
         // unused                   = 0x4f,
         GenericVarianceInfo         = 0x50,

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -1229,16 +1229,6 @@ namespace ILCompiler.DependencyAnalysis
                 layoutInfo.Append(BagElementKind.BaseType, factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.TypeSignatureVertex(_type.BaseType)).WriteVertex(factory));
             }
 
-            if (!_type.IsArrayTypeWithoutGenericInterfaces() && ConstructedEETypeNode.CreationAllowed(_type))
-            {
-                SealedVTableNode sealedVTable = factory.SealedVTable(_type.ConvertToCanonForm(CanonicalFormKind.Specific));
-
-                sealedVTable.BuildSealedVTableSlots(factory, relocsOnly: false /* This is the final emission phase */);
-
-                if (sealedVTable.NumSealedVTableEntries > 0)
-                    layoutInfo.AppendUnsigned(BagElementKind.SealedVTableEntries, (uint)sealedVTable.NumSealedVTableEntries);
-            }
-
             if (_type.GetTypeDefinition().HasVariance || factory.TypeSystemContext.IsGenericArrayInterfaceType(_type))
             {
                 // Runtime casting logic relies on all interface types implemented on arrays


### PR DESCRIPTION
The sealed vtable is identical for all canonically equivalent types. We had a to make a copy because in the presence of universal shared generics, new sealed vtables could be created for dynamic types and those need to use pointer-sized slots (the slots are relative pointers in the static case and have been since Redhawk times).

Cc @dotnet/ilc-contrib 