### PR TITLE
[iOS][tvOS] Skip NullableTests.ClassWithDictionariesWithNullableValues

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
@@ -174,6 +174,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/79583", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void ClassWithDictionariesWithNullableValues()
         {
             string json =


### PR DESCRIPTION
The test is failing on device and is tracked by https://github.com/dotnet/runtime/issues/79583