### PR TITLE
Make DacValidateMD more resilient to invalid MethodDesc

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -194,7 +194,12 @@ BOOL DacValidateMD(PTR_MethodDesc pMD)
         PTR_MethodTable pMethodTable = pMD->GetMethodTable();
 
         // Standard fast check
-        if (!pMethodTable->ValidateWithPossibleAV())
+        if ((pMethodTable == NULL) || dac_cast<TADDR>(pMethodTable) == (TADDR)-1)
+        {
+            retval = FALSE;
+        }
+
+        if (retval && !pMethodTable->ValidateWithPossibleAV())
         {
             retval = FALSE;
         }


### PR DESCRIPTION
The DacValidateMD is not resilient to invalid MethodDesc that contains NULL in its m_pMethTab field. It was found when using the ClrMD in the BenchmarkDotNet disassembler code which is trying to find if some constants in the code represent MethodDesc so that it can dump the related method name.

This change fixes it by checking the MethodTable after it is extracted from the MethodDesc. There are two values that are not translated between the target and the debugger sides - NULL and -1. So I have added handling both as invalid there.