### PR TITLE
[mono] Fix crash when GetDelegateForFunctionPointer is passed non delegate type

### DIFF
--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -557,6 +557,11 @@ mono_ftnptr_to_delegate_impl (MonoClass *klass, gpointer ftn, MonoError *error)
 		MonoObjectHandle  this_obj;
 		int i;
 
+		if (!invoke) {
+			mono_error_set_argument_format (error, "t", "Type %s has no Invoke method.", m_class_get_name (klass));
+			goto leave;
+		}
+
 		if (use_aot_wrappers) {
 			wrapper = mono_marshal_get_native_func_wrapper_aot (klass);
 			this_obj = MONO_HANDLE_NEW (MonoObject, mono_value_box_checked (mono_defaults.int_class, &ftn, error));


### PR DESCRIPTION
When GetDelegateForFunctionPointer is invoked with non-delegate type, it iterates over all the methods available to check if these methods are present. "Invoke" method is one such method which is executed by the coreCLR for any type of delegates. Having said that with non-delegate's "Invoke" method is not supported hence "mono_class_get_method_from_name_checked" returns NULL. Handle this case whenever mono_class_get_method_from_name_checked returns NULL for any methods which are not supported.