### PR TITLE
Fix diagnostics found with new analyzer - CA1858

### DIFF
--- a/src/libraries/System.Management/src/System/Management/ManagementQuery.cs
+++ b/src/libraries/System.Management/src/System/Management/ManagementQuery.cs
@@ -126,7 +126,7 @@ namespace System.Management
             // Next character should be the operator if any
             if (op != null)
             {
-                if (0 != q.IndexOf(op, StringComparison.Ordinal))
+                if (!q.StartsWith(op, StringComparison.Ordinal))
                     throw new ArgumentException(SR.InvalidQuery);    // Invalid query
 
                 // Strip off the op and any leading WS
@@ -1666,7 +1666,7 @@ namespace System.Management
             q = q.Remove(0, TokenOf.Length).TrimStart(null);
 
             // Next character should be "{"
-            if (0 != q.IndexOf('{'))
+            if (!q.StartsWith('{'))
                 throw new ArgumentException(SR.InvalidQuery);    // Invalid query
 
             // Strip off the "{" and any leading WS
@@ -2183,7 +2183,7 @@ namespace System.Management
             q = q.Remove(0, TokenOf.Length).TrimStart(null);
 
             // Next character should be "{"
-            if (0 != q.IndexOf('{'))
+            if (!q.StartsWith('{'))
                 throw new ArgumentException(SR.InvalidQuery);    // Invalid query
 
             // Strip off the "{" and any leading WS

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
@@ -114,12 +114,7 @@ namespace System.Reflection.PortableExecutable
             }
 
             // We allow NUL characters to allow for padding for backward compat purposes.
-            if (pdbPath.Length == 0 ||
-#if NETCOREAPP
-                pdbPath.StartsWith('\0'))
-#else
-                pdbPath[0] == '\0')
-#endif
+            if (pdbPath.Length == 0 || pdbPath[0] == '\0')
             {
                 Throw.InvalidArgument(SR.ExpectedNonEmptyString, nameof(pdbPath));
             }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
@@ -118,7 +118,7 @@ namespace System.Reflection.PortableExecutable
 #if NETCOREAPP
                 pdbPath.StartsWith('\0'))
 #else
-                pdbPath.Length > 0 && pdbPath[0] == '\0')
+                pdbPath[0] == '\0')
 #endif
             {
                 Throw.InvalidArgument(SR.ExpectedNonEmptyString, nameof(pdbPath));

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
@@ -114,7 +114,12 @@ namespace System.Reflection.PortableExecutable
             }
 
             // We allow NUL characters to allow for padding for backward compat purposes.
-            if (pdbPath.Length == 0 || pdbPath.IndexOf('\0') == 0)
+            if (pdbPath.Length == 0 ||
+#if NETCOREAPP
+                pdbPath.StartsWith('\0'))
+#else
+                pdbPath.Length > 0 && pdbPath[0] == '\0')
+#endif
             {
                 Throw.InvalidArgument(SR.ExpectedNonEmptyString, nameof(pdbPath));
             }

--- a/src/libraries/System.Speech/src/Internal/ObjectToken/ObjectTokenCategory.cs
+++ b/src/libraries/System.Speech/src/Internal/ObjectToken/ObjectTokenCategory.cs
@@ -32,7 +32,7 @@ namespace System.Speech.Internal.ObjectTokens
         {
             // Check if the token is for a voice
             string tokenName = keyName;
-            if (!string.IsNullOrEmpty(tokenName) && tokenName.IndexOf("HKEY_", StringComparison.Ordinal) != 0)
+            if (!string.IsNullOrEmpty(tokenName) && !tokenName.StartsWith("HKEY_", StringComparison.Ordinal))
             {
                 tokenName = string.Format(CultureInfo.InvariantCulture, @"{0}\Tokens\{1}", Id, tokenName);
             }

--- a/src/libraries/System.Speech/src/Internal/SrgsCompiler/BackEnd.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsCompiler/BackEnd.cs
@@ -576,7 +576,7 @@ namespace System.Speech.Internal.SrgsCompiler
                         string ruleName;
 
                         // Check for DYNAMIC grammars
-                        if (arc.RuleRef.Name.IndexOf("URL:DYNAMIC#", StringComparison.Ordinal) == 0)
+                        if (arc.RuleRef.Name.StartsWith("URL:DYNAMIC#", StringComparison.Ordinal))
                         {
                             ruleName = arc.RuleRef.Name.Substring(12);
                             if (fromOrg && FindInRules(ruleName) == null)
@@ -589,7 +589,7 @@ namespace System.Speech.Internal.SrgsCompiler
                                 CloneSubGraph(ruleExtra, org, extra, srcToDestHash, false);
                             }
                         }
-                        else if (arc.RuleRef.Name.IndexOf("URL:STATIC#", StringComparison.Ordinal) == 0)
+                        else if (arc.RuleRef.Name.StartsWith("URL:STATIC#", StringComparison.Ordinal))
                         {
                             ruleName = arc.RuleRef.Name.Substring(11);
                             if (fromOrg == false && FindInRules(ruleName) == null)

--- a/src/libraries/System.Speech/src/Internal/SrgsParser/XmlParser.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsParser/XmlParser.cs
@@ -1847,7 +1847,7 @@ namespace System.Speech.Internal.SrgsParser
             // in srgs.xml: or  <ruleref uri="srgs.xml>
             if (_filename != null)
             {
-                if (uri.IndexOf(_shortFilename, StringComparison.Ordinal) == 0 && (uri.Length > _shortFilename.Length && uri[_shortFilename.Length] == '#' || uri.Length == _shortFilename.Length))
+                if (uri.StartsWith(_shortFilename, StringComparison.Ordinal) && (uri.Length > _shortFilename.Length && uri[_shortFilename.Length] == '#' || uri.Length == _shortFilename.Length))
                 {
                     ThrowSrgsException(SRID.InvalidRuleRefSelf);
                 }

--- a/src/libraries/System.Speech/src/Recognition/SrgsGrammar/SrgsRuleRef.cs
+++ b/src/libraries/System.Speech/src/Recognition/SrgsGrammar/SrgsRuleRef.cs
@@ -188,7 +188,7 @@ namespace System.Speech.Recognition.SrgsGrammar
                 if (sUri[0] == '#')
                 {
                     bool uriFound = false;
-                    if (sUri.IndexOf("#grammar:dictation", StringComparison.Ordinal) == 0 || sUri.IndexOf("#grammar:dictation#spelling", StringComparison.Ordinal) == 0)
+                    if (sUri.StartsWith("#grammar:dictation", StringComparison.Ordinal))
                     {
                         uriFound = true;
                     }


### PR DESCRIPTION
Fix diagnostics found with the new analyzer CA1858 [`Use 'StartsWith' instead of comparing the result of 'IndexOf' to 0`](https://github.com/dotnet/runtime/issues/78608) implemented [by @Youssef1313](https://github.com/dotnet/roslyn-analyzers/pull/6295/files)