### PR TITLE
Enforce HttpClient limits on GetFromJsonAsync

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -726,7 +726,7 @@ namespace System.Net.Test.Common
             public async Task WriteStringAsync(string s)
             {
                 byte[] bytes = Encoding.ASCII.GetBytes(s);
-                await _stream.WriteAsync(bytes);
+                await _stream.WriteAsync(bytes, 0, bytes.Length);
             }
 
             public async Task SendResponseAsync(string response)
@@ -736,7 +736,7 @@ namespace System.Net.Test.Common
 
             public async Task SendResponseAsync(byte[] response)
             {
-                await _stream.WriteAsync(response);
+                await _stream.WriteAsync(response, 0, response.Length);
             }
 
             public async Task SendResponseAsync(HttpStatusCode statusCode = HttpStatusCode.OK, string additionalHeaders = null, string content = null)

--- a/src/libraries/System.Net.Http.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http.Json/src/Resources/Strings.resx
@@ -129,4 +129,10 @@
   <data name="SerializeWrongType" xml:space="preserve">
     <value>The specified type {0} must derive from the specific value's type {1}.</value>
   </data>
+  <data name="net_http_request_timedout" xml:space="preserve">
+    <value>The request was canceled due to the configured HttpClient.Timeout of {0} seconds elapsing.</value>
+  </data>
+  <data name="net_http_content_buffersize_exceeded" xml:space="preserve">
+    <value>Cannot write more bytes to the buffer than the configured maximum buffer size: {0}.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Http.Json/src/System.Net.Http.Json.csproj
+++ b/src/libraries/System.Net.Http.Json/src/System.Net.Http.Json.csproj
@@ -12,6 +12,7 @@ System.Net.Http.Json.JsonContent</PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="System\Net\Http\Json\HttpClientJsonExtensions.cs" />
     <Compile Include="System\Net\Http\Json\JsonHelpers.cs" />
     <Compile Include="System\Net\Http\Json\HttpClientJsonExtensions.Delete.cs" />
     <Compile Include="System\Net\Http\Json\HttpClientJsonExtensions.Get.cs" />
@@ -21,6 +22,7 @@ System.Net.Http.Json.JsonContent</PackageDescription>
     <Compile Include="System\Net\Http\Json\HttpContentJsonExtensions.cs" />
     <Compile Include="System\Net\Http\Json\JsonContent.cs" />
     <Compile Include="System\Net\Http\Json\JsonContentOfT.cs" />
+    <Compile Include="System\Net\Http\Json\LengthLimitReadStream.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Delete.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Delete.cs
@@ -15,28 +15,8 @@ namespace System.Net.Http.Json
     /// </summary>
     public static partial class HttpClientJsonExtensions
     {
-        /// <summary>
-        /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
-        /// </summary>
-        /// <param name="client">The client used to send the request.</param>
-        /// <param name="requestUri">The Uri the request is sent to.</param>
-        /// <param name="type">The type of the object to deserialize to and return.</param>
-        /// <param name="options">Options to control the behavior during serialization. The default options are those specified by <see cref="JsonSerializerDefaults.Web"/>.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <returns>The task object representing the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax("Uri")] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.DeleteAsync(requestUri, cancellationToken);
-            return DeleteFromJsonAsyncCore(taskResponse, type, options, cancellationToken);
-        }
+        private static readonly Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> s_deleteAsync =
+            static (client, uri, cancellation) => client.DeleteAsync(uri, cancellation);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -50,16 +30,23 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
+        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            DeleteFromJsonAsync(client, CreateUri(requestUri), type, options, cancellationToken);
 
