### PR TITLE
[mono] Export unmanagedcallersonly method symbols

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -5257,7 +5257,11 @@ MONO_RESTORE_WARNING
 				add_method (acfg, wrapper);
 				if (export_name) {
 					g_hash_table_insert (acfg->export_names, wrapper, export_name);
+#ifdef TARGET_APPLE_MOBILE
 					g_string_append_printf (export_symbols, "_%s\n", export_name);
+#else
+					g_string_append_printf (export_symbols, "%s\n", export_name);
+#endif
 				}
 			}
 

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -734,11 +734,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             }
         }
 
-        if ((parsedAotMode == MonoAotMode.Full ||
-            parsedAotMode == MonoAotMode.FullInterp ||
-            parsedAotMode == MonoAotMode.LLVMOnly ||
-            parsedAotMode == MonoAotMode.LLVMOnlyInterp) &&
-            EnableUnmanagedCallersOnlyMethodsExport)
+        if (EnableUnmanagedCallersOnlyMethodsExport)
         {
             string exportSymbolsFile = Path.Combine(OutputDir, Path.ChangeExtension(assemblyFilename, ".exportsymbols"));
             ProxyFile proxyFile = _cache.NewFile(exportSymbolsFile);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/79377

Native developers want to be able to call managed functions from their native applications using a shared library with the mono runtime. In order for this to happen, symbols corresponding to the managed functions need to be known while linking together the shared library. Typically, such methods are marked with [UnmanagedCallersOnly Attribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.unmanagedcallersonlyattribute?view=net-7.0), and the expectation is that the developers will designate an `EntryPoint` field corresponding to the desired function on the native side. (e.g. `[UnmanagedCallersOnly(EntryPoint = "<native_function/symbol>"]`)

In order to build the shared library, a list of symbols corresponding to the methods decorated with such attributes exemplified above need to be generated while compiling each assembly, and consumed when building the shared library.
This PR targets the first part by generating for each assembly an `.exportsymbols` file which is a plain text file containing each EntryPoint symbol on its own line if and only if there is a positive number of such EntryPoint symbols.

Specifically, this PR:

- Introduces an export symbols outfile parameter to the mono aot compiler that is designated as `<assembly>.exportsymbols` in the MonoAOTCompiler Task when in full aot mode and when the `EnableUnmanagedCallersOnlyMethodsExport` flag is on.
- Generates the corresponding export symbols outfile if and only if there is a positive number of methods decorated with the `UnmanagedCallersOnly` attribute containing an `EntryPoint` corresponding to the desired native function, where each symbol is formatted based on the target platform.
- Bundles the outfile into the MonoAOTCompiler Task's output assembly's metadata to be consumed by respective App Builders