### PR TITLE
Don't require singlefilehost in host.native

### DIFF
--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -54,6 +54,7 @@
   </Target>
 
   <Target Name="PrepareSingleFileHostWithEmbeddedDac"
+          Condition="Exists('$(SingleFileHostPath)')"
           DependsOnTargets="PrepareSingleFileHostWithEmbeddedDacPrereqs;PrepareSingleFileHostWithEmbeddedDacCore"
           AfterTargets="Build"/>
 

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -44,7 +44,8 @@
             @(InjectResourceTool)"
     Outputs="$(SingleFileHostDestinationPath);$(SingleFileHostSymbolsDestinationPath)"
     DependsOnTargets="ResolveProjectReferences"
-    Condition="'$(RuntimeFlavor)' != 'Mono'">
+    Condition="'$(RuntimeFlavor)' != 'Mono' and
+               Exists('$(SingleFileHostPath)')">
     <Copy SourceFiles="$(SingleFileHostPath)" DestinationFiles="$(SingleFileHostDestinationPath)" />
     <Exec Condition="'$(TargetOS)' == 'windows'"
           Command="&quot;$(DotNetTool)&quot; exec @(InjectResourceTool) --bin &quot;$(DacPath)&quot; --image &quot;$(SingleFileHostDestinationPath)&quot; --name MINIDUMP_EMBEDDED_AUXILIARY_PROVIDER" />
@@ -54,7 +55,6 @@
   </Target>
 
   <Target Name="PrepareSingleFileHostWithEmbeddedDac"
-          Condition="Exists('$(SingleFileHostPath)')"
           DependsOnTargets="PrepareSingleFileHostWithEmbeddedDacPrereqs;PrepareSingleFileHostWithEmbeddedDacCore"
           AfterTargets="Build"/>
 


### PR DESCRIPTION
The corehost project currently tries to build the singlefilehost with the embedded DAC, which we can skip if we never built the singlefilehost in the first place.

Fixes https://github.com/dotnet/runtime/issues/79144