### PR TITLE
Update packaging.targets

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -99,7 +99,7 @@
     <NETStandardCompatError Include="netcoreapp2.0"
                             Supported="$(NetCoreAppMinimum)"
                             Condition="$(TargetFrameworks.Contains('netstandard2.')) and
-                                       ($(TargetFrameworks.Contains('$(NetCoreAppMinimum)')) or $(TargetFrameworks.Contains('$(NetCoreAppCurrent)')))" />
+                                       ($(TargetFrameworks.Contains('$(NetCoreAppMinimum)')) or $(TargetFrameworks.Contains('$(NetCoreAppPrevious)')) or $(TargetFrameworks.Contains('$(NetCoreAppCurrent)')))" />
     <NETStandardCompatError Include="net461"
                             Supported="$(NetFrameworkMinimum)"
                             Condition="$(TargetFrameworks.Contains('netstandard2.0')) and


### PR DESCRIPTION
This doesn't fix any existing issue but if a package would only target NetCoreAppPrevious (= net7.0), then we would not add the `NETStandardCompatError` msbuild item.