### PR TITLE
Skip parsing types in ILLinkTrim.Descriptors if not needed

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ManifestResourceBlockingPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ManifestResourceBlockingPolicy.cs
@@ -109,6 +109,8 @@ namespace ILCompiler
             {
             }
 
+            protected override bool ShouldProcessTypes => false;
+
             public static HashSet<string> GetSubstitutions(TypeSystemContext context, XmlReader reader, ModuleDesc module, IReadOnlyDictionary<string, bool> featureSwitchValues)
             {
                 var rdr = new SubstitutionsReader(context, reader, module, featureSwitchValues);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessXmlBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessXmlBase.cs
@@ -129,9 +129,11 @@ namespace ILCompiler
             _reader.ReadEndElement();
         }
 
+        protected virtual bool ShouldProcessTypes => true;
+
         private void ProcessType(ModuleDesc assembly)
         {
-            if (ShouldProcessElement())
+            if (ShouldProcessElement() && ShouldProcessTypes)
             {
                 string typeName = _reader.GetAttribute("fullname");
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessXmlBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessXmlBase.cs
@@ -133,7 +133,7 @@ namespace ILCompiler
 
         private void ProcessType(ModuleDesc assembly)
         {
-            if (ShouldProcessElement() && ShouldProcessTypes)
+            if (ShouldProcessTypes && ShouldProcessElement())
             {
                 string typeName = _reader.GetAttribute("fullname");
 


### PR DESCRIPTION
We should not even be using this parser (#79802). It's surprisingly slow.

This saves about 10% of wallclock time when compiling Hello World (yes, I can't believe my measurements either). We parse the descriptors for the purposes of manifest resources pretty late in the single threaded phase and apparently there's a lot of things to parse that we don't care about.

Cc @dotnet/ilc-contrib 