### PR TITLE
add EventSource log to alpn on macOS

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -427,7 +427,7 @@ internal static partial class Interop
             }
         }
 
-        internal static unsafe bool SslCtxSetAlpnProtocol(SafeSslHandle ctx, SslApplicationProtocol protocol)
+        internal static unsafe int SslCtxSetAlpnProtocol(SafeSslHandle ctx, SslApplicationProtocol protocol)
         {
             int osStatus;
 
@@ -440,7 +440,7 @@ internal static partial class Interop
                 }
             }
 
-            return osStatus == 0;
+            return osStatus;
         }
 
         internal static byte[]? SslGetAlpnSelected(SafeSslHandle ssl)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -61,9 +61,17 @@ namespace System.Net.Security
                     ReadOnlySpan<byte> protocol = protocols.Slice(1, length);
                     if (protocol.SequenceCompareTo<byte>(applicationProtcol.Protocol.Span) == 0)
                     {
-                        if (Interop.AppleCrypto.SslCtxSetAlpnProtocol(context.SslContext, applicationProtcol))
+                        int osStatus = Interop.AppleCrypto.SslCtxSetAlpnProtocol(context.SslContext, applicationProtcol);
+                        if (osStatus == 0)
                         {
                             context.SelectedApplicationProtocol = applicationProtcol;
+                            if (NetEventSource.Log.IsEnabled())
+                                NetEventSource.Info(context, $"Selected '{applicationProtcol}' ALPN");
+                        }
+                        else
+                        {
+                            if (NetEventSource.Log.IsEnabled())
+                                NetEventSource.Error(context, $"Failed to set ALPN: {osStatus}");
                         }
 
                         // We ignore failure and we will move on with ALPN


### PR DESCRIPTION
follow-up on #79434 to address https://github.com/dotnet/runtime/pull/79434#issuecomment-1349519141
Hopefully, this should be enough to make it visible @davidfowl 

contributes to https://github.com/dotnet/runtime/issues/27727