### PR TITLE
disable SslStream_AllowRenegotiation_False_Throws

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
@@ -70,6 +70,7 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [OuterLoop] // Test hits external azure server.
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77414", TestPlatforms.AnyUnix)]
         public async Task SslStream_AllowRenegotiation_False_Throws()
         {
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
contributes to  #77414
It feels like something changed with the test server. It does not behave as the test expect so the test fails reliably. 
Disabling for now so it does not break outerloop.