### PR TITLE
[mono][llvm] Added a null-check for 2-dim array access

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -4321,6 +4321,11 @@ mini_emit_ldelema_2_ins (MonoCompile *cfg, MonoClass *klass, MonoInst *arr, Mono
 	// FIXME: Do we need to do something here for i8 indexes, like in ldelema_1_ins ?
 #endif
 
+	if (COMPILE_LLVM (cfg)) {
+		// null checking in LLVM to address https://github.com/dotnet/runtime/issues/79022
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, arr->dreg, 0);
+		MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+	}
 	/* range checking */
 	MONO_EMIT_NEW_LOAD_MEMBASE (cfg, bounds_reg,
 				       arr->dreg, MONO_STRUCT_OFFSET (MonoArray, bounds));

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -4322,15 +4322,9 @@ mini_emit_ldelema_2_ins (MonoCompile *cfg, MonoClass *klass, MonoInst *arr, Mono
 #endif
 
 	/* range checking */
-	if (COMPILE_LLVM (cfg)) {
-		// null checking in LLVM to address https://github.com/dotnet/runtime/issues/79022
-		MONO_EMIT_NEW_LOAD_MEMBASE_FAULT (cfg, bounds_reg,
-				    		arr->dreg, MONO_STRUCT_OFFSET (MonoArray, bounds));
-	} else {
-		MONO_EMIT_NEW_LOAD_MEMBASE (cfg, bounds_reg,
-			       		arr->dreg, MONO_STRUCT_OFFSET (MonoArray, bounds));
-	}
-	
+	MONO_EMIT_NEW_LOAD_MEMBASE_FAULT (cfg, bounds_reg,
+				       arr->dreg, MONO_STRUCT_OFFSET (MonoArray, bounds));
+
 	MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADI4_MEMBASE, low1_reg,
 				       bounds_reg, MONO_STRUCT_OFFSET (MonoArrayBounds, lower_bound));
 	MONO_EMIT_NEW_BIALU (cfg, OP_PSUB, realidx1_reg, index1, low1_reg);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -4321,15 +4321,16 @@ mini_emit_ldelema_2_ins (MonoCompile *cfg, MonoClass *klass, MonoInst *arr, Mono
 	// FIXME: Do we need to do something here for i8 indexes, like in ldelema_1_ins ?
 #endif
 
+	/* range checking */
 	if (COMPILE_LLVM (cfg)) {
 		// null checking in LLVM to address https://github.com/dotnet/runtime/issues/79022
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, arr->dreg, 0);
-		MONO_EMIT_NEW_COND_EXC (cfg, EQ, "NullReferenceException");
+		MONO_EMIT_NEW_LOAD_MEMBASE_FAULT (cfg, bounds_reg,
+				    		arr->dreg, MONO_STRUCT_OFFSET (MonoArray, bounds));
+	} else {
+		MONO_EMIT_NEW_LOAD_MEMBASE (cfg, bounds_reg,
+			       		arr->dreg, MONO_STRUCT_OFFSET (MonoArray, bounds));
 	}
-	/* range checking */
-	MONO_EMIT_NEW_LOAD_MEMBASE (cfg, bounds_reg,
-				       arr->dreg, MONO_STRUCT_OFFSET (MonoArray, bounds));
-
+	
 	MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADI4_MEMBASE, low1_reg,
 				       bounds_reg, MONO_STRUCT_OFFSET (MonoArrayBounds, lower_bound));
 	MONO_EMIT_NEW_BIALU (cfg, OP_PSUB, realidx1_reg, index1, low1_reg);

--- a/src/tests/Regressions/coreclr/GitHub_79022/test79022.cs
+++ b/src/tests/Regressions/coreclr/GitHub_79022/test79022.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    // This is a regression test for https://github.com/dotnet/runtime/issues/79022
+    static ulong[,] s_1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Test()
+    {
+        try
+        {
+            ushort vr10 = default(ushort);
+            bool vr11 = 0 < ((s_1[0, 0] * (uint)(0 / vr10)) % 1);
+        }
+        catch 
+        {
+        }
+    }
+
+    public static int Main()
+    {
+        try
+        {
+            Test();
+        }
+        catch
+        {
+            return -1;
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_79022/test79022.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_79022/test79022.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+    <WarningsNotAsErrors>CS0649</WarningsNotAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test79022.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This addresses [#79022](https://github.com/dotnet/runtime/issues/79022) by adding a null-check to 2-dim array accessors. This ensures that a managed exception is generated in the right place. Otherwise a native exception may be generated instead when reading inaccessible memory. This would not be caught correctly in LLVM AOT.
