### PR TITLE
Prefer interpreted execution for AsQueryable

### DIFF
--- a/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableExecutor.cs
@@ -43,7 +43,7 @@ namespace System.Linq
             EnumerableRewriter rewriter = new EnumerableRewriter();
             Expression body = rewriter.Visit(_expression);
             Expression<Func<T>> f = Expression.Lambda<Func<T>>(body, (IEnumerable<ParameterExpression>?)null);
-            Func<T> func = f.Compile();
+            Func<T> func = f.Compile(preferInterpretation: true);
             return func();
         }
     }

--- a/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
+++ b/src/libraries/System.Linq.Queryable/src/System/Linq/EnumerableQuery.cs
@@ -108,7 +108,7 @@ namespace System.Linq
                 EnumerableRewriter rewriter = new EnumerableRewriter();
                 Expression body = rewriter.Visit(_expression);
                 Expression<Func<IEnumerable<T>>> f = Expression.Lambda<Func<IEnumerable<T>>>(body, (IEnumerable<ParameterExpression>?)null);
-                IEnumerable<T> enumerable = f.Compile()();
+                IEnumerable<T> enumerable = f.Compile(preferInterpretation: true)();
                 if (enumerable == this)
                     throw Error.EnumeratingNullEnumerableExpression();
                 _enumerable = enumerable;


### PR DESCRIPTION
[AsQueryable](https://learn.microsoft.com/en-us/dotnet/api/system.linq.queryable.asqueryable?view=net-7.0#system-linq-queryable-asqueryable(system-collections-ienumerable)) converts an IEnumerable to an IQueryable, allowing an abstraction over queries regardless of whether they're executed locally via LINQ to Objects (IEnumerable) or translated via a LINQ provider.

When the IEnumerable-based IQueryable is executed, we internally compile the expression tree and then invoke it; the delegate is then discarded (single-use). This practice is also being done in EF, and benchmarking it shows that interpretation is very significantly more performant than compilation followed by single use. This PR applies `preferInterpretation: true` for those cases.

Note that when trimming and using CoreCLR (not NativeAOT), this may cause a size increase since the interpreter is brought in where it could be trimmed (since by default, `Compile()` on CoreCLR doesn't use the interpreter). I have no idea if the linker is that smart though (on NativeAOT this wouldn't change anything since the interpreter must be used anyway).

/cc @jkotas @vitek-karas @ajcvickers