### PR TITLE
[NativeAOT] Cleanup and rationalizing process/thread termination scenario

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -94,7 +94,6 @@ static char& __unbox_z = __stop___unbox;
 #endif // _MSC_VER
 
 extern "C" bool RhInitialize();
-extern "C" void RhpShutdown();
 extern "C" void RhSetRuntimeInitializationCallback(int (*fPtr)());
 
 extern "C" bool RhRegisterOSModule(void * pModule,
@@ -213,11 +212,7 @@ int main(int argc, char* argv[])
     if (initval != 0)
         return initval;
 
-    int retval = __managed__Main(argc, argv);
-
-    RhpShutdown();
-
-    return retval;
+    return __managed__Main(argc, argv);
 }
 #endif // !NATIVEAOT_DLL
 

--- a/src/coreclr/nativeaot/Runtime/Crst.h
+++ b/src/coreclr/nativeaot/Runtime/Crst.h
@@ -8,6 +8,9 @@
 // functionality (in particular there is no rank violation checking).
 //
 
+#ifndef __Crst_h__
+#define __Crst_h__
+
 enum CrstType
 {
     CrstHandleTable,
@@ -20,7 +23,7 @@ enum CrstType
     CrstRestrictedCallouts,
     CrstObjectiveCMarshalCallouts,
     CrstGcStressControl,
-    CrstSuspendEE,
+    CrstThreadStore,
     CrstCastCache,
     CrstYieldProcessorNormalized,
 };
@@ -126,3 +129,5 @@ public:
         return m_pLock;
     }
 };
+
+#endif //__Crst_h__

--- a/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/FinalizerHelpers.cpp
@@ -29,14 +29,12 @@ GPTR_DECL(Thread, g_pFinalizerThread);
 CLREventStatic g_FinalizerEvent;
 CLREventStatic g_FinalizerDoneEvent;
 
-// Finalizer method implemented by redhawkm.
 extern "C" void __cdecl ProcessFinalizers();
 
 // Unmanaged front-end to the finalizer thread. We require this because at the point the GC creates the
-// finalizer thread we're still executing the DllMain for RedhawkU. At that point we can't run managed code
-// successfully (in particular module initialization code has not run for RedhawkM). Instead this method waits
+// finalizer thread we can't run managed code. Instead this method waits
 // for the first finalization request (by which time everything must be up and running) and kicks off the
-// managed portion of the thread at that point.
+// managed portion of the thread at that point
 uint32_t WINAPI FinalizerStart(void* pContext)
 {
     HANDLE hFinalizerEvent = (HANDLE)pContext;
@@ -62,8 +60,7 @@ uint32_t WINAPI FinalizerStart(void* pContext)
     UInt32_BOOL fResult = PalSetEvent(hFinalizerEvent);
     ASSERT(fResult);
 
-    // Run the managed portion of the finalizer. Until we implement (non-process) shutdown this call will
-    // never return.
+    // Run the managed portion of the finalizer. This call will never return.
 
     ProcessFinalizers();
 

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -144,7 +144,6 @@ uint32_t EtwCallback(uint32_t IsEnabled, RH_ETW_CONTEXT * pContext)
 // success or false if a subsystem failed to initialize.
 
 #ifndef DACCESS_COMPILE
-CrstStatic g_SuspendEELock;
 #ifdef _MSC_VER
 #pragma warning(disable:4815) // zero-sized array in stack object will have no elements
 #endif // _MSC_VER
@@ -168,9 +167,6 @@ bool RedhawkGCInterface::InitializeSubsystems()
     // Initialize the special MethodTable used to mark free list entries in the GC heap.
     g_FreeObjectEEType.InitializeAsGcFreeType();
     g_pFreeObjectEEType = &g_FreeObjectEEType;
-
-    if (!g_SuspendEELock.InitNoThrow(CrstSuspendEE))
-        return false;
 
 #ifdef FEATURE_SVR_GC
     g_heap_type = (g_pRhConfig->GetgcServer() && PalGetProcessCpuCount() > 1) ? GC_HEAP_SVR : GC_HEAP_WKS;
@@ -642,10 +638,8 @@ void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
 
     FireEtwGCSuspendEEBegin_V1(Info.SuspendEE.Reason, Info.SuspendEE.GcCount, GetClrInstanceId());
 
-    g_SuspendEELock.Enter();
-
+    GetThreadStore()->LockThreadStore();
     GCHeapUtilities::GetGCHeap()->SetGCInProgress(TRUE);
-
     GetThreadStore()->SuspendAllThreads(true);
 
     FireEtwGCSuspendEEEnd_V1(GetClrInstanceId());
@@ -669,8 +663,7 @@ void GCToEEInterface::RestartEE(bool /*bFinishedGC*/)
 
     GetThreadStore()->ResumeAllThreads(true);
     GCHeapUtilities::GetGCHeap()->SetGCInProgress(FALSE);
-
-    g_SuspendEELock.Leave();
+    GetThreadStore()->UnlockThreadStore();
 
     FireEtwGCRestartEEEnd_V1(GetClrInstanceId());
 }

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -477,10 +477,9 @@ void RuntimeThreadShutdown(void* thread)
     ASSERT((Thread*)thread == ThreadStore::GetCurrentThread());
 
     // Do not try detaching the thread that performs the shutdown.
