### PR TITLE
JIT: Fix indir flags propagation for a couple of cases

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9239,7 +9239,7 @@ void Compiler::gtUpdateNodeOperSideEffects(GenTree* tree)
         tree->gtFlags &= ~GTF_EXCEPT;
         if (tree->OperIsIndirOrArrMetaData())
         {
-            tree->SetIndirExceptionFlags(this);
+            tree->gtFlags |= GTF_IND_NONFAULTING;
         }
     }
 
@@ -9986,9 +9986,12 @@ bool GenTree::Precedes(GenTree* other)
 // Arguments:
 //    comp  - compiler instance
 //
+// Remarks:
+//    This should only be used for reads.
+//
 void GenTree::SetIndirExceptionFlags(Compiler* comp)
 {
-    assert(OperIsIndirOrArrMetaData());
+    assert(OperIsIndirOrArrMetaData() && OperIsUnary());
 
     if (OperMayThrow(comp))
     {

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1593,7 +1593,16 @@ GenTree* Compiler::fgMorphStoreDynBlock(GenTreeStoreDynBlk* tree)
     }
 
     tree->SetAllEffectsFlags(tree->Addr(), tree->Data(), tree->gtDynamicSize);
-    tree->SetIndirExceptionFlags(this);
+
+    if (tree->OperMayThrow(this))
+    {
+        tree->gtFlags |= GTF_EXCEPT;
+    }
+    else
+    {
+        tree->gtFlags |= GTF_IND_NONFAULTING;
+    }
+
     tree->gtFlags |= GTF_ASG;
 
     return tree;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_79750/Runtime_79750.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_79750/Runtime_79750.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+class Runtime_79750
+{
+    static int Main(string[] args)
+    {
+        byte dest = 0;
+        byte source = 100;
+        uint size = GetSize();
+        Unsafe.CopyBlock(ref dest, ref GetAddr(ref source), size);
+
+        return dest;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ref byte GetAddr(ref byte a) => ref a;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint GetSize() => 1;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_79750/Runtime_79750.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_79750/Runtime_79750.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
SetIndirExceptionFlags expects only unary indirs (reads) and does not handle other cases correctly. Add an assert for it and fix the users.

Only fgMorphStoreDynBlock had the bug since gtUpdateNodeOperSideEffects assumes the caller will propagate effect flags from operands afterwards.

Extracted from #79346.

Fix #79750