### PR TITLE
Decommit memory as needed

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -41072,6 +41072,12 @@ bool gc_heap::decommit_step (uint64_t step_milliseconds)
             if (!use_large_pages_p)
             {
                 decommit_succeeded_p = virtual_decommit(page_start, size, recorded_committed_free_bucket);
+#ifdef MULTIPLE_HEAPS
+                gc_heap* hp = heap_segment_heap (region);
+#else
+                gc_heap* hp = __this;
+#endif
+                hp->decommit_mark_array_by_seg (region);
                 dprintf(REGIONS_LOG, ("decommitted region %p(%p-%p) (%zu bytes) - success: %d",
                     region,
                     page_start,

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2078,8 +2078,6 @@ protected:
 #ifdef USE_REGIONS
     PER_HEAP_ISOLATED
     size_t decommit_region (heap_segment* region, int bucket, int h_number);
-    PER_HEAP_ISOLATED
-    void delete_region (heap_segment* region);
 #endif //USE_REGIONS
     PER_HEAP
     void decommit_heap_segment (heap_segment* seg);

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2075,6 +2075,12 @@ protected:
     size_t decommit_heap_segment_pages_worker (heap_segment* seg, uint8_t *new_committed);
     PER_HEAP_ISOLATED
     bool decommit_step (uint64_t step_milliseconds);
+#ifdef USE_REGIONS
+    PER_HEAP_ISOLATED
+    size_t decommit_region (heap_segment* region, int bucket, int h_number);
+    PER_HEAP_ISOLATED
+    void delete_region (heap_segment* region);
+#endif //USE_REGIONS
     PER_HEAP
     void decommit_heap_segment (heap_segment* seg);
     PER_HEAP_ISOLATED


### PR DESCRIPTION
This change makes sure:

1. The mark array is decommitted when we decommit the region, and
2. The region is decommitted if we fail to commit the corresponding mark array.

Fixes https://github.com/dotnet/runtime/issues/79882