-    if (g_threadPerformingShutdown != nullptr)
+    if (g_threadPerformingShutdown == thread)
     {
-        ASSERT(g_threadPerformingShutdown == thread);
-        // At this point other threads are gone and could be terminated rudely while leaving runtime
+        // At this point other threads could be terminated rudely while leaving runtime
         // in inconsistent state, so we would be risking blocking the process from exiting.
         return;
     }

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -455,7 +455,7 @@ Thread* g_threadPerformingShutdown = NULL;
 static void __cdecl OnProcessExit()
 {
     // The process is exiting and the current thread is performing the shutdown.
-    // At the point when this thread exits some threads may be already rudely terminated.
+    // When this thread exits some threads may be already rudely terminated.
     // It would not be a good idea for this thread to wait on any locks
     // or run managed code at shutdown, so we will not try detaching it.
     Thread* currentThread = ThreadStore::RawGetCurrentThread();

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -459,7 +459,6 @@ static void __cdecl OnProcessExit()
     // It would not be a good idea for this thread to wait on any locks
     // or run managed code at shutdown, so we will not try detaching it.
     Thread* currentThread = ThreadStore::RawGetCurrentThread();
-    ASSERT(!currentThread->IsDetached());
     g_threadPerformingShutdown = currentThread;
 }
 #endif

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -511,49 +511,4 @@ extern "C" bool RhInitialize()
     return true;
 }
 
-#ifdef _WIN32
-EXTERN_C UInt32_BOOL WINAPI RtuDllMain(HANDLE hPalInstance, uint32_t dwReason, void* pvReserved)
-{
-    switch (dwReason)
-    {
-    case DLL_PROCESS_ATTACH:
-    {
-        STARTUP_TIMELINE_EVENT(PROCESS_ATTACH_BEGIN);
-
-        if (!InitDLL(hPalInstance))
-            return FALSE;
-
-        STARTUP_TIMELINE_EVENT(PROCESS_ATTACH_COMPLETE);
-    }
-    break;
-
-    case DLL_PROCESS_DETACH:
-        if (pvReserved == nullptr)
-        {
-            OnProcessExit();
-        }
-
-        UninitDLL();
-        break;
-
-    case DLL_THREAD_DETACH:
-        // BEWARE: loader lock is held here!
-
-        // Should have already received a call to FiberDetach for this thread's "home" fiber.
-        Thread* pCurrentThread = ThreadStore::GetCurrentThreadIfAvailable();
-        if (pCurrentThread != NULL &&
-            pCurrentThread != g_threadPerformingShutdown &&
-            !pCurrentThread->IsDetached())
-        {
-            ASSERT_UNCONDITIONALLY("Detaching thread whose home fiber has not been detached");
-            RhFailFast();
-        }
-
-        break;
-    }
-
-    return TRUE;
-}
-#endif // _WIN32
-
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -339,12 +339,8 @@ bool Thread::IsCurrentThread()
 
 void Thread::Detach()
 {
-    // Thread::Destroy is called when the thread's "home" fiber dies.  We mark the thread as "detached" here
-    // so that we can validate, in our DLL_THREAD_DETACH handler, that the thread was already destroyed at that
-    // point.
-    SetDetached();
-
     RedhawkGCInterface::ReleaseAllocContext(GetAllocContext());
+    SetDetached();
 }
 
 void Thread::Destroy()

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -278,8 +278,6 @@ void Thread::Construct()
     if (!PalGetMaximumStackBounds(&m_pStackLow, &m_pStackHigh))
         RhFailFast();
 
