### PR TITLE
Fix Sse3 => Ssse3 typo

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/IndexOfAnyValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IndexOfAnyValues/IndexOfAnyValues.cs
@@ -56,7 +56,7 @@ namespace System.Buffers
             {
                 IndexOfAnyAsciiSearcher.ComputeBitmap(values, out Vector128<byte> bitmap, out BitVector256 lookup);
 
-                return Sse3.IsSupported && lookup.Contains(0)
+                return Ssse3.IsSupported && lookup.Contains(0)
                     ? new IndexOfAnyAsciiByteValues<IndexOfAnyAsciiSearcher.Ssse3HandleZeroInNeedle>(bitmap, lookup)
                     : new IndexOfAnyAsciiByteValues<IndexOfAnyAsciiSearcher.Default>(bitmap, lookup);
             }
@@ -101,7 +101,7 @@ namespace System.Buffers
             {
                 IndexOfAnyAsciiSearcher.ComputeBitmap(values, out Vector128<byte> bitmap, out BitVector256 lookup);
 
-                return Sse3.IsSupported && lookup.Contains(0)
+                return Ssse3.IsSupported && lookup.Contains(0)
                     ? new IndexOfAnyAsciiCharValues<IndexOfAnyAsciiSearcher.Ssse3HandleZeroInNeedle>(bitmap, lookup)
                     : new IndexOfAnyAsciiCharValues<IndexOfAnyAsciiSearcher.Default>(bitmap, lookup);
             }


### PR DESCRIPTION
By the time we get here we've already checked `Ssse3.IsSupported || AdvSimd.Arm64.IsSupported`, and `Ssse3` implies `Sse3`, so this is acting more so as an "is X86" check. The typo is therefore harmless, but annoys me every time I see it.