### PR TITLE
Handle `LCL_FLD_ADDR` in TreeLifeUpdater

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8006,10 +8006,6 @@ public:
     // not all JIT Helper calls follow the standard ABI on the target architecture.
     regMaskTP compHelperCallKillSet(CorInfoHelpFunc helper);
 
-    // If "tree" is a indirection (GT_IND, or GT_OBJ) whose arg is an ADDR, whose arg is a LCL_VAR, return that LCL_VAR
-    // node, else NULL.
-    static GenTreeLclVar* fgIsIndirOfAddrOfLocal(GenTree* tree);
-
     // This map is indexed by GT_OBJ nodes that are address of promoted struct variables, which
     // have been annotated with the GTF_VAR_DEATH flag.  If such a node is *not* mapped in this
     // table, one may assume that all the (tracked) field vars die at this GT_OBJ.  Otherwise,

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -734,29 +734,6 @@ bool Compiler::fgIsCommaThrow(GenTree* tree, bool forFolding /* = false */)
     return false;
 }
 
-//------------------------------------------------------------------------
-// fgIsIndirOfAddrOfLocal: Determine whether "tree" is an indirection of a local.
-//
-// Arguments:
-//    tree - The tree node under consideration
-//
-// Return Value:
-//    If "tree" is a indirection (GT_IND, GT_BLK, or GT_OBJ) whose arg is:
-//    - a LCL_VAR_ADDR, return that LCL_VAR_ADDR;
-//    - else nullptr.
-//
-// static
-GenTreeLclVar* Compiler::fgIsIndirOfAddrOfLocal(GenTree* tree)
-{
-    GenTreeLclVar* res = nullptr;
-    if (tree->OperIsIndir() && tree->AsIndir()->Addr()->OperIs(GT_LCL_VAR_ADDR))
-    {
-        res = tree->AsIndir()->Addr()->AsLclVar();
-    }
-
-    return res;
-}
-
 GenTreeCall* Compiler::fgGetStaticsCCtorHelper(CORINFO_CLASS_HANDLE cls, CorInfoHelpFunc helper)
 {
     bool         bNeedClassID = true;

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -17,7 +17,7 @@ public:
     bool UpdateLifeFieldVar(GenTreeLclVar* lclNode, unsigned multiRegIndex);
 
 private:
-    void UpdateLifeVar(GenTree* tree);
+    void UpdateLifeVar(GenTree* tree, GenTreeLclVarCommon* lclVarTree);
 
 private:
     Compiler* compiler;


### PR DESCRIPTION
Credit to @BruceForstall for investigating the issue.

Fixes #79518.

No code [diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=118859&view=ms.vss-build-web.run-extensions-tab), but some GC info diffs that look like fixed GC holes. Some TP losses on 32 bit, payed for with #79194.