### PR TITLE
TarReader should dispose underlying stream if leaveOpen is false

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -48,7 +48,7 @@ namespace System.Formats.Tar
         }
 
         /// <summary>
-        /// Disposes the current <see cref="TarReader"/> instance, and disposes the non-null <see cref="TarEntry.DataStream"/> instances of all the entries that were read from the archive.
+        /// Disposes the current <see cref="TarReader"/> instance, closes the archive stream, and disposes the non-null <see cref="TarEntry.DataStream"/> instances of all the entries that were read from the archive if the <c>leaveOpen</c> argument was set to <see langword="false"/> in the constructor.
         /// </summary>
         /// <remarks>The <see cref="TarEntry.DataStream"/> property of any entry can be replaced with a new stream. If the user decides to replace it on a <see cref="TarEntry"/> instance that was obtained using a <see cref="TarReader"/>, the underlying stream gets disposed immediately, freeing the <see cref="TarReader"/> of origin from the responsibility of having to dispose it.</remarks>
         public void Dispose()
@@ -57,11 +57,16 @@ namespace System.Formats.Tar
             {
                 _isDisposed = true;
 
-                if (!_leaveOpen && _dataStreamsToDispose?.Count > 0)
+                if (!_leaveOpen)
                 {
-                    foreach (Stream s in _dataStreamsToDispose)
+                    _archiveStream.Dispose();
+
+                    if (_dataStreamsToDispose?.Count > 0)
                     {
-                        s.Dispose();
+                        foreach (Stream s in _dataStreamsToDispose)
+                        {
+                            s.Dispose();
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.Tests.cs
@@ -38,6 +38,8 @@ namespace System.Formats.Tar.Tests
                 }
             }
 
+            Assert.Throws<ObjectDisposedException>(() => ms.ReadByte());
+
             Assert.True(dataStreams.Any());
             foreach (Stream ds in dataStreams)
             {
@@ -61,6 +63,8 @@ namespace System.Formats.Tar.Tests
                     }
                 }
             }
+
+            ms.ReadByte(); // Should not throw
 
             Assert.True(dataStreams.Any());
             foreach (Stream ds in dataStreams)


### PR DESCRIPTION
Potentially fixes https://github.com/dotnet/runtime/issues/77012.
