### PR TITLE
Resolve generic virtual methods in managed type system

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -634,7 +634,7 @@ namespace Internal.Runtime
         {
             get
             {
-                Debug.Assert(IsGeneric);
+                Debug.Assert(IsGeneric || IsGenericTypeDefinition);
 
                 if (!HasGenericVariance)
                     return null;
@@ -1452,10 +1452,10 @@ namespace Internal.Runtime
 
             if (eField == EETypeField.ETF_GenericComposition)
             {
-                Debug.Assert(IsGeneric);
+                Debug.Assert(IsGeneric || (IsGenericTypeDefinition && HasGenericVariance));
                 return cbOffset;
             }
-            if (IsGeneric)
+            if (IsGeneric || (IsGenericTypeDefinition && HasGenericVariance))
             {
                 cbOffset += relativeOrFullPointerOffset;
             }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -17,7 +17,6 @@ namespace Internal.Runtime.TypeLoader
     using DynamicGenericsRegistrationData = TypeLoaderEnvironment.DynamicGenericsRegistrationData;
     using GenericTypeEntry = TypeLoaderEnvironment.GenericTypeEntry;
     using GenericMethodEntry = TypeLoaderEnvironment.GenericMethodEntry;
-    using HandleBasedGenericMethodLookup = TypeLoaderEnvironment.HandleBasedGenericMethodLookup;
     using MethodDescBasedGenericMethodLookup = TypeLoaderEnvironment.MethodDescBasedGenericMethodLookup;
 
     internal static class LowLevelListExtensions
@@ -76,31 +75,16 @@ namespace Internal.Runtime.TypeLoader
         }
 
 
-        private static bool CheckAllHandlesValidForMethod(MethodDesc method)
-        {
-            if (!method.OwningType.RetrieveRuntimeTypeHandleIfPossible())
-                return false;
-
-            for (int i = 0; i < method.Instantiation.Length; i++)
-                if (!method.Instantiation[i].RetrieveRuntimeTypeHandleIfPossible())
-                    return false;
-
-            return true;
-        }
-
         internal static bool RetrieveMethodDictionaryIfPossible(InstantiatedMethod method)
         {
             if (method.RuntimeMethodDictionary != IntPtr.Zero)
                 return true;
 
-            bool allHandlesValid = CheckAllHandlesValidForMethod(method);
-
-            TypeLoaderLogger.WriteLine("Looking for method dictionary for method " + method.ToString() + " ... " + (allHandlesValid ? "(All type arg handles valid)" : ""));
+            TypeLoaderLogger.WriteLine("Looking for method dictionary for method " + method.ToString() + " ... ");
 
             IntPtr methodDictionary;
 
-            if ((allHandlesValid && TypeLoaderEnvironment.Instance.TryLookupGenericMethodDictionaryForComponents(new HandleBasedGenericMethodLookup(method), out methodDictionary)) ||
-                 (!allHandlesValid && TypeLoaderEnvironment.Instance.TryLookupGenericMethodDictionaryForComponents(new MethodDescBasedGenericMethodLookup(method), out methodDictionary)))
+            if (TypeLoaderEnvironment.Instance.TryLookupGenericMethodDictionary(new MethodDescBasedGenericMethodLookup(method), out methodDictionary))
             {
                 TypeLoaderLogger.WriteLine("Found DICT = " + methodDictionary.LowLevelToString() + " for method " + method.ToString());
                 method.AssociateWithRuntimeMethodDictionary(methodDictionary);
@@ -1287,22 +1271,6 @@ namespace Internal.Runtime.TypeLoader
             }
 
             return true;
-        }
-
-        public static bool TryBuildGenericMethod(RuntimeTypeHandle declaringTypeHandle, RuntimeTypeHandle[] genericMethodArgHandles, MethodNameAndSignature methodNameAndSignature, out IntPtr methodDictionary)
-        {
-            TypeSystemContext context = TypeSystemContextFactory.Create();
-
-            DefType declaringType = (DefType)context.ResolveRuntimeTypeHandle(declaringTypeHandle);
-            InstantiatedMethod methodBeingLoaded = (InstantiatedMethod)context.ResolveGenericMethodInstantiation(false, declaringType, methodNameAndSignature, context.ResolveRuntimeTypeHandles(genericMethodArgHandles), IntPtr.Zero, false);
-
-            bool success = TryBuildGenericMethod(methodBeingLoaded, out methodDictionary);
-
-            // Recycle the context only if we successfully built the method. The state may be partially initialized otherwise.
-            if (success)
-                TypeSystemContextFactory.Recycle(context);
-
-            return success;
         }
 
         internal static bool TryBuildGenericMethod(InstantiatedMethod methodBeingLoaded, out IntPtr methodDictionary)

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericMethodsLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericMethodsLookup.cs
@@ -293,14 +293,14 @@ namespace Internal.Runtime.TypeLoader
             return true;
         }
 
