### PR TITLE
[wasm] Let browser-bench post bootstrap flag

### DIFF
--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -101,10 +101,18 @@ class MainApp {
         this.yieldBench();
     }
 
+    bootstraped = false;
 
     yieldBench() {
         let promise = runBenchmark();
         promise.then(ret => {
+            if (!this.bootstraped) {
+                fetch("/bootstrap.flag", {
+                    method: 'POST',
+                    body: "ok"
+                }).then(r => { console.log("bootstrap post request complete, response: ", r); });
+                this.bootstraped = true;
+            }
             document.getElementById("out").innerHTML += ret;
             if (ret.length > 0) {
                 setTimeout(() => { this.yieldBench(); }, 0);


### PR DESCRIPTION
This helps our perf measurements infrastructure to detect successful bootstrap of the bench run