### PR TITLE
[wasm] Disable running blazor template projects

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -84,7 +84,6 @@ public class BuildPublishTests : BuildTestBase
     [Theory]
     [InlineData("Debug")]
     [InlineData("Release")]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/79514")]
     public async Task WithDllImportInMainAssembly(string config)
     {
         // Based on https://github.com/dotnet/runtime/issues/59255
@@ -125,11 +124,12 @@ public class BuildPublishTests : BuildTestBase
         BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
         CheckNativeFileLinked(forPublish: true);
 
-        await BlazorRun(config, async (page) => {
-            await page.Locator("text=\"cpp_add\"").ClickAsync();
-            var txt = await page.Locator("p[role='test']").InnerHTMLAsync();
-            Assert.Equal("Output: 22", txt);
-        });
+        // [ActiveIssue("https://github.com/dotnet/runtime/issues/79514")]
+        //await BlazorRun(config, async (page) => {
+            //await page.Locator("text=\"cpp_add\"").ClickAsync();
+            //var txt = await page.Locator("p[role='test']").InnerHTMLAsync();
+            //Assert.Equal("Output: 22", txt);
+        //});
 
         void CheckNativeFileLinked(bool forPublish)
         {

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -84,7 +84,7 @@ public class BuildPublishTests : BuildTestBase
     [Theory]
     [InlineData("Debug")]
     [InlineData("Release")]
-    public async Task WithDllImportInMainAssembly(string config)
+    public void WithDllImportInMainAssembly(string config)
     {
         // Based on https://github.com/dotnet/runtime/issues/59255
         string id = $"blz_dllimp_{config}";

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -35,7 +35,7 @@ internal class BrowserRunner : IAsyncDisposable
     public BrowserRunner(ITestOutputHelper testOutput) => _testOutput = testOutput;
 
     // FIXME: options
-    public async Task<IPage> RunAsync(ToolCommand cmd, string args, bool headless = true)
+    public async Task<IPage> RunAsync(ToolCommand cmd, string args, bool headless = true, Action<IConsoleMessage>? onConsoleMessage = null)
     {
         TaskCompletionSource<string> urlAvailable = new();
         Action<string?> outputHandler = msg =>
@@ -90,6 +90,8 @@ internal class BrowserRunner : IAsyncDisposable
         });
 
         IPage page = await Browser.NewPageAsync();
+        if (onConsoleMessage is not null)
+            page.Console += (_, msg) => onConsoleMessage(msg);
         await page.GotoAsync(urlAvailable.Task.Result);
         RunTask = runTask;
         return page;

--- a/src/mono/wasm/Wasm.Build.Tests/BuildEnvironment.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildEnvironment.cs
@@ -70,6 +70,7 @@ namespace Wasm.Build.Tests
                 s_runtimePackVersions[$"net{verStr}.0"] = versionValue;
             }
 
+            DefaultBuildArgs = string.Empty;
             WorkloadPacksDir = Path.Combine(sdkForWorkloadPath, "packs");
             EnvVars = new Dictionary<string, string>();
             bool workloadInstalled = EnvironmentVariables.SdkHasWorkloadInstalled != null && EnvironmentVariables.SdkHasWorkloadInstalled == "true";

--- a/src/mono/wasm/Wasm.Build.Tests/BuildEnvironment.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildEnvironment.cs
@@ -77,21 +77,10 @@ namespace Wasm.Build.Tests
             {
                 DirectoryBuildPropsContents = s_directoryBuildPropsForWorkloads;
                 DirectoryBuildTargetsContents = s_directoryBuildTargetsForWorkloads;
-
-                var appRefDir = EnvironmentVariables.AppRefDir;
-                if (string.IsNullOrEmpty(appRefDir))
-                    throw new Exception($"Cannot test with workloads without AppRefDir environment variable being set");
-
-                DefaultBuildArgs = $" /p:AppRefDir={appRefDir}";
                 IsWorkload = true;
             }
             else
             {
-                var appRefDir = EnvironmentVariables.AppRefDir;
-                if (string.IsNullOrEmpty(appRefDir))
-                    throw new Exception($"Cannot test with workloads without AppRefDir environment variable being set");
-
-                DefaultBuildArgs = $" /p:AppRefDir={appRefDir}";
                 DirectoryBuildPropsContents = s_directoryBuildPropsForLocal;
                 DirectoryBuildTargetsContents = s_directoryBuildTargetsForLocal;
             }

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -835,7 +835,7 @@ namespace Wasm.Build.Tests
                                         .WithWorkingDirectory(_projectDir!);
 
             await using var runner = new BrowserRunner(_testOutput);
-            var page = await runner.RunAsync(runCommand, $"run -c {config} {extraArgs}");
+            var page = await runner.RunAsync(runCommand, $"run -c {config} {extraArgs}", onConsoleMessage: OnConsoleMessage);
 
             await page.Locator("text=Counter").ClickAsync();
             var txt = await page.Locator("p[role='status']").InnerHTMLAsync();
@@ -847,6 +847,13 @@ namespace Wasm.Build.Tests
 
             if (test is not null)
                 await test(page);
+
+            void OnConsoleMessage(IConsoleMessage msg)
+            {
+                if (EnvironmentVariables.ShowBuildOutput)
+                    Console.WriteLine($"[{msg.Type}] {msg.Text}");
+                _testOutput.WriteLine($"[{msg.Type}] {msg.Text}");
+            }
         }
 
         public static (int exitCode, string buildOutput) RunProcess(string path,

--- a/src/mono/wasm/Wasm.Build.Tests/EnvironmentVariables.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/EnvironmentVariables.cs
@@ -12,7 +12,6 @@ namespace Wasm.Build.Tests
         internal static readonly string? SdkForWorkloadTestingPath = Environment.GetEnvironmentVariable("SDK_FOR_WORKLOAD_TESTING_PATH");
         internal static readonly string? SdkHasWorkloadInstalled   = Environment.GetEnvironmentVariable("SDK_HAS_WORKLOAD_INSTALLED");
         internal static readonly string? WorkloadPacksVersion      = Environment.GetEnvironmentVariable("WORKLOAD_PACKS_VER");
-        internal static readonly string? AppRefDir                 = Environment.GetEnvironmentVariable("AppRefDir");
         internal static readonly string? TestLogPath               = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
         internal static readonly string? SkipProjectCleanup        = Environment.GetEnvironmentVariable("SKIP_PROJECT_CLEANUP");
         internal static readonly string? XHarnessCliPath           = Environment.GetEnvironmentVariable("XHARNESS_CLI_PATH");

--- a/src/mono/wasm/Wasm.Build.Tests/data/RunScriptTemplate.cmd
+++ b/src/mono/wasm/Wasm.Build.Tests/data/RunScriptTemplate.cmd
@@ -114,5 +114,4 @@ if [%HELIX_CORRELATION_PAYLOAD%] NEQ [] (
 
 set "PATH=%_SDK_DIR%;%PATH%"
 set "SDK_FOR_WORKLOAD_TESTING_PATH=%_SDK_DIR%"
-set "AppRefDir=%BASE_DIR%\microsoft.netcore.app.ref"
 EXIT /b 0

--- a/src/mono/wasm/Wasm.Build.Tests/data/RunScriptTemplate.sh
+++ b/src/mono/wasm/Wasm.Build.Tests/data/RunScriptTemplate.sh
@@ -89,7 +89,6 @@ function set_env_vars()
 
     export PATH=$_SDK_DIR:$PATH
     export SDK_FOR_WORKLOAD_TESTING_PATH=$_SDK_DIR
-    export AppRefDir=$BASE_DIR/microsoft.netcore.app.ref
 }
 
 export TEST_LOG_PATH=${XHARNESS_OUT}/logs


### PR DESCRIPTION
Blazor projects still target `net7.0`, but `dotnet/runtime` has moved to `net8.0`. This causes running such projects to fail - https://github.com/dotnet/runtime/issues/79514 .

These tests were disabled, but instead only the *run* part should be disabled. Once `dotnet/aspnetcore` moves to `net8.0` these tests can be re-enabed - https://github.com/dotnet/aspnetcore/issues/45492 .