### PR TITLE
Split TryRead implementation into TryPopulate and TryCreateObject

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -106,6 +106,8 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonRequiredAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyOrderAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonUnmappedMemberHandlingAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\IEnumerableConverterBase.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\JsonAdvancedConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\CastingConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ImmutableDictionaryOfTKeyTValueConverterWithReflection.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ImmutableEnumerableOfTConverterWithReflection.cs" />
@@ -388,15 +390,8 @@ The System.Text.Json library is built-in as part of the shared framework in .NET
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn3.11.csproj"
-                      ReferenceOutputAssembly="false"
-                      PackAsAnalyzer="true"
-                      Condition="'$(DotNetBuildFromSource)' != 'true'" />
-    <ProjectReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn4.0.csproj"
-                      ReferenceOutputAssembly="false"
-                      PackAsAnalyzer="true" />
-    <ProjectReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn4.4.csproj"
-                      ReferenceOutputAssembly="false"
-                      PackAsAnalyzer="true" />
+    <ProjectReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn3.11.csproj" ReferenceOutputAssembly="false" PackAsAnalyzer="true" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+    <ProjectReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn4.0.csproj" ReferenceOutputAssembly="false" PackAsAnalyzer="true" />
+    <ProjectReference Include="..\gen\System.Text.Json.SourceGeneration.Roslyn4.4.csproj" ReferenceOutputAssembly="false" PackAsAnalyzer="true" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
@@ -17,7 +17,6 @@ namespace System.Text.Json.Serialization.Converters
         internal override Type? ElementType => _sourceConverter.ElementType;
 
         public override bool HandleNull { get; }
-        internal override bool SupportsCreateObjectDelegate => _sourceConverter.SupportsCreateObjectDelegate;
 
         internal CastingConverter(JsonConverter sourceConverter, bool handleNull, bool handleNullOnRead, bool handleNullOnWrite)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
