### PR TITLE
Fix nullable annotations in ITypedList

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -702,8 +702,8 @@ namespace System.ComponentModel
     }
     public partial interface ITypedList
     {
-        System.ComponentModel.PropertyDescriptorCollection GetItemProperties(System.ComponentModel.PropertyDescriptor[] listAccessors);
-        string GetListName(System.ComponentModel.PropertyDescriptor[] listAccessors);
+        System.ComponentModel.PropertyDescriptorCollection GetItemProperties(System.ComponentModel.PropertyDescriptor[]? listAccessors);
+        string GetListName(System.ComponentModel.PropertyDescriptor[]? listAccessors);
     }
     public abstract partial class License : System.IDisposable
     {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ITypedList.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ITypedList.cs
@@ -5,8 +5,8 @@ namespace System.ComponentModel
 {
     public interface ITypedList
     {
-        string GetListName(PropertyDescriptor[] listAccessors);
+        string GetListName(PropertyDescriptor[]? listAccessors);
 
-        PropertyDescriptorCollection GetItemProperties(PropertyDescriptor[] listAccessors);
+        PropertyDescriptorCollection GetItemProperties(PropertyDescriptor[]? listAccessors);
     }
 }

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -1049,8 +1049,8 @@ namespace System.Data
         void System.ComponentModel.IBindingList.RemoveSort() { }
         void System.ComponentModel.IBindingListView.ApplySort(System.ComponentModel.ListSortDescriptionCollection sorts) { }
         void System.ComponentModel.IBindingListView.RemoveFilter() { }
-        System.ComponentModel.PropertyDescriptorCollection System.ComponentModel.ITypedList.GetItemProperties(System.ComponentModel.PropertyDescriptor[] listAccessors) { throw null; }
-        string System.ComponentModel.ITypedList.GetListName(System.ComponentModel.PropertyDescriptor[] listAccessors) { throw null; }
+        System.ComponentModel.PropertyDescriptorCollection System.ComponentModel.ITypedList.GetItemProperties(System.ComponentModel.PropertyDescriptor[]? listAccessors) { throw null; }
+        string System.ComponentModel.ITypedList.GetListName(System.ComponentModel.PropertyDescriptor[]? listAccessors) { throw null; }
         public System.Data.DataTable ToTable() { throw null; }
         public System.Data.DataTable ToTable(bool distinct, params string[] columnNames) { throw null; }
         public System.Data.DataTable ToTable(string? tableName) { throw null; }
@@ -1103,8 +1103,8 @@ namespace System.Data
         int System.ComponentModel.IBindingList.Find(System.ComponentModel.PropertyDescriptor property, object key) { throw null; }
         void System.ComponentModel.IBindingList.RemoveIndex(System.ComponentModel.PropertyDescriptor property) { }
         void System.ComponentModel.IBindingList.RemoveSort() { }
-        System.ComponentModel.PropertyDescriptorCollection System.ComponentModel.ITypedList.GetItemProperties(System.ComponentModel.PropertyDescriptor[] listAccessors) { throw null; }
-        string System.ComponentModel.ITypedList.GetListName(System.ComponentModel.PropertyDescriptor[] listAccessors) { throw null; }
+        System.ComponentModel.PropertyDescriptorCollection System.ComponentModel.ITypedList.GetItemProperties(System.ComponentModel.PropertyDescriptor[]? listAccessors) { throw null; }
+        string System.ComponentModel.ITypedList.GetListName(System.ComponentModel.PropertyDescriptor[]? listAccessors) { throw null; }
         protected virtual void TableCollectionChanged(object sender, System.ComponentModel.CollectionChangeEventArgs e) { }
     }
     [System.ComponentModel.EditorAttribute("Microsoft.VSDesigner.Data.Design.DataViewRowStateEditor, Microsoft.VSDesigner, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]

--- a/src/libraries/System.Data.Common/src/System/Data/DataView.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataView.cs
@@ -1151,7 +1151,7 @@ namespace System.Data
 
         #region ITypedList
 
-        string System.ComponentModel.ITypedList.GetListName(PropertyDescriptor[] listAccessors)
+        string System.ComponentModel.ITypedList.GetListName(PropertyDescriptor[]? listAccessors)
         {
             if (_table != null)
             {
@@ -1175,7 +1175,7 @@ namespace System.Data
             return string.Empty;
         }
 
-        PropertyDescriptorCollection System.ComponentModel.ITypedList.GetItemProperties(PropertyDescriptor[] listAccessors)
+        PropertyDescriptorCollection System.ComponentModel.ITypedList.GetItemProperties(PropertyDescriptor[]? listAccessors)
         {
             if (_table != null)
             {

--- a/src/libraries/System.Data.Common/src/System/Data/DataViewManager.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataViewManager.cs
@@ -256,7 +256,7 @@ namespace System.Data
         }
 
         // SDUB: GetListName and GetItemProperties almost the same in DataView and DataViewManager
-        string System.ComponentModel.ITypedList.GetListName(PropertyDescriptor[] listAccessors)
+        string System.ComponentModel.ITypedList.GetListName(PropertyDescriptor[]? listAccessors)
         {
             DataSet? dataSet = DataSet;
             if (dataSet == null)
@@ -279,7 +279,7 @@ namespace System.Data
             return string.Empty;
         }
 
-        PropertyDescriptorCollection System.ComponentModel.ITypedList.GetItemProperties(PropertyDescriptor[] listAccessors)
+        PropertyDescriptorCollection System.ComponentModel.ITypedList.GetItemProperties(PropertyDescriptor[]? listAccessors)
         {
             DataSet? dataSet = DataSet;
             if (dataSet == null)


### PR DESCRIPTION
According to:
https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.itypedlist.getitemproperties
https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.itypedlist.getlistname
the parameters can be null.
I bumped into this problem while annotating `ListBindingHelper` in WinForms repository.
https://github.com/dotnet/winforms/blob/bc73fc2790fdce8ac7399eddf76824161bdd35cc/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs