### PR TITLE
Skip nested types in `EcmaModule.GetType`

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -292,6 +292,9 @@ namespace Internal.TypeSystem.Ecma
                 foreach (var typeDefinitionHandle in metadataReader.TypeDefinitions)
                 {
                     var typeDefinition = metadataReader.GetTypeDefinition(typeDefinitionHandle);
+                    if (typeDefinition.Attributes.IsNested())
+                        continue;
+
                     if (stringComparer.Equals(typeDefinition.Name, name) &&
                         stringComparer.Equals(typeDefinition.Namespace, nameSpace))
                     {


### PR DESCRIPTION
Opened this methods because I saw it in the profiler, but I think this is a correctness issue. Might help perf. Didn't measure.

cc @dotnet/ilc-contrib 