### PR TITLE
Remove unnecesary library selection checking

### DIFF
--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -557,29 +557,26 @@ namespace
             it = libName.Begin();
             bool containsDelim = libName.Find(it, DIRECTORY_SEPARATOR_STR_W);
 
-            if (containsSuffix)
+            if (containsSuffix && containsDelim)
             {
                 libNameVariations[varCount++] = NameFmt;
-
-                if (!containsDelim)
-                    libNameVariations[varCount++] = PrefixNameFmt;
-
-                libNameVariations[varCount++] = NameSuffixFmt;
-
-                if (!containsDelim)
-                    libNameVariations[varCount++] = PrefixNameSuffixFmt;
             }
-            else
+            else if (containsSuffix && !containsDelim)
+            {
+                libNameVariations[varCount++] = NameFmt;
+                libNameVariations[varCount++] = PrefixNameFmt;
+            }
+            else if (!containsSuffix && containsDelim)
             {
                 libNameVariations[varCount++] = NameSuffixFmt;
-
-                if (!containsDelim)
-                    libNameVariations[varCount++] = PrefixNameSuffixFmt;
-
                 libNameVariations[varCount++] = NameFmt;
-
-                if (!containsDelim)
-                    libNameVariations[varCount++] = PrefixNameFmt;
+            }
+            else if (!containsSuffix && !containsDelim)
+            {
+                libNameVariations[varCount++] = PrefixNameSuffixFmt;
+                libNameVariations[varCount++] = NameSuffixFmt;
+                libNameVariations[varCount++] = PrefixNameFmt;
+                libNameVariations[varCount++] = NameFmt;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/LibraryNameVariation.Unix.cs
@@ -35,31 +35,26 @@ namespace System.Runtime.Loader
 
                 bool containsDelim = libName.Contains(Path.DirectorySeparatorChar);
 
-                if (containsSuffix)
+                if (containsSuffix && containsDelim)
                 {
                     yield return new LibraryNameVariation(string.Empty, string.Empty);
-                    if (!containsDelim)
-                    {
-                        yield return new LibraryNameVariation(LibraryNamePrefix, string.Empty);
-                    }
-                    yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
-                    if (!containsDelim)
-                    {
-                        yield return new LibraryNameVariation(LibraryNamePrefix, LibraryNameSuffix);
-                    }
                 }
-                else
+                else if (containsSuffix && !containsDelim)
+                {
+                    yield return new LibraryNameVariation(string.Empty, string.Empty);
+                    yield return new LibraryNameVariation(LibraryNamePrefix, string.Empty);
+                }
+                else if (!containsSuffix && containsDelim)
                 {
                     yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
-                    if (!containsDelim)
-                    {
-                        yield return new LibraryNameVariation(LibraryNamePrefix, LibraryNameSuffix);
-                    }
                     yield return new LibraryNameVariation(string.Empty, string.Empty);
-                    if (!containsDelim)
-                    {
-                        yield return new LibraryNameVariation(LibraryNamePrefix, string.Empty);
-                    }
+                }
+                else if (!containsSuffix && !containsDelim)
+                {
+                    yield return new LibraryNameVariation(LibraryNamePrefix, LibraryNameSuffix);
+                    yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
+                    yield return new LibraryNameVariation(LibraryNamePrefix, string.Empty);
+                    yield return new LibraryNameVariation(string.Empty, string.Empty);
                 }
             }
         }


### PR DESCRIPTION
If suffix is contained in the library name, there is no need to check suffix added name variation. 
Also, if delimiter is added in the library name, there is no need to check prefix added name variation.

I reorganized library selection code with below table.
| containsSuffix | containsDelim |  1st | 2nd | 3rd | 4th
| --- | --- | --- | --- | --- | --- |
| O | O | NameFmt | | | |
| O | X | NameFmt | PrefixNameFmt | | |
| X | O | NameSuffixFmt | NameFmt | | |
| X | X | PrefixNameSuffixFmt | NameSuffixFmt | PrefixNameFmt | NameFmt |