### PR TITLE
Change RunningPublish property name to _IsPublishing

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -8,10 +8,10 @@
     <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
     <!-- Trimming is not currently working, but set the appropriate feature flags for NativeAOT -->
     <PublishTrimmed Condition="'$(NativeAotSupported)' == 'true'">true</PublishTrimmed>
-    <RuntimeIdentifiers Condition="'$(RunningPublish)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">linux-x64;linux-musl-x64;linux-arm;linux-musl-arm;linux-arm64;linux-musl-arm64;freebsd-x64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64;win-arm</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(_IsPublishing)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">linux-x64;linux-musl-x64;linux-arm;linux-musl-arm;linux-arm64;linux-musl-arm64;freebsd-x64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64;win-arm</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(PackageRID)</RuntimeIdentifiers>
     <SelfContained>false</SelfContained>
-    <SelfContained Condition="'$(RunningPublish)' == 'true'">true</SelfContained>
+    <SelfContained Condition="'$(_IsPublishing)' == 'true'">true</SelfContained>
   </PropertyGroup>
 
   <Import Project="crossgen2.props" />
@@ -43,10 +43,10 @@
 
   <Import Project="$(R2ROverridePath)" Condition="'$(R2ROverridePath)' != ''" />
   <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets"
-          Condition="'$(NativeAotSupported)' == 'true' and '$(RunningPublish)' == 'true'" />
+          Condition="'$(NativeAotSupported)' == 'true' and '$(_IsPublishing)' == 'true'" />
 
   <Target Name="RewriteRuntimePackDir"
-          Condition="'$(RunningPublish)' == 'true'"
+          Condition="'$(_IsPublishing)' == 'true'"
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           BeforeTargets="ResolveRuntimePackAssets">
       <ItemGroup>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -32,14 +32,14 @@
 <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2.csproj"
              Targets="Restore"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())
-              ;RunningPublish=true
+              ;_IsPublishing=true
               ;RuntimeIdentifier=$(PackageRID)
               ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
               ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets" />
 
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2.csproj"
              Targets="Publish;PublishItemsOutputGroup"
-             Properties="RunningPublish=true
+             Properties="_IsPublishing=true
               ;RuntimeIdentifier=$(PackageRID)
               ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
               ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets">


### PR DESCRIPTION
The crossgen publish capability currently uses a RunningPublish property to signal that certain settings should be enabled. The SDK now provides a property that serves the same purpose called '_IsPublishing'. By using the SDK property, the right publish behavior will automatically happen if a user runs 'dotnet publish' on the crossgen2 project.