### PR TITLE
[wasm] WasmDebugLevel in samples

### DIFF
--- a/src/mono/sample/wasm/DefaultBrowserSample.targets
+++ b/src/mono/sample/wasm/DefaultBrowserSample.targets
@@ -4,7 +4,8 @@
     <WasmMainJSPath>main.js</WasmMainJSPath>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
-    <WasmDebugLevel Condition="'$(Configuration)' == 'Debug'">1</WasmDebugLevel>
+    <!-- note that enabling debugger disables interp optimizations -->
+    <WasmDebugLevel Condition="'$(Configuration)' == 'Debug'">-1</WasmDebugLevel>
     <GenerateRunScriptForSample Condition="'$(ArchiveTests)' == 'true'">true</GenerateRunScriptForSample>
     <RunScriptCommand>$(ExecXHarnessCmd) wasm test-browser  --app=. --browser=Chrome $(XHarnessBrowserPathArg) $(WasmXHarnessArgs) --html-file=index.html --output-directory=$(XHarnessOutput) -- $(MSBuildProjectName).dll</RunScriptCommand>
   </PropertyGroup>

--- a/src/mono/sample/wasm/DefaultBrowserSample.targets
+++ b/src/mono/sample/wasm/DefaultBrowserSample.targets
@@ -4,7 +4,7 @@
     <WasmMainJSPath>main.js</WasmMainJSPath>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
-    <WasmDebugLevel>1</WasmDebugLevel>
+    <WasmDebugLevel Condition="'$(Configuration)' == 'Debug'">1</WasmDebugLevel>
     <GenerateRunScriptForSample Condition="'$(ArchiveTests)' == 'true'">true</GenerateRunScriptForSample>
     <RunScriptCommand>$(ExecXHarnessCmd) wasm test-browser  --app=. --browser=Chrome $(XHarnessBrowserPathArg) $(WasmXHarnessArgs) --html-file=index.html --output-directory=$(XHarnessOutput) -- $(MSBuildProjectName).dll</RunScriptCommand>
   </PropertyGroup>


### PR DESCRIPTION
do not enable debugging is samples in release mode because it disables interp optimizations

See https://github.com/dotnet/runtime/blob/8e15d9f523209caf08db57897777b7beb0516c99/src/mono/wasm/runtime/driver.c#L567-L571
