### PR TITLE
Handle crash when [out] parameter of type Intptr* is passed to delegate

### DIFF
--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -2629,6 +2629,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 			case MONO_TYPE_SZARRAY:
 			case MONO_TYPE_CLASS:
 			case MONO_TYPE_VALUETYPE:
+			case MONO_TYPE_PTR:
 				mono_emit_marshal (m, i, invoke_sig->params [i], mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
 				break;
 			default:

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
@@ -13,6 +13,9 @@ public partial class FunctionPtr
 
         [DllImport(nameof(FunctionPointerNative))]
         public static extern bool CheckFcnPtr(IntPtr fcnptr);
+
+        [DllImport(nameof(FunctionPointerNative))]
+        static unsafe extern void FillOutPtr(IntPtr* p);
     }
 
     delegate void VoidDelegate();
@@ -56,12 +59,34 @@ public partial class FunctionPtr
         }
     }
 
+
+    [DllImport(nameof(FunctionPointerNative))]
+    static unsafe extern void FillOutPtr(IntPtr* p);
+
+    private unsafe delegate void DelegateToFillOutPtr([Out] IntPtr* p);
+
+    public static void RunGetDelForOutPtrTest()
+    {
+        Console.WriteLine($"Running {nameof(RunGetDelForOutPtrTest)}...");
+        IntPtr outVar = 0;
+        int expectedValue = 60;
+        unsafe
+        {
+            DelegateToFillOutPtr d = new DelegateToFillOutPtr(FillOutPtr);
+            IntPtr ptr = Marshal.GetFunctionPointerForDelegate(d);
+            DelegateToFillOutPtr OutPtrDelegate = Marshal.GetDelegateForFunctionPointer<DelegateToFillOutPtr>(ptr);
+            OutPtrDelegate(&outVar);
+        }
+        Assert.Equal(expectedValue, outVar);
+    }
+
     public static int Main()
     {
         try
         {
             RunGetDelForFcnPtrTest();
             RunGetFcnPtrSingleMulticastTest();
+            RunGetDelForOutPtrTest();
         }
         catch (Exception e)
         {

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointerNative.cpp
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointerNative.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <xplatform.h>
 #include <platformdefines.h>
+#include <stdint.h>
 
 namespace
 {
@@ -28,4 +29,9 @@ extern "C" DLL_EXPORT bool CheckFcnPtr(bool(STDMETHODCALLTYPE *fcnptr)(long long
     {
         return fcnptr(999999999999);
     }
+}
+
+extern "C" DLL_EXPORT void FillOutPtr(intptr_t *p)
+{
+    *p = 60;
 }

--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />


### PR DESCRIPTION
When a delegate is passed an [out] parameter of type "intptr *" it will crash since this data type is not handled in emit_managed_wrapper_ilgen. This will lead to a crash. With this fix [out] parameter of type "Intptr *" is handled after adding an addition case statement to handle MONO_TYPE_PTR in emit_managed_wrapper_ilgen. Supporting UT is added. 