### PR TITLE
Make MethodDesc.IsStaticConstructor more efficient

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
@@ -130,6 +130,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool IsStaticConstructor
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public override MethodDesc GetMethodDefinition()
         {
             return _methodDef;

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDelegator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDelegator.cs
@@ -24,6 +24,7 @@ namespace Internal.TypeSystem
         public override Instantiation Instantiation => _wrappedMethod.Instantiation;
 
         public override bool IsDefaultConstructor => _wrappedMethod.IsDefaultConstructor;
+        public override bool IsStaticConstructor => _wrappedMethod.IsStaticConstructor;
 
         public override string Name => _wrappedMethod.Name;
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -519,7 +519,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets a value indicating whether this method is a static constructor.
         /// </summary>
-        public bool IsStaticConstructor
+        public virtual bool IsStaticConstructor
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -127,6 +127,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool IsStaticConstructor
+        {
+            get
+            {
+                return _typicalMethodDef.IsStaticConstructor;
+            }
+        }
+
         public override string Name
         {
             get

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -370,6 +370,14 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
+        public override bool IsStaticConstructor
+        {
+            get
+            {
+                return Attributes.IsRuntimeSpecialName() && Name == ".cctor";
+            }
+        }
+
         public MethodAttributes Attributes
         {
             get


### PR DESCRIPTION
This is called a lot from reflection-dataflow-related places and for most types we walk all the methods and then come up empty handed.

Cc @dotnet/ilc-contrib 