-            Task<HttpResponseMessage> taskResponse = client.DeleteAsync(requestUri, cancellationToken);
-            return DeleteFromJsonAsyncCore(taskResponse, type, options, cancellationToken);
-        }
+        /// <summary>
+        /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
+        /// </summary>
+        /// <param name="client">The client used to send the request.</param>
+        /// <param name="requestUri">The Uri the request is sent to.</param>
+        /// <param name="type">The type of the object to deserialize to and return.</param>
+        /// <param name="options">Options to control the behavior during serialization. The default options are those specified by <see cref="JsonSerializerDefaults.Web"/>.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
+        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
+        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(s_deleteAsync, client, requestUri, type, options, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -73,16 +60,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax("Uri")] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.DeleteAsync(requestUri, cancellationToken);
-            return DeleteFromJsonAsyncCore<TValue>(taskResponse, options, cancellationToken);
-        }
+        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            DeleteFromJsonAsync<TValue>(client, CreateUri(requestUri), options, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -96,16 +75,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.DeleteAsync(requestUri, cancellationToken);
-            return DeleteFromJsonAsyncCore<TValue>(taskResponse, options, cancellationToken);
-        }
+        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore<TValue>(s_deleteAsync, client, requestUri, options, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -117,16 +88,8 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax("Uri")] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.DeleteAsync(requestUri, cancellationToken);
-            return DeleteFromJsonAsyncCore(taskResponse, type, context, cancellationToken);
-        }
+        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            DeleteFromJsonAsync(client, CreateUri(requestUri), type, context, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -138,16 +101,8 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.DeleteAsync(requestUri, cancellationToken);
-            return DeleteFromJsonAsyncCore(taskResponse, type, context, cancellationToken);
-        }
+        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(s_deleteAsync, client, requestUri, type, context, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -159,16 +114,8 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax("Uri")] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.DeleteAsync(requestUri, cancellationToken);
-            return DeleteFromJsonAsyncCore(taskResponse, jsonTypeInfo, cancellationToken);
-        }
+        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
+            DeleteFromJsonAsync(client, CreateUri(requestUri), jsonTypeInfo, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -180,16 +127,8 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.DeleteAsync(requestUri, cancellationToken);
-            return DeleteFromJsonAsyncCore<TValue>(taskResponse, jsonTypeInfo, cancellationToken);
-        }
+        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(s_deleteAsync, client, requestUri, jsonTypeInfo, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -202,8 +141,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax("Uri")] string? requestUri, Type type, CancellationToken cancellationToken = default)
-            => client.DeleteFromJsonAsync(requestUri, type, options: null, cancellationToken);
+        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, CancellationToken cancellationToken = default) =>
+            DeleteFromJsonAsync(client, requestUri, type, options: null, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -216,8 +155,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default)
-            => client.DeleteFromJsonAsync(requestUri, type, options: null, cancellationToken);
+        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default) =>
+            DeleteFromJsonAsync(client, requestUri, type, options: null, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -230,8 +169,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax("Uri")] string? requestUri, CancellationToken cancellationToken = default)
-            => client.DeleteFromJsonAsync<TValue>(requestUri, options: null, cancellationToken);
+        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken = default) =>
+            DeleteFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -244,53 +183,7 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default)
-            => client.DeleteFromJsonAsync<TValue>(requestUri, options: null, cancellationToken);
-
-        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        private static async Task<object?> DeleteFromJsonAsyncCore(Task<HttpResponseMessage> taskResponse, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await taskResponse.ConfigureAwait(false))
-            {
-                response.EnsureSuccessStatusCode();
-                // Nullable forgiving reason:
-                // DeleteAsync will usually return Content as not-null.
-                // If Content happens to be null, the extension will throw.
-                return await response.Content!.ReadFromJsonAsync(type, options, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        private static async Task<T?> DeleteFromJsonAsyncCore<T>(Task<HttpResponseMessage> taskResponse, JsonSerializerOptions? options, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await taskResponse.ConfigureAwait(false))
-            {
-                response.EnsureSuccessStatusCode();
-                // Nullable forgiving reason:
-                // DeleteAsync will usually return Content as not-null.
-                // If Content happens to be null, the extension will throw.
-                return await response.Content!.ReadFromJsonAsync<T>(options, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        private static async Task<object?> DeleteFromJsonAsyncCore(Task<HttpResponseMessage> taskResponse, Type type, JsonSerializerContext context, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await taskResponse.ConfigureAwait(false))
-            {
-                response.EnsureSuccessStatusCode();
-                return await response.Content!.ReadFromJsonAsync(type, context, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        private static async Task<T?> DeleteFromJsonAsyncCore<T>(Task<HttpResponseMessage> taskResponse, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await taskResponse.ConfigureAwait(false))
-            {
-                response.EnsureSuccessStatusCode();
-                return await response.Content!.ReadFromJsonAsync<T>(jsonTypeInfo, cancellationToken).ConfigureAwait(false);
-            }
-        }
+        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default) =>
+            DeleteFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken);
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.cs
@@ -15,166 +15,59 @@ namespace System.Net.Http.Json
     /// </summary>
     public static partial class HttpClientJsonExtensions
     {
-        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            return GetFromJsonAsyncCore(taskResponse, type, options, cancellationToken);
-        }
+        private static readonly Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> s_getAsync =
+            static (client, uri, cancellation) => client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellation);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            return GetFromJsonAsyncCore(taskResponse, type, options, cancellationToken);
-        }
+        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            GetFromJsonAsync(client, CreateUri(requestUri), type, options, cancellationToken);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            return GetFromJsonAsyncCore<TValue>(taskResponse, options, cancellationToken);
-        }
+        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(static (client, uri, cancellation) => client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellation), client, requestUri, type, options, cancellationToken);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            return GetFromJsonAsyncCore<TValue>(taskResponse, options, cancellationToken);
-        }
-
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            return GetFromJsonAsyncCore(taskResponse, type, context, cancellationToken);
-        }
-
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            return GetFromJsonAsyncCore(taskResponse, type, context, cancellationToken);
-        }
-
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            return GetFromJsonAsyncCore(taskResponse, jsonTypeInfo, cancellationToken);
-        }
-
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            Task<HttpResponseMessage> taskResponse = client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            return GetFromJsonAsyncCore<TValue>(taskResponse, jsonTypeInfo, cancellationToken);
-        }
+        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            GetFromJsonAsync<TValue>(client, CreateUri(requestUri), options, cancellationToken);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, CancellationToken cancellationToken = default)
-            => client.GetFromJsonAsync(requestUri, type, options: null, cancellationToken);
+        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore<TValue>(s_getAsync, client, requestUri, options, cancellationToken);
+
+        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            GetFromJsonAsync(client, CreateUri(requestUri), type, context, cancellationToken);
+
+        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(s_getAsync, client, requestUri, type, context, cancellationToken);
+
+        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
+            GetFromJsonAsync(client, CreateUri(requestUri), jsonTypeInfo, cancellationToken);
+
+        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(s_getAsync, client, requestUri, jsonTypeInfo, cancellationToken);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default)
-            => client.GetFromJsonAsync(requestUri, type, options: null, cancellationToken);
+        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, CancellationToken cancellationToken = default) =>
+            GetFromJsonAsync(client, requestUri, type, options: null, cancellationToken);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken = default)
-            => client.GetFromJsonAsync<TValue>(requestUri, options: null, cancellationToken);
+        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default) =>
+            GetFromJsonAsync(client, requestUri, type, options: null, cancellationToken);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default)
-            => client.GetFromJsonAsync<TValue>(requestUri, options: null, cancellationToken);
+        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken = default) =>
+            GetFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        private static async Task<object?> GetFromJsonAsyncCore(Task<HttpResponseMessage> taskResponse, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await taskResponse.ConfigureAwait(false))
-            {
-                response.EnsureSuccessStatusCode();
-                // Nullable forgiving reason:
-                // GetAsync will usually return Content as not-null.
-                // If Content happens to be null, the extension will throw.
-                return await response.Content!.ReadFromJsonAsync(type, options, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        private static async Task<T?> GetFromJsonAsyncCore<T>(Task<HttpResponseMessage> taskResponse, JsonSerializerOptions? options, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await taskResponse.ConfigureAwait(false))
-            {
-                response.EnsureSuccessStatusCode();
-                // Nullable forgiving reason:
-                // GetAsync will usually return Content as not-null.
-                // If Content happens to be null, the extension will throw.
-                return await response.Content!.ReadFromJsonAsync<T>(options, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        private static async Task<object?> GetFromJsonAsyncCore(Task<HttpResponseMessage> taskResponse, Type type, JsonSerializerContext context, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await taskResponse.ConfigureAwait(false))
-            {
-                response.EnsureSuccessStatusCode();
-                return await response.Content!.ReadFromJsonAsync(type, context, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        private static async Task<T?> GetFromJsonAsyncCore<T>(Task<HttpResponseMessage> taskResponse, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken)
-        {
-            using (HttpResponseMessage response = await taskResponse.ConfigureAwait(false))
-            {
-                response.EnsureSuccessStatusCode();
-                return await response.Content!.ReadFromJsonAsync<T>(jsonTypeInfo, cancellationToken).ConfigureAwait(false);
-            }
-        }
+        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default) =>
+            GetFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken);
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Json
+{
+    public static partial class HttpClientJsonExtensions
+    {
+        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
+        private static Task<object?> FromJsonAsyncCore(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(getMethod, client, requestUri, static (stream, options, cancellation) => JsonSerializer.DeserializeAsync(stream, options.type, options.options ?? JsonHelpers.s_defaultSerializerOptions, cancellation), (type, options), cancellationToken);
+
+        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
+        private static Task<TValue?> FromJsonAsyncCore<TValue>(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(getMethod, client, requestUri, static (stream, options, cancellation) => JsonSerializer.DeserializeAsync<TValue>(stream, options ?? JsonHelpers.s_defaultSerializerOptions, cancellation), options, cancellationToken);
+
+        private static Task<object?> FromJsonAsyncCore(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            FromJsonAsyncCore(getMethod, client, requestUri, static (stream, options, cancellation) => JsonSerializer.DeserializeAsync(stream, options.type, options.context, cancellation), (type, context), cancellationToken);
+
+        private static Task<TValue?> FromJsonAsyncCore<TValue>(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken) =>
+            FromJsonAsyncCore(getMethod, client, requestUri, static (stream, options, cancellation) => JsonSerializer.DeserializeAsync(stream, options, cancellation), jsonTypeInfo, cancellationToken);
+
+        private static Task<TValue?> FromJsonAsyncCore<TValue, TJsonOptions>(
+            Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod,
+            HttpClient client,
+            Uri? requestUri,
+            Func<Stream, TJsonOptions, CancellationToken, ValueTask<TValue?>> deserializeMethod,
+            TJsonOptions jsonOptions,
+            CancellationToken cancellationToken)
+        {
+            if (client is null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            TimeSpan timeout = client.Timeout;
+
+            // Create the CTS before the initial SendAsync so that the SendAsync counts against the timeout.
+            CancellationTokenSource? linkedCTS = null;
+            if (timeout != Timeout.InfiniteTimeSpan)
+            {
+                linkedCTS = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                linkedCTS.CancelAfter(timeout);
+            }
+
+            // We call SendAsync outside of the async Core method to propagate exception even without awaiting the returned task.
+            Task<HttpResponseMessage> responseTask;
+            try
+            {
+                // Intentionally using cancellationToken instead of the linked one here as HttpClient will enforce the Timeout on its own for this part
+                responseTask = getMethod(client, requestUri, cancellationToken);
+            }
+            catch
+            {
+                linkedCTS?.Dispose();
+                throw;
+            }
+
+            return Core(client, responseTask, linkedCTS, deserializeMethod, jsonOptions, cancellationToken);
+
+            static async Task<TValue?> Core(
+                HttpClient client,
+                Task<HttpResponseMessage> responseTask,
+                CancellationTokenSource? linkedCTS,
+                Func<Stream, TJsonOptions, CancellationToken, ValueTask<TValue?>> deserializeMethod,
+                TJsonOptions jsonOptions,
+                CancellationToken cancellationToken)
+            {
+                try
+                {
+                    using HttpResponseMessage response = await responseTask.ConfigureAwait(false);
+                    response.EnsureSuccessStatusCode();
+
+                    Debug.Assert(client.MaxResponseContentBufferSize is > 0 and <= int.MaxValue);
+                    int contentLengthLimit = (int)client.MaxResponseContentBufferSize;
+
+                    HttpContent content = response.Content ?? throw new ArgumentNullException(nameof(content));
+
+                    if (content.Headers.ContentLength is long contentLength && contentLength > contentLengthLimit)
+                    {
+                        LengthLimitReadStream.ThrowExceededBufferLimit(contentLengthLimit);
+                    }
+
+                    try
+                    {
+                        using Stream contentStream = await HttpContentJsonExtensions.GetContentStreamAsync(content, linkedCTS?.Token ?? cancellationToken).ConfigureAwait(false);
+
+                        var lengthLimitStream = new LengthLimitReadStream(contentStream, (int)client.MaxResponseContentBufferSize);
+
+                        return await deserializeMethod(lengthLimitStream, jsonOptions, linkedCTS?.Token ?? cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException oce) when ((linkedCTS?.Token.IsCancellationRequested == true) && !cancellationToken.IsCancellationRequested)
+                    {
+                        // Matches how HttpClient throws a timeout exception.
+                        string message = SR.Format(SR.net_http_request_timedout, client.Timeout.TotalSeconds);
+#if NETCOREAPP
+                        throw new TaskCanceledException(message, new TimeoutException(oce.Message, oce), oce.CancellationToken);
+#else
+                        throw new TaskCanceledException(message, new TimeoutException(oce.Message, oce));
+#endif
+                    }
+                }
+                finally
+                {
+                    linkedCTS?.Dispose();
+                }
+            }
+        }
+
+        private static Uri? CreateUri(string? uri) =>
+            string.IsNullOrEmpty(uri) ? null : new Uri(uri, UriKind.RelativeOrAbsolute);
+    }
+}

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.cs
@@ -87,16 +87,14 @@ namespace System.Net.Http.Json
                     Debug.Assert(client.MaxResponseContentBufferSize is > 0 and <= int.MaxValue);
                     int contentLengthLimit = (int)client.MaxResponseContentBufferSize;
 
-                    HttpContent content = response.Content ?? throw new ArgumentNullException(nameof(content));
-
-                    if (content.Headers.ContentLength is long contentLength && contentLength > contentLengthLimit)
+                    if (response.Content.Headers.ContentLength is long contentLength && contentLength > contentLengthLimit)
                     {
                         LengthLimitReadStream.ThrowExceededBufferLimit(contentLengthLimit);
                     }
 
                     try
                     {
-                        using Stream contentStream = await HttpContentJsonExtensions.GetContentStreamAsync(content, linkedCTS?.Token ?? cancellationToken).ConfigureAwait(false);
+                        using Stream contentStream = await HttpContentJsonExtensions.GetContentStreamAsync(response.Content, linkedCTS?.Token ?? cancellationToken).ConfigureAwait(false);
 
                         // If ResponseHeadersRead wasn't used, HttpClient will have already buffered the whole response upfront. No need to check the limit again.
                         Stream readStream = usingResponseHeadersRead

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.netstandard.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.netstandard.cs
@@ -13,8 +13,7 @@ namespace System.Net.Http.Json
 
         private static Task<HttpResponseMessage> PatchAsync(this HttpClient client, string? requestUri, HttpContent content, CancellationToken cancellationToken)
         {
-            Uri? uri = string.IsNullOrEmpty(requestUri) ? null : new Uri(requestUri, UriKind.RelativeOrAbsolute);
-            return client.PatchAsync(uri, content, cancellationToken);
+            return client.PatchAsync(CreateUri(requestUri), content, cancellationToken);
         }
 
         private static Task<HttpResponseMessage> PatchAsync(this HttpClient client, Uri? requestUri, HttpContent content, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -69,7 +69,7 @@ namespace System.Net.Http.Json
             Justification = "The ctor is annotated with RequiresDynamicCode.")]
         private async Task SerializeToStreamAsyncCore(Stream targetStream, bool async, CancellationToken cancellationToken)
         {
-            Encoding? targetEncoding = JsonHelpers.GetEncoding(Headers.ContentType?.CharSet);
+            Encoding? targetEncoding = JsonHelpers.GetEncoding(this);
 
             // Wrap provided stream into a transcoding stream that buffers the data transcoded from utf-8 to the targetEncoding.
             if (targetEncoding != null && targetEncoding != Encoding.UTF8)

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContentOfT.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContentOfT.cs
@@ -48,7 +48,7 @@ namespace System.Net.Http.Json
         /// </summary>
         private async Task SerializeToStreamAsyncCore(Stream targetStream, bool async, CancellationToken cancellationToken)
         {
-            Encoding? targetEncoding = JsonHelpers.GetEncoding(Headers.ContentType?.CharSet);
+            Encoding? targetEncoding = JsonHelpers.GetEncoding(this);
 
             // Wrap provided stream into a transcoding stream that buffers the data transcoded from utf-8 to the targetEncoding.
             if (targetEncoding != null && targetEncoding != Encoding.UTF8)

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonHelpers.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonHelpers.cs
@@ -14,11 +14,11 @@ namespace System.Net.Http.Json
 
         internal static MediaTypeHeaderValue GetDefaultMediaType() => new("application/json") { CharSet = "utf-8" };
 
-        internal static Encoding? GetEncoding(string? charset)
+        internal static Encoding? GetEncoding(HttpContent content)
         {
             Encoding? encoding = null;
 
-            if (charset != null)
+            if (content.Headers.ContentType?.CharSet is string charset)
             {
                 try
                 {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/LengthLimitReadStream.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/LengthLimitReadStream.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Json
+{
+    internal sealed class LengthLimitReadStream : Stream
+    {
+        private readonly Stream _innerStream;
+        private readonly int _lengthLimit;
+        private int _remainingLength;
+
+        public LengthLimitReadStream(Stream innerStream, int lengthLimit)
+        {
+            _innerStream = innerStream;
+            _lengthLimit = _remainingLength = lengthLimit;
+        }
+
+        private void CheckLengthLimit(int read)
+        {
+            _remainingLength -= read;
+            if (_remainingLength < 0)
+            {
+                ThrowExceededBufferLimit(_lengthLimit);
+            }
+        }
+
+        internal static void ThrowExceededBufferLimit(int limit)
+        {
+            throw new HttpRequestException(SR.Format(SR.net_http_content_buffersize_exceeded, limit));
+        }
+
+        public override bool CanRead => _innerStream.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+
+#if NETCOREAPP
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ValueTask<int> readTask = _innerStream.ReadAsync(buffer, cancellationToken);
+
+            if (buffer.IsEmpty)
+            {
+                return readTask;
+            }
+
+            if (readTask.IsCompletedSuccessfully)
+            {
+                int read = readTask.Result;
+                CheckLengthLimit(read);
+                return new ValueTask<int>(read);
+            }
+
+            return Core(readTask);
+
+            async ValueTask<int> Core(ValueTask<int> readTask)
+            {
+                int read = await readTask.ConfigureAwait(false);
+                CheckLengthLimit(read);
+                return read;
+            }
+        }
+#else
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            int read = await _innerStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            CheckLengthLimit(read);
+            return read;
+        }
+#endif
+
+        public override void Flush() => throw new InvalidOperationException();
+        public override int Read(byte[] buffer, int offset, int count) => throw new InvalidOperationException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new InvalidOperationException();
+        public override void SetLength(long value) => throw new InvalidOperationException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new InvalidOperationException();
+        public override long Length => throw new InvalidOperationException();
+        public override long Position { get => throw new InvalidOperationException(); set => throw new InvalidOperationException(); }
+    }
+}

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/LengthLimitReadStream.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/LengthLimitReadStream.cs
@@ -34,7 +34,7 @@ namespace System.Net.Http.Json
         }
 
         public override bool CanRead => _innerStream.CanRead;
-        public override bool CanSeek => false;
+        public override bool CanSeek => _innerStream.CanSeek;
         public override bool CanWrite => false;
 
 #if NETCOREAPP
@@ -75,12 +75,20 @@ namespace System.Net.Http.Json
         }
 #endif
 
-        public override void Flush() => throw new InvalidOperationException();
-        public override int Read(byte[] buffer, int offset, int count) => throw new InvalidOperationException();
-        public override long Seek(long offset, SeekOrigin origin) => throw new InvalidOperationException();
-        public override void SetLength(long value) => throw new InvalidOperationException();
-        public override void Write(byte[] buffer, int offset, int count) => throw new InvalidOperationException();
-        public override long Length => throw new InvalidOperationException();
-        public override long Position { get => throw new InvalidOperationException(); set => throw new InvalidOperationException(); }
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int read = _innerStream.Read(buffer, offset, count);
+            CheckLengthLimit(read);
+            return read;
+        }
+
+        public override void Flush() => _innerStream.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => _innerStream.FlushAsync(cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+        public override void SetLength(long value) => _innerStream.SetLength(value);
+        public override long Length => _innerStream.Length;
+        public override long Position { get => _innerStream.Position; set => _innerStream.Position = value; }
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
@@ -355,7 +355,7 @@ namespace System.Net.Http.Json.Functional.Tests
                 });
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))] // No Socket support
         [InlineData(100, 100, true)]
         [InlineData(100, 100, false)]
         [InlineData(100, 101, true)]
@@ -391,7 +391,7 @@ namespace System.Net.Http.Json.Functional.Tests
             });
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))] // No Socket support
         [InlineData(true)]
         [InlineData(false)]
         public async Task GetFromJsonAsync_EnforcesTimeout(bool slowHeaders)

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/System.Net.Http.Json.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/System.Net.Http.Json.Functional.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);net48</TargetFrameworks>
   </PropertyGroup>
@@ -13,11 +13,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Net\Capability.Security.cs" Link="Common\System\Net\Capability.Security.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Configuration.Certificates.cs" Link="Common\System\Net\Configuration.Certificates.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.cs" Link="Common\System\Net\Configuration.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Http.cs" Link="Common\System\Net\Configuration.Http.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs" Link="Common\System\Net\Configuration.Security.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpMessageHandlerLoopbackServer.cs" Link="Common\System\Net\Http\HttpMessageHandlerLoopbackServer.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\GenericLoopbackServer.cs" Link="Common\System\Net\Http\GenericLoopbackServer.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\Http\LoopbackServer.cs" Link="Common\System\Net\Http\LoopbackServer.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs" Link="CommonTest\System\Security\Cryptography\PlatformSupport.cs" />
     <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs" Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
   </ItemGroup>


### PR DESCRIPTION
Enforces `HttpClient.Timeout` and `HttpClient.MaxResponseContentBufferSize` on the whole response (including the content transfer) to match `HttpClient.Get{String/ByteArray}Async`.