### PR TITLE
Report FOH segments

### DIFF
--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -1326,6 +1326,8 @@ public:
     HRESULT EnumMemDumpAppDomainInfo(CLRDataEnumMemoryFlags flags);
     HRESULT EnumMemDumpAllThreadsStack(CLRDataEnumMemoryFlags flags);
     HRESULT EnumMemCLRMainModuleInfo();
+    HRESULT EnumMemCollectFrozenHeap();
+    HRESULT EnumMemCollectFrozenSegments(CLRDATA_ADDRESS segment);
 
     bool ReportMem(TADDR addr, TSIZE_T size, bool fExpectSuccess = true);
     bool DacUpdateMemoryRegion(TADDR addr, TSIZE_T bufferSize, BYTE* buffer);


### PR DESCRIPTION
This PR fixes the issue that `!dumpheap` failed on a heap dump (captured using `createdump --type heap`) because the FOH segments are not enumerated during the dump capture.

It was working before we moved the underlying storage from `ClrVirtualAlloc` to `ExecutableAllocator` in #78292.

This change makes sure they are enumerated.