### PR TITLE
Create live publishing workflow

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,6 +9,7 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="$(RepositoryEngineeringDir)liveBuilds.targets" />
+  <Import Project="$(RepositoryEngineeringDir)livePublish.targets" Condition="'$(LivePublish)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)generators.targets" />
   <Import Project="$(RepositoryEngineeringDir)python.targets" />
   <Import Project="$(RepositoryEngineeringDir)resolveContract.targets" Condition="'$(IsSourceProject)' == 'true'" />

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -24,7 +24,7 @@
   <PropertyGroup>
     <CoreCLRSharedFrameworkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'sharedFramework'))</CoreCLRSharedFrameworkDir>
     <CoreCLRCrossgen2Dir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'crossgen2'))</CoreCLRCrossgen2Dir>
-    <CoreCLRILCompilerDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'ilc-published'))</CoreCLRILCompilerDir>
+    <CoreCLRILCompilerDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'ilc'))</CoreCLRILCompilerDir>
     <CoreCLRCrossILCompilerDir Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)'">$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', '$(BuildArchitecture)', 'ilc'))</CoreCLRCrossILCompilerDir>
     <CoreCLRAotSdkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'aotsdk'))</CoreCLRAotSdkDir>
     <CoreCLRBuildIntegrationDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'build'))</CoreCLRBuildIntegrationDir>
@@ -52,7 +52,6 @@
     <CoreCLRCrossTargetComponentDirName Condition="'$(TargetArchitecture)' == 'armel' and '$(BuildArchitecture)' != 'armel' and '$(TargetsLinux)' == 'true'">x64</CoreCLRCrossTargetComponentDirName>
 
     <AppHostSourcePath Condition="'$(UseLocalAppHostPack)' == 'true'">$([MSBuild]::NormalizePath('$(DotNetHostBinDir)', 'apphost$(ExeSuffix)'))</AppHostSourcePath>
-    <SingleFileHostSourcePath>$([MSBuild]::NormalizePath('$(CoreCLRArtifactsPath)', 'corehost', 'singlefilehost$(ExeSuffix)'))</SingleFileHostSourcePath>
   </PropertyGroup>
 
   <Target Name="ResolveRuntimeFilesFromLocalBuild">
@@ -223,6 +222,23 @@
           DependsOnTargets="
             ResolveLibrariesRefAssembliesFromLocalBuild;
             ResolveLibrariesRuntimeFilesFromLocalBuild" />
+
+  <!--
+  Native files that are always included in the singlefile bundle can be listed here.
+
+  Example:
+    <SingleFileHostIncludeFilename Include="somefile.dll" />
+  -->
+  <ItemGroup>
+    <!-- include at least one item. Otherwise there will be no opt-in list and everything will be included -->
+    <SingleFileHostIncludeFilename Include="NONE" />
+
+    <!-- LINUX -->
+
+    <!-- OSX -->
+
+    <!-- Windows -->
+  </ItemGroup>
 
   <PropertyGroup>
     <!-- Keep in sync with outputs defined in Microsoft.NETCore.Platforms.csproj. -->

