### PR TITLE
Rename RdXmlFile to _DirectivesFile

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -37,7 +37,7 @@
   <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets" Condition="'$(TestNativeAot)' == 'true'" />
 
   <ItemGroup Condition="'$(TestNativeAot)' == 'true'">
-    <RdXmlFile Include="$(MSBuildThisFileDirectory)default.rd.xml" />
+    <_DirectivesFile Include="$(MSBuildThisFileDirectory)default.rd.xml" />
 
     <!-- Tests are doing private reflection. -->
     <IlcArg Include="--nometadatablocking" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -195,7 +195,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Target>
 
   <Target Name="WriteIlcRspFileForCompilation"
-      Inputs="@(IlcCompileInput);@(RdXmlFile);@(TrimmerRootDescriptor)"
+      Inputs="@(IlcCompileInput);@(_DirectivesFile);@(TrimmerRootDescriptor)"
       Outputs="%(ManagedBinary.IlcRspFile)"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
@@ -223,7 +223,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcGenerateMstatFile) == 'true'" Include="--mstat:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).mstat" />
       <IlcArg Condition="$(IlcGenerateDgmlFile) == 'true'" Include="--dgmllog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).codegen.dgml.xml" />
       <IlcArg Condition="$(IlcGenerateDgmlFile) == 'true'" Include="--scandgmllog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).scan.dgml.xml" />
-      <IlcArg Include="@(RdXmlFile->'--rdxml:%(FullPath)')" />
+      <IlcArg Include="@(_DirectivesFile->'--rdxml:%(FullPath)')" />
       <IlcArg Include="@(TrimmerRootDescriptor->'--descriptor:%(FullPath)')" />
       <IlcArg Condition="'$(NativeLib)' != ''" Include="--nativelib" />
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
@@ -272,7 +272,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Target>
 
   <Target Name="IlcCompile"
-      Inputs="@(IlcCompileInput);@(IlcReference);@(RdXmlFile);%(ManagedBinary.IlcRspFile)"
+      Inputs="@(IlcCompileInput);@(IlcReference);@(_DirectivesFile);%(ManagedBinary.IlcRspFile)"
       Outputs="%(ManagedBinary.IlcOutputFile)"
       DependsOnTargets="WriteIlcRspFileForCompilation;$(IlcCompileDependsOn)">
     <Message Text="Generating native code" Importance="high" />

--- a/src/coreclr/nativeaot/docs/reflection-in-aot-mode.md
+++ b/src/coreclr/nativeaot/docs/reflection-in-aot-mode.md
@@ -71,7 +71,7 @@ If compiler cannot detect types used by the aplication, an rd.xml file can be su
 For that, file `rd.xml` should be created and following lines added to project file
 ```xml
 <ItemGroup>
-  <RdXmlFile Include="rd.xml" />
+  <_DirectivesFile Include="rd.xml" />
 </ItemGroup>
 ```
 

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/Microsoft.Extensions.FileSystemGlobbing.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/Microsoft.Extensions.FileSystemGlobbing.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
+++ b/src/libraries/System.Collections.Immutable/tests/System.Collections.Immutable.Tests.csproj
@@ -5,7 +5,7 @@
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Collections\DictionaryExtensions.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" Link="Common\System\Collections\DictionaryExtensions.cs" />

--- a/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
@@ -5,7 +5,7 @@
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <!-- Common Collections tests -->

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -7,7 +7,7 @@
     <DefineConstants Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">$(DefineConstants);MEMORYMARSHAL_SUPPORT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />

--- a/src/libraries/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/libraries/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -6,7 +6,7 @@
     <IgnoreForCI Condition="'$(TargetsMobile)' == 'true'">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/src/libraries/System.Globalization/tests/NlsTests/System.Globalization.Nls.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/NlsTests/System.Globalization.Nls.Tests.csproj
@@ -8,7 +8,7 @@
     <UnicodeUcdVersion>14.0</UnicodeUcdVersion>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="..\default.rd.xml" />
+    <_DirectivesFile Include="..\default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <!-- Include tests from System.Globalization.Tests -->

--- a/src/libraries/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -7,7 +7,7 @@
     <UnicodeUcdVersion>14.0</UnicodeUcdVersion>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -6,7 +6,7 @@
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MemoryMappedFile.CreateFromFile.Tests.cs" />

--- a/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/libraries/System.Linq/tests/System.Linq.Tests.csproj
@@ -4,7 +4,7 @@
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AggregateTests.cs" />

--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArrayBufferWriter\ArrayBufferWriterTests.Byte.cs" />

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -6,7 +6,7 @@
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -14,7 +14,7 @@
     <Compile Include="AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <Import Project="$(CommonTestPath)System\Net\Security\Kerberos\System.Net.Security.Kerberos.Shared.projitems" />
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'Browser'">

--- a/src/libraries/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
+++ b/src/libraries/System.Net.WebSockets/tests/System.Net.WebSockets.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="WebSocketTests.cs" />

--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -11,7 +11,7 @@
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Reflection\MockParameterInfo.cs"

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetCoreAppCurrent)-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CreateTests.cs" />

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -8,7 +8,7 @@
     <EnableLibraryImportGenerator>true</EnableLibraryImportGenerator>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/libraries/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);SYSLIB0003</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <RdXmlFile Include="default.rd.xml" />
+    <_DirectivesFile Include="default.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationTrustTests.cs" />

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.csproj
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RdXmlFile Include="rd.xml" />
+    <_DirectivesFile Include="rd.xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #79210.

* This file format is not the RD.XML that is documented on docs.microsoft.com.
* The `RdXmlFile` item that is the entrypoint to this misnomer of a workaround file format is not documented.

Nobody should be really using this. These problems need to be fixed at the source and not worked around.

Cc @dotnet/ilc-contrib 