### PR TITLE
[release/7.0] Prevent warning for implicit ILCompiler reference

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -46,7 +46,8 @@
   <!-- Generate a warning if the non-SDK path is used  -->
   <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true' and '$(ILCompilerTargetsPath)' != ''  and '$(NeedNativePublishSupportForSDK6)' != 'true'" 
       BeforeTargets="ImportRuntimeIlcPackageTarget">
-    <Warning Text="Set PublishAot property to true and delete explicit 'Microsoft.DotNet.ILCompiler' package reference in your project file. Explicit 'Microsoft.DotNet.ILCompiler' package reference can run into version errors." />
+    <Warning Condition="'%(PackageReference.Identity)' == 'Microsoft.DotNet.ILCompiler' And '%(PackageReference.IsImplicitlyDefined)' != 'true'"
+             Text="Delete explicit 'Microsoft.DotNet.ILCompiler' package reference in your project file. Explicit 'Microsoft.DotNet.ILCompiler' package reference can run into version errors." />
   </Target>
 
   <!-- Locate the runtime package according to the current target runtime -->


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/79240. Since I am touching this, I'm also backporting a change to the warning message from https://github.com/dotnet/runtime/pull/75043.

## Customer Impact

Context: https://github.com/dotnet/sdk/issues/28823

`PublishAot` with .NET 8 SDK targeting `net7.0` produces the following warning:

```
Set PublishAot property to true and delete explicit 'Microsoft.DotNet.ILCompiler' package reference in your project file. Explicit 'Microsoft.DotNet.ILCompiler' package reference can run into version errors.
```

The 7.0 ILCompiler package produces this warning. This is by design for 7.0 scenarios, but the .NET 8 SDK uses an implicit `PackageReference` to reference the 7.0 ILCompiler, which should not warn.

This fix removes the warning in the .NET 8 SDK scenario, and rewords the warning when using an explicit `PackageReference` (a 7.0 scenario) to avoid recommendation to set `PublishAot`, since this is only reachable when `PublishAot` is already set.

## Testing

There are existing tests for the unchanged behavior in https://github.com/dotnet/sdk/blob/7663c1f4d5896acfb71067be3fb9510be7bde4f1/src/Tests/Microsoft.NET.Publish.Tests/GivenThatWeWantToPublishAnAotApp.cs#L266.
Tests are being added for the 8.0 behavior in https://github.com/dotnet/sdk/pull/29393. 

## Risk

Very low. The implicit packagereference didn't exist in 7.0, so only the warning message changes when using the NET 7 SDK.