--- a/eng/livePublish.targets
+++ b/eng/livePublish.targets
@@ -1,0 +1,43 @@
+<Project>
+
+  <PropertyGroup>
+    <SingleFileHostSourcePath>$([MSBuild]::NormalizePath('$(CoreCLRArtifactsPath)', 'corehost', 'singlefilehost$(ExeSuffix)'))</SingleFileHostSourcePath>
+    <StripSymbols>true</StripSymbols>
+  </PropertyGroup>
+
+  <!-- Native AOT live hosting configuration-->
+  <PropertyGroup>
+    <IlcToolsPath>$(CoreCLRILCompilerDir)</IlcToolsPath>
+    <IlcToolsPath Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)'">$(CoreCLRCrossILCompilerDir)</IlcToolsPath>
+    <CppCompilerAndLinker Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(HostOS)' == 'linux' and '$(RuntimeIdentifier)' == 'linux-musl-arm64'">clang-15</CppCompilerAndLinker>
+    <CppCompilerAndLinker Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(HostOS)' == 'linux' and '$(RuntimeIdentifier)' != 'linux-musl-arm64'">clang-9</CppCompilerAndLinker>
+    <SysRoot Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
+    <IlcBuildTasksPath>$(CoreCLRILCompilerDir)netstandard/ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
+    <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
+    <IlcFrameworkPath>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</IlcFrameworkPath>
+    <IlcFrameworkNativePath>$(MicrosoftNetCoreAppRuntimePackNativeDir)</IlcFrameworkNativePath>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
+  <Import Project="$(R2ROverridePath)" Condition="'$(R2ROverridePath)' != ''" />
+  <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.props"
+          Condition="'$(PublishAot)' == 'true' or Exists('$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.props')" />
+
+  <Target Name="PublishOnBuild"
+          Condition="'$(PublishOnBuild)' == 'true'"
+          AfterTargets="Build"
+          DependsOnTargets="Publish" />
+
+  <Target Name="RewriteRuntimePackDir"
+          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
+          BeforeTargets="ResolveRuntimePackAssets">
+      <ItemGroup>
+        <!-- Remove AspNetCore runtime pack since we don't build it locally -->
+        <ResolvedRuntimePack Remove="Microsoft.AspNetCore.App.Runtime.$(RuntimeIdentifier)" />
+
+        <ResolvedRuntimePack Update="Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)">
+          <PackageDirectory>$(MicrosoftNetCoreAppRuntimePackDir)</PackageDirectory>
+        </ResolvedRuntimePack>
+      </ItemGroup>
+  </Target>
+</Project>

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ILCompiler.Build.Tasks.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>ILCompiler.Build.Tasks</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>$(RuntimeBinDir)/ilc-published/netstandard</OutputPath>
+    <OutputPath>$(RuntimeBinDir)/ilc/netstandard</OutputPath>
     <Configurations>Debug;Release;Checked</Configurations>
     <PlatformTarget>AnyCPU</PlatformTarget>
 

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -4,30 +4,6 @@
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
   </PropertyGroup>
 
-  <Import Project="ILCompiler.props" />
+  <Import Project="$(MSBuildThisFileDirectory)ILCompiler.props" />
 
-
-  <!-- BEGIN: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
-    <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
-    <PublishTrimmed>true</PublishTrimmed>
-    <!-- Don't R2R on ARM64 machines because ARM64 crossgen2 that comes with .NET SDK <= 7.0 Preview 7 crashes.-->
-    <PublishReadyToRun Condition="'$(BuildArchitecture)' != 'arm64'">true</PublishReadyToRun>
-    <PublishSingleFile>true</PublishSingleFile>
-  </PropertyGroup>
-
-  <Target Name="PublishCompiler"
-          Condition="'$(BuildingInsideVisualStudio)' != 'true'"
-          AfterTargets="Build"
-          DependsOnTargets="Publish;StompSingleFileHostPath" />
-
-  <!--  HACK: liveBuilds stomps over SingleFileHostSourcePath, setting it to the host that we just built.
-        That's unfortunate because it's not the host we're supposed to use here. -->
-  <Target Name="StompSingleFileHostPath"
-          BeforeTargets="ResolveFrameworkReferences">
-    <PropertyGroup>
-      <SingleFileHostSourcePath></SingleFileHostSourcePath>
-    </PropertyGroup>
-  </Target>
-  <!-- END: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SelfContained>true</SelfContained>
+    <SelfContained>false</SelfContained>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseAppHost>true</UseAppHost>
   </PropertyGroup>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.props
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SelfContained>false</SelfContained>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseAppHost>true</UseAppHost>
   </PropertyGroup>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler_live.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler_live.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputPath>$(RuntimeBinDir)ilc_live</OutputPath>
