### PR TITLE
Refactoring store liveness update

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1219,8 +1219,7 @@ protected:
 
 #endif // !defined(TARGET_64BIT)
 
-    // Do liveness update for register produced by the current node in codegen after
-    // code has been emitted for it.
+    void genUpdateLifeStore(GenTree* tree, regNumber targetReg, LclVarDsc* varDsc);
     void genProduceReg(GenTree* tree);
     void genSpillLocal(unsigned varNum, var_types type, GenTreeLclVar* lclNode, regNumber regNum);
     void genUnspillLocal(

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1116,19 +1116,14 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
                 emitter* emit = GetEmitter();
                 emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
-
-                // Updating variable liveness after instruction was emitted
-                genUpdateLife(tree);
-
-                varDsc->SetRegNum(REG_STK);
             }
             else // store into register (i.e move into register)
             {
                 // Assign into targetReg when dataReg (from op1) is not the same register
                 inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
-
-                genProduceReg(tree);
             }
+
+            genUpdateLifeStore(tree, targetReg, varDsc);
         }
     }
 }

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2928,7 +2928,6 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
                 if (targetReg != REG_NA)
                 {
                     emit->emitIns_R_I(INS_movi, emitActualTypeSize(targetType), targetReg, 0x00, INS_OPTS_16B);
-                    genProduceReg(lclNode);
                 }
                 else
                 {
@@ -2941,8 +2940,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
                         assert(targetType == TYP_SIMD8);
                         GetEmitter()->emitIns_S_R(INS_str, EA_8BYTE, REG_ZR, varNum, 0);
                     }
-                    genUpdateLife(lclNode);
                 }
+                genUpdateLifeStore(lclNode, targetReg, varDsc);
                 return;
             }
             if (zeroInit)

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2971,18 +2971,13 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
             emitAttr    attr = emitActualTypeSize(targetType);
 
             emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
-
-            genUpdateLife(lclNode);
-
-            varDsc->SetRegNum(REG_STK);
         }
         else // store into register (i.e move into register)
         {
             // Assign into targetReg when dataReg (from op1) is not the same register
             inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
-
-            genProduceReg(lclNode);
         }
+        genUpdateLifeStore(lclNode, targetReg, varDsc);
     }
 }
 
@@ -5609,18 +5604,14 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
         // Simply use mov if we move a SIMD12 reg to another SIMD12 reg
         inst_Mov(treeNode->TypeGet(), targetReg, operandReg, /* canSkip */ true);
-        genProduceReg(treeNode);
     }
     else
     {
         // Need an additional integer register to extract upper 4 bytes from data.
         regNumber tmpReg = lclVar->GetSingleTempReg();
         GetEmitter()->emitStoreSIMD12ToLclOffset(varNum, offs, operandReg, tmpReg);
-
-        // Update life after instruction emitted
-        genUpdateLife(treeNode);
-        varDsc->SetRegNum(REG_STK);
     }
+    genUpdateLifeStore(treeNode, targetReg, varDsc);
 }
 
 #endif // FEATURE_SIMD

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -5575,8 +5575,9 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
     GenTreeLclVarCommon* lclVar = treeNode->AsLclVarCommon();
 
-    unsigned offs   = lclVar->GetLclOffs();
-    unsigned varNum = lclVar->GetLclNum();
+    unsigned   offs   = lclVar->GetLclOffs();
+    unsigned   varNum = lclVar->GetLclNum();
+    LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
     assert(varNum < compiler->lvaCount);
 
     GenTree* op1 = lclVar->gtGetOp1();
@@ -5591,6 +5592,10 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
         // Store upper 4 bytes
         GetEmitter()->emitIns_S_R(ins_Store(TYP_FLOAT), EA_4BYTE, REG_ZR, varNum, offs + 8);
+
+        // Update life after instruction emitted
+        genUpdateLife(treeNode);
+        varDsc->SetRegNum(REG_STK);
 
         return;
     }
@@ -5611,6 +5616,10 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
         // Need an additional integer register to extract upper 4 bytes from data.
         regNumber tmpReg = lclVar->GetSingleTempReg();
         GetEmitter()->emitStoreSIMD12ToLclOffset(varNum, offs, operandReg, tmpReg);
+
+        // Update life after instruction emitted
+        genUpdateLife(treeNode);
+        varDsc->SetRegNum(REG_STK);
     }
 }
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -8769,6 +8769,7 @@ void CodeGenInterface::VariableLiveKeeper::VariableLiveDescriptor::endLiveRangeA
     // Using [close, open) ranges so as to not compute the size of the last instruction
     m_VariableLiveRanges->back().m_EndEmitLocation.CaptureLocation(emit);
 
+    JITDUMP("Closing debug range.\n");
     // No m_EndEmitLocation has to be Valid
     noway_assert(m_VariableLiveRanges->back().m_EndEmitLocation.Valid());
 }

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2083,6 +2083,30 @@ void CodeGen::genSpillLocal(unsigned varNum, var_types type, GenTreeLclVar* lclN
 }
 
 //-------------------------------------------------------------------------
