### PR TITLE
Fix parsing the output of `ping` on Samsung phones

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -15,8 +15,6 @@ namespace System.Net.NetworkInformation
 {
     public partial class Ping
     {
-        private static char[] s_ttlExceededAddressSeparators = new[] { ' ', ':' };
-
         private Process GetPingProcess(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
             bool isIpv4 = address.AddressFamily == AddressFamily.InterNetwork;
@@ -139,7 +137,7 @@ namespace System.Net.NetworkInformation
             // - "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
             // - "From 172.21.64.1: icmp_seq=1 Time to live exceeded"
             int addressStart = stdout.IndexOf("From ", StringComparison.Ordinal) + 5;
-            int addressLength = stdout.IndexOfAny(s_ttlExceededAddressSeparators, Math.Max(addressStart, 0)) - addressStart;
+            int addressLength = stdout.AsSpan(Math.Max(addressStart, 0)).IndexOfAny(' ', ':');
             IPAddress? address;
             if (addressStart < 5 || addressLength <= 0 || !IPAddress.TryParse(stdout.AsSpan(addressStart, addressLength), out address))
             {

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -15,6 +15,8 @@ namespace System.Net.NetworkInformation
 {
     public partial class Ping
     {
+        private static char[] s_ttlExceededAddressSeparators = new[] { ' ', ':' };
+
         private Process GetPingProcess(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
             bool isIpv4 = address.AddressFamily == AddressFamily.InterNetwork;
@@ -133,9 +135,11 @@ namespace System.Net.NetworkInformation
                 return false;
             }
 
-            // look for address in "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
+            // look for address in:
+            // - "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
+            // - "From 172.21.64.1: icmp_seq=1 Time to live exceeded"
             int addressStart = stdout.IndexOf("From ", StringComparison.Ordinal) + 5;
-            int addressLength = stdout.IndexOf(' ', Math.Max(addressStart, 0)) - addressStart;
+            int addressLength = stdout.IndexOfAny(s_ttlExceededAddressSeparators, Math.Max(addressStart, 0)) - addressStart;
             IPAddress? address;
             if (addressStart < 5 || addressLength <= 0 || !IPAddress.TryParse(stdout.AsSpan(addressStart, addressLength), out address))
             {


### PR DESCRIPTION
Fixes #78990

While investigating #78990 I noticed that some Android installations contain a `ping` utility that produces slightly different output when ttl is exceeded from what our code expects. This seems to be the case at least on Samsung phones. This PR updates the parser to account for this variation.