### PR TITLE
Fix DAC hardware exception handling on Unix

### DIFF
--- a/src/coreclr/debug/daccess/CMakeLists.txt
+++ b/src/coreclr/debug/daccess/CMakeLists.txt
@@ -43,6 +43,10 @@ target_precompile_headers(daccess PRIVATE [["stdafx.h"]])
 
 add_dependencies(daccess eventing_headers)
 
+if(CLR_CMAKE_HOST_UNIX)
+  add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
+endif()
+
 if(CLR_CMAKE_HOST_FREEBSD OR CLR_CMAKE_HOST_NETBSD OR CLR_CMAKE_HOST_SUNOS)
   add_definitions(-DUSE_DAC_TABLE_RVA)
 

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -64,6 +64,7 @@ BOOL WINAPI DllMain(HANDLE instance, DWORD reason, LPVOID reserved)
         }
 
 #ifdef HOST_UNIX
+        PAL_SetInitializeDLLFlags(PAL_INITIALIZE_DLL | PAL_INITIALIZE_REGISTER_SIGNALS);
         int err = PAL_InitializeDLL();
         if(err != 0)
         {


### PR DESCRIPTION
Currently libmscordac doesn't install sigsegv handler and also isn't compiled with support for handling hardware exceptions in its native code. So when debugger ends up calling e.g.
`MethodTable::ValidateWithPossibleAV` and the passed in `MethodTable` is invalid, e.g. located in an unmapped region of memory, the sigsegv causes the debugger to abort. It was found when using the ClrMD in BnechmarkDotNet disassembler code which is trying to find if some constants in the code represent `MethodTable` or `MethodDesc`.

This change fixes it by setting the `PAL_INITIALIZE_REGISTER_SIGNALS` flag for `PAL_InitializeDLL` called from the mscordac's `DllMain` and adding the `FEATURE_ENABLE_HARDWARE_EXCEPTIONS` for the mscordac build.`