### PR TITLE
Base64.Decode: fixed latent bug for invalid input that is less than a block-size

### DIFF
--- a/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -58,6 +58,19 @@ namespace System.Buffers.Text.Tests
         }
 
         [Fact]
+        public void BasicDecodingInvalidInputWithSlicedSource()
+        {
+            ReadOnlySpan<byte> source = stackalloc byte[] { (byte)'A', (byte)'B', (byte)'C', (byte)'D' };
+            Span<byte> decodedBytes = stackalloc byte[128];
+
+            source = source[..3];   // now it's invalid as only 3 bytes are present
+
+            Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+            Assert.Equal(0, consumed);
+            Assert.Equal(0, decodedByteCount);
+        }
+
+        [Fact]
         public void BasicDecodingWithFinalBlockFalse()
         {
             var rnd = new Random(42);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs
@@ -101,7 +101,7 @@ namespace System.Buffers.Text
                 }
 
                 ref sbyte decodingMap = ref MemoryMarshal.GetReference(DecodingMap);
-                srcMax = srcBytes + (uint)maxSrcLength;
+                srcMax = srcBytes + maxSrcLength;
 
                 while (src < srcMax)
                 {


### PR DESCRIPTION
Repro:
```c#
ReadOnlySpan<byte> base64 = stackalloc byte[] { (byte)'A', (byte)'B', (byte)'C', (byte)'D' };
Span<byte> data = stackalloc byte[128];

base64 = base64[..3];

OperationStatus status = Base64.DecodeFromUtf8(base64, data, out int consumed, out int written);
Console.WriteLine($"status: {status}, consumed: {consumed}, written: {written}");
```

We fill `base64` with four valid base64-bytes, then we slice it to only contain 3 bytes.
Thus decoding should result in `InvalidData` (which is does) and `consumed`, `written` should be both `0`, but they are `4`, `3` which is wrong, as it's read beyond the valid range.

See https://github.com/dotnet/runtime/pull/79334#issuecomment-1364514457 for an investigation of this 🐛.
As in the loop condition https://github.com/dotnet/runtime/blob/dca7ee6d6bdc28d8d2af0a111731f8584baaba0f/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Decoder.cs#L200-L210 `srcMax` is more than `int.MaxValue` away from `src` and iff `[src, src + 4)` contains valid base64 encoded bytes, then it may consume a lot of data outside of valid ranges.

There was a test-hole, as the test `BasicDecodingInvalidInputLength` has a [too big start for the range](https://github.com/gfoidl/dotnet-runtime/blob/88868b7a781f4e5b9037b8721f30440207a7aa42/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs#L43). Thus a new specific test for this case (input length < BlockSize) got added.

This 🐛 got introduced with https://github.com/dotnet/corefx/pull/34529 (🙈), so it's there since .NET Core 3.1.
And as by accident I know the author of that PR quite well the `uint`-cast is placed there to avoid a `movsxd`.

---

The repro above is artificial and constructed to investigate https://github.com/dotnet/runtime/pull/79334#issuecomment-1364453361. In real-world usage it may or may not happen, that depends on the value read `base64[3]`. If this is by accident valid base64 byte, then the 🐛 manifests.

Even if `InvalidData` is reported correctly, the real problem is that it's read beyond the given / allowed range.
Since this bug exists for quite some time now and we don't have any bug-reports for this, I don't assume it's critical enough to backport that change.