### PR TITLE
Hosting DirectSettingsOverrideConfigurationSetting and ConfigurationSettingCanInfluenceEnvironment test failures in CI

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
@@ -234,41 +234,48 @@ namespace Microsoft.Extensions.Hosting.Tests
         [InlineData(false)]
         public void ConfigurationSettingCanInfluenceEnvironment(bool disableDefaults)
         {
-            var tempPath = Path.GetTempPath();
+            var tempPath = CreateTempSubdirectory();
 
-            using var config = new ConfigurationManager();
-
-            config.AddInMemoryCollection(new KeyValuePair<string, string>[]
+            try
             {
-                new(HostDefaults.ApplicationKey, "AppA" ),
-                new(HostDefaults.EnvironmentKey, "EnvA" ),
-                new(HostDefaults.ContentRootKey, tempPath)
-            });
+                using var config = new ConfigurationManager();
 
-            var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+                config.AddInMemoryCollection(new KeyValuePair<string, string>[]
+                {
+                    new(HostDefaults.ApplicationKey, "AppA" ),
+                    new(HostDefaults.EnvironmentKey, "EnvA" ),
+                    new(HostDefaults.ContentRootKey, tempPath)
+                });
+
+                var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+                {
+                    DisableDefaults = disableDefaults,
+                    Configuration = config,
+                });
+
+                Assert.Equal("AppA", builder.Configuration[HostDefaults.ApplicationKey]);
+                Assert.Equal("EnvA", builder.Configuration[HostDefaults.EnvironmentKey]);
+                Assert.Equal(tempPath, builder.Configuration[HostDefaults.ContentRootKey]);
+
+                Assert.Equal("AppA", builder.Environment.ApplicationName);
+                Assert.Equal("EnvA", builder.Environment.EnvironmentName);
+                Assert.Equal(tempPath, builder.Environment.ContentRootPath);
+                var fileProviderFromBuilder = Assert.IsType<PhysicalFileProvider>(builder.Environment.ContentRootFileProvider);
+                Assert.Equal(tempPath, fileProviderFromBuilder.Root);
+
+                using IHost host = builder.Build();
+
+                var hostEnvironmentFromServices = host.Services.GetRequiredService<IHostEnvironment>();
+                Assert.Equal("AppA", hostEnvironmentFromServices.ApplicationName);
+                Assert.Equal("EnvA", hostEnvironmentFromServices.EnvironmentName);
+                Assert.Equal(tempPath, hostEnvironmentFromServices.ContentRootPath);
+                var fileProviderFromServices = Assert.IsType<PhysicalFileProvider>(hostEnvironmentFromServices.ContentRootFileProvider);
+                Assert.Equal(tempPath, fileProviderFromServices.Root);
+            }
+            finally
             {
-                DisableDefaults = disableDefaults,
-                Configuration = config,
-            });
-
-            Assert.Equal("AppA", builder.Configuration[HostDefaults.ApplicationKey]);
-            Assert.Equal("EnvA", builder.Configuration[HostDefaults.EnvironmentKey]);
-            Assert.Equal(tempPath, builder.Configuration[HostDefaults.ContentRootKey]);
-
-            Assert.Equal("AppA", builder.Environment.ApplicationName);
-            Assert.Equal("EnvA", builder.Environment.EnvironmentName);
-            Assert.Equal(tempPath, builder.Environment.ContentRootPath);
-            var fileProviderFromBuilder = Assert.IsType<PhysicalFileProvider>(builder.Environment.ContentRootFileProvider);
-            Assert.Equal(tempPath, fileProviderFromBuilder.Root);
-
-            using IHost host = builder.Build();
-
-            var hostEnvironmentFromServices = host.Services.GetRequiredService<IHostEnvironment>();
-            Assert.Equal("AppA", hostEnvironmentFromServices.ApplicationName);
-            Assert.Equal("EnvA", hostEnvironmentFromServices.EnvironmentName);
-            Assert.Equal(tempPath, hostEnvironmentFromServices.ContentRootPath);
-            var fileProviderFromServices = Assert.IsType<PhysicalFileProvider>(hostEnvironmentFromServices.ContentRootFileProvider);
-            Assert.Equal(tempPath, fileProviderFromServices.Root);
+                Directory.Delete(tempPath);
+            }
         }
 
         [Theory]
