### PR TITLE
[wasm] fix marshaling Error to C# as JSType.Any

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportExportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportExportTest.cs
@@ -1391,6 +1391,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
+        public void JSImportReturnError()
+        {
+            var err = JavaScriptTestHelper.returnError() as Exception;
+            Assert.NotNull(err);
+            Assert.Contains("this-is-error", err.Message);
+        }
+
+        [Fact]
         public void JsExportCatchToString()
         {
             var toString = JavaScriptTestHelper.catch1toString("-t-e-s-t-", nameof(JavaScriptTestHelper.ThrowFromJSExport));

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -109,6 +109,10 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [return: JSMarshalAs<JSType.Discard>]
         internal static partial void throw0();
 
+        [JSImport("returnError", "JavaScriptTestHelper")]
+        [return: JSMarshalAs<JSType.Any>]
+        internal static partial object returnError();
+
         [JSImport("echo1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Promise<JSType.Void>>]
         internal static partial Task echo1_Task([JSMarshalAs<JSType.Promise<JSType.Void>>] Task arg1);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
@@ -110,6 +110,10 @@ export function throw0fn() {
     throw new Error('throw-0-msg');
 }
 
+export function returnError() {
+    return new Error('this-is-error');
+}
+
 export function catch1toString(message, functionName) {
     const JavaScriptTestHelper = dllExports.System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper;
     const fn = JavaScriptTestHelper[functionName];

--- a/src/mono/wasm/runtime/marshal-to-cs.ts
+++ b/src/mono/wasm/runtime/marshal-to-cs.ts
@@ -386,9 +386,7 @@ function _marshal_cs_object_to_cs(arg: JSMarshalerArgument, value: any): void {
                 set_arg_date(arg, value);
             }
             else if (value instanceof Error) {
-                set_arg_type(arg, MarshalerType.JSException);
-                const js_handle = mono_wasm_get_js_handle(value);
-                set_js_handle(arg, js_handle);
+                marshal_exception_to_cs(arg, value);
             }
             else if (value instanceof Uint8Array) {
                 marshal_array_to_cs_impl(arg, value, MarshalerType.Byte);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/78972

`_marshal_cs_object_to_cs` is dynamic marshaling by type of JavaScript object. 
It used incomplete implementation of `Error` marshaling and created managed string reference to random pointer as result.
This fix is using common method for marshaling Error, instead of the broken duplicate.