### PR TITLE
JIT: Enable retbuf optimization for non-temporaries

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -11101,6 +11101,10 @@ public:
                            ((retBuf->GetEarlyNode() == nullptr) != (retBuf->GetLateNode() == nullptr)));
                     GenTree** use = retBuf->GetLateNode() == nullptr ? &retBuf->EarlyNodeRef() : &retBuf->LateNodeRef();
                     result        = WalkTree(use, call);
+                    if (result == fgWalkResult::WALK_ABORT)
+                    {
+                        return result;
+                    }
                 }
 
                 break;

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2599,19 +2599,12 @@ void Compiler::lvaSetVarAddrExposed(unsigned varNum DEBUGARG(AddressExposedReaso
 //    that escape to calls leave the local in question address-exposed. For this very special case of
 //    a return buffer, however, it is known that the callee will not do anything with it except write
 //    to it, once. As such, we handle addresses of locals that represent return buffers specially: we
-//    *do not* mark the local address-exposed, instead saving the address' "Use*" in the call node, and
+//    *do not* mark the local address-exposed, instead flagging the call as having an optimized retbuf, and
 //    treat the call much like an "ASG(IND(addr), ...)" node throughout the compilation. A complicating
 //    factor here is that the address can be moved to the late args list, and we have to fetch it from
 //    the ASG setup node in that case. In the future, we should make it such that these addresses do
 //    not ever need temps (currently they may because of conservative GLOB_REF setting on FIELD nodes).
 //
-//    TODO-ADDR-Bug: currently, we rely on these locals not being present in call argument lists,
-//    outside of the buffer address argument itself, as liveness - currently - treats the location node
-//    associated with the address itself as the definition point, and call arguments can be reordered
-//    rather arbitrarily. We should fix liveness to treat the call as the definition point instead and
-//    enable this optimization for "!lvIsTemp" locals.
-//
-
 void Compiler::lvaSetHiddenBufferStructArg(unsigned varNum)
 {
     LclVarDsc* varDsc = lvaGetDesc(varNum);


### PR DESCRIPTION
This enables retbuf optimization for non-temporaries by changing the evaluation order for calls that define a local, such that the local is always visited right before the call itself (in post-order). This ensures liveness sees it at the right point for both threaded IR and LIR.

FWIW, it seems unnatural to me that we consider the address node as the definition here, especially considering that it is associated with actual codegen and is a "real" node. Would there be any immediate issues with considering it a use (or maybe a special third kind of thing)? Then we would need to consider the call as the definition like the comment I deleted says. That would avoid tying these two concepts (codegen for the retbuf arg and there being a definition) together.