### PR TITLE
Fixing compressed singlefile scenario on osx-arm64

### DIFF
--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -776,7 +776,10 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
 #endif // FEATURE_ENABLE_NO_ADDRESS_SPACE_RANDOMIZATION
 
     DWORD allocationType = MEM_RESERVE | MEM_COMMIT;
-#if defined(__APPLE__) && defined(HOST_ARM64)
+#ifdef HOST_UNIX
+    // Tell PAL to use the executable memory allocator to satisfy this request for virtual memory.
+    // This is required on MacOS and otherwise will allow us to place native R2R code close to the
+    // coreclr library and thus improve performance by avoiding jump stubs in managed code.
     allocationType |= MEM_RESERVE_EXECUTABLE;
 #endif
 

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -775,10 +775,15 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
     }
 #endif // FEATURE_ENABLE_NO_ADDRESS_SPACE_RANDOMIZATION
 
+    DWORD allocationType = MEM_RESERVE | MEM_COMMIT;
+#if defined(__APPLE__) && defined(HOST_ARM64)
+    allocationType |= MEM_RESERVE_EXECUTABLE;
+#endif
+
     COUNT_T allocSize = ALIGN_UP(this->GetVirtualSize(), g_SystemInfo.dwAllocationGranularity);
-    LPVOID base = ClrVirtualAlloc(preferredBase, allocSize, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+    LPVOID base = ClrVirtualAlloc(preferredBase, allocSize, allocationType, PAGE_READWRITE);
     if (base == NULL && preferredBase != NULL)
-        base = ClrVirtualAlloc(NULL, allocSize, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        base = ClrVirtualAlloc(NULL, allocSize, allocationType, PAGE_READWRITE);
 
     if (base == NULL)
         ThrowLastError();
@@ -819,9 +824,13 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
     // Finally, apply proper protection to copied sections
     for (section = sectionStart; section < sectionEnd; section++)
     {
+        DWORD executableProtection = PAGE_EXECUTE_READ;
+#if defined(__APPLE__) && defined(HOST_ARM64)
+        executableProtection = PAGE_EXECUTE_READWRITE;
+#endif
         // Add appropriate page protection.
         DWORD newProtection = section->Characteristics & IMAGE_SCN_MEM_EXECUTE ?
-            PAGE_EXECUTE_READ :
+            executableProtection :
             section->Characteristics & IMAGE_SCN_MEM_WRITE ?
             PAGE_READWRITE :
             PAGE_READONLY;

--- a/src/installer/tests/Assets/TestProjects/Directory.Build.props
+++ b/src/installer/tests/Assets/TestProjects/Directory.Build.props
@@ -6,8 +6,4 @@
     <RestoreNoCache>true</RestoreNoCache>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)StandaloneApp3x\StandaloneApp3x.csproj" />
-  </ItemGroup>
-  
 </Project>

--- a/src/installer/tests/Assets/TestProjects/Directory.Build.props
+++ b/src/installer/tests/Assets/TestProjects/Directory.Build.props
@@ -6,4 +6,8 @@
     <RestoreNoCache>true</RestoreNoCache>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)StandaloneApp3x\StandaloneApp3x.csproj" />
+  </ItemGroup>
+  
 </Project>

--- a/src/installer/tests/Assets/TestProjects/StandaloneApp3x/StandaloneApp3x.csproj
+++ b/src/installer/tests/Assets/TestProjects/StandaloneApp3x/StandaloneApp3x.csproj
@@ -5,4 +5,12 @@
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>$(TestTargetRid)</RuntimeIdentifier>
   </PropertyGroup>
+
+  <!--
+  Change for 6.0 for osx-arm64 as that is the earliest supported tfm.
+  Otherwise the test assets will fail to restore.
+  -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>
 </Project>

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleLegacy.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleLegacy.cs
@@ -10,6 +10,7 @@ using BundleTests.Helpers;
 
 namespace Microsoft.NET.HostModel.Tests
 {
+    [SkipOnPlatform(TestPlatforms.OSX, "Not supported on OSX.")]
     public class BundleLegacy : IClassFixture<BundleLegacy.SharedTestState>
     {
         private SharedTestState sharedTestState;


### PR DESCRIPTION
Re: https://github.com/dotnet/runtime/issues/79267

Also fixes host tests so they can restore/run on osx-arm64
Fixes: #79470
