### PR TITLE
createdump: only dump committed memory

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -58,7 +58,8 @@ private:
     vm_map_t m_task;                                // the mach task for the process
 #else
     bool m_canUseProcVmReadSyscall;
-    int m_fd;                                       // /proc/<pid>/mem handle
+    int m_fdMem;                                    // /proc/<pid>/mem handle
+    int m_fdPagemap;                                // /proc/<pid>/pagemap handle
 #endif
     std::string m_coreclrPath;                      // the path of the coreclr module or empty if none
     uint64_t m_runtimeBaseAddress;
@@ -158,7 +159,8 @@ private:
     void AddOrReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, ULONG64 size, const std::string& pszName);
     int InsertMemoryRegion(const MemoryRegion& region);
     uint32_t GetMemoryRegionFlags(uint64_t start);
-    bool ValidRegion(const MemoryRegion& region);
+    bool PageCanBeRead(uint64_t start);
+    bool PageMappedToPhysicalMemory(uint64_t start);
     void Trace(const char* format, ...);
     void TraceVerbose(const char* format, ...);
 };

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -19,8 +19,8 @@ CrashInfo::Initialize()
     char memPath[128];
     _snprintf_s(memPath, sizeof(memPath), sizeof(memPath), "/proc/%lu/mem", m_pid);
 
-    m_fd = open(memPath, O_RDONLY);
-    if (m_fd == -1)
+    m_fdMem = open(memPath, O_RDONLY);
+    if (m_fdMem == -1)
     {
         int err = errno;
         const char* message = "Problem accessing memory";
@@ -35,6 +35,15 @@ CrashInfo::Initialize()
         printf_error("%s: open(%s) FAILED %s (%d)\n", message, memPath, strerror(err), err);
         return false;
     }
+
+    char pagemapPath[128];
+    _snprintf_s(pagemapPath, sizeof(pagemapPath), sizeof(pagemapPath), "/proc/%lu/pagemap", m_pid);
+    m_fdPagemap = open(pagemapPath, O_RDONLY);
+    if (m_fdPagemap == -1)
+    {
+        TRACE("open(%s) FAILED %d (%s), will fallback to dumping all memory regions without checking if they are committed\n", pagemapPath, errno, strerror(errno));
+    }
+
     // Get the process info
     if (!GetStatus(m_pid, &m_ppid, &m_tgid, &m_name))
     {
@@ -57,10 +66,15 @@ CrashInfo::CleanupAndResumeProcess()
             waitpid(thread->Tid(), &waitStatus, __WALL);
         }
     }
-    if (m_fd != -1)
+    if (m_fdMem != -1)
     {
-        close(m_fd);
-        m_fd = -1;
+        close(m_fdMem);
+        m_fdMem = -1;
+    }
+    if (m_fdPagemap != -1)
+    {
+        close(m_fdPagemap);
+        m_fdPagemap = -1;
     }
 }
 
@@ -443,8 +457,8 @@ CrashInfo::ReadProcessMemory(void* address, void* buffer, size_t size, size_t* r
         // After all, the use of process_vm_readv is largely as a
         // performance optimization.
         m_canUseProcVmReadSyscall = false;
-        assert(m_fd != -1);
-        *read = pread64(m_fd, buffer, size, (off64_t)address);
+        assert(m_fdMem != -1);
+        *read = pread64(m_fdMem, buffer, size, (off64_t)address);
     }
 
     if (*read == (size_t)-1)


### PR DESCRIPTION
Dumping memory regions as they are listed in `/proc/pid/maps` results in increase of RAM usage of the target application on some Linux kernels.

This change uses `/proc/pid/pagemap` to check if the page is committed before adding it to the regions list. As the file is not available on kernels 4.0 and 4.1 without elevated permissions there's a fallback to previous behavior.

Fixes #71472