### PR TITLE
Use LockFreeReaderHashtable for some of the NodeCaches

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -164,9 +164,9 @@ namespace ILCompiler.DependencyAnalysis
 
         private void CreateNodeCaches()
         {
-            _typeSymbols = new NodeCache<TypeDesc, IEETypeNode>(CreateNecessaryTypeNode);
+            _typeSymbols = new NecessaryTypeSymbolHashtable(this);
 
-            _constructedTypeSymbols = new NodeCache<TypeDesc, IEETypeNode>(CreateConstructedTypeNode);
+            _constructedTypeSymbols = new ConstructedTypeSymbolHashtable(this);
 
             _clonedTypeSymbols = new NodeCache<TypeDesc, IEETypeNode>((TypeDesc type) =>
             {
@@ -253,7 +253,7 @@ namespace ILCompiler.DependencyAnalysis
                 return new PInvokeMethodFixupNode(methodData);
             });
 
-            _methodEntrypoints = new NodeCache<MethodDesc, IMethodNode>(CreateMethodEntrypointNode);
+            _methodEntrypoints = new MethodEntrypointHashtable(this);
 
             _unboxingStubs = new NodeCache<MethodDesc, IMethodNode>(CreateUnboxingStubNode);
 
@@ -479,7 +479,7 @@ namespace ILCompiler.DependencyAnalysis
             return new ReadyToRunGenericLookupFromTypeNode(this, helperKey.HelperId, helperKey.Target, helperKey.DictionaryOwner);
         }
 
-        protected virtual IEETypeNode CreateNecessaryTypeNode(TypeDesc type)
+        private IEETypeNode CreateNecessaryTypeNode(TypeDesc type)
         {
             Debug.Assert(!_compilationModuleGroup.ShouldReferenceThroughImportTable(type));
             if (_compilationModuleGroup.ContainsType(type))
@@ -507,7 +507,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected virtual IEETypeNode CreateConstructedTypeNode(TypeDesc type)
+        private IEETypeNode CreateConstructedTypeNode(TypeDesc type)
         {
             // Canonical definition types are *not* constructed types (call NecessaryTypeSymbol to get them)
             Debug.Assert(!type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
@@ -541,7 +541,23 @@ namespace ILCompiler.DependencyAnalysis
             return new ThreadStaticsNode(type, this);
         }
 
-        private NodeCache<TypeDesc, IEETypeNode> _typeSymbols;
+        private abstract class TypeSymbolHashtable : LockFreeReaderHashtable<TypeDesc, IEETypeNode>
+        {
+            protected readonly NodeFactory _factory;
+            public TypeSymbolHashtable(NodeFactory factory) => _factory = factory;
+            protected override bool CompareKeyToValue(TypeDesc key, IEETypeNode value) => key == value.Type;
+            protected override bool CompareValueToValue(IEETypeNode value1, IEETypeNode value2) => value1.Type == value2.Type;
+            protected override int GetKeyHashCode(TypeDesc key) => key.GetHashCode();
+            protected override int GetValueHashCode(IEETypeNode value) => value.Type.GetHashCode();
+        }
+
+        private sealed class NecessaryTypeSymbolHashtable : TypeSymbolHashtable
+        {
+            public NecessaryTypeSymbolHashtable(NodeFactory factory) : base(factory) { }
+            protected override IEETypeNode CreateValueFromKey(TypeDesc key) => _factory.CreateNecessaryTypeNode(key);
+        }
+
+        private NecessaryTypeSymbolHashtable _typeSymbols;
 
         public IEETypeNode NecessaryTypeSymbol(TypeDesc type)
         {
@@ -557,10 +573,16 @@ namespace ILCompiler.DependencyAnalysis
 
             Debug.Assert(!TypeCannotHaveEEType(type));
 
-            return _typeSymbols.GetOrAdd(type);
+            return _typeSymbols.GetOrCreateValue(type);
         }
 
-        private NodeCache<TypeDesc, IEETypeNode> _constructedTypeSymbols;
+        private sealed class ConstructedTypeSymbolHashtable : TypeSymbolHashtable
+        {
+            public ConstructedTypeSymbolHashtable(NodeFactory factory) : base(factory) { }
+            protected override IEETypeNode CreateValueFromKey(TypeDesc key) => _factory.CreateConstructedTypeNode(key);
+        }
+
+        private ConstructedTypeSymbolHashtable _constructedTypeSymbols;
 
         public IEETypeNode ConstructedTypeSymbol(TypeDesc type)
         {
@@ -571,7 +593,7 @@ namespace ILCompiler.DependencyAnalysis
 
             Debug.Assert(!TypeCannotHaveEEType(type));
 
-            return _constructedTypeSymbols.GetOrAdd(type);
+            return _constructedTypeSymbols.GetOrCreateValue(type);
         }
 
         private NodeCache<TypeDesc, IEETypeNode> _clonedTypeSymbols;
@@ -789,7 +811,18 @@ namespace ILCompiler.DependencyAnalysis
             return _stringAllocators.GetOrAdd(stringConstructor);
         }
 
-        protected NodeCache<MethodDesc, IMethodNode> _methodEntrypoints;
+        private sealed class MethodEntrypointHashtable : LockFreeReaderHashtable<MethodDesc, IMethodNode>
+        {
+            private readonly NodeFactory _factory;
+            public MethodEntrypointHashtable(NodeFactory factory) => _factory = factory;
+            protected override bool CompareKeyToValue(MethodDesc key, IMethodNode value) => key == value.Method;
+            protected override bool CompareValueToValue(IMethodNode value1, IMethodNode value2) => value1.Method == value2.Method;
+            protected override IMethodNode CreateValueFromKey(MethodDesc key) => _factory.CreateMethodEntrypointNode(key);
+            protected override int GetKeyHashCode(MethodDesc key) => key.GetHashCode();
+            protected override int GetValueHashCode(IMethodNode value) => value.Method.GetHashCode();
+        }
+
+        private MethodEntrypointHashtable _methodEntrypoints;
         private NodeCache<MethodDesc, IMethodNode> _unboxingStubs;
         private NodeCache<IMethodNode, MethodAssociatedDataNode> _methodAssociatedData;
 
@@ -800,7 +833,7 @@ namespace ILCompiler.DependencyAnalysis
                 return _unboxingStubs.GetOrAdd(method);
             }
 
-            return _methodEntrypoints.GetOrAdd(method);
+            return _methodEntrypoints.GetOrCreateValue(method);
         }
 
         public MethodAssociatedDataNode MethodAssociatedData(IMethodNode methodNode)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VirtualMethodUseNode.cs
@@ -22,6 +22,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private readonly MethodDesc _decl;
 
+        public MethodDesc Method => _decl;
+
         public VirtualMethodUseNode(MethodDesc decl)
         {
             Debug.Assert(!decl.IsRuntimeDeterminedExactMethod);


### PR DESCRIPTION
Not replacing everything because the only reason `LockFreeReaderHashtable` has better perf than `ConcurrentDictionary` is that the API surface is totally unergonomic. These nodes are the heaviest hitters.

I'm seeing ~4% wallclock time throughput improvement when compiling hello world. (Measured with ILC-compiled ILC, because getting stable-ish TP numbers with CoreCLR-hosted ILC has become impossible).

cc @dotnet/ilc-contrib 