### PR TITLE
[release/7.0][wasm][debugger] Improvements in debugging in async methods

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1424,7 +1424,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
                 VarInfo[] varIds = scope.Method.Info.GetLiveVarsAt(scope.Location.IlLocation.Offset);
 
-                var values = await context.SdbAgent.StackFrameGetValues(scope.Method, context.ThreadId, scopeId, varIds, token);
+                var values = await context.SdbAgent.StackFrameGetValues(scope.Method, context.ThreadId, scopeId, varIds, scope.Location.IlLocation.Offset, token);
                 if (values != null)
                 {
                     if (values == null || values.Count == 0)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -786,8 +786,10 @@ namespace Microsoft.WebAssembly.Diagnostics
         private DebugStore store;
         private SessionId sessionId;
 
-        private readonly ILogger logger;
-        private static readonly Regex regexForAsyncLocals = new (@"\<([^)]*)\>", RegexOptions.Singleline);
+        internal readonly ILogger logger;
+        private static readonly Regex regexForAsyncLocals = new(@"\<([^)]*)\>([^)]*)([_][_])([0-9]*)", RegexOptions.Singleline); //<testCSharpScope>5__1
+        private static readonly Regex regexForVBAsyncLocals = new(@"\$VB\$ResumableLocal_([^)]*)\$([0-9]*)", RegexOptions.Singleline); //$VB$ResumableLocal_testVbScope$2
+        private static readonly Regex regexForVBAsyncMethodName = new(@"VB\$StateMachine_([0-9]*)_([^)]*)", RegexOptions.Singleline); //VB$StateMachine_2_RunVBScope
         private static readonly Regex regexForAsyncMethodName = new (@"\<([^>]*)\>([d][_][_])([0-9]*)", RegexOptions.Compiled);
         private static readonly Regex regexForGenericArgs = new (@"[`][0-9]+", RegexOptions.Compiled);
         private static readonly Regex regexForNestedLeftRightAngleBrackets = new ("^(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!))[^<>]*", RegexOptions.Compiled);
@@ -1269,6 +1271,14 @@ namespace Microsoft.WebAssembly.Diagnostics
                         {
                             if (anonymousMethodId.LastIndexOf('_') >= 0)
                                 anonymousMethodId = klassName.Substring(klassName.LastIndexOf('_') + 1);
+                        }
+                        else if (klassName.StartsWith("VB$"))
+                        {
+                            var match = regexForVBAsyncMethodName.Match(klassName);
+                            if (match.Success)
+                                ret = ret.Insert(0, match.Groups[2].Value);
+                            else
+                                ret = ret.Insert(0, klassName);
                         }
                         else
                         {
@@ -1911,7 +1921,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         fieldName.StartsWith ("<>8__", StringComparison.Ordinal);
         }
 
-        public async Task<JArray> GetHoistedLocalVariables(int objectId, IEnumerable<JToken> asyncLocals, CancellationToken token)
+        public async Task<JArray> GetHoistedLocalVariables(MethodInfoWithDebugInformation method, int objectId, IEnumerable<JToken> asyncLocals, int offset, CancellationToken token)
         {
             JArray asyncLocalsFull = new JArray();
             List<int> objectsAlreadyRead = new();
@@ -1922,7 +1932,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                 if (fieldName.EndsWith("__this", StringComparison.Ordinal))
                 {
                     asyncLocal["name"] = "this";
-                    asyncLocalsFull.Add(asyncLocal);
                 }
                 else if (IsClosureReferenceField(fieldName)) //same code that has on debugger-libs
                 {
@@ -1932,10 +1941,11 @@ namespace Microsoft.WebAssembly.Diagnostics
                         {
                             var asyncProxyMembersFromObject = await MemberObjectsExplorer.GetObjectMemberValues(
                                 this, dotnetObjectId.Value, GetObjectCommandOptions.WithProperties, token);
-                            var hoistedLocalVariable = await GetHoistedLocalVariables(dotnetObjectId.Value, asyncProxyMembersFromObject.Flatten(), token);
+                            var hoistedLocalVariable = await GetHoistedLocalVariables(method, dotnetObjectId.Value, asyncProxyMembersFromObject.Flatten(), offset, token);
                             asyncLocalsFull = new JArray(asyncLocalsFull.Union(hoistedLocalVariable));
                         }
                     }
+                    continue;
                 }
                 else if (fieldName.StartsWith("<>", StringComparison.Ordinal)) //examples: <>t__builder, <>1__state
                 {
@@ -1945,18 +1955,37 @@ namespace Microsoft.WebAssembly.Diagnostics
                 {
                     var match = regexForAsyncLocals.Match(fieldName);
                     if (match.Success)
+                    {
+                        if (!method.Info.ContainsAsyncScope(Convert.ToInt32(match.Groups[4].Value), offset))
+                            continue;
                         asyncLocal["name"] = match.Groups[1].Value;
-                    asyncLocalsFull.Add(asyncLocal);
+                    }
                 }
-                else
+                //VB language
+                else if (fieldName.StartsWith("$VB$Local_", StringComparison.Ordinal))
                 {
-                    asyncLocalsFull.Add(asyncLocal);
+                    asyncLocal["name"] = fieldName.Remove(0, 10);
                 }
+                else if (fieldName.StartsWith("$VB$ResumableLocal_", StringComparison.Ordinal))
+                {
+                    var match = regexForVBAsyncLocals.Match(fieldName);
+                    if (match.Success)
+                    {
+                        if (!method.Info.ContainsAsyncScope(Convert.ToInt32(match.Groups[2].Value) + 1, offset))
+                            continue;
+                        asyncLocal["name"] = match.Groups[1].Value;
+                    }
+                }
+                else if (fieldName.StartsWith("$"))
+                {
+                    continue;
+                }
+                asyncLocalsFull.Add(asyncLocal);
             }
             return asyncLocalsFull;
         }
 