-    m_pTEB = PalNtCurrentTeb();
-
 #ifdef STRESS_LOG
     if (StressLog::StressLogOn(~0u, 0))
         m_pThreadStressLog = StressLog::CreateThreadStressLog(this);
@@ -1097,20 +1095,6 @@ void Thread::ValidateExInfoStack()
     }
 #endif // _DEBUG
 #endif // !DACCESS_COMPILE
-}
-
-
-
-// Retrieve the start of the TLS storage block allocated for the given thread for a specific module identified
-// by the TLS slot index allocated to that module and the offset into the OS allocated block at which
-// Redhawk-specific data is stored.
-PTR_UInt8 Thread::GetThreadLocalStorage(uint32_t uTlsIndex, uint32_t uTlsStartOffset)
-{
-#if 0
-    return (*(uint8_t***)(m_pTEB + OFFSETOF__TEB__ThreadLocalStoragePointer))[uTlsIndex] + uTlsStartOffset;
-#else
-    return (*dac_cast<PTR_PTR_PTR_UInt8>(dac_cast<TADDR>(m_pTEB) + OFFSETOF__TEB__ThreadLocalStoragePointer))[uTlsIndex] + uTlsStartOffset;
-#endif
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -37,18 +37,10 @@ class Thread;
 // can be retrieved via GetInterruptedContext()
 #define INTERRUPTED_THREAD_MARKER ((PInvokeTransitionFrame*)(ptrdiff_t)-2)
 
-enum SyncRequestResult
-{
-    TryAgain,
-    SuccessUnmanaged,
-    SuccessManaged,
-};
-
 typedef DPTR(PAL_LIMITED_CONTEXT) PTR_PAL_LIMITED_CONTEXT;
 
 struct ExInfo;
 typedef DPTR(ExInfo) PTR_ExInfo;
-
 
 // Also defined in ExceptionHandling.cs, layouts must match.
 // When adding new fields to this struct, ensure they get properly initialized in the exception handling
@@ -94,7 +86,6 @@ struct ThreadBuffer
     GCFrameRegistration*    m_pGCFrameRegistrations;
     PTR_VOID                m_pStackLow;
     PTR_VOID                m_pStackHigh;
-    PTR_UInt8               m_pTEB;                                 // Pointer to OS TEB structure for this thread
     EEThreadId              m_threadId;                             // OS thread ID
     PTR_VOID                m_pThreadStressLog;                     // pointer to head of thread's StressLogChunks
     NATIVE_CONTEXT*         m_interruptedContext;                   // context for an asynchronously interrupted thread.
@@ -105,7 +96,6 @@ struct ThreadBuffer
 #ifdef FEATURE_GC_STRESS
     uint32_t                m_uRand;                                // current per-thread random number
 #endif // FEATURE_GC_STRESS
-
 };
 
 struct ReversePInvokeFrame
@@ -212,11 +202,7 @@ public:
     void                SetSuppressGcStress();
     void                ClearSuppressGcStress();
     bool                IsWithinStackBounds(PTR_VOID p);
-
     void                GetStackBounds(PTR_VOID * ppStackLow, PTR_VOID * ppStackHigh);
-
-    PTR_UInt8           GetThreadLocalStorage(uint32_t uTlsIndex, uint32_t uTlsStartOffset);
-
     void                PushExInfo(ExInfo * pExInfo);
     void                ValidateExInfoPop(ExInfo * pExInfo, void * limitSP);
     void                ValidateExInfoStack();

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -172,13 +172,16 @@ private:
     void GcScanRootsWorker(void * pfnEnumCallback, void * pvCallbackData, StackFrameIterator & sfIter);
 
 public:
-
-    void Detach(); // First phase of thread destructor, executed with thread store lock taken
-    void Destroy(); // Second phase of thread destructor, executed without thread store lock taken
+    // First phase of thread destructor, disposes stuff related to GC.
+    // Executed with thread store lock taken so GC cannot happen.
+    void Detach();
+    // Second phase of thread destructor.
+    // Executed without thread store lock taken.
+    void Destroy();
 
     bool                IsInitialized();
 
-    gc_alloc_context *  GetAllocContext();  // @TODO: I would prefer to not expose this in this way
+    gc_alloc_context *  GetAllocContext();
 
 #ifndef DACCESS_COMPILE
     uint64_t            GetPalThreadIdForLogging();

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -129,7 +129,7 @@ void ThreadStore::AttachCurrentThread(bool fAcquireThreadStoreLock)
     ASSERT(pAttachingThread->m_ThreadStateFlags == Thread::TSF_Unknown);
 
     // fAcquireThreadStoreLock is false when threads are created/attached for GC purpose