+// genProduceReg: Do liveness udpate after tree store instructions were
+// emitted, update result var's home if it was stored on stack.
+//
+// Arguments:
+//     tree        -  Gentree node
+//     targetReg   -  of the tree
+//     varDsc      -  result value's variable
+//
+// Return Value:
+//     None.
+void CodeGen::genUpdateLifeStore(GenTree* tree, regNumber targetReg, LclVarDsc* varDsc)
+{
+    if (targetReg != REG_NA)
+    {
+        genProduceReg(tree);
+    }
+    else
+    {
+        genUpdateLife(tree);
+        varDsc->SetRegNum(REG_STK);
+    }
+}
+
+//-------------------------------------------------------------------------
 // genProduceReg: do liveness update for register produced by the current
 // node in codegen after code has been emitted for it.
 //

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4789,8 +4789,6 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     assert(tree->OperIs(GT_STORE_LCL_FLD));
 
     var_types targetType = tree->TypeGet();
-    GenTree*  op1        = tree->gtGetOp1();
-
     noway_assert(targetType != TYP_STRUCT);
 
 #ifdef FEATURE_SIMD
@@ -4802,6 +4800,11 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     }
 #endif // FEATURE_SIMD
 
+    GenTree*   op1       = tree->gtGetOp1();
+    regNumber  targetReg = tree->GetRegNum();
+    unsigned   lclNum    = tree->GetLclNum();
+    LclVarDsc* varDsc    = compiler->lvaGetDesc(lclNum);
+
     assert(varTypeUsesFloatReg(targetType) == varTypeUsesFloatReg(op1));
     assert(genTypeSize(genActualType(targetType)) == genTypeSize(genActualType(op1->TypeGet())));
 
@@ -4809,19 +4812,14 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
 
     if (op1->OperIs(GT_BITCAST) && op1->isContained())
     {
-        regNumber targetReg  = tree->GetRegNum();
         GenTree*  bitCastSrc = op1->gtGetOp1();
         var_types srcType    = bitCastSrc->TypeGet();
         noway_assert(!bitCastSrc->isContained());
 
         if (targetReg == REG_NA)
         {
-            unsigned   lclNum = tree->GetLclNum();
-            LclVarDsc* varDsc = compiler->lvaGetDesc(lclNum);
-
             GetEmitter()->emitIns_S_R(ins_Store(srcType, compiler->isSIMDTypeLocalAligned(lclNum)),
                                       emitTypeSize(targetType), bitCastSrc->GetRegNum(), lclNum, tree->GetLclOffs());
-            varDsc->SetRegNum(REG_STK);
         }
         else
         {
@@ -4834,7 +4832,15 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     }
 
     // Updating variable liveness after instruction was emitted
-    genUpdateLife(tree);
+    if (targetReg != REG_NA)
+    {
+        genUpdateLife(tree);
+        varDsc->SetRegNum(REG_STK);
+    }
+    else
+    {
+        genProduceReg(tree);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -4906,8 +4912,6 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
             {
                 emit->emitIns_S_R(ins_Store(srcType, compiler->isSIMDTypeLocalAligned(lclNum)),
                                   emitTypeSize(targetType), bitCastSrc->GetRegNum(), lclNum, 0);
-                genUpdateLife(lclNode);
-                varDsc->SetRegNum(REG_STK);
             }
             else
             {
@@ -4919,7 +4923,6 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
             // stack store
             emit->emitInsStoreLcl(ins_Store(targetType, compiler->isSIMDTypeLocalAligned(lclNum)),
                                   emitTypeSize(targetType), lclNode);
-            varDsc->SetRegNum(REG_STK);
         }
         else
         {
@@ -4959,6 +4962,12 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
         if (targetReg != REG_NA)
         {
             genProduceReg(lclNode);
+        }
+        else
+        {
+            // Updating variable liveness after instruction was emitted
+            genUpdateLife(lclNode);
+            varDsc->SetRegNum(REG_STK);
         }
     }
 }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4830,17 +4830,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     {
         GetEmitter()->emitInsBinary(ins_Store(targetType), emitTypeSize(tree), tree, op1);
     }
-
-    // Updating variable liveness after instruction was emitted
-    if (targetReg != REG_NA)
-    {
-        genProduceReg(tree);
-    }
-    else
-    {
-        genUpdateLife(tree);
-        varDsc->SetRegNum(REG_STK);
-    }
+    genUpdateLifeStore(tree, targetReg, varDsc);
 }
 
 //------------------------------------------------------------------------
@@ -4959,16 +4949,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
                                 emitTypeSize(targetType));
             }
         }