+    <PublishOnBuild>true</PublishOnBuild>
+    <LivePublish>true</LivePublish>
+    <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
+    <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
+    <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
+    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <!-- If we can't publish AOT, publish trimmed single-file -->
+  <PropertyGroup Condition="'$(PublishAot)' != 'true'">
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)ILCompiler.props" />
+</Project>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -1,62 +1,9 @@
-<Project>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputPath>$(RuntimeBinDir)crossgen2</OutputPath>
-    <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
-    <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
-    <!-- Trimming is not currently working, but set the appropriate feature flags for NativeAOT -->
-    <PublishTrimmed Condition="'$(NativeAotSupported)' == 'true'">true</PublishTrimmed>
-    <RuntimeIdentifiers Condition="'$(_IsPublishing)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">linux-x64;linux-musl-x64;linux-arm;linux-musl-arm;linux-arm64;linux-musl-arm64;freebsd-x64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64;win-arm</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(PackageRID)</RuntimeIdentifiers>
-    <SelfContained>false</SelfContained>
-    <SelfContained Condition="'$(_IsPublishing)' == 'true'">true</SelfContained>
   </PropertyGroup>
 
   <Import Project="crossgen2.props" />
-
-  <PropertyGroup Condition="'$(NativeAotSupported)' != 'true'">
-    <PublishSingleFile>true</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <!-- Disable crossgen on NetBSD, illumos and Solaris for now. This can be revisited when we have full support. -->
-    <PublishReadyToRun Condition="'$(TargetOS)'=='NetBSD' Or '$(TargetOS)'=='illumos' Or '$(TargetOS)'=='Solaris'">false</PublishReadyToRun>
-    <!-- Disable crossgen on FreeBSD when cross building from Linux. -->
-    <PublishReadyToRun Condition="'$(TargetOS)'=='FreeBSD' and '$(CrossBuild)'=='true'">false</PublishReadyToRun>
-    <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
-  </PropertyGroup>
-
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-
-  <PropertyGroup Condition="'$(NativeAotSupported)' == 'true'">
-    <IlcToolsPath>$(CoreCLRILCompilerDir)</IlcToolsPath>
-    <IlcToolsPath Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)'">$(CoreCLRCrossILCompilerDir)</IlcToolsPath>
-    <CppCompilerAndLinker Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(HostOS)' == 'linux' and '$(RuntimeIdentifier)' == 'linux-musl-arm64'">clang-15</CppCompilerAndLinker>
-    <CppCompilerAndLinker Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(HostOS)' == 'linux' and '$(RuntimeIdentifier)' != 'linux-musl-arm64'">clang-9</CppCompilerAndLinker>
-    <SysRoot Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
-    <IlcBuildTasksPath>$(CoreCLRILCompilerDir)netstandard/ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
-    <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
-    <IlcFrameworkPath>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</IlcFrameworkPath>
-    <IlcFrameworkNativePath>$(MicrosoftNetCoreAppRuntimePackNativeDir)</IlcFrameworkNativePath>
-    <TrimmerSingleWarn>false</TrimmerSingleWarn>
-  </PropertyGroup>
-
-  <Import Project="$(R2ROverridePath)" Condition="'$(R2ROverridePath)' != ''" />
-  <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets"
-          Condition="'$(NativeAotSupported)' == 'true' and '$(_IsPublishing)' == 'true'" />
-
-  <Target Name="RewriteRuntimePackDir"
-          Condition="'$(_IsPublishing)' == 'true'"
-          DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
-          BeforeTargets="ResolveRuntimePackAssets">
-      <ItemGroup>
-        <!-- Remove AspNetCore runtime pack since we don't build it locally -->
-        <ResolvedRuntimePack Remove="Microsoft.AspNetCore.App.Runtime.$(RuntimeIdentifier)" />
-
-        <ResolvedRuntimePack Update="Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)">
-          <PackageDirectory>$(MicrosoftNetCoreAppRuntimePackDir)</PackageDirectory>
-        </ResolvedRuntimePack>
-      </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -16,10 +16,12 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EventSourceSupport>true</EventSourceSupport>
     <RunAnalyzers>false</RunAnalyzers>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup Label="Embedded Resources">
