### PR TITLE
Clean-up ILLink targets and avoid binplacing

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -1,20 +1,10 @@
 <Project>
+
   <PropertyGroup>
     <IsTrimmable Condition="'$(IsTrimmable)' == ''">true</IsTrimmable>
     <PrepareResourcesDependsOn>_EmbedILLinkXmls;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">$(TargetsTriggeredByCompilation);ILLinkTrimAssembly</TargetsTriggeredByCompilation>
-  </PropertyGroup>
-  
-  <!-- Flow the IsTrimmable property down to consuming projects, in order for oob.proj
-       to exclude non trimmable assemblies. -->
-  <ItemDefinitionGroup>
-    <TargetPathWithTargetPlatformMoniker>
-      <IsTrimmable>$(IsTrimmable)</IsTrimmable>
-    </TargetPathWithTargetPlatformMoniker>
-  </ItemDefinitionGroup>
 
-  <!-- Inputs and outputs of ILLinkTrimAssembly -->
-  <PropertyGroup>
     <ILLinkDirectory Condition="'$(ILLinkDirectory)' == ''">$(MSBuildProjectDirectory)\ILLink\</ILLinkDirectory>
     <ILLinkTrimAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ILLinkTrimAssemblyPath>
     <ILLinkTrimAssemblySymbols>$(IntermediateOutputPath)$(TargetName).pdb</ILLinkTrimAssemblySymbols>
@@ -40,82 +30,64 @@
 
     <!-- if building a PDB, tell illink to rewrite the symbols file -->
     <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == '' and '$(DebugSymbols)' != 'false'">true</ILLinkRewritePDBs>
+
+    <ILLinkResourcesSubstitutionIntermediatePath>$(IntermediateOutputPath)ILLink.Resources.Substitutions.xml</ILLinkResourcesSubstitutionIntermediatePath>
+    <GenerateResourcesSubstitutions Condition="'$(GenerateResourcesSubstitutions)' == '' and '$(StringResourcesPath)' != ''">true</GenerateResourcesSubstitutions>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(ILLinkDescriptorsLibraryBuildXml)" Condition="'$(ILLinkDescriptorsLibraryBuildXml)' != ''" />
+    <ILLinkSuppressionsXmls Include="$(ILLinkSuppressionsXmlFile)"
+                            Condition="Exists('$(ILLinkSuppressionsXmlFile)')" />
+    <ILLinkSuppressionsXmls Include="$(ILLinkSuppressionsConfigurationSpecificXmlFile)"
+                            Condition="Exists('$(ILLinkSuppressionsConfigurationSpecificXmlFile)')" />
+    <ILLinkSuppressionsXmls Include="$(ILLinkSuppressionsLibraryBuildXmlFile)"
+                            Condition="Exists('$(ILLinkSuppressionsLibraryBuildXmlFile)')" />
+    <ILLinkSuppressionsXmls Update="@(ILLinkSuppressionsXmls)"
+                            TargetPath="%(FileName).$(AssemblyName).xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ILLinkSubstitutionsXmls Include="$(ILLinkResourcesSubstitutionIntermediatePath)"
+                             Condition="'$(GenerateResourcesSubstitutions)' == 'true'" />
     <None Include="@(ILLinkSubstitutionsXmls)" />
