### PR TITLE
Do not generate cctor info on generic definition `MethodTable`

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -730,7 +730,6 @@ namespace Internal.Runtime.TypeLoader
             if (!state.HasStaticConstructor)
                 return;
 
-            Debug.Assert(state.ClassConstructorPointer.HasValue);
             IntPtr canonicalClassConstructorFunctionPointer = state.ClassConstructorPointer.Value;
 
             IntPtr generatedTypeStaticData = GetRuntimeTypeHandle(type).ToEETypePtr()->DynamicNonGcStaticsData;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -295,10 +295,7 @@ namespace Internal.Runtime.TypeLoader
         public int GcDataSize;
         public int ThreadDataSize;
 
-        public bool HasStaticConstructor
-        {
-            get { return TypeBeingBuilt.HasStaticConstructor; }
-        }
+        public bool HasStaticConstructor => ClassConstructorPointer.HasValue;
 
         public IntPtr? ClassConstructorPointer;
         public IntPtr GcStaticDesc;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderTypeSystemContext.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderTypeSystemContext.cs
@@ -150,15 +150,13 @@ namespace Internal.Runtime.TypeLoader
 
         protected internal override bool ComputeHasStaticConstructor(TypeDesc type)
         {
-            if (type.RetrieveRuntimeTypeHandleIfPossible())
-            {
-                unsafe
-                {
-                    return type.RuntimeTypeHandle.ToEETypePtr()->HasCctor;
-                }
-            }
-            Debug.Assert(type is not DefType);
-            return false;
+            // This assumes we can compute the information from a type definition
+            // (`type` is going to be a definition here because that's how the type system is structured).
+            // We don't maintain consistency for this at runtime. Different instantiations of
+            // a single definition may or may not have a static constructor after AOT compilation.
+            // Asking about this for a definition is an invalid question.
+            // If this is ever needed, we need to restructure things in the common type system.
+            throw new NotImplementedException();
         }
 
         public override bool SupportsUniversalCanon => false;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -43,8 +43,6 @@ namespace ILCompiler.DependencyAnalysis
             EETypeRareFlags rareFlags = 0;
 
             uint flags = EETypeBuilderHelpers.ComputeFlags(_type);
-            if (factory.PreinitializationManager.HasLazyStaticConstructor(_type))
-                rareFlags |= EETypeRareFlags.HasCctorFlag;
             if (_type.IsByRefLike)
                 rareFlags |= EETypeRareFlags.IsByRefLikeFlag;
 


### PR DESCRIPTION
This is already wrong, irrespective of #79384.

Cc @dotnet/ilc-contrib 