### PR TITLE
Always set `addlDelta` to zero on x86

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -277,9 +277,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_34094/Test34094/*">
             <Issue>https://github.com/dotnet/runtime/issues/57458</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_31615/Runtime_31615/*">
-            <Issue>https://github.com/dotnet/runtime/issues/79170</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_63354/Runtime_63354/**">
             <Issue>https://github.com/dotnet/runtime/issues/78898</Issue>
         </ExcludeList>


### PR DESCRIPTION
As best as I am able to infer from reading the code, this value is only meant to be used for reporting relocations of RIP-relative addresses, which x86 doesn't have.

Fixes #79170.

No diffs are expected.