### PR TITLE
Use ArrayBuffer for write buffer management in HttpConnection

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
@@ -28,9 +28,6 @@ namespace System.Net.Http
                     throw new HttpRequestException(SR.net_http_content_write_larger_than_content_length);
                 }
 
-                // Have the connection write the data, skipping the buffer. Importantly, this will
-                // force a flush of anything already in the buffer, i.e. any remaining request headers
-                // that are still buffered.
                 HttpConnection connection = GetConnectionOrThrow();
                 Debug.Assert(connection._currentRequest != null);
                 connection.Write(buffer);
@@ -45,12 +42,9 @@ namespace System.Net.Http
                     return ValueTask.FromException(new HttpRequestException(SR.net_http_content_write_larger_than_content_length));
                 }
 
-                // Have the connection write the data, skipping the buffer. Importantly, this will
-                // force a flush of anything already in the buffer, i.e. any remaining request headers
-                // that are still buffered.
                 HttpConnection connection = GetConnectionOrThrow();
                 Debug.Assert(connection._currentRequest != null);
-                return connection.WriteAsync(buffer, async: true);
+                return connection.WriteAsync(buffer);
             }
 
             public override Task FinishAsync(bool async)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -108,7 +108,7 @@ namespace System.Net.Http
         internal uint _lastSeenHttp3MaxHeaderListSize;
 
         /// <summary>For non-proxy connection pools, this is the host name in bytes; for proxies, null.</summary>
-        private readonly byte[]? _hostHeaderValueBytes;
+        private readonly byte[]? _hostHeaderLineBytes;
         /// <summary>Options specialized and cached for this pool and its key.</summary>
         private readonly SslClientAuthenticationOptions? _sslOptionsHttp11;
         private readonly SslClientAuthenticationOptions? _sslOptionsHttp2;
@@ -242,8 +242,15 @@ namespace System.Net.Http
                     _originAuthority.HostValue;
 
                 // Note the IDN hostname should always be ASCII, since it's already been IDNA encoded.
-                _hostHeaderValueBytes = Encoding.ASCII.GetBytes(hostHeader);
-                Debug.Assert(Encoding.ASCII.GetString(_hostHeaderValueBytes) == hostHeader);
+                byte[] hostHeaderLine = new byte[6 + hostHeader.Length + 2]; // Host: foo\r\n
+                "Host: "u8.CopyTo(hostHeaderLine);
+                Encoding.ASCII.GetBytes(hostHeader, hostHeaderLine.AsSpan(6));
+                hostHeaderLine[^2] = (byte)'\r';
+                hostHeaderLine[^1] = (byte)'\n';
+                _hostHeaderLineBytes = hostHeaderLine;
+
+                Debug.Assert(Encoding.ASCII.GetString(_hostHeaderLineBytes) == $"Host: {hostHeader}\r\n");
+
                 if (sslHostName == null)
                 {
                     _http2EncodedAuthorityHostHeader = HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingToAllocatedArray(H2StaticTable.Authority, hostHeader);
@@ -348,7 +355,7 @@ namespace System.Net.Http
         public bool IsSecure => _kind == HttpConnectionKind.Https || _kind == HttpConnectionKind.SslProxyTunnel || _kind == HttpConnectionKind.SslSocksTunnel;
         public Uri? ProxyUri => _proxyUri;
         public ICredentials? ProxyCredentials => _poolManager.ProxyCredentials;
-        public byte[]? HostHeaderValueBytes => _hostHeaderValueBytes;
+        public byte[]? HostHeaderLineBytes => _hostHeaderLineBytes;
         public CredentialCache? PreAuthCredentials { get; }
 
         /// <summary>


### PR DESCRIPTION
Contributes to #61223

Similar idea as #79524 - makes the code easier to work with, allowing us to make future improvements such as pooling easier.

This PR replaces the `WriteHeadersAsync` logic to synchronously buffer the headers, as we do in HTTP/2 and HTTP/3. This also gives us a slight perf advantage.

Sample in-memory numbers copying around 1000-byte requests and 1000-byte responses:

|    Method | Toolchain | RequestHeaders | ChunkedResponse |     Mean |     Error | Ratio |
|---------- |---------- |--------------- |---------------- |---------:|----------:|------:|
| SendAsync |      main |              4 |           False | 1.613 us | 0.0181 us |  1.00 |
| SendAsync |        pr |              4 |           False | 1.345 us | 0.0262 us |  0.83 |
|           |           |                |                 |          |           |       |
| SendAsync |      main |              4 |            True | 1.608 us | 0.0125 us |  1.00 |
| SendAsync |        pr |              4 |            True | 1.364 us | 0.0052 us |  0.85 |
|           |           |                |                 |          |           |       |
| SendAsync |      main |              8 |           False | 1.717 us | 0.0043 us |  1.00 |
| SendAsync |        pr |              8 |           False | 1.506 us | 0.0066 us |  0.88 |
|           |           |                |                 |          |           |       |
| SendAsync |      main |              8 |            True | 1.747 us | 0.0068 us |  1.00 |
| SendAsync |        pr |              8 |            True | 1.544 us | 0.0080 us |  0.88 |
|           |           |                |                 |          |           |       |
| SendAsync |      main |             16 |           False | 2.142 us | 0.0075 us |  1.00 |
| SendAsync |        pr |             16 |           False | 1.874 us | 0.0071 us |  0.88 |
|           |           |                |                 |          |           |       |
| SendAsync |      main |             16 |            True | 2.085 us | 0.0045 us |  1.00 |
| SendAsync |        pr |             16 |            True | 1.872 us | 0.0126 us |  0.90 |