### PR TITLE
[wasm] dotnet-runtime-perf: Fix V8 version to 11.0.162

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -71,7 +71,7 @@ jobs:
           curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&
           sudo apt-get -y install nodejs &&
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
-          $HELIX_WORKITEM_PAYLOAD/bin/jsvu v8@11.0.162 &&
+          $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 v8@11.0.162 &&
           rm ~/.jsvu/v8 &&
           ln -s ~/.jsvu/v8-11.0.162 ~/.jsvu/v8
     - ${{ if ne(parameters.runtimeType, 'wasm') }}:

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -71,7 +71,9 @@ jobs:
           curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&
           sudo apt-get -y install nodejs &&
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
-          $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 --engines=v8,javascriptcore
+          $HELIX_WORKITEM_PAYLOAD/bin/jsvu v8@11.0.162 &&
+          rm ~/.jsvu/v8 &&
+          ln -s ~/.jsvu/v8-11.0.162 ~/.jsvu/v8
     - ${{ if ne(parameters.runtimeType, 'wasm') }}:
       - HelixPreCommandsWasmOnLinux: echo
     - HelixPreCommandStemWindows: 'set ORIGPYPATH=%PYTHONPATH%;py -m pip install -U pip;py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install -U pip;py -3 -m pip install azure.storage.blob==12.0.0;py -3 -m pip install azure.storage.queue==12.0.0;set "PERFLAB_UPLOAD_TOKEN=$(HelixPerfUploadTokenValue)"'

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -72,7 +72,7 @@ jobs:
           sudo apt-get -y install nodejs &&
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
           $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 v8@11.0.162 &&
-          rm ~/.jsvu/v8 &&
+          rm -f ~/.jsvu/v8 &&
           ln -s ~/.jsvu/v8-11.0.162 ~/.jsvu/v8
     - ${{ if ne(parameters.runtimeType, 'wasm') }}:
       - HelixPreCommandsWasmOnLinux: echo


### PR DESCRIPTION
Context: investigating https://github.com/dotnet/perf-autofiling-issues/issues/10711

The `baseline` was run with V8 `11.0.162`, whereas the the `compare` was run with `11.0.216`. Fixing the version to the baseline one to check if V8 might the cause here.