### PR TITLE
Remove null annotation from *HeaderValue.Parse methods

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -462,7 +462,7 @@ namespace System.Net.Http.Headers
         public string Scheme { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.AuthenticationHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.AuthenticationHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.AuthenticationHeaderValue? parsedValue) { throw null; }
@@ -508,7 +508,7 @@ namespace System.Net.Http.Headers
         public long? Size { get { throw null; } set { } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.ContentDispositionHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.ContentDispositionHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.ContentDispositionHeaderValue? parsedValue) { throw null; }
@@ -526,7 +526,7 @@ namespace System.Net.Http.Headers
         public string Unit { get { throw null; } set { } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.ContentRangeHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.ContentRangeHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.ContentRangeHeaderValue? parsedValue) { throw null; }
@@ -540,7 +540,7 @@ namespace System.Net.Http.Headers
         public string Tag { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.EntityTagHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.EntityTagHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.EntityTagHeaderValue? parsedValue) { throw null; }
@@ -710,7 +710,7 @@ namespace System.Net.Http.Headers
         public System.Collections.Generic.ICollection<System.Net.Http.Headers.NameValueHeaderValue> Parameters { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.MediaTypeHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.MediaTypeHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.MediaTypeHeaderValue? parsedValue) { throw null; }
@@ -720,7 +720,7 @@ namespace System.Net.Http.Headers
         public MediaTypeWithQualityHeaderValue(string mediaType) : base (default(System.Net.Http.Headers.MediaTypeHeaderValue)) { }
         public MediaTypeWithQualityHeaderValue(string mediaType, double quality) : base (default(System.Net.Http.Headers.MediaTypeHeaderValue)) { }
         public double? Quality { get { throw null; } set { } }
-        public static new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue Parse(string? input) { throw null; }
+        public static new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.MediaTypeWithQualityHeaderValue? parsedValue) { throw null; }
     }
@@ -733,7 +733,7 @@ namespace System.Net.Http.Headers
         public string? Value { get { throw null; } set { } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.NameValueHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.NameValueHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.NameValueHeaderValue? parsedValue) { throw null; }
@@ -746,7 +746,7 @@ namespace System.Net.Http.Headers
         public System.Collections.Generic.ICollection<System.Net.Http.Headers.NameValueHeaderValue> Parameters { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static new System.Net.Http.Headers.NameValueWithParametersHeaderValue Parse(string? input) { throw null; }
+        public static new System.Net.Http.Headers.NameValueWithParametersHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.NameValueWithParametersHeaderValue? parsedValue) { throw null; }
@@ -759,7 +759,7 @@ namespace System.Net.Http.Headers
         public string? Version { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.ProductHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.ProductHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.ProductHeaderValue? parsedValue) { throw null; }
@@ -787,7 +787,7 @@ namespace System.Net.Http.Headers
         public System.Net.Http.Headers.EntityTagHeaderValue? EntityTag { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.RangeConditionHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.RangeConditionHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.RangeConditionHeaderValue? parsedValue) { throw null; }
@@ -800,7 +800,7 @@ namespace System.Net.Http.Headers
         public string Unit { get { throw null; } set { } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.RangeHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.RangeHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.RangeHeaderValue? parsedValue) { throw null; }
@@ -823,7 +823,7 @@ namespace System.Net.Http.Headers
         public System.TimeSpan? Delta { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.RetryConditionHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.RetryConditionHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.RetryConditionHeaderValue? parsedValue) { throw null; }
@@ -836,7 +836,7 @@ namespace System.Net.Http.Headers
         public string Value { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.StringWithQualityHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.StringWithQualityHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.StringWithQualityHeaderValue? parsedValue) { throw null; }
@@ -849,7 +849,7 @@ namespace System.Net.Http.Headers
         public string Value { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.TransferCodingHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.TransferCodingHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.TransferCodingHeaderValue? parsedValue) { throw null; }
@@ -859,7 +859,7 @@ namespace System.Net.Http.Headers
         public TransferCodingWithQualityHeaderValue(string value) : base (default(System.Net.Http.Headers.TransferCodingHeaderValue)) { }
         public TransferCodingWithQualityHeaderValue(string value, double quality) : base (default(System.Net.Http.Headers.TransferCodingHeaderValue)) { }
         public double? Quality { get { throw null; } set { } }
