### PR TITLE
Disposed change token registration should not raise consumer

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -98,9 +98,12 @@ namespace Microsoft.Extensions.Primitives
                 {
                     return;
                 }
-
                 IDisposable registraton = token.RegisterChangeCallback(s => ((ChangeTokenRegistration<TState>?)s)!.OnChangeTokenFired(), this);
-
+                if (token.HasChanged && token.ActiveChangeCallbacks)
+                {
+                    registraton?.Dispose();
+                    return;
+                }
                 SetDisposable(registraton);
             }
 

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -180,6 +180,28 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        public void DisposingChangeTokenRegistrationDoesNotRaiseConsumerIfTokenProviderReturnsCancelledToken()
+        {
+            var provider = new ResettableChangeTokenProvider();
+            Func<Func<IChangeToken>> changeTokenProviderFactory = () =>
+            {
+                int n = 0;
+                return () =>
+                {
+                    var token = provider.GetChangeToken();
+                    if (n++ is 0) provider.Changed();
+                    return token;
+                };
+            };
+            int count = 0;
+            var reg = ChangeToken.OnChange(changeTokenProviderFactory(), () => count++);
+            reg.Dispose();
+            provider.Changed();
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
         public void DisposingChangeTokenRegistrationDuringCallbackWorks()
         {
             var provider = new ResettableChangeTokenProvider();


### PR DESCRIPTION
If `changeTokenProducer` returns token that has been changed for some reason and if the token proactively raises callbacks then in [this line of code](https://github.com/dotnet/runtime/blob/88868b7a781f4e5b9037b8721f30440207a7aa42/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs#L102) `OnChangeTokenFired` method will be called immediatly. This will result in a recursive call to the `RegisterChangeTokenCallback` method. As a result, we get the situation where regisration of the first (changed) token resets registration of the second token. Please see unit test for more details.