-        // Updating variable liveness after instruction was emitted
-        if (targetReg != REG_NA)
-        {
-            genProduceReg(lclNode);
-        }
-        else
-        {
-            genUpdateLife(lclNode);
-            varDsc->SetRegNum(REG_STK);
-        }
+        genUpdateLifeStore(lclNode, targetReg, varDsc);
     }
 }
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4834,12 +4834,12 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     // Updating variable liveness after instruction was emitted
     if (targetReg != REG_NA)
     {
-        genUpdateLife(tree);
-        varDsc->SetRegNum(REG_STK);
+        genProduceReg(tree);
     }
     else
     {
-        genProduceReg(tree);
+        genUpdateLife(tree);
+        varDsc->SetRegNum(REG_STK);
     }
 }
 
@@ -4959,13 +4959,13 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
                                 emitTypeSize(targetType));
             }
         }
+        // Updating variable liveness after instruction was emitted
         if (targetReg != REG_NA)
         {
             genProduceReg(lclNode);
         }
         else
         {
-            // Updating variable liveness after instruction was emitted
             genUpdateLife(lclNode);
             varDsc->SetRegNum(REG_STK);
         }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4492,9 +4492,6 @@ void emitter::emitInsStoreLcl(instruction ins, emitAttr attr, GenTreeLclVarCommo
         assert(!data->isContained());
         emitIns_S_R(ins, attr, data->GetRegNum(), varNode->GetLclNum(), 0);
     }
-
-    // Updating variable liveness after instruction was emitted
-    codeGen->genUpdateLife(varNode);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -974,6 +974,12 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
         // Store upper 4 bytes
         GetEmitter()->emitIns_S_R(ins_Store(TYP_FLOAT), EA_4BYTE, operandReg, varNum, offs + 8);
+
+        // Update the life of treeNode
+        genUpdateLife(treeNode);
+
+        LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
+        varDsc->SetRegNum(REG_STK);
     }
 }
 

--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -938,8 +938,8 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 {
     assert((treeNode->OperGet() == GT_STORE_LCL_FLD) || (treeNode->OperGet() == GT_STORE_LCL_VAR));
 
+    treeNode->SetRegNum(REG_STK); // we always store the result on stack
     const GenTreeLclVarCommon* lclVar = treeNode->AsLclVarCommon();
-
     unsigned offs   = lclVar->GetLclOffs();
     unsigned varNum = lclVar->GetLclNum();
     assert(varNum < compiler->lvaCount);
@@ -964,6 +964,8 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
     // Store upper 4 bytes
     GetEmitter()->emitIns_S_R(ins_Store(TYP_FLOAT), EA_4BYTE, operandReg, varNum, offs + 8);
+    // do varDsc and liveness update
+    genUpdateLife(treeNode);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -946,16 +946,15 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
     GenTree* op1 = lclVar->gtOp1;
 
     assert(!op1->isContained());
-    regNumber targetReg  = treeNode->GetRegNum();
-    regNumber operandReg = genConsumeReg(op1);
+    regNumber  targetReg  = treeNode->GetRegNum();
+    regNumber  operandReg = genConsumeReg(op1);
+    LclVarDsc* varDsc     = compiler->lvaGetDesc(varNum);
 
     if (targetReg != REG_NA)
     {
         assert(!GetEmitter()->isGeneralRegister(targetReg));
 
         inst_Mov(treeNode->TypeGet(), targetReg, operandReg, /* canSkip */ true);
-
-        genProduceReg(treeNode);
     }
     else
     {
@@ -974,13 +973,9 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
         // Store upper 4 bytes
         GetEmitter()->emitIns_S_R(ins_Store(TYP_FLOAT), EA_4BYTE, operandReg, varNum, offs + 8);
-
-        // Update the life of treeNode
-        genUpdateLife(treeNode);
-
-        LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
-        varDsc->SetRegNum(REG_STK);
     }
+
+    genUpdateLifeStore(treeNode, targetReg, varDsc);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -940,8 +940,8 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 
     treeNode->SetRegNum(REG_STK); // we always store the result on stack
     const GenTreeLclVarCommon* lclVar = treeNode->AsLclVarCommon();
-    unsigned offs   = lclVar->GetLclOffs();
-    unsigned varNum = lclVar->GetLclNum();
+    unsigned                   offs   = lclVar->GetLclOffs();
+    unsigned                   varNum = lclVar->GetLclNum();
     assert(varNum < compiler->lvaCount);
 
     GenTree* op1 = lclVar->gtOp1;


### PR DESCRIPTION
Following up [79182](https://github.com/dotnet/runtime/pull/79182). When storing a variable means a spill, we are updating its liveness and setting the register to REG_STK. When the target is a register and not the stack, then we usually call genProduceReg which triggers the liveness update. This pr refactor similar code to avoid unintentional changes breaking either var home or var liveness, and fix one case on arm 64 which was not considered (emitIns_S_R and emitIns_R_I don't update var home).