### PR TITLE
Fix size regression from enum sorting

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -98,9 +98,7 @@ namespace Internal.Reflection.Core.Execution
         // Other
         //==============================================================================================
         public abstract FieldAccessor CreateLiteralFieldAccessor(object value, RuntimeTypeHandle fieldTypeHandle);
-        public abstract EnumInfo<TUnderlyingValue> GetEnumInfo<TUnderlyingValue>(RuntimeTypeHandle typeHandle)
-            where TUnderlyingValue : struct, INumber<TUnderlyingValue>;
-
+        public abstract void GetEnumInfo(RuntimeTypeHandle typeHandle, out string[] names, out object[] values, out bool isFlags);
         public abstract IntPtr GetDynamicInvokeThunk(MethodInvoker invoker);
 
         //==============================================================================================

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -430,17 +430,17 @@ namespace System.Reflection.Runtime.General
 
         private class EnumUnderlyingTypeComparer : IComparer<object>
         {
-            public static EnumUnderlyingTypeComparer Instance = new EnumUnderlyingTypeComparer();
+            public readonly static EnumUnderlyingTypeComparer Instance = new EnumUnderlyingTypeComparer();
 
             public int Compare(object? x, object? y)
                 => x switch
                 {
-                    byte b => b.CompareTo((byte)y!),
-                    sbyte sb => sb.CompareTo((sbyte)y!),
-                    short s => s.CompareTo((short)y!),
-                    ushort us => us.CompareTo((ushort)y!),
                     int i => i.CompareTo((int)y!),
                     uint ui => ui.CompareTo((uint)y!),
+                    byte b => b.CompareTo((byte)y!),
+                    ushort us => us.CompareTo((ushort)y!),
+                    short s => s.CompareTo((short)y!),
+                    sbyte sb => sb.CompareTo((sbyte)y!),
                     long l => l.CompareTo((long)y!),
                     _ => ((ulong)x!).CompareTo((ulong)y!),
                 };

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -423,7 +423,7 @@ namespace System.Reflection.Runtime.General
             for (int i = 0; i < unsortedValues.Length; i++)
                 values[i] = (TUnderlyingValue)unsortedValues[i];
 
-            info = new EnumInfo<TUnderlyingValue>(type, values, unsortedNames, isFlags);
+            info = new EnumInfo<TUnderlyingValue>(RuntimeAugments.GetEnumUnderlyingType(runtimeType.TypeHandle), values, unsortedNames, isFlags);
             runtimeType.GenericCache = info;
             return info;
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -430,7 +430,7 @@ namespace System.Reflection.Runtime.General
 
         private class EnumUnderlyingTypeComparer : IComparer<object>
         {
-            public readonly static EnumUnderlyingTypeComparer Instance = new EnumUnderlyingTypeComparer();
+            public static readonly EnumUnderlyingTypeComparer Instance = new EnumUnderlyingTypeComparer();
 
             public int Compare(object? x, object? y)
                 => x switch

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -412,9 +412,38 @@ namespace System.Reflection.Runtime.General
             if (info != null)
                 return info;
 
-            info = ReflectionCoreExecution.ExecutionDomain.ExecutionEnvironment.GetEnumInfo<TUnderlyingValue>(runtimeType.TypeHandle);
+            ReflectionCoreExecution.ExecutionDomain.ExecutionEnvironment.GetEnumInfo(runtimeType.TypeHandle, out string[] unsortedNames, out object[] unsortedValues, out bool isFlags);
+
+            // Call into IntrospectiveSort directly to avoid the Comparer<T>.Default codepath.
+            // That codepath would bring functionality to compare everything that was ever allocated in the program.
+            ArraySortHelper<object, string>.IntrospectiveSort(unsortedValues, unsortedNames, EnumUnderlyingTypeComparer.Instance);
+
+            // Only after we've sorted, create the underlying array.
+            var values = new TUnderlyingValue[unsortedValues.Length];
+            for (int i = 0; i < unsortedValues.Length; i++)
+                values[i] = (TUnderlyingValue)unsortedValues[i];
+
+            info = new EnumInfo<TUnderlyingValue>(type, values, unsortedNames, isFlags);
             runtimeType.GenericCache = info;
             return info;
+        }
+
+        private class EnumUnderlyingTypeComparer : IComparer<object>
+        {
+            public static EnumUnderlyingTypeComparer Instance = new EnumUnderlyingTypeComparer();
+
+            public int Compare(object? x, object? y)
+                => x switch
+                {
+                    byte b => b.CompareTo((byte)y!),
+                    sbyte sb => sb.CompareTo((sbyte)y!),
+                    short s => s.CompareTo((short)y!),
+                    ushort us => us.CompareTo((ushort)y!),
+                    int i => i.CompareTo((int)y!),
+                    uint ui => ui.CompareTo((uint)y!),
+                    long l => l.CompareTo((long)y!),
+                    _ => ((ulong)x!).CompareTo((ulong)y!),
+                };
         }
 
         public sealed override DynamicInvokeInfo GetDelegateDynamicInvokeInfo(Type type)


### PR DESCRIPTION
Use a specialized comparer instead of `Comparer<T>.Default` that brings the implementation of `IComparable.ComparerTo` on everything. Also get rid of the generic virtual method call.

Saves 0.9% on Hello World.

Contributes to #79437.