### PR TITLE
[release/6.0][wasm] Partially fix issue caused during VS upgrade

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoTargets.Sdk/Sdk/RuntimeComponentManifest.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoTargets.Sdk/Sdk/RuntimeComponentManifest.targets
@@ -115,4 +115,13 @@
              Text="_MonoComponent item list includes components '@(_MonoRuntimeSelectedMissingComponents)' which are not defined in the runtime pack. Runtime pack includes '@(_MonoRuntimeComponentNameForRid)'" />
 
   </Target>
+
+  <!-- This for use by Wasm targets, but moved here as a workaround to https://github.com/dotnet/sdk/issues/21032
+       only for 6.0 -->
+  <UsingTask TaskName="ReadEmccProps" AssemblyFile="$(JsonToItemsTaskFactoryTasksAssemblyPath)"
+             TaskFactory="JsonToItemsTaskFactory.JsonToItemsTaskFactory">
+    <ParameterGroup>
+      <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+    </ParameterGroup>
+  </UsingTask>
 </Project>

--- a/src/mono/wasm/build/WasmApp.InTree.targets
+++ b/src/mono/wasm/build/WasmApp.InTree.targets
@@ -51,4 +51,13 @@
     <ZipDirectory SourceDirectory="$(WasmAppDir)" DestinationFile="$(ZippedApp)" />
     <Copy SourceFiles="$(ZippedApp)" DestinationFolder="$(HelixArchiveRunOnlyAppsDir)" />
   </Target>
+
+  <!-- This for use by Wasm targets, but moved here as a workaround to https://github.com/dotnet/sdk/issues/21032
+       only for 6.0 -->
+  <UsingTask TaskName="ReadEmccProps" AssemblyFile="$(JsonToItemsTaskFactoryTasksAssemblyPath)"
+             TaskFactory="JsonToItemsTaskFactory.JsonToItemsTaskFactory">
+    <ParameterGroup>
+      <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+    </ParameterGroup>
+  </UsingTask>
 </Project>

--- a/src/mono/wasm/build/WasmApp.LocalBuild.props
+++ b/src/mono/wasm/build/WasmApp.LocalBuild.props
@@ -71,4 +71,12 @@
     <JsonToItemsTaskFactoryTasksAssemblyPath>$([MSBuild]::NormalizePath('$(JsonToItemsTaskFactoryDir)', 'JsonToItemsTaskFactory.dll'))</JsonToItemsTaskFactoryTasksAssemblyPath>
   </PropertyGroup>
 