+    <None Include="$(ILLinkDescriptorsLibraryBuildXml)"
+          Condition="'$(ILLinkDescriptorsLibraryBuildXml)' != ''" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <NetCoreAppCurrentBuildSettings Condition="'$(NetCoreAppCurrentBuildSettings)' == ''">$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)</NetCoreAppCurrentBuildSettings>
-    <ILLinkTrimAssemblyArtifactsRootDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ILLinkTrimAssembly', '$(NetCoreAppCurrentBuildSettings)'))</ILLinkTrimAssemblyArtifactsRootDir>
-    <ILLinkTrimAssemblyRuntimePackSuppressionsXmlsDir>$(ILLinkTrimAssemblyArtifactsRootDir)suppressions-xmls\</ILLinkTrimAssemblyRuntimePackSuppressionsXmlsDir>
-    <ILLinkTrimAssemblyOOBSuppressionsXmlsDir>$(ILLinkTrimAssemblyArtifactsRootDir)oob-suppressions-xmls\</ILLinkTrimAssemblyOOBSuppressionsXmlsDir>
-    <ILLinkTrimAssemblySuppressionsXmlsDir Condition="'$(IsNETCoreAppSrc)' == 'true'">$(ILLinkTrimAssemblyRuntimePackSuppressionsXmlsDir)</ILLinkTrimAssemblySuppressionsXmlsDir>
-    <ILLinkTrimAssemblySuppressionsXmlsDir Condition="'$(IsNETCoreAppSrc)' != 'true'">$(ILLinkTrimAssemblyOOBSuppressionsXmlsDir)</ILLinkTrimAssemblySuppressionsXmlsDir>
-  </PropertyGroup>
+  <!-- Flow the IsTrimmable property down to consuming projects, in order for oob.proj
+       to exclude non trimmable assemblies. -->
+  <ItemDefinitionGroup>
+    <TargetPathWithTargetPlatformMoniker>
+      <IsTrimmable>$(IsTrimmable)</IsTrimmable>
+    </TargetPathWithTargetPlatformMoniker>
+  </ItemDefinitionGroup>
 
-  <!-- Custom binplacing for pre/post-trimming and reports that is useful for analysis
-       Must be enabled by setting BinPlaceILLinkTrimAssembly=true
-  -->
-  <ItemGroup Condition="'$(BinPlaceILLinkTrimAssembly)' == 'true'">
-    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrentBuildSettings)">
-      <RuntimePath>$(ILLinkTrimAssemblyArtifactsRootDir)trimmed</RuntimePath>
-      <ItemName>TrimmedItem</ItemName>
-    </BinPlaceTargetFrameworks>
-    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrentBuildSettings)">
-      <RuntimePath>$(ILLinkTrimAssemblyArtifactsRootDir)reports</RuntimePath>
-      <ItemName>TrimmingReport</ItemName>
-    </BinPlaceTargetFrameworks>
-    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrentBuildSettings)">
-      <RuntimePath>$(ILLinkTrimAssemblyArtifactsRootDir)pretrimmed</RuntimePath>
-      <ItemName>PreTrimmedItem</ItemName>
-    </BinPlaceTargetFrameworks>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ILLinkSuppressionsXmls Condition="Exists('$(ILLinkSuppressionsXmlFile)')"
-                            Include="$(ILLinkSuppressionsXmlFile)" />
-    <ILLinkSuppressionsXmls Condition="Exists('$(ILLinkSuppressionsConfigurationSpecificXmlFile)')"
-                            Include="$(ILLinkSuppressionsConfigurationSpecificXmlFile)" />
-    <ILLinkSuppressionsXmls Condition="Exists('$(ILLinkSuppressionsLibraryBuildXmlFile)')"
-                            Include="$(ILLinkSuppressionsLibraryBuildXmlFile)" />
-    <ILLinkSuppressionsXmls Update="@(ILLinkSuppressionsXmls)" TargetPath="%(FileName).$(AssemblyName).xml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)">
-      <RuntimePath>$(ILLinkTrimAssemblySuppressionsXmlsDir)</RuntimePath>
-      <ItemName>ILLinkSuppressionsXmls</ItemName>
-    </BinPlaceTargetFrameworks>
-    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS.ToLowerInvariant())">
-      <RuntimePath>$(ILLinkTrimAssemblySuppressionsXmlsDir)</RuntimePath>
-      <ItemName>ILLinkSuppressionsXmls</ItemName>
-    </BinPlaceTargetFrameworks>
-  </ItemGroup>
+  <!-- Flow the ILLinkSuppressionsXmls item list down to consuming projects, in order for sfx.proj and oob.proj to
+       receive the suppression files. -->
+  <Target Name="AnnotateTargetPathWithILLinkSuppressionsXmlsProp"
+          AfterTargets="GetTargetPathWithTargetPlatformMoniker">
+    <ItemGroup>
+      <TargetPathWithTargetPlatformMoniker ILLinkSuppressionsXmls="@(ILLinkSuppressionsXmls->Metadata('FullPath'))" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="_EmbedILLinkXmls"
-          DependsOnTargets="_CombineILLinkDescriptorsXmls;_CombineILLinkSubstitutionsXmls;_CombineILLinkLinkAttributesXmls">
+          DependsOnTargets="_CombineILLinkDescriptorsXmls;
+                            _CombineILLinkSubstitutionsXmls;
+                            _CombineILLinkLinkAttributesXmls">
+    <ItemGroup>
+      <EmbeddedResource Include="$(ILLinkDescriptorsXml)"
+                        LogicalName="ILLink.Descriptors.xml"
+                        Condition="'$(ILLinkDescriptorsXml)' != ''" />
 
