### PR TITLE
Use non-generic Array.Sort in EnumInfo on nativeaot

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
@@ -34,7 +34,10 @@ namespace System.Reflection
         {
             Debug.Assert(values.Length == names.Length);
 
-            Array.Sort(keys: values, items: names);
+            if (!Enum.AreSorted(values))
+            {
+                Array.Sort(keys: (Array)values, items: names); // using non-generic overload to avoid generic expansion for every underlying enum type
+            }
 
             Values = values;
             ValuesAreSequentialFromZero = Enum.AreSequentialFromZero(values);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/EnumInfo.cs
@@ -33,11 +33,7 @@ namespace System.Reflection
             base(underlyingType, names, isFlags)
         {
             Debug.Assert(values.Length == names.Length);
-
-            if (!Enum.AreSorted(values))
-            {
-                Array.Sort(keys: (Array)values, items: names); // using non-generic overload to avoid generic expansion for every underlying enum type
-            }
+            Debug.Assert(Enum.AreSorted(values));
 
             Values = values;
             ValuesAreSequentialFromZero = Enum.AreSequentialFromZero(values);

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
@@ -46,7 +46,6 @@ namespace Internal.Reflection.Execution
             }
 
             // Using object overload to avoid generic expansion for every underlying enum type
-            // TODO: Sort the values in the aot compiler
             Array.Sort<object, string>(boxedValues, names);
 
             sortedBoxedValues = boxedValues;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
@@ -13,8 +13,8 @@ namespace Internal.Reflection.Execution
 {
     static class NativeFormatEnumInfo
     {
-        public static EnumInfo<TUnderlyingValue> Create<TUnderlyingValue>(RuntimeTypeHandle typeHandle, MetadataReader reader, TypeDefinitionHandle typeDefHandle)
-            where TUnderlyingValue : struct, INumber<TUnderlyingValue>
+        private static void GetEnumValuesAndNames(MetadataReader reader, TypeDefinitionHandle typeDefHandle,
+            out object[] sortedBoxedValues, out string[] sortedNames, out bool isFlags)
         {
             TypeDefinition typeDef = reader.GetTypeDefinition(typeDefHandle);
 
@@ -30,8 +30,8 @@ namespace Internal.Reflection.Execution
                 }
             }
 
-            string[] names = new string[staticFieldCount];
-            TUnderlyingValue[] values = new TUnderlyingValue[staticFieldCount];
+            var names = new string[staticFieldCount];
+            var boxedValues = new object[staticFieldCount]; // TODO: Avoid boxing the values
 
             int i = 0;
             foreach (FieldHandle fieldHandle in typeDef.Fields)
@@ -40,17 +40,34 @@ namespace Internal.Reflection.Execution
                 if (0 != (field.Flags & FieldAttributes.Static))
                 {
                     names[i] = field.Name.GetString(reader);
-                    values[i] = (TUnderlyingValue)field.DefaultValue.ParseConstantNumericValue(reader);
+                    boxedValues[i] = field.DefaultValue.ParseConstantNumericValue(reader);
                     i++;
                 }
             }
 
-            bool isFlags = false;
+            // Using object overload to avoid generic expansion for every underlying enum type
+            // TODO: Sort the values in the aot compiler
+            Array.Sort<object, string>(boxedValues, names);
+
+            sortedBoxedValues = boxedValues;
+            sortedNames = names;
+
+            isFlags = false;
             foreach (CustomAttributeHandle cah in typeDef.CustomAttributes)
             {
                 if (cah.IsCustomAttributeOfType(reader, "System", "FlagsAttribute"))
                     isFlags = true;
             }
+        }
+
+        public static EnumInfo<TUnderlyingValue> Create<TUnderlyingValue>(RuntimeTypeHandle typeHandle, MetadataReader reader, TypeDefinitionHandle typeDefHandle)
+            where TUnderlyingValue : struct, INumber<TUnderlyingValue>
+        {
+            GetEnumValuesAndNames(reader, typeDefHandle, out object[] boxedValues, out string[] names, out bool isFlags);
+
+            var values = new TUnderlyingValue[boxedValues.Length];
+            for (int i = 0; i < boxedValues.Length; i++)
+                values[i] = (TUnderlyingValue)boxedValues[i];
 
             return new EnumInfo<TUnderlyingValue>(RuntimeAugments.GetEnumUnderlyingType(typeHandle), values, names, isFlags);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
@@ -22,7 +22,10 @@ namespace System
                 Values = values;
                 Names = names;
 
-                Array.Sort(keys: values, items: names);
+                if (!AreSorted(values))
+                {
+                    Array.Sort(keys: values, items: names);
+                }
 
                 ValuesAreSequentialFromZero = AreSequentialFromZero(values);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
@@ -22,10 +22,7 @@ namespace System
                 Values = values;
                 Names = names;
 
-                if (!AreSorted(values))
-                {
-                    Array.Sort(keys: values, items: names);
-                }
+                Array.Sort(keys: values, items: names);
 
                 ValuesAreSequentialFromZero = AreSequentialFromZero(values);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -2293,5 +2293,18 @@ namespace System
 
             return true;
         }
+
+        internal static bool AreSorted<TUnderlyingValue>(TUnderlyingValue[] values) where TUnderlyingValue : struct, IComparable<TUnderlyingValue>
+        {
+            for (int i = 1; i < values.Length; i++)
+            {
+                if (values[i - 1].CompareTo(values[i]) > 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/79437

@jkotas, worthwhile?  We'll pay boxing costs as part of the sort, but it should be only once per enum and only if the values aren't already sorted.