### PR TITLE
Add experimental Regex test based on SampleMatches

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
@@ -30,6 +30,8 @@ namespace System.Text.RegularExpressions.Symbolic
         [ExcludeFromCodeCoverage(Justification = "Currently only used for testing")]
         public override IEnumerable<string> SampleMatches(int k, int randomseed)
         {
+            var results = new List<string>();
+
             lock (this)
             {
                 // Zero is treated as no seed, instead using a system provided one
@@ -119,7 +121,7 @@ namespace System.Text.RegularExpressions.Symbolic
                             // Choose to stop here based on a coin-toss
                             if (FlipBiasedCoin(random, SampleMatchesStoppingProbability))
                             {
-                                yield return latestCandidate.ToString();
+                                results.Add(latestCandidate.ToString());
                                 break;
                             }
                         }
@@ -153,12 +155,14 @@ namespace System.Text.RegularExpressions.Symbolic
                             // such as @"no\bway" or due to poor choice of c -- no anchor is enabled -- so this is a deadend.
                             if (latestCandidate != null)
                             {
-                                yield return latestCandidate.ToString();
+                                results.Add(latestCandidate.ToString());
                             }
                             break;
                         }
                     }
                 }
+
+                return results;
             }
 
             static BDD ToBDD(TSet set, ISolver<TSet> solver, CharSetSolver charSetSolver) => solver.ConvertToBDD(set, charSetSolver);


### PR DESCRIPTION
This adds a (currently disactivated) test that takes the ~15K regexes in our pattern database, generates inputs for each using the NonBacktracking engine's sampler, and then validates all the engines with that pattern.  The sampler currently hangs on some patterns, and it asserts on others, so this is manual-only until such issues can be fixed.  Still, I was able to run another ~10K patterns through all the engines before it fell over with an assert.  The sampler also only currently supports generating inputs known to match; it'd be good to also generate inputs known to not match.

Closes https://github.com/dotnet/runtime/issues/25372