### PR TITLE
[mono] Introduce designated direct pinvokes to mono aot compiler

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6161,6 +6161,9 @@ get_pinvoke_import (MonoAotCompile *acfg, MonoMethod *method)
 static gboolean
 is_direct_pinvoke_specified_for_method (MonoAotCompile *acfg, MonoMethod *method)
 {
+	if (acfg->aot_opts.direct_pinvoke)
+		return TRUE;
+
 	if (!acfg->aot_opts.direct_pinvokes && !acfg->aot_opts.direct_pinvoke_lists)
 		return FALSE;
 
@@ -6231,8 +6234,6 @@ is_direct_callable (MonoAotCompile *acfg, MonoMethod *method, MonoJumpInfo *patc
 		/* Cross assembly calls */
 		return method_is_externally_callable (acfg, patch_info->data.method);
 	} else if ((patch_info->type == MONO_PATCH_INFO_ICALL_ADDR_CALL && patch_info->data.method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)) {
-		if (acfg->aot_opts.direct_pinvoke)
-			return TRUE;
 		return is_direct_pinvoke_specified_for_method (acfg, patch_info->data.method);
 	} else if (patch_info->type == MONO_PATCH_INFO_ICALL_ADDR_CALL) {
 		if (acfg->aot_opts.direct_icalls)
@@ -10181,7 +10182,7 @@ mono_aot_get_direct_call_symbol (MonoJumpInfoType type, gconstpointer data)
 			MonoMethod *method = (MonoMethod *)data;
 			if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
 				sym = lookup_icall_symbol_name_aot (method);
-			else if (llvm_acfg->aot_opts.direct_pinvoke || is_direct_pinvoke_specified_for_method (llvm_acfg, method))
+			else if (is_direct_pinvoke_specified_for_method (llvm_acfg, method))
 				sym = get_pinvoke_import (llvm_acfg, method);
 		} else if (type == MONO_PATCH_INFO_JIT_ICALL_ID) {
 			MonoJitICallInfo const * const info = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -8666,6 +8666,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			printf ("    outfile=\n");
 			printf ("    profile=\n");
 			printf ("    profile-only\n");
+			printf ("    mibc-profile=\n");
 			printf ("    print-skipped-methods\n");
 			printf ("    readonly-value=\n");
 			printf ("    save-temps\n");

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14297,7 +14297,7 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 		aot_printerrf (acfg, "The 'direct-pinvoke' flag, 'direct-pinvokes', and 'direct-pinvoke-lists' AOT options also require the 'static' AOT option.\n");
 		return 1;
 	}
-	if ((acfg->aot_opts.direct_pinvoke && (acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_list))
+	if ((acfg->aot_opts.direct_pinvoke && (acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_lists))
 		g_warning ("The 'direct-pinvoke' argument trumps specified 'direct-pinvokes' and 'direct-pinvoke-lists' arguments.\n");
 	gboolean added_direct_pinvoke = TRUE;
 	if (acfg->aot_opts.direct_pinvokes) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -13803,10 +13803,18 @@ aot_opts_free (MonoAotOptions *aot_opts)
 	g_free (aot_opts->outfile);
 	g_free (aot_opts->llvm_outfile);
 	g_free (aot_opts->data_outfile);
+	for (GList *elem = aot_opts->profile_files; elem; elem = elem->next)
+		g_free (elem->data);
 	g_list_free (aot_opts->profile_files);
+	for (GList *elem = aot_opts->mibc_profile_files; elem; elem = elem->next)
+		g_free (elem->data);
 	g_list_free (aot_opts->mibc_profile_files);
 	g_free (aot_opts->gen_msym_dir_path);
+	for (GList *elem = aot_opts->direct_pinvokes; elem; elem = elem->next)
+		g_free (elem->data);
 	g_list_free (aot_opts->direct_pinvokes);
+	for (GList *elem = aot_opts->direct_pinvoke_lists; elem; elem = elem->next)
+		g_free (elem->data);
 	g_list_free (aot_opts->direct_pinvoke_lists);
 	g_free (aot_opts->dedup_include);
 	g_free (aot_opts->tool_prefix);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14295,10 +14295,12 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 	}
 #endif
 
-	if ((acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_lists) && !acfg->aot_opts.static_link) {
-		aot_printerrf (acfg, "The 'direct-pinvokes' and 'direct-pinvoke-lists' AOT options also require the 'static' AOT option.\n");
+	if ((acfg->aot_opts.direct_pinvoke || acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_lists) && !acfg->aot_opts.static_link) {
+		aot_printerrf (acfg, "The 'direct-pinvoke' flag, 'direct-pinvokes', and 'direct-pinvoke-lists' AOT options also require the 'static' AOT option.\n");
 		return 1;
 	}
+	if ((acfg->aot_opts.direct_pinvoke && (acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_list))
+		g_warning ("The 'direct-pinvoke' argument trumps specified 'direct-pinvokes' and 'direct-pinvoke-lists' arguments.\n");
 	gboolean added_direct_pinvoke = TRUE;
 	if (acfg->aot_opts.direct_pinvokes) {
 		GList *l;

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14341,7 +14341,7 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 		aot_printerrf (acfg, "The 'direct-pinvoke' flag, 'direct-pinvokes', and 'direct-pinvoke-lists' AOT options also require the 'static' AOT option.\n");
 		return 1;
 	}
-	if ((acfg->aot_opts.direct_pinvoke && (acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_lists))
+	if (acfg->aot_opts.direct_pinvoke && (acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_lists))
 		g_warning ("The 'direct-pinvoke' argument trumps specified 'direct-pinvokes' and 'direct-pinvoke-lists' arguments.\n");
 	gboolean added_direct_pinvoke = TRUE;
 	if (acfg->aot_opts.direct_pinvokes) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -15167,7 +15167,7 @@ emit_aot_image (MonoAotCompile *acfg)
 int
 mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 jit_opts, const char *aot_options)
 {
-	int res;
+	int res = 0;
 	MonoAotOptions aot_opts;
 
 	init_options (&aot_opts);
@@ -15207,6 +15207,7 @@ mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 jit_opt
 		res = aot_assembly (assemblies [i], jit_opts, &aot_opts);
 		if (res != 0) {
 			fprintf (stderr, "AOT of image %s failed.\n", assemblies [i]->image->name);
+			res = 1;
 			goto early_exit;
 		}
 	}

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6183,7 +6183,6 @@ get_pinvoke_import (MonoAotCompile *acfg, MonoMethod *method, const char **modul
 static gboolean
 is_direct_pinvoke_specified_for_method (MonoAotCompile *acfg, MonoMethod *method)
 {
-	gboolean direct_pinvoke_specified = FALSE;
 	const char *module_name, *sym = NULL;
 	GHashTable *val;
 
@@ -6195,12 +6194,12 @@ is_direct_pinvoke_specified_for_method (MonoAotCompile *acfg, MonoMethod *method
 
 	if (get_pinvoke_import (acfg, method, &module_name, &sym) && g_hash_table_lookup_extended (acfg->direct_pinvokes, module_name, NULL, (gpointer *)&val)) {
 		if (!val)
-			direct_pinvoke_specified = TRUE;
-		else
-			direct_pinvoke_specified = g_hash_table_contains (val, sym);
+			return TRUE;
+
+		return g_hash_table_contains (val, sym);
 	}
 
-	return direct_pinvoke_specified;
+	return FALSE;
 }
 
 /*

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6153,6 +6153,25 @@ get_pinvoke_import (MonoAotCompile *acfg, MonoMethod *method)
 #endif
 
 /*
+ * mono_aot_direct_pinvoke_enabled_for_method
+ *
+ * Return whether the method is specified to be directly pinvoked
+ */
+static gboolean
+mono_aot_direct_pinvoke_enabled_for_method (MonoAotCompile *acfg, MonoMethod *method)
+{
+	const char *sym = get_pinvoke_import (acfg, method);
+	const char *module_name = acfg->image->module_name;
+	if (g_hash_table_contains (acfg->direct_pinvokes, module_name)) {
+		GHashTable *val = g_hash_table_lookup (acfg->direct_pinvokes, module_name);
+		if (!val)
+			return TRUE;
+		return g_hash_table_contains (val, sym);
+	}
+	return FALSE;
+}
+
+/*
  * is_direct_callable:
  *
  *   Return whenever the method identified by JI is directly callable without

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -308,7 +308,7 @@ typedef struct MonoAotCompile {
 	GHashTable *image_hash;
 	GHashTable *method_to_cfg;
 	GHashTable *token_info_hash;
-	GHashTable *method_to_pinvoke_scope_import;
+	GHashTable *method_to_pinvoke_import;
 	GHashTable *direct_pinvokes;
 	GHashTable *method_to_external_icall_symbol_name;
 	GPtrArray *extra_methods;
@@ -6116,7 +6116,7 @@ method_is_externally_callable (MonoAotCompile *acfg, MonoMethod *method)
 
 #ifdef MONO_ARCH_AOT_SUPPORTED
 static gboolean
-method_to_pinvoke_has_scope_import (MonoAotCompile *acfg, MonoMethod *method, const char **module, const char **entrypoint)
+get_pinvoke_import (MonoAotCompile *acfg, MonoMethod *method, const char **module, const char **entrypoint)
 {
 	MonoImage *image = m_class_get_image (method->klass);
 	MonoMethodPInvoke *piinfo = (MonoMethodPInvoke *) method;
@@ -6125,14 +6125,14 @@ method_to_pinvoke_has_scope_import (MonoAotCompile *acfg, MonoMethod *method, co
 	MonoTableInfo *mr = &tables [MONO_TABLE_MODULEREF];
 	guint32 im_cols [MONO_IMPLMAP_SIZE];
 	int module_idx;
-	const char **scope_import;
+	char **scope_import;
 	guint32 scope_token;
 
-	if (g_hash_table_lookup_extended (acfg->method_to_pinvoke_scope_import, method, NULL, (gpointer *)&scope_import) && scope_import) {
+	if (g_hash_table_lookup_extended (acfg->method_to_pinvoke_import, method, NULL, (gpointer *)&scope_import) && scope_import) {
 		if (module)
-			*module = g_strdup (scope_import[0]);
+			*module = scope_import[0];
 		if (entrypoint)
-			*entrypoint = g_strdup (scope_import[1]);
+			*entrypoint = scope_import[1];
 		return TRUE;
 	}
 
@@ -6145,23 +6145,23 @@ method_to_pinvoke_has_scope_import (MonoAotCompile *acfg, MonoMethod *method, co
 	if (module_idx == 0 || mono_metadata_table_bounds_check (image, MONO_TABLE_MODULEREF, module_idx))
 		return FALSE;
 
-	scope_import = (const char **) g_malloc0 (3 * sizeof (scope_import));
+	scope_import = (char **) g_malloc0 (2 * sizeof (char *));
 	scope_token = mono_metadata_decode_row_col (mr, im_cols [MONO_IMPLMAP_SCOPE] - 1, MONO_MODULEREF_NAME);
 	scope_import[0] = g_strdup_printf ("%s", mono_metadata_string_heap (image, scope_token));
 	scope_import[1] = g_strdup_printf ("%s", mono_metadata_string_heap (image, im_cols [MONO_IMPLMAP_NAME]));
 
-	g_hash_table_insert (acfg->method_to_pinvoke_scope_import, method, scope_import);
+	g_hash_table_insert (acfg->method_to_pinvoke_import, method, scope_import);
 
 	if (module)
-		*module = g_strdup (scope_import[0]);
+		*module = scope_import[0];
 	if (entrypoint)
-		*entrypoint = g_strdup (scope_import[1]);
+		*entrypoint = scope_import[1];
 
 	return TRUE;
 }
 #else
 static gboolean
-method_to_pinvoke_has_scope_import (MonoAotCompile *acfg, MonoMethod *method, const char **module, const char **entrypoint)
+get_pinvoke_import (MonoAotCompile *acfg, MonoMethod *method, const char **module, const char **entrypoint)
 {
 	return FALSE;
 }
@@ -6177,7 +6177,7 @@ static gboolean
 is_direct_pinvoke_specified_for_method (MonoAotCompile *acfg, MonoMethod *method)
 {
 	gboolean direct_pinvoke_specified = FALSE;
-	const char *module_name, *sym;
+	const char *module_name, *sym = NULL;
 	GHashTable *val;
 
 	if (acfg->aot_opts.direct_pinvoke)
@@ -6186,14 +6186,12 @@ is_direct_pinvoke_specified_for_method (MonoAotCompile *acfg, MonoMethod *method
 	if (!acfg->aot_opts.direct_pinvokes && !acfg->aot_opts.direct_pinvoke_lists)
 		return FALSE;
 
-	if (method_to_pinvoke_has_scope_import (acfg, method, &module_name, &sym) && g_hash_table_lookup_extended (acfg->direct_pinvokes, module_name, NULL, (gpointer *)&val)) {
+	if (get_pinvoke_import (acfg, method, &module_name, &sym) && g_hash_table_lookup_extended (acfg->direct_pinvokes, module_name, NULL, (gpointer *)&val)) {
 		if (!val)
 			direct_pinvoke_specified = TRUE;
 		else
 			direct_pinvoke_specified = g_hash_table_contains (val, sym);
 	}
-	g_free ((char *)module_name);
-	g_free ((char *)sym);
 
 	return direct_pinvoke_specified;
 }
@@ -6543,7 +6541,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						if (!(patch_info->data.method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
 							direct_pinvoke = lookup_icall_symbol_name_aot (patch_info->data.method);
 						else
-							method_to_pinvoke_has_scope_import (acfg, patch_info->data.method, NULL, &direct_pinvoke);
+							get_pinvoke_import (acfg, patch_info->data.method, NULL, &direct_pinvoke);
 						if (direct_pinvoke && !never_direct_pinvoke (direct_pinvoke)) {
 							direct_call = TRUE;
 							g_assert (strlen (direct_pinvoke) < 1000);
@@ -10223,7 +10221,7 @@ mono_aot_get_direct_call_symbol (MonoJumpInfoType type, gconstpointer data)
 			if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
 				sym = lookup_icall_symbol_name_aot (method);
 			else if (is_direct_pinvoke_specified_for_method (llvm_acfg, method))
-				method_to_pinvoke_has_scope_import (llvm_acfg, method, NULL, &sym);
+				get_pinvoke_import (llvm_acfg, method, NULL, &sym);
 		} else if (type == MONO_PATCH_INFO_JIT_ICALL_ID) {
 			MonoJitICallInfo const * const info = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
 			char const * const name = info->c_symbol;
@@ -13747,6 +13745,17 @@ add_mibc_profile_methods (MonoAotCompile *acfg, char *filename)
 }
 
 static void
+free_method_pinvoke_import_value (gpointer data)
+{
+	gchar **value = (gchar **)data;
+	if (!value)
+		return;
+	g_free (value[0]);
+	g_free (value[1]);
+	g_free (value);
+}
+
+static void
 init_got_info (GotInfo *info)
 {
 	int i;
@@ -13772,7 +13781,7 @@ acfg_create (MonoAssembly *ass, guint32 jit_opts)
 	acfg->patch_to_plt_entry = g_new0 (GHashTable*, MONO_PATCH_INFO_NUM);
 	acfg->method_to_cfg = g_hash_table_new (NULL, NULL);
 	acfg->token_info_hash = g_hash_table_new_full (NULL, NULL, NULL, NULL);
-	acfg->method_to_pinvoke_scope_import = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify)g_strfreev);
+	acfg->method_to_pinvoke_import = g_hash_table_new_full (NULL, NULL, NULL, (GDestroyNotify)free_method_pinvoke_import_value);
 	acfg->direct_pinvokes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify)g_hash_table_destroy);
 	acfg->method_to_external_icall_symbol_name = g_hash_table_new_full (NULL, NULL, NULL, g_free);
 	acfg->image_hash = g_hash_table_new (NULL, NULL);
@@ -13877,7 +13886,7 @@ acfg_free (MonoAotCompile *acfg)
 	g_free (acfg->patch_to_plt_entry);
 	g_hash_table_destroy (acfg->method_to_cfg);
 	g_hash_table_destroy (acfg->token_info_hash);
-	g_hash_table_destroy (acfg->method_to_pinvoke_scope_import);
+	g_hash_table_destroy (acfg->method_to_pinvoke_import);
 	g_hash_table_destroy (acfg->direct_pinvokes);
 	g_hash_table_destroy (acfg->method_to_external_icall_symbol_name);
 	g_hash_table_destroy (acfg->image_hash);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6445,7 +6445,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 	gboolean direct_call, external_call;
 	guint32 got_slot;
 	const char *direct_call_target = 0;
-	const char *direct_pinvoke;
+	const char *direct_pinvoke = NULL;
 #endif
 
 	if (acfg->gas_line_numbers && method && debug_info) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6115,6 +6115,27 @@ method_is_externally_callable (MonoAotCompile *acfg, MonoMethod *method)
 }
 
 #ifdef MONO_ARCH_AOT_SUPPORTED
+//---------------------------------------------------------------------------------------
+//
+// get_pinvoke_import:
+//
+// Returns whether or not module and entrypoint pinvoke information could be grabbed
+// from the MonoMethod. It populates module and entrypoint if they are not NULL. A
+// hash table is populated with key value pairs corresponding to the MonoMethod and
+// module entrypoint string array to serve as a fast path cache. The module and
+// entrypoint string data are owned by the hash table.
+//
+// Arguments:
+//  * acfg - the MonoAotCompiler instance
+//  * method - the MonoMethod to grab pinvoke scope and import information from
+//  ** module - the pointer to the module name string (owned by the hashtable)
+//  ** entrypoint - the pointer to the entrypoint name string (owned by the hashtable)
+//
+// Return Value:
+//  gboolean corresponding to whether or not module and entrypoint pinvoke information
+//  could be grabbed from the provided MonoMethod.
+//
+
 static gboolean
 get_pinvoke_import (MonoAotCompile *acfg, MonoMethod *method, const char **module, const char **entrypoint)
 {
@@ -8682,59 +8703,59 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			opts->depfile = g_strdup (arg + strlen ("depfile="));
 		} else if (str_begins_with (arg, "help") || str_begins_with (arg, "?")) {
 			printf ("Supported options for --aot:\n");
-			printf ("    asmonly\n");
-			printf ("    bind-to-runtime-version\n");
-			printf ("    bitcode\n");
-			printf ("    data-outfile=\n");
-			printf ("    direct-icalls\n");
-			printf ("    direct-pinvokes=\n");
-			printf ("    direct-pinvoke-lists=\n");
-			printf ("    direct-pinvoke\n");
-			printf ("    dwarfdebug\n");
-			printf ("    full\n");
-			printf ("    hybrid\n");
-			printf ("    info\n");
-			printf ("    keep-temps\n");
-			printf ("    llvm\n");
-			printf ("    llvmonly\n");
-			printf ("    llvm-outfile=\n");
-			printf ("    llvm-path=\n");
-			printf ("    msym-dir=\n");
-			printf ("    mtriple\n");
-			printf ("    nimt-trampolines=\n");
-			printf ("    nodebug\n");
-			printf ("    no-direct-calls\n");
-			printf ("    no-write-symbols\n");
-			printf ("    nrgctx-trampolines=\n");
-			printf ("    nrgctx-fetch-trampolines=\n");
-			printf ("    ngsharedvt-trampolines=\n");
-			printf ("    nftnptr-arg-trampolines=\n");
-			printf ("    nunbox-arbitrary-trampolines=\n");
-			printf ("    ntrampolines=\n");
-			printf ("    outfile=\n");
-			printf ("    profile=\n");
-			printf ("    profile-only\n");
-			printf ("    mibc-profile=\n");
-			printf ("    print-skipped-methods\n");
-			printf ("    readonly-value=\n");
-			printf ("    save-temps\n");
-			printf ("    soft-debug\n");
-			printf ("    static\n");
-			printf ("    stats\n");
-			printf ("    temp-path=\n");
-			printf ("    tool-prefix=\n");
-			printf ("    threads=\n");
-			printf ("    write-symbols\n");
-			printf ("    verbose\n");
-			printf ("    allow-errors\n");
-			printf ("    no-opt\n");
-			printf ("    llvmopts=\n");
-			printf ("    llvmllc=\n");
-			printf ("    clangxx=\n");
-			printf ("    depfile=\n");
-			printf ("    mcpu=\n");
-			printf ("    mattr=\n");
-			printf ("    help/?\n");
+			printf ("    asmonly                              - \n");
+			printf ("    bind-to-runtime-version              - \n");
+			printf ("    bitcode                              - \n");
+			printf ("    data-outfile=<string>                - \n");
+			printf ("    direct-icalls                        - \n");
+			printf ("    direct-pinvokes=<string>             - Specific direct pinvokes to generate direct calls for an entire 'module' or specific 'module!entrypoint' separated by semi-colons. Incompatible with 'direct-pinvoke' option.\n");
+			printf ("    direct-pinvoke-lists=<string>        - Files containing specific direct pinvokes to generate direct calls for an entire 'module' or specific 'module!entrypoint' on separate lines. Incompatible with 'direct-pinvoke' option.\n");
+			printf ("    direct-pinvoke                       - Generate direct calls for all direct pinvokes encountered in the managed assembly.\n");
+			printf ("    dwarfdebug                           - \n");
+			printf ("    full                                 - \n");
+			printf ("    hybrid                               - \n");
+			printf ("    info                                 - \n");
+			printf ("    keep-temps                           - \n");
+			printf ("    llvm                                 - \n");
+			printf ("    llvmonly                             - \n");
+			printf ("    llvm-outfile=<string>                - \n");
+			printf ("    llvm-path=<string>                   - \n");
+			printf ("    msym-dir=<string>                    - \n");
+			printf ("    mtriple                              - \n");
+			printf ("    nimt-trampolines=<value>             - \n");
+			printf ("    nodebug                              - \n");
+			printf ("    no-direct-calls                      - \n");
+			printf ("    no-write-symbols                     - \n");
+			printf ("    nrgctx-trampolines=<value>           - \n");
+			printf ("    nrgctx-fetch-trampolines=<value>     - \n");
+			printf ("    ngsharedvt-trampolines=<value>       - \n");
+			printf ("    nftnptr-arg-trampolines=<value>      - \n");
+			printf ("    nunbox-arbitrary-trampolines=<value> - \n");
+			printf ("    ntrampolines=<value>                 - \n");
+			printf ("    outfile=<string>                     - \n");
+			printf ("    profile=<string>                     - \n");
+			printf ("    profile-only                         - \n");
+			printf ("    mibc-profile=<string>                - \n");
+			printf ("    print-skipped-methods                - \n");
+			printf ("    readonly-value=<value>               - \n");
+			printf ("    save-temps                           - \n");
+			printf ("    soft-debug                           - \n");
+			printf ("    static                               - \n");
+			printf ("    stats                                - \n");
+			printf ("    temp-path=<string>                   - \n");
+			printf ("    tool-prefix=<value>                  - \n");
+			printf ("    threads=<value>                      - \n");
+			printf ("    write-symbols                        - \n");
+			printf ("    verbose                              - \n");
+			printf ("    allow-errors                         - \n");
+			printf ("    no-opt                               - \n");
+			printf ("    llvmopts=<value>                     - \n");
+			printf ("    llvmllc=<value>                      - \n");
+			printf ("    clangxx=<value>                      - \n");
+			printf ("    depfile=<value>                      - \n");
+			printf ("    mcpu=<value>                         - \n");
+			printf ("    mattr=<value>                        - \n");
+			printf ("    help/?                                 \n");
 			exit (0);
 		} else {
 			fprintf (stderr, "AOT : Unknown argument '%s'.\n", arg);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14212,13 +14212,18 @@ typedef enum {
 static DirectPInvokeParsedResult
 parsed_direct_pinvoke (MonoAotCompile *acfg, char *dpi, char **module_name_ptr, char **entrypoint_name_ptr)
 {
-	DirectPInvokeParsedResult res = DIRECT_PINVOKE_SKIP;
+	DirectPInvokeParsedResult res = DIRECT_PINVOKE_PARSED;
 	char *direct_pinvoke = g_strdup (dpi);
-	if (!direct_pinvoke)
+	if (!direct_pinvoke) {
+		aot_printerrf (acfg, "Failed to strdup the direct pinvoke '%s'.\n", dpi);
+		res = DIRECT_PINVOKE_ERR;
 		goto early_exit;
+	}
 
-	if (!g_strstrip (direct_pinvoke))
+	if (!g_strstrip (direct_pinvoke)) {
+		res = DIRECT_PINVOKE_SKIP;
 		goto cleanup;
+	}
 
 	char **direct_pinvoke_split = g_strsplit (direct_pinvoke, "!", 2);
 	if (!direct_pinvoke_split) {
@@ -14227,7 +14232,6 @@ parsed_direct_pinvoke (MonoAotCompile *acfg, char *dpi, char **module_name_ptr, 
 		goto cleanup;
 	}
 
-	res = DIRECT_PINVOKE_PARSED;
 	*module_name_ptr = g_strdup (direct_pinvoke_split[0]);
 	if (!*module_name_ptr) {
 		aot_printerrf (acfg, "Failed to strdup the module name portion of direct pinvoke '%s'.\n", direct_pinvoke);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -13798,6 +13798,33 @@ got_info_free (GotInfo *info)
 }
 
 static void
+aot_opts_free (MonoAotOptions *aot_opts)
+{
+	g_free (aot_opts->outfile);
+	g_free (aot_opts->llvm_outfile);
+	g_free (aot_opts->data_outfile);
+	g_list_free (aot_opts->profile_files);
+	g_list_free (aot_opts->mibc_profile_files);
+	g_free (aot_opts->gen_msym_dir_path);
+	g_list_free (aot_opts->direct_pinvokes);
+	g_list_free (aot_opts->direct_pinvoke_lists);
+	g_free (aot_opts->dedup_include);
+	g_free (aot_opts->tool_prefix);
+	g_free (aot_opts->ld_flags);
+	g_free (aot_opts->ld_name);
+	g_free (aot_opts->mtriple);
+	g_free (aot_opts->llvm_path);
+	g_free (aot_opts->temp_path);
+	g_free (aot_opts->instances_logfile_path);
+	g_free (aot_opts->logfile);
+	g_free (aot_opts->llvm_opts);
+	g_free (aot_opts->llvm_llc);
+	g_free (aot_opts->llvm_cpu_attr);
+	g_free (aot_opts->clangxx);
+	g_free (aot_opts->depfile);
+}
+
+static void
 acfg_free (MonoAotCompile *acfg)
 {
 	mono_img_writer_destroy (acfg->w);
@@ -13839,6 +13866,7 @@ acfg_free (MonoAotCompile *acfg)
 	got_info_free (&acfg->llvm_got_info);
 	arch_free_unwind_info_section_cache (acfg);
 	mono_mempool_destroy (acfg->mempool);
+	aot_opts_free (&acfg->aot_opts);
 
 	method_to_external_icall_symbol_name = NULL;
 	g_free (acfg);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -207,7 +207,6 @@ typedef struct MonoAotOptions {
 	gboolean log_instances;
 	gboolean gen_msym_dir;
 	char *gen_msym_dir_path;
-	gboolean direct_pinvoke;
 	GList *direct_pinvokes;
 	GList *direct_pinvoke_lists;
 	gboolean direct_icalls;
@@ -6227,7 +6226,7 @@ is_direct_callable (MonoAotCompile *acfg, MonoMethod *method, MonoJumpInfo *patc
 		/* Cross assembly calls */
 		return method_is_externally_callable (acfg, patch_info->data.method);
 	} else if ((patch_info->type == MONO_PATCH_INFO_ICALL_ADDR_CALL && patch_info->data.method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)) {
-		if (acfg->aot_opts.direct_pinvoke)
+		if (mono_aot_direct_pinvoke_enabled_for_method (acfg, patch_info->data.method))
 			return TRUE;
 	} else if (patch_info->type == MONO_PATCH_INFO_ICALL_ADDR_CALL) {
 		if (acfg->aot_opts.direct_icalls)
@@ -8523,8 +8522,6 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			mini_debug_options.no_seq_points_compact_data = FALSE;
 			opts->gen_msym_dir = TRUE;
 			opts->gen_msym_dir_path = g_strdup (arg + strlen ("msym_dir="));
-		} else if (str_begins_with (arg, "direct-pinvoke")) {
-			opts->direct_pinvoke = TRUE;
 		} else if (str_begins_with (arg, "direct-pinvokes")) {
 			opts->direct_pinvokes = g_list_append (opts->direct_pinvokes, g_strdup (arg + strlen ("direct-pinvokes=")));
 		} else if (str_begins_with (arg, "direct-pinvoke-lists")) {
@@ -8643,7 +8640,6 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			printf ("    bitcode\n");
 			printf ("    data-outfile=\n");
 			printf ("    direct-icalls\n");
-			printf ("    direct-pinvoke\n");
 			printf ("    direct-pinvokes=\n");
 			printf ("    direct-pinvoke-lists=\n");
 			printf ("    dwarfdebug\n");
@@ -9156,7 +9152,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 		flags = (JitFlags)(flags | JIT_FLAG_LLVM_ONLY | JIT_FLAG_EXPLICIT_NULL_CHECKS);
 	if (acfg->aot_opts.no_direct_calls)
 		flags = (JitFlags)(flags | JIT_FLAG_NO_DIRECT_ICALLS);
-	if (acfg->aot_opts.direct_pinvoke)
+	if (acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_lists)
 		flags = (JitFlags)(flags | JIT_FLAG_DIRECT_PINVOKE);
 	if (acfg->aot_opts.interp)
 		flags = (JitFlags)(flags | JIT_FLAG_INTERP);
@@ -10175,7 +10171,7 @@ mono_aot_get_direct_call_symbol (MonoJumpInfoType type, gconstpointer data)
 			MonoMethod *method = (MonoMethod *)data;
 			if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
 				sym = lookup_icall_symbol_name_aot (method);
-			else if (llvm_acfg->aot_opts.direct_pinvoke)
+			else if (mono_aot_direct_pinvoke_enabled_for_method (llvm_acfg, method))
 				sym = get_pinvoke_import (llvm_acfg, method);
 		} else if (type == MONO_PATCH_INFO_JIT_ICALL_ID) {
 			MonoJitICallInfo const * const info = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -8532,19 +8532,19 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 		} else if (str_begins_with (arg, "direct-pinvokes=")) {
 			char *direct_pinvokes = g_strdup (arg + strlen ("direct-pinvokes="));
 			gchar *direct_pinvoke_ctx = NULL;
-			gchar *direct_pinvoke = strtok_r (direct_pinvokes, ",", direct_pinvoke_ctx);
+			gchar *direct_pinvoke = strtok_r (direct_pinvokes, ";", &direct_pinvoke_ctx);
 			while (direct_pinvoke) {
-				opts->direct_pinvokes = g_list_append (opts->direct_pinvoke, g_strdup (direct_pinvoke));
-				direct_pinvoke = strtok_r (NULL, ",", direct_pinvoke_ctx);
+				opts->direct_pinvokes = g_list_append (opts->direct_pinvokes, g_strdup (direct_pinvoke));
+				direct_pinvoke = strtok_r (NULL, ";", &direct_pinvoke_ctx);
 			}
 			g_free (direct_pinvokes);
 		} else if (str_begins_with (arg, "direct-pinvoke-lists=")) {
 			char *direct_pinvoke_lists = g_strdup (arg + strlen ("direct-pinvoke-lists="));
 			gchar *direct_pinvoke_list_ctx = NULL;
-			gchar *direct_pinvoke_list = strtok_r (direct_pinvoke_lists, ",", direct_pinvoke_list_ctx);
+			gchar *direct_pinvoke_list = strtok_r (direct_pinvoke_lists, ";", &direct_pinvoke_list_ctx);
 			while (direct_pinvoke_list) {
 				opts->direct_pinvoke_lists = g_list_append (opts->direct_pinvoke_lists, g_strdup (direct_pinvoke_list));
-				direct_pinvoke_list = strtok_r (NULL, ",", direct_pinvoke_list_ctx);
+				direct_pinvoke_list = strtok_r (NULL, ";", &direct_pinvoke_list_ctx);
 			}
 			g_free (direct_pinvoke_lists);
 		} else if (str_begins_with (arg, "direct-pinvoke")) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14341,8 +14341,11 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 		aot_printerrf (acfg, "The 'direct-pinvoke' flag, 'direct-pinvokes', and 'direct-pinvoke-lists' AOT options also require the 'static' AOT option.\n");
 		return 1;
 	}
-	if (acfg->aot_opts.direct_pinvoke && (acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_lists))
-		g_warning ("The 'direct-pinvoke' argument trumps specified 'direct-pinvokes' and 'direct-pinvoke-lists' arguments.\n");
+	if (acfg->aot_opts.direct_pinvoke && (acfg->aot_opts.direct_pinvokes || acfg->aot_opts.direct_pinvoke_lists)) {
+		aot_printerrf (acfg, "The 'direct-pinvoke' flag trumps specified 'direct-pinvokes' and 'direct-pinvoke-lists' arguments. Unset either the flag or the specific direct pinvoke arguments.\n");
+		return 1;
+	}
+
 	gboolean added_direct_pinvoke = TRUE;
 	if (acfg->aot_opts.direct_pinvokes) {
 		GList *l;

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -109,12 +109,12 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     /// <summary>
     /// PInvokes to call directly.
     /// </summary>
-    public string[] DirectPInvokes { get; set; } = Array.Empty<string>();
+    public ITaskItem[] DirectPInvokes { get; set; } = Array.Empty<ITaskItem>();
 
     /// <summary>
     /// File with list of PInvokes to call directly.
     /// </summary>
-    public string[] DirectPInvokeLists { get; set; } = Array.Empty<string>();
+    public ITaskItem[] DirectPInvokeLists { get; set; } = Array.Empty<ITaskItem>();
 
     /// <summary>
     /// Instructs the AOT compiler to emit DWARF debugging information.
@@ -386,7 +386,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
             foreach (var directPInvokeList in DirectPInvokeLists)
             {
-                if (!File.Exists(directPInvokeList))
+                if (!File.Exists(directPInvokeList.GetMetadata("FullPath")))
                     throw new LogAsErrorException($"Could not find file '{directPInvokeList}'.");
             }
         }
@@ -640,12 +640,16 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         if (DirectPInvokes.Length > 0)
         {
-            aotArgs.Add($"direct-pinvokes={string.Join(",", DirectPInvokes)}");
+            var directPInvokesSB = new StringBuilder("direct-pinvokes=");
+            Array.ForEach(DirectPInvokes, directPInvokeItem => directPInvokesSB.Append($"{directPInvokeItem.GetMetadata("Identity")};"));
+            aotArgs.Add(directPInvokesSB.ToString());
         }
 
         if (DirectPInvokeLists.Length > 0)
         {
-            aotArgs.Add($"direct-pinvoke-lists={string.Join(",", DirectPInvokeLists)}");
+            var directPInvokeListsSB = new StringBuilder("direct-pinvoke-lists=");
+            Array.ForEach(DirectPInvokeLists, directPInvokeListItem => directPInvokeListsSB.Append($"{directPInvokeListItem.GetMetadata("FullPath")};"));
+            aotArgs.Add(directPInvokeListsSB.ToString());
         }
 
         if (UseDwarfDebug)

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -107,12 +107,42 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public bool UseDirectPInvoke { get; set; }
 
     /// <summary>
-    /// PInvokes to call directly.
+    /// When this option is specified, the mono aot compiler will generate direct calls for only specified direct pinvokes.
+    /// Specified direct pinvokes can be in the format of 'module' to generate direct calls for all entrypoints in the module,
+    /// or 'module!entrypoint' to generate direct calls for individual entrypoints in a module. 'module' will trump 'module!entrypoint'.
+    /// For a direct call to be generated, the managed code must call the native function through a direct pinvoke, e.g.
+    ///
+    /// [DllImport("module", EntryPoint="entrypoint")]
+    /// public static extern <ret> ManagedName (arg)
+    ///
+    /// or
+    ///
+    /// [DllImport("module")]
+    /// public static extern <ret> entrypoint (arg)
+    ///
+    /// The native sources must be supplied in the direct pinvoke sources parammeter in the LibraryBuilder to generate a shared library.
+    /// If not using the LibraryBuilder, the native sources must be linked manually in the final executable or library.
+    /// This requires UseStaticLinking=true, can be used in conjunction with DirectPInvokeLists, but is incompatible with UseDirectPInvoke.
     /// </summary>
     public ITaskItem[] DirectPInvokes { get; set; } = Array.Empty<ITaskItem>();
 
     /// <summary>
-    /// List of files with list of PInvokes to call directly.
+    /// When this option is specified, the mono aot compiler will generate direct calls for only specified direct pinvokes in the provided files.
+    /// Specified direct pinvokes can be in the format of 'module' to generate direct calls for all entrypoints in the module,
+    /// or 'module!entrypoint' to generate direct calls for individual entrypoints in a module. 'module' will trump 'module!entrypoint'.
+    /// For a direct call to be generated, the managed code must call the native function through a direct pinvoke, e.g.
+    ///
+    /// [DllImport("module", EntryPoint="entrypoint")]
+    /// public static extern <ret> ManagedName (arg)
+    ///
+    /// or
+    ///
+    /// [DllImport("module")]
+    /// public static extern <ret> entrypoint (arg)
+    ///
+    /// The native sources must be supplied in the direct pinvoke sources parammeter in the LibraryBuilder to generate a shared library.
+    /// If not using the LibraryBuilder, the native sources must be linked manually in the final executable or library.
+    /// This requires UseStaticLinking=true, can be used in conjunction with DirectPInvokes, but is incompatible with UseDirectPInvoke.
     /// </summary>
     public ITaskItem[] DirectPInvokeLists { get; set; } = Array.Empty<ITaskItem>();
 

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -374,6 +374,11 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             throw new LogAsErrorException($"'{nameof(UseDirectIcalls)}' can only be used with '{nameof(UseStaticLinking)}=true'.");
         }
 
+        if (UseDirectPInvoke && (DirectPInvokes.Length > 0 || DirectPInvokeLists.Length > 0))
+        {
+            Log.LogWarning($"'{nameof(UseDirectPInvoke)}' is enabled and will trump '{nameof(DirectPInvokes)}' and '{nameof(DirectPInvokeLists)}'.");
+        }
+
         if (UseDirectPInvoke || DirectPInvokes.Length > 0 || DirectPInvokeLists.Length > 0)
         {
             if (!UseStaticLinking)

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -376,7 +376,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         if (UseDirectPInvoke && (DirectPInvokes.Length > 0 || DirectPInvokeLists.Length > 0))
         {
-            Log.LogWarning($"'{nameof(UseDirectPInvoke)}' is enabled and will trump '{nameof(DirectPInvokes)}' and '{nameof(DirectPInvokeLists)}'.");
+            throw new LogAsErrorException($"'{nameof(UseDirectPInvoke)}' flag trumps specified '{nameof(DirectPInvokes)}' and '{nameof(DirectPInvokeLists)}' arguments. Unset either the flag or the specific direct pinvoke arguments.");
         }
 
         if (UseDirectPInvoke || DirectPInvokes.Length > 0 || DirectPInvokeLists.Length > 0)

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -640,18 +640,12 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         if (DirectPInvokes.Length > 0)
         {
-            foreach (var directPInvoke in DirectPInvokes)
-            {
-                aotArgs.Add($"direct-pinvokes={directPInvoke}");
-            }
+            aotArgs.Add($"direct-pinvokes={string.Join(",", DirectPInvokes)}");
         }
 
         if (DirectPInvokeLists.Length > 0)
         {
-            foreach (var directPInvokeList in DirectPInvokeLists)
-            {
-                aotArgs.Add($"direct-pinvoke-lists={directPInvokeList}");
-            }
+            aotArgs.Add($"direct-pinvoke-lists={string.Join(",", DirectPInvokeLists)}");
         }
 
         if (UseDwarfDebug)

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -112,7 +112,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public ITaskItem[] DirectPInvokes { get; set; } = Array.Empty<ITaskItem>();
 
     /// <summary>
-    /// File with list of PInvokes to call directly.
+    /// List of files with list of PInvokes to call directly.
     /// </summary>
     public ITaskItem[] DirectPInvokeLists { get; set; } = Array.Empty<ITaskItem>();
 
@@ -641,7 +641,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         if (DirectPInvokes.Length > 0)
         {
             var directPInvokesSB = new StringBuilder("direct-pinvokes=");
-            Array.ForEach(DirectPInvokes, directPInvokeItem => directPInvokesSB.Append($"{directPInvokeItem.GetMetadata("Identity")};"));
+            Array.ForEach(DirectPInvokes, directPInvokeItem => directPInvokesSB.Append($"{directPInvokeItem.ItemSpec};"));
             aotArgs.Add(directPInvokesSB.ToString());
         }
 

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -650,7 +650,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         {
             foreach (var directPInvokeList in DirectPInvokeLists)
             {
-                aotArgs.Add($"direct-pinvoke-list={directPInvokeList}");
+                aotArgs.Add($"direct-pinvoke-lists={directPInvokeList}");
             }
         }
 

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -101,6 +101,12 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     public bool UseDirectIcalls { get; set; }
 
     /// <summary>
+    /// When this option is specified, P/Invoke methods are invoked directly instead of going through the operating system symbol lookup operation
+    /// This requires UseStaticLinking=true.
+    /// </summary>
+    public bool UseDirectPInvoke { get; set; }
+
+    /// <summary>
     /// PInvokes to call directly.
     /// </summary>
     public string[] DirectPInvokes { get; set; } = Array.Empty<string>();
@@ -368,10 +374,10 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             throw new LogAsErrorException($"'{nameof(UseDirectIcalls)}' can only be used with '{nameof(UseStaticLinking)}=true'.");
         }
 
-        if (DirectPInvokes.Length > 0 || DirectPInvokeLists.Length > 0)
+        if (UseDirectPInvoke || DirectPInvokes.Length > 0 || DirectPInvokeLists.Length > 0)
         {
             if (!UseStaticLinking)
-                throw new LogAsErrorException($"'{nameof(DirectPInvokes)}' and '{nameof(DirectPInvokeLists)}' can only be used with '{nameof(UseStaticLinking)}=true'.");
+                throw new LogAsErrorException($"'{nameof(UseDirectPInvoke)}', '{nameof(DirectPInvokes)}', and '{nameof(DirectPInvokeLists)}' can only be used with '{nameof(UseStaticLinking)}=true'.");
 
             foreach (var directPInvokeList in DirectPInvokeLists)
             {
@@ -620,6 +626,11 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         if (UseStaticLinking)
         {
             aotArgs.Add($"static");
+        }
+
+        if (UseDirectPInvoke)
+        {
+            aotArgs.Add($"direct-pinvoke");
         }
 
         if (DirectPInvokes.Length > 0)


### PR DESCRIPTION
Contributes to #79377

On Mono, the Managed/native Interop story does not facilitate a granular specification of which native libraries or entry points for generating direct pinvoke calls. Instead, there was only a blanket boolean flag to handle direct pinvoke logic. On the other hand, Native AOT allows [specification of which unmanaged libraries, entrypoints, or even files containing a list of such unmanaged libraries and entrypoints to generate direct pinvoke calls](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/interop.md). To expand the capabilities on mono, similar logic can be introduced to the mono aot compiler.

This PR does the following:
- Introduce direct-pinvokes and direct-pinvoke-list parameters to the mono aot compiler, hooked in by the MonoAOTCompiler Task
- Processes the passed in direct_pinvokes and direct_pinvoke_list values to generate a Hash Table mapping of modules:symbols-list to determine direct pinvoke calls
- Replaces the blanket direct-pinvoke flag logic with `mono_aot_direct_pinvoke_enabled_for_method` that compares the method being aot compiled with the direct-pinvoke Hash Table mapping