### PR TITLE
Fix WebClient url encoding regression

### DIFF
--- a/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -35,5 +35,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Threading" />
+    <Reference Include="System.Web.HttpUtility" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
+++ b/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
@@ -12,6 +12,7 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace System.Net
 {
@@ -1175,7 +1176,7 @@ namespace System.Net
         [return: NotNullIfNotNull(nameof(str))]
         private static string? UrlEncode(string? str) =>
             str is null ? null :
-            WebUtility.UrlEncode(str);
+            HttpUtility.UrlEncode(str);
 
         private void InvokeOperationCompleted(AsyncOperation asyncOp, SendOrPostCallback callback, AsyncCompletedEventArgs eventArgs)
         {

--- a/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
@@ -489,7 +489,7 @@ namespace System.Net.Tests
 
         const string ExpectedTextAfterUrlEncode =
             "To+be%2c+or+not+to+be%2c+that+is+the+question%3a" +
-            "Whether+'tis+Nobler+in+the+mind+to+suffer" +
+            "Whether+%27tis+Nobler+in+the+mind+to+suffer" +
             "The+Slings+and+Arrows+of+outrageous+Fortune%2c" +
             "Or+to+take+Arms+against+a+Sea+of+troubles%2c" +
             "And+by+opposing+end+them%3a";


### PR DESCRIPTION
Fixes #79731

#75896 introduced two subtle changes to how we encoded values in `WebClient`:
1. We are now encoding the `'` character.
    - Previous behavior looks like a bug though - regression between Framework and Core, see https://github.com/dotnet/runtime/issues/79731#issuecomment-1354150483
3. We started using upper-case letters for percent-encoding values instead of lower-case
    - It turns out `WebUtility.UrlEncode` and `HttpUtility.UrlEncode` differ only in this casing behavior ... because reasons

I updated the test to expect `'` to be encoded to fix nr. 1, and swapped the implementation to use `HttpUtility` instead for nr. 2.