### PR TITLE
Avoid boxing in DeferredDisposableLifetime

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/DeferredDisposableLifetime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/DeferredDisposableLifetime.cs
@@ -50,7 +50,7 @@ namespace System.Threading
                 int oldCount = Volatile.Read(ref _count);
 
                 // Have we been disposed?
-                ObjectDisposedException.ThrowIf(oldCount < 0, this);
+                ObjectDisposedException.ThrowIf(oldCount < 0, typeof(T));
 
                 int newCount = checked(oldCount + 1);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/DeferredDisposableLifetime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/DeferredDisposableLifetime.cs
@@ -50,7 +50,8 @@ namespace System.Threading
                 int oldCount = Volatile.Read(ref _count);
 
                 // Have we been disposed?
-                ObjectDisposedException.ThrowIf(oldCount < 0, typeof(T));
+                if (oldCount < 0)
+                    throw new ObjectDisposedException(typeof(T).ToString());
 
                 int newCount = checked(oldCount + 1);
 


### PR DESCRIPTION
Fixes #79774

`this` in this case is a struct, and `ObjectDisposedException` has two overloads
```c#
void ThrowIf(bool condition, object instance);
void ThrowIf(bool condition, Type type); 
```