### PR TITLE
Fix GC stress C on macOS arm64

### DIFF
--- a/src/coreclr/pal/src/arch/arm64/context2.S
+++ b/src/coreclr/pal/src/arch/arm64/context2.S
@@ -221,12 +221,12 @@ LEAF_END RtlRestoreContext, _TEXT
 //
 LEAF_ENTRY RestoreCompleteContext, _TEXT
     // We cannot restore all registers in the user mode code, so we rely on a help from kernel here. 
-    // The following instruction is an invalid instruction. In the hardware exception handler, we check
+    // The following instruction is an undefined instruction. In the hardware exception handler, we check
     // if the faulting address is the RtlRestoreContext and in case it is, we update the context of
     // the faulting thread using the CONTEXT pointed to by the x0 register.
     // While this could be used for the full fidelity RtlRestoreContext implementation, it is too
     // expensive for general usage of the RtlRestoreContext.
-    .quad 0xBADC0DE3
+    UDF #0
 LEAF_END RestoreCompleteContext, _TEXT
 
 #endif // __APPLE__

--- a/src/coreclr/pal/src/arch/arm64/context2.S
+++ b/src/coreclr/pal/src/arch/arm64/context2.S
@@ -212,3 +212,21 @@ LOCAL_LABEL(No_Restore_CONTEXT_CONTROL):
     ret
 
 LEAF_END RtlRestoreContext, _TEXT
+
+#ifdef __APPLE__
+
+// Incoming:
+//  x0: Context*
+//  x1: Exception*
+//
+LEAF_ENTRY RestoreCompleteContext, _TEXT
+    // We cannot restore all registers in the user mode code, so we rely on a help from kernel here. 
+    // The following instruction is an invalid instruction. In the hardware exception handler, we check
+    // if the faulting address is the RtlRestoreContext and in case it is, we update the context of
+    // the faulting thread using the CONTEXT pointed to by the x0 register.
+    // While this could be used for the full fidelity RtlRestoreContext implementation, it is too
+    // expensive for general usage of the RtlRestoreContext.
+    .quad 0xBADC0DE3
+LEAF_END RestoreCompleteContext, _TEXT
+
+#endif // __APPLE__


### PR DESCRIPTION
Tests relying on `SIGCHLD` signal are intermittently hanging when running with GC stress C enabled. Investigations have shown that the problem is that while according to dtrace the `SIGCHLD` was delivered to a thread, the signal handler for it was actually not invoked. That caused tests waiting for child completion to wait forever, thus the tests were hanging.
Further investigations have uncovered the real issue. The problem is that when we return from the coreclr hardware exception handler to PAL after processing an invalid instruction used by the GC stress C machinery, we use `MachSetThreadContext` to update the context of the thread and to resume its execution. The problem is that the `MachSetThreadContext` uses the pattern of suspend thread / set thread state / resume thread. This pattern is problematic when async signals can be delivered to the thread. The kernel can update the thread state to point to the signal handler even when the thread is suspended. So in our case, the kernel has set the state to execute the signal handler, but in race conditions, we have overwritten that by our context, effectively going back to the managed code and preventing the signal handler execution.
We are using `MachSetThreadContext` instead of `RtlRestoreContext` at that place because we need all registers to be restored and it is not possible to restore all the registers and jump to the target in user mode code. We are left with at least one register containing different value (the target address).

This change uses a trick to achieve full thread state restoration. It invokes a new helper `RestoreCompleteContext` which contains just a single invalid instruction. The hardware exception handling is triggered by that, we detect that the fault address is the `RestoreCompleteContext` address and we set the context of the faulting thread to the desired context. In this case, the signal handling cannot interfere with this process and so there is no race.

I have originally modified `RtlRestoreContext` instead of creating the new `RestoreCompleteContext`, but it turned out that for the other usages of `RtlRestoreContext`, it is too expensive. And for the other usages, we don't require the full fidelity restoration.

Close #69092