### PR TITLE
Fix bunch of incompatibilies of ComWrappers

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -541,16 +541,13 @@ namespace System.Runtime.InteropServices
                             externalComObject,
                             this,
                             retValue);
-                        if (_rcwTable.TryAdd(retValue, wrapper))
-                        {
-                            _rcwCache.Add(externalComObject, wrapper._proxyHandle);
-                            return true;
-                        }
-                        else
+                        if (!_rcwTable.TryAdd(retValue, wrapper))
                         {
                             wrapper.Release();
                             throw new NotSupportedException();
                         }
+                        _rcwCache.Add(externalComObject, wrapper._proxyHandle);
+                        return true;
                     }
                 }
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -290,7 +290,7 @@ namespace System.Runtime.InteropServices
         internal unsafe class NativeObjectWrapper
         {
             private IntPtr _externalComObject;
-            private readonly ComWrappers _comWrappers;
+            private ComWrappers _comWrappers;
             internal GCHandle _proxyHandle;
 
             public NativeObjectWrapper(IntPtr externalComObject, ComWrappers comWrappers, object comProxy)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -500,7 +500,7 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentNullException(nameof(externalComObject));
 
             if (innerMaybe != IntPtr.Zero && !flags.HasFlag(CreateObjectFlags.Aggregation))
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(SR.InvalidOperation_SuppliedInnerMustBeMarkedAggregation);
 
             if (flags.HasFlag(CreateObjectFlags.Aggregation))
                 throw new NotImplementedException();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -22,6 +22,7 @@ namespace System.Runtime.InteropServices
         private const ulong DestroySentinel = 0x0000000080000000UL;
         private const ulong TrackerRefCountMask = 0xffffffff00000000UL;
         private const ulong ComRefCountMask = 0x000000007fffffffUL;
+        private const int COR_E_ACCESSING_CCW = unchecked((int)0x80131544);
 
         internal static IntPtr DefaultIUnknownVftblPtr { get; } = CreateDefaultIUnknownVftbl();
         internal static IntPtr DefaultIReferenceTrackerTargetVftblPtr { get; } = CreateDefaultIReferenceTrackerTargetVftbl();
@@ -161,6 +162,12 @@ namespace System.Runtime.InteropServices
 
             public unsafe int QueryInterface(in Guid riid, out IntPtr ppvObject)
             {
+                if (GetComCount(RefCount) == 0)
+                {
+                    ppvObject = IntPtr.Zero;
+                    return COR_E_ACCESSING_CCW;
+                }
+
                 ppvObject = AsRuntimeDefined(in riid);
                 if (ppvObject == IntPtr.Zero)
                 {
@@ -270,6 +277,8 @@ namespace System.Runtime.InteropServices
 
             public unsafe IntPtr ComIp => _wrapper->As(in ComWrappers.IID_IUnknown);
 
+            public uint AddRef() => _wrapper->AddRef();
+
             ~ManagedObjectWrapperHolder()
             {
                 // Release GC handle created when MOW was built.
@@ -333,6 +342,7 @@ namespace System.Runtime.InteropServices
             ManagedObjectWrapperHolder? ccwValue;
             if (_ccwTable.TryGetValue(instance, out ccwValue))
             {
+                ccwValue.AddRef();
                 return ccwValue.ComIp;
             }
 
@@ -347,6 +357,10 @@ namespace System.Runtime.InteropServices
         private unsafe ManagedObjectWrapper* CreateCCW(object instance, CreateComInterfaceFlags flags)
         {
             ComInterfaceEntry* userDefined = ComputeVtables(instance, flags, out int userDefinedCount);
+            if (userDefinedCount < 0)
+            {
+                throw new ArgumentException();
+            }
 
             // Maximum number of runtime supplied vtables.
             Span<IntPtr> runtimeDefinedVtable = stackalloc IntPtr[4];
@@ -485,6 +499,9 @@ namespace System.Runtime.InteropServices
             if (externalComObject == IntPtr.Zero)
                 throw new ArgumentNullException(nameof(externalComObject));
 
+            if (innerMaybe != IntPtr.Zero && !flags.HasFlag(CreateObjectFlags.Aggregation))
+                throw new InvalidOperationException();
+
             if (flags.HasFlag(CreateObjectFlags.Aggregation))
                 throw new NotImplementedException();
 
@@ -505,6 +522,26 @@ namespace System.Runtime.InteropServices
                     if (_rcwCache.TryGetValue(externalComObject, out GCHandle handle))
                     {
                         retValue = handle.Target;
+                        return true;
+                    }
+
+                    if (wrapperMaybe is not null)
+                    {
+                        retValue = wrapperMaybe;
+                        NativeObjectWrapper wrapper = new NativeObjectWrapper(
+                            externalComObject,
+                            this,
+                            retValue);
+                        if (!_rcwTable.TryGetValue(retValue, out var existingWrapper))
+                        {
+                            _rcwTable.Add(retValue, wrapper);
+                        }
+                        else
+                        {
+                            throw new NotSupportedException();
+                        }
+
+                        _rcwCache.Add(externalComObject, wrapper._proxyHandle);
                         return true;
                     }
                 }
@@ -667,7 +704,7 @@ namespace System.Runtime.InteropServices
         {
             ManagedObjectWrapper* wrapper = ComInterfaceDispatch.ToManagedObjectWrapper((ComInterfaceDispatch*)pThis);
             uint refcount = wrapper->Release();
-            if (refcount == 0)
+            if (wrapper->RefCount == 0)
             {
                 wrapper->Destroy();
             }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -303,7 +303,12 @@ namespace System.Runtime.InteropServices
 
             public void Release()
             {
-                _comWrappers.RemoveRCWFromCache(_externalComObject);
+                if (_comWrappers != null)
+                {
+                    _comWrappers.RemoveRCWFromCache(_externalComObject);
+                    _comWrappers = null;
+                }
+
                 if (_proxyHandle.IsAllocated)
                 {
                     _proxyHandle.Free();


### PR DESCRIPTION
The only tests from ComWrappersTestsBuiltInComDisabled not working is
- ValidateFallbackQueryInterface
- ValidateAggregationWithComObject
- ValidateAggregationWithReferenceTrackerObject

Related #74620