### PR TITLE
Fix `IDesignerSerializationManager` nullability

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -2192,11 +2192,11 @@ namespace System.ComponentModel.Design.Serialization
         event System.ComponentModel.Design.Serialization.ResolveNameEventHandler ResolveName;
         event System.EventHandler SerializationComplete;
         void AddSerializationProvider(System.ComponentModel.Design.Serialization.IDesignerSerializationProvider provider);
-        object CreateInstance(System.Type type, System.Collections.ICollection arguments, string name, bool addToContainer);
-        object GetInstance(string name);
-        string GetName(object value);
-        object GetSerializer(System.Type objectType, System.Type serializerType);
-        System.Type GetType(string typeName);
+        object CreateInstance(System.Type type, System.Collections.ICollection? arguments, string? name, bool addToContainer);
+        object? GetInstance(string name);
+        string? GetName(object value);
+        object? GetSerializer(System.Type? objectType, System.Type serializerType);
+        System.Type? GetType(string typeName);
         void RemoveSerializationProvider(System.ComponentModel.Design.Serialization.IDesignerSerializationProvider provider);
         void ReportError(object errorInformation);
         void SetName(object instance, string name);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationManager.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationManager.cs
@@ -71,30 +71,30 @@ namespace System.ComponentModel.Design.Serialization
         /// of named instances. Objects that implement IComponent will be
         /// added to the design time container if addToContainer is true.
         /// </summary>
-        object CreateInstance(Type type, ICollection arguments, string name, bool addToContainer);
+        object CreateInstance(Type type, ICollection arguments, string? name, bool addToContainer);
 
         /// <summary>
         /// Retrieves an instance of a created object of the given name, or
         /// null if that object does not exist.
         /// </summary>
-        object GetInstance(string name);
+        object? GetInstance(string name);
 
         /// <summary>
         /// Retrieves a name for the specified object, or null if the object
         /// has no name.
         /// </summary>
-        string GetName(object value);
+        string? GetName(object value);
 
         /// <summary>
         /// Retrieves a serializer of the requested type for the given
         /// object type.
         /// </summary>
-        object GetSerializer(Type objectType, Type serializerType);
+        object? GetSerializer(Type objectType, Type serializerType);
 
         /// <summary>
         /// Retrieves a type of the given name.
         /// </summary>
-        Type GetType(string typeName);
+        Type? GetType(string typeName);
 
         /// <summary>
         /// Removes a previously added serialization provider.

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationManager.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationManager.cs
@@ -71,7 +71,7 @@ namespace System.ComponentModel.Design.Serialization
         /// of named instances. Objects that implement IComponent will be
         /// added to the design time container if addToContainer is true.
         /// </summary>
-        object CreateInstance(Type type, ICollection arguments, string? name, bool addToContainer);
+        object CreateInstance(Type type, ICollection? arguments, string? name, bool addToContainer);
 
         /// <summary>
         /// Retrieves an instance of a created object of the given name, or
@@ -89,7 +89,7 @@ namespace System.ComponentModel.Design.Serialization
         /// Retrieves a serializer of the requested type for the given
         /// object type.
         /// </summary>
-        object? GetSerializer(Type objectType, Type serializerType);
+        object? GetSerializer(Type? objectType, Type serializerType);
 
         /// <summary>
         /// Retrieves a type of the given name.


### PR DESCRIPTION
The documentation states that many of the functions can return `null`. So I have updated the nullability based on the documentation.

https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.design.serialization.idesignerserializationmanager?view=net-7.0

Related: https://github.com/dotnet/winforms/issues/8342, #41720