### PR TITLE
[release/6.0] Update 10.15 to 12.00 queues

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -28,7 +28,7 @@ jobs:
 
     # iOS/tvOS simulator x64/x86
     - ${{ if in(parameters.platform, 'iOSSimulator_x64', 'tvOSSimulator_x64') }}:
-      - OSX.1015.Amd64.Open
+      - OSX.1200.Amd64.Open
 
     # Android arm64
     - ${{ if in(parameters.platform, 'Android_arm64') }}:
@@ -112,9 +112,9 @@ jobs:
     # OSX x64
     - ${{ if eq(parameters.platform, 'OSX_x64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - OSX.1015.Amd64.Open
+        - OSX.1200.Amd64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - OSX.1015.Amd64
+        - OSX.1200.Amd64
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -92,7 +92,7 @@ jobs:
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'OSX_x64') }}:
-        - OSX.1015.Amd64.Open
+        - OSX.1200.Amd64.Open
 
     # Android
     - ${{ if in(parameters.platform, 'Android_x86', 'Android_x64') }}:
@@ -106,15 +106,15 @@ jobs:
 
     # iOS/tvOS simulator x64/x86 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iOSSimulator_x64', 'iOSSimulator_x86', 'tvOSSimulator_x64', 'MacCatalyst_x64') }}:
-      - OSX.1015.Amd64.Open
+      - OSX.1200.Amd64.Open
 
     # iOS devices
     - ${{ if in(parameters.platform, 'iOS_arm64') }}:
-      - OSX.1015.Amd64.Iphone.Open
+      - OSX.1200.Amd64.Iphone.Open
 
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvOS_arm64') }}:
-      - OSX.1015.Amd64.AppleTV.Open
+      - OSX.1200.Amd64.AppleTV.Open
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:


### PR DESCRIPTION
Fixes Issue https://github.com/dotnet/runtime/issues/80029

The Helix queues we use for osx x64 are being decommissioned on 1/1/23. Normalize testing to 12.00.

# Customer Impact

Testing only fix - needed to keep PRs green and testing working. 
