### PR TITLE
Fix BN_is_zero for OpenSSL 1.0.2 non-portable build

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -54,6 +54,7 @@
 #if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_1_0_RTM
 
 // Remove problematic #defines
+#undef BN_is_zero
 #undef SSL_get_state
 #undef SSL_is_init_finished
 #undef X509_get_X509_PUBKEY


### PR DESCRIPTION
I checked this change against CentOS 7.

Before this change, running `build-native.sh -portableBuild=false` would produce:

```
#define BN_is_zero local_BN_is_zero
        ^
/usr/include/openssl/bn.h:403:10: note: previous definition is here
# define BN_is_zero(a)       ((a)->top == 0)
```

After this change, I am able to do a non-portable build successfully. This issue was introduced in https://github.com/dotnet/runtime/pull/79013#issuecomment-1341682575.

/cc @mmitche 