@@ -276,43 +283,74 @@ namespace Microsoft.Extensions.Hosting.Tests
         [InlineData(false)]
         public void DirectSettingsOverrideConfigurationSetting(bool disableDefaults)
         {
-            var tempPath = Path.GetTempPath();
+            var tempPath = CreateTempSubdirectory();
 
-            using var config = new ConfigurationManager();
-
-            config.AddInMemoryCollection(new KeyValuePair<string, string>[]
+            try
             {
-                new(HostDefaults.ApplicationKey, "AppA" ),
-                new(HostDefaults.EnvironmentKey, "EnvA" ),
-            });
+                using var config = new ConfigurationManager();
 
-            var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+                config.AddInMemoryCollection(new KeyValuePair<string, string>[]
+                {
+                    new(HostDefaults.ApplicationKey, "AppA" ),
+                    new(HostDefaults.EnvironmentKey, "EnvA" ),
+                });
+
+                var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+                {
+                    DisableDefaults = disableDefaults,
+                    Configuration = config,
+                    ApplicationName = "AppB",
+                    EnvironmentName = "EnvB",
+                    ContentRootPath = tempPath,
+                });
+
+                Assert.Equal("AppB", builder.Configuration[HostDefaults.ApplicationKey]);
+                Assert.Equal("EnvB", builder.Configuration[HostDefaults.EnvironmentKey]);
+                Assert.Equal(tempPath, builder.Configuration[HostDefaults.ContentRootKey]);
+
+                Assert.Equal("AppB", builder.Environment.ApplicationName);
+                Assert.Equal("EnvB", builder.Environment.EnvironmentName);
+                Assert.Equal(tempPath, builder.Environment.ContentRootPath);
+                var fileProviderFromBuilder = Assert.IsType<PhysicalFileProvider>(builder.Environment.ContentRootFileProvider);
+                Assert.Equal(tempPath, fileProviderFromBuilder.Root);
+
+                using IHost host = builder.Build();
+
+                var hostEnvironmentFromServices = host.Services.GetRequiredService<IHostEnvironment>();
+                Assert.Equal("AppB", hostEnvironmentFromServices.ApplicationName);
+                Assert.Equal("EnvB", hostEnvironmentFromServices.EnvironmentName);
+                Assert.Equal(tempPath, hostEnvironmentFromServices.ContentRootPath);
+                var fileProviderFromServices = Assert.IsType<PhysicalFileProvider>(hostEnvironmentFromServices.ContentRootFileProvider);
+                Assert.Equal(tempPath, fileProviderFromServices.Root);
+            }
+            finally
             {
-                DisableDefaults = disableDefaults,
-                Configuration = config,
-                ApplicationName = "AppB",
-                EnvironmentName = "EnvB",
-                ContentRootPath = tempPath,
-            });
+                Directory.Delete(tempPath);
+            }
+        }
 
-            Assert.Equal("AppB", builder.Configuration[HostDefaults.ApplicationKey]);
-            Assert.Equal("EnvB", builder.Configuration[HostDefaults.EnvironmentKey]);
-            Assert.Equal(tempPath, builder.Configuration[HostDefaults.ContentRootKey]);
+        private static string CreateTempSubdirectory()
+        {
+#if NETCOREAPP
+            DirectoryInfo directoryInfo = Directory.CreateTempSubdirectory();
+#else
+            DirectoryInfo directoryInfo = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+            directoryInfo.Create();
+#endif
 
-            Assert.Equal("AppB", builder.Environment.ApplicationName);
-            Assert.Equal("EnvB", builder.Environment.EnvironmentName);
-            Assert.Equal(tempPath, builder.Environment.ContentRootPath);
-            var fileProviderFromBuilder = Assert.IsType<PhysicalFileProvider>(builder.Environment.ContentRootFileProvider);
-            Assert.Equal(tempPath, fileProviderFromBuilder.Root);
+            // PhysicalFileProvider will always ensure the path has a trailing slash
+            return EnsureTrailingSlash(directoryInfo.FullName);
+        }
 
-            using IHost host = builder.Build();
-
-            var hostEnvironmentFromServices = host.Services.GetRequiredService<IHostEnvironment>();
-            Assert.Equal("AppB", hostEnvironmentFromServices.ApplicationName);
-            Assert.Equal("EnvB", hostEnvironmentFromServices.EnvironmentName);
-            Assert.Equal(tempPath, hostEnvironmentFromServices.ContentRootPath);
-            var fileProviderFromServices = Assert.IsType<PhysicalFileProvider>(hostEnvironmentFromServices.ContentRootFileProvider);
-            Assert.Equal(tempPath, fileProviderFromServices.Root);
+        private static string EnsureTrailingSlash(string path)
+        {
+            if (!string.IsNullOrEmpty(path) &&
+                path[path.Length - 1] != Path.DirectorySeparatorChar)
+            {
+                return path + Path.DirectorySeparatorChar;
+            }
+ 
+            return path;
         }
 
         [Fact]


### PR DESCRIPTION
Ensure the temp directory used is always empty, so it doesn't pick up appsettings.json files randomly.

Fix #79453