-        public bool TryLookupExactMethodPointerForComponents(RuntimeTypeHandle declaringType, MethodNameAndSignature nameAndSignature, RuntimeTypeHandle[] genericMethodArgumentHandles, out IntPtr result)
+        public bool TryLookupExactMethodPointerForComponents(InstantiatedMethod method, out IntPtr result)
         {
-            int lookupHashcode = declaringType.GetHashCode();
+            int lookupHashcode = method.OwningType.GetHashCode();
 
             NativeHashtable hashtable;
             ExternalReferencesTable externalReferencesLookup;
 
-            HandleBasedGenericMethodLookup lookupData = new HandleBasedGenericMethodLookup(declaringType, nameAndSignature, genericMethodArgumentHandles);
+            MethodDescBasedGenericMethodLookup lookupData = new MethodDescBasedGenericMethodLookup(method);
 
             foreach (NativeFormatModuleInfo module in ModuleList.EnumerateModules())
             {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeGenericParameterDesc.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeGenericParameterDesc.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Internal.TypeSystem
+{
+    internal class RuntimeGenericParameterDesc : GenericParameterDesc
+    {
+        private readonly GenericParameterKind _kind;
+        private readonly int _index;
+        private readonly TypeSystemContext _context;
+        private readonly GenericVariance _variance;
+
+        public RuntimeGenericParameterDesc(GenericParameterKind kind, int index, TypeSystemContext context, GenericVariance variance)
+        {
+            _kind = kind;
+            _index = index;
+            _context = context;
+            _variance = variance;
+        }
+
+        public override GenericParameterKind Kind => _kind;
+
+        public override int Index => _index;
+
+        public override TypeSystemContext Context => _context;
+
+        public override GenericVariance Variance => _variance;
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeMethodDesc.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeMethodDesc.cs
@@ -52,7 +52,7 @@ namespace Internal.TypeSystem.NoMetadata
                         TypeDesc[] genericParameters = new TypeDesc[genericArgCount];
                         for (int i = 0; i < genericParameters.Length; i++)
                         {
-                            genericParameters[i] = Context.GetSignatureVariable(i, true);
+                            genericParameters[i] = new RuntimeGenericParameterDesc(GenericParameterKind.Method, i, Context, GenericVariance.None);
                         }
                         _instantiation = new Instantiation(genericParameters);
                     }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeNoMetadataType.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeNoMetadataType.cs
@@ -187,6 +187,17 @@ namespace Internal.TypeSystem.NoMetadata
                 }
             }
 
+            if ((mask & TypeFlags.HasGenericVarianceComputed) != 0)
+            {
+                flags |= TypeFlags.HasGenericVarianceComputed;
+
+                unsafe
+                {
+                    if (_genericTypeDefinition.ToEETypePtr()->HasGenericVariance)
+                        flags |= TypeFlags.HasGenericVariance;
+                }
+            }
+
             return flags;
         }
 
@@ -212,7 +223,7 @@ namespace Internal.TypeSystem.NoMetadata
             if (needsChange)
             {
                 TypeDesc openType = GetTypeDefinition();
-                return openType.InstantiateSignature(canonInstantiation, new Instantiation());
+                return Context.ResolveGenericInstantiation((DefType)openType, canonInstantiation);
             }
 
             return this;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -131,9 +131,18 @@ namespace Internal.TypeSystem
                 unsafe
                 {
                     TypeDesc[] genericParameters = new TypeDesc[rtth.ToEETypePtr()->GenericArgumentCount];
+                    Runtime.GenericVariance* runtimeVariance = rtth.ToEETypePtr()->HasGenericVariance ?
+                        rtth.ToEETypePtr()->GenericVariance : null;
                     for (int i = 0; i < genericParameters.Length; i++)
                     {
-                        genericParameters[i] = GetSignatureVariable(i, false);
+                        GenericVariance variance = runtimeVariance == null ? GenericVariance.None : runtimeVariance[i] switch
+                        {
+                            Runtime.GenericVariance.Contravariant => GenericVariance.Contravariant,
+                            Runtime.GenericVariance.Covariant => GenericVariance.Covariant,
+                            Runtime.GenericVariance.NonVariant or Runtime.GenericVariance.ArrayCovariant => GenericVariance.None,
+                            _ => throw new NotImplementedException()
+                        };
+                        genericParameters[i] = genericParameters[i] = new RuntimeGenericParameterDesc(GenericParameterKind.Type, i, this, variance);
                     }
 
                     returnedType = new NoMetadataType(this, rtth, null, new Instantiation(genericParameters), rtth.GetHashCode());

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -265,6 +265,7 @@
     <Compile Include="Internal\TypeSystem\MethodDesc.Runtime.cs" />
     <Compile Include="Internal\TypeSystem\MethodForInstantiatedType.Runtime.cs" />
     <Compile Include="Internal\TypeSystem\NoMetadataMethodDesc.cs" />
+    <Compile Include="Internal\TypeSystem\RuntimeGenericParameterDesc.cs" />
     <Compile Include="Internal\TypeSystem\RuntimeMethodDesc.Canon.cs" />
     <Compile Include="Internal\TypeSystem\RuntimeMethodDesc.cs" />
     <Compile Include="Internal\TypeSystem\RuntimeNoMetadataType.cs" />

--- a/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -55,6 +55,11 @@ namespace Internal.Runtime
                 flags |= (uint)EETypeFlags.HasComponentSizeFlag;
             }
 
