### PR TITLE
decorate SequenceEqual with AggressiveOptimization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -566,6 +566,7 @@ namespace System
 
         // Optimized byte-based SequenceEquals. The "length" parameter for this one is declared a nuint rather than int as we also use it for types other than byte
         // where the length can exceed 2Gb once scaled by sizeof(T).
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe bool SequenceEqual(ref byte first, ref byte second, nuint length)
         {
             bool result;


### PR DESCRIPTION
I'm not sure this is good idea or not, I'm looking for feedback.

We found out with @ilonatommy that `string.Normalize` could be slow when running on Mono interp (in browser).
The reason is that interp would tier up and optimize the `SequenceEqual` method only after 1000 calls.
If we add `[MethodImpl(MethodImplOptions.AggressiveOptimization)]` the Mono interpreter would optimize it right away.

Many of the other methods in the `SpanHelpers` are decorated same way. Is `SequenceEqual` just missing the attribute ?

At this point I don't know what is customer impact.