-        public async Task<JArray> StackFrameGetValues(MethodInfoWithDebugInformation method, int thread_id, int frame_id, VarInfo[] varIds, CancellationToken token)
+        public async Task<JArray> StackFrameGetValues(MethodInfoWithDebugInformation method, int thread_id, int frame_id, VarInfo[] varIds, int offset, CancellationToken token)
         {
             using var commandParamsWriter = new MonoBinaryWriter();
             commandParamsWriter.Write(thread_id);
@@ -1973,7 +2002,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 retDebuggerCmdReader.ReadByte(); //ignore type
                 var objectId = retDebuggerCmdReader.ReadInt32();
                 GetMembersResult asyncProxyMembers = await MemberObjectsExplorer.GetObjectMemberValues(this, objectId, GetObjectCommandOptions.WithProperties, token, includeStatic: true);
-                var asyncLocals = await GetHoistedLocalVariables(objectId, asyncProxyMembers.Flatten(), token);
+                var asyncLocals = await GetHoistedLocalVariables(method, objectId, asyncProxyMembers.Flatten(), offset, token);
                 return asyncLocals;
             }
 

--- a/src/mono/wasm/debugger/tests/debugger-test-vb/debugger-test-vb.vb
+++ b/src/mono/wasm/debugger/tests/debugger-test-vb/debugger-test-vb.vb
@@ -1,0 +1,30 @@
+Public Class TestVbScope
+    Public Shared Async Function Run() As Task
+        Await RunVBScope(10)
+        Await RunVBScope(1000)
+    End Function
+
+    Public Shared Async Function RunVBScope(data As Integer) As Task(Of Integer)
+        Dim a As Integer
+        a = 10
+        If data < 999 Then
+            Dim testVbScope As String
+            Dim onlyInFirstScope As String
+            testVbScope = "hello"
+            onlyInFirstScope = "only-in-first-scope"
+            System.Diagnostics.Debugger.Break()
+            Await Task.Delay(1)
+            Return data
+        Else
+            Dim testVbScope As String
+            Dim onlyInSecondScope As String
+            testVbScope = "hi"
+            onlyInSecondScope = "only-in-second-scope"
+            System.Diagnostics.Debugger.Break()
+            Await Task.Delay(1)
+            Return data
+        End If
+
+    End Function
+
+End Class

--- a/src/mono/wasm/debugger/tests/debugger-test-vb/debugger-test-vb.vbproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-vb/debugger-test-vb.vbproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>DebuggerTestVB</RootNamespace>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-async-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-async-test.cs
@@ -230,4 +230,118 @@ namespace DebuggerTests.AsyncTests
         }
     }
 
