### PR TITLE
Ensure that OptionsCache only permits creating a single options instance per name

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsCache.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsCache.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.Options
 #if NET || NETSTANDARD2_1
             return _cache.GetOrAdd(
                 name ?? Options.DefaultName,
-                static (name, arg) => new Lazy<TOptions>(arg.createOptions(name, arg.factoryArgument)), (createOptions, factoryArgument)).Value;
+                static (name, arg) => new Lazy<TOptions>(() => arg.createOptions(name, arg.factoryArgument)), (createOptions, factoryArgument)).Value;
 #endif
         }
 

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
@@ -485,5 +486,55 @@ namespace Microsoft.Extensions.Options.Tests
             Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - initialBytes);
         }
 #endif
+
+        /// <summary>
+        /// Replicates https://github.com/dotnet/runtime/issues/79529
+        /// </summary>
+        [Fact]
+        public void InstantiatesOnlyOneOptionsInstance()
+        {
+            using AutoResetEvent @event = new(initialState: false);
+
+            OptionsMonitor<FakeOptions> monitor = new(
+                // WaitHandleConfigureOptions makes instance configuration slow enough to force a race condition
+                new OptionsFactory<FakeOptions>(new[] { new WaitHandleConfigureOptions(@event) }, Enumerable.Empty<IPostConfigureOptions<FakeOptions>>()),
+                Enumerable.Empty<IOptionsChangeTokenSource<FakeOptions>>(),
+                new OptionsCache<FakeOptions>());
+
+            using Barrier barrier = new(participantCount: 2);
+            Task<FakeOptions>[] instanceTasks = Enumerable.Range(0, 2)
+                .Select(_ => Task.Factory.StartNew(
+                    () =>
+                    {
+                        barrier.SignalAndWait();
+                        return monitor.Get("someName");
+                    },
+                    CancellationToken.None,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default)
+                )
+                .ToArray();
+
+            // No tasks can finish yet; but give them a chance to run and get blocked on the WaitHandle
+            Assert.Equal(-1, Task.WaitAny(instanceTasks, TimeSpan.FromSeconds(0.01)));
+
+            // 1 release should be sufficient to complete both tasks
+            @event.Set();
+            Assert.True(Task.WaitAll(instanceTasks, TimeSpan.FromSeconds(30)));
+            Assert.Equal(1, instanceTasks.Select(t => t.Result).Distinct().Count());
+        }
+
+        private class WaitHandleConfigureOptions : IConfigureNamedOptions<FakeOptions>
+        {
+            private readonly WaitHandle _waitHandle;
+
+            public WaitHandleConfigureOptions(WaitHandle waitHandle)
+            {
+                _waitHandle = waitHandle;
+            }
+
+            void IConfigureNamedOptions<FakeOptions>.Configure(string? name, FakeOptions options) => _waitHandle.WaitOne();
+            void IConfigureOptions<FakeOptions>.Configure(FakeOptions options) => _waitHandle.WaitOne();
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsMonitorTest.cs
@@ -491,6 +491,7 @@ namespace Microsoft.Extensions.Options.Tests
         /// Replicates https://github.com/dotnet/runtime/issues/79529
         /// </summary>
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Synchronous wait is not supported on browser")]
         public void InstantiatesOnlyOneOptionsInstance()
         {
             using AutoResetEvent @event = new(initialState: false);


### PR DESCRIPTION


This incurs an extra delegate allocation, but only on instance creation.

fix #79529