-    // in such casse the lock is already held and GC takes care to ensure safe access to the threadstore
+    // in such case the lock is already held and GC takes care to ensure safe access to the threadstore
 
     ThreadStore* pTS = GetThreadStore();
     CrstHolderWithState threadStoreLock(&pTS->m_Lock, fAcquireThreadStoreLock);
@@ -160,21 +160,21 @@ void ThreadStore::DetachCurrentThread()
         return;
     }
 
-    // unregister from OS notifications
-    // this can return false if detach notification is spurious and does not belong to this thread.
+    // Unregister from OS notifications
+    // This can return false if detach notification is spurious and does not belong to this thread.
     if (!PalDetachThread(pDetachingThread))
     {
         return;
     }
 
-    // run pre-mortem callbacks while we still can run managed code and not holding locks.
+    // Run pre-mortem callbacks while we still can run managed code and not holding locks.
     if (g_threadExitCallback != NULL)
     {
         g_threadExitCallback();
     }
 
-    // the following makes the thread no longer able to run managed code or participate in GC.
-    // we need to hold threadstore lock while doing that.
+    // The following makes the thread no longer able to run managed code or participate in GC.
+    // We need to hold threadstore lock while doing that.
     {
         ThreadStore* pTS = GetThreadStore();
         // Note that when process is shutting down, the threads may be rudely terminated,

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -186,7 +186,7 @@ void ThreadStore::DetachCurrentThread()
         pDetachingThread->Detach();
     }
 
-    // post-mortem clean up of native data structures.
+    // post-mortem clean up.
     pDetachingThread->Destroy();
 }
 
@@ -195,7 +195,7 @@ void ThreadStore::DetachCurrentThread()
 // released.  This way, the GC always enumerates a consistent set of threads each time
 // it enumerates threads between SuspendAllThreads and ResumeAllThreads.
 //
-// @TODO: Investigate if this requirement is actually necessary.  Threads already may
+// @TODO:  Investigate if this requirement is actually necessary.  Threads already may
 // not enter managed code during GC, so if new threads are added to the thread store,
 // but haven't yet entered managed code, is that really a problem?
 //

--- a/src/coreclr/nativeaot/Runtime/threadstore.h
+++ b/src/coreclr/nativeaot/Runtime/threadstore.h
@@ -1,5 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#include "Crst.h"
+
 class Thread;
 class CLREventStatic;
 class RuntimeInstance;
@@ -21,18 +24,18 @@ class ThreadStore
 
     SList<Thread>       m_ThreadList;
     PTR_RuntimeInstance m_pRuntimeInstance;
-    ReaderWriterLock    m_Lock;
+    Crst                m_Lock;
 
 private:
     ThreadStore();
 
+public:
     void                    LockThreadStore();
     void                    UnlockThreadStore();
 
 public:
     class Iterator
     {
-        ReaderWriterLock::ReadHolder    m_readHolder;
         PTR_Thread                      m_pCurrentPosition;
     public:
         Iterator();

--- a/src/coreclr/nativeaot/Runtime/threadstore.h
+++ b/src/coreclr/nativeaot/Runtime/threadstore.h
@@ -48,7 +48,7 @@ public:
     static PTR_Thread       GetSuspendingThread();
     static void             AttachCurrentThread();
     static void             AttachCurrentThread(bool fAcquireThreadStoreLock);
-    static void             DetachCurrentThread(bool shutdownStarted);
+    static void             DetachCurrentThread();
 #ifndef DACCESS_COMPILE
     static void             SaveCurrentThreadOffsetForDAC();
     void                    InitiateThreadAbort(Thread* targetThread, Object * threadAbortException, bool doRudeAbort);

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -459,8 +459,7 @@ EXTERN_C intptr_t RhGetCurrentThunkContext()
 }
 #endif //FEATURE_EMULATED_TLS
 
-// Attach thread to PAL.
-// It can be called multiple times for the same thread.
+// Register the thread with OS to be notified when thread is about to be destroyed
 // It fails fast if a different thread was already registered.
 // Parameters:
 //  thread        - thread to attach
@@ -477,8 +476,7 @@ extern "C" void PalAttachThread(void* thread)
 #endif
 }
 
