### PR TITLE
Fix type name parsing in NativeAOT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
@@ -23,7 +23,7 @@ namespace ILCompiler.DependencyAnalysis
             StringBuilder typeName = new StringBuilder();
             StringBuilder typeNamespace = new StringBuilder();
             string containingTypeName = null;
-            while (i < name.Length && (char.IsLetterOrDigit(name[i]) || name[i] == '.' || name[i] == '`' || name[i] == '+'))
+            while (i < name.Length && (char.IsLetterOrDigit(name[i]) || name[i] == '.' || name[i] == '_' || name[i] == '`' || name[i] == '+'))
             {
                 if (name[i] == '.')
                 {
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis
 
             // Consume assembly name
             StringBuilder assemblyName = new StringBuilder();
-            while (i < name.Length && (char.IsLetterOrDigit(name[i]) || name[i] == '.'))
+            while (i < name.Length && (char.IsLetterOrDigit(name[i]) || name[i] == '.' || name[i] == '_'))
             {
                 assemblyName.Append(name[i]);
                 i++;


### PR DESCRIPTION
Simplified type name parsing was breaking if full name or assembly name has underscode ('_') in it. That breaks referencing `SQLitePCL.Batteries_V2, SQLitePCLRaw.batteries_v2` type inside `Microsoft.Data.Sqlite`

Fixes https://github.com/dotnet/efcore/issues/29725