### PR TITLE
Delete MetadataType from the runtime type system

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -1364,6 +1364,12 @@ namespace Internal.Runtime
             {
                 return (EETypeElementType)((_uFlags & (uint)EETypeFlags.ElementTypeMask) >> (byte)EETypeFlags.ElementTypeShift);
             }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                _uFlags = (_uFlags & ~(uint)EETypeFlags.ElementTypeMask) | ((uint)value << (byte)EETypeFlags.ElementTypeShift);
+            }
+#endif
         }
 
         public bool HasCctor

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -635,8 +635,7 @@ namespace Internal.Runtime.TypeLoader
 
             // We used a pointer as a template. We need to make this a byref.
             Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType == EETypeElementType.Pointer);
-            state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->Flags = EETypeBuilderHelpers.ComputeFlags(byRefType);
-            Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType == EETypeElementType.ByRef);
+            state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType = EETypeElementType.ByRef;
             Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ParameterizedTypeShape == ParameterizedTypeShapeConstants.Pointer);
             state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ParameterizedTypeShape = ParameterizedTypeShapeConstants.ByRef;
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -851,8 +851,7 @@ namespace Internal.Runtime.TypeLoader
                         Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ParameterizedTypeShape == ParameterizedTypeShapeConstants.Pointer);
                         state.HalfBakedRuntimeTypeHandle.SetParameterizedTypeShape(ParameterizedTypeShapeConstants.ByRef);
                         Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType == EETypeElementType.Pointer);
-                        state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->Flags = EETypeBuilderHelpers.ComputeFlags(type);
-                        Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType == EETypeElementType.ByRef);
+                        state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType = EETypeElementType.ByRef;
                     }
                 }
             }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemExtensions.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemExtensions.cs
@@ -7,7 +7,7 @@ using System;
 using Internal.Runtime.Augments;
 using Internal.TypeSystem;
 
