### PR TITLE
[wasm] fix aotProfiler init

### DIFF
--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -86,7 +86,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_set_main_args", "void", ["number", "number"]],
     [false, "mono_wasm_enable_on_demand_gc", "void", ["number"]],
     // These two need to be lazy because they may be missing
-    [true, "mono_wasm_profiler_init_aot", "void", ["number"]],
+    [true, "mono_wasm_profiler_init_aot", "void", ["string"]],
     [true, "mono_wasm_profiler_init_browser", "void", ["number"]],
     [false, "mono_wasm_exec_regression", "number", ["number", "string"]],
     [false, "mono_wasm_invoke_method_bound", "number", ["number", "number"]],


### PR DESCRIPTION
This is also wrong on Net7 but this code path via cwraps was not used and it worked via `ccall`.
We don't need to backport it.