-    <ItemGroup Condition="'$(ILLinkDescriptorsXml)' != ''">
-      <EmbeddedResource Include="$(ILLinkDescriptorsXml)">
-        <LogicalName>ILLink.Descriptors.xml</LogicalName>
-      </EmbeddedResource>
+      <EmbeddedResource Include="$(ILLinkSubstitutionsXml)"
+                        LogicalName="ILLink.Substitutions.xml"
+                        Condition="'$(ILLinkSubstitutionsXml)' != ''" />
+
+      <EmbeddedResource Include="$(ILLinkLinkAttributesXml)"
+                        LogicalName="ILLink.LinkAttributes.xml"
+                        Condition="'$(ILLinkLinkAttributesXml)' != ''" />
     </ItemGroup>
-
-    <ItemGroup Condition="'$(ILLinkSubstitutionsXml)' != ''">
-      <EmbeddedResource Include="$(ILLinkSubstitutionsXml)">
-        <LogicalName>ILLink.Substitutions.xml</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(ILLinkLinkAttributesXml)' != ''">
-      <EmbeddedResource Include="$(ILLinkLinkAttributesXml)">
-        <LogicalName>ILLink.LinkAttributes.xml</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-
   </Target>
 
   <UsingTask TaskName="CombineLinkerXmlFiles" AssemblyFile="$(ILLinkTasksAssembly)" Condition="'$(ILLinkTasksAssembly)' != ''" />
@@ -134,15 +106,6 @@
       <FileWrites Include="$(ILLinkDescriptorsXml)" />
     </ItemGroup>
   </Target>
-
-  <PropertyGroup>
-    <ILLinkResourcesSubstitutionIntermediatePath>$(IntermediateOutputPath)ILLink.Resources.Substitutions.xml</ILLinkResourcesSubstitutionIntermediatePath>
-    <GenerateResourcesSubstitutions Condition="'$(GenerateResourcesSubstitutions)' == '' and '$(StringResourcesPath)' != ''">true</GenerateResourcesSubstitutions>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(GenerateResourcesSubstitutions)' == 'true'">
-    <ILLinkSubstitutionsXmls Include="$(ILLinkResourcesSubstitutionIntermediatePath)" />
-  </ItemGroup>
 
   <!-- If a library uses string resources, the following target generates a substitution xml that will be embedded on the
   library so that if a consumer wants to run the linker they can specify a feature switch to strip out all resources
@@ -218,10 +181,8 @@
     </PropertyGroup>
   </Target>
 
-  <!-- ILLinkTrimAssembly
-       Examines the "input assembly" for IL that is unreachable from public API and trims that,
-       rewriting the assembly to an "output assembly"
-  -->
+  <!-- Examines the "input assembly" for IL that is unreachable from public API and trims that,
+       rewriting the assembly to an "output assembly" -->
   <UsingTask TaskName="ILLink" AssemblyFile="$(ILLinkTasksAssembly)" Condition="'$(ILLinkTasksAssembly)' != ''" />
   <Target Name="ILLinkTrimAssembly"
           Condition="'$(ILLinkTrimAssembly)' == 'true'"