+            if (type.HasVariance)
+            {
+                flags |= (uint)EETypeFlags.GenericVarianceFlag;
+            }
+
             if (type.IsGenericDefinition)
             {
                 flags |= (uint)EETypeKind.GenericTypeDefEEType;
@@ -86,11 +91,6 @@ namespace Internal.Runtime
             if (type.HasInstantiation)
             {
                 flags |= (uint)EETypeFlags.IsGenericFlag;
-
-                if (type.HasVariance)
-                {
-                    flags |= (uint)EETypeFlags.GenericVarianceFlag;
-                }
             }
 
             return flags;

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
@@ -212,6 +212,7 @@ namespace Internal.TypeSystem
 
             flags |= TypeFlags.HasFinalizerComputed;
             flags |= TypeFlags.AttributeCacheComputed;
+            flags |= TypeFlags.HasGenericVarianceComputed;
 
             return flags;
         }

--- a/src/coreclr/tools/Common/TypeSystem/Sorting/TypeSystemComparer.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Sorting/TypeSystemComparer.cs
@@ -31,10 +31,9 @@ namespace Internal.TypeSystem
 
         public int Compare(TypeDesc x, TypeDesc y)
         {
-            if (x == y)
-            {
-                return 0;
-            }
+            if (x == y) return 0;
+            if (x == null) return -1;
+            if (y == null) return 1;
 
             int codeX = x.ClassCode;
             int codeY = y.ClassCode;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1007,15 +1007,18 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        private void OutputGenericInstantiationDetails(NodeFactory factory, ref ObjectDataBuilder objData)
+        protected void OutputGenericInstantiationDetails(NodeFactory factory, ref ObjectDataBuilder objData)
         {
-            if (_type.HasInstantiation && !_type.IsTypeDefinition)
+            if (_type.HasInstantiation)
             {
-                IEETypeNode typeDefNode = factory.NecessaryTypeSymbol(_type.GetTypeDefinition());
-                if (factory.Target.SupportsRelativePointers)
-                    objData.EmitRelativeRelocOrIndirectionReference(typeDefNode);
-                else
-                    objData.EmitPointerRelocOrIndirectionReference(typeDefNode);
+                if (!_type.IsTypeDefinition)
+                {
+                    IEETypeNode typeDefNode = factory.NecessaryTypeSymbol(_type.GetTypeDefinition());
+                    if (factory.Target.SupportsRelativePointers)
+                        objData.EmitRelativeRelocOrIndirectionReference(typeDefNode);
+                    else
+                        objData.EmitPointerRelocOrIndirectionReference(typeDefNode);
+                }
 
                 GenericCompositionDetails details;
                 if (_type.GetTypeDefinition() == factory.ArrayOfTEnumeratorType)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -65,6 +65,10 @@ namespace ILCompiler.DependencyAnalysis
             OutputWritableData(factory, ref dataBuilder);
             OutputOptionalFields(factory, ref dataBuilder);
 
+            // Generic composition only meaningful if there's variance
+            if ((flags & (uint)EETypeFlags.GenericVarianceFlag) != 0)
+                OutputGenericInstantiationDetails(factory, ref dataBuilder);
+
             return dataBuilder.ToObjectData();
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -256,6 +256,8 @@ namespace ILCompiler.DependencyAnalysis
 
             dependencies.Add(factory.GVMDependencies(canonMethod), "Potential generic virtual method call");
 
+            // TODO: this should not be needed - we no longer need to materialize RuntimeTypeHandles as part
+            // of the dispatch. Investigate getting rid of this.
             // Variant generic virtual method calls at runtime might need to build the concrete version of the
             // type we could be dispatching on to find the appropriate GVM entry.
             if (_method.OwningType.HasVariance)


### PR DESCRIPTION
Generic virtual method resolution currently happens on top of `RuntimeTypeHandle`s (i.e. the runtime type system). This works as long as we only need to do generic virtual method resolution on top of types that exist in the runtime.

In order to lay foundation for fixing #77070, we need to be able to resolve not just with types that have a type handle, but also for types that we're in the process of building (e.g. due to MakeGeneric, or due to another generic virtual method dispatch).

This pull request rewrites generic virtual method dispatch to happen on top of the managed type system, instead of the runtime type system. It's a bit more than just a mechanical replacement because the existing algorithm was set up in a confusing way, with `ref` parameters that were changing what we were resolving and an odd `slotChanged` logic that I don't fully understand. I replaced the `slotChanged` with the straightforward thing (if we resolve interface method to a virtual method on a type, find the implementation of the virtual method on the current type). Tests seem to be passing. Also instead of a bunch of `ref` parameters we now just pass a `MethodDesc`.

This also includes a compiler change, because in order for the managed type system's casting logic to work, we need to be able to find out the variance of parameters on generic definitions. The compiler change is about generating this info.

Cc @dotnet/ilc-contrib 