### PR TITLE
Fix mcs -dumpMap

### DIFF
--- a/src/coreclr/tools/superpmi/mcs/verbildump.cpp
+++ b/src/coreclr/tools/superpmi/mcs/verbildump.cpp
@@ -67,13 +67,32 @@ void DumpPrimToConsoleBare(MethodContext* mc, CorInfoType prim, DWORDLONG classH
         case CORINFO_TYPE_VALUECLASS:
         case CORINFO_TYPE_CLASS:
         {
-            char className[256];
-            mc->repPrintClassName((CORINFO_CLASS_HANDLE)classHandle, className, sizeof(className));
+            CORINFO_CLASS_HANDLE cls = (CORINFO_CLASS_HANDLE)classHandle;
+            unsigned arrayRank = mc->repGetArrayRank(cls);
+            if (arrayRank > 0)
+            {
+                CORINFO_CLASS_HANDLE childCls;
+                CorInfoType          childType = mc->repGetChildType(cls, &childCls);
+                DumpPrimToConsoleBare(mc, childType, (DWORDLONG)childCls);
 
-            printf(
-                "%s %s",
-                prim == CORINFO_TYPE_VALUECLASS ? "valueclass" : "class",
-                className);
+                printf("[");
+                for (unsigned i = 1; i < arrayRank; i++)
+                {
+                    printf(",");
+                }
+                printf("]");
+            }
+            else
+            {
+                char className[256];
+                mc->repPrintClassName((CORINFO_CLASS_HANDLE)classHandle, className, sizeof(className));
+
+                printf(
+                    "%s %s",
+                    prim == CORINFO_TYPE_VALUECLASS ? "valueclass" : "class",
+                    className);
+            }
+
             return;
         }
         case CORINFO_TYPE_REFANY:


### PR DESCRIPTION
This needs to be in sync with how printing in the JIT works to ensure that we don't ask for data that the JIT did not make available.

Fix #79568