@@ -260,18 +221,18 @@
       <ILLinkArgs Condition="'$(ILLinkDisableIPConstProp)' == 'true'">$(ILLinkArgs) --disable-opt ipconstprop</ILLinkArgs>
     </PropertyGroup>
 
-    <MakeDir Directories="$(ILLinkTrimInputPath)" />
-
     <!-- Move the assembly into a subdirectory for ILLink -->
     <Move SourceFiles="$(ILLinkTrimAssemblyPath)"
-          DestinationFolder="$(ILLinkTrimInputPath)"
-    />
+          DestinationFolder="$(ILLinkTrimInputPath)">
+      <Output TaskParameter="MovedFiles" ItemName="FileWrites" />
+    </Move>
 
     <!-- Move the PDB into a subdirectory for ILLink if we are rewriting PDBs -->
     <Move SourceFiles="$(ILLinkTrimAssemblySymbols)"
           DestinationFolder="$(ILLinkTrimInputPath)"
-          Condition="'$(ILLinkRewritePDBs)' == 'true' and Exists('$(ILLinkTrimAssemblySymbols)')"
-    />
+          Condition="'$(ILLinkRewritePDBs)' == 'true' and Exists('$(ILLinkTrimAssemblySymbols)')">
+      <Output TaskParameter="MovedFiles" ItemName="FileWrites" />
+    </Move>
 
     <ItemGroup>
       <_DependencyDirectoriesTemp Include="@(ReferencePathWithRefAssemblies->'%(RootDir)%(Directory)')" />
@@ -333,21 +294,4 @@
     <Message Text="Assembly trimming report: $(AsmDiffList)" />
   </Target>
 
-  <!-- Similar to _CheckForCompileOutputs and runs in the same places,
-       always set these even if compile didn't run. -->
-  <Target Name="_CheckForILLinkTrimAssemblyOutputs"
-          BeforeTargets="CopyFilesToOutputDirectory;_CleanGetCurrentAndPriorFileWrites"
-          Condition="'$(ILLinkTrimAssembly)' == 'true'">
-    <ItemGroup>
-      <PreTrimmedItem Condition="Exists('$(ILLinkTrimInputAssembly)')" Include="$(ILLinkTrimInputAssembly)" />
-      <PreTrimmedItem Condition="'$(ILLinkRewritePDBs)' == 'true' and Exists('$(ILLinkTrimInputSymbols)')" Include="$(ILLinkTrimInputSymbols)" />
-      <FileWrites Include="@(PreTrimmedItem)" />
-
-      <TrimmedItem Condition="Exists('$(ILLinkTrimAssemblyPath)')" Include="$(ILLinkTrimAssemblyPath)" />
-      <TrimmedItem Condition="'$(ILLinkRewritePDBs)' == 'true' and Exists('$(ILLinkTrimAssemblySymbols)')" Include="$(ILLinkTrimAssemblySymbols)" />
-
-      <TrimmingReport Condition="Exists('$(AsmDiffReport)')" Include="$(AsmDiffReport)" />
-      <TrimmingReport Condition="Exists('$(AsmDiffList)')" Include="$(AsmDiffList)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/libraries/oob.proj
+++ b/src/libraries/oob.proj
@@ -37,13 +37,12 @@
   <Target Name="GetTrimOOBAssembliesInputs"
           DependsOnTargets="ResolveProjectReferences">
     <PropertyGroup>
