### PR TITLE
Fix the ARM's `double` register name displayed in JitDisasm/JitDump

### DIFF
--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -6927,8 +6927,18 @@ void emitter::emitDispReg(regNumber reg, emitAttr attr, bool addComma)
 {
     if (isFloatReg(reg))
     {
-        const char* size = attr == EA_8BYTE ? "d" : "s";
-        printf("%s%s", size, emitFloatRegName(reg, attr) + 1);
+        if (attr == EA_8BYTE)
+        {
+            char     regNum[2];
+            unsigned regIndex = reg - REG_F0;
+            regIndex >>= 1;
+
+            printf("d%s", _itoa(regIndex, regNum, 10));
+        }
+        else
+        {
+            printf("s%s", emitFloatRegName(reg, attr) + 1);
+        }
     }
     else
     {

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -6929,11 +6929,18 @@ void emitter::emitDispReg(regNumber reg, emitAttr attr, bool addComma)
     {
         if (attr == EA_8BYTE)
         {
-            char     regNum[2];
             unsigned regIndex = reg - REG_F0;
             regIndex >>= 1;
 
-            printf("d%s", _itoa(regIndex, regNum, 10));
+            if (regIndex < 10)
+            {
+                printf("d%c", regIndex + '0');
+            }
+            else
+            {
+                assert(regIndex < 100);
+                printf("d%c%c", (regIndex / 10), (regIndex % 10));
+            }
         }
         else
         {


### PR DESCRIPTION
Fix the display of ARM double register name in JitDisasm and JitDump. We would just display the floating register name, but instead should be displaying the accurate double register name (that the encoding reflects).

Fixes: https://github.com/dotnet/runtime/issues/8121