### PR TITLE
Cache DocumentUrl in PortablePdbSymbolReader

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs
@@ -117,6 +117,21 @@ namespace Internal.TypeSystem.Ecma
             return kickoffMethod.IsNil ? 0 : MetadataTokens.GetToken(kickoffMethod);
         }
 
+        private Dictionary<DocumentHandle, string> _urlCache;
+
+        private string GetUrl(DocumentHandle handle)
+        {
+            lock (this)
+            {
+                _urlCache ??= new Dictionary<DocumentHandle, string>();
+                if (!_urlCache.TryGetValue(handle, out var url))
+                    _urlCache.Add(handle, url = _reader.GetString(_reader.GetDocument(handle).Name));
+
+                return url;
+            }
+        }
+
+
         public override IEnumerable<ILSequencePoint> GetSequencePointsForMethod(int methodToken)
         {
             var debugInformationHandle = ((MethodDefinitionHandle)MetadataTokens.EntityHandle(methodToken)).ToDebugInformationHandle();
@@ -140,7 +155,7 @@ namespace Internal.TypeSystem.Ecma
                 }
                 else
                 {
-                    url = _reader.GetString(_reader.GetDocument(sequencePoint.Document).Name);
+                    url = GetUrl(sequencePoint.Document);
                     previousDocumentHandle = sequencePoint.Document;
                     previousDocumentUrl = url;
                 }


### PR DESCRIPTION
This uses the exact same strategy as the unmanaged reader (`Dictionary` with a `lock` around `this` - wouldn't be my first choice, but we should use the same thing).

That was 100,000+ string allocations in a hello world:

![image](https://user-images.githubusercontent.com/13110571/208353051-c8a16a7a-daf2-473c-963c-b370c11917b0.png)

Cc @dotnet/ilc-contrib 