+  <!-- This for use by Wasm targets, but moved here as a workaround to https://github.com/dotnet/sdk/issues/21032
+       only for 6.0 -->
+  <UsingTask TaskName="ReadEmccProps" AssemblyFile="$(JsonToItemsTaskFactoryTasksAssemblyPath)"
+             TaskFactory="JsonToItemsTaskFactory.JsonToItemsTaskFactory">
+    <ParameterGroup>
+      <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+    </ParameterGroup>
+  </UsingTask>
 </Project>

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -560,11 +560,4 @@ EMSCRIPTEN_KEEPALIVE void mono_wasm_load_profiler_aot (const char *desc) { mono_
       <_WasmAssembliesInternal Include="@(_WasmStrippedAssemblies)" />
     </ItemGroup>
   </Target>
-
-  <UsingTask TaskName="ReadEmccProps" AssemblyFile="$(JsonToItemsTaskFactoryTasksAssemblyPath)"
-             TaskFactory="JsonToItemsTaskFactory.JsonToItemsTaskFactory">
-    <ParameterGroup>
-      <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
-    </ParameterGroup>
-  </UsingTask>
 </Project>


### PR DESCRIPTION
## Issue:

TL;dr After some VS upgrades, or possibly messed up workload installs users get the above exception when trying to build their projects. But this error is a side effect of the real issue of msbuild failing to load a workload pack. This fix allows the real error to get surfaced to the user.

Upgrading from VS 17.3.6 to 17.4.2 caused wasm project builds to break with:

`Unhandled exception: Microsoft.Build.Exceptions.InvalidProjectFileException: The result “” of evaluating the value “$(JsonToItemsTaskFactoryTasksAssemblyPath)” of the “AssemblyFile” attribute in element  is not valid. C:\Program Files\dotnet\packs\Microsoft.NET.Runtime.WebAssembly.Sdk\6.0.11\Sdk\WasmApp.Native.targets`

<details>
    at Microsoft.Build.Shared.ProjectErrorUtilities.ThrowInvalidProject(String errorSubCategoryResourceName, IElementLocation elementLocation, String resourceName, Object[] args)
    at Microsoft.Build.Shared.ProjectErrorUtilities.VerifyThrowInvalidProject[T1,T2,T3,T4](Boolean condition, String errorSubCategoryResourceName, IElementLocation elementLocation, String resourceName, T1 arg0, T2 arg1, T3 arg2, T4 arg3)
    at Microsoft.Build.Shared.ProjectErrorUtilities.VerifyThrowInvalidProject[T1,T2,T3,T4](Boolean condition, IElementLocation elementLocation, String resourceName, T1 arg0, T2 arg1, T3 arg2, T4 arg3)
    at Microsoft.Build.Execution.TaskRegistry.RegisterTasksFromUsingTaskElement[P,I](ILoggingService loggingService, BuildEventContext buildEventContext, String directoryOfImportingFile, ProjectUsingTaskElement projectUsingTaskXml, TaskRegistry taskRegistry, Expander`2 expander, ExpanderOptions expanderOptions, IFileSystem fileSystem) at Microsoft.Build.Evaluation.Evaluator`4.EvaluateUsingTaskElement(String directoryOfImportingFile, ProjectUsingTaskElement projectUsingTaskElement)
    at Microsoft.Build.Evaluation.Evaluator`4.Evaluate() at Microsoft.Build.Evaluation.Evaluator`4.Evaluate(IEvaluatorData`4 data, Project project, ProjectRootElement root, ProjectLoadSettings loadSettings, Int32 maxNodeCount, PropertyDictionary`1 environmentProperties, ILoggingService loggingService, IItemFactory`2 itemFactory, IToolsetProvider toolsetProvider, ProjectRootElementCacheBase projectRootElementCache, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, Int32 submissionId, EvaluationContext evaluationContext, Boolean interactive) at Microsoft.Build.Execution.ProjectInstance.Initialize(ProjectRootElement xml, IDictionary`2 globalProperties, String explicitToolsVersion, String explicitSubToolsetVersion, Int32 visualStudioVersionFromSolution, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, Int32 submissionId, Nullable`1 projectLoadSettings, EvaluationContext evaluationContext) at Microsoft.Build.Execution.ProjectInstance..ctor(String projectFile, IDictionary`2 globalProperties, String toolsVersion, String subToolsetVersion, ProjectCollection projectCollection, Nullable`1 projectLoadSettings, EvaluationContext evaluationContext) at Microsoft.Build.Execution.ProjectInstance..ctor(String projectFile, IDictionary`2 globalProperties, String toolsVersion)
    at Microsoft.DotNet.Workloads.Workload.Restore.WorkloadRestoreCommand.RunTargetToGetWorkloadIds(IEnumerable`1 allProjects)
    at Microsoft.DotNet.Workloads.Workload.Restore.WorkloadRestoreCommand.Execute()
    at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<b__0>d.MoveNext()
    — End of stack trace from previous location —
    at Microsoft.DotNet.Cli.Parser.<>c__DisplayClass17_0.<b__0>d.MoveNext()
    — End of stack trace from previous location —
    at System.CommandLine.CommandLineBuilderExtensions.<>c__DisplayClass11_0.<b__0>d.MoveNext()
    — End of stack trace from previous location —
    at System.CommandLine.CommandLineBuilderExtensions.<>c.<b__17_0>d.MoveNext()
    — End of stack trace from previous location —
    at System.CommandLine.CommandLineBuilderExtensions.<>c__DisplayClass15_0.<b__0>d.MoveNext()
    — End of stack trace from previous location —
    at System.CommandLine.CommandLineBuilderExtensions.<>c__DisplayClass7_0.<b__0>d.MoveNext()
</details>

There are two issues here:

1. The error seen by the user (seen above)
2. And the real error underneath which is that some workload packs fail to load (possibly because they are missing), but the error gets swallowed by msbuild.

This is explained in https://github.com/dotnet/sdk/issues/21032#issuecomment-938136533 .

```
For the workload failure, what is going on is that the workload missing
error comes from running a Target, while the failure about the empty
value for AssemblyFile comes from evaluation. So you get the
AssemblyFile failure before it gets a chance to tell you about the
missing workload.
```

Details:

- the `MonoTargets` pack is missing, or doesn't have the correct version, and the SDK cannot be loaded (see (2))

- And this in turn causes (1) because: - the `UsingTask` for `ReadEmccProps` in `WebAssembly.Sdk`'s `WasmApp.Native.targets` uses `AssemblyFile=$(JsonToItemsTaskFactoryTasksAssemblyPath)` - and `$(JsonToItemsTaskFactoryTasksAssemblyPath)` is set in the `MonoTargets.Sdk` pack - because of the missing pack the above property is unset, causing the `UsingTask` evaluation to fail.

As a workaround, we move the `UsingTask` to `MonoTargets.Sdk` too, which should cause the real error to surface.

Original issue: https://github.com/dotnet/runtime/issues/78237

## Customer Impact

This fix would allow the real error about the missing workload pack to be surfaced to the user, instead of the unhelpful exception message.

## Risk

Low. This has been manually tested to check that the change does not *break* anything. But note that we can't actually reproduce the original user issue.