### PR TITLE
Fix generic dataflow for generic virtual methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -56,7 +56,8 @@ namespace ILCompiler.DependencyAnalysis
 
                 // GVM analysis happens on canonical forms, but this is potentially injecting new genericness
                 // into the system. Ensure reflection analysis can still see this.
-                factory.MetadataManager.GetDependenciesDueToMethodCodePresence(ref dependencies, factory, _targetMethod, methodIL: null);
+                if (_targetMethod.IsAbstract)
+                    factory.MetadataManager.GetDependenciesDueToMethodCodePresence(ref dependencies, factory, _targetMethod, methodIL: null);
             }
 
             factory.MetadataManager.GetDependenciesDueToLdToken(ref dependencies, factory, _targetMethod);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -53,6 +53,10 @@ namespace ILCompiler.DependencyAnalysis
             {
                 dependencies ??= new DependencyList();
                 dependencies.Add(factory.GVMDependencies(_targetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific)), "GVM dependencies for runtime method handle");
+
+                // GVM analysis happens on canonical forms, but this is potentially injecting new genericness
+                // into the system. Ensure reflection analysis can still see this.
+                factory.MetadataManager.GetDependenciesDueToMethodCodePresence(ref dependencies, factory, _targetMethod, methodIL: null);
             }
 
             factory.MetadataManager.GetDependenciesDueToLdToken(ref dependencies, factory, _targetMethod);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -567,9 +567,9 @@ namespace ILCompiler
 
             Debug.Assert(methodIL != null || method.IsAbstract || method.IsPInvoke || method.IsInternalCall);
 
-            if (methodIL != null && scanReflection)
+            if (scanReflection)
             {
-                if (FlowAnnotations.RequiresDataflowAnalysis(method))
+                if (methodIL != null && FlowAnnotations.RequiresDataflowAnalysis(method))
                 {
                     AddDataflowDependency(ref dependencies, factory, methodIL, "Method has annotated parameters");
                 }

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Dataflow.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Dataflow.cs
@@ -243,6 +243,13 @@ class Dataflow
             private static void RemovedMethod() { }
         }
 
+        class Type4WithPublicKept
+        {
+            public static void KeptMethod() { }
+            public static void AlsoKeptMethod() { }
+            private static void RemovedMethod() { }
+        }
+
         struct Struct1WithPublicKept
         {
             public static void KeptMethod() { }
@@ -276,6 +283,21 @@ class Dataflow
             }
         }
 
+        static IKeepPublicThroughGvm s_keepPublicThroughGvm = new KeepPublicThroughGvm();
+
+        interface IKeepPublicThroughGvm
+        {
+            void Keep<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>();
+        }
+
+        class KeepPublicThroughGvm : IKeepPublicThroughGvm
+        {
+            public void Keep<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>()
+            {
+                Assert.NotNull(typeof(T).GetMethod("KeptMethod", BindingFlags.Public | BindingFlags.Static));
+            }
+        }
+
         public static void Run()
         {
             new KeepsNonPublic();
@@ -293,6 +315,10 @@ class Dataflow
             KeepsPublic<Type3WithPublicKept>.Keep<object>();
             Assert.Equal(2, typeof(Type3WithPublicKept).CountMethods());
             Assert.Equal(2, typeof(Type3WithPublicKept).CountPublicMethods());
+
+            s_keepPublicThroughGvm.Keep<Type4WithPublicKept>();
+            Assert.Equal(2, typeof(Type4WithPublicKept).CountMethods());
+            Assert.Equal(2, typeof(Type4WithPublicKept).CountPublicMethods());
         }
     }
 


### PR DESCRIPTION
Generic virtual method analysis happens on top of canonical forms, so we would miss the fact that `IFoo.SomeMethod<SomeType>` was called and only see `IFoo.SomeMethod<__Canon>`.

Fixes #80002.

Cc @dotnet/ilc-contrib 