### PR TITLE
enable SslStream_AllowRenegotiation_False_Throws again

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
@@ -70,7 +70,6 @@ namespace System.Net.Security.Tests
 
         [Fact]
         [OuterLoop] // Test hits external azure server.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/77414", TestPlatforms.AnyUnix)]
         public async Task SslStream_AllowRenegotiation_False_Throws()
         {
             Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
The test failure was caused by external changes in APP service. I updated the configuration and  `SslStream_AllowRenegotiation_False_Throws` pass on Linux & macOS again.
 
fixes  #77414

