### PR TITLE
Only align loops when optimizations are enabled

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3910,7 +3910,7 @@ _SetMinOpts:
         }
         else
         {
-            codeGen->SetAlignLoops(JitConfig.JitAlignLoops() == 1);
+            codeGen->SetAlignLoops(opts.OptimizationEnabled() && (JitConfig.JitAlignLoops() == 1));
         }
     }
 


### PR DESCRIPTION
Loop alignment is currently being done always which is going to cause code bloat and extra cycles being spent for `minOpts`. This also means its being done for code which is either not hot or will likely be replaced fairly quickly by OSR or TC.

This changes it to only occur when optimizations are enabled instead which should improve throughput and reduce code size for T0 code.