### PR TITLE
[wasm] fix browser profiler exceptions

### DIFF
--- a/src/mono/wasm/runtime/profiler.ts
+++ b/src/mono/wasm/runtime/profiler.ts
@@ -93,7 +93,6 @@ export function mono_wasm_profiler_leave(method: MonoMethod): void {
             const chars = cwraps.mono_wasm_method_get_name(method);
             methodName = Module.UTF8ToString(chars);
             methodNames.set(method as any, methodName);
-            Module._free(chars as any);
         }
         globalThis.performance.measure(methodName, options);
     }


### PR DESCRIPTION
do not free method name