### PR TITLE
 Use function pointers instead of marshalled delegates in EventSource

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.CoreCLR.cs
@@ -29,7 +29,9 @@ namespace System.Diagnostics.Tracing
         // These PInvokes are used by EventSource to interact with the EventPipe.
         //
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_CreateProvider", StringMarshalling = StringMarshalling.Utf16)]
-        internal static partial IntPtr CreateProvider(string providerName, Interop.Advapi32.EtwEnableCallback callbackFunc);
+        internal static unsafe partial IntPtr CreateProvider(string providerName,
+            delegate* unmanaged<byte*, int, byte, long, long, Interop.Advapi32.EVENT_FILTER_DESCRIPTOR*, void*, void> callbackFunc,
+            void* callbackContext);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_DefineEvent")]
         internal static unsafe partial IntPtr DefineEvent(IntPtr provHandle, uint eventID, long keywords, uint eventVersion, uint level, void *pMetadata, uint metadataLength);

--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -1035,7 +1035,7 @@ create_provider (
 
     ep_return_null_if_nok (provider_name_utf8 != NULL);
 
-    EventPipeProvider *provider = ep_create_provider (provider_name_utf8, callback_func, NULL, NULL);
+    EventPipeProvider *provider = ep_create_provider (provider_name_utf8, callback_func, NULL);
 
     g_free (provider_name_utf8);
     return provider;

--- a/src/coreclr/vm/eventpipeadapter.h
+++ b/src/coreclr/vm/eventpipeadapter.h
@@ -318,7 +318,7 @@ public:
 		ep_add_provider_to_session (provider, session);
 	}
 
