### PR TITLE
Use ReferencePathWithRefAssemblies for libs ILLink

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -274,7 +274,7 @@
     />
 
     <ItemGroup>
-      <_DependencyDirectoriesTemp Include="@(ReferencePath->'%(RootDir)%(Directory)')" />
+      <_DependencyDirectoriesTemp Include="@(ReferencePathWithRefAssemblies->'%(RootDir)%(Directory)')" />
       <!-- Remove duplicate directories by batching over them -->
       <!-- Add project references first to give precedence to project-specific files -->
       <_DependencyDirectories Condition="'%(_DependencyDirectoriesTemp.ReferenceSourceTarget)'=='ProjectReference'" Include="%(_DependencyDirectoriesTemp.Identity)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/79513

The libraries build invokes ILLink to perform "library" mode trimming. The libraries build step is expected to be runtime agnostic and shouldn't bind against a specific CoreLib runtime implementation.

During compilation, even though we have a ProjectReference pointing to the CoreLib/src project, we build against CoreLib/ref. But that ILLink invocation doesn't honor that as it uses the ReferencePath msbuild item instead of ReferencePathWithRefAssemblies.