### PR TITLE
Only create MethodTable optional fields when needed

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -858,10 +858,13 @@ namespace Internal.Runtime
                 if (NumInterfaces == 0)
                     return false;
                 byte* optionalFields = OptionalFieldsPtr;
-                if (optionalFields == null)
-                    return false;
-                uint idxDispatchMap = OptionalFieldsReader.GetInlineField(optionalFields, EETypeOptionalFieldTag.DispatchMap, 0xffffffff);
-                if (idxDispatchMap == 0xffffffff)
+
+                const uint NoDispatchMap = 0xffffffff;
+                uint idxDispatchMap = NoDispatchMap;
+                if (optionalFields != null)
+                    idxDispatchMap = OptionalFieldsReader.GetInlineField(optionalFields, EETypeOptionalFieldTag.DispatchMap, NoDispatchMap);
+
+                if (idxDispatchMap == NoDispatchMap)
                 {
                     if (IsDynamicType)
                         return DynamicTemplateType->HasDispatchMap;
@@ -878,12 +881,15 @@ namespace Internal.Runtime
                 if (NumInterfaces == 0)
                     return null;
                 byte* optionalFields = OptionalFieldsPtr;
-                if (optionalFields == null)
-                    return null;
-                uint idxDispatchMap = OptionalFieldsReader.GetInlineField(optionalFields, EETypeOptionalFieldTag.DispatchMap, 0xffffffff);
-                if (idxDispatchMap == 0xffffffff && IsDynamicType)
+                const uint NoDispatchMap = 0xffffffff;
+                uint idxDispatchMap = NoDispatchMap;
+                if (optionalFields != null)
+                    idxDispatchMap = OptionalFieldsReader.GetInlineField(optionalFields, EETypeOptionalFieldTag.DispatchMap, NoDispatchMap);
+                if (idxDispatchMap == NoDispatchMap)
                 {
-                    return DynamicTemplateType->DispatchMap;
+                    if (IsDynamicType)
+                        return DynamicTemplateType->DispatchMap;
+                    return null;
                 }
 
                 if (SupportsRelativePointers)

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -226,6 +226,10 @@ namespace Internal.Runtime.TypeLoader
                 // Compute size of optional fields encoding
                 cbOptionalFieldsSize = optionalFields.Encode();
 
+                // Clear the optional fields flag. We'll set it if we set optional fields later in this method.
+                if (cbOptionalFieldsSize == 0)
+                    flags &= ~(uint)EETypeFlags.OptionalFieldsFlag;
+
                 // Note: The number of vtable slots on the MethodTable to create is not necessary equal to the number of
                 // vtable slots on the template type for universal generics (see ComputeVTableLayout)
                 ushort numVtableSlots = state.NumVTableSlots;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -217,14 +217,14 @@ namespace Internal.Runtime.TypeLoader
                 if (state.ThreadDataSize != 0)
                     rareFlags |= (uint)EETypeRareFlags.IsDynamicTypeWithThreadStatics;
 
-                optionalFields.SetFieldValue(EETypeOptionalFieldTag.RareFlags, rareFlags);
+                if (rareFlags != 0)
+                    optionalFields.SetFieldValue(EETypeOptionalFieldTag.RareFlags, rareFlags);
 
                 // Dispatch map is fetched from template type
                 optionalFields.ClearField(EETypeOptionalFieldTag.DispatchMap);
 
                 // Compute size of optional fields encoding
                 cbOptionalFieldsSize = optionalFields.Encode();
-                Debug.Assert(cbOptionalFieldsSize > 0);
 
                 // Note: The number of vtable slots on the MethodTable to create is not necessary equal to the number of
                 // vtable slots on the template type for universal generics (see ComputeVTableLayout)
@@ -243,7 +243,7 @@ namespace Internal.Runtime.TypeLoader
                         numVtableSlots,
                         runtimeInterfacesLength,
                         hasFinalizer,
-                        true,
+                        cbOptionalFieldsSize > 0,
                         (rareFlags & (int)EETypeRareFlags.HasSealedVTableEntriesFlag) != 0,
                         isGeneric,
                         allocatedNonGCDataSize != 0,
@@ -278,10 +278,11 @@ namespace Internal.Runtime.TypeLoader
                     Debug.Assert(pEEType->HasGCPointers == (cbGCDesc != 0));
 
                     // Copy the encoded optional fields buffer to the newly allocated memory, and update the OptionalFields field on the MethodTable
-                    // It is important to set the optional fields first on the newly created MethodTable, because all other 'setters'
-                    // will assert that the type is dynamic, just to make sure we are not making any changes to statically compiled types
-                    pEEType->OptionalFieldsPtr = (byte*)pEEType + cbEEType;
-                    optionalFields.WriteToEEType(pEEType, cbOptionalFieldsSize);
+                    if (cbOptionalFieldsSize > 0)
+                    {
+                        pEEType->OptionalFieldsPtr = (byte*)pEEType + cbEEType;
+                        optionalFields.WriteToEEType(pEEType, cbOptionalFieldsSize);
+                    }
 
                     // Copy VTable entries from template type
                     IntPtr* pVtable = (IntPtr*)((byte*)pEEType + sizeof(MethodTable));


### PR DESCRIPTION
Noticed a difference between statically built and dynamically built `MethodTable` for `int*[]`.

Cc @dotnet/ilc-contrib 