### PR TITLE
Include corerun in Mono testhost

### DIFF
--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -98,6 +98,9 @@
       <!-- copy the host files to make the desktop samples work -->
       <RuntimeFiles Include="@(HostFxrFile)" Condition="Exists('@(HostFxrFile)') and '$(TargetsMobile)' != 'true'"/>
       <RuntimeFiles Include="@(HostPolicyFile)" Condition="Exists('@(HostPolicyFile)') and '$(TargetsMobile)' != 'true'" />
+      <!-- CoreRun is not used for testing anymore, but we still use it for benchmarking and profiling -->
+      <RuntimeFiles Include="$(CoreCLRArtifactsPath)\corerun*" />
+      <RuntimeFiles Include="$(CoreCLRArtifactsPath)\PDB\corerun*" />
       <ReferenceCopyLocalPaths Include="@(RuntimeFiles)" />
       <!-- Setup runtime pack native. -->
       <ReferenceCopyLocalPaths Include="@(MonoCrossFiles)"


### PR DESCRIPTION
Benchmark.NET has a `--coreRun` parameter that enables running a benchmark against a private build of the .NET runtime. See [these instructions in dotnet/performance](https://github.com/dotnet/performance/blob/main/docs/benchmarking-workflow-dotnet-runtime.md#dotnet-runtime-prerequisites-for-clr) for how it is used. Currently the `corerun` program is only being included in the CoreCLR version of the testhost. This change also includes it in the Mono version of the testhost, making it slightly easier to run benchmarks against the desktop version of Mono.

I tested building `./build.sh -s mono+libs` to confirm that this does not introduce a requirement to build the `clr.hosts` subset. I also tested running `./build.sh -s mono+libs+clr.hosts` and then running Benchmark.NET against the resulting test host.