### PR TITLE
Avoid hydrating type system entities for all of CoreLib

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/CodeGen/MethodDelegator.CodeGen.cs
+++ b/src/coreclr/tools/Common/TypeSystem/CodeGen/MethodDelegator.CodeGen.cs
@@ -85,14 +85,6 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override bool IsRuntimeExport
-        {
-            get
-            {
-                return _wrappedMethod.IsRuntimeExport;
-            }
-        }
-
         public override bool IsSpecialName
         {
             get

--- a/src/coreclr/tools/Common/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
+++ b/src/coreclr/tools/Common/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
@@ -130,18 +130,6 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Gets a value specifying whether this method is an exported managed
-        /// entrypoint.
-        /// </summary>
-        public virtual bool IsRuntimeExport
-        {
-            get
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Gets a value specifying whether this method has special semantics.
         /// The name indicates the semantics.
         /// </summary>

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -30,7 +30,6 @@ namespace Internal.TypeSystem.Ecma
             public const int AttributeMetadataCache = 0x02000;
             public const int Intrinsic              = 0x04000;
             public const int UnmanagedCallersOnly   = 0x08000;
-            public const int RuntimeExport          = 0x10000;
         };
 
         private EcmaType _type;
@@ -201,14 +200,6 @@ namespace Internal.TypeSystem.Ecma
                             flags |= MethodFlags.UnmanagedCallersOnly;
                         }
                     }
-                    else
-                    if (metadataReader.StringComparer.Equals(namespaceHandle, "System.Runtime"))
-                    {
-                        if (metadataReader.StringComparer.Equals(nameHandle, "RuntimeExportAttribute"))
-                        {
-                            flags |= MethodFlags.RuntimeExport;
-                        }
-                    }
                 }
 
                 flags |= MethodFlags.AttributeMetadataCache;
@@ -338,14 +329,6 @@ namespace Internal.TypeSystem.Ecma
             get
             {
                 return (GetMethodFlags(MethodFlags.AttributeMetadataCache | MethodFlags.UnmanagedCallersOnly) & MethodFlags.UnmanagedCallersOnly) != 0;
-            }
-        }
-
-        public override bool IsRuntimeExport
-        {
-            get
-            {
-                return (GetMethodFlags(MethodFlags.AttributeMetadataCache | MethodFlags.RuntimeExport) & MethodFlags.RuntimeExport) != 0;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportedMethodsRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportedMethodsRootProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Reflection.Metadata;
 
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -24,14 +25,31 @@ namespace ILCompiler
         {
             get
             {
-                foreach (var type in _module.GetAllTypes())
+                MetadataReader reader = _module.MetadataReader;
+                MetadataStringComparer comparer = reader.StringComparer;
+                foreach (CustomAttributeHandle caHandle in reader.CustomAttributes)
                 {
-                    foreach (var method in type.GetMethods())
+                    CustomAttribute ca = reader.GetCustomAttribute(caHandle);
+                    if (ca.Parent.Kind != HandleKind.MethodDefinition)
+                        continue;
+
+                    if (!reader.GetAttributeNamespaceAndName(caHandle, out StringHandle nsHandle, out StringHandle nameHandle))
+                        continue;
+
+                    if (comparer.Equals(nameHandle, "RuntimeExportAttribute")
+                        && comparer.Equals(nsHandle, "System.Runtime"))
                     {
-                        EcmaMethod ecmaMethod = (EcmaMethod)method;
-                        if ((ecmaMethod.IsRuntimeExport && ecmaMethod.GetRuntimeExportName() != null) ||
-                            (ecmaMethod.IsUnmanagedCallersOnly && ecmaMethod.GetUnmanagedCallersOnlyExportName() != null))
-                            yield return ecmaMethod;
+                        var method = (EcmaMethod)_module.GetMethod(ca.Parent);
+                        if (method.GetRuntimeExportName() != null)
+                            yield return method;
+                    }
+
+                    if (comparer.Equals(nameHandle, "UnmanagedCallersOnlyAttribute")
+                        && comparer.Equals(nsHandle, "System.Runtime.InteropServices"))
+                    {
+                        var method = (EcmaMethod)_module.GetMethod(ca.Parent);
+                        if (method.GetRuntimeExportName() != null)
+                            yield return method;
                     }
                 }
             }
@@ -41,15 +59,15 @@ namespace ILCompiler
         {
             foreach (var ecmaMethod in ExportedMethods)
             {
-                if (ecmaMethod.IsRuntimeExport)
-                {
-                    string runtimeExportName = ecmaMethod.GetRuntimeExportName();
-                    rootProvider.AddCompilationRoot((MethodDesc)ecmaMethod, "Runtime export", runtimeExportName);
-                }
-                else if (ecmaMethod.IsUnmanagedCallersOnly)
+                if (ecmaMethod.IsUnmanagedCallersOnly)
                 {
                     string unmanagedCallersOnlyExportName = ecmaMethod.GetUnmanagedCallersOnlyExportName();
                     rootProvider.AddCompilationRoot((MethodDesc)ecmaMethod, "Native callable", unmanagedCallersOnlyExportName);
+                }
+                else
+                {
+                    string runtimeExportName = ecmaMethod.GetRuntimeExportName();
+                    rootProvider.AddCompilationRoot((MethodDesc)ecmaMethod, "Runtime export", runtimeExportName);
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportedMethodsRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportedMethodsRootProvider.cs
@@ -48,7 +48,7 @@ namespace ILCompiler
                         && comparer.Equals(nsHandle, "System.Runtime.InteropServices"))
                     {
                         var method = (EcmaMethod)_module.GetMethod(ca.Parent);
-                        if (method.GetRuntimeExportName() != null)
+                        if (method.GetUnmanagedCallersOnlyExportName() != null)
                             yield return method;
                     }
                 }


### PR DESCRIPTION
Instead of `foreach (TypeInModule) foreach (MethodOnType) CheckCustomAttribute` do a `foreach (CustomAttribute)`.

Saves about 30 ms wallclock time.

Cc @dotnet/ilc-contrib 