### PR TITLE
Disable loop alignment during asmdiffs

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1495,6 +1495,7 @@ class SuperPMIReplayAsmDiffs:
             "DOTNET_JitDisasm": "*",
             "DOTNET_JitUnwindDump": "*",
             "DOTNET_JitEHDump": "*",
+            "DOTNET_JitAlignLoops": "0", # disable loop alignment to filter noise
             "DOTNET_JitDiffableDasm": "1",
             "DOTNET_JitEnableNoWayAssert": "1",
             "DOTNET_JitNoForceFallback": "1",


### PR DESCRIPTION
Disable loop alignment during asmdiffs as there is no action to be taken there and it introduces noise in final diffs.