### PR TITLE
Allow preinitializing types with canonical forms

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -118,7 +118,7 @@ namespace ILCompiler
         protected PreinitializationManager GetPreinitializationManager()
         {
             if (_preinitializationManager == null)
-                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), enableInterpreter: false);
+                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy());
             return _preinitializationManager;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericTypesTemplateMap.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericTypesTemplateMap.cs
@@ -50,17 +50,10 @@ namespace ILCompiler.DependencyAnalysis
             Section nativeSection = nativeWriter.NewSection();
             nativeSection.Place(hashtable);
 
-            foreach (TypeDesc type in factory.MetadataManager.GetTypesWithConstructedEETypes())
+            foreach (TypeDesc type in factory.MetadataManager.GetTypeTemplates())
             {
-                if (!IsEligibleToHaveATemplate(type))
-                    continue;
-
                 // Type's native layout info
                 NativeLayoutTemplateTypeLayoutVertexNode templateNode = factory.NativeLayout.TemplateTypeLayout(type);
-
-                // If this template isn't considered necessary, don't emit it.
-                if (!templateNode.Marked)
-                    continue;
                 Vertex nativeLayout = templateNode.SavedVertex;
 
                 // Hashtable Entry

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -921,6 +921,8 @@ namespace ILCompiler.DependencyAnalysis
         private TypeDesc _type;
         private bool _isUniversalCanon;
 
+        public TypeDesc CanonType => _type.ConvertToCanonForm(CanonicalFormKind.Specific);
+
         protected override string GetName(NodeFactory factory) => "NativeLayoutTemplateTypeLayoutVertexNode_" + factory.NameMangler.GetMangledTypeName(_type);
 
         public NativeLayoutTemplateTypeLayoutVertexNode(NodeFactory factory, TypeDesc type)
@@ -989,7 +991,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            if (context.PreinitializationManager.HasLazyStaticConstructor(_type))
+            if (context.PreinitializationManager.HasLazyStaticConstructor(_type.ConvertToCanonForm(CanonicalFormKind.Specific)))
             {
                 yield return new DependencyListEntry(context.MethodEntrypoint(_type.GetStaticConstructor().GetCanonMethodTarget(CanonicalFormKind.Specific)), "cctor for template");
             }
@@ -1188,7 +1190,7 @@ namespace ILCompiler.DependencyAnalysis
                 layoutInfo.Append(BagElementKind.DictionaryLayout, dictionaryLayout.WriteVertex(factory));
             }
 
