### PR TITLE
Fix declaration of local in regex source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -3870,7 +3870,8 @@ namespace System.Text.RegularExpressions.Generator
                     // only to find we can't iterate further, and will need to clear any pushed state from the backtracking
                     // stack.  For both cases, we need to store the starting stack index so it can be reset to that position.
                     startingStackpos = ReserveName("startingStackpos");
-                    writer.WriteLine($"int {startingStackpos} = stackpos;");
+                    additionalDeclarations.Add($"int {startingStackpos} = 0;");
+                    writer.WriteLine($"{startingStackpos} = stackpos;");
                 }
 
                 string originalDoneLabel = doneLabel;


### PR DESCRIPTION
Caught by an outer loop test I neglected to run on a previous change.  It's possible now with the additional use of startingStackpos that the C# compiler might see the local as being used uninitialized even though the paths that lead to it being used always have it initialized.