### PR TITLE
[WIP][mono] Add ILLink vector substitutions

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoArmIntrinsics.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoArmIntrinsics.xml
@@ -1,6 +1,15 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Numerics.Vector">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
     <type fullname="System.Runtime.Intrinsics.Vector64">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Vector128">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Vector256">
       <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
     </type>
     <type fullname="System.Runtime.Intrinsics.Arm.AdvSimd">

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoX86Intrinsics.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoX86Intrinsics.xml
@@ -1,5 +1,14 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Numerics.Vector">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Vector64">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Vector128">
+      <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
+    </type>
     <type fullname="System.Runtime.Intrinsics.Vector256">
       <method signature="System.Boolean get_IsHardwareAccelerated()" body="stub" value="false" />
     </type>


### PR DESCRIPTION
Add ILLink substitutions to allow `Vector` classes trimming. Size reduction for iOS sample app should be 8%. Similar is done in https://github.com/dotnet/runtime/pull/79672.

Draft PR should confirm if the runtime works as expected.

cc @ivanpovazan 