-      <OOBAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-oobs'))</OOBAssembliesTrimmedArtifactsPath>
-      <OOBAssembliesMarkerFile>$(IntermediateOutputPath)linker-$(TargetArchitecture)-marker.txt</OOBAssembliesMarkerFile>
+      <OOBAssembliesTrimDir>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'illink-$(TargetArchitecture)'))</OOBAssembliesTrimDir>
+      <OOBAssembliesTrimMarkerFile>$(OOBAssembliesTrimDir)marker.txt</OOBAssembliesTrimMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- Include suppression XML files bin-placed in earlier per-library linker run. -->
-      <OOBLibrarySuppressionsXml Include="$(ILLinkTrimAssemblyOOBSuppressionsXmlsDir)*.xml" />
+      <OOBLibrarySuppressionsXml Include="@(OOBAssembly->Metadata('ILLinkSuppressionsXmls'))" />
 
       <OOBAssemblyToTrim Include="@(OOBAssembly->WithMetadataValue('IsTrimmable', 'true'))" />
       <OOBAssemblyReference Include="@(OOBAssembly->WithMetadataValue('IsTrimmable', 'false'));
@@ -56,7 +55,7 @@
           Condition="'$(RefOnly)' != 'true' and '@(OOBAssembly)' != ''"
           DependsOnTargets="GetTrimOOBAssembliesInputs;PrepareForAssembliesTrim"
           Inputs="$(ILLinkTasksAssembly);@(OOBAssemblyToTrim);@(OOBAssemblyReference);@(OOBLibrarySuppressionsXml)"
-          Outputs="$(OOBAssembliesMarkerFile)">
+          Outputs="$(OOBAssembliesTrimMarkerFile)">
     <Message Text="$(MSBuildProjectName) -> Trimming $(OutputRid) out-of-band assemblies with ILLinker..." Importance="high" />
 
     <PropertyGroup>
@@ -66,17 +65,17 @@
       <OOBILLinkArgs Condition="'@(OOBLibrarySuppressionsXml)' != ''" >$(OOBILLinkArgs) --link-attributes &quot;@(OOBLibrarySuppressionsXml->'%(FullPath)', '&quot; --link-attributes &quot;')&quot;</OOBILLinkArgs>
     </PropertyGroup>
 
+    <MakeDir Directories="$(OOBAssembliesTrimDir)" />
     <ILLink AssemblyPaths=""
         RootAssemblyNames="@(OOBAssemblyToTrim)"
         ReferenceAssemblyPaths="@(OOBAssemblyReference)"
-        OutputDirectory="$(OOBAssembliesTrimmedArtifactsPath)"
+        OutputDirectory="$(OOBAssembliesTrimDir)"
         ExtraArgs="$(OOBILLinkArgs)"
         ToolExe="$(_DotNetHostFileName)"
         ToolPath="$(_DotNetHostDirectory)" />
 
     <!-- Create a marker file which serves as the target's output to enable incremental builds. -->
-    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(OOBAssembliesMarkerFile)'))" />
-    <Touch Files="$(OOBAssembliesMarkerFile)"
+    <Touch Files="$(OOBAssembliesTrimMarkerFile)"
            AlwaysCreate="true" />
   </Target>
 

--- a/src/libraries/sfx.proj
+++ b/src/libraries/sfx.proj
@@ -24,17 +24,16 @@
   <!-- Import the illink file which contains some of the logic required to illink the shared framework assemblies. -->
   <Import Project="$(RepositoryEngineeringDir)illink.targets" />
 
-  <Target Name="GetTrimSharedFrameworkAssembliesInputs">
+  <Target Name="GetTrimSharedFrameworkAssembliesInputs"
+          DependsOnTargets="ResolveProjectReferences">
     <PropertyGroup>
-      <SharedFrameworkAssembliesMarkerFile>$(IntermediateOutputPath)linker-$(TargetArchitecture)-marker.txt</SharedFrameworkAssembliesMarkerFile>
+      <SharedFrameworkAssembliesTrimDir>$([MSBuild]::NormalizeDirectory('$(IntermediateOutputPath)', 'illink-$(TargetArchitecture)'))</SharedFrameworkAssembliesTrimDir>
+      <SharedFrameworkAssembliesTrimMarkerFile>$(SharedFrameworkAssembliesTrimDir)linker-marker.txt</SharedFrameworkAssembliesTrimMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- Include suppression XML files bin-placed in earlier per-library linker run. -->
-      <SharedFrameworkSuppressionsXml Include="$(ILLinkTrimAssemblyRuntimePackSuppressionsXmlsDir)*.xml" />
-      <!-- Collect CoreLib suppression XML files not bin-placed in earlier per-library linker run. CoreLib doesn't use bin-place logic. -->
+      <SharedFrameworkSuppressionsXml Include="@(SharedFrameworkAssembly->Metadata('ILLinkSuppressionsXmls'))" />
       <SharedFrameworkSuppressionsXml Include="$(CoreLibSharedDir)ILLink\ILLink.Suppressions.LibraryBuild.xml" />