-    <EmbeddedResource Include="Properties\Resources.resx">
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Properties\Resources.resx">
       <GenerateSource>true</GenerateSource>
       <ClassName>System.SR</ClassName>
     </EmbeddedResource>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputPath>$(RuntimeBinDir)crossgen2_live</OutputPath>
+    <PublishOnBuild>true</PublishOnBuild>
+    <LivePublish>true</LivePublish>
+    <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
+    <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
+    <PublishAot Condition="'$(NativeAotSupported)' == 'true'">true</PublishAot>
+    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+    <StripSymbols>true</StripSymbols>
+  </PropertyGroup>
+
+  <!-- If we can't publish AOT, publish trimmed single-file -->
+  <PropertyGroup Condition="'$(PublishAot)' != 'true'">
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)crossgen2.props" />
+</Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -12,23 +12,6 @@
   </ItemGroup>
 
   <!--
-  Native files that are always included in the singlefile bundle can be listed here.
-
-  Example:
-    <SingleFileHostIncludeFilename Include="somefile.dll" />
-  -->
-  <ItemGroup>
-    <!-- include at least one item. Otherwise there will be no opt-in list and everything will be included -->
-    <SingleFileHostIncludeFilename Include="NONE" />
-
-    <!-- LINUX -->
-
-    <!-- OSX -->
-
-    <!-- Windows -->
-  </ItemGroup>
-
-  <!--
     Platform manifest needs to include all native shims from previous releases.
     This itemgroup adds them explicitly.
   -->

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -36,12 +36,12 @@
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())
               ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
               ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets" />
-              
+
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
              Targets="Publish;PublishItemsOutputGroup"
              Properties="PublishOnBuild=false
               ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
-              ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets" />
+              ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets">
       <Output TaskParameter="TargetOutputs"
               ItemName="_RawCrossgenPublishFiles" />
     </MSBuild>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -32,12 +32,16 @@
           SkipUnchangedFiles="true" />
 
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
-                Targets="Restore"
-                Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
-
+             Targets="Restore"
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())
+              ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
+              ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets" />
+              
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
              Targets="Publish;PublishItemsOutputGroup"
-             Properties="PublishOnBuild=false">
+             Properties="PublishOnBuild=false
+              ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
+              ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets" />
       <Output TaskParameter="TargetOutputs"
               ItemName="_RawCrossgenPublishFiles" />
     </MSBuild>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -34,14 +34,12 @@
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
              Targets="Restore"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())
-              ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
-              ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets" />
+              ;RuntimeArtifactsPath=$(RuntimeArtifactsPath)" />
 
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
              Targets="Publish;PublishItemsOutputGroup"
              Properties="PublishOnBuild=false
-              ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
-              ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets">
+              ;RuntimeArtifactsPath=$(RuntimeArtifactsPath)">
       <Output TaskParameter="TargetOutputs"
               ItemName="_RawCrossgenPublishFiles" />
     </MSBuild>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -23,26 +23,21 @@
   <Target Name="PublishCrossgen"
           BeforeTargets="GetFilesToPackage">
 
-    <!-- Copy System.Private.CoreLib from the coreclr bin directory to the runtime pack directory,
-         as we always need the copy of System.Private.CoreLib that matches exactly with the runtime. -->
-    <Copy SourceFiles="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll"
+    <!-- Copy System.Private.CoreLib from the coreclr bin directory to the runtime pack directory
+         if we're not using Native AOT, as we always need the copy of System.Private.CoreLib that
+         matches exactly with the runtime. -->
+    <Copy Condition="'$(NativeAotSupported)' != 'true'"
+          SourceFiles="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll"
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"
           SkipUnchangedFiles="true" />
 
