### PR TITLE
Fix workloads build step in official builds

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -174,7 +174,8 @@
       <MsiPackageProjects Include="%(Msis.PackageProject)" />
     </ItemGroup>
 
-    <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir)" Targets="restore;pack" />
+    <!-- We disable PackageValidation which runs because these projects import the repo's Directory.Build.props and Directory.Build.targets file. -->
+    <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir);EnablePackageValidation=false" Targets="restore;pack" />
   </Target>
 
   <!-- Target to create a single wixpack for signing -->


### PR DESCRIPTION
Fixes the latest official build failure because the generated msi projects import the repo's Directory.Build.* files which enable Package Validation.