-      <SharedFrameworkSuppressionsXml Condition="'$(RuntimeFlavor)' == 'CoreCLR'" Include="$(CoreClrProjectRoot)System.Private.CoreLib\src\ILLink\ILLink.Suppressions.LibraryBuild.xml" />
     </ItemGroup>
   </Target>
 
@@ -43,30 +42,30 @@
           DependsOnTargets="ResolveProjectReferences;GetTrimSharedFrameworkAssembliesInputs;PrepareForAssembliesTrim"
           Condition="'$(RefOnly)' != 'true'"
           Inputs="@(SharedFrameworkAssembly);@(SharedFrameworkSuppressionsXml);$(ILLinkTasksAssembly)"
-          Outputs="$(SharedFrameworkAssembliesMarkerFile)">
+          Outputs="$(SharedFrameworkAssembliesTrimMarkerFile)">
     <Message Text="$(MSBuildProjectName) -> Trimming $(OutputRid) shared framework assemblies with ILLinker..." Importance="high" />
 
     <PropertyGroup>
       <SharedFrameworkILLinkArgs>$(ILLinkArgs)</SharedFrameworkILLinkArgs>
       <!-- update debug symbols -->
       <SharedFrameworkILLinkArgs>$(SharedFrameworkILLinkArgs) -b true</SharedFrameworkILLinkArgs>
-      <SharedFrameworkILLinkArgs Condition="'@(SharedFrameworkSuppressionsXml)' != ''" >$(SharedFrameworkILLinkArgs) --link-attributes &quot;@(SharedFrameworkSuppressionsXml->'%(FullPath)', '&quot; --link-attributes &quot;')&quot;</SharedFrameworkILLinkArgs>
+      <SharedFrameworkILLinkArgs Condition="'@(SharedFrameworkSuppressionsXml)' != ''" >$(SharedFrameworkILLinkArgs) --link-attributes &quot;@(SharedFrameworkSuppressionsXml, '&quot; --link-attributes &quot;')&quot;</SharedFrameworkILLinkArgs>
     </PropertyGroup>
 
     <ItemGroup>
       <SharedFrameworkAssembly RootMode="library" />
     </ItemGroup>
 
+    <MakeDir Directories="$(SharedFrameworkAssembliesTrimDir)" />
     <ILLink AssemblyPaths=""
         RootAssemblyNames="@(SharedFrameworkAssembly)"
-        OutputDirectory="$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-runtimepack'))"
+        OutputDirectory="$(SharedFrameworkAssembliesTrimDir)"
         ExtraArgs="$(SharedFrameworkILLinkArgs)"
         ToolExe="$(_DotNetHostFileName)"
         ToolPath="$(_DotNetHostDirectory)" />
 
     <!-- Create a marker file which serves as the target's output to enable incremental builds. -->  
-    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(SharedFrameworkAssembliesMarkerFile)'))" />
-    <Touch Files="$(SharedFrameworkAssembliesMarkerFile)"
+    <Touch Files="$(SharedFrameworkAssembliesTrimMarkerFile)"
            AlwaysCreate="true" />
   </Target>
 


### PR DESCRIPTION
Clean-up illink.targets file, remove outdated logic that doesn't work and isn't used anymore. Avoid binplacing and instead use the P2P protocol to communicate a projects illink settings. Such information is then available in consuming projects like sfx.proj and oob.proj and avoids IO operations (binplacing).