### PR TITLE
Make sure that NS2.0 source generators are built

### DIFF
--- a/src/libraries/sfx-gen.proj
+++ b/src/libraries/sfx-gen.proj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- Filter ProjectReferences to build the best matching target framework only. -->
+    <FilterTraversalProjectReferences>true</FilterTraversalProjectReferences>
   </PropertyGroup>
 
   <!-- Reference all NetCoreAppCurrent shared framework generator projects. -->


### PR DESCRIPTION
97a51ccdb147992b80d427b83a77caa967d275b4 regressed the binplacing of source generators into the targeting pack as the `netstandard2.0` inner build is never chosen by the sfx-gen.proj traversal project. Noticed in the SDK consumption PR: https://github.com/dotnet/sdk/pull/29406