### PR TITLE
[wasm] Improve terser setup

### DIFF
--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -97,7 +97,6 @@ const linked_functions = [
     "mono_wasm_release_cs_owned_object",
     "mono_wasm_typed_array_to_array_ref",
     "mono_wasm_typed_array_from_ref",
-    "mono_wasm_compile_function_ref",
     "mono_wasm_bind_js_function",
     "mono_wasm_invoke_bound_function",
     "mono_wasm_invoke_import",
@@ -121,8 +120,7 @@ const linked_functions = [
 // -- this javascript file is evaluated by emcc during compilation! --
 // we generate simple proxy for each exported function so that emcc will include them in the final output
 for (let linked_function of linked_functions) {
-    const fn_template = `return __dotnet_runtime.__linker_exports.${linked_function}.apply(__dotnet_runtime, arguments)`;
-    DotnetSupportLib[linked_function] = new Function(fn_template);
+    DotnetSupportLib[linked_function] = new Function("");
 }
 
 autoAddDeps(DotnetSupportLib, "$DOTNET");

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -19,24 +19,10 @@ const monoWasmThreads = process.env.MonoWasmThreads === "true" ? true : false;
 const monoDiagnosticsMock = process.env.MonoDiagnosticsMock === "true" ? true : false;
 const terserConfig = {
     compress: {
-        defaults: false,// too agressive minification breaks subsequent emcc compilation
+        defaults: true,
+        passes: 2,
         drop_debugger: false,// we invoke debugger
         drop_console: false,// we log to console
-        unused: false,// this breaks stuff
-        // below are minification features which seems to work fine
-        collapse_vars: true,
-        conditionals: true,
-        computed_props: true,
-        properties: true,
-        dead_code: true,
-        if_return: true,
-        inline: true,
-        join_vars: true,
-        loops: true,
-        reduce_vars: true,
-        evaluate: true,
-        hoist_props: true,
-        sequences: true,
     },
     mangle: {
         // because of stack walk at src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -44,6 +30,9 @@ const terserConfig = {
         keep_fnames: /(mono_wasm_runtime_ready|mono_wasm_fire_debugger_agent_message|mono_wasm_set_timeout_exec)/,
         keep_classnames: /(ManagedObject|ManagedError|Span|ArraySegment|WasmRootBuffer|SessionOptionsBuilder)/,
     },
+    format: {
+        wrap_iife: true
+    }
 };
 const plugins = isDebug ? [writeOnChangePlugin()] : [terser(terserConfig), writeOnChangePlugin()];
 const banner = "//! Licensed to the .NET Foundation under one or more agreements.\n//! The .NET Foundation licenses this file to you under the MIT license.\n";
@@ -81,7 +70,7 @@ function consts(dict) {
     let newDict = {};
     for (const k in dict) {
         const newKey = "consts:" + k;
-        const newVal = JSON.stringify (dict[k]);
+        const newVal = JSON.stringify(dict[k]);
         newDict[newKey] = `export default ${newVal}`;
     }
     return virtual(newDict);

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -395,7 +395,7 @@
     <_RollupInputs Include="$(MonoProjectRoot)wasm/runtime/*.js"/>
   </ItemGroup>
 
-  <Target Name="SetMonoRollupEnvironment">
+  <Target Name="SetMonoRollupEnvironment" DependsOnTargets="GetProductVersions">
     <PropertyGroup>
       <MonoRollupEnvironment>Configuration:$(Configuration),NativeBinDir:$(NativeBinDir),ProductVersion:$(ProductVersion),MonoWasmThreads:$(MonoWasmThreads),MonoDiagnosticsMock:$(MonoDiagnosticsMock)</MonoRollupEnvironment>
     </PropertyGroup>


### PR DESCRIPTION
- default terser config for smaller size
- fix ProducVersion
- dotn't generate dummy linker functions

Makes `dotnet.js` Release uncompressed 342 162 bytes, 11 461 bytes smaller. 