### PR TITLE
Enable `runtime-coreclr jitstress-isas-avx512` pipeline on Linux

### DIFF
--- a/eng/pipelines/coreclr/jitstress-isas-avx512.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-avx512.yml
@@ -32,9 +32,7 @@ extends:
           jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
           buildConfig: checked
           platforms:
-          # Current Linux and OSX x64 pipelines do not have machines which support AVX-512.
-          # - Linux_x64
-          # - OSX_x64
+          - Linux_x64
           - windows_x64
           - windows_x86
           - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
@@ -55,9 +53,7 @@ extends:
           jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
           buildConfig: checked
           platforms:
-          # Current Linux and OSX x64 pipelines do not have machines which support AVX-512.
-          # - Linux_x64
-          # - OSX_x64
+          - Linux_x64
           - windows_x64
           - windows_x86
           helixQueueGroup: ci


### PR DESCRIPTION
Now our Linux x64 machines in CI are AVX-512 capable.