-	static inline EventPipeProvider * CreateProvider(const SString &providerName, EventPipeCallback callback)
+	static inline EventPipeProvider * CreateProvider(const SString &providerName, EventPipeCallback callback, void* callbackContext = nullptr)
 	{
 		CONTRACTL
 		{
@@ -329,7 +329,7 @@ public:
 		CONTRACTL_END;
 
 		ep_char8_t *providerNameUTF8 = ep_rt_utf16_to_utf8_string(reinterpret_cast<const ep_char16_t *>(providerName.GetUnicode ()), -1);
-		EventPipeProvider * provider = ep_create_provider (providerNameUTF8, callback, NULL, NULL);
+		EventPipeProvider * provider = ep_create_provider (providerNameUTF8, callback, callbackContext);
 		ep_rt_utf8_string_free (providerNameUTF8);
 		return provider;
 	}

--- a/src/coreclr/vm/eventpipeinternal.cpp
+++ b/src/coreclr/vm/eventpipeinternal.cpp
@@ -85,7 +85,8 @@ extern "C" BOOL QCALLTYPE EventPipeInternal_GetSessionInfo(UINT64 sessionID, Eve
 
 extern "C" INT_PTR QCALLTYPE EventPipeInternal_CreateProvider(
     _In_z_ LPCWSTR providerName,
-    EventPipeCallback pCallbackFunc)
+    EventPipeCallback pCallbackFunc,
+    void* pCallbackContext)
 {
     QCALL_CONTRACT;
 
@@ -93,7 +94,7 @@ extern "C" INT_PTR QCALLTYPE EventPipeInternal_CreateProvider(
 
     BEGIN_QCALL;
 
-    pProvider = EventPipeAdapter::CreateProvider(providerName, pCallbackFunc);
+    pProvider = EventPipeAdapter::CreateProvider(providerName, pCallbackFunc, pCallbackContext);
 
     END_QCALL;
 

--- a/src/coreclr/vm/eventpipeinternal.h
+++ b/src/coreclr/vm/eventpipeinternal.h
@@ -55,7 +55,8 @@ extern "C" BOOL QCALLTYPE EventPipeInternal_GetSessionInfo(UINT64 sessionID, Eve
 
 extern "C" INT_PTR QCALLTYPE EventPipeInternal_CreateProvider(
     _In_z_ LPCWSTR providerName,
-    EventPipeCallback pCallbackFunc);
+    EventPipeCallback pCallbackFunc,
+    void* pCallbackContext);
 
 extern "C" INT_PTR QCALLTYPE EventPipeInternal_DefineEvent(
     INT_PTR provHandle,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EtwEnableCallback.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EtwEnableCallback.cs
@@ -19,14 +19,5 @@ internal static partial class Interop
             public int Size;
             public int Type;
         }
-
-        internal unsafe delegate void EtwEnableCallback(
-            Guid* sourceId,
-            int isEnabled,
-            byte level,
-            long matchAnyKeywords,
-            long matchAllKeywords,
-            EVENT_FILTER_DESCRIPTOR* filterData,
-            void* callbackContext);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EventRegister.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EventRegister.cs
@@ -10,9 +10,9 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Advapi32)]
         internal static unsafe partial uint EventRegister(
-            in Guid providerId,
-            EtwEnableCallback enableCallback,
+            Guid* providerId,
+            delegate* unmanaged<Guid*, int, byte, long, long, EVENT_FILTER_DESCRIPTOR*, void*, void> enableCallback,
             void* callbackContext,
-            ref long registrationHandle);
+            long* registrationHandle);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -1,47 +1,58 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
+
 namespace System.Diagnostics.Tracing
 {
     internal sealed class EventPipeEventProvider : IEventProvider
     {
-        // The EventPipeProvider handle.
-        private IntPtr m_provHandle = IntPtr.Zero;
+        private EventEnableCallback? _enableCallback;
+        private IntPtr _provHandle;
+        private GCHandle _gcHandle;
+
+        [UnmanagedCallersOnly]
+        private static unsafe void Callback(byte* sourceId, int isEnabled, byte level,
+            long matchAnyKeywords, long matchAllKeywords, Interop.Advapi32.EVENT_FILTER_DESCRIPTOR* filterData, void* callbackContext)
+        {
+            ((EventPipeEventProvider)GCHandle.FromIntPtr((IntPtr)callbackContext).Target!)._enableCallback!(
+                isEnabled, level, matchAnyKeywords, matchAllKeywords, filterData);
+        }
 
         // Register an event provider.
-        unsafe uint IEventProvider.EventRegister(
+        unsafe void IEventProvider.EventRegister(
             EventSource eventSource,
-            Interop.Advapi32.EtwEnableCallback enableCallback,
-            void* callbackContext,
-            ref long registrationHandle)
+            EventEnableCallback enableCallback)
         {
-            uint returnStatus = 0;
-            m_provHandle = EventPipeInternal.CreateProvider(eventSource.Name, enableCallback);
-            if (m_provHandle != IntPtr.Zero)
-            {
-                // Fixed registration handle because a new EventPipeEventProvider
-                // will be created for each new EventSource.
-                registrationHandle = 1;
-            }
-            else
+            _enableCallback = enableCallback;
+
+            Debug.Assert(!_gcHandle.IsAllocated);
+            _gcHandle = GCHandle.Alloc(this);
+
+            _provHandle = EventPipeInternal.CreateProvider(eventSource.Name, &Callback, (void*)GCHandle.ToIntPtr(_gcHandle));
+            if (_provHandle == 0)
             {
                 // Unable to create the provider.
-                returnStatus = 1;
+                throw new OutOfMemoryException();
             }
-
-            return returnStatus;
         }
 
         // Unregister an event provider.
-        uint IEventProvider.EventUnregister(long registrationHandle)
+        void IEventProvider.EventUnregister()
         {
-            EventPipeInternal.DeleteProvider(m_provHandle);
-            return 0;
+            if (_provHandle != 0)
+            {
+                EventPipeInternal.DeleteProvider(_provHandle);
+                _provHandle = 0;
+            }
+            if (_gcHandle.IsAllocated)
+            {
+                _gcHandle.Free();
+            }
         }
 
         // Write an event.
         unsafe EventProvider.WriteEventErrorCode IEventProvider.EventWriteTransfer(
-            long registrationHandle,
             in EventDescriptor eventDescriptor,
             IntPtr eventHandle,
             Guid* activityId,
@@ -82,8 +93,7 @@ namespace System.Diagnostics.Tracing
         unsafe IntPtr IEventProvider.DefineEventHandle(uint eventID, string eventName, long keywords, uint eventVersion, uint level,
             byte *pMetadata, uint metadataLength)
         {
-            IntPtr eventHandlePtr = EventPipeInternal.DefineEvent(m_provHandle, eventID, keywords, eventVersion, level, pMetadata, metadataLength);
-            return eventHandlePtr;
+            return EventPipeInternal.DefineEvent(_provHandle, eventID, keywords, eventVersion, level, pMetadata, metadataLength);
         }
 
         // Get or set the per-thread activity ID.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -33,6 +33,7 @@ namespace System.Diagnostics.Tracing
             if (_provHandle == 0)
             {
                 // Unable to create the provider.
+                _gcHandle.Free();
                 throw new OutOfMemoryException();
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -122,11 +122,6 @@ namespace System.Diagnostics.Tracing
         /// Vista or above. If not a PlatformNotSupported exception will be thrown. If for some
         /// reason the ETW Register call failed a NotSupported exception will be thrown.
         /// </summary>
-        // <SecurityKernel Critical="True" Ring="0">
-        // <CallsSuppressUnmanagedCode Name="Interop.Advapi32.EventRegister(System.Guid*,Microsoft.Win32.Interop.Advapi32+EtwEnableCallback,System.Void*,System.Int64&):System.UInt32" />
-        // <SatisfiesLinkDemand Name="Win32Exception..ctor(System.Int32)" />
-        // <ReferencesCritical Name="Method: EtwEnableCallBack(Guid*, Int32, Byte, Int64, Int64, Void*, Void*):Void" Ring="1" />
-        // </SecurityKernel>
         internal unsafe void Register(EventSource eventSource)
         {
             uint status;
@@ -155,9 +150,6 @@ namespace System.Diagnostics.Tracing
             GC.SuppressFinalize(this);
         }
 
-        // <SecurityKernel Critical="True" TreatAsSafe="Does not expose critical resource" Ring="1">
-        // <ReferencesCritical Name="Method: Deregister():Void" Ring="1" />
-        // </SecurityKernel>
         protected virtual void Dispose(bool disposing)
         {
             //
@@ -217,10 +209,6 @@ namespace System.Diagnostics.Tracing
             Dispose(false);
         }
 
-        // <SecurityKernel Critical="True" Ring="0">
-        // <UsesUnsafeCode Name="Parameter filterData of type: Void*" />
-        // <UsesUnsafeCode Name="Parameter callbackContext of type: Void*" />
-        // </SecurityKernel>
         private unsafe void EtwEnableCallBack(
                         System.Guid* sourceId,
                         int controlCode,
@@ -642,26 +630,6 @@ namespace System.Diagnostics.Tracing
             s_returnCode = error;
         }
 
-        // <SecurityKernel Critical="True" Ring="0">
-        // <UsesUnsafeCode Name="Local intptrPtr of type: IntPtr*" />
-        // <UsesUnsafeCode Name="Local intptrPtr of type: Int32*" />
-        // <UsesUnsafeCode Name="Local longptr of type: Int64*" />
-        // <UsesUnsafeCode Name="Local uintptr of type: UInt32*" />
-        // <UsesUnsafeCode Name="Local ulongptr of type: UInt64*" />
-        // <UsesUnsafeCode Name="Local charptr of type: Char*" />
-        // <UsesUnsafeCode Name="Local byteptr of type: Byte*" />
-        // <UsesUnsafeCode Name="Local shortptr of type: Int16*" />
-        // <UsesUnsafeCode Name="Local sbyteptr of type: SByte*" />
-        // <UsesUnsafeCode Name="Local ushortptr of type: UInt16*" />
-        // <UsesUnsafeCode Name="Local floatptr of type: Single*" />
-        // <UsesUnsafeCode Name="Local doubleptr of type: Double*" />
-        // <UsesUnsafeCode Name="Local boolptr of type: Boolean*" />
-        // <UsesUnsafeCode Name="Local guidptr of type: Guid*" />
-        // <UsesUnsafeCode Name="Local decimalptr of type: Decimal*" />
-        // <UsesUnsafeCode Name="Local booleanptr of type: Boolean*" />
-        // <UsesUnsafeCode Name="Parameter dataDescriptor of type: EventData*" />
-        // <UsesUnsafeCode Name="Parameter dataBuffer of type: Byte*" />
-        // </SecurityKernel>
         private static unsafe object? EncodeObject(ref object? data, ref EventData* dataDescriptor, ref byte* dataBuffer, ref uint totalEventSize)
         /*++
 
@@ -887,23 +855,6 @@ namespace System.Diagnostics.Tracing
         /// <param name="eventPayload">
         /// Payload for the ETW event.
         /// </param>
-        // <SecurityKernel Critical="True" Ring="0">
-        // <CallsSuppressUnmanagedCode Name="Interop.Advapi32.EventWrite(System.Int64,EventDescriptor&,System.UInt32,System.Void*):System.UInt32" />
-        // <UsesUnsafeCode Name="Local dataBuffer of type: Byte*" />
-        // <UsesUnsafeCode Name="Local pdata of type: Char*" />
-        // <UsesUnsafeCode Name="Local userData of type: EventData*" />
-        // <UsesUnsafeCode Name="Local userDataPtr of type: EventData*" />
-        // <UsesUnsafeCode Name="Local currentBuffer of type: Byte*" />
-        // <UsesUnsafeCode Name="Local v0 of type: Char*" />
-        // <UsesUnsafeCode Name="Local v1 of type: Char*" />
-        // <UsesUnsafeCode Name="Local v2 of type: Char*" />
-        // <UsesUnsafeCode Name="Local v3 of type: Char*" />
-        // <UsesUnsafeCode Name="Local v4 of type: Char*" />
-        // <UsesUnsafeCode Name="Local v5 of type: Char*" />
-        // <UsesUnsafeCode Name="Local v6 of type: Char*" />
-        // <UsesUnsafeCode Name="Local v7 of type: Char*" />
-        // <ReferencesCritical Name="Method: EncodeObject(Object&, EventData*, Byte*):String" Ring="1" />
-        // </SecurityKernel>
         internal unsafe bool WriteEvent(ref EventDescriptor eventDescriptor, IntPtr eventHandle, Guid* activityID, Guid* childActivityID, object?[] eventPayload)
         {
             WriteEventErrorCode status = WriteEventErrorCode.NoError;
@@ -1129,9 +1080,6 @@ namespace System.Diagnostics.Tracing
         /// <param name="data">
         /// pointer  do the event data
         /// </param>
-        // <SecurityKernel Critical="True" Ring="0">
-        // <CallsSuppressUnmanagedCode Name="Interop.Advapi32.EventWrite(System.Int64,EventDescriptor&,System.UInt32,System.Void*):System.UInt32" />
-        // </SecurityKernel>
         protected internal unsafe bool WriteEvent(ref EventDescriptor eventDescriptor, IntPtr eventHandle, Guid* activityID, Guid* childActivityID, int dataCount, IntPtr data)
         {
             if (childActivityID != null)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -1162,6 +1162,7 @@ namespace System.Diagnostics.Tracing
                 &registrationHandle);
             if (status != 0)
             {
+                _gcHandle.Free();
                 throw new ArgumentException(Interop.Kernel32.GetMessage((int)status));
             }
             Debug.Assert(_registrationHandle == 0);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/IEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/IEventProvider.cs
@@ -7,18 +7,15 @@ namespace System.Diagnostics.Tracing
     internal interface IEventProvider
     {
         // Register an event provider.
-        unsafe uint EventRegister(
+        unsafe void EventRegister(
             EventSource eventSource,
-            Interop.Advapi32.EtwEnableCallback enableCallback,
-            void* callbackContext,
-            ref long registrationHandle);
+            EventEnableCallback enableCallback);
 
         // Unregister an event provider.
-        uint EventUnregister(long registrationHandle);
+        void EventUnregister();
 
         // Write an event.
         unsafe EventProvider.WriteEventErrorCode EventWriteTransfer(
-            long registrationHandle,
             in EventDescriptor eventDescriptor,
             IntPtr eventHandle,
             Guid* activityId,

--- a/src/mono/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipe.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipe.Mono.cs
@@ -21,7 +21,12 @@ namespace System.Diagnostics.Tracing
         // These ICalls are used by EventSource to interact with the EventPipe.
         //
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern IntPtr CreateProvider(string providerName, Interop.Advapi32.EtwEnableCallback callbackFunc);
+        private static extern unsafe IntPtr CreateProvider(string providerName, IntPtr callbackFunc, IntPtr callbackContext);
+
+        internal static unsafe IntPtr CreateProvider(string providerName,
+            delegate* unmanaged<byte*, int, byte, long, long, Interop.Advapi32.EVENT_FILTER_DESCRIPTOR*, void*, void> callbackFunc,
+            void* callbackContext)
+            => CreateProvider(providerName, (IntPtr)callbackFunc, (IntPtr)callbackContext);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern unsafe IntPtr DefineEvent(IntPtr provHandle, uint eventID, long keywords, uint eventVersion, uint level, byte* pMetadata, uint metadataLength);

--- a/src/mono/mono/component/event_pipe-stub.c
+++ b/src/mono/mono/component/event_pipe-stub.c
@@ -76,7 +76,6 @@ static EventPipeProvider *
 event_pipe_stub_create_provider (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data);
 
 static void
@@ -327,7 +326,6 @@ static EventPipeProvider *
 event_pipe_stub_create_provider (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data)
 {
 	return (EventPipeProvider *)_max_event_pipe_type_size;

--- a/src/mono/mono/component/event_pipe.h
+++ b/src/mono/mono/component/event_pipe.h
@@ -101,7 +101,6 @@ typedef EventPipeProvider *
 (*event_pipe_component_create_provider_func) (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data);
 
 typedef void

--- a/src/mono/mono/eventpipe/test/ep-buffer-manager-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-buffer-manager-tests.c
@@ -116,7 +116,7 @@ buffer_manager_init (
 
 	test_location = 3;
 
-	*provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	*provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (*provider != NULL);
 
 	test_location = 4;

--- a/src/mono/mono/eventpipe/test/ep-buffer-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-buffer-tests.c
@@ -98,7 +98,7 @@ load_buffer_with_events_init (
 
 	test_location = 2;
 
-	*provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	*provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (*provider != NULL);
 
 	test_location = 3;

--- a/src/mono/mono/eventpipe/test/ep-fastserializer-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-fastserializer-tests.c
@@ -76,7 +76,7 @@ test_fast_serializer_object_fast_serialize (void)
 
 	test_location = 2;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 3;

--- a/src/mono/mono/eventpipe/test/ep-file-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-file-tests.c
@@ -79,7 +79,7 @@ test_file_write_event (EventPipeSerializationFormat format, bool write_event, bo
 	test_location = 2;
 
 	if (write_event) {
-		provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+		provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 		ep_raise_error_if_nok (provider != NULL);
 
 		test_location = 3;

--- a/src/mono/mono/eventpipe/test/ep-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-tests.c
@@ -59,7 +59,7 @@ test_create_delete_provider (void)
 	RESULT result = NULL;
 	uint32_t test_location = 0;
 
-	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	if (!test_provider) {
 		result = FAILED ("Failed to create provider %s, ep_create_provider returned NULL", TEST_PROVIDER_NAME);
 		ep_raise_error ();
@@ -113,7 +113,7 @@ test_get_provider (void)
 	RESULT result = NULL;
 	uint32_t test_location = 0;
 
-	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	if (!test_provider) {
 		result = FAILED ("Failed to create provider %s, ep_create_provider returned NULL", TEST_PROVIDER_NAME);
 		ep_raise_error ();
@@ -157,7 +157,7 @@ test_create_same_provider_twice (void)
 	EventPipeProvider *test_provider2 = NULL;
 	EventPipeProvider *returned_test_provider = NULL;
 
-	test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	if (!test_provider) {
 		result = FAILED ("Failed to create provider %s, ep_create_provider returned NULL", TEST_PROVIDER_NAME);
 		ep_raise_error ();
@@ -173,7 +173,7 @@ test_create_same_provider_twice (void)
 
 	test_location = 2;
 
-	test_provider2 = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	test_provider2 = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	if (!test_provider2) {
 		result = FAILED ("Creating to create an already existing provider %s", TEST_PROVIDER_NAME);
 		ep_raise_error ();
@@ -646,7 +646,7 @@ test_create_delete_provider_with_callback (void)
 
 	ep_start_streaming (session_id);
 
-	test_provider = ep_create_provider (TEST_PROVIDER_NAME, provider_callback, NULL, &provider_callback_data);
+	test_provider = ep_create_provider (TEST_PROVIDER_NAME, provider_callback, &provider_callback_data);
 	ep_raise_error_if_nok (test_provider != NULL);
 
 	test_location = 3;
@@ -679,7 +679,7 @@ test_build_event_metadata (void)
 	EventPipeEventInstance *ep_event_instance = NULL;
 	EventPipeEventMetadataEvent *metadata_event = NULL;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 1;
@@ -776,7 +776,7 @@ test_session_write_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -829,7 +829,7 @@ test_session_write_event_seq_point (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -886,7 +886,7 @@ test_session_write_wait_get_next_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -951,7 +951,7 @@ test_session_write_get_next_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -1028,7 +1028,7 @@ test_session_write_suspend_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -1088,7 +1088,7 @@ test_write_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -1139,7 +1139,7 @@ test_write_get_next_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -1199,7 +1199,7 @@ test_write_wait_get_next_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -1279,7 +1279,7 @@ test_write_event_perf (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;

--- a/src/mono/mono/metadata/icall-def.h
+++ b/src/mono/mono/metadata/icall-def.h
@@ -157,7 +157,7 @@ NOHANDLES(ICALL(DEBUGR_2, "IsLogging", ves_icall_System_Diagnostics_Debugger_IsL
 NOHANDLES(ICALL(DEBUGR_3, "Log_icall", ves_icall_System_Diagnostics_Debugger_Log))
 
 ICALL_TYPE(EVENTPIPE, "System.Diagnostics.Tracing.EventPipeInternal", EVENTPIPE_1)
-HANDLES(EVENTPIPE_1, "CreateProvider", ves_icall_System_Diagnostics_Tracing_EventPipeInternal_CreateProvider, gconstpointer, 2, (MonoString, MonoDelegate))
+HANDLES(EVENTPIPE_1, "CreateProvider", ves_icall_System_Diagnostics_Tracing_EventPipeInternal_CreateProvider, gconstpointer, 3, (MonoString, gpointer, gpointer))
 NOHANDLES(ICALL(EVENTPIPE_2, "DefineEvent", ves_icall_System_Diagnostics_Tracing_EventPipeInternal_DefineEvent))
 NOHANDLES(ICALL(EVENTPIPE_3, "DeleteProvider", ves_icall_System_Diagnostics_Tracing_EventPipeInternal_DeleteProvider))
 NOHANDLES(ICALL(EVENTPIPE_4, "Disable", ves_icall_System_Diagnostics_Tracing_EventPipeInternal_Disable))

--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -7,95 +7,23 @@
 #include <mono/metadata/components.h>
 #include <mono/metadata/assembly-internals.h>
 
-/*
- * Forward declares of all static functions.
- */
-
-static
-void
-delegate_callback_data_free_func (
-	EventPipeCallback callback_func,
-	void *callback_data);
-
-static
-void
-delegate_callback_func (
-	const uint8_t *source_id,
-	unsigned long is_enabled,
-	uint8_t level,
-	uint64_t match_any_keywords,
-	uint64_t match_all_keywords,
-	EventFilterDescriptor *filter_data,
-	void *callback_context);
-
-static
-void
-delegate_callback_data_free_func (
-	EventPipeCallback callback_func,
-	void *callback_data)
-{
-	if (callback_data)
-		mono_gchandle_free_internal ((MonoGCHandle)callback_data);
-}
-
-static
-void
-delegate_callback_func (
-	const uint8_t *source_id,
-	unsigned long is_enabled,
-	uint8_t level,
-	uint64_t match_any_keywords,
-	uint64_t match_all_keywords,
-	EventFilterDescriptor *filter_data,
-	void *callback_context)
-{
-
-	/*internal unsafe delegate void EtwEnableCallback(
-		in Guid sourceId,
-		int isEnabled,
-		byte level,
-		long matchAnyKeywords,
-		long matchAllKeywords,
-		EVENT_FILTER_DESCRIPTOR* filterData,
-		void* callbackContext);*/
-
-	MonoGCHandle delegate_object_handle = (MonoGCHandle)callback_context;
-	MonoObject *delegate_object = delegate_object_handle ? mono_gchandle_get_target_internal (delegate_object_handle) : NULL;
-	if (delegate_object) {
-		void *params [7];
-		params [0] = (void *)source_id;
-		params [1] = (void *)&is_enabled;
-		params [2] = (void *)&level;
-		params [3] = (void *)&match_any_keywords;
-		params [4] = (void *)&match_all_keywords;
-		params [5] = (void *)filter_data;
-		params [6] = NULL;
-
-		ERROR_DECL (error);
-		mono_runtime_delegate_invoke_checked (delegate_object, params, error);
-	}
-}
-
 gconstpointer
 ves_icall_System_Diagnostics_Tracing_EventPipeInternal_CreateProvider (
 	MonoStringHandle provider_name,
-	MonoDelegateHandle callback_func,
+	gpointer callback_func,
+	gpointer callback_context,
 	MonoError *error)
 {
 	EventPipeProvider *provider = NULL;
-	void *callback_data = NULL;
 
 	if (MONO_HANDLE_IS_NULL (provider_name)) {
 		mono_error_set_argument_null (error, "providerName", "");
 		return NULL;
 	}
 
-	if (!MONO_HANDLE_IS_NULL (callback_func))
-		callback_data = (void *)mono_gchandle_new_weakref_internal (MONO_HANDLE_RAW (MONO_HANDLE_CAST (MonoObject, callback_func)), FALSE);
-
 	char *provider_name_utf8 = mono_string_handle_to_utf8 (provider_name, error);
 	if (is_ok (error) && provider_name_utf8) {
-		provider = mono_component_event_pipe ()->create_provider (provider_name_utf8, delegate_callback_func, delegate_callback_data_free_func, callback_data);
+		provider = mono_component_event_pipe ()->create_provider (provider_name_utf8, callback_func, callback_context);
 	}
 
 	g_free (provider_name_utf8);
@@ -506,7 +434,8 @@ ves_icall_System_Diagnostics_Tracing_NativeRuntimeEventSource_LogThreadPoolIOPac
 gconstpointer
 ves_icall_System_Diagnostics_Tracing_EventPipeInternal_CreateProvider (
 	MonoStringHandle provider_name,
-	MonoDelegateHandle callback_func,
+	gpointer callback_func,
+	gpointer callback_context,
 	MonoError *error)
 {
 	mono_error_set_not_implemented (error, "System.Diagnostics.Tracing.EventPipeInternal.CreateProvider");

--- a/src/native/eventpipe/ep-config-internals.h
+++ b/src/native/eventpipe/ep-config-internals.h
@@ -29,7 +29,6 @@ config_create_provider (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue);
 

--- a/src/native/eventpipe/ep-config.c
+++ b/src/native/eventpipe/ep-config.c
@@ -173,7 +173,7 @@ ep_config_init (EventPipeConfiguration *config)
 	ep_raise_error_if_nok (ep_rt_provider_list_is_valid (&config->provider_list));
 
 	EP_LOCK_ENTER (section1)
-		config->config_provider = provider_create_register (ep_config_get_default_provider_name_utf8 (), NULL, NULL, NULL, provider_callback_data_queue);
+		config->config_provider = provider_create_register (ep_config_get_default_provider_name_utf8 (), NULL, NULL, provider_callback_data_queue);
 	EP_LOCK_EXIT (section1)
 
 	ep_raise_error_if_nok (config->config_provider != NULL);
@@ -239,7 +239,6 @@ ep_config_create_provider (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue)
 {
@@ -250,7 +249,7 @@ ep_config_create_provider (
 
 	EventPipeProvider *provider = NULL;
 	EP_LOCK_ENTER (section1)
-		provider = config_create_provider (config, provider_name, callback_func, callback_data_free_func, callback_data, provider_callback_data_queue);
+		provider = config_create_provider (config, provider_name, callback_func, callback_data, provider_callback_data_queue);
 		ep_raise_error_if_nok_holding_lock (provider != NULL, section1);
 	EP_LOCK_EXIT (section1)
 
@@ -461,7 +460,6 @@ config_create_provider (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue)
 {
@@ -470,7 +468,7 @@ config_create_provider (
 
 	ep_requires_lock_held ();
 
-	EventPipeProvider *provider = ep_provider_alloc (config, provider_name, callback_func, callback_data_free_func, callback_data);
+	EventPipeProvider *provider = ep_provider_alloc (config, provider_name, callback_func, callback_data);
 	ep_raise_error_if_nok (provider != NULL);
 
 	config_register_provider (config, provider, provider_callback_data_queue);

--- a/src/native/eventpipe/ep-config.h
+++ b/src/native/eventpipe/ep-config.h
@@ -56,7 +56,6 @@ ep_config_create_provider (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue);
 

--- a/src/native/eventpipe/ep-event-source.c
+++ b/src/native/eventpipe/ep-event-source.c
@@ -98,7 +98,7 @@ ep_event_source_init (EventPipeEventSource *event_source)
 
 	EP_ASSERT (event_source != NULL);
 
-	event_source->provider = ep_create_provider (ep_provider_get_default_name_utf8 (), NULL, NULL, NULL);
+	event_source->provider = ep_create_provider (ep_provider_get_default_name_utf8 (), NULL, NULL);
 	ep_raise_error_if_nok (event_source->provider != NULL);
 
 	event_source->provider_name = ep_provider_get_default_name_utf8 ();

--- a/src/native/eventpipe/ep-provider-internals.h
+++ b/src/native/eventpipe/ep-provider-internals.h
@@ -46,7 +46,6 @@ EventPipeProvider *
 provider_create_register (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue);
 

--- a/src/native/eventpipe/ep-provider.h
+++ b/src/native/eventpipe/ep-provider.h
@@ -33,8 +33,6 @@ struct _EventPipeProvider_Internal {
 	ep_rt_event_list_t event_list;
 	// The optional provider callback function.
 	EventPipeCallback callback_func;
-	// The optional provider callback_data free callback function.
-	EventPipeCallbackDataFree callback_data_free_func;
 	// The optional provider callback data pointer.
 	void *callback_data;
 	// The configuration object.
@@ -96,7 +94,6 @@ ep_provider_alloc (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data);
 
 void

--- a/src/native/eventpipe/ep-sample-profiler.c
+++ b/src/native/eventpipe/ep-sample-profiler.c
@@ -211,7 +211,7 @@ ep_sample_profiler_init (EventPipeProviderCallbackDataQueue *provider_callback_d
 	ep_requires_lock_held ();
 
 	if (!_sampling_provider) {
-		_sampling_provider = provider_create_register (ep_config_get_sample_profiler_provider_name_utf8 (), NULL, NULL, NULL, provider_callback_data_queue);
+		_sampling_provider = provider_create_register (ep_config_get_sample_profiler_provider_name_utf8 (), NULL, NULL, provider_callback_data_queue);
 		ep_raise_error_if_nok (_sampling_provider != NULL);
 		_thread_time_event = provider_add_event (
 			_sampling_provider,

--- a/src/native/eventpipe/ep-types-forward.h
+++ b/src/native/eventpipe/ep-types-forward.h
@@ -186,10 +186,6 @@ typedef void (*EventPipeCallback)(
 	EventFilterDescriptor *filter_data,
 	void *callback_data);
 
-typedef void (*EventPipeCallbackDataFree)(
-	EventPipeCallback callback,
-	void *callback_data);
-
 typedef void (*EventPipeSessionSynchronousCallback)(
 	EventPipeProvider *provider,
 	uint32_t event_id,

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -1205,7 +1205,6 @@ EventPipeProvider *
 ep_create_provider (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data)
 {
 	ep_return_null_if_nok (provider_name != NULL);
@@ -1218,7 +1217,7 @@ ep_create_provider (
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue = ep_provider_callback_data_queue_init (&data_queue);
 
 	EP_LOCK_ENTER (section1)
-		provider = config_create_provider (ep_config_get (), provider_name, callback_func, callback_data_free_func, callback_data, provider_callback_data_queue);
+		provider = config_create_provider (ep_config_get (), provider_name, callback_func, callback_data, provider_callback_data_queue);
 		ep_raise_error_if_nok_holding_lock (provider != NULL, section1);
 	EP_LOCK_EXIT (section1)
 

--- a/src/native/eventpipe/ep.h
+++ b/src/native/eventpipe/ep.h
@@ -164,7 +164,6 @@ EventPipeProvider *
 ep_create_provider (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
-	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data);
 
 void

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -432,7 +432,7 @@ internal sealed class PInvokeTableGenerator
             {
                 if (pindex > 0)
                     sb.Append(',');
-                sb.Append(MapType(method.GetParameters()[pindex].ParameterType));
+                sb.Append(MapType(p.ParameterType));
                 sb.Append($" arg{pindex}");
                 pindex++;
             }
@@ -443,7 +443,7 @@ internal sealed class PInvokeTableGenerator
             pindex = 0;
             if (!is_void)
             {
-                sb.Append("&res");
+                sb.Append("(int*)&res");
                 pindex++;
             }
             int aindex = 0;
@@ -451,7 +451,7 @@ internal sealed class PInvokeTableGenerator
             {
                 if (pindex > 0)
                     sb.Append(", ");
-                sb.Append($"&arg{aindex}");
+                sb.Append($"(int*)&arg{aindex}");
                 pindex++;
                 aindex++;
             }


### PR DESCRIPTION
Function pointers are more efficient and avoid JITing. This is one of the last remaining uses of marshalled delegates in core framework. It allows the infrastructure for marshalled delegates to be trimmed.