### PR TITLE
Avoid a race condition in restoring the GenerateHWIntrinsicTests_* projects

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/Directory.Build.targets
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Directory.Build.targets
@@ -12,7 +12,7 @@
           Inputs="$(MSBuildAllProjects);$(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_Arm.cs"
           Outputs="$(GeneratedHWIntrinsicTestListFile)"
           Condition="'$(Language)' == 'C#'">
-    <Exec Command="$(DotNetCli) build $(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_Arm.csproj -c $(Configuration) /p:IntermediateOutputPath=$(IntermediateOutputPath)/GenerateHWIntrinsicTests/ /p:OutputPath=$(OutputPath)/GenerateHWIntrinsicTests/" />
+    <Exec Command="$(DotNetCli) build $(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_Arm.csproj -c $(Configuration) --no-restore /p:IntermediateOutputPath=$(IntermediateOutputPath)/GenerateHWIntrinsicTests/ /p:OutputPath=$(OutputPath)/GenerateHWIntrinsicTests/" />
     <Exec Command="$(DotNetCli) exec $(OutputPath)/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_Arm.dll $(MSBuildProjectName) $(MSBuildThisFileDirectory)Shared $(GeneratedHWIntrinsicTestDirectory) $(GeneratedHWIntrinsicTestListFile)" />
   </Target>
 

--- a/src/tests/JIT/HardwareIntrinsics/General/Directory.Build.targets
+++ b/src/tests/JIT/HardwareIntrinsics/General/Directory.Build.targets
@@ -12,7 +12,7 @@
           Inputs="$(MSBuildAllProjects);$(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_General.cs"
           Outputs="$(GeneratedHWIntrinsicTestListFile)"
           Condition="'$(Language)' == 'C#'">
-    <Exec Command="$(DotNetCli) build $(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_General.csproj -c $(Configuration) /p:IntermediateOutputPath=$(IntermediateOutputPath)/GenerateHWIntrinsicTests/ /p:OutputPath=$(OutputPath)/GenerateHWIntrinsicTests/" />
+    <Exec Command="$(DotNetCli) build $(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_General.csproj -c $(Configuration) --no-restore /p:IntermediateOutputPath=$(IntermediateOutputPath)/GenerateHWIntrinsicTests/ /p:OutputPath=$(OutputPath)/GenerateHWIntrinsicTests/" />
     <Exec Command="$(DotNetCli) exec $(OutputPath)/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_General.dll $(MSBuildProjectName) $(MSBuildThisFileDirectory)Shared $(GeneratedHWIntrinsicTestDirectory) $(GeneratedHWIntrinsicTestListFile)" />
   </Target>
 

--- a/src/tests/JIT/HardwareIntrinsics/X86/Directory.Build.targets
+++ b/src/tests/JIT/HardwareIntrinsics/X86/Directory.Build.targets
@@ -12,7 +12,7 @@
           Inputs="$(MSBuildAllProjects);$(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_X86.cs"
           Outputs="$(GeneratedHWIntrinsicTestListFile)"
           Condition="'$(Language)' == 'C#'">
-    <Exec Command="$(DotNetCli) build $(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_X86.csproj -c $(Configuration) /p:IntermediateOutputPath=$(IntermediateOutputPath)/GenerateHWIntrinsicTests/ /p:OutputPath=$(OutputPath)/GenerateHWIntrinsicTests/" />
+    <Exec Command="$(DotNetCli) build $(RepoRoot)/src/tests/Common/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_X86.csproj -c $(Configuration) --no-restore /p:IntermediateOutputPath=$(IntermediateOutputPath)/GenerateHWIntrinsicTests/ /p:OutputPath=$(OutputPath)/GenerateHWIntrinsicTests/" />
     <Exec Command="$(DotNetCli) exec $(OutputPath)/GenerateHWIntrinsicTests/GenerateHWIntrinsicTests_X86.dll $(MSBuildProjectName) $(MSBuildThisFileDirectory)Shared $(GeneratedHWIntrinsicTestDirectory) $(GeneratedHWIntrinsicTestListFile)" />
   </Target>
 


### PR DESCRIPTION
This resolves #79843 