### PR TITLE
MacOS Ventura createdump fix - Part II

### DIFF
--- a/src/coreclr/debug/dbgutil/machoreader.h
+++ b/src/coreclr/debug/dbgutil/machoreader.h
@@ -55,7 +55,7 @@ public:
     bool EnumerateModules(mach_vm_address_t dyldInfoAddress);
 
 private:
-    bool CreateModule(const struct mach_header*	imageAddress, const char* imageFilePathAddress);
+    bool TryRegisterModule(const struct mach_header* imageAddress, const char* imageFilePathAddress, bool dylinker);
     bool ReadString(const char* address, std::string& str);
     virtual void VisitModule(MachOModule& module) { };
     virtual void VisitSegment(MachOModule& module, const segment_command_64& segment) { };


### PR DESCRIPTION
Need to ensure the symbol table and symbol string table for the dylinker module is part of the core dump for the dump readers. They still need to look up the "dyld_all_image_infos" symbol.