### PR TITLE
Handle RSA zero modulus for Android

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -306,7 +306,7 @@ namespace System.Security.Cryptography
                 ValidateParameters(ref parameters);
                 ThrowIfDisposed();
 
-                if (parameters.Exponent == null || parameters.Modulus == null)
+                if (parameters.Exponent == null || parameters.Modulus.AsSpan().IndexOfAnyExcept((byte)0) < 0)
                 {
                     throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
                 }

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -311,6 +311,8 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
                 }
 
+                Debug.Assert(parameters.Modulus is not null);
+
                 // Check that either all parameters are not null or all are null, if a subset were set, then the parameters are invalid.
                 // If the parameters are all not null, verify the integrity of their lengths.
                 if (parameters.D == null)


### PR DESCRIPTION
This handles an RSA key for Android where the modulus is zero.

Fixes #79584.