-<MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2.csproj"
-             Targets="Restore"
-             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())
-              ;_IsPublishing=true
-              ;RuntimeIdentifier=$(PackageRID)
-              ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
-              ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets" />
+    <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
+                Targets="Restore"
+                Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
 
-    <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2.csproj"
+    <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
              Targets="Publish;PublishItemsOutputGroup"
-             Properties="_IsPublishing=true
-              ;RuntimeIdentifier=$(PackageRID)
-              ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)
-              ;R2ROverridePath=$(MSBuildThisFileDirectory)ReadyToRun.targets">
+             Properties="PublishOnBuild=false">
       <Output TaskParameter="TargetOutputs"
               ItemName="_RawCrossgenPublishFiles" />
     </MSBuild>
@@ -59,14 +54,14 @@
     <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
       <!-- Treat all native aot assets as native runtime assets -->
       <FilesToPackage Include="@(_CrossgenPublishFiles->Distinct())"
-                          Condition="'%(Extension)' != '.pdb'"
-                          TargetPath="tools/" />
+                      Condition="'%(Extension)' != '.pdb'"
+                      TargetPath="tools/" />
     </ItemGroup>
   </Target>
 
   <Target Name="RunPublishedCrossgen" AfterTargets="PublishCrossgen"
           Condition="'$(TargetOS)' == '$(HostOS)' and '$(TargetArchitecture)' == '$(BuildArchitecture)'">
-    <!-- Run the published crossgen if we're not cross-compiling -->
+    <!-- Run the published crossgen if we're not cross-compiling to check that it works. -->
     <Exec Command="@(FilesToPackage) $(CoreCLRArtifactsPath)IL/System.Private.CoreLib.dll --out $(IntermediateOutputPath)S.P.C.tmp" Condition="'%(FileName)%(Extension)' == 'crossgen2$(ExeSuffix)'">
       <Output TaskParameter="ExitCode" PropertyName="CrossgenExitCode" />
     </Exec>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -34,12 +34,12 @@
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
              Targets="Restore"
              Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid())
-              ;RuntimeArtifactsPath=$(RuntimeArtifactsPath)" />
+              ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)" />
 
     <MSBuild Projects="$(RepoRoot)src/coreclr/tools/aot/crossgen2/crossgen2_live.csproj"
              Targets="Publish;PublishItemsOutputGroup"
              Properties="PublishOnBuild=false
-              ;RuntimeArtifactsPath=$(RuntimeArtifactsPath)">
+              ;CoreCLRArtifactsPath=$(CoreCLRArtifactsPath)">
       <Output TaskParameter="TargetOutputs"
               ItemName="_RawCrossgenPublishFiles" />
     </MSBuild>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -144,6 +144,7 @@
     <CreateFrameworkListFile Files="@(RuntimePackLibFile);@(RuntimePackNativeFile)"
                              TargetFile="$(MicrosoftNetCoreAppRuntimePackDir)data\RuntimeList.xml"
                              TargetFilePrefixes="ref/;runtimes/"
+                             SingleFileHostIncludeFilenames="@(SingleFileHostIncludeFilename)"
                              RootAttributes="@(FrameworkListRootAttribute)" />
   </Target>
 


### PR DESCRIPTION
This PR attempts to create a dedicated live publishing workflow that many different projects can use to publish with live bits, specifically in self-contained scenarios. The two consumers right now are crossgen2 and ILC. The ILC binaries currently don't go anywhere (they don't ship in any packages), but they could if we decide to go that route.

The new suggested workflow would be to create a new dedicated project for publishing, which avoids potential headaches with shared assets from the original project. Then, setting the 'LivePublish' MSBuild variable should enable the Publish task to use live bits. Setting the 'PublishOnBuild' property to 'true' will let a project publish itself whenever build is executed.