-            if (factory.PreinitializationManager.HasLazyStaticConstructor(_type))
+            if (factory.PreinitializationManager.HasLazyStaticConstructor(_type.ConvertToCanonForm(CanonicalFormKind.Specific)))
             {
                 MethodDesc cctorMethod = _type.GetStaticConstructor();
                 MethodDesc canonCctorMethod = cctorMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -74,24 +74,23 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public bool HasCCtorContext
+        public static bool TypeHasCctorContext(PreinitializationManager preinitializationManager, MetadataType type)
         {
-            get
-            {
-                // If the type has a lazy static constructor, we need the cctor context.
-                if (_preinitializationManager.HasLazyStaticConstructor(_type))
-                    return true;
+            // If the type has a lazy static constructor, we need the cctor context.
+            if (preinitializationManager.HasLazyStaticConstructor(type))
+                return true;
 
-                // If the type has a canonical form and accessing the base from a canonical
-                // context requires a cctor check, we need the cctor context.
-                TypeDesc canonType = _type.ConvertToCanonForm(CanonicalFormKind.Specific);
-                if (canonType != _type && _preinitializationManager.HasLazyStaticConstructor(canonType))
-                    return true;
+            // If the type has a canonical form and accessing the base from a canonical
+            // context requires a cctor check, we need the cctor context.
+            TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
+            if (canonType != type && preinitializationManager.HasLazyStaticConstructor(canonType))
+                return true;
 
-                // Otherwise no cctor context needed.
-                return false;
-            }
+            // Otherwise no cctor context needed.
+            return false;
         }
+
+        public bool HasCCtorContext => TypeHasCctorContext(_preinitializationManager, _type);
 
         public bool HasLazyStaticConstructor => _preinitializationManager.HasLazyStaticConstructor(_type);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -33,7 +33,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override ObjectNodeSection GetDehydratedSection(NodeFactory factory)
         {
-            if (_preinitializationManager.HasLazyStaticConstructor(_type)
+            if (HasCCtorContext
                 || _preinitializationManager.IsPreinitialized(_type))
             {
                 // We have data to be emitted so this needs to be in an initialized data section
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis
             get
             {
                 // Make sure the NonGCStatics symbol always points to the beginning of the data.
-                if (_preinitializationManager.HasLazyStaticConstructor(_type))
+                if (HasCCtorContext)
                 {
                     return GetClassConstructorContextStorageSize(_type.Context.Target, _type);
                 }
@@ -74,7 +74,26 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public bool HasCCtorContext => _preinitializationManager.HasLazyStaticConstructor(_type);
+        public bool HasCCtorContext
+        {
+            get
+            {
+                // If the type has a lazy static constructor, we need the cctor context.
+                if (_preinitializationManager.HasLazyStaticConstructor(_type))
+                    return true;
+
+                // If the type has a canonical form and accessing the base from a canonical
+                // context requires a cctor check, we need the cctor context.
+                TypeDesc canonType = _type.ConvertToCanonForm(CanonicalFormKind.Specific);
+                if (canonType != _type && _preinitializationManager.HasLazyStaticConstructor(canonType))
+                    return true;
+
+                // Otherwise no cctor context needed.
+                return false;
+            }
+        }
+
+        public bool HasLazyStaticConstructor => _preinitializationManager.HasLazyStaticConstructor(_type);
 
         public override bool IsShareable => EETypeNode.IsTypeNodeShareable(_type);
 
@@ -124,7 +143,7 @@ namespace ILCompiler.DependencyAnalysis
 
             // If the type has a class constructor, its non-GC statics section is prefixed
             // by System.Runtime.CompilerServices.StaticClassConstructionContext struct.
-            if (factory.PreinitializationManager.HasLazyStaticConstructor(_type))
+            if (HasCCtorContext)
             {
                 int alignmentRequired = Math.Max(_type.NonGCStaticFieldAlignment.AsInt, GetClassConstructorContextAlignment(_type.Context.Target));
                 int classConstructorContextStorageSize = GetClassConstructorContextStorageSize(factory.Target, _type);
@@ -138,7 +157,24 @@ namespace ILCompiler.DependencyAnalysis
                 // Emit the actual StaticClassConstructionContext
                 MethodDesc cctorMethod = _type.GetStaticConstructor();
                 builder.EmitPointerReloc(factory.ExactCallableAddress(cctorMethod));
-                builder.EmitZeroPointer();
+
+                // If we're emitting the cctor context, but the type is actually preinitialized, emit the
+                // cctor context as already executed.
+                if (!HasLazyStaticConstructor)
+                {
+                    // Constructor executed
+                    // TODO-NICE: introduce a named constant and also use it in the runner in CoreLib
+                    builder.EmitInt(1);
+                }
+                else
+                {
+                    // Constructor didn't execute
+                    builder.EmitInt(0);
+                }
+
+                // Emit padding if needed
+                if (builder.TargetPointerSize == 8)
+                    builder.EmitInt(0);
             }
             else
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
@@ -57,7 +57,7 @@ namespace ILCompiler.DependencyAnalysis
                     dependencies.Add(factory.TypeGCStaticsSymbol(metadataType), "GC statics indirection for StaticsInfoHashtable");
                 }
 
-                if (metadataType.NonGCStaticFieldSize.AsInt > 0 || factory.PreinitializationManager.HasLazyStaticConstructor(type))
+                if (metadataType.NonGCStaticFieldSize.AsInt > 0 || NonGCStaticsNode.TypeHasCctorContext(factory.PreinitializationManager, metadataType))
                 {
                     // The entry in the StaticsInfoHashtable points at the beginning of the static fields data, rather than the cctor
                     // context offset.
@@ -98,7 +98,7 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     bag.AppendUnsigned(BagElementKind.GcStaticData, _nativeStaticsReferences.GetIndex(factory.TypeGCStaticsSymbol(metadataType)));
                 }
-                if (metadataType.NonGCStaticFieldSize.AsInt > 0 || factory.PreinitializationManager.HasLazyStaticConstructor(type))
+                if (metadataType.NonGCStaticFieldSize.AsInt > 0 || NonGCStaticsNode.TypeHasCctorContext(factory.PreinitializationManager, metadataType))
                 {
                     bag.AppendUnsigned(BagElementKind.NonGcStaticData, _nativeStaticsReferences.GetIndex(factory.TypeNonGCStaticsSymbol(metadataType)));
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -70,8 +70,7 @@ namespace ILCompiler.DependencyAnalysis
 
                         EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
 
-                        MetadataType target = (MetadataType)_target;
-                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (!TriggersLazyStaticConstructor(factory))
                         {
                             encoder.EmitRET();
                         }
@@ -99,7 +98,7 @@ namespace ILCompiler.DependencyAnalysis
                         encoder.EmitLDR(encoder.TargetRegister.Result, encoder.TargetRegister.Result);
 
                         MetadataType target = (MetadataType)_target;
-                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (!TriggersLazyStaticConstructor(factory))
                         {
                             encoder.EmitRET();
                         }
@@ -132,7 +131,7 @@ namespace ILCompiler.DependencyAnalysis
                         EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Arg1, _lookupSignature, relocsOnly);
 
                         ISymbolNode helperEntrypoint;
-                        if (factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (TriggersLazyStaticConstructor(factory))
                         {
                             // There is a lazy class constructor. We need the non-GC static base because that's where the
                             // class constructor context lives.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunGenericHelperNode.cs
@@ -81,8 +81,7 @@ namespace ILCompiler.DependencyAnalysis
 
                         EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
 
-                        MetadataType target = (MetadataType)_target;
-                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (!TriggersLazyStaticConstructor(factory))
                         {
                             encoder.EmitRET();
                         }
@@ -111,7 +110,7 @@ namespace ILCompiler.DependencyAnalysis
                         encoder.EmitLDR(encoder.TargetRegister.Result, encoder.TargetRegister.Result);
 
                         MetadataType target = (MetadataType)_target;
-                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (!TriggersLazyStaticConstructor(factory))
                         {
                             encoder.EmitRET();
                         }
@@ -144,7 +143,7 @@ namespace ILCompiler.DependencyAnalysis
                         EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Arg1, _lookupSignature, relocsOnly);
 
                         ISymbolNode helperEntrypoint;
-                        if (factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (TriggersLazyStaticConstructor(factory))
                         {
                             // There is a lazy class constructor. We need the non-GC static base because that's where the
                             // class constructor context lives.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunGenericHelperNode.cs
@@ -70,8 +70,7 @@ namespace ILCompiler.DependencyAnalysis
 
                         EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
 
-                        MetadataType target = (MetadataType)_target;
-                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (!TriggersLazyStaticConstructor(factory))
                         {
                             encoder.EmitRET();
                         }
@@ -100,7 +99,7 @@ namespace ILCompiler.DependencyAnalysis
                         encoder.EmitLD(encoder.TargetRegister.Result, encoder.TargetRegister.Result, 0);
 
                         MetadataType target = (MetadataType)_target;
-                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (!TriggersLazyStaticConstructor(factory))
                         {
                             encoder.EmitRET();
                         }
@@ -133,7 +132,7 @@ namespace ILCompiler.DependencyAnalysis
                         EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Arg1, _lookupSignature, relocsOnly);
 
                         ISymbolNode helperEntrypoint;
-                        if (factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (TriggersLazyStaticConstructor(factory))
                         {
                             // There is a lazy class constructor. We need the non-GC static base because that's where the
                             // class constructor context lives.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -82,9 +82,7 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         Debug.Assert(contextRegister == encoder.TargetRegister.Arg0);
 
-                        MetadataType target = (MetadataType)_target;
-
-                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (!TriggersLazyStaticConstructor(factory))
                         {
                             EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
                             encoder.EmitRET();
@@ -119,7 +117,7 @@ namespace ILCompiler.DependencyAnalysis
                         AddrMode loadFromResult = new AddrMode(encoder.TargetRegister.Result, null, 0, 0, AddrModeSize.Int64);
                         encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromResult);
 
-                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (!TriggersLazyStaticConstructor(factory))
                         {
                             encoder.EmitRET();
                         }
@@ -153,7 +151,7 @@ namespace ILCompiler.DependencyAnalysis
                         EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Arg1, _lookupSignature, relocsOnly);
 
                         ISymbolNode helperEntrypoint;
-                        if (factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        if (TriggersLazyStaticConstructor(factory))
                         {
                             // There is a lazy class constructor. We need the non-GC static base because that's where the
                             // class constructor context lives.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -247,6 +247,11 @@ namespace ILCompiler
             return new ScannedMethodImportationErrorProvider(MarkedNodes);
         }
 
+        public TypePreinit.TypePreinitializationPolicy GetPreinitializationPolicy()
+        {
+            return new ScannedPreinitializationPolicy(MarkedNodes);
+        }
+
         private sealed class ScannedVTableProvider : VTableSliceProvider
         {
             private Dictionary<TypeDesc, IReadOnlyList<MethodDesc>> _vtableSlices = new Dictionary<TypeDesc, IReadOnlyList<MethodDesc>>();
@@ -628,6 +633,48 @@ namespace ILCompiler
 
             public override TypeSystemException GetCompilationError(MethodDesc method)
                 => _importationErrors.TryGetValue(method, out var exception) ? exception : null;
+        }
+
+        private sealed class ScannedPreinitializationPolicy : TypePreinit.TypePreinitializationPolicy
+        {
+            private readonly HashSet<TypeDesc> _canonFormsWithCctorChecks = new HashSet<TypeDesc>();
+
+            public ScannedPreinitializationPolicy(ImmutableArray<DependencyNodeCore<NodeFactory>> markedNodes)
+            {
+                foreach (var markedNode in markedNodes)
+                {
+                    // If there's a type loader template for a type, we can create new instances
+                    // at runtime that will not be preinitialized.
+                    // This makes sure accessing static bases of template-constructed types
+                    // goes through a cctor check.
+                    if (markedNode is NativeLayoutTemplateTypeLayoutVertexNode typeTemplate)
+                    {
+                        _canonFormsWithCctorChecks.Add(typeTemplate.CanonType);
+                    }
+
+                    // If there's a type for which we have a canonical form that requires
+                    // a cctor check, make sure accessing the static base from a shared generic context
+                    // will trigger the cctor.
+                    // This makes sure that "static object Read<T>() => SomeType<T>.StaticField" will do
+                    // a cctor check if any of the canonically-equivalent SomeType instantiations required
+                    // a cctor check.
+                    if (markedNode is NonGCStaticsNode nonGCStatics
+                        && nonGCStatics.Type.ConvertToCanonForm(CanonicalFormKind.Specific) != nonGCStatics.Type
+                        && nonGCStatics.HasLazyStaticConstructor)
+                    {
+                        _canonFormsWithCctorChecks.Add(nonGCStatics.Type.ConvertToCanonForm(CanonicalFormKind.Specific));
+                    }
+                }
+            }
+
+            public override bool CanPreinitialize(DefType type) => true;
+
+            public override bool CanPreinitializeAllConcreteFormsForCanonForm(DefType type)
+            {
+                Debug.Assert(type.ConvertToCanonForm(CanonicalFormKind.Specific) == type);
+                Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
+                return !_canonFormsWithCctorChecks.Contains(type);
+            }
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -671,9 +671,9 @@ namespace ILCompiler
 
             public override bool CanPreinitializeAllConcreteFormsForCanonForm(DefType type)
             {
-                Debug.Assert(type.ConvertToCanonForm(CanonicalFormKind.Specific) == type);
+                // The form we're asking about should be canonical, but may not be normalized
                 Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
-                return !_canonFormsWithCctorChecks.Contains(type);
+                return !_canonFormsWithCctorChecks.Contains(type.NormalizeInstantiation());
             }
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -63,6 +63,7 @@ namespace ILCompiler
         private readonly SortedSet<DefType> _typesWithDelegateMarshalling = new SortedSet<DefType>(TypeSystemComparer.Instance);
         private readonly SortedSet<DefType> _typesWithStructMarshalling = new SortedSet<DefType>(TypeSystemComparer.Instance);
         private HashSet<NativeLayoutTemplateMethodSignatureVertexNode> _templateMethodEntries = new HashSet<NativeLayoutTemplateMethodSignatureVertexNode>();
+        private readonly SortedSet<TypeDesc> _typeTemplates = new SortedSet<TypeDesc>(TypeSystemComparer.Instance);
 
         private List<(DehydratableObjectNode Node, ObjectNode.ObjectData Data)> _dehydratableData = new List<(DehydratableObjectNode Node, ObjectNode.ObjectData data)>();
 
@@ -240,7 +241,7 @@ namespace ILCompiler
             }
 
             var nonGcStaticSectionNode = obj as NonGCStaticsNode;
-            if (nonGcStaticSectionNode != null && nonGcStaticSectionNode.HasCCtorContext)
+            if (nonGcStaticSectionNode != null && nonGcStaticSectionNode.HasLazyStaticConstructor)
             {
                 _cctorContextsGenerated.Add(nonGcStaticSectionNode);
             }
@@ -278,6 +279,11 @@ namespace ILCompiler
             if (obj is NativeLayoutTemplateMethodSignatureVertexNode templateMethodEntry)
             {
                 _templateMethodEntries.Add(templateMethodEntry);
+            }
+
+            if (obj is NativeLayoutTemplateTypeLayoutVertexNode typeTemplate)
+            {
+                _typeTemplates.Add(typeTemplate.CanonType);
             }
 
             if (obj is FrozenObjectNode frozenObj)
@@ -709,6 +715,11 @@ namespace ILCompiler
         public IEnumerable<MethodDesc> GetReflectableMethods()
         {
             return _reflectableMethods;
+        }
+
+        public IEnumerable<TypeDesc> GetTypeTemplates()
+        {
+            return _typeTemplates;
         }
 
         public IEnumerable<EmbeddedObjectNode> GetFrozenObjects()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
@@ -13,13 +13,11 @@ namespace ILCompiler
     public class PreinitializationManager
     {
         private readonly bool _supportsLazyCctors;
-        private readonly bool _enableInterpreter;
 
-        public PreinitializationManager(TypeSystemContext context, CompilationModuleGroup compilationGroup, ILProvider ilprovider, bool enableInterpreter)
+        public PreinitializationManager(TypeSystemContext context, CompilationModuleGroup compilationGroup, ILProvider ilprovider, TypePreinit.TypePreinitializationPolicy policy)
         {
             _supportsLazyCctors = context.SystemModule.GetType("System.Runtime.CompilerServices", "ClassConstructorRunner", throwIfNotFound: false) != null;
-            _preinitHashTable = new PreinitializationInfoHashtable(compilationGroup, ilprovider);
-            _enableInterpreter = enableInterpreter;
+            _preinitHashTable = new PreinitializationInfoHashtable(compilationGroup, ilprovider, policy);
         }
 
         /// <summary>
@@ -82,10 +80,6 @@ namespace ILCompiler
 
         public bool IsPreinitialized(MetadataType type)
         {
-            // If the cctor interpreter is not enabled, no type is preinitialized.
-            if (!_enableInterpreter)
-                return false;
-
             if (!type.HasStaticConstructor)
                 return false;
 
@@ -102,7 +96,7 @@ namespace ILCompiler
 
         public void LogStatistics(Logger logger)
         {
-            if (!_enableInterpreter)
+            if (_preinitHashTable._policy is TypePreinit.DisabledPreinitializationPolicy)
                 return;
 
             int totalEligibleTypes = 0;
@@ -112,6 +106,10 @@ namespace ILCompiler
             {
                 foreach (var item in LockFreeReaderHashtable<MetadataType, TypePreinit.PreinitializationInfo>.Enumerator.Get(_preinitHashTable))
                 {
+                    // Canonical types are not actual types. They represent the pessimized version of all types that share the form.
+                    if (item.Type.IsCanonicalSubtype(CanonicalFormKind.Any))
+                        continue;
+
                     totalEligibleTypes++;
                     if (item.IsPreinitialized)
                     {
@@ -137,11 +135,13 @@ namespace ILCompiler
         {
             private readonly CompilationModuleGroup _compilationGroup;
             private readonly ILProvider _ilProvider;
+            internal readonly TypePreinit.TypePreinitializationPolicy _policy;
 
-            public PreinitializationInfoHashtable(CompilationModuleGroup compilationGroup, ILProvider ilProvider)
+            public PreinitializationInfoHashtable(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinit.TypePreinitializationPolicy policy)
             {
                 _compilationGroup = compilationGroup;
                 _ilProvider = ilProvider;
+                _policy = policy;
             }
 
             protected override bool CompareKeyToValue(MetadataType key, TypePreinit.PreinitializationInfo value) => key == value.Type;
@@ -151,7 +151,7 @@ namespace ILCompiler
 
             protected override TypePreinit.PreinitializationInfo CreateValueFromKey(MetadataType key)
             {
-                return TypePreinit.ScanType(_compilationGroup, _ilProvider, key);
+                return TypePreinit.ScanType(_compilationGroup, _ilProvider, _policy, key);
             }
         }
         private PreinitializationInfoHashtable _preinitHashTable;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/PreinitializationManager.cs
@@ -151,7 +151,15 @@ namespace ILCompiler
 
             protected override TypePreinit.PreinitializationInfo CreateValueFromKey(MetadataType key)
             {
-                return TypePreinit.ScanType(_compilationGroup, _ilProvider, _policy, key);
+                var info = TypePreinit.ScanType(_compilationGroup, _ilProvider, _policy, key);
+
+                // We either successfully preinitialized or
+                // the type doesn't have a canonical form or
+                // the policy doesn't allow treating canonical forms of this type as preinitialized
+                Debug.Assert(info.IsPreinitialized ||
+                    (key.ConvertToCanonForm(CanonicalFormKind.Specific) is DefType canonType && (key == canonType || !_policy.CanPreinitializeAllConcreteFormsForCanonForm(canonType))));
+
+                return info;
             }
         }
         private PreinitializationInfoHashtable _preinitHashTable;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -2573,19 +2573,7 @@ namespace ILCompiler
         /// </summary>
         public sealed class TypeLoaderAwarePreinitializationPolicy : TypePreinitializationPolicy
         {
-            public override bool CanPreinitialize(DefType type)
-            {
-                // If the type has a canonical form the runtime type loader could create
-                // a new type sharing code with this one. They need to agree on how
-                // initialization happens. We can't preinitialize runtime-created
-                // generic types at compile time - they need a functioning cctor
-                // to initialize themselves.
-                if (type.ConvertToCanonForm(CanonicalFormKind.Specific)
-                    .IsCanonicalSubtype(CanonicalFormKind.Any))
-                    return false;
-
-                return true;
-            }
+            public override bool CanPreinitialize(DefType type) => true;
 
             public override bool CanPreinitializeAllConcreteFormsForCanonForm(DefType type) => false;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -32,14 +32,16 @@ namespace ILCompiler
         private readonly MetadataType _type;
         private readonly CompilationModuleGroup _compilationGroup;
         private readonly ILProvider _ilProvider;
+        private readonly TypePreinitializationPolicy _policy;
         private readonly Dictionary<FieldDesc, Value> _fieldValues = new Dictionary<FieldDesc, Value>();
         private readonly Dictionary<string, StringInstance> _internedStrings = new Dictionary<string, StringInstance>();
 
-        private TypePreinit(MetadataType owningType, CompilationModuleGroup compilationGroup, ILProvider ilProvider)
+        private TypePreinit(MetadataType owningType, CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinitializationPolicy policy)
         {
             _type = owningType;
             _compilationGroup = compilationGroup;
             _ilProvider = ilProvider;
+            _policy = policy;
 
             // Zero initialize all fields we model.
             foreach (var field in owningType.GetFields())
@@ -51,38 +53,34 @@ namespace ILCompiler
             }
         }
 
-        // Could potentially expose this as a policy class. When type loader is not present or
-        // the given type can't be constructed by the type loader, preinitialization could still
-        // happen.
-        private static bool CanPreinitializeByPolicy(TypeDesc type)
-        {
-            // If the type has a canonical form the runtime type loader could create
-            // a new type sharing code with this one. They need to agree on how
-            // initialization happens. We can't preinitialize runtime-created
-            // generic types at compile time.
-            if (type.ConvertToCanonForm(CanonicalFormKind.Specific)
-                .IsCanonicalSubtype(CanonicalFormKind.Any))
-                return false;
-
-            return true;
-        }
-
-        public static PreinitializationInfo ScanType(CompilationModuleGroup compilationGroup, ILProvider ilProvider, MetadataType type)
+        public static PreinitializationInfo ScanType(CompilationModuleGroup compilationGroup, ILProvider ilProvider, TypePreinitializationPolicy policy, MetadataType type)
         {
             Debug.Assert(type.HasStaticConstructor);
             Debug.Assert(!type.IsGenericDefinition);
+            Debug.Assert(!type.IsRuntimeDeterminedSubtype);
 
-            if (!CanPreinitializeByPolicy(type))
+            if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
+            {
+                // It's an odd question to ask about canonical types. Defer to policy that might
+                // have more information.
+                // If the policy allows it, we allow it, but create invalid field values so that
+                // things still crash if someone wanted to do more with canonical types than just
+                // ask if a cctor check is necessary to access.
+                if (policy.CanPreinitializeAllConcreteFormsForCanonForm(type))
+                    return new PreinitializationInfo(type, Array.Empty<KeyValuePair<FieldDesc, ISerializableValue>>());
+
                 return new PreinitializationInfo(type, "Disallowed by policy");
+            }
 
-            Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Any));
+            if (!policy.CanPreinitialize(type))
+                return new PreinitializationInfo(type, "Disallowed by policy");
 
             TypePreinit preinit = null;
 
             Status status;
             try
             {
-                preinit = new TypePreinit(type, compilationGroup, ilProvider);
+                preinit = new TypePreinit(type, compilationGroup, ilProvider, policy);
                 int instructions = 0;
                 status = preinit.TryScanMethod(type.GetStaticConstructor(), null, null, ref instructions, out _);
             }
@@ -337,9 +335,9 @@ namespace ILCompiler
                             }
                             else if (field.IsInitOnly
                                 && field.OwningType.HasStaticConstructor
-                                && CanPreinitializeByPolicy(field.OwningType))
+                                && _policy.CanPreinitialize(field.OwningType))
                             {
-                                TypePreinit nestedPreinit = new TypePreinit((MetadataType)field.OwningType, _compilationGroup, _ilProvider);
+                                TypePreinit nestedPreinit = new TypePreinit((MetadataType)field.OwningType, _compilationGroup, _ilProvider, _policy);
                                 recursionProtect ??= new Stack<MethodDesc>();
                                 recursionProtect.Push(methodIL.OwningMethod);
 
@@ -2544,6 +2542,52 @@ namespace ILCompiler
                 Debug.Assert(field.IsStatic && !field.HasRva && !field.IsThreadStatic && !field.IsLiteral);
                 return _fieldValues[field];
             }
+        }
+
+        public abstract class TypePreinitializationPolicy
+        {
+            /// <summary>
+            /// Returns true if the preinitialization system may attempt to preinitialize this type.
+            /// </summary>
+            public abstract bool CanPreinitialize(DefType type);
+
+            /// <summary>
+            /// Returns true if all concrete forms of this canonical form will be preinitialized.
+            /// This can only be answered by a whole program view.
+            /// </summary>
+            public abstract bool CanPreinitializeAllConcreteFormsForCanonForm(DefType type);
+        }
+
+        /// <summary>
+        /// Preinitialization policy that doesn't allow preinitialization.
+        /// </summary>
+        public sealed class DisabledPreinitializationPolicy : TypePreinitializationPolicy
+        {
+            public override bool CanPreinitialize(DefType type) => false;
+            public override bool CanPreinitializeAllConcreteFormsForCanonForm(DefType type) => false;
+        }
+
+        /// <summary>
+        /// Preinitialization policy that assumes new canonical forms of types could be created
+        /// at runtime.
+        /// </summary>
+        public sealed class TypeLoaderAwarePreinitializationPolicy : TypePreinitializationPolicy
+        {
+            public override bool CanPreinitialize(DefType type)
+            {
+                // If the type has a canonical form the runtime type loader could create
+                // a new type sharing code with this one. They need to agree on how
+                // initialization happens. We can't preinitialize runtime-created
+                // generic types at compile time - they need a functioning cctor
+                // to initialize themselves.
+                if (type.ConvertToCanonForm(CanonicalFormKind.Specific)
+                    .IsCanonicalSubtype(CanonicalFormKind.Any))
+                    return false;
+
+                return true;
+            }
+
+            public override bool CanPreinitializeAllConcreteFormsForCanonForm(DefType type) => false;
         }
     }
 }

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using BindingFlags = System.Reflection.BindingFlags;
@@ -46,6 +47,7 @@ internal class Program
         TestDuplicatedFields.Run();
         TestInstanceDelegate.Run();
         TestStringFields.Run();
+        TestSharedCode.Run();
 #else
         Console.WriteLine("Preinitialization is disabled in multimodule builds for now. Skipping test.");
 #endif
@@ -945,6 +947,59 @@ class TestStringFields
     }
 }
 
+class TestSharedCode
+{
+    class ClassWithTemplate<T>
+    {
+        public static int Cookie = 42;
+        public static T[] Array = new T[0];
+    }
+
+    class C1 { }
+    class C2 { }
+    class C3 { }
+    class C4 { }
+    class C5 { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int AccessCookie<T>()
+        => ClassWithTemplate<T>.Cookie;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static object AccessArray<T>()
+        => ClassWithTemplate<T>.Array;
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050:MakeGeneric",
+        Justification = "MakeGeneric is over reference types")]
+    public static void Run()
+    {
+        {
+            int val = AccessCookie<C1>();
+            Assert.AreEqual(42, val);
+
+            val = (int)typeof(ClassWithTemplate<>).MakeGenericType(typeof(C2)).GetField("Cookie").GetValue(null);
+            Assert.AreEqual(42, val);
+
+            val = (int)typeof(TestSharedCode).GetMethod(nameof(AccessCookie)).MakeGenericMethod(typeof(C3)).Invoke(null, Array.Empty<object>());
+            Assert.AreEqual(42, val);
+        }
+
+        {
+            // Expecting this to be a frozen array, and reported as Gen2 by the GC
+            object val = AccessArray<C1>();
+            Assert.AreEqual(2, GC.GetGeneration(val));
+
+            val = typeof(ClassWithTemplate<>).MakeGenericType(typeof(C4)).GetField("Array").GetValue(null);
+            Assert.AreEqual(0, GC.GetGeneration(val));
+            Assert.AreEqual(nameof(C4), val.GetType().GetElementType().Name);
+
+            val = typeof(TestSharedCode).GetMethod(nameof(AccessArray)).MakeGenericMethod(typeof(C5)).Invoke(null, Array.Empty<object>());
+            Assert.AreEqual(0, GC.GetGeneration(val));
+            Assert.AreEqual(nameof(C5), val.GetType().GetElementType().Name);
+        }
+    }
+}
+
 static class Assert
 {
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
@@ -979,6 +1034,12 @@ static class Assert
     }
 
     public static unsafe void AreEqual(int v1, int v2)
+    {
+        if (v1 != v2)
+            throw new Exception();
+    }
+
+    public static void AreEqual(string v1, string v2)
     {
         if (v1 != v2)
             throw new Exception();


### PR DESCRIPTION
The number of preinitialized types in a hello world goes from 156 to 244 (out of 431 with a cctor in total). The size of hello world goes from 2,908,160 bytes to 2,899,456 (although this is not a size optimization).

We were disallowing compile time execution of class constructors for types that have canonical forms because they could have a matching type loader template that allows creating new types at runtime.

Consider:

```csharp
_ = ClassWithTemplate<C1>.Cookie;

var val = (int)typeof(ClassWithTemplate<>).MakeGenericType(typeof(C2)).GetField("Cookie").GetValue(null);

class ClassWithTemplate<T>
{
    public static int Cookie = 42;
}
```

If we allowed `ClassWithTemplate<C1>` to preinitialize, what does it mean for `ClassWithTemplate<__Canon>`? And what about the runtime-created `ClassWithTemplate<C2>` - who will run the cctor? And what if there was a `ClassWithTemplate<C3>` (could even be statically present) that for whatever reason requires a cctor (assume a more complicated cctor than the above example).

It was easier to just ban this.

But since we have a scanning phase in optimized builds, we can know exactly what types will end up with a template (that ultimately allows creating new canonical types at runtime) and whether we were able to preinitialize all types with the same canonical form.

If we know a template is not possible, we don't have to worry about the runtime case - we just need to ensure all canonically equivalent types either get preinitialized, or they don't.

This pull request does that:
* we keep information about type templates from the scanning phase into compilation phase
* we extract the policy decision about whether preinitialization for a type is allowed into a separate class
* we add an extra policy decision about whether canonical forms of types require preinitialization
* one implementation of this class follows the old conservative policy
* another implementation uses whole program view to allow preinitialization of types that don't have a matching template and fully preinitialized during scanning

Cc @dotnet/ilc-contrib 