### PR TITLE
Ignoring test regression runtime_63354 in x86

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -280,6 +280,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_31615/Runtime_31615/*">
             <Issue>https://github.com/dotnet/runtime/issues/79170</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_63354/Runtime_63354/*">
+            <Issue>https://github.com/dotnet/runtime/issues/78898</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows arm32 specific excludes -->

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -280,7 +280,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_31615/Runtime_31615/*">
             <Issue>https://github.com/dotnet/runtime/issues/79170</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_63354/Runtime_63354/*">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_63354/Runtime_63354/**">
             <Issue>https://github.com/dotnet/runtime/issues/78898</Issue>
         </ExcludeList>
     </ItemGroup>


### PR DESCRIPTION
Ignoring the test for the moment until solving the [issue 78898](https://github.com/dotnet/runtime/issues/78898)