### PR TITLE
Only apply addlDelta for IMAGE_REL_BASED_REL32 relocs

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3752,10 +3752,14 @@ namespace Internal.JitInterface
                     break;
             }
 
-            relocDelta += addlDelta;
-
             TargetArchitecture targetArchitecture = _compilation.TypeSystemContext.Target.Architecture;
             RelocType relocType = GetRelocType(targetArchitecture, fRelocType);
+
+            if (relocType == RelocType.IMAGE_REL_BASED_REL32)
+            {
+                relocDelta += addlDelta;
+            }
+
             // relocDelta is stored as the value
             Relocation.WriteValue(relocType, location, relocDelta);
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -277,9 +277,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_34094/Test34094/*">
             <Issue>https://github.com/dotnet/runtime/issues/57458</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_31615/Runtime_31615/*">
-            <Issue>https://github.com/dotnet/runtime/issues/79170</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows arm32 specific excludes -->


### PR DESCRIPTION
This matches what ngen did, and makes sense since only IP-relative relocations need to addlDelta to determine the address of the next instruction.

Fixes #79170