### PR TITLE
Fix a few profiler related issues associated with frozen objects

### DIFF
--- a/src/coreclr/gc/gcee.cpp
+++ b/src/coreclr/gc/gcee.cpp
@@ -451,7 +451,7 @@ segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)
     heap_segment_used(seg) = heap_segment_allocated(seg);
     heap_segment_plan_allocated(seg) = 0;
 #ifdef USE_REGIONS
-    heap_segment_gen_num(seg) = 2;
+    heap_segment_gen_num(seg) = max_generation;
 #endif //USE_REGIONS
     seg->flags = heap_segment_flags_readonly;
 

--- a/src/coreclr/gc/gcee.cpp
+++ b/src/coreclr/gc/gcee.cpp
@@ -450,6 +450,9 @@ segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)
     heap_segment_next(seg) = 0;
     heap_segment_used(seg) = heap_segment_allocated(seg);
     heap_segment_plan_allocated(seg) = 0;
+#ifdef USE_REGIONS
+    heap_segment_gen_num(seg) = 2;
+#endif //USE_REGIONS
     seg->flags = heap_segment_flags_readonly;
 
 #ifdef MULTIPLE_HEAPS

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1697,8 +1697,10 @@ protected:
 
     PER_HEAP
     void walk_relocation (void* profiling_context, record_surv_fn fn);
+#ifdef USE_REGIONS
     PER_HEAP
-    heap_segment* walk_relocation_special_segments (heap_segment* current_heap_segment, void* profiling_context, record_surv_fn fn);
+    heap_segment* walk_relocation_sip (heap_segment* current_heap_segment, void* profiling_context, record_surv_fn fn);
+#endif // USE_REGIONS
     PER_HEAP
     void walk_relocation_in_brick (uint8_t* tree, walk_relocate_args* args);
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1697,10 +1697,8 @@ protected:
 
     PER_HEAP
     void walk_relocation (void* profiling_context, record_surv_fn fn);
-#ifdef USE_REGIONS
     PER_HEAP
-    heap_segment* walk_relocation_sip (heap_segment* current_heap_segment, void* profiling_context, record_surv_fn fn);
-#endif // USE_REGIONS
+    heap_segment* walk_relocation_special_segments (heap_segment* current_heap_segment, void* profiling_context, record_surv_fn fn);
     PER_HEAP
     void walk_relocation_in_brick (uint8_t* tree, walk_relocate_args* args);
 

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -18,7 +18,7 @@ FrozenObjectHeapManager::FrozenObjectHeapManager():
 // Allocates an object of the give size (including header) on a frozen segment.
 // May return nullptr if object is too large (larger than FOH_COMMIT_SIZE)
 // in such cases caller is responsible to find a more appropriate heap to allocate it
-Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t objectSize)
+Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t objectSize, bool publish)
 {
     CONTRACTL
     {
@@ -32,51 +32,59 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
     return nullptr;
 #else // FEATURE_BASICFREEZE
 
-    CrstHolder ch(&m_Crst);
-
-    _ASSERT(type != nullptr);
-    _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
-
-#ifdef FEATURE_64BIT_ALIGNMENT
-    _ASSERT(!type->RequiresAlign8());
-#endif
-
-    // NOTE: objectSize is expected be the full size including header
-    _ASSERT(objectSize >= MIN_OBJECT_SIZE);
-
-    if (objectSize > FOH_COMMIT_SIZE)
+    Object* obj = nullptr;
     {
-        // The current design doesn't allow objects larger than FOH_COMMIT_SIZE and
-        // since FrozenObjectHeap is just an optimization, let's not fill it with huge objects.
-        return nullptr;
-    }
+        CrstHolder ch(&m_Crst);
 
-    if (m_CurrentSegment == nullptr)
-    {
-        // Create the first segment on first allocation
-        m_CurrentSegment = new FrozenObjectSegment(FOH_SEGMENT_DEFAULT_SIZE);
-        m_FrozenSegments.Append(m_CurrentSegment);
-        _ASSERT(m_CurrentSegment != nullptr);
-    }
+        _ASSERT(type != nullptr);
+        _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
 
-    Object* obj = m_CurrentSegment->TryAllocateObject(type, objectSize);
+    #ifdef FEATURE_64BIT_ALIGNMENT
+        _ASSERT(!type->RequiresAlign8());
+    #endif
 
-    // The only case where it can be null is when the current segment is full and we need
-    // to create a new one
-    if (obj == nullptr)
-    {
-        // Double the reserved size to reduce the number of frozen segments in apps with lots of frozen objects
-        // Use the same size in case if prevSegmentSize*2 operation overflows.
-        size_t prevSegmentSize = m_CurrentSegment->GetSize();
-        m_CurrentSegment = new FrozenObjectSegment(max(prevSegmentSize, prevSegmentSize * 2));
-        m_FrozenSegments.Append(m_CurrentSegment);
+        // NOTE: objectSize is expected be the full size including header
+        _ASSERT(objectSize >= MIN_OBJECT_SIZE);
 
-        // Try again
+        if (objectSize > FOH_COMMIT_SIZE)
+        {
+            // The current design doesn't allow objects larger than FOH_COMMIT_SIZE and
+            // since FrozenObjectHeap is just an optimization, let's not fill it with huge objects.
+            return nullptr;
+        }
+
+        if (m_CurrentSegment == nullptr)
+        {
+            // Create the first segment on first allocation
+            m_CurrentSegment = new FrozenObjectSegment(FOH_SEGMENT_DEFAULT_SIZE);
+            m_FrozenSegments.Append(m_CurrentSegment);
+            _ASSERT(m_CurrentSegment != nullptr);
+        }
+
         obj = m_CurrentSegment->TryAllocateObject(type, objectSize);
 
-        // This time it's not expected to be null
-        _ASSERT(obj != nullptr);
+        // The only case where it can be null is when the current segment is full and we need
+        // to create a new one
+        if (obj == nullptr)
+        {
+            // Double the reserved size to reduce the number of frozen segments in apps with lots of frozen objects
+            // Use the same size in case if prevSegmentSize*2 operation overflows.
+            size_t prevSegmentSize = m_CurrentSegment->GetSize();
+            m_CurrentSegment = new FrozenObjectSegment(max(prevSegmentSize, prevSegmentSize * 2));
+            m_FrozenSegments.Append(m_CurrentSegment);
+
+            // Try again
+            obj = m_CurrentSegment->TryAllocateObject(type, objectSize);
+
+            // This time it's not expected to be null
+            _ASSERT(obj != nullptr);
+        }
     }
+    if (publish)
+    {
+        PublishFrozenObject(obj);
+    }
+
     return obj;
 #endif // !FEATURE_BASICFREEZE
 }

--- a/src/coreclr/vm/frozenobjectheap.h
+++ b/src/coreclr/vm/frozenobjectheap.h
@@ -27,7 +27,7 @@ class FrozenObjectHeapManager
 {
 public:
     FrozenObjectHeapManager();
-    Object* TryAllocateObject(PTR_MethodTable type, size_t objectSize);
+    Object* TryAllocateObject(PTR_MethodTable type, size_t objectSize, bool publish = true);
 
 private:
     Crst m_Crst;

--- a/src/coreclr/vm/gchelpers.h
+++ b/src/coreclr/vm/gchelpers.h
@@ -68,4 +68,7 @@ extern void ThrowOutOfMemoryDimensionsExceeded();
 
 void ErectWriteBarrier(OBJECTREF* dst, OBJECTREF ref);
 void SetCardsAfterBulkCopy(Object **start, size_t len);
+
+void PublishFrozenObject(Object*& orObject);
+
 #endif // _GCHELPERS_H_


### PR DESCRIPTION
This change fixes a few profiler-related issues associated with frozen objects.

1. Reset the pinned queue only once
2. Publish frozen objects
~3. Report the frozen segments as survived~
4. Set frozen segment `gen_num`

**Reset the pinned queue only once**

This was an existing bug that is unrelated to frozen objects (for reason I don't understand it only got exposed recently). 

In `walk_relocation`, we walk the generations (from old to young), the associated bricks (in region list order), and the associated plug trees (using an in-order traversal).  During the walk, we dequeue the pinned plugs from the pinned plug queue. 

There is only one pinned queue shared across all generations. Therefore we should not reset the pinned queue for every generation.

**Publish frozen objects**

Some profilers track object instances. If we don't report an object as allocated, they won't be tracking it, and they might be surprised if later on the object is reported as root.

Before the change, frozen objects are not reported as allocated.

After the change, frozen objects allocated through `FrozenObjectHeapManager::TryAllocate` are now reported to the profiler through `PublishObjectAndNotify`, and therefore they will be available through `ICorProfiler::ObjectAllocated` callback.

~**Report the frozen segments as survived**~

~Some profilers might assume that objects previously allocated not falling in that survived range are being collected.~

~Before the change, frozen segments are not reported, and therefore the profiler might assume frozen objects are collected, while they are not, and then got surprised that they got reported as root.~

~After the change, the frozen segments are reported as survived, to do that, the `walk_relocation_sip` method is renamed to `walk_relocation_special_segments` to also handle the special case for frozen segments.~

**Set frozen segment `gen_num`**

As we report the regions to the profiler, we will read the `gen_num` of the heap segment. The current code didn't set that value, so we might be reading random numbers in the profiler. That's not good. As an implementation detail, we thread the frozen segment into gen2, so we might as well set the `gen_num` to 2 there.

@dotnet/gc