### PR TITLE
Clean up tar file at the end of WriteEntry_LongFileSizeAsync test

### DIFF
--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.LongFile.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.LongFile.Tests.cs
@@ -86,6 +86,7 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(size, dataStream.Position);
 
             Assert.Null(reader.GetNextEntry());
+            tarFile.Close();
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.LongFile.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.LongFile.Tests.cs
@@ -76,6 +76,7 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(size, dataStream.Position);
 
             Assert.Null(await reader.GetNextEntryAsync());
+            tarFile.Close();
         }
     }
 }


### PR DESCRIPTION
Otherwise multiple tar files could stick around for some time, contributing to issues like https://github.com/dotnet/runtime/issues/77012

With this I've never seen disk usage go below the 8GB that a single test run takes.