### PR TITLE
Condition some NamedPipe tests on COM support

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs
@@ -118,6 +118,7 @@ namespace System.IO.Pipes.Tests
     /// <summary>
     /// Negative tests for PipeOptions.CurrentUserOnly in Windows.
     /// </summary>
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltInComEnabled))]
     public class NamedPipeTest_CurrentUserOnly_Windows : IClassFixture<TestAccountImpersonator>
     {
         public static bool IsSupportedWindowsVersionAndPrivilegedProcess => PlatformDetection.IsPrivilegedProcess
@@ -210,7 +211,6 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/79180", TestRuntimes.Mono)]
         [ConditionalTheory(nameof(IsSupportedWindowsVersionAndPrivilegedProcess))]
         [InlineData(false)]
         [InlineData(true)]


### PR DESCRIPTION
There's nothing we can do about this, these should be conditional.

Fixes #79180.

These are failing on NativeAOT:

```
   at System.Runtime.InteropServices.ComWrappers.ComObjectForInterface(IntPtr) + 0x5c
   at System.DirectoryServices.UnsafeNativeMethods.ADsOpenObject(String, String, String, Int32, Guid&, Object&) + 0x94
   at System.DirectoryServices.DirectoryEntry.Bind(Boolean) + 0x1ac
   at System.DirectoryServices.DirectoryEntry.RefreshCache() + 0x1c
   at System.DirectoryServices.AccountManagement.PrincipalContext.DoMachineInit() + 0x190
   at System.DirectoryServices.AccountManagement.PrincipalContext.Initialize() + 0x78
   at System.DirectoryServices.AccountManagement.Principal.FindByIdentityWithTypeHelper(PrincipalContext, Type, Nullable`1, String, DateTime) + 0x30
   at System.DirectoryServices.AccountManagement.Principal.FindByIdentityWithType(PrincipalContext, Type, String) + 0x48
   at System.DirectoryServices.AccountManagement.UserPrincipal.FindByIdentity(PrincipalContext, String) + 0x30
   at System.IO.Pipes.Tests.TestAccountImpersonator..ctor() + 0xa8
```

They also fail on Mono when one drills into the logs but don't show as failing in the CI legs:

```
        ----- Inner Stack Trace #1 (System.PlatformNotSupportedException) -----
        /_/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs(274,0): at System.Threading.Thread.SetApartmentStateUnchecked(ApartmentState state, Boolean throwOnError)
        /_/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs(521,0): at System.Threading.Thread.SetApartmentState(ApartmentState state, Boolean throwOnError)
        /_/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs(499,0): at System.Threading.Thread.SetApartmentState(ApartmentState state)
        /_/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs(528,0): at System.DirectoryServices.DirectoryEntry.Bind(Boolean throwIfFail)
        /_/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs(499,0): at System.DirectoryServices.DirectoryEntry.Bind()
        /_/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs(934,0): at System.DirectoryServices.DirectoryEntry.RefreshCache()
        /_/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs(663,0): at System.DirectoryServices.AccountManagement.PrincipalContext.DoMachineInit()
        /_/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs(577,0): at System.DirectoryServices.AccountManagement.PrincipalContext.Initialize()
        /_/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs(1062,0): at System.DirectoryServices.AccountManagement.PrincipalContext.get_QueryCtx()
        /_/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Principal.cs(929,0): at System.DirectoryServices.AccountManagement.Principal.FindByIdentityWithTypeHelper(PrincipalContext context, Type principalType, Nullable`1 identityType, String identityValue, DateTime refDate)
        /_/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Principal.cs(908,0): at System.DirectoryServices.AccountManagement.Principal.FindByIdentityWithType(PrincipalContext context, Type principalType, String identityValue)
        /_/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/User.cs(256,0): at System.DirectoryServices.AccountManagement.UserPrincipal.FindByIdentity(PrincipalContext context, String identityValue)
        /_/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CurrentUserOnly.Windows.cs(34,0): at System.IO.Pipes.Tests.TestAccountImpersonator..ctor()
```