### PR TITLE
Fix numbering of exposed `LCL_VAR`s

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8822,7 +8822,8 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                                              vnStore->VNForIntPtrCon(lcl->GetLclOffs()));
                         ValueNum loadVN = fgValueNumberByrefExposedLoad(lcl->TypeGet(), addrVN);
 
-                        lcl->gtVNPair.SetBoth(loadVN);
+                        lcl->gtVNPair.SetLiberal(loadVN);
+                        lcl->gtVNPair.SetConservative(vnStore->VNForExpr(compCurBB, lcl->TypeGet()));
                     }
                     else
                     {

--- a/src/tests/JIT/opt/ValueNumbering/ExposedLocalsNumbering.cs
+++ b/src/tests/JIT/opt/ValueNumbering/ExposedLocalsNumbering.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+unsafe class ExposedLocalsNumbering
+{
+    private static volatile bool s_mutateIndex;
+    private static volatile bool s_finished;
+    private static int* s_pIndex = (int*)NativeMemory.Alloc(4);
+
+    public static int Main()
+    {
+        const int RetryCount = 100;
+        const int UnsafeIndex = 1;
+
+        new Thread(_ =>
+        {
+            while (!s_finished)
+            {
+                if (s_mutateIndex)
+                {
+                    *s_pIndex = UnsafeIndex;
+                }
+            }
+        }).Start();
+
+        int[] array = new int[UnsafeIndex + 1];
+        array[UnsafeIndex] = 1;
+
+        int safeIndex = 0;
+        for (int i = 0; i < RetryCount; i++)
+        {
+            try
+            {
+                if (RunBoundsChecks(array.AsSpan(0, UnsafeIndex), &safeIndex) != 0)
+                {
+                    s_finished = true;
+                    return 101;
+                }
+            }
+            catch (IndexOutOfRangeException) { }
+        }
+
+        s_finished = true;
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int RunBoundsChecks(Span<int> span, int* pSafeIndex)
+    {
+        int result = 0;
+        int index = 0;
+        CaptureIndex(&index);
+
+        result += span[index];
+        result += span[index];
+        result += span[index];
+        result += span[index];
+
+        result += span[index];
+        result += span[index];
+        result += span[index];
+        result += span[index];
+
+        result += span[index];
+        result += span[index];
+        result += span[index];
+        result += span[index];
+
+        s_pIndex = pSafeIndex;
+        s_mutateIndex = false;
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CaptureIndex(int* pIndex)
+    {
+        s_pIndex = pIndex;
+        s_mutateIndex = true;
+    }
+}

--- a/src/tests/JIT/opt/ValueNumbering/ExposedLocalsNumbering.cs
+++ b/src/tests/JIT/opt/ValueNumbering/ExposedLocalsNumbering.cs
@@ -17,16 +17,23 @@ unsafe class ExposedLocalsNumbering
         const int RetryCount = 100;
         const int UnsafeIndex = 1;
 
-        new Thread(_ =>
+        try
         {
-            while (!s_finished)
+            new Thread(_ =>
             {
-                if (s_mutateIndex)
+                while (!s_finished)
                 {
-                    *s_pIndex = UnsafeIndex;
+                    if (s_mutateIndex)
+                    {
+                        *s_pIndex = UnsafeIndex;
+                    }
                 }
-            }
-        }).Start();
+            }).Start();
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return 100;
+        }
 
         int[] array = new int[UnsafeIndex + 1];
         array[UnsafeIndex] = 1;

--- a/src/tests/JIT/opt/ValueNumbering/ExposedLocalsNumbering.csproj
+++ b/src/tests/JIT/opt/ValueNumbering/ExposedLocalsNumbering.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JitNoCSE" Value="1" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2606,6 +2606,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_74635/Runtime_74635/**">
             <Issue>https://github.com/dotnet/runtime/issues/74687</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/ValueNumbering/ExposedLocalsNumbering/ExposedLocalsNumbering/**">
+            <Issue>https://github.com/dotnet/runtime/issues/80184</Issue>
+        </ExcludeList>
         <!-- End interpreter issues -->
     </ItemGroup>
 


### PR DESCRIPTION
The conservative VN must be unique for different uses lest we risk running into memory safety issues, by, e. g., removing range checks based on "racy" data.

It is very easy to reproduce bad codegen with this simple method and `JitNoCSE=1`:
```cs
[MethodImpl(MethodImplOptions.NoInlining)]
private static int Problem(int[] a, int b)
{
    JitUse(&b);
    return a[b] + a[b];
}
```
Assertion propagation removes the second check, which is not legal as `b`'s value may change once we get to it from the first check.

Diffs will be regressions; I see in some cases we did illegal bounds checks removal.