### PR TITLE
Fix creation of pointer arrays

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -658,14 +658,6 @@ namespace Internal.Runtime.TypeLoader
 
                 pTemplateEEType = templateTypeHandle.ToEETypePtr();
             }
-            else if (type.IsMdArray || (type.IsSzArray && ((ArrayType)type).ElementType.IsPointer))
-            {
-                // Multidimensional arrays and szarrays of pointers don't implement generic interfaces and
-                // we don't need to do much for them in terms of type building. We can pretty much just take
-                // the MethodTable for any of those, massage the bits that matter (GCDesc, element type,
-                // component size,...) to be of the right shape and we're done.
-                pTemplateEEType = typeof(object[,]).TypeHandle.ToEETypePtr();
-            }
             else
             {
                 Debug.Assert(state.TemplateType != null && !state.TemplateType.RuntimeTypeHandle.IsNull());

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -56,11 +56,22 @@ namespace Internal.Runtime.TypeLoader
             {
                 if (!_templateComputed)
                 {
-                    // Multidimensional arrays and szarrays of pointers don't implement generic interfaces and are special cases. They use
+                    // Multidimensional arrays don't implement generic interfaces and are special cases. They use
                     // typeof(object[,]) as their template.
-                    if (TypeBeingBuilt.IsMdArray || (TypeBeingBuilt.IsSzArray && ((ArrayType)TypeBeingBuilt).ElementType.IsPointer))
+                    if (TypeBeingBuilt.IsMdArray)
                     {
                         _templateType = TypeBeingBuilt.Context.ResolveRuntimeTypeHandle(typeof(object[,]).TypeHandle);
+                        _templateTypeLoaderNativeLayout = false;
+                        _nativeLayoutComputed = _nativeLayoutTokenComputed = _templateComputed = true;
+
+                        return _templateType;
+                    }
+
+                    // Arrays of pointers don't implement generic interfaces and are special cases. They use
+                    // typeof(char*[]) as their template.
+                    if (TypeBeingBuilt.IsSzArray && ((ArrayType)TypeBeingBuilt).ElementType.IsPointer)
+                    {
+                        _templateType = TypeBeingBuilt.Context.ResolveRuntimeTypeHandle(typeof(char*[]).TypeHandle);
                         _templateTypeLoaderNativeLayout = false;
                         _nativeLayoutComputed = _nativeLayoutTokenComputed = _templateComputed = true;
 


### PR DESCRIPTION
Creation of pointer arrays is on a similar plan to multi-dim arrays - we create them from a template type, but the template is slightly off. Previously, EETypeCreator would massage the bits into the correct shape, but now we mostly just copy the bits from the template. Use a more precise template for pointer arrays.

Without this, the base size and element type of pointer arrays was slightly wrong.

I'm also deleting the duplicated "use a special template for this one" logic.

This should fix #79403 (it didn't repro for me locally, but I didn't try too hard because I just followed a hunch and saw the `MethodTable` being wrong).

Cc @dotnet/ilc-contrib 