-namespace Internal.Runtime.TypeLoader
+namespace Internal.TypeSystem
 {
     internal static class TypeDescExtensions
     {
@@ -20,6 +20,22 @@ namespace Internal.Runtime.TypeLoader
         {
             DefType typeAsDefType = type as DefType;
             return typeAsDefType != null && typeAsDefType.HasInstantiation;
+        }
+
+        public static bool IsWellKnownType(this TypeDesc type, WellKnownType wellKnownType)
+        {
+            return type == type.Context.GetWellKnownType(wellKnownType, false);
+        }
+
+        public static ByRefType MakeByRefType(this TypeDesc type)
+        {
+            return type.Context.GetByRefType(type);
+        }
+
+        public static TypeDesc GetParameterType(this TypeDesc type)
+        {
+            ParameterizedType paramType = (ParameterizedType)type;
+            return paramType.ParameterType;
         }
     }
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/CanonTypes.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/CanonTypes.Runtime.cs
@@ -9,6 +9,8 @@ using Internal.Runtime.Augments;
 
 namespace Internal.TypeSystem
 {
+    public partial class CanonBaseType : DefType { }
+
     internal partial class CanonType
     {
         partial void Initialize()

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/ThrowHelper.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/ThrowHelper.cs
@@ -53,10 +53,7 @@ namespace Internal.TypeSystem
         {
             public static string OwningModule(TypeDesc type)
             {
-                if (type is NoMetadata.NoMetadataType)
-                    return ((NoMetadata.NoMetadataType)type).DiagnosticModuleName;
-
-                return Module((type as MetadataType)?.Module);
+                return (type as NoMetadata.NoMetadataType)?.DiagnosticModuleName ?? "Unknown";
             }
         }
     }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -389,11 +389,6 @@ namespace Internal.TypeSystem
         {
             Debug.Assert(typeDef.Instantiation.IsNull || typeDef.Instantiation.Length == arguments.Length);
 
-            MetadataType typeAsMetadataType = typeDef as MetadataType;
-
-            if (typeAsMetadataType != null)
-                return GetInstantiatedType(typeAsMetadataType, arguments);
-
             _genericTypeInstances ??= new LowLevelDictionary<GenericTypeInstanceKey, DefType>();
 
             GenericTypeInstanceKey key = new GenericTypeInstanceKey(typeDef, arguments);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -32,9 +32,6 @@
     <Compile Include="$(CompilerCommonPath)\Internal\Runtime\MappingTableFlags.cs">
       <Link>MappingTableFlags.cs</Link>
     </Compile>
-    <Compile Include="$(CompilerCommonPath)\Internal\Runtime\EETypeBuilderHelpers.cs">
-      <Link>EETypeBuilderHelpers.cs</Link>
-    </Compile>
     <Compile Include="$(CompilerCommonPath)\Internal\Runtime\RuntimeConstants.cs">
       <Link>RuntimeConstants.cs</Link>
     </Compile>
@@ -84,9 +81,6 @@
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Canon\InstantiatedType.Canon.cs">
       <Link>Internal\TypeSystem\InstantiatedType.Canon.cs</Link>
     </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Canon\MetadataType.Canon.cs">
-      <Link>Internal\TypeSystem\MetadataType.Canon.cs</Link>
-    </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Canon\MethodDesc.Canon.cs">
       <Link>Internal\TypeSystem\MethodDesc.Canon.cs</Link>
     </Compile>
@@ -114,9 +108,6 @@
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\AlignmentHelper.cs">
       <Link>Internal\TypeSystem\AlignmentHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs">
-      <Link>Internal\TypeSystem\ArrayOfTRuntimeInterfacesAlgorithm.cs</Link>
-    </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\ArrayType.cs">
       <Link>Internal\TypeSystem\ArrayType.cs</Link>
     </Compile>
@@ -129,26 +120,14 @@
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\CastingHelper.cs">
       <Link>Internal\TypeSystem\CastingHelper.cs</Link>
     </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\ConstructedTypeRewritingHelpers.cs">
-      <Link>Internal\TypeSystem\ConstructedTypeRewritingHelpers.cs</Link>
-    </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\DefType.cs">
       <Link>Internal\TypeSystem\DefType.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\DefType.FieldLayout.cs">
-      <Link>Internal\TypeSystem\DefType.FieldLayout.cs</Link>
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\FieldDesc.cs">
       <Link>Internal\TypeSystem\FieldDesc.cs</Link>
     </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\FieldDesc.FieldLayout.cs">
-      <Link>Internal\TypeSystem\FieldDesc.FieldLayout.cs</Link>
-    </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\FieldForInstantiatedType.cs">
       <Link>Internal\TypeSystem\FieldForInstantiatedType.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\FieldLayoutAlgorithm.cs">
-      <Link>Internal\TypeSystem\FieldLayoutAlgorithm.cs</Link>
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\FunctionPointerType.cs">
       <Link>Internal\TypeSystem\FunctionPointerType.cs</Link>
@@ -159,38 +138,17 @@
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\IAssemblyDesc.cs">
       <Link>Internal\TypeSystem\IAssemblyDesc.cs</Link>
     </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\IModuleResolver.cs">
-      <Link>Internal\TypeSystem\IModuleResolver.cs</Link>
-    </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\InstantiatedMethod.cs">
       <Link>Internal\TypeSystem\InstantiatedMethod.cs</Link>
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\InstantiatedType.cs">
       <Link>Internal\TypeSystem\InstantiatedType.cs</Link>
     </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\InstantiatedType.Interfaces.cs">
-      <Link>Internal\TypeSystem\InstantiatedType.Interfaces.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\InstantiatedType.MethodImpls.cs">
-      <Link>Internal\TypeSystem\InstantiatedType.MethodImpls.cs</Link>
-    </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\Instantiation.cs">
       <Link>Internal\TypeSystem\Instantiation.cs</Link>
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\LayoutInt.cs">
       <Link>Internal\TypeSystem\LayoutInt.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\ExplicitLayoutValidator.cs">
-      <Link>Internal\TypeSystem\Common\ExplicitLayoutValidator.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\MetadataType.cs">
-      <Link>Internal\TypeSystem\MetadataType.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\MetadataType.Interfaces.cs">
-      <Link>Internal\TypeSystem\MetadataType.Interfaces.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\MetadataType.MethodImpls.cs">
-      <Link>Internal\TypeSystem\MetadataType.MethodImpls.cs</Link>
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\MethodDesc.cs">
       <Link>Internal\TypeSystem\MethodDesc.cs</Link>
@@ -203,9 +161,6 @@
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\NotFoundBehavior.cs">
       <Link>TypeSystem\Common\NotFoundBehavior.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\ResolutionFailure.cs">
-      <Link>TypeSystem\Common\ResolutionFailure.cs</Link>
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\ParameterizedType.cs">
       <Link>Internal\TypeSystem\ParameterizedType.cs</Link>
@@ -245,9 +200,6 @@
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\ThrowHelper.Common.cs">
       <Link>Internal\TypeSystem\ThrowHelper.Common.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\TypeSystemHelpers.cs">
-      <Link>Internal\TypeSystem\TypeSystemHelpers.cs</Link>
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Common\Utilities\LockFreeReaderHashtableOfPointers.cs">
       <Link>LockFreeReaderHashtableOfPointers.cs</Link>
@@ -321,18 +273,6 @@
     <Compile Include="Internal\TypeSystem\TypeSystemContext.Runtime.cs" />
     <Compile Include="$(AotCommonPath)\System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs">
       <Link>System\Runtime\CompilerServices\__BlockAllReflectionAttribute.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Interop\MetadataType.Interop.cs">
-      <Link>Internal\TypeSystem\Interop\MetadataType.Interop.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Interop\InstantiatedType.Interop.cs">
-      <Link>Internal\TypeSystem\Interop\InstantiatedType.Interop.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Canon\CanonTypes.Interop.cs">
-      <Link>Internal\TypeSystem\Canon\CanonTypes.Interop.cs</Link>
-    </Compile>
-    <Compile Include="$(CompilerCommonPath)\TypeSystem\Interop\MarshalAsDescriptor.cs">
-      <Link>Internal\TypeSystem\Interop\MarshalAsDescriptor.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.Metadata.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.Metadata.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+using Internal.NativeFormat;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.TypeSystem
+{
+    public abstract partial class CanonBaseType : MetadataType
+    {
+        protected override MethodImplRecord[] ComputeVirtualMethodImplsForType()
+        {
+            return Array.Empty<MethodImplRecord>();
+        }
+
+        public override MetadataType MetadataBaseType => (MetadataType)BaseType;
+
+        public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
+
+        public override bool IsAbstract => false;
+
+        public override bool IsBeforeFieldInit => false;
+
+        public override bool IsSequentialLayout => false;
+
+        public override bool IsExplicitLayout => false;
+
+        public override ModuleDesc Module => _context.SystemModule;
+
+        public override bool IsModuleType => false;
+
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(string name)
+        {
+            return null;
+        }
+
+        public override ClassLayoutMetadata GetClassLayout()
+        {
+            return default(ClassLayoutMetadata);
+        }
+
+        public override MetadataType GetNestedType(string name)
+        {
+            return null;
+        }
+
+        public override IEnumerable<MetadataType> GetNestedTypes()
+        {
+            return Array.Empty<MetadataType>();
+        }
+
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
+        {
+            return false;
+        }
+    }
+
+    internal sealed partial class CanonType
+    {
+        public override bool IsSealed => false;
+    }
+
+    internal sealed partial class UniversalCanonType
+    {
+        public override bool IsSealed => true;
+    }
+}

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
@@ -34,7 +34,7 @@ namespace Internal.TypeSystem
     /// <summary>
     /// Base class for specialized and universal canon types
     /// </summary>
-    public abstract partial class CanonBaseType : MetadataType
+    public abstract partial class CanonBaseType
     {
         private TypeSystemContext _context;
 
@@ -51,53 +51,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        protected override MethodImplRecord[] ComputeVirtualMethodImplsForType()
-        {
-            return Array.Empty<MethodImplRecord>();
-        }
-
-        public override MetadataType MetadataBaseType => (MetadataType)BaseType;
-
         public override DefType ContainingType => null;
-
-        public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
-
-        public override bool IsAbstract => false;
-
-        public override bool IsBeforeFieldInit => false;
-
-        public override bool IsSequentialLayout => false;
-
-        public override bool IsExplicitLayout => false;
-
-        public override ModuleDesc Module => _context.SystemModule;
-
-        public override bool IsModuleType => false;
-
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(string name)
-        {
-            return null;
-        }
-
-        public override ClassLayoutMetadata GetClassLayout()
-        {
-            return default(ClassLayoutMetadata);
-        }
-
-        public override MetadataType GetNestedType(string name)
-        {
-            return null;
-        }
-
-        public override IEnumerable<MetadataType> GetNestedTypes()
-        {
-            return Array.Empty<MetadataType>();
-        }
-
-        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
-        {
-            return false;
-        }
     }
 
     /// <summary>
@@ -126,8 +80,6 @@ namespace Internal.TypeSystem
                 return _Name;
             }
         }
-
-        public override bool IsSealed => false;
 
         public CanonType(TypeSystemContext context)
             : base(context)
@@ -216,8 +168,6 @@ namespace Internal.TypeSystem
                 return _Name;
             }
         }
