### PR TITLE
Fix/multi server ldap binding linux

### DIFF
--- a/src/libraries/Common/tests/System/DirectoryServices/LDAP.Configuration.xml
+++ b/src/libraries/Common/tests/System/DirectoryServices/LDAP.Configuration.xml
@@ -20,7 +20,7 @@ this command views the status
 SLAPD OPENLDAP SERVER
 =====================
 
-    docker run -p:390:389 -e LDAP_DOMAIN=example.com -e LDAP_ROOTPASS=password -d nickstenning/slapd
+    docker run -p 390:389 -e LDAP_DOMAIN=example.com -e LDAP_ROOTPASS=password -d nickstenning/slapd
 
 and to test and view status
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
@@ -13,14 +13,14 @@ namespace System.DirectoryServices.Protocols
         // Linux doesn't support setting FQDN so we mark the flag as if it is already set so we don't make a call to set it again.
         private bool _setFQDNDone = true;
 
-        private void InternalInitConnectionHandle(string hostname)
+        private void InternalInitConnectionHandle()
         {
             if ((LdapDirectoryIdentifier)_directoryIdentifier == null)
             {
                 throw new NullReferenceException();
             }
 
-            _ldapHandle = new ConnectionHandle($"ldap://{hostname}:{((LdapDirectoryIdentifier)_directoryIdentifier).PortNumber}");
+            _ldapHandle = new ConnectionHandle();
         }
 
         private int InternalConnectToServer()

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Windows.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Net;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace System.DirectoryServices.Protocols
 {
@@ -11,8 +12,31 @@ namespace System.DirectoryServices.Protocols
     {
         private bool _setFQDNDone;
 
-        private void InternalInitConnectionHandle(string hostname)
+        private void InternalInitConnectionHandle()
         {
+            string hostname = null;
+            string[] servers = ((LdapDirectoryIdentifier)_directoryIdentifier)?.Servers;
+            if (servers != null && servers.Length != 0)
+            {
+                var temp = new StringBuilder(200);
+                for (int i = 0; i < servers.Length; i++)
+                {
+                    if (servers[i] != null)
+                    {
+                        temp.Append(servers[i]);
+                        if (i < servers.Length - 1)
+                        {
+                            temp.Append(' ');
+                        }
+                    }
+                }
+
+                if (temp.Length != 0)
+                {
+                    hostname = temp.ToString();
+                }
+            }
+
             LdapDirectoryIdentifier directoryIdentifier = _directoryIdentifier as LdapDirectoryIdentifier;
 
             // User wants to setup a connectionless session with server.

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -173,30 +173,7 @@ namespace System.DirectoryServices.Protocols
 
         internal void Init()
         {
-            string hostname = null;
-            string[] servers = ((LdapDirectoryIdentifier)_directoryIdentifier)?.Servers;
-            if (servers != null && servers.Length != 0)
-            {
-                var temp = new StringBuilder(200);
-                for (int i = 0; i < servers.Length; i++)
-                {
-                    if (servers[i] != null)
-                    {
-                        temp.Append(servers[i]);
-                        if (i < servers.Length - 1)
-                        {
-                            temp.Append(' ');
-                        }
-                    }
-                }
-
-                if (temp.Length != 0)
-                {
-                    hostname = temp.ToString();
-                }
-            }
-
-            InternalInitConnectionHandle(hostname);
+            InternalInitConnectionHandle();
 
             // Create a WeakReference object with the target of ldapHandle and put it into our handle table.
             lock (s_objectLock)


### PR DESCRIPTION
Fixes #79653.

There are changes that technically affect Windows, but should be a no-op. However, I am unable to test them because I don't have access to a Windows machine. I am also not sure if this particular test runs in CI.

If someone could build this fork and run the following test, I'd appreciate it:

```pwsh
docker run -p 1389:1389 -e ROOT_USER_DN='cn=admin,dc=example,dc=com' -e BASE_DN='dc=example,dc=com' -e ROOT_PASSWORD=password -d openidentityplatform/opendj
cd src/libraries/System.DirectoryServices.Protocols/tests
$env:LDAP_TEST_SERVER_INDEX = 0
dotnet test
```