### PR TITLE
Enable CoreCLR init failure logging in single exe host

### DIFF
--- a/src/native/corehost/hostpolicy/static/coreclr_resolver.cpp
+++ b/src/native/corehost/hostpolicy/static/coreclr_resolver.cpp
@@ -8,6 +8,8 @@
 #include <pal.h>
 #include <trace.h>
 
+typedef void (*coreclr_error_writer_callback_fn) (const char *message);
+
 extern "C"
 {
     pal::hresult_t STDMETHODCALLTYPE coreclr_initialize(
@@ -39,6 +41,9 @@ extern "C"
         const char* entryPointTypeName,
         const char* entryPointMethodName,
         void** delegate);
+
+    pal::hresult_t STDMETHODCALLTYPE coreclr_set_error_writer(
+        coreclr_error_writer_callback_fn error_writer);
 }
 
 
@@ -49,6 +54,7 @@ bool coreclr_resolver_t::resolve_coreclr(const pal::string_t& libcoreclr_path, c
     coreclr_resolver_contract.coreclr_shutdown = reinterpret_cast<coreclr_shutdown_fn>(coreclr_shutdown_2);
     coreclr_resolver_contract.coreclr_execute_assembly = reinterpret_cast<coreclr_execute_assembly_fn>(coreclr_execute_assembly);
     coreclr_resolver_contract.coreclr_create_delegate = reinterpret_cast<coreclr_create_delegate_fn>(coreclr_create_delegate);
+    coreclr_resolver_contract.coreclr_set_error_writer = reinterpret_cast<coreclr_set_error_writer_fn>(coreclr_set_error_writer);
 
     return true;
 }

--- a/src/native/corehost/hostpolicy/static/coreclr_resolver.cpp
+++ b/src/native/corehost/hostpolicy/static/coreclr_resolver.cpp
@@ -8,8 +8,6 @@
 #include <pal.h>
 #include <trace.h>
 
-typedef void (*coreclr_error_writer_callback_fn) (const char *message);
-
 extern "C"
 {
     pal::hresult_t STDMETHODCALLTYPE coreclr_initialize(


### PR DESCRIPTION
When adding the CoreCLR initialization failure logging recently, I have missed the fact that there are two versions of the coreclr_resolver.cpp. One for standalone host that I have added support for, but also for linking into single exe.

This change adds the missing support to the single exe host.