### PR TITLE
[wasm] Add the illink substitutions for SIMD

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -248,6 +248,8 @@
     <PlatformManifestFileEntry Include="emcc-default.rsp" IsNative="true" />
     <PlatformManifestFileEntry Include="emcc-link.rsp" IsNative="true" />
     <PlatformManifestFileEntry Include="emcc-props.json" IsNative="true" />
+    <PlatformManifestFileEntry Include="ILLink.Substitutions.WasmIntrinsics.xml" IsNative="true" />
+    <PlatformManifestFileEntry Include="ILLink.Substitutions.NoWasmIntrinsics.xml" IsNative="true" />
     <!-- ICU-specific files -->
     <PlatformManifestFileEntry Include="libicudata.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libicui18n.a" IsNative="true" />

--- a/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj
@@ -12,6 +12,7 @@
 
     <PackageFile Include="Sdk\AutoImport.props" TargetPath="Sdk" />
     <PackageFile Include="Sdk\Sdk.props" TargetPath="Sdk" />
+    <PackageFile Include="$(RepoRoot)\src\mono\wasm\build\ILLink.Substitutions.*.xml" TargetPath="Sdk" />
     <PackageFile Include="$(RepoRoot)\src\mono\wasm\build\WasmApp.props" TargetPath="Sdk" />
     <PackageFile Include="$(RepoRoot)\src\mono\wasm\build\WasmApp.targets" TargetPath="Sdk" />
     <PackageFile Include="$(RepoRoot)\src\mono\wasm\build\WasmApp.Native.*" TargetPath="Sdk" />

--- a/src/mono/wasm/build/ILLink.Substitutions.NoWasmIntrinsics.xml
+++ b/src/mono/wasm/build/ILLink.Substitutions.NoWasmIntrinsics.xml
@@ -1,0 +1,13 @@
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Numerics.Vector">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Vector128">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Wasm.PackedSimd">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/mono/wasm/build/ILLink.Substitutions.WasmIntrinsics.xml
+++ b/src/mono/wasm/build/ILLink.Substitutions.WasmIntrinsics.xml
@@ -1,0 +1,13 @@
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Numerics.Vector">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="true" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Vector128">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="true" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Wasm.PackedSimd">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="true" />
+    </type>
+  </assembly>
+</linker>

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -109,6 +109,8 @@
     <WasmGenerateAppBundle Condition="'$(WasmGenerateAppBundle)' == ''">false</WasmGenerateAppBundle>
     <UseAppHost>false</UseAppHost>
     <TrimMode Condition="'$(TrimMode)' == ''">partial</TrimMode>
+    <_ExtraTrimmerArgs Condition="'$(WasmEnableSIMD)' == 'true'">$(_ExtraTrimmerArgs) --substitutions $(MSBuildThisFileDirectory)/ILLink.Substitutions.WasmIntrinsics.xml</_ExtraTrimmerArgs>
+    <_ExtraTrimmerArgs Condition="'$(WasmEnableSIMD)' != 'true'">$(_ExtraTrimmerArgs) --substitutions $(MSBuildThisFileDirectory)/ILLink.Substitutions.NoWasmIntrinsics.xml</_ExtraTrimmerArgs>
 
     <!-- Temporarily `false`, till sdk gets a fix for supporting the new file -->
     <WasmEmitSymbolMap Condition="'$(WasmEmitSymbolMap)' == '' and '$(RunAOTCompilation)' != 'true'">false</WasmEmitSymbolMap>


### PR DESCRIPTION
This should fix size regression introduced with https://github.com/dotnet/runtime/pull/78068

The untrimmed S.N.Vector class added few kilobytes to the assemblies of the bench sample. That wasn't that bad, OTOH the code produced by the aot compiler was much larger, 5MB in this case.

So this will case default non-SIMD case. In the case of SIMD build we will need more investigation.