+    public class VariablesWithSameNameDifferentScopes
+    {
+        public static async Task Run()
+        {
+            await RunCSharpScope(10);
+            await RunCSharpScope(1000);
+        }
+
+        public static async Task<string> RunCSharpScope(int number)
+        {
+            await Task.Delay(1);
+            if (number < 999)
+            {
+                string testCSharpScope = "hello"; string onlyInFirstScope = "only-in-first-scope";
+                System.Diagnostics.Debugger.Break();
+                return testCSharpScope;
+            }
+            else
+            {
+                string testCSharpScope = "hi"; string onlyInSecondScope = "only-in-second-scope";
+                System.Diagnostics.Debugger.Break();
+                return testCSharpScope;
+            }
+        }
+
+        public static async Task RunContinueWith()
+        {
+            await RunContinueWithSameVariableName(10);
+            await RunContinueWithSameVariableName(1000);
+        }
+
+        public static async Task RunNestedContinueWith()
+        {
+            await RunNestedContinueWithSameVariableName(10);
+            await RunNestedContinueWithSameVariableName(1000);
+        }
+
+        public static async Task RunContinueWithSameVariableName(int number)
+        {
+            await Task.Delay(500).ContinueWith(async t =>
+            {
+                await Task.Delay(1);
+                if (number < 999)
+                {
+                    var testCSharpScope = new String("hello"); string onlyInFirstScope = "only-in-first-scope";
+                    System.Diagnostics.Debugger.Break();
+                    return testCSharpScope;
+                }
+                else
+                {
+                    var testCSharpScope = new String("hi"); string onlyInSecondScope = "only-in-second-scope";
+                    System.Diagnostics.Debugger.Break();
+                    return testCSharpScope;
+                }
+            });
+            Console.WriteLine ($"done with this method");
+        }
+
+        public static async Task RunNestedContinueWithSameVariableName(int number)
+        {
+            await Task.Delay(500).ContinueWith(async t =>
+            {
+                if (number < 999)
+                {
+                    var testCSharpScope = new String("hello_out"); string onlyInFirstScope = "only-in-first-scope_out";
+                    Console.WriteLine(testCSharpScope);
+                }
+                else
+                {
+                    var testCSharpScope = new String("hi_out"); string onlyInSecondScope = "only-in-second-scope_out";
+                    Console.WriteLine(testCSharpScope);
+                }
+                await Task.Delay(300).ContinueWith(t2 =>
+                {
+                    if (number < 999)
+                    {
+                        var testCSharpScope = new String("hello"); string onlyInFirstScope = "only-in-first-scope";
+                        System.Diagnostics.Debugger.Break();
+                        return testCSharpScope;
+                    }
+                    else
+                    {
+                        var testCSharpScope = new String("hi"); string onlyInSecondScope = "only-in-second-scope";
+                        System.Diagnostics.Debugger.Break();
+                        return testCSharpScope;
+                    }
+                });
+            });
+            Console.WriteLine ($"done with this method");
+        }
+
+        public static void RunNonAsyncMethod()
+        {
+            RunNonAsyncMethodSameVariableName(10);
+            RunNonAsyncMethodSameVariableName(1000);
+        }
+
+        public static string RunNonAsyncMethodSameVariableName(int number)
+        {
+            if (number < 999)
+            {
+                var testCSharpScope = new String("hello"); string onlyInFirstScope = "only-in-first-scope";
+                System.Diagnostics.Debugger.Break();
+                return testCSharpScope;
+            }
+            else
+            {
+                var testCSharpScope = new String("hi"); string onlyInSecondScope = "only-in-second-scope";
+                System.Diagnostics.Debugger.Break();
+                return testCSharpScope;
+            }
+        }
+    }
+
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" ReferenceOutputAssembly="false" Private="true" />
     <ProjectReference Include="..\debugger-test-without-debug-symbols-to-load\debugger-test-without-debug-symbols-to-load.csproj" Private="true" />
     <ProjectReference Include="..\debugger-test-with-non-user-code-class\debugger-test-with-non-user-code-class.csproj" Private="true" />
+    <ProjectReference Include="..\debugger-test-vb\debugger-test-vb.vbproj" Private="true" />
     <!-- loaded by *tests*, and not the test app -->
     <ProjectReference Include="..\lazy-debugger-test-embedded\lazy-debugger-test-embedded.csproj" ReferenceOutputAssembly="false" Private="true" />
 
@@ -61,6 +62,7 @@
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-without-debug-symbols-to-load.dll" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-non-user-code-class.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-vb.dll" />
       <WasmAssembliesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidDir)\lib\$(NetCoreappCurrent)\System.Runtime.InteropServices.JavaScript.dll" />
 
       <!-- Assemblies only dynamically loaded -->


### PR DESCRIPTION
Backport of #78651  to release/7.0

/cc @thaystg

## Customer Impact
When a async method has 2 variables with same name in different scopes, the debugger was always getting the value from the last scope, so if it was debugging and paused in a if block, that has an else with the same variable in two blocks, it would show the wrong value for the variable in debugger.
Fixed this for C# and VB, also fixed names of async variables and methods while debugging VB code.
Issues related:
https://github.com/dotnet/runtime/issues/77031
https://github.com/dotnet/runtime/issues/77481
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1697672

## Testing
Manually tested using a Blazor app, also created unit tests.

## Risk
Medium risk, now it's considering the scope of variables in async method, this was completely ignored before.
