### PR TITLE
Fix JsonSerializer.SerializeAsync not passing the cancellation token to converters

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
@@ -121,6 +121,8 @@ namespace System.Text.Json.Serialization.Metadata
                     supportContinuation: true,
                     supportAsync: true);
 
+                state.CancellationToken = cancellationToken;
+
                 using var bufferWriter = new PooledByteBufferWriter(Options.DefaultBufferSize);
                 using var writer = new Utf8JsonWriter(bufferWriter, Options.GetWriterOptions());
 

--- a/src/libraries/System.Text.Json/tests/Common/Utf8MemoryStream.cs
+++ b/src/libraries/System.Text.Json/tests/Common/Utf8MemoryStream.cs
@@ -2,18 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Text.Json.Serialization.Tests
 {
     public sealed class Utf8MemoryStream : MemoryStream
     {
-        public Utf8MemoryStream() : base()
+        private readonly bool _ignoreCancellationTokenOnWriteAsync;
+
+        public Utf8MemoryStream(bool ignoreCancellationTokenOnWriteAsync = false) : base()
         {
+            _ignoreCancellationTokenOnWriteAsync = ignoreCancellationTokenOnWriteAsync;
         }
 
         public Utf8MemoryStream(string text) : base(Encoding.UTF8.GetBytes(text))
         {
         }
+
+#if NETCOREAPP
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => base.WriteAsync(buffer, _ignoreCancellationTokenOnWriteAsync ? default : cancellationToken);
+#endif
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => base.WriteAsync(buffer, offset, count, _ignoreCancellationTokenOnWriteAsync ? default : cancellationToken);
 
         public string AsString() => Encoding.UTF8.GetString(ToArray());
     }


### PR DESCRIPTION
Fix #79556.