### PR TITLE
Fix ldarg_i test

### DIFF
--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_i.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ldarg_i.il
@@ -24,7 +24,6 @@
 	ldsflda		int32 _ldarg::FOO
 	ldc.i4		0x2
 	add
-	conv.i4
 	ldsflda		int32 _ldarg::FOO		
 	call	native int _ldarg::args(native int)
 	ceq


### PR DESCRIPTION
When changing the test recently, I have missed the conv.i4 that I should have removed from the preexisting code. The test was passing when `runincontext` was passed to the coreclr test run, so I have incorrectly assumed that it will work in regular runs too.