### PR TITLE
Avoid touching `NameMangler` during scanning

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/CompilerComparer.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/CompilerComparer.cs
@@ -14,10 +14,9 @@ namespace ILCompiler.DependencyAnalysis
 
         public int Compare(ISortableNode x, ISortableNode y)
         {
-            if (x == y)
-            {
-                return 0;
-            }
+            if (x == y) return 0;
+            if (x == null) return -1;
+            if (y == null) return 1;
 
             int codeX = x.ClassCode;
             int codeY = y.ClassCode;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -65,6 +65,7 @@ namespace ILCompiler.DependencyAnalysis
         protected readonly TypeDesc _type;
         internal readonly EETypeOptionalFieldsBuilder _optionalFieldsBuilder = new EETypeOptionalFieldsBuilder();
         internal readonly EETypeOptionalFieldsNode _optionalFieldsNode;
+        private readonly WritableDataNode _writableDataNode;
         protected bool? _mightHaveInterfaceDispatchMap;
         private bool _hasConditionalDependenciesFromMetadataManager;
 
@@ -78,6 +79,7 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(!type.IsRuntimeDeterminedSubtype);
             _type = type;
             _optionalFieldsNode = new EETypeOptionalFieldsNode(this);
+            _writableDataNode = factory.Target.SupportsRelativePointers ? new WritableDataNode(type) : null;
             _hasConditionalDependenciesFromMetadataManager = factory.MetadataManager.HasConditionalDependenciesDueToEETypePresence(type);
 
             factory.TypeSystemContext.EnsureLoadableType(type);
@@ -971,16 +973,9 @@ namespace ILCompiler.DependencyAnalysis
 
         protected void OutputWritableData(NodeFactory factory, ref ObjectDataBuilder objData)
         {
-            if (factory.Target.SupportsRelativePointers)
+            if (_writableDataNode != null)
             {
-                Utf8StringBuilder writableDataBlobName = new Utf8StringBuilder();
-                writableDataBlobName.Append("__writableData");
-                writableDataBlobName.Append(factory.NameMangler.GetMangledTypeName(_type));
-
-                BlobNode blob = factory.UninitializedWritableDataBlob(writableDataBlobName.ToUtf8String(),
-                    WritableData.GetSize(factory.Target.PointerSize), WritableData.GetAlignment(factory.Target.PointerSize));
-
-                objData.EmitReloc(blob, RelocType.IMAGE_REL_BASED_RELPTR32);
+                objData.EmitReloc(_writableDataNode, RelocType.IMAGE_REL_BASED_RELPTR32);
             }
         }
 
@@ -1258,6 +1253,32 @@ namespace ILCompiler.DependencyAnalysis
                 return bytesEmitted / builder.TargetPointerSize;
             }
 
+        }
+
+        private sealed class WritableDataNode : ObjectNode, ISymbolDefinitionNode
+        {
+            private readonly TypeDesc _type;
+
+            public WritableDataNode(TypeDesc type) => _type = type;
+            public override ObjectNodeSection GetSection(NodeFactory factory) => ObjectNodeSection.BssSection;
+            public override bool StaticDependenciesAreComputed => true;
+            public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+                => sb.Append("__writableData").Append(nameMangler.GetMangledTypeName(_type));
+            public int Offset => 0;
+            public override bool IsShareable => true;
+
+            public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+                => new ObjectData(new byte[WritableData.GetSize(factory.Target.PointerSize)],
+                    Array.Empty<Relocation>(),
+                    WritableData.GetAlignment(factory.Target.PointerSize),
+                    new ISymbolDefinitionNode[] { this });
+
+            protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
+
+            public override int ClassCode => -5647893;
+
+            public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+                => comparer.Compare(_type, ((WritableDataNode)other)._type);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -656,7 +656,7 @@ namespace ILCompiler.DependencyAnalysis
                 (GenericDictionaryNode)factory.TypeGenericDictionary((TypeDesc)contextOwner) :
                 (GenericDictionaryNode)factory.MethodGenericDictionary((MethodDesc)contextOwner);
 
-            return factory.InterfaceDispatchCell(instantiatedMethod, dictionary.GetMangledName(factory.NameMangler));
+            return factory.InterfaceDispatchCell(instantiatedMethod, dictionary);
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellSectionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellSectionNode.cs
@@ -104,7 +104,7 @@ namespace ILCompiler.DependencyAnalysis
         private sealed class DispatchCellComparer : IComparer<InterfaceDispatchCellNode>
         {
             private readonly NodeFactory _factory;
-            private readonly TypeSystemComparer _comparer = TypeSystemComparer.Instance;
+            private readonly CompilerComparer _comparer = CompilerComparer.Instance;
 
             public DispatchCellComparer(NodeFactory factory)
             {
@@ -130,7 +130,7 @@ namespace ILCompiler.DependencyAnalysis
                 if (result != 0)
                     return result;
 
-                result = StringComparer.Ordinal.Compare(x.CallSiteIdentifier, y.CallSiteIdentifier);
+                result = _comparer.Compare(x.CallSiteIdentifier, y.CallSiteIdentifier);
                 if (result != 0)
                     return result;
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1562,7 +1562,7 @@ namespace Internal.JitInterface
                     pResult->codePointerOrStubLookup.constLookup.addr = (void*)ObjectToHandle(
                         _compilation.NodeFactory.InterfaceDispatchCell(targetMethod
 #if !SUPPORT_JIT
-                        , _compilation.NameMangler.GetMangledMethodName(MethodBeingCompiled).ToString()
+                        , _methodCodeNode
 #endif
                         ));
 #pragma warning restore SA1001, SA1113, SA1115 // Commas should be spaced correctly


### PR DESCRIPTION
When we're running in a scan-only mode (such as when running trimming tests), we were still computing mangled names for things because two nodes eagerly needed them. This structures things a bit differently so that we can finish scanning without ever touching the `NameMangler`.

This is also an improvement for end user scenarios because we really don't need them during scanning (we avoid the work), and we don't have to hold on to a useless string for who knows how many GC collections.

Cc @dotnet/ilc-contrib 