### PR TITLE
Update doc to describe host_runtime_contract

### DIFF
--- a/docs/design/features/host-runtime-information.md
+++ b/docs/design/features/host-runtime-information.md
@@ -1,12 +1,36 @@
-# Host: well-known runtime properties
+# Host: providing information to the runtime
 
-The host passes information to the runtime via a set of runtime properties - key and value strings. These properties include [runtime configuration settings](https://learn.microsoft.com/dotnet/core/runtime-config) that a user can specify in a [runtimeconfig.json](https://learn.microsoft.com/dotnet/core/runtime-config/#runtimeconfigjson) or [MSBuild properties](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#runtime-configuration-properties). The host itself also has a set of well-known properties that it will pass to the runtime when applicable. This document describes those well-known properties.
+The host passes information to the runtime via a set of runtime properties - key and value strings. These properties include [runtime configuration settings](https://learn.microsoft.com/dotnet/core/runtime-config) that a user can specify in a [runtimeconfig.json](https://learn.microsoft.com/dotnet/core/runtime-config/#runtimeconfigjson) or [MSBuild properties](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#runtime-configuration-properties). The host itself also has a set of well-known properties that it will pass to the runtime when applicable.
 
-### Path separator
+Starting with .NET 8, one of those properties represents a contract between the host and runtime. This document describes that contract and other well-known properties.
+
+## Host runtime contract
+
+Relying on key-value strings as part of initialization of the runtime comes with some drawbacks:
+
+- Any information has to be represented as a string. Other structured or non-string data becomes awkward to communicate.
+- Each property comes with non-trivial overhead. As the properties flow through the hosting layer, runtime, and libraries, multiple copies are made of each name and value.
+- Properties are pre-computed and set at startup. Every application, regardless of whether or not it requires a specific property, much pay the cost of all properties.
+
+To allow a more flexible and less costly way to pass information between the host and runtime, in .NET 8+, the host passes a contract to the runtime as a property. This contract servers as a mechanism for runtime to query for information for the host and for the host to provide structured information to the runtime.
+
+`HOST_RUNTIME_CONTRACT`
+
+Hex string representation of a pointer to a [`host_runtime_contract` struct](/src/native/corehost/host_runtime_contract.h).
+
+The `get_runtime_property` function provides key-value string information (like that provided for runtime initialization). This removes the requirement to pre-compute and store all properties. [Existing properties](#well-known-runtime-properties) can be migrated to go through this mechanism, allowing for pay-for-play properties and reducing the cost of properties.
+
+Some existing properties (for example, [probing path properties](#probing-paths)) would benefit from being structured data rather than a single string. The contract can be extended to allow querying for that specific, structured information rather than relying only on strings. For backwards compatibility for existing properties, we would still allow getting the string via `get_runtime_property`, but that would be an on-demand cost.
+
+## Well-known runtime properties
+
+These can be retrieved via the `host_runtime_contract.get_runtime_property` function. Before the introduction of the host runtime contract, these all had to be passed directly to `coreclr_initialize`.
+
+#### Path separator
 
 All properties that contain a list of paths use a platform-specific path separator. This corresponds to `;` on Windows and `:` on Unix.
 
-## App information
+### App information
 
 `APP_CONTEXT_BASE_DIRECTORY`
 
@@ -16,7 +40,7 @@ Directory containing the application. This is used for [`AppContext.BaseDirector
 
 [Runtime identifier](https://learn.microsoft.com/dotnet/core/rid-catalog) for the application. This is used for [`RuntimeInformation.RuntimeIdentifier`](https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.runtimeinformation.runtimeidentifier).
 
-## Deps files
+### Deps files
 
 `APP_CONTEXT_DEPS_FILES`
 
@@ -26,13 +50,13 @@ Path to the `deps.json` file for the application. This is used by [`Microsoft.Ex
 
 Path to the `deps.json` file the root shared framework - `Microsoft.NETCore.App` - for framework-dependent applications. This is used by [`Microsoft.Extensions.DependencyModel`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.dependencymodel).
 
-## Startup
+### Startup
 
 `STARTUP_HOOKS`
 
 List of assemblies (paths or names) containing a [`StartupHook`](./host-startup-hook.md) to be run before the application's main entry point. Paths are delimited by a [platform-specific path separator](#path-separator).
 
-## Probing paths
+### Probing paths
 
 `TRUSTED_PLATFORM_ASSEMBLIES`
 
@@ -54,7 +78,7 @@ List of directory paths to search for managed assemblies. Paths are delimited by
 
 List of directory paths corresponding to shared store paths and additional probing paths used by the host for [probing paths](./host-probing.md#probing-paths). Paths are delimited by a [platform-specific path separator](#path-separator).
 
-## Single-file
+### Single-file
 
 `BUNDLE_PROBE`
 

--- a/docs/design/features/host-runtime-information.md
+++ b/docs/design/features/host-runtime-information.md
@@ -10,9 +10,9 @@ Relying on key-value strings as part of initialization of the runtime comes with
 
 - Any information has to be represented as a string. Other structured or non-string data becomes awkward to communicate.
 - Each property comes with non-trivial overhead. As the properties flow through the hosting layer, runtime, and libraries, multiple copies are made of each name and value.
-- Properties are pre-computed and set at startup. Every application, regardless of whether or not it requires a specific property, much pay the cost of all properties.
+- Properties are pre-computed and set at startup. Every application, regardless of whether or not it requires a specific property, must pay the cost of all properties.
 
-To allow a more flexible and less costly way to pass information between the host and runtime, in .NET 8+, the host passes a contract to the runtime as a property. This contract servers as a mechanism for runtime to query for information for the host and for the host to provide structured information to the runtime.
+To allow a more flexible and less costly way to pass information between the host and runtime, in .NET 8+, the host passes a contract to the runtime as a property. This contract servers as a mechanism for runtime to query for information from the host and for the host to provide structured information to the runtime.
 
 `HOST_RUNTIME_CONTRACT`
 


### PR DESCRIPTION
Add description for host runtime contract to doc describing host-runtime properties (and rename to be a doc describing host-runtime information passing).

Related: https://github.com/dotnet/runtime/pull/78798