### PR TITLE
Include GC in the default rundown keyword for eventpipe

### DIFF
--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -267,13 +267,14 @@ ep_session_enable_rundown (EventPipeSession *session)
 
 	//! This is CoreCLR specific keywords for native ETW events (ending up in event pipe).
 	//! The keywords below seems to correspond to:
+	//!  GCKeyword                          (0x00000001)
 	//!  LoaderKeyword                      (0x00000008)
 	//!  JitKeyword                         (0x00000010)
 	//!  NgenKeyword                        (0x00000020)
 	//!  unused_keyword                     (0x00000100)
 	//!  JittedMethodILToNativeMapKeyword   (0x00020000)
 	//!  ThreadTransferKeyword              (0x80000000)
-	const uint64_t keywords = 0x80020138;
+	const uint64_t keywords = 0x80020139;
 	const EventPipeEventLevel verbose_logging_level = EP_EVENT_LEVEL_VERBOSE;
 
 	EventPipeProviderConfiguration rundown_providers [2];


### PR DESCRIPTION
This change will turn on [`bIsGCRundownEnabled`](https://github.com/dotnet/runtime/blob/58e82be63f411b76cd391b2c3f4862686d95590f/src/coreclr/vm/eventtrace.cpp#L4178) and therefore [`SendGCRundownEvent`](https://github.com/dotnet/runtime/blob/58e82be63f411b76cd391b2c3f4862686d95590f/src/coreclr/vm/eventtrace.cpp#L4253) for dotnet-trace.