### PR TITLE
Generate fewer `ExactMethodInstantiationsHashtable` entries

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
@@ -148,10 +148,6 @@ namespace ILCompiler.DependencyAnalysis
             if (method.IsVirtual)
                 return true;
 
-            // The hashtable is also used for reflection
-            if (!factory.MetadataManager.IsReflectionBlocked(method))
-                return true;
-
             // The rest of the entries are potentially only useful for the universal
             // canonical type loader.
             return factory.TypeSystemContext.SupportsUniversalCanon;

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -57,6 +57,7 @@ internal static class ReflectionTest
 #if !REFLECTION_FROM_USAGE
         TestNotReflectedIsNotReflectable.Run();
         TestGenericInstantiationsAreEquallyReflectable.Run();
+        TestStackTraces.Run();
 #endif
         TestAttributeInheritance2.Run();
         TestInvokeMethodMetadata.Run();
@@ -1598,6 +1599,58 @@ internal static class ReflectionTest
             var t = (Type)s_type.MakeGenericType(typeof(double)).GetMethod("Gimme").Invoke(null, Array.Empty<object>());
             if (t != typeof(double))
                 throw new Exception();
+        }
+    }
+
+    class TestStackTraces
+    {
+        class RefType { }
+        struct ValType { }
+
+        class C1<T>
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string M1(T c1m1param) => Environment.StackTrace;
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string M2(T c1m2param) => Environment.StackTrace;
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string M3<U>(T c1m3param1, U c1m3param2) => Environment.StackTrace;
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string M4<U>(T c1m4param1, U c1m4param2) => Environment.StackTrace;
+        }
+
+        public static void Run()
+        {
+            // These methods are visible to reflection
+            typeof(C1<RefType>).GetMethod(nameof(C1<RefType>.M1));
+            typeof(C1<RefType>).GetMethod(nameof(C1<RefType>.M3));
+            typeof(C1<ValType>).GetMethod(nameof(C1<ValType>.M1));
+            typeof(C1<ValType>).GetMethod(nameof(C1<ValType>.M3));
+
+            Check("C1", "M1", "c1m1param", true, C1<RefType>.M1(default));
+            Check("C1", "M1", "c1m1param", true, C1<ValType>.M1(default));
+            Check("C1", "M2", "c1m2param", false, C1<RefType>.M2(default));
+            Check("C1", "M2", "c1m2param", false, C1<ValType>.M2(default));
+            Check("C1", "M3", "c1m3param", true, C1<RefType>.M3<RefType>(default, default));
+            Check("C1", "M3", "c1m3param", true, C1<RefType>.M3<ValType>(default, default));
+            Check("C1", "M3", "c1m3param", true, C1<ValType>.M3<RefType>(default, default));
+            Check("C1", "M3", "c1m3param", true, C1<ValType>.M3<ValType>(default, default));
+            Check("C1", "M4", "c1m4param", false, C1<RefType>.M4<RefType>(default, default));
+            Check("C1", "M4", "c1m4param", false, C1<RefType>.M4<ValType>(default, default));
+            Check("C1", "M4", "c1m4param", false, C1<ValType>.M4<RefType>(default, default));
+            Check("C1", "M4", "c1m4param", false, C1<ValType>.M4<ValType>(default, default));
+
+            static void Check(string type, string method, string param, bool hasParam, string s)
+            {
+                if (!s.Contains(type))
+                    throw new Exception($"'{s}' doesn't contain '{type}'");
+                if (!s.Contains(method))
+                    throw new Exception($"'{s}' doesn't contain '{method}'");
+                if (hasParam && !s.Contains(param))
+                    throw new Exception($"'{s}' doesn't contain '{param}'");
+                if (!hasParam && s.Contains(param))
+                    throw new Exception($"'{s}' contains '{param}'");
+            }
         }
     }
 #endif


### PR DESCRIPTION
This hashtable contains information about unshared generic methods. We really only need it for generic virtual methods. There was some code in the reflection stack that was reading it to support stack traces and `Delegate.GetMethodInfo` but:

1. For stack traces, we have this information in the stack trace metadata table.
2. For `Delegate.GetMethodInfo` we have a rule that all targets of delegates should become reflectable in the compiler. We should have all this data in the reflection invoke table that we also parse for this purpose.

Cc @dotnet/ilc-contrib 