### PR TITLE
Refactoring store liveness update

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1193,8 +1193,7 @@ protected:
 
 #endif // !defined(TARGET_64BIT)
 
-    // Do liveness update for register produced by the current node in codegen after
-    // code has been emitted for it.
+    void genUpdateLifeStore(GenTree* tree, regNumber targetReg, LclVarDsc* varDsc);
     void genProduceReg(GenTree* tree);
     void genSpillLocal(unsigned varNum, var_types type, GenTreeLclVar* lclNode, regNumber regNum);
     void genUnspillLocal(

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1116,19 +1116,14 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
                 emitter* emit = GetEmitter();
                 emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
-
-                // Updating variable liveness after instruction was emitted
-                genUpdateLife(tree);
-
-                varDsc->SetRegNum(REG_STK);
             }
             else // store into register (i.e move into register)
             {
                 // Assign into targetReg when dataReg (from op1) is not the same register
                 inst_Mov(targetType, targetReg, dataReg, /* canSkip */ true);
-
-                genProduceReg(tree);
             }
+
+            genUpdateLifeStore(tree, targetReg, varDsc);
         }
     }
 }

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2928,7 +2928,6 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
                 if (targetReg != REG_NA)
                 {
                     emit->emitIns_R_I(INS_movi, emitActualTypeSize(targetType), targetReg, 0x00, INS_OPTS_16B);
-                    genProduceReg(lclNode);
                 }
                 else
                 {
@@ -2941,8 +2940,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
                         assert(targetType == TYP_SIMD8);
                         GetEmitter()->emitIns_S_R(INS_str, EA_8BYTE, REG_ZR, varNum, 0);
                     }
-                    genUpdateLife(lclNode);
                 }
+                genUpdateLifeStore(lclNode, targetReg, varDsc);
                 return;
             }
             if (zeroInit)

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2084,6 +2084,30 @@ void CodeGen::genSpillLocal(unsigned varNum, var_types type, GenTreeLclVar* lclN
 }
 
 //-------------------------------------------------------------------------
+// genProduceReg: Do liveness udpate after tree store instructions were
+// emitted, update result var's home if it was stored on stack.
+//
+// Arguments:
+//     tree        -  Gentree node
+//     targetReg   -  of the tree
+//     varDsc      -  result value's variable
+//
+// Return Value:
+//     None.
+void CodeGen::genUpdateLifeStore(GenTree* tree, regNumber targetReg, LclVarDsc* varDsc)
+{
+    if (targetReg != REG_NA)
+    {
+        genProduceReg(tree);
+    }
+    else
+    {
+        genUpdateLife(tree);
+        varDsc->SetRegNum(REG_STK);
+    }
+}
+
+//-------------------------------------------------------------------------
 // genProduceReg: do liveness update for register produced by the current
 // node in codegen after code has been emitted for it.
 //

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4883,17 +4883,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     {
         GetEmitter()->emitInsBinary(ins_Store(targetType), emitTypeSize(tree), tree, op1);
     }
-
-    // Updating variable liveness after instruction was emitted
-    if (targetReg != REG_NA)
-    {
-        genProduceReg(tree);
-    }
-    else
-    {
-        genUpdateLife(tree);
-        varDsc->SetRegNum(REG_STK);
-    }
+    genUpdateLifeStore(tree, targetReg, varDsc);
 }
 
 //------------------------------------------------------------------------
@@ -5012,16 +5002,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
                                 emitTypeSize(targetType));
             }
         }
-        // Updating variable liveness after instruction was emitted
-        if (targetReg != REG_NA)
-        {
-            genProduceReg(lclNode);
-        }
-        else
-        {
-            genUpdateLife(lclNode);
-            varDsc->SetRegNum(REG_STK);
-        }
+        genUpdateLifeStore(lclNode, targetReg, varDsc);
     }
 }
 

--- a/src/coreclr/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/jit/simdcodegenxarch.cpp
@@ -238,6 +238,7 @@ void CodeGen::genStoreLclTypeSimd12(GenTreeLclVarCommon* treeNode)
 
     regNumber tgtReg  = treeNode->GetRegNum();
     regNumber dataReg = genConsumeReg(data);
+    LclVarDsc* varDsc     = compiler->lvaGetDesc(varNum);
 
     if (tgtReg != REG_NA)
     {
@@ -245,7 +246,6 @@ void CodeGen::genStoreLclTypeSimd12(GenTreeLclVarCommon* treeNode)
         assert(genIsValidFloatReg(tgtReg));
 
         inst_Mov(treeNode->TypeGet(), tgtReg, dataReg, /* canSkip */ true);
-        genProduceReg(treeNode);
     }
     else
     {
@@ -272,13 +272,9 @@ void CodeGen::genStoreLclTypeSimd12(GenTreeLclVarCommon* treeNode)
             // Store upper 4 bytes
             emit->emitIns_S_R(INS_movss, EA_4BYTE, tmpReg, varNum, offs + 8);
         }
-
-        // Update the life of treeNode
-        genUpdateLife(treeNode);
-
-        LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
-        varDsc->SetRegNum(REG_STK);
     }
+
+    genUpdateLifeStore(treeNode, tgtReg, varDsc);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Following up [79182](https://github.com/dotnet/runtime/pull/79182). When storing a variable means a spill, we are updating its liveness and setting the register to REG_STK. When the target is a register and not the stack, then we usually call genProduceReg which triggers the liveness update. This pr refactor similar code to avoid unintentional changes breaking either var home or var liveness and fix one case on arm 64 which was not considered (emitIns_S_R and emitIns_R_I don't update var home).