### PR TITLE
Do less work when resolving members of types

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -8,6 +8,8 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace Internal.TypeSystem.Ecma
 {
     public partial class EcmaModule : ModuleDesc
@@ -374,6 +376,26 @@ namespace Internal.TypeSystem.Ecma
             if (field == null)
                 ThrowHelper.ThrowBadImageFormatException($"field expected for handle {handle}");
             return field;
+        }
+
+        internal EcmaField GetField(FieldDefinitionHandle handle, EcmaType owningType)
+        {
+            if (!_resolvedTokens.TryGetValue(handle, out IEntityHandleObject result))
+            {
+                Debug.Assert(_metadataReader.GetFieldDefinition(handle).GetDeclaringType() == owningType.Handle);
+                result = _resolvedTokens.AddOrGetExisting(new EcmaField(owningType, handle));
+            }
+            return (EcmaField)result;
+        }
+
+        internal EcmaMethod GetMethod(MethodDefinitionHandle handle, EcmaType owningType)
+        {
+            if (!_resolvedTokens.TryGetValue(handle, out IEntityHandleObject result))
+            {
+                Debug.Assert(_metadataReader.GetMethodDefinition(handle).GetDeclaringType() == owningType.Handle);
+                result = _resolvedTokens.AddOrGetExisting(new EcmaMethod(owningType, handle));
+            }
+            return (EcmaMethod)result;
         }
 
         public object GetObject(EntityHandle handle, NotFoundBehavior notFoundBehavior = NotFoundBehavior.Throw)

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -305,7 +305,7 @@ namespace Internal.TypeSystem.Ecma
         {
             foreach (var handle in _typeDefinition.GetMethods())
             {
-                yield return (EcmaMethod)_module.GetObject(handle);
+                yield return _module.GetMethod(handle, this);
             }
         }
 
@@ -316,7 +316,7 @@ namespace Internal.TypeSystem.Ecma
             {
                 MethodDefinition methodDef = reader.GetMethodDefinition(handle);
                 if ((methodDef.Attributes & MethodAttributes.Virtual) != 0)
-                    yield return (EcmaMethod)_module.GetObject(handle);
+                    yield return _module.GetMethod(handle, this);
             }
         }
 
@@ -329,7 +329,7 @@ namespace Internal.TypeSystem.Ecma
             {
                 if (stringComparer.Equals(metadataReader.GetMethodDefinition(handle).Name, name))
                 {
-                    var method = (EcmaMethod)_module.GetObject(handle);
+                    var method = _module.GetMethod(handle, this);
                     if (signature == null || signature.Equals(method.Signature.ApplySubstitution(substitution)))
                         return method;
                 }
@@ -349,7 +349,7 @@ namespace Internal.TypeSystem.Ecma
                 if (methodDefinition.Attributes.IsRuntimeSpecialName() &&
                     stringComparer.Equals(methodDefinition.Name, ".cctor"))
                 {
-                    var method = (EcmaMethod)_module.GetObject(handle);
+                    var method = _module.GetMethod(handle, this);
                     return method;
                 }
             }
@@ -372,7 +372,7 @@ namespace Internal.TypeSystem.Ecma
                 if (attributes.IsRuntimeSpecialName() && attributes.IsPublic()
                     && stringComparer.Equals(methodDefinition.Name, ".ctor"))
                 {
-                    var method = (EcmaMethod)_module.GetObject(handle);
+                    var method = _module.GetMethod(handle, this);
                     MethodSignature sig = method.Signature;
 
                     if (sig.Length != 0)
@@ -424,7 +424,7 @@ namespace Internal.TypeSystem.Ecma
         {
             foreach (var handle in _typeDefinition.GetFields())
             {
-                var field = (EcmaField)_module.GetObject(handle);
+                var field = _module.GetField(handle, this);
                 yield return field;
             }
         }
@@ -438,7 +438,7 @@ namespace Internal.TypeSystem.Ecma
 
                 foreach (var handle in _typeDefinition.GetFields())
                 {
-                    var field = (EcmaField)_module.GetObject(handle);
+                    var field = _module.GetField(handle, this);
                     if (!field.IsStatic)
                         return field.FieldType;
                 }
@@ -456,7 +456,7 @@ namespace Internal.TypeSystem.Ecma
             {
                 if (stringComparer.Equals(metadataReader.GetFieldDefinition(handle).Name, name))
                 {
-                    var field = (EcmaField)_module.GetObject(handle);
+                    var field = _module.GetField(handle, this);
                     return field;
                 }
             }
@@ -560,7 +560,7 @@ namespace Internal.TypeSystem.Ecma
                     // Note: GetOffset() returns -1 when offset was not set in the metadata
                     int specifiedOffset = fieldDefinition.GetOffset();
                     result.Offsets[index] =
-                        new FieldAndOffset((EcmaField)_module.GetObject(handle), specifiedOffset == -1 ? FieldAndOffset.InvalidOffset : new LayoutInt(specifiedOffset));
+                        new FieldAndOffset(_module.GetField(handle, this), specifiedOffset == -1 ? FieldAndOffset.InvalidOffset : new LayoutInt(specifiedOffset));
 
                     index++;
                 }


### PR DESCRIPTION
When constructing type system representation of a type member, we need two things - the token of the member, and type system representation of the owning type.

We have a couple places where we iterate members on a type - in those places, we already have a type system representation of the owning type. Shortcut the codepath that would recompute this information. This avoids finding the parent token of the token in metadata (this is an $O(log(N))$ operation) and the type system representation of the parent token (a hash table lookup, so $O(1)$ operation).

This kicks in quite often because a lot of `EcmaMethod`s are materialized as part of virtual method resolution when we iterate all virtual methods on a type.

Cc @dotnet/ilc-contrib 