### PR TITLE
[mono][debugger] Fix Debugger.Break() behavior when running on release mode

### DIFF
--- a/src/mono/mono/component/debugger-stub.c
+++ b/src/mono/mono/component/debugger-stub.c
@@ -161,7 +161,8 @@ stub_debugger_end_exception_filter (MonoException *exc, MonoContext *ctx, MonoCo
 static void
 stub_debugger_user_break (void)
 {
-	G_BREAKPOINT ();
+	if (get_mini_debug_options ()->native_debugger_break)
+		G_BREAKPOINT ();
 }
 
 static void


### PR DESCRIPTION
If native_debugger_break is disabled do not call G_BREAKPOINT otherwise the app will be interrupted by a signal when running in release mode a code that has a Debugger.Break()

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1675269