@@ -20,12 +20,9 @@ namespace System.Text.Json.Serialization.Converters
             collection.Add(value);
         }
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
-        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out List<TElement>? obj)
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            obj = new List<TElement>();
-            return true;
+            jsonTypeInfo.CreateObject ??= () => new List<TElement>();
         }
 
         private protected override bool TryConvert(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, List<TElement> obj, out TElement[] value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ConcurrentQueueOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ConcurrentQueueOfTConverter.cs
@@ -2,16 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ConcurrentQueueOfTConverter<TCollection, TElement>
-        : IEnumerableDefaultConverter<TCollection, TElement>
+        : IEnumerableDefaultConverter<TCollection, TElement, TCollection>
         where TCollection : ConcurrentQueue<TElement>
     {
-        protected override void Add(in TElement value, ref ReadStack state)
+        private protected override void Add(ref TCollection collection, in TElement value, JsonTypeInfo collectionTypeInfo)
         {
-            ((TCollection)state.Current.ReturnValue!).Enqueue(value);
+            collection.Enqueue(value);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ConcurrentStackOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ConcurrentStackOfTConverter.cs
@@ -2,16 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ConcurrentStackOfTConverter<TCollection, TElement>
-        : IEnumerableDefaultConverter<TCollection, TElement>
+        : IEnumerableDefaultConverter<TCollection, TElement, TCollection>
         where TCollection : ConcurrentStack<TElement>
     {
-        protected override void Add(in TElement value, ref ReadStack state)
+        private protected override void Add(ref TCollection collection, in TElement value, JsonTypeInfo collectionTypeInfo)
         {
-            ((TCollection)state.Current.ReturnValue!).Push(value);
+            collection.Push(value);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
@@ -11,14 +9,14 @@ namespace System.Text.Json.Serialization.Converters
     /// <summary>
     /// Default base class implementation of <cref>JsonDictionaryConverter{TCollection}</cref> .
     /// </summary>
-    internal abstract class DictionaryDefaultConverter<TDictionary, TKey, TValue>
-        : JsonDictionaryConverter<TDictionary, TKey, TValue>
+    internal abstract class DictionaryDefaultConverter<TDictionary, TKey, TValue, IntermediateType>
+        : JsonDictionaryConverter<TDictionary, TKey, TValue, IntermediateType>
         where TDictionary : IEnumerable<KeyValuePair<TKey, TValue>>
         where TKey : notnull
     {
         internal override bool CanHaveMetadata => true;
 
-        protected internal override bool OnWriteResume(
+        private protected override bool OnWriteResumeCore(
             Utf8JsonWriter writer,
             TDictionary value,
             JsonSerializerOptions options,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
@@ -11,16 +11,16 @@ namespace System.Text.Json.Serialization.Converters
     /// representing the dictionary element key and value.
     /// </summary>
     internal sealed class DictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>
-        : DictionaryDefaultConverter<TCollection, TKey, TValue>
+        : DictionaryDefaultConverter<TCollection, TKey, TValue, TCollection>
         where TCollection : Dictionary<TKey, TValue>
         where TKey : notnull
     {
-        protected override void Add(TKey key, in TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(ref TCollection collection, TKey key, in TValue value, JsonSerializerOptions options)
         {
-            ((TCollection)state.Current.ReturnValue!)[key] = value;
+            collection[key] = value;
         }
 
-        protected internal override bool OnWriteResume(
+        private protected override bool OnWriteResumeCore(
             Utf8JsonWriter writer,
             TCollection value,
             JsonSerializerOptions options,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
@@ -29,12 +29,9 @@ namespace System.Text.Json.Serialization.Converters
             ((BufferedAsyncEnumerable)collection)._buffer.Add(value);
         }
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
-        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out IAsyncEnumerable<TElement>? obj)
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            obj = new BufferedAsyncEnumerable();
-            return true;
+            jsonTypeInfo.CreateObject ??= () => new BufferedAsyncEnumerable();
         }
 
         internal override bool OnTryWrite(Utf8JsonWriter writer, TAsyncEnumerable value, JsonSerializerOptions options, ref WriteStack state)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ICollectionOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ICollectionOfTConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
@@ -11,28 +12,15 @@ namespace System.Text.Json.Serialization.Converters
     /// Converter for <cref>System.Collections.Generic.ICollection{TElement}</cref>.
     /// </summary>
     internal sealed class ICollectionOfTConverter<TCollection, TElement>
-        : IEnumerableDefaultConverter<TCollection, TElement>
+        : IEnumerableDefaultConverter<TCollection, TElement, TCollection>
         where TCollection : ICollection<TElement>
     {
-        protected override void Add(in TElement value, ref ReadStack state)
-        {
-            TCollection collection = (TCollection)state.Current.ReturnValue!;
-            collection.Add(value);
-            if (IsValueType)
-            {
-                state.Current.ReturnValue = collection;
-            };
-        }
+        private protected sealed override bool IsReadOnly(object obj)
+            => ((TCollection)obj).IsReadOnly;
 
-        protected override void CreateCollection(ref Utf8JsonReader reader, scoped ref ReadStack state, JsonSerializerOptions options)
+        private protected override void Add(ref TCollection collection, in TElement value, JsonTypeInfo collectionTypeInfo)
         {
-            base.CreateCollection(ref reader, ref state, options);
-            TCollection returnValue = (TCollection)state.Current.ReturnValue!;
-            if (returnValue.IsReadOnly)
-            {
-                state.Current.ReturnValue = null; // clear out for more accurate JsonPath reporting.
-                ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(TypeToConvert, ref reader, ref state);
-            }
+            collection.Add(value);
         }
 
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
@@ -23,19 +23,22 @@ namespace System.Text.Json.Serialization.Converters
             collection.Add(value);
         }
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
         private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out List<object?>? obj)
         {
-            // TODO: IsReadOnly
             if (!_isDeserializable)
             {
                 ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(TypeToConvert, ref reader, ref state);
             }
 
-            // TODO: should use default TryCreateObject and use ConfigureJsonTypeInfo
-            obj = new List<object?>();
-            return true;
+            return base.TryCreateObject(ref reader, jsonTypeInfo, ref state, out obj);
+        }
+
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
+        {
+            if (jsonTypeInfo.CreateObject == null && _isDeserializable)
+            {
+                jsonTypeInfo.CreateObject = () => new List<object?>();
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableOfTConverter.cs
@@ -22,19 +22,22 @@ namespace System.Text.Json.Serialization.Converters
             collection.Add(value);
         }
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
         private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out List<TElement>? obj)
         {
-            // TODO: IsReadOnly
             if (!_isDeserializable)
             {
                 ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(TypeToConvert, ref reader, ref state);
             }
 
-            // TODO: ConfigureJsonTypeInfo + remove this method
-            obj = new List<TElement>();
-            return true;
+            return base.TryCreateObject(ref reader, jsonTypeInfo, ref state, out obj);
+        }
+
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
+        {
+            if (jsonTypeInfo.CreateObject is null && _isDeserializable)
+            {
+                jsonTypeInfo.CreateObject = () => new List<TElement>();
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListOfTConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
@@ -11,28 +12,15 @@ namespace System.Text.Json.Serialization.Converters
     /// Converter for <cref>System.Collections.Generic.IList{TElement}</cref>.
     /// </summary>
     internal sealed class IListOfTConverter<TCollection, TElement>
-        : IEnumerableDefaultConverter<TCollection, TElement>
+        : IEnumerableDefaultConverter<TCollection, TElement, TCollection>
         where TCollection : IList<TElement>
     {
-        protected override void Add(in TElement value, ref ReadStack state)
-        {
-            TCollection collection = (TCollection)state.Current.ReturnValue!;
-            collection.Add(value);
-            if (IsValueType)
-            {
-                state.Current.ReturnValue = collection;
-            };
-        }
+        private protected sealed override bool IsReadOnly(object obj)
+            => ((TCollection)obj).IsReadOnly;
 
-        protected override void CreateCollection(ref Utf8JsonReader reader, scoped ref ReadStack state, JsonSerializerOptions options)
+        private protected override void Add(ref TCollection collection, in TElement value, JsonTypeInfo collectionTypeInfo)
         {
-            base.CreateCollection(ref reader, ref state, options);
-            TCollection returnValue = (TCollection)state.Current.ReturnValue!;
-            if (returnValue.IsReadOnly)
-            {
-                state.Current.ReturnValue = null; // clear out for more accurate JsonPath reporting.
-                ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(TypeToConvert, ref reader, ref state);
-            }
+            collection.Add(value);
         }
 
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfTKeyTValueConverter.cs
@@ -8,30 +8,33 @@ using System.Text.Json.Serialization.Metadata;
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class IReadOnlyDictionaryOfTKeyTValueConverter<TDictionary, TKey, TValue>
-        : DictionaryDefaultConverter<TDictionary, TKey, TValue, Dictionary<TKey, TValue>>
+        : DictionaryDefaultConverter<TDictionary, TKey, TValue, IReadOnlyDictionary<TKey, TValue>>
         where TDictionary : IReadOnlyDictionary<TKey, TValue>
         where TKey : notnull
     {
         private readonly bool _isDeserializable = typeof(TDictionary).IsAssignableFrom(typeof(Dictionary<TKey, TValue>));
 
-        protected override void Add(ref Dictionary<TKey, TValue> collection, TKey key, in TValue value, JsonSerializerOptions options)
+        protected override void Add(ref IReadOnlyDictionary<TKey, TValue> collection, TKey key, in TValue value, JsonSerializerOptions options)
         {
-            collection[key] = value;
+            ((Dictionary<TKey, TValue>)collection)[key] = value;
         }
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
-        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out Dictionary<TKey, TValue>? obj)
+        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out IReadOnlyDictionary<TKey, TValue>? obj)
         {
-            // TODO: IsReadOnly?
             if (!_isDeserializable)
             {
                 ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(TypeToConvert, ref reader, ref state);
             }
 
-            // TODO: should use default implementation and ConfigureJsonTypeInfo
-            obj = new Dictionary<TKey, TValue>();
-            return true;
+            return base.TryCreateObject(ref reader, jsonTypeInfo, ref state, out obj);
+        }
+
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
+        {
+            if (jsonTypeInfo.CreateObject == null && _isDeserializable)
+            {
+                jsonTypeInfo.CreateObject = () => new Dictionary<TKey, TValue>();
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ISetOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ISetOfTConverter.cs
@@ -22,10 +22,9 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            // Deserialize as HashSet<TElement> for interface types that support it.
+            // Deserialize as HashSet<TElement> for types that support it.
             if (jsonTypeInfo.CreateObject is null && TypeToConvert.IsAssignableFrom(typeof(HashSet<TElement>)))
             {
-                Debug.Assert(TypeToConvert.IsInterface);
                 jsonTypeInfo.CreateObject = () => new HashSet<TElement>();
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
@@ -20,12 +20,10 @@ namespace System.Text.Json.Serialization.Converters
 
         internal sealed override bool CanHaveMetadata => false;
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
-        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out Dictionary<TKey, TValue>? obj)
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            obj = new Dictionary<TKey, TValue>();
-            return true;
+            jsonTypeInfo.CreateObject ??= () => new Dictionary<TKey, TValue>();
+            jsonTypeInfo.NotSupportedExtensionDataProperty = true;
         }
 
         private protected override bool TryConvert(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, Dictionary<TKey, TValue> obj, out TDictionary value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
@@ -19,12 +19,9 @@ namespace System.Text.Json.Serialization.Converters
 
         internal sealed override bool CanHaveMetadata => false;
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
-        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out List<TElement>? obj)
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            obj = new List<TElement>();
-            return true;
+            jsonTypeInfo.CreateObject ??= () => new List<TElement>();
         }
 
         private protected override bool TryConvert(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, List<TElement> obj, out TCollection value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -15,7 +15,6 @@ namespace System.Text.Json.Serialization
     /// </summary>
     internal abstract class JsonCollectionConverter<TCollection, TElement, IntermediateType> : JsonAdvancedConverter<TCollection, IntermediateType>
     {
-        internal override bool SupportsCreateObjectDelegate => true;
         private protected sealed override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Enumerable;
         internal override Type ElementType => typeof(TElement);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -13,7 +13,6 @@ namespace System.Text.Json.Serialization
     /// </summary>
     internal abstract class JsonDictionaryConverter<TDictionary, IntermediateType> : JsonAdvancedConverter<TDictionary, IntermediateType>
     {
-        internal override bool SupportsCreateObjectDelegate => true;
         private protected sealed override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Dictionary;
 
         internal override bool IsJsonDictionaryConverter => true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
@@ -2,30 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
     /// Converter for <cref>System.Collections.Generic.List{TElement}</cref>.
     internal sealed class ListOfTConverter<TCollection, TElement>
-        : IEnumerableDefaultConverter<TCollection, TElement>
-        where TCollection: List<TElement>
+        : IEnumerableDefaultConverter<TCollection, TElement, TCollection>
+        where TCollection : List<TElement>
     {
-        protected override void Add(in TElement value, ref ReadStack state)
+        private protected sealed override void Add(ref TCollection collection, in TElement value, JsonTypeInfo collectionTypeInfo)
         {
-            ((TCollection)state.Current.ReturnValue!).Add(value);
+            collection.Add(value);
         }
 
-        protected override void CreateCollection(ref Utf8JsonReader reader, scoped ref ReadStack state, JsonSerializerOptions options)
-        {
-            if (state.Current.JsonTypeInfo.CreateObject == null)
-            {
-                ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
-            }
-
-            state.Current.ReturnValue = state.Current.JsonTypeInfo.CreateObject();
-        }
-
-        protected override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
+        internal override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
         {
             List<TElement> list = value;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
@@ -2,26 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class QueueOfTConverter<TCollection, TElement>
-        : IEnumerableDefaultConverter<TCollection, TElement>
+        : IEnumerableDefaultConverter<TCollection, TElement, TCollection>
         where TCollection : Queue<TElement>
     {
-        protected override void Add(in TElement value, ref ReadStack state)
+        private protected sealed override void Add(ref TCollection collection, in TElement value, JsonTypeInfo collectionTypeInfo)
         {
-            ((TCollection)state.Current.ReturnValue!).Enqueue(value);
-        }
-
-        protected override void CreateCollection(ref Utf8JsonReader reader, scoped ref ReadStack state, JsonSerializerOptions options)
-        {
-            if (state.Current.JsonTypeInfo.CreateObject == null)
-            {
-                ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
-            }
-
-            state.Current.ReturnValue = state.Current.JsonTypeInfo.CreateObject();
+            collection.Enqueue(value);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOfTConverter.cs
@@ -3,26 +3,17 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class StackOfTConverter<TCollection, TElement>
-        : IEnumerableDefaultConverter<TCollection, TElement>
+        : IEnumerableDefaultConverter<TCollection, TElement, TCollection>
         where TCollection : Stack<TElement>
     {
-        protected override void Add(in TElement value, ref ReadStack state)
+        private protected override void Add(ref TCollection collection, in TElement value, JsonTypeInfo collectionTypeInfo)
         {
-            ((TCollection)state.Current.ReturnValue!).Push(value);
-        }
-
-        protected override void CreateCollection(ref Utf8JsonReader reader, scoped ref ReadStack state, JsonSerializerOptions options)
-        {
-            if (state.Current.JsonTypeInfo.CreateObject == null)
-            {
-                ThrowHelper.ThrowNotSupportedException_SerializationNotSupported(state.Current.JsonTypeInfo.Type);
-            }
-
-            state.Current.ReturnValue = state.Current.JsonTypeInfo.CreateObject();
+            collection.Push(value);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpListConverter.cs
@@ -25,12 +25,9 @@ namespace System.Text.Json.Serialization.Converters
             collection.Add(value);
         }
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
-        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out List<TElement>? obj)
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            obj = new List<TElement>();
-            return true;
+            jsonTypeInfo.CreateObject ??= () => new List<TElement>();
         }
 
         private protected override bool TryConvert(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, List<TElement> obj, out TList value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpListConverter.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization.Metadata;
 namespace System.Text.Json.Serialization.Converters
 {
     // Converter for F# lists: https://fsharp.github.io/fsharp-core-docs/reference/fsharp-collections-list-1.html
-    internal sealed class FSharpListConverter<TList, TElement> : IEnumerableDefaultConverter<TList, TElement>
+    internal sealed class FSharpListConverter<TList, TElement> : IEnumerableDefaultConverter<TList, TElement, List<TElement>>
         where TList : IEnumerable<TElement>
     {
         private readonly Func<IEnumerable<TElement>, TList> _listConstructor;
@@ -20,20 +20,23 @@ namespace System.Text.Json.Serialization.Converters
             _listConstructor = FSharpCoreReflectionProxy.Instance.CreateFSharpListConstructor<TList, TElement>();
         }
 
-        protected override void Add(in TElement value, ref ReadStack state)
+        private protected override void Add(ref List<TElement> collection, in TElement value, JsonTypeInfo collectionTypeInfo)
         {
-            ((List<TElement>)state.Current.ReturnValue!).Add(value);
+            collection.Add(value);
         }
 
         internal override bool SupportsCreateObjectDelegate => false;
-        protected override void CreateCollection(ref Utf8JsonReader reader, scoped ref ReadStack state, JsonSerializerOptions options)
+
+        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out List<TElement>? obj)
         {
-            state.Current.ReturnValue = new List<TElement>();
+            obj = new List<TElement>();
+            return true;
         }
 
-        protected override void ConvertCollection(ref ReadStack state, JsonSerializerOptions options)
+        private protected override bool TryConvert(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, List<TElement> obj, out TList value)
         {
-            state.Current.ReturnValue = _listConstructor((List<TElement>)state.Current.ReturnValue!);
+            value = _listConstructor(obj);
+            return true;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpMapConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpMapConverter.cs
@@ -28,12 +28,9 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override bool CanHaveMetadata => false;
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
-        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out List<Tuple<TKey, TValue>>? obj)
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            obj = new List<Tuple<TKey, TValue>>();
-            return true;
+            jsonTypeInfo.CreateObject ??= () => new List<Tuple<TKey, TValue>>();
         }
 
         private protected override bool TryConvert(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, List<Tuple<TKey, TValue>> obj, out TMap value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpSetConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpSetConverter.cs
@@ -25,12 +25,9 @@ namespace System.Text.Json.Serialization.Converters
             collection.Add(value);
         }
 
-        internal override bool SupportsCreateObjectDelegate => false;
-
-        private protected override bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out List<TElement>? obj)
+        internal override void ConfigureJsonTypeInfo(JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options)
         {
-            obj = new List<TElement>();
-            return true;
+            jsonTypeInfo.CreateObject ??= () => new List<TElement>();
         }
 
         private protected override bool TryConvert(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, List<TElement> obj, out TSet value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonAdvancedConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonAdvancedConverter.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal abstract class JsonAdvancedConverter<T> : JsonResumableConverter<T>
+    {
+        internal virtual bool IsJsonDictionaryConverter => false;
+
+        internal virtual bool OnWriteResume(Utf8JsonWriter writer, T dictionary, JsonSerializerOptions options, ref WriteStack state)
+        {
+            Debug.Fail("We should have overriden it if we got here");
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Base class for object, enumerable and dictionary converters
+    /// </summary>
+    internal abstract class JsonAdvancedConverter<T, IntermediateType> : JsonAdvancedConverter<T>
+    {
+        private protected virtual bool TryCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out IntermediateType? obj)
+        {
+            // TODO: generalize exceptions
+            if (jsonTypeInfo.CreateObject == null)
+            {
+                // The contract model was not able to produce a default constructor for two possible reasons:
+                // 1. Either the declared collection type is abstract and cannot be instantiated.
+                // 2. The collection type does not specify a default constructor.
+                if (TypeToConvert.IsAbstract || TypeToConvert.IsInterface)
+                {
+                    ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(TypeToConvert, ref reader, ref state);
+                }
+                else
+                {
+                    ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(TypeToConvert, ref reader, ref state);
+                }
+            }
+
+            obj = (IntermediateType)jsonTypeInfo.CreateObject();
+
+            if (IsReadOnly(obj))
+            {
+                // TODO: not possible for objects, might be a good idea to still generalize exception
+                ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(TypeToConvert, ref reader, ref state);
+            }
+
+            return true;
+        }
+
+        private protected bool TryGetOrCreateObject(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, [NotNullWhen(true)] out IntermediateType? obj)
+        {
+            Debug.Assert((!state.SupportContinuation && !state.Current.CanContainMetadata) || state.Current.ObjectState < StackFrameObjectState.CreatedObject,
+                $"SupportsContinuation: {state.SupportContinuation}, CanContainMetadata: {state.Current.CanContainMetadata}, ObjectState: {state.Current.ObjectState}");
+            Debug.Assert(!state.Current.MetadataPropertyNames.HasFlag(MetadataPropertyName.Ref), "References should already be resolved");
+
+            if (TryCreateObject(ref reader, jsonTypeInfo, ref state, out obj))
+            {
+                if (state.Current.MetadataPropertyNames.HasFlag(MetadataPropertyName.Id))
+                {
+                    Debug.Assert(state.ReferenceId != null);
+                    Debug.Assert(jsonTypeInfo.Options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.Preserve);
+                    state.ReferenceResolver.AddReference(state.ReferenceId, obj);
+                    state.ReferenceId = null;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private protected virtual bool IsReadOnly(object obj) => false;
+
+        private protected abstract bool TryPopulate(ref Utf8JsonReader reader, JsonSerializerOptions options, scoped ref ReadStack state, ref IntermediateType obj);
+
+        private protected virtual bool TryConvert(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo, scoped ref ReadStack state, IntermediateType obj, out T value)
+        {
+            // TODO: consider removing this method
+            // Unbox
+            Debug.Assert(obj != null);
+            value = (T)(object)obj;
+            return true;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -35,7 +35,6 @@ namespace System.Text.Json.Serialization.Converters
         internal override Type? ElementType => Converter.ElementType;
 
         internal override bool ConstructorIsParameterized => Converter.ConstructorIsParameterized;
-        internal override bool SupportsCreateObjectDelegate => Converter.SupportsCreateObjectDelegate;
         internal override bool CanHaveMetadata => Converter.CanHaveMetadata;
 
         public JsonMetadataServicesConverter(Func<JsonConverter<T>> converterCreator, ConverterStrategy converterStrategy)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/JsonObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/JsonObjectConverter.cs
@@ -1,13 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Converters;
+using System.Text.Json.Serialization.Metadata;
+
 namespace System.Text.Json.Serialization
 {
     /// <summary>
     /// Base class for non-enumerable, non-primitive objects where public properties
     /// are (de)serialized as a JSON object.
     /// </summary>
-    internal abstract class JsonObjectConverter<T> : JsonResumableConverter<T>
+    internal abstract class JsonObjectConverter<T> : JsonAdvancedConverter<T, object>
     {
         private protected sealed override ConverterStrategy GetDefaultConverterStrategy() => ConverterStrategy.Object;
         internal sealed override Type? ElementType => null;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -15,7 +15,6 @@ namespace System.Text.Json.Serialization.Converters
     internal class ObjectDefaultConverter<T> : JsonObjectConverter<T> where T : notnull
     {
         internal override bool CanHaveMetadata => true;
-        internal override bool SupportsCreateObjectDelegate => true;
 
         internal sealed override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, [MaybeNullWhen(false)] out T? value)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -48,10 +48,8 @@ namespace System.Text.Json.Serialization.Converters
             return obj;
         }
 
-        protected sealed override void InitializeConstructorArgumentCaches(ref ReadStack state, JsonSerializerOptions options)
+        private protected sealed override object CreateArguments(JsonTypeInfo typeInfo)
         {
-            JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
-
             Debug.Assert(typeInfo.ParameterCache != null);
 
             List<KeyValuePair<string, JsonParameterInfo>> cache = typeInfo.ParameterCache.List;
@@ -63,7 +61,7 @@ namespace System.Text.Json.Serialization.Converters
                 arguments[parameterInfo.ClrInfo.Position] = parameterInfo.DefaultValue;
             }
 
-            state.Current.CtorArgumentState!.Arguments = arguments;
+            return arguments;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -79,10 +79,8 @@ namespace System.Text.Json.Serialization.Converters
             return success;
         }
 
-        protected override void InitializeConstructorArgumentCaches(ref ReadStack state, JsonSerializerOptions options)
+        private protected sealed override object CreateArguments(JsonTypeInfo typeInfo)
         {
-            JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
-
             typeInfo.CreateObjectWithArgs ??=
                 JsonSerializerOptions.MemberAccessorStrategy.CreateParameterizedConstructor<T, TArg0, TArg1, TArg2, TArg3>(ConstructorInfo!);
 
@@ -120,7 +118,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
             }
 
-            state.Current.CtorArgumentState!.Arguments = arguments;
+            return arguments;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -47,14 +47,6 @@ namespace System.Text.Json.Serialization
         private protected abstract ConverterStrategy GetDefaultConverterStrategy();
 
         /// <summary>
-        /// Indicates that the converter can consume the <see cref="JsonTypeInfo.CreateObject"/> delegate.
-        /// Needed because certain collection converters cannot support arbitrary delegates.
-        /// TODO remove once https://github.com/dotnet/runtime/pull/73395/ and
-        /// https://github.com/dotnet/runtime/issues/71944 have been addressed.
-        /// </summary>
-        internal virtual bool SupportsCreateObjectDelegate => false;
-
-        /// <summary>
         /// Can direct Read or Write methods be called (for performance).
         /// </summary>
         internal bool CanUseDirectReadOrWrite { get; set; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -484,10 +484,10 @@ namespace System.Text.Json.Serialization
                 return TryWrite(writer, value, options, ref state);
             }
 
-            JsonDictionaryConverter<T>? dictionaryConverter = this as JsonDictionaryConverter<T>
-                ?? (this as JsonMetadataServicesConverter<T>)?.Converter as JsonDictionaryConverter<T>;
+            JsonAdvancedConverter<T>? dictionaryConverter = (this as JsonAdvancedConverter<T>)
+                ?? (this as JsonMetadataServicesConverter<T>)?.Converter as JsonAdvancedConverter<T>;
 
-            if (dictionaryConverter == null)
+            if (dictionaryConverter == null || !dictionaryConverter.IsJsonDictionaryConverter)
             {
                 // If not JsonDictionaryConverter<T> then we are JsonObject.
                 // Avoid a type reference to JsonObject and its converter to support trimming.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -132,7 +132,7 @@ namespace System.Text.Json
                 Func<object>? createObjectForExtensionDataProp = jsonPropertyInfo.JsonTypeInfo.CreateObject
                     ?? jsonPropertyInfo.JsonTypeInfo.CreateObjectForExtensionDataProperty;
 
-                if (createObjectForExtensionDataProp == null)
+                if (createObjectForExtensionDataProp == null || jsonPropertyInfo.JsonTypeInfo.NotSupportedExtensionDataProperty)
                 {
                     // Avoid a reference to the JsonNode type for trimming
                     if (jsonPropertyInfo.PropertyType.FullName == JsonTypeInfo.JsonObjectTypeName)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -286,6 +286,9 @@ namespace System.Text.Json.Serialization.Metadata
 
         internal PolymorphicTypeResolver? PolymorphicTypeResolver { get; private set; }
 
+        // TODO: this can be supported when https://github.com/dotnet/runtime/issues/31645 is fixed
+        internal bool NotSupportedExtensionDataProperty { get; set; }
+
         // If enumerable or dictionary, the JsonTypeInfo for the element type.
         private JsonTypeInfo? _elementTypeInfo;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -62,13 +62,6 @@ namespace System.Text.Json.Serialization.Metadata
                 ThrowHelper.ThrowInvalidOperationException_JsonTypeInfoOperationNotPossibleForKind(Kind);
             }
 
-            if (!Converter.SupportsCreateObjectDelegate)
-            {
-                Debug.Assert(_createObject is null);
-                Debug.Assert(_typedCreateObject == null);
-                ThrowHelper.ThrowInvalidOperationException_CreateObjectConverterNotCompatible(Type);
-            }
-
             Func<object>? untypedCreateObject;
             Func<T>? typedCreateObject;
 
@@ -99,7 +92,7 @@ namespace System.Text.Json.Serialization.Metadata
 
             // Guard against the reflection resolver/source generator attempting to pass
             // a CreateObject delegate to converters/metadata that do not support it.
-            if (Converter.SupportsCreateObjectDelegate && !Converter.ConstructorIsParameterized)
+            if (!Converter.ConstructorIsParameterized && Kind != JsonTypeInfoKind.None)
             {
                 SetCreateObject(createObject);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/ReflectionJsonTypeInfoOfT.cs
@@ -28,13 +28,18 @@ namespace System.Text.Json.Serialization.Metadata
             PopulatePolymorphismMetadata();
             MapInterfaceTypesToCallbacks();
 
-            Func<object>? createObject = JsonSerializerOptions.MemberAccessorStrategy.CreateConstructor(typeof(T));
-            SetCreateObjectIfCompatible(createObject);
-            CreateObjectForExtensionDataProperty = createObject;
-
-            // Plug in any converter configuration -- should be run last.
             converter.ConfigureJsonTypeInfo(this, options);
             converter.ConfigureJsonTypeInfoUsingReflection(this, options);
+
+            Func<object>? createObject = ((JsonTypeInfo)this).CreateObject;
+
+            if (createObject == null)
+            {
+                createObject = JsonSerializerOptions.MemberAccessorStrategy.CreateConstructor(typeof(T));
+                SetCreateObjectIfCompatible(createObject);
+            }
+
+            CreateObjectForExtensionDataProperty ??= createObject;
         }
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -121,19 +121,17 @@ namespace System.Text.Json
         {
             if (propertyInfo.IsRequired)
             {
-                Debug.Assert(RequiredPropertiesSet != null);
+                Debug.Assert(RequiredPropertiesSet != null, "Required properties are not initialized.");
                 RequiredPropertiesSet[propertyInfo.RequiredPropertyIndex] = true;
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void InitializeRequiredPropertiesValidationState(JsonTypeInfo typeInfo)
+        internal void EnsureInitializedRequiredPropertiesValidationState(JsonTypeInfo typeInfo)
         {
-            Debug.Assert(RequiredPropertiesSet == null);
-
             if (typeInfo.NumberOfRequiredProperties > 0)
             {
-                RequiredPropertiesSet = new BitArray(typeInfo.NumberOfRequiredProperties);
+                RequiredPropertiesSet ??= new BitArray(typeInfo.NumberOfRequiredProperties);
             }
         }
 
@@ -142,7 +140,7 @@ namespace System.Text.Json
         {
             if (typeInfo.NumberOfRequiredProperties > 0)
             {
-                Debug.Assert(RequiredPropertiesSet != null);
+                Debug.Assert(RequiredPropertiesSet != null, "Required properties are not initialized.");
 
                 if (!RequiredPropertiesSet.AllBitsEqual(true))
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/StackFrameObjectState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/StackFrameObjectState.cs
@@ -13,7 +13,6 @@ namespace System.Text.Json
 
         StartToken,
         ReadMetadata,
-        ConstructorArguments,
         CreatedObject,
         ReadElements,
         EndToken,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/MetadataTests/DefaultJsonTypeInfoResolverTests.JsonTypeInfo.cs
@@ -508,20 +508,59 @@ namespace System.Text.Json.Serialization.Tests
             Assert.True(isDelegateInvoked);
         }
 
-        [Theory]
-        [InlineData(typeof(int[]))]
-        [InlineData(typeof(ImmutableArray<int>))]
-        [InlineData(typeof(IEnumerable))]
-        [InlineData(typeof(IEnumerable<int>))]
-        [InlineData(typeof(IAsyncEnumerable<int>))]
-        [InlineData(typeof(IReadOnlyDictionary<string, int>))]
-        [InlineData(typeof(ImmutableDictionary<string, int>))]
-        public static void JsonTypeInfo_CreateObject_UnsupportedCollection_ThrowsInvalidOperationException(Type collectionType)
+        // TODO: finish writing tests similar to the ones below
+        //[Theory]
+        //[InlineData(typeof(int[]))]
+        //[InlineData(typeof(ImmutableArray<int>))]
+        //[InlineData(typeof(IEnumerable))]
+        //[InlineData(typeof(IEnumerable<int>))]
+        //[InlineData(typeof(IAsyncEnumerable<int>))]
+        //[InlineData(typeof(IReadOnlyDictionary<string, int>))]
+        //[InlineData(typeof(ImmutableDictionary<string, int>))]
+        //public static void JsonTypeInfo_CreateObject_UnsupportedCollection_ThrowsInvalidOperationException(Type collectionType)
+        //{
+        //    var options = new JsonSerializerOptions();
+        //    JsonTypeInfo jsonTypeInfo = JsonTypeInfo.CreateJsonTypeInfo(collectionType, options);
+        //    Assert.Throws<InvalidOperationException>(() => jsonTypeInfo.CreateObject = () => new object());
+        //}
+
+        [Fact]
+        public static void JsonTypeInfo_CreateObject_ArrayOfInt()
         {
-            var options = new JsonSerializerOptions();
-            JsonTypeInfo jsonTypeInfo = JsonTypeInfo.CreateJsonTypeInfo(collectionType, options);
-            Assert.Throws<InvalidOperationException>(() => jsonTypeInfo.CreateObject = () => new object());
+            var options = CreateOptionsWithCustomizedCreateObjectForEnumerableOfInt(typeof(int[]));
+
+            int[] obj = JsonSerializer.Deserialize<int[]>("[]", options);
+            Assert.Equal(3, obj.Length);
+            Assert.Equal(1, obj[0]);
+            Assert.Equal(2, obj[1]);
+            Assert.Equal(3, obj[2]);
+
+            obj = JsonSerializer.Deserialize<int[]>("[4, 5]", options);
+            Assert.Equal(5, obj.Length);
+            Assert.Equal(1, obj[0]);
+            Assert.Equal(2, obj[1]);
+            Assert.Equal(3, obj[2]);
+            Assert.Equal(4, obj[3]);
+            Assert.Equal(5, obj[4]);
         }
+
+        private static JsonSerializerOptions CreateOptionsWithCustomizedCreateObjectForEnumerableOfInt(Type type)
+            => new JsonSerializerOptions()
+            {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+                {
+                    Modifiers =
+                    {
+                        (ti) =>
+                        {
+                            if (ti.Type == type)
+                            {
+                                ti.CreateObject = () => new List<int>() { 1, 2, 3 };
+                            }
+                        }
+                    }
+                }
+            };
 
         [Theory]
         [InlineData(typeof(object), JsonTypeInfoKind.None)]


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/78556
Contibutes to: https://github.com/dotnet/runtime/issues/77018

Cleanup converter internal implementation - splits TryRead into:
- TryCreateObject - creates intermediate object (it can be same as final)
- TryPopulate - populates intermediate object
- TryConvert - converts intermediate object into final object (or just casts for most of the cases)


TODO:
- [X] finish TryPopulate on collections
- [x] finish TryPopulate on dictionaries
-   [ ] possibly TryPopulate can be generalized
- [ ] Consider implementing Parametrized ctors in terms of: intermediate object = arguments state; final object - call ctor and go over props
- [ ] check if TryCreateObject can be strongly typed
- [ ] consider removing unused args
- [ ] TODOs in code (i.e. generalize exceptions)
- [ ] consider fixing https://github.com/dotnet/runtime/issues/73382 as part of this - it will also simplify implementation
  - [ ] Also see JsonConverter.SupportsCreateObjectDelegate
  - [ ] consider sealing TryCreateObject
  - [ ] ensure IReadOnlyDictionary<TKey, TValue> can be deserialized but not populated
  - [ ] finish writing tests replacing `JsonTypeInfo_CreateObject_UnsupportedCollection_ThrowsInvalidOperationException`
- [ ] consider fixing https://github.com/dotnet/runtime/issues/31645 as part of this, it requires us to track extension data instance in TryPopulate and calling TryConvert and setter later than we currently do - it might require a bit plumbing so might be better as follow up work
- [ ] run benchmarks