-        public static new System.Net.Http.Headers.TransferCodingWithQualityHeaderValue Parse(string? input) { throw null; }
+        public static new System.Net.Http.Headers.TransferCodingWithQualityHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.TransferCodingWithQualityHeaderValue? parsedValue) { throw null; }
     }
@@ -874,7 +874,7 @@ namespace System.Net.Http.Headers
         public string ReceivedBy { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.ViaHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.ViaHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.ViaHeaderValue? parsedValue) { throw null; }
@@ -889,7 +889,7 @@ namespace System.Net.Http.Headers
         public string Text { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static System.Net.Http.Headers.WarningHeaderValue Parse(string? input) { throw null; }
+        public static System.Net.Http.Headers.WarningHeaderValue Parse(string input) { throw null; }
         object System.ICloneable.Clone() { throw null; }
         public override string ToString() { throw null; }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Net.Http.Headers.WarningHeaderValue? parsedValue) { throw null; }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AuthenticationHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AuthenticationHeaderValue.cs
@@ -93,7 +93,7 @@ namespace System.Net.Http.Headers
             return result;
         }
 
-        public static AuthenticationHeaderValue Parse(string? input)
+        public static AuthenticationHeaderValue Parse(string input)
         {
             int index = 0;
             return (AuthenticationHeaderValue)GenericHeaderParser.SingleValueAuthenticationParser.ParseValue(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
@@ -184,7 +184,7 @@ namespace System.Net.Http.Headers
 
         #region Parsing
 
-        public static ContentDispositionHeaderValue Parse(string? input)
+        public static ContentDispositionHeaderValue Parse(string input)
         {
             int index = 0;
             return (ContentDispositionHeaderValue)GenericHeaderParser.ContentDispositionParser.ParseValue(input,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
@@ -165,7 +165,7 @@ namespace System.Net.Http.Headers
             return sb.ToString();
         }
 
-        public static ContentRangeHeaderValue Parse(string? input)
+        public static ContentRangeHeaderValue Parse(string input)
         {
             int index = 0;
             return (ContentRangeHeaderValue)GenericHeaderParser.ContentRangeParser.ParseValue(input, null, ref index);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/EntityTagHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/EntityTagHeaderValue.cs
@@ -88,7 +88,7 @@ namespace System.Net.Http.Headers
             return _tag.GetHashCode() ^ _isWeak.GetHashCode();
         }
 
-        public static EntityTagHeaderValue Parse(string? input)
+        public static EntityTagHeaderValue Parse(string input)
         {
             int index = 0;
             return (EntityTagHeaderValue)GenericHeaderParser.SingleValueEntityTagParser.ParseValue(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
@@ -149,7 +149,7 @@ namespace System.Net.Http.Headers
         /// <returns>A <see cref="MediaTypeHeaderValue"/> instance.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="input"/> is a <see langword="null"/> reference.</exception>
         /// <exception cref="FormatException"><parmref name="input"/> is not valid media type header value information.</exception>
-        public static MediaTypeHeaderValue Parse(string? input)
+        public static MediaTypeHeaderValue Parse(string input)
         {
             int index = 0;
             return (MediaTypeHeaderValue)MediaTypeHeaderParser.SingleValueParser.ParseValue(input, null, ref index);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeWithQualityHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeWithQualityHeaderValue.cs
@@ -42,7 +42,7 @@ namespace System.Net.Http.Headers
             return new MediaTypeWithQualityHeaderValue(this);
         }
 
-        public static new MediaTypeWithQualityHeaderValue Parse(string? input)
+        public static new MediaTypeWithQualityHeaderValue Parse(string input)
         {
             int index = 0;
             return (MediaTypeWithQualityHeaderValue)MediaTypeHeaderParser.SingleValueWithQualityParser.ParseValue(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueHeaderValue.cs
@@ -112,7 +112,7 @@ namespace System.Net.Http.Headers
             }
         }
 
-        public static NameValueHeaderValue Parse(string? input)
+        public static NameValueHeaderValue Parse(string input)
         {
             int index = 0;
             return (NameValueHeaderValue)GenericHeaderParser.SingleValueNameValueParser.ParseValue(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueWithParametersHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/NameValueWithParametersHeaderValue.cs
@@ -72,7 +72,7 @@ namespace System.Net.Http.Headers
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 
-        public static new NameValueWithParametersHeaderValue Parse(string? input)
+        public static new NameValueWithParametersHeaderValue Parse(string input)
         {
             int index = 0;
             return (NameValueWithParametersHeaderValue)GenericHeaderParser.SingleValueNameValueWithParametersParser

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ProductHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ProductHeaderValue.cs
@@ -82,7 +82,7 @@ namespace System.Net.Http.Headers
             return result;
         }
 
-        public static ProductHeaderValue Parse(string? input)
+        public static ProductHeaderValue Parse(string input)
         {
             int index = 0;
             return (ProductHeaderValue)GenericHeaderParser.SingleValueProductParser.ParseValue(input, null, ref index);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RangeConditionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RangeConditionHeaderValue.cs
@@ -86,7 +86,7 @@ namespace System.Net.Http.Headers
             return _entityTag.GetHashCode();
         }
 
-        public static RangeConditionHeaderValue Parse(string? input)
+        public static RangeConditionHeaderValue Parse(string input)
         {
             int index = 0;
             return (RangeConditionHeaderValue)GenericHeaderParser.RangeConditionParser.ParseValue(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RangeHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RangeHeaderValue.cs
@@ -109,7 +109,7 @@ namespace System.Net.Http.Headers
             return result;
         }
 
-        public static RangeHeaderValue Parse(string? input)
+        public static RangeHeaderValue Parse(string input)
         {
             int index = 0;
             return (RangeHeaderValue)GenericHeaderParser.RangeParser.ParseValue(input, null, ref index);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RetryConditionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RetryConditionHeaderValue.cs
@@ -86,7 +86,7 @@ namespace System.Net.Http.Headers
             return _delta.Value.GetHashCode();
         }
 
-        public static RetryConditionHeaderValue Parse(string? input)
+        public static RetryConditionHeaderValue Parse(string input)
         {
             int index = 0;
             return (RetryConditionHeaderValue)GenericHeaderParser.RetryConditionParser.ParseValue(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/StringWithQualityHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/StringWithQualityHeaderValue.cs
@@ -99,7 +99,7 @@ namespace System.Net.Http.Headers
             return result;
         }
 
-        public static StringWithQualityHeaderValue Parse(string? input)
+        public static StringWithQualityHeaderValue Parse(string input)
         {
             int index = 0;
             return (StringWithQualityHeaderValue)GenericHeaderParser.SingleValueStringWithQualityParser.ParseValue(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/TransferCodingHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/TransferCodingHeaderValue.cs
@@ -37,7 +37,7 @@ namespace System.Net.Http.Headers
             _value = value;
         }
 
-        public static TransferCodingHeaderValue Parse(string? input)
+        public static TransferCodingHeaderValue Parse(string input)
         {
             int index = 0;
             return (TransferCodingHeaderValue)TransferCodingHeaderParser.SingleValueParser.ParseValue(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/TransferCodingWithQualityHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/TransferCodingWithQualityHeaderValue.cs
@@ -41,7 +41,7 @@ namespace System.Net.Http.Headers
             return new TransferCodingWithQualityHeaderValue(this);
         }
 
-        public static new TransferCodingWithQualityHeaderValue Parse(string? input)
+        public static new TransferCodingWithQualityHeaderValue Parse(string input)
         {
             int index = 0;
             return (TransferCodingWithQualityHeaderValue)TransferCodingHeaderParser.SingleValueWithQualityParser

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ViaHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ViaHeaderValue.cs
@@ -134,7 +134,7 @@ namespace System.Net.Http.Headers
             return result;
         }
 
-        public static ViaHeaderValue Parse(string? input)
+        public static ViaHeaderValue Parse(string input)
         {
             int index = 0;
             return (ViaHeaderValue)GenericHeaderParser.SingleValueViaParser.ParseValue(input, null, ref index);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
@@ -132,7 +132,7 @@ namespace System.Net.Http.Headers
             return result;
         }
 
-        public static WarningHeaderValue Parse(string? input)
+        public static WarningHeaderValue Parse(string input)
         {
             int index = 0;
             return (WarningHeaderValue)GenericHeaderParser.SingleValueWarningParser.ParseValue(input, null, ref index);


### PR DESCRIPTION
All Parse(string) methods in *HeaderValue.cs classes (e.g. ProductHeaderValue) have the input parameter annotated as nullable, however null values cause an exception. Therefore removing the nullable annotation.

Fix #77160