### PR TITLE
RhpGetTickCount64: set the return type to match the definition in InternalCalls.cs 

### DIFF
--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -388,9 +388,9 @@ EXTERN_C NATIVEAOT_API void __cdecl RhpReleaseThunkPoolLock()
     g_ThunkPoolLock.Leave();
 }
 
-EXTERN_C NATIVEAOT_API void __cdecl RhpGetTickCount64()
+EXTERN_C NATIVEAOT_API uint64_t __cdecl RhpGetTickCount64()
 {
-    PalGetTickCount64();
+    return PalGetTickCount64();
 }
 
 EXTERN_C int32_t __cdecl RhpCalculateStackTraceWorker(void* pOutputBuffer, uint32_t outputBufferLength, void* pAddressInCurrentFrame);


### PR DESCRIPTION
This PR fixes a mismatch in the return type for this function between the cpp implementation in `MiscHelpers.cpp` and the `extern` import in `InternalCalls.cs` where it is:
```
[DllImport(Redhawk.BaseName, CallingConvention = CallingConvention.Cdecl)]
internal static extern ulong RhpGetTickCount64();
```
 The mismatch is a problem in the runtimelab NativeAOT-LLVM experiment where the linker, wasm-ld, complains and fails.

Return type changed from `void` to `uint64_t`.

Thanks,