### PR TITLE
Disable failing outerloop tests with ActiveIssue

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -248,6 +248,7 @@ namespace System.Diagnostics.Metrics.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
         [OuterLoop("Slow and has lots of console spew")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/79749", TargetFrameworkMonikers.NetFramework)]
         public void EventSourceFiltersInstruments()
         {
             using Meter meterA = new Meter("TestMeterA");

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -218,6 +218,7 @@ namespace System.Net.Sockets.Tests
 
         [OuterLoop]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/79820", TestPlatforms.Linux | TestPlatforms.Android)]
         public static void Connect_ThrowSocketException_Success()
         {
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
@@ -697,6 +697,7 @@ namespace System.Net.Tests
         [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServers))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/79731")]
         public async Task UploadValues_Success(Uri echoServer)
         {
             var wc = new WebClient();


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/79731 and https://github.com/dotnet/runtime/issues/79749 and https://github.com/dotnet/runtime/issues/79820