-
-        public override bool IsSealed => true;
 
         public UniversalCanonType(TypeSystemContext context)
             : base(context)

--- a/src/coreclr/tools/Common/TypeSystem/Canon/InstantiatedType.Canon.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/InstantiatedType.Canon.cs
@@ -1,6 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if TYPE_LOADER_IMPLEMENTATION
+using MetadataType = Internal.TypeSystem.DefType;
+#endif
+
 namespace Internal.TypeSystem
 {
     // Implements canonicalization for generic instantiations

--- a/src/coreclr/tools/Common/TypeSystem/Canon/TypeSystemContext.Canon.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/TypeSystemContext.Canon.cs
@@ -94,7 +94,7 @@ namespace Internal.TypeSystem
         public abstract bool SupportsCanon { get; }
         public abstract bool SupportsUniversalCanon { get; }
 
-        public MetadataType GetCanonType(string name)
+        public DefType GetCanonType(string name)
         {
             switch (name)
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.Metadata.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.Metadata.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Internal.TypeSystem
+{
+    public sealed partial class InstantiatedType : MetadataType
+    {
+        public override MetadataType MetadataBaseType
+        {
+            get
+            {
+                if (_baseType == this)
+                    return InitializeBaseType();
+                return _baseType;
+            }
+        }
+
+        // Properties that are passed through from the type definition
+        public override ClassLayoutMetadata GetClassLayout()
+        {
+            return _typeDef.GetClassLayout();
+        }
+
+        public override bool IsExplicitLayout
+        {
+            get
+            {
+                return _typeDef.IsExplicitLayout;
+            }
+        }
+
+        public override bool IsSequentialLayout
+        {
+            get
+            {
+                return _typeDef.IsSequentialLayout;
+            }
+        }
+
+        public override bool IsBeforeFieldInit
+        {
+            get
+            {
+                return _typeDef.IsBeforeFieldInit;
+            }
+        }
+
+        public override bool IsModuleType
+        {
+            get
+            {
+                // The global module type cannot be generic.
+                return false;
+            }
+        }
+
+        public override bool IsSealed
+        {
+            get
+            {
+                return _typeDef.IsSealed;
+            }
+        }
+
+        public override bool IsAbstract
+        {
+            get
+            {
+                return _typeDef.IsAbstract;
+            }
+        }
+
+        public override ModuleDesc Module
+        {
+            get
+            {
+                return _typeDef.Module;
+            }
+        }
+
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
+        {
+            return _typeDef.HasCustomAttribute(attributeNamespace, attributeName);
+        }
+
+        public override MetadataType GetNestedType(string name)
+        {
+            // Return the result from the typical type definition.
+            return _typeDef.GetNestedType(name);
+        }
+
+        public override IEnumerable<MetadataType> GetNestedTypes()
+        {
+            // Return the result from the typical type definition.
+            return _typeDef.GetNestedTypes();
+        }
+    }
+}

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
@@ -4,6 +4,10 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#if TYPE_LOADER_IMPLEMENTATION
+using MetadataType = Internal.TypeSystem.DefType;
+#endif
+
 namespace Internal.TypeSystem
 {
     public sealed partial class InstantiatedType : MetadataType
@@ -51,22 +55,12 @@ namespace Internal.TypeSystem
 
         private MetadataType InitializeBaseType()
         {
-            var uninst = _typeDef.MetadataBaseType;
+            var uninst = _typeDef.BaseType;
 
             return (_baseType = (uninst != null) ? (MetadataType)uninst.InstantiateSignature(_instantiation, default(Instantiation)) : null);
         }
 
         public override DefType BaseType
-        {
-            get
-            {
-                if (_baseType == this)
-                    return InitializeBaseType();
-                return _baseType;
-            }
-        }
-
-        public override MetadataType MetadataBaseType
         {
             get
             {
@@ -181,7 +175,7 @@ namespace Internal.TypeSystem
             if (typicalFinalizer == null)
                 return null;
 
-            MetadataType typeInHierarchy = this;
+            DefType typeInHierarchy = this;
 
             // Note, we go back to the type definition/typical method definition in this code.
             // If the finalizer is implemented on a base type that is also a generic, then the
@@ -190,7 +184,7 @@ namespace Internal.TypeSystem
 
             while (typicalFinalizer.OwningType.GetTypeDefinition() != typeInHierarchy.GetTypeDefinition())
             {
-                typeInHierarchy = typeInHierarchy.MetadataBaseType;
+                typeInHierarchy = typeInHierarchy.BaseType;
             }
 
             if (typeInHierarchy == typicalFinalizer.OwningType)
@@ -280,74 +274,6 @@ namespace Internal.TypeSystem
             return _typeDef;
         }
 
-        // Properties that are passed through from the type definition
-        public override ClassLayoutMetadata GetClassLayout()
-        {
-            return _typeDef.GetClassLayout();
-        }
-
-        public override bool IsExplicitLayout
-        {
-            get
-            {
-                return _typeDef.IsExplicitLayout;
-            }
-        }
-
-        public override bool IsSequentialLayout
-        {
-            get
-            {
-                return _typeDef.IsSequentialLayout;
-            }
-        }
-
-        public override bool IsBeforeFieldInit
-        {
-            get
-            {
-                return _typeDef.IsBeforeFieldInit;
-            }
-        }
-
-        public override bool IsModuleType
-        {
-            get
-            {
-                // The global module type cannot be generic.
-                return false;
-            }
-        }
-
-        public override bool IsSealed
-        {
-            get
-            {
-                return _typeDef.IsSealed;
-            }
-        }
-
-        public override bool IsAbstract
-        {
-            get
-            {
-                return _typeDef.IsAbstract;
-            }
-        }
-
-        public override ModuleDesc Module
-        {
-            get
-            {
-                return _typeDef.Module;
-            }
-        }
-
-        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
-        {
-            return _typeDef.HasCustomAttribute(attributeNamespace, attributeName);
-        }
-
         public override DefType ContainingType
         {
             get
@@ -355,18 +281,6 @@ namespace Internal.TypeSystem
                 // Return the result from the typical type definition.
                 return _typeDef.ContainingType;
             }
-        }
-
-        public override MetadataType GetNestedType(string name)
-        {
-            // Return the result from the typical type definition.
-            return _typeDef.GetNestedType(name);
-        }
-
-        public override IEnumerable<MetadataType> GetNestedTypes()
-        {
-            // Return the result from the typical type definition.
-            return _typeDef.GetNestedTypes();
         }
 
         public override TypeDesc UnderlyingType

--- a/src/coreclr/tools/Common/TypeSystem/Common/ModuleDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ModuleDesc.cs
@@ -3,6 +3,10 @@
 
 using System.Collections.Generic;
 
+#if TYPE_LOADER_IMPLEMENTATION
+using MetadataType = Internal.TypeSystem.DefType;
+#endif
+
 namespace Internal.TypeSystem
 {
     public abstract partial class ModuleDesc : TypeSystemEntity

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemContext.FieldLayout.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemContext.FieldLayout.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Internal.TypeSystem
+{
+    public abstract partial class TypeSystemContext
+    {
+        /// <summary>
+        /// Abstraction to allow the type system context to affect the field layout
+        /// algorithm used by types to lay themselves out.
+        /// </summary>
+        public virtual FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)
+        {
+            // Type system contexts that support computing field layout need to override this.
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemContext.Resolution.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemContext.Resolution.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+using Internal.NativeFormat;
+
+namespace Internal.TypeSystem
+{
+    public abstract partial class TypeSystemContext : IModuleResolver
+    {
+        public ModuleDesc SystemModule
+        {
+            get;
+            private set;
+        }
+
+        protected void InitializeSystemModule(ModuleDesc systemModule)
+        {
+            Debug.Assert(SystemModule == null);
+            SystemModule = systemModule;
+        }
+
+        public virtual ModuleDesc ResolveAssembly(AssemblyName name, bool throwIfNotFound = true)
+        {
+            if (throwIfNotFound)
+                throw new NotSupportedException();
+            return null;
+        }
+
+        internal virtual ModuleDesc ResolveModule(IAssemblyDesc referencingModule, string fileName, bool throwIfNotFound = true)
+        {
+            if (throwIfNotFound)
+                throw new NotSupportedException();
+            return null;
+        }
+
+        ModuleDesc IModuleResolver.ResolveModule(IAssemblyDesc referencingModule, string fileName, bool throwIfNotFound)
+        {
+            return ResolveModule(referencingModule, fileName, throwIfNotFound);
+        }
+    }
+}

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemContext.cs
@@ -4,13 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 
 using Internal.NativeFormat;
 
+#if TYPE_LOADER_IMPLEMENTATION
+using MetadataType = Internal.TypeSystem.DefType;
+#endif
+
 namespace Internal.TypeSystem
 {
-    public abstract partial class TypeSystemContext : IModuleResolver
+    public abstract partial class TypeSystemContext
     {
         public TypeSystemContext() : this(new TargetDetails(TargetArchitecture.Unknown, TargetOS.Unknown, TargetAbi.Unknown))
         {
@@ -44,38 +47,7 @@ namespace Internal.TypeSystem
             get;
         }
 
-        public ModuleDesc SystemModule
-        {
-            get;
-            private set;
-        }
-
-        protected void InitializeSystemModule(ModuleDesc systemModule)
-        {
-            Debug.Assert(SystemModule == null);
-            SystemModule = systemModule;
-        }
-
         public abstract DefType GetWellKnownType(WellKnownType wellKnownType, bool throwIfNotFound = true);
-
-        public virtual ModuleDesc ResolveAssembly(AssemblyName name, bool throwIfNotFound = true)
-        {
-            if (throwIfNotFound)
-                throw new NotSupportedException();
-            return null;
-        }
-
-        internal virtual ModuleDesc ResolveModule(IAssemblyDesc referencingModule, string fileName, bool throwIfNotFound = true)
-        {
-            if (throwIfNotFound)
-                throw new NotSupportedException();
-            return null;
-        }
-
-        ModuleDesc IModuleResolver.ResolveModule(IAssemblyDesc referencingModule, string fileName, bool throwIfNotFound)
-        {
-            return ResolveModule(referencingModule, fileName, throwIfNotFound);
-        }
 
         //
         // Array types
@@ -680,16 +652,6 @@ namespace Internal.TypeSystem
         protected internal virtual IEnumerable<MethodDesc> GetAllVirtualMethods(TypeDesc type)
         {
             return type.GetVirtualMethods();
-        }
-
-        /// <summary>
-        /// Abstraction to allow the type system context to affect the field layout
-        /// algorithm used by types to lay themselves out.
-        /// </summary>
-        public virtual FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)
-        {
-            // Type system contexts that support computing field layout need to override this.
-            throw new NotSupportedException();
         }
 
         /// <summary>

--- a/src/coreclr/tools/Common/TypeSystem/Common/Utilities/DebugNameFormatter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Utilities/DebugNameFormatter.cs
@@ -182,6 +182,9 @@ namespace Internal.TypeSystem
 
         private static void AssemblyQualify(StringBuilder sb, DefType type, FormatOptions options)
         {
+            // TODO: We should introduce a DiagnosticModuleName to use here instead. The type
+            // loader already has that.
+#if !TYPE_LOADER_IMPLEMENTATION
             if (((options & FormatOptions.AssemblyQualify) != 0)
                 && type is MetadataType mdType
                 && mdType.Module is IAssemblyDesc)
@@ -211,6 +214,7 @@ namespace Internal.TypeSystem
 
                 sb.Append(']');
             }
+#endif
         }
 
         private static void NamespaceQualify(StringBuilder sb, DefType type, FormatOptions options)

--- a/src/coreclr/tools/ILVerification/ILVerification.projitems
+++ b/src/coreclr/tools/ILVerification/ILVerification.projitems
@@ -112,6 +112,9 @@
     <Compile Include="$(ToolsCommonPath)TypeSystem\Common\InstantiatedType.cs">
       <Link>TypeSystem\Common\InstantiatedType.cs</Link>
     </Compile>
+    <Compile Include="$(ToolsCommonPath)TypeSystem\Common\InstantiatedType.Metadata.cs">
+      <Link>TypeSystem\Common\InstantiatedType.Metadata.cs</Link>
+    </Compile>
     <Compile Include="$(ToolsCommonPath)TypeSystem\Common\InstantiatedType.Interfaces.cs">
       <Link>TypeSystem\Common\InstantiatedType.Interfaces.cs</Link>
     </Compile>
@@ -174,6 +177,12 @@
     </Compile>
     <Compile Include="$(ToolsCommonPath)TypeSystem\Common\TypeSystemContext.cs">
       <Link>TypeSystem\Common\TypeSystemContext.cs</Link>
+    </Compile>
+    <Compile Include="$(ToolsCommonPath)TypeSystem\Common\TypeSystemContext.Resolution.cs">
+      <Link>TypeSystem\Common\TypeSystemContext.Resolution.cs</Link>
+    </Compile>
+    <Compile Include="$(ToolsCommonPath)TypeSystem\Common\TypeSystemContext.FieldLayout.cs">
+      <Link>TypeSystem\Common\TypeSystemContext.FieldLayout.cs</Link>
     </Compile>
     <Compile Include="$(ToolsCommonPath)TypeSystem\Common\TypeSystemHelpers.cs">
       <Link>TypeSystem\Common\TypeSystemHelpers.cs</Link>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
@@ -45,6 +45,9 @@
     <Compile Include="..\..\Common\TypeSystem\Canon\CanonTypes.cs">
       <Link>TypeSystem\Canon\CanonTypes.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Canon\CanonTypes.Metadata.cs">
+      <Link>TypeSystem\Canon\CanonTypes.Metadata.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Canon\CanonTypes.Diagnostic.cs">
       <Link>TypeSystem\Canon\CanonTypes.Diagnostic.cs</Link>
     </Compile>
@@ -228,6 +231,9 @@
     <Compile Include="..\..\Common\TypeSystem\Common\InstantiatedType.cs">
       <Link>TypeSystem\Common\InstantiatedType.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\InstantiatedType.Metadata.cs">
+      <Link>TypeSystem\Common\InstantiatedType.Metadata.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\InstantiatedType.Diagnostic.cs">
       <Link>TypeSystem\Common\InstantiatedType.Diagnostic.cs</Link>
     </Compile>
@@ -305,6 +311,12 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemContext.cs">
       <Link>TypeSystem\Common\TypeSystemContext.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemContext.Resolution.cs">
+      <Link>TypeSystem\Common\TypeSystemContext.Resolution.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemContext.FieldLayout.cs">
+      <Link>TypeSystem\Common\TypeSystemContext.FieldLayout.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemHelpers.cs">
       <Link>TypeSystem\Common\TypeSystemHelpers.cs</Link>


### PR DESCRIPTION
Casts to `MetadataType` will never succeed in the runtime type system. We had some.

* Making it so that `InstantiatedType` and `CanonType` derive from `DefType` instead of `MetadataType` in the runtime type system.
* Moved some things into dotfiles.

Even though the compiler has been trimming most of this already, we still save 16 kB on a hello world with this. Not bad for mechanically deleting a bunch of dead code.

Cc @dotnet/ilc-contrib 