### PR TITLE
This fixes emitGetVexPrefixSize to support detecting 2-byte prefix support

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -747,7 +747,7 @@ static bool IsDstSrcImmAvxInstruction(instruction ins)
 // Note that this should be true for any of the instructions in instrsXArch.h
 // that use the SSE38 or SSE3A macro but returns false if the VEX encoding is
 // in use, since that encoding does not require an additional byte.
-bool emitter::Is4ByteSSEInstruction(instruction ins)
+bool emitter::Is4ByteSSEInstruction(instruction ins) const
 {
     return !UseVEXEncoding() && EncodedBySSE38orSSE3A(ins);
 }
@@ -1289,7 +1289,7 @@ bool isPrefix(BYTE b)
 // Return Value:
 //    The extracted EVEX prefix.
 //
-emitter::code_t emitter::emitExtractEvexPrefix(instruction ins, code_t& code)
+emitter::code_t emitter::emitExtractEvexPrefix(instruction ins, code_t& code) const
 {
     assert(IsEvexEncodedInstruction(ins));
 
@@ -1425,7 +1425,7 @@ emitter::code_t emitter::emitExtractEvexPrefix(instruction ins, code_t& code)
 // Return Value:
 //    The extracted VEX prefix.
 //
-emitter::code_t emitter::emitExtractVexPrefix(instruction ins, code_t& code)
+emitter::code_t emitter::emitExtractVexPrefix(instruction ins, code_t& code) const
 {
     assert(IsVexEncodedInstruction(ins));
 
@@ -1784,7 +1784,7 @@ unsigned emitter::emitGetRexPrefixSize(instruction ins)
 // Returns:
 //    Prefix size in bytes.
 //
-unsigned emitter::emitGetEvexPrefixSize(instrDesc* id)
+unsigned emitter::emitGetEvexPrefixSize(instrDesc* id) const
 {
     instruction ins = id->idIns();
     assert(IsEvexEncodedInstruction(ins));
@@ -1802,7 +1802,7 @@ unsigned emitter::emitGetEvexPrefixSize(instrDesc* id)
 // Returns:
 //    Updated size.
 //
-unsigned emitter::emitGetAdjustedSize(instrDesc* id, code_t code)
+unsigned emitter::emitGetAdjustedSize(instrDesc* id, code_t code) const
 {
     instruction ins  = id->idIns();
     emitAttr    attr = id->idOpSize();
@@ -2340,7 +2340,7 @@ inline bool hasCodeMR(instruction ins)
 // Returns:
 //    Prefix size in bytes.
 //
-unsigned emitter::emitGetVexPrefixSize(instrDesc* id)
+unsigned emitter::emitGetVexPrefixSize(instrDesc* id) const
 {
     instruction ins  = id->idIns();
     emitAttr    size = id->idOpSize();
@@ -2555,7 +2555,7 @@ inline insTupleType insTupleTypeInfo(instruction ins)
 }
 
 // Return true if the instruction uses the SSE38 or SSE3A macro in instrsXArch.h.
-bool emitter::EncodedBySSE38orSSE3A(instruction ins)
+bool emitter::EncodedBySSE38orSSE3A(instruction ins) const
 {
     const size_t SSE38 = 0x0F660038;
     const size_t SSE3A = 0x0F66003A;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2337,6 +2337,12 @@ unsigned emitter::emitGetVexPrefixSize(instrDesc* id)
 
     assert(IsVexEncodedInstruction(ins));
 
+    if (!emitComp->opts.OptimizationEnabled())
+    {
+        // Don't worry about saving code size when optimizations are disabled
+        return 3;
+    }
+
     if (EncodedBySSE38orSSE3A(ins))
     {
         // When the prefix is 0x0F38 or 0x0F3A, we must use the 3-byte encoding

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2411,6 +2411,14 @@ unsigned emitter::emitGetVexPrefixSize(instrDesc* id)
             break;
         }
 
+        case IF_RRD_CNS:
+        case IF_RRW_CNS:
+        case IF_RWR_CNS:
+        {
+            regFor012Bits = id->idReg1();
+            break;
+        }
+
         case IF_RRD_RRD:
         case IF_RRW_RRD:
         case IF_RWR_RRD:

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -1658,7 +1658,7 @@ unsigned emitter::emitOutputRexOrSimdPrefixIfNeeded(instruction ins, BYTE* dst, 
             // prefix if optimizations are enabled or we know we won't negatively impact the
             // estimated alignment sizes.
 
-            if (emitComp->opts.OptimizationEnabled() || (emitCurIG->igNum > emitLastAlignedIgNum))
+            if (!emitComp->opts.MinOpts() || (emitCurIG->igNum > emitLastAlignedIgNum))
             {
                 emitOutputByte(dst, 0xC5);
                 emitOutputByte(dst + 1, ((vexPrefix >> 8) & 0x80) | (vexPrefix & 0x7F));
@@ -2347,7 +2347,7 @@ unsigned emitter::emitGetVexPrefixSize(instrDesc* id)
 
     assert(IsVexEncodedInstruction(ins));
 
-    if (!emitComp->opts.OptimizationEnabled())
+    if (emitComp->opts.MinOpts())
     {
         // Don't worry about saving code size when optimizations are disabled
         return 3;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -1776,8 +1776,7 @@ unsigned emitter::emitGetRexPrefixSize(instruction ins)
 //
 unsigned emitter::emitGetEvexPrefixSize(instrDesc* id) const
 {
-    instruction ins = id->idIns();
-    assert(IsEvexEncodedInstruction(ins));
+    assert(IsEvexEncodedInstruction(id->idIns()));
     return 4;
 }
 
@@ -1794,10 +1793,8 @@ unsigned emitter::emitGetEvexPrefixSize(instrDesc* id) const
 //
 unsigned emitter::emitGetAdjustedSize(instrDesc* id, code_t code) const
 {
-    instruction ins  = id->idIns();
-    emitAttr    attr = id->idOpSize();
-
-    unsigned adjustedSize = 0;
+    instruction ins          = id->idIns();
+    unsigned    adjustedSize = 0;
 
     // TODO-XArch-AVX512: Remove redundant code and possiblly collapse EVEX and VEX into a single pathway
     // IsEvexEncodedInstruction(ins) is `true` for AVX/SSE instructions also which needs to be VEX encoded unless
@@ -1909,6 +1906,8 @@ unsigned emitter::emitGetAdjustedSize(instrDesc* id, code_t code) const
             // Adjust code size for CRC32 that has 4-byte opcode but does not use SSE38 or EES3A encoding.
             adjustedSize++;
         }
+
+        emitAttr attr = id->idOpSize();
 
         if ((attr == EA_2BYTE) && (ins != INS_movzx) && (ins != INS_movsx))
         {
@@ -2322,7 +2321,7 @@ inline bool hasCodeMR(instruction ins)
 }
 
 //------------------------------------------------------------------------
-// emitGetVexPrefixSize: Gets Size of VEX prefix in bytes
+// emitGetVexPrefixSize: Gets size of VEX prefix in bytes
 //
 // Arguments:
 //    id   -- The instruction descriptor
@@ -2332,9 +2331,8 @@ inline bool hasCodeMR(instruction ins)
 //
 unsigned emitter::emitGetVexPrefixSize(instrDesc* id) const
 {
-    assert(IsVexEncodedInstruction(id->idIns()));
-
     instruction ins = id->idIns();
+    assert(IsVexEncodedInstruction(ins));
 
     if (EncodedBySSE38orSSE3A(ins))
     {
@@ -3060,12 +3058,7 @@ inline UNATIVE_OFFSET emitter::emitInsSizeRR(instrDesc* id, code_t code, int val
 //
 inline UNATIVE_OFFSET emitter::emitInsSizeRR(instrDesc* id)
 {
-    instruction ins  = id->idIns();
-    regNumber   reg1 = id->idReg1();
-    regNumber   reg2 = id->idReg2();
-    emitAttr    attr = id->idOpSize();
-
-    emitAttr size = EA_SIZE(attr);
+    instruction ins = id->idIns();
 
     // If Byte 4 (which is 0xFF00) is zero, that's where the RM encoding goes.
     // Otherwise, it will be placed after the 4 byte encoding, making the total 5 bytes.
@@ -3078,6 +3071,11 @@ inline UNATIVE_OFFSET emitter::emitInsSizeRR(instrDesc* id)
     // REX prefix
     if (!hasRexPrefix(code))
     {
+        regNumber reg1 = id->idReg1();
+        regNumber reg2 = id->idReg2();
+        emitAttr  attr = id->idOpSize();
+        emitAttr  size = EA_SIZE(attr);
+
         if ((TakesRexWPrefix(ins, size) && ((ins != INS_xor) || (reg1 != reg2))) || IsExtendedReg(reg1, attr) ||
             IsExtendedReg(reg2, attr))
         {

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -71,7 +71,6 @@ unsigned emitGetVexPrefixSize(instruction ins, emitAttr attr);
 unsigned emitGetEvexPrefixSize(instruction ins);
 unsigned emitGetPrefixSize(code_t code, bool includeRexPrefixSize);
 unsigned emitGetAdjustedSize(instruction ins, emitAttr attr, code_t code);
-unsigned emitGetAdjustedSizeEvexAware(instruction ins, emitAttr attr, code_t code);
 
 unsigned insEncodeReg012(instruction ins, regNumber reg, emitAttr size, code_t* code);
 unsigned insEncodeReg345(instruction ins, regNumber reg, emitAttr size, code_t* code);

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -67,7 +67,7 @@ BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* id);
 
 unsigned emitOutputRexOrSimdPrefixIfNeeded(instruction ins, BYTE* dst, code_t& code);
 unsigned emitGetRexPrefixSize(instruction ins);
-unsigned emitGetVexPrefixSize(instruction ins, emitAttr attr);
+unsigned emitGetVexPrefixSize(instruction ins);
 unsigned emitGetEvexPrefixSize(instruction ins);
 unsigned emitGetPrefixSize(code_t code, bool includeRexPrefixSize);
 unsigned emitGetAdjustedSize(instruction ins, emitAttr attr, code_t code);

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -65,8 +65,7 @@ BYTE* emitOutputRRR(BYTE* dst, instrDesc* id);
 
 BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* id);
 
-unsigned emitOutputSimdPrefixIfNeeded(instruction ins, BYTE* dst, code_t& code);
-unsigned emitOutputRexOrVexPrefixIfNeeded(instruction ins, BYTE* dst, code_t& code);
+unsigned emitOutputRexOrSimdPrefixIfNeeded(instruction ins, BYTE* dst, code_t& code);
 unsigned emitGetRexPrefixSize(instruction ins);
 unsigned emitGetVexPrefixSize(instruction ins, emitAttr attr);
 unsigned emitGetEvexPrefixSize(instruction ins);

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -38,7 +38,7 @@ struct CnsVal
     bool    cnsReloc;
 };
 
-UNATIVE_OFFSET emitInsSize(code_t code, bool includeRexPrefixSize);
+UNATIVE_OFFSET emitInsSize(instrDesc* id, code_t code, bool includeRexPrefixSize);
 UNATIVE_OFFSET emitInsSizeSVCalcDisp(instrDesc* id, code_t code, int var, int dsp);
 UNATIVE_OFFSET emitInsSizeSV(instrDesc* id, code_t code, int var, int dsp);
 UNATIVE_OFFSET emitInsSizeSV(instrDesc* id, code_t code, int var, int dsp, int val);
@@ -69,7 +69,7 @@ unsigned emitOutputRexOrSimdPrefixIfNeeded(instruction ins, BYTE* dst, code_t& c
 unsigned emitGetRexPrefixSize(instruction ins);
 unsigned emitGetVexPrefixSize(instrDesc* id);
 unsigned emitGetEvexPrefixSize(instrDesc* id);
-unsigned emitGetPrefixSize(code_t code, bool includeRexPrefixSize);
+unsigned emitGetPrefixSize(instrDesc* id, code_t code, bool includeRexPrefixSize);
 unsigned emitGetAdjustedSize(instrDesc* id, code_t code);
 
 code_t emitExtractVexPrefix(instruction ins, code_t& code);

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -44,7 +44,7 @@ UNATIVE_OFFSET emitInsSizeSV(instrDesc* id, code_t code, int var, int dsp);
 UNATIVE_OFFSET emitInsSizeSV(instrDesc* id, code_t code, int var, int dsp, int val);
 UNATIVE_OFFSET emitInsSizeRR(instrDesc* id, code_t code);
 UNATIVE_OFFSET emitInsSizeRR(instrDesc* id, code_t code, int val);
-UNATIVE_OFFSET emitInsSizeRR(instruction ins, regNumber reg1, regNumber reg2, emitAttr attr);
+UNATIVE_OFFSET emitInsSizeRR(instrDesc* id);
 UNATIVE_OFFSET emitInsSizeAM(instrDesc* id, code_t code);
 UNATIVE_OFFSET emitInsSizeAM(instrDesc* id, code_t code, int val);
 UNATIVE_OFFSET emitInsSizeCV(instrDesc* id, code_t code);
@@ -67,10 +67,10 @@ BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* id);
 
 unsigned emitOutputRexOrSimdPrefixIfNeeded(instruction ins, BYTE* dst, code_t& code);
 unsigned emitGetRexPrefixSize(instruction ins);
-unsigned emitGetVexPrefixSize(instruction ins);
-unsigned emitGetEvexPrefixSize(instruction ins);
+unsigned emitGetVexPrefixSize(instrDesc* id);
+unsigned emitGetEvexPrefixSize(instrDesc* id);
 unsigned emitGetPrefixSize(code_t code, bool includeRexPrefixSize);
-unsigned emitGetAdjustedSize(instruction ins, emitAttr attr, code_t code);
+unsigned emitGetAdjustedSize(instrDesc* id, code_t code);
 
 code_t emitExtractVexPrefix(instruction ins, code_t& code);
 code_t emitExtractEvexPrefix(instruction ins, code_t& code);

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -67,13 +67,13 @@ BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* id);
 
 unsigned emitOutputRexOrSimdPrefixIfNeeded(instruction ins, BYTE* dst, code_t& code);
 unsigned emitGetRexPrefixSize(instruction ins);
-unsigned emitGetVexPrefixSize(instrDesc* id);
-unsigned emitGetEvexPrefixSize(instrDesc* id);
+unsigned emitGetVexPrefixSize(instrDesc* id) const;
+unsigned emitGetEvexPrefixSize(instrDesc* id) const;
 unsigned emitGetPrefixSize(instrDesc* id, code_t code, bool includeRexPrefixSize);
-unsigned emitGetAdjustedSize(instrDesc* id, code_t code);
+unsigned emitGetAdjustedSize(instrDesc* id, code_t code) const;
 
-code_t emitExtractVexPrefix(instruction ins, code_t& code);
-code_t emitExtractEvexPrefix(instruction ins, code_t& code);
+code_t emitExtractVexPrefix(instruction ins, code_t& code) const;
+code_t emitExtractEvexPrefix(instruction ins, code_t& code) const;
 
 unsigned insEncodeReg012(instruction ins, regNumber reg, emitAttr size, code_t* code);
 unsigned insEncodeReg345(instruction ins, regNumber reg, emitAttr size, code_t* code);
@@ -111,8 +111,8 @@ code_t AddRexXPrefix(instruction ins, code_t code);
 code_t AddRexBPrefix(instruction ins, code_t code);
 code_t AddRexPrefix(instruction ins, code_t code);
 
-bool EncodedBySSE38orSSE3A(instruction ins);
-bool Is4ByteSSEInstruction(instruction ins);
+bool EncodedBySSE38orSSE3A(instruction ins) const;
+bool Is4ByteSSEInstruction(instruction ins) const;
 static bool IsMovInstruction(instruction ins);
 bool HasSideEffect(instruction ins, emitAttr size);
 bool IsRedundantMov(

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -72,6 +72,9 @@ unsigned emitGetEvexPrefixSize(instruction ins);
 unsigned emitGetPrefixSize(code_t code, bool includeRexPrefixSize);
 unsigned emitGetAdjustedSize(instruction ins, emitAttr attr, code_t code);
 
+code_t emitExtractVexPrefix(instruction ins, code_t& code);
+code_t emitExtractEvexPrefix(instruction ins, code_t& code);
+
 unsigned insEncodeReg012(instruction ins, regNumber reg, emitAttr size, code_t* code);
 unsigned insEncodeReg345(instruction ins, regNumber reg, emitAttr size, code_t* code);
 code_t insEncodeReg3456(instruction ins, regNumber reg, emitAttr size, code_t code);


### PR DESCRIPTION
As raised on https://github.com/dotnet/runtime/pull/79363 and in various past PR/issues, we did not correctly estimate the size of the VEX prefix when used. This had negative side effects such as allocating more memory than necessary and when loop alignment support was added, it meant that we could no longer use the 2-byte prefix when also aligning loops.

This resolves that by updating `emitGetVexPrefixSize` to check the relevant `instrDesc` inputs to determine if the 2-byte or 3-byte prefix will be used.

As a side effect, this also removes some code that was dead and does some other minor cleanup to improve the general handling of the VEX prefix.