-// Detach thread from PAL.
-// It fails fast if some other thread value was attached to PAL.
+// Detach thread from OS notifications.
 // Parameters:
 //  thread        - thread to detach
 // Return:
@@ -486,10 +484,6 @@ extern "C" void PalAttachThread(void* thread)
 extern "C" bool PalDetachThread(void* thread)
 {
     UNREFERENCED_PARAMETER(thread);
-    if (g_threadExitCallback != nullptr)
-    {
-        g_threadExitCallback();
-    }
     return true;
 }
 

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -163,10 +163,8 @@ REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalInit()
     return true;
 }
 
-// Attach thread to PAL.
-// It can be called multiple times for the same thread.
-// It fails fast if a different thread was already registered with the current fiber
-// or if the thread was already registered with a different fiber.
+// Register the thread with OS to be notified when thread is about to be destroyed
+// It fails fast if a different thread was already registered with the current fiber.
 // Parameters:
 //  thread        - thread to attach
 REDHAWK_PALEXPORT void REDHAWK_PALAPI PalAttachThread(void* thread)
@@ -185,8 +183,8 @@ REDHAWK_PALEXPORT void REDHAWK_PALAPI PalAttachThread(void* thread)
     FlsSetValue(g_flsIndex, thread);
 }
 
-// Detach thread from PAL.
-// It fails fast if some other thread value was attached to PAL.
+// Detach thread from OS notifications.
+// It fails fast if some other thread value was attached to the current fiber.
 // Parameters:
 //  thread        - thread to detach
 // Return:
@@ -207,11 +205,6 @@ REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalDetachThread(void* thread)
     {
         ASSERT_UNCONDITIONALLY("Detaching a thread from the wrong fiber");
         RhFailFast();
-    }
-    
-    if (g_threadExitCallback != NULL)
-    {
-        g_threadExitCallback();
     }
 
     FlsSetValue(g_flsIndex, NULL);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Environment.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Environment.NativeAot.cs
@@ -28,7 +28,6 @@ namespace System
         {
             s_latchedExitCode = exitCode;
             ShutdownCore();
-            RuntimeImports.RhpShutdown();
             ExitRaw();
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -172,10 +172,6 @@ namespace System.Runtime
         internal static extern int RhEndNoGCRegion();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhpShutdown")]
-        internal static extern void RhpShutdown();
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetGCSegmentSize")]
         internal static extern ulong RhGetGCSegmentSize();
 


### PR DESCRIPTION
It was noticed a while ago that while the current scheme works, it has some ad-hoc parts that may not be robust enough for broader set of scenarios such as terminating the process from multiple threads or by calling `ExitProcess` from native code, or in a context of a `.dll`

This PR tries to take care of that debt.
Fixes: https://github.com/dotnet/runtime/issues/74711

- [x] unified `CrstSuspendEE` and threadstore lock into one `CrstThreadStore`
- the locks had largerly overlapping purpose and one lock is better than two.
- [x] 3 stage thread detach 
1. call managed pre-mortem callbacks while still safe. (especially important on Unix as we need to release/signal wait subsystem locks)
1. remove ability to run managed code (this stage takes threadstore lock for thread removal and to make sure that GC cannot happen)
1. perform remaining cleanup of native data structures.
- [x] rationalized thread shutdown on Windows vs. non-Windows
- on Windows the thread that initiates and performs the process shutdown, by calling native `ExitProcess`, processing `CTRL-C`  or in [few other ways](https://learn.microsoft.com/en-us/windows/win32/procthread/terminating-a-process#how-processes-are-terminated) is special. Blocking it will prevent process exiting. We detect this thread via `DLL_PROCESS_DETACH` (.dll) or `atexit()` (.exe) and remember to not detach this thread. We do not want to run managed code or take threadstore lock and risk blocking this thread when process may already be in inconsitent state.
- other, not special, threads are allowed to do regular detach sequence. At process shutdown, if timing is tight, some such threads may be destroyed rudely or get into deadlocks. Not much can be done about that, but we do not care at that point.
- on Unix there are no such special threads.
- [x] the purpose of `PalAttachThread` is to register with OS thread premortem notification. `PalDetachThread` just unregisters. 
We use:
- fiber detach notification (Windows)
- pthread_setspecific (Linux, Android)
- tls destructor (default)

In either case the notification comes without loader/OS locks held, so detaching is safe. 
The only case where loader lock could be held is shutting down the special thread on Windows. One more reason to not detach that one.
- [x] addressed some TODOs and obvious dead code.



