### PR TITLE
JIT: Allow cloning addresses even before initobj

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8387,8 +8387,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     {
                         clone = true;
                     }
-                    else if (op1->TypeIs(TYP_BYREF, TYP_I_IMPL) && impIsAddressInLocal(op1) &&
-                             (OPCODE)impGetNonPrefixOpcode(codeAddr + sz, codeEndp) != CEE_INITOBJ)
+                    else if (op1->TypeIs(TYP_BYREF, TYP_I_IMPL) && impIsAddressInLocal(op1))
                     {
                         // We mark implicit byrefs with GTF_GLOB_REF (see gtNewFieldRef for why).
                         // Avoid cloning for these.


### PR DESCRIPTION
Roslyn emits ldloca + dup + initobj when initializing structs. Normally we clone address trees instead of creating a local for them (which will address expose the local), but we treat this initobj pattern specially.

Remove this special treatment. It means we sometimes end up with slightly larger code because we no longer have a register with the address in it (could potentially be fixed by CSE), but avoiding the address exposure seems like the right trade off to me.

Fix #42354
Fix #57055