### PR TITLE
Fix WXORX issue in EEClass::Destruct

### DIFF
--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -162,7 +162,8 @@ void EEClass::Destruct(MethodTable * pOwningMT)
         }
         if (pDelegateEEClass->m_pInstRetBuffCallStub)
         {
-            pDelegateEEClass->m_pInstRetBuffCallStub->DecRef();
+            ExecutableWriterHolder<Stub> stubWriterHolder(pDelegateEEClass->m_pInstRetBuffCallStub, sizeof(Stub));
+            stubWriterHolder.GetRW()->DecRef();
         }
         // While m_pMultiCastInvokeStub is also a member,
         // it is owned by the m_pMulticastStubCache, not by the class


### PR DESCRIPTION
While investigating failures of some coreclr tests when running in an unloadable context, I've hit AV in `EEClass::Destruct` in one of the tests. The reason is that we are missing `ExecutableWriterHolder` when updating refCount on `pDelegateEEClass->m_pInstRetBuffCallStub`.

This change fixes it.