### PR TITLE
[mono] Handle Assert failure when GetDelegateForFunctionPointer is invoked with VoidDelegate type

### DIFF
--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3713,7 +3713,6 @@ mono_marshal_get_native_func_wrapper (MonoImage *image, MonoMethodSignature *sig
 	MonoMethod *res;
 	GHashTable *cache;
 	gboolean found;
-	char *name;
 	MonoNativeWrapperFlags flags;
 
 	key.sig = sig;
@@ -3726,8 +3725,7 @@ mono_marshal_get_native_func_wrapper (MonoImage *image, MonoMethodSignature *sig
 	if ((res = mono_marshal_find_in_cache (cache, &key)))
 		return res;
 
-	name = g_strdup_printf ("wrapper_native_%p", func);
-	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_MANAGED_TO_NATIVE);
+	mb = mono_mb_new (mono_defaults.object_class, "Invoke", MONO_WRAPPER_MANAGED_TO_NATIVE);
 	mb->method->save_lmf = 1;
 
 	flags = EMIT_NATIVE_WRAPPER_CHECK_EXCEPTIONS;

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
@@ -36,14 +36,7 @@ public partial class FunctionPtr
             IntPtr fcnptr = FunctionPointerNative.GetVoidVoidFcnPtr();
             VoidDelegate del = (VoidDelegate)Marshal.GetDelegateForFunctionPointer(fcnptr, typeof(VoidDelegate));
             Assert.Equal(null, del.Target);
-            if (TestLibrary.Utilities.IsMonoRuntime)
-            {
-                Assert.StartsWith("wrapper_native", del.Method.Name);
-            }
-            else
-            {
-                Assert.Equal("Invoke", del.Method.Name);
-            }
+            Assert.Equal("Invoke", del.Method.Name);
 
             // Round trip of a native function pointer is never legal for a non-concrete Delegate type
             Assert.Throws<ArgumentException>(() =>

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
@@ -36,7 +36,14 @@ public partial class FunctionPtr
             IntPtr fcnptr = FunctionPointerNative.GetVoidVoidFcnPtr();
             VoidDelegate del = (VoidDelegate)Marshal.GetDelegateForFunctionPointer(fcnptr, typeof(VoidDelegate));
             Assert.Equal(null, del.Target);
-            Assert.Equal("Invoke", del.Method.Name);
+            if (TestLibrary.Utilities.IsMonoRuntime)
+            {
+                Assert.StartsWith("wrapper_native", del.Method.Name);
+            }
+            else
+            {
+                Assert.Equal("Invoke", del.Method.Name);
+            }
 
             // Round trip of a native function pointer is never legal for a non-concrete Delegate type
             Assert.Throws<ArgumentException>(() =>


### PR DESCRIPTION
RunGetDelForFcnPtrTest is checking if "Invoke" Method is invoked when "GetDelegateForFunctionPointer" is passed
"VoidDelegate". In mono runtime instead of "Invoke" method, "wrapper_native_***" is invoked. The suffix of
"Wrapper_native" keeps changing with every run. With this fix "Invoke" method is returned instead of "wrapper_native_*"
