### PR TITLE
fix determin lib name varation logic

### DIFF
--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -549,7 +549,7 @@ namespace
             SString::CIterator it = libName.Begin();
             if (libName.Find(it, PLATFORM_SHARED_LIB_SUFFIX_W))
             {
-                it += ARRAY_SIZE(PLATFORM_SHARED_LIB_SUFFIX_W);
+                it += (ARRAY_SIZE(PLATFORM_SHARED_LIB_SUFFIX_W) - 1);
                 containsSuffix = it == libName.End() || *it == (WCHAR)'.';
             }
 


### PR DESCRIPTION
When checking whether the suffix is contained, the size calcuation is wrong.

In case of Linux, u".so" is defined to PLATFORM_SHARED_LIB_SUFFIX_W. 
So, string length "3" should be added to iterator. 
But, in the current implementation, ARRAY_SIZE(PLATFORM_SHARED_LIB_SUFFIX_W) "4" is added to iterator and it make wrong checking.

If libName is "libc.so.6", iterator points '6' not '.' while checking suffix.