### PR TITLE
[release/6.0] [mono][interp] Add unbox when calling valuetype method through delegate

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3450,7 +3450,12 @@ main_loop:
 					} else if (del_imethod->method->flags & METHOD_ATTRIBUTE_VIRTUAL && !del->target && !m_class_is_valuetype (del_imethod->method->klass)) {
 						// 'this' is passed dynamically, we need to recompute the target method
 						// with each call
-						del_imethod = get_virtual_method (del_imethod, LOCAL_VAR (call_args_offset + MINT_STACK_SLOT_SIZE, MonoObject*)->vtable);
+						MonoObject *obj = LOCAL_VAR (call_args_offset + MINT_STACK_SLOT_SIZE, MonoObject*);
+						del_imethod = get_virtual_method (del_imethod, obj->vtable);
+						if (m_class_is_valuetype (obj->vtable->klass) && m_class_is_valuetype (del_imethod->method->klass)) {
+							// We are calling into a value type method, `this` needs to be unboxed
+							LOCAL_VAR (call_args_offset + MINT_STACK_SLOT_SIZE, gpointer) = mono_object_unbox_internal (obj);
+						}
 					} else {
 						del->interp_invoke_impl = del_imethod;
 					}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_79354/Runtime_79354.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_79354/Runtime_79354.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+
+public interface IGetContents {
+    (string, int, string) GetContents();
+}
+
+public struct MyStruct : IGetContents {
+    public string s1;
+    public int a;
+    public string s2;
+
+    public (string, int, string) GetContents()
+    {
+        return (s1, a, s2);
+    }
+}
+
+public class Program {
+
+    public delegate (string, int, string) MyDelegate(IGetContents arg);
+
+    public static int Main(string[] args)
+    {
+        MyStruct str = new MyStruct();
+        str.s1 = "test1";
+        str.a = 42;
+        str.s2 = "test2";
+
+        MethodInfo mi = typeof(IGetContents).GetMethod("GetContents");
+        MyDelegate func = (MyDelegate)mi.CreateDelegate(typeof(MyDelegate));
+
+        (string c1, int c2, string c3) = func(str);
+        if (c1 != "test1")
+            return 1;
+        if (c2 != 42)
+            return 2;
+        if (c3 != "test2")
+            return 3;
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_79354/Runtime_79354.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_79354/Runtime_79354.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2008,6 +2008,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/GC/Scenarios/FinalNStruct/finalnstruct/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_79354/Runtime_79354/**">
+            <Issue>https://github.com/dotnet/runtime/issues/57350</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Methodical/eh/interactions/strswitchfinal_do/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
If we are calling an open instance delegate, where the target method is on a valuetype, we will need to unbox this pointer.

Backport of https://github.com/dotnet/runtime/pull/79445

Fixes #79354

## Customer Impact

MAUI iOS applications making use of the popular `AutoMapper` NuGet library can crash in  debug builds. Workaround is to disable mono interpreter and implicitly hot reload. Other platforms using interpreter, like blazor wasm, can potentially hit this issue even in Release.

## Testing

Verified fix on sample app provided in the bug report and created a simple test case that is included in our suite.

## Risk

Low. The fix only touches the code path for a very specific type of delegate invocation pattern which was previously handled incorrectly before.