### PR TITLE
Add ImmutableArray<T>.Builder.DrainToImmutable()

### DIFF
--- a/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/libraries/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -364,6 +364,7 @@ namespace System.Collections.Immutable
             public void CopyTo(T[] destination) { throw null; }
             public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { throw null; }
             public void CopyTo(System.Span<T> destination) { }
+            public System.Collections.Immutable.ImmutableArray<T> DrainToImmutable() { throw null; }
             public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
             public int IndexOf(T item) { throw null; }
             public int IndexOf(T item, int startIndex) { throw null; }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -214,6 +214,33 @@ namespace System.Collections.Immutable
             }
 
             /// <summary>
+            /// Returns the current contents as an <see cref="ImmutableArray{T}"/> and sets the collection to a zero length array.
+            /// </summary>
+            /// <remarks>
+            /// If <see cref="Capacity"/> equals <see cref="Count"/>, the internal array will be extracted
+            /// as an <see cref="ImmutableArray{T}"/> without copying the contents. Otherwise, the contents
+            /// will be copied into a new array. The collection will then be set to a zero length array.
+            /// </remarks>
+            /// <returns>An immutable array.</returns>
+            public ImmutableArray<T> DrainToImmutable()
+            {
+                ImmutableArray<T> result;
+
+                if (Capacity == Count)
+                {
+                    result = MoveToImmutable();
+                }
+                else
+                {
+                    result = ToImmutable();
+                    _elements = ImmutableArray<T>.Empty.array!;
+                    _count = 0;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Removes all items from the <see cref="ICollection{T}"/>.
             /// </summary>
             public void Clear()

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -224,20 +224,17 @@ namespace System.Collections.Immutable
             /// <returns>An immutable array.</returns>
             public ImmutableArray<T> DrainToImmutable()
             {
-                ImmutableArray<T> result;
+                T[] result = _elements;
 
-                if (Capacity == Count)
+                if (result.Length != _count)
                 {
-                    result = MoveToImmutable();
-                }
-                else
-                {
-                    result = ToImmutable();
-                    _elements = ImmutableArray<T>.Empty.array!;
-                    _count = 0;
+                    result = ToArray();
                 }
 
-                return result;
+                _elements = ImmutableArray<T>.Empty.array!;
+                _count = 0;
+
+                return new ImmutableArray<T>(result);
             }
 
             /// <summary>

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -881,6 +881,107 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void DrainToImmutableAtCapacity()
+        {
+            var builder = CreateBuilderWithCount<string>(2);
+            Assert.Equal(2, builder.Count);
+            Assert.Equal(2, builder.Capacity);
+            builder[1] = "b";
+            builder[0] = "a";
+            var array = builder.DrainToImmutable();
+            Assert.Equal(new[] { "a", "b" }, array);
+            Assert.Equal(0, builder.Count);
+            Assert.Equal(0, builder.Capacity);
+        }
+
+        [Fact]
+        public void DrainToImmutablePartialFill()
+        {
+            var builder = ImmutableArray.CreateBuilder<int>(4);
+            builder.Add(42);
+            builder.Add(13);
+            Assert.Equal(4, builder.Capacity);
+            Assert.Equal(2, builder.Count);
+            var array = builder.DrainToImmutable();
+            Assert.Equal(new[] { 42, 13 }, array);
+            Assert.Equal(0, builder.Capacity);
+            Assert.Equal(0, builder.Count);
+        }
+
+        [Fact]
+        public void DrainToImmutablePartialFillWithCountUpdate()
+        {
+            var builder = ImmutableArray.CreateBuilder<int>(4);
+            builder.Add(42);
+            builder.Add(13);
+            Assert.Equal(4, builder.Capacity);
+            Assert.Equal(2, builder.Count);
+            builder.Count = builder.Capacity;
+            var array = builder.DrainToImmutable();
+            Assert.Equal(new[] { 42, 13, 0, 0 }, array);
+            Assert.Equal(0, builder.Capacity);
+            Assert.Equal(0, builder.Count);
+        }
+
+        [Fact]
+        public void DrainToImmutableRepeat()
+        {
+            var builder = CreateBuilderWithCount<string>(2);
+            builder[0] = "a";
+            builder[1] = "b";
+            var array1 = builder.DrainToImmutable();
+            var array2 = builder.DrainToImmutable();
+            Assert.Equal(new[] { "a", "b" }, array1);
+            Assert.Equal(0, array2.Length);
+        }
+
+        [Fact]
+        public void DrainToImmutableThenUse()
+        {
+            var builder = CreateBuilderWithCount<string>(2);
+            Assert.Equal(2, builder.DrainToImmutable().Length);
+            Assert.Equal(0, builder.Capacity);
+            builder.Add("a");
+            builder.Add("b");
+            Assert.Equal(2, builder.Count);
+            Assert.True(builder.Capacity >= 2);
+            Assert.Equal(new[] { "a", "b" }, builder.DrainToImmutable());
+        }
+
+        [Fact]
+        public void DrainToImmutableAfterClear()
+        {
+            var builder = CreateBuilderWithCount<string>(2);
+            builder[0] = "a";
+            builder[1] = "b";
+            builder.Clear();
+            var array = builder.DrainToImmutable();
+            Assert.Equal(0, array.Length);
+            Assert.Equal(0, builder.Capacity);
+            Assert.Equal(0, builder.Count);
+        }
+
+        [Fact]
+        public void DrainToImmutableAtCapacityClearsCollection()
+        {
+            var builder = CreateBuilderWithCount<int>(2);
+            builder.AddRange(1, 2);
+            builder.DrainToImmutable();
+            builder.Count = 4;
+            Assert.Equal(new[] { 0, 0, 0, 0 }, builder.DrainToImmutable());
+        }
+
+        [Fact]
+        public void DrainToImmutablePartialFillClearsCollection()
+        {
+            var builder = CreateBuilderWithCount<int>(4);
+            builder.AddRange(1, 2);
+            builder.DrainToImmutable();
+            builder.Count = 6;
+            Assert.Equal(new[] { 0, 0, 0, 0, 0, 0 }, builder.DrainToImmutable());
+        }
+
+        [Fact]
         public void CapacitySetToZero()
         {
             var builder = ImmutableArray.CreateBuilder<int>(initialCapacity: 10);

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -881,13 +881,35 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void DrainToImmutableEmptyZeroCapacity()
+        {
+            var builder = ImmutableArray.CreateBuilder<int>(0);
+            var array = builder.DrainToImmutable();
+            Assert.Equal(0, array.Length);
+            Assert.Equal(0, builder.Capacity);
+            Assert.Equal(0, builder.Count);
+        }
+
+        [Fact]
+        public void DrainToImmutableEmptyNonZeroCapacity()
+        {
+            var builder = ImmutableArray.CreateBuilder<int>(10);
+            var array = builder.DrainToImmutable();
+            Assert.Equal(0, array.Length);
+            Assert.Equal(0, builder.Capacity);
+            Assert.Equal(0, builder.Count);
+        }
+
+        [Fact]
         public void DrainToImmutableAtCapacity()
         {
-            var builder = CreateBuilderWithCount<string>(2);
-            Assert.Equal(2, builder.Count);
-            Assert.Equal(2, builder.Capacity);
+            var builder = ImmutableArray.CreateBuilder<string>(2);
+            builder.Count = 2;
             builder[1] = "b";
             builder[0] = "a";
+            Assert.Equal(2, builder.Count);
+            Assert.Equal(2, builder.Capacity);
+
             var array = builder.DrainToImmutable();
             Assert.Equal(new[] { "a", "b" }, array);
             Assert.Equal(0, builder.Count);
@@ -898,10 +920,10 @@ namespace System.Collections.Immutable.Tests
         public void DrainToImmutablePartialFill()
         {
             var builder = ImmutableArray.CreateBuilder<int>(4);
-            builder.Add(42);
-            builder.Add(13);
+            builder.AddRange(42, 13);
             Assert.Equal(4, builder.Capacity);
             Assert.Equal(2, builder.Count);
+
             var array = builder.DrainToImmutable();
             Assert.Equal(new[] { 42, 13 }, array);
             Assert.Equal(0, builder.Capacity);
@@ -912,11 +934,11 @@ namespace System.Collections.Immutable.Tests
         public void DrainToImmutablePartialFillWithCountUpdate()
         {
             var builder = ImmutableArray.CreateBuilder<int>(4);
-            builder.Add(42);
-            builder.Add(13);
-            Assert.Equal(4, builder.Capacity);
-            Assert.Equal(2, builder.Count);
+            builder.AddRange(42, 13);
             builder.Count = builder.Capacity;
+            Assert.Equal(4, builder.Capacity);
+            Assert.Equal(4, builder.Count);
+
             var array = builder.DrainToImmutable();
             Assert.Equal(new[] { 42, 13, 0, 0 }, array);
             Assert.Equal(0, builder.Capacity);
@@ -926,35 +948,39 @@ namespace System.Collections.Immutable.Tests
         [Fact]
         public void DrainToImmutableRepeat()
         {
-            var builder = CreateBuilderWithCount<string>(2);
-            builder[0] = "a";
-            builder[1] = "b";
+            var builder = ImmutableArray.CreateBuilder<string>(2);
+            builder.AddRange("a", "b");
+
             var array1 = builder.DrainToImmutable();
             var array2 = builder.DrainToImmutable();
             Assert.Equal(new[] { "a", "b" }, array1);
             Assert.Equal(0, array2.Length);
+            Assert.Equal(0, builder.Capacity);
+            Assert.Equal(0, builder.Count);
         }
 
         [Fact]
         public void DrainToImmutableThenUse()
         {
-            var builder = CreateBuilderWithCount<string>(2);
+            var builder = ImmutableArray.CreateBuilder<string>(2);
+            builder.Count = 2;
             Assert.Equal(2, builder.DrainToImmutable().Length);
             Assert.Equal(0, builder.Capacity);
-            builder.Add("a");
-            builder.Add("b");
+            builder.AddRange("a", "b");
             Assert.Equal(2, builder.Count);
             Assert.True(builder.Capacity >= 2);
-            Assert.Equal(new[] { "a", "b" }, builder.DrainToImmutable());
+
+            var array = builder.DrainToImmutable();
+            Assert.Equal(new[] { "a", "b" }, array);
         }
 
         [Fact]
         public void DrainToImmutableAfterClear()
         {
-            var builder = CreateBuilderWithCount<string>(2);
-            builder[0] = "a";
-            builder[1] = "b";
+            var builder = ImmutableArray.CreateBuilder<string>(2);
+            builder.AddRange("a", "b");
             builder.Clear();
+
             var array = builder.DrainToImmutable();
             Assert.Equal(0, array.Length);
             Assert.Equal(0, builder.Capacity);
@@ -964,21 +990,25 @@ namespace System.Collections.Immutable.Tests
         [Fact]
         public void DrainToImmutableAtCapacityClearsCollection()
         {
-            var builder = CreateBuilderWithCount<int>(2);
+            var builder = ImmutableArray.CreateBuilder<int>(2);
             builder.AddRange(1, 2);
             builder.DrainToImmutable();
             builder.Count = 4;
-            Assert.Equal(new[] { 0, 0, 0, 0 }, builder.DrainToImmutable());
+
+            var array = builder.DrainToImmutable();
+            Assert.Equal(new[] { 0, 0, 0, 0 }, array);
         }
 
         [Fact]
         public void DrainToImmutablePartialFillClearsCollection()
         {
-            var builder = CreateBuilderWithCount<int>(4);
+            var builder = ImmutableArray.CreateBuilder<int>(4);
             builder.AddRange(1, 2);
             builder.DrainToImmutable();
             builder.Count = 6;
-            Assert.Equal(new[] { 0, 0, 0, 0, 0, 0 }, builder.DrainToImmutable());
+
+            var array = builder.DrainToImmutable();
+            Assert.Equal(new[] { 0, 0, 0, 0, 0, 0 }, array);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #72625. Approved API details: https://github.com/dotnet/runtime/issues/72625#issuecomment-1238477596.

`DrainToImmutable` will "do the cheapest thing possible" to return the current contents as an immutable array and then reset the collection to a zero-length array.