### PR TITLE
[wasm] Revert back to using latest stable versions of chrome for testing

### DIFF
--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -39,7 +39,7 @@
 
     Refer to `GetChromeVersions` task in `src/tasks` to see how we find
     these snapshot urls.
-  -->
+
   <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('linux'))">
     <ChromeVersion>107.0.5304.110</ChromeVersion>
     <ChromeRevision>1047731</ChromeRevision>
@@ -50,6 +50,8 @@
     <ChromeRevision>1047731</ChromeRevision>
     <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1047737</_ChromeBaseSnapshotUrl>
   </PropertyGroup>
+
+  -->
 
   <PropertyGroup Condition="'$(BrowserHost)' != 'windows'">
     <FirefoxRevision>108.0.1</FirefoxRevision>

--- a/src/tasks/WasmBuildTasks/GetChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/GetChromeVersions.cs
@@ -103,7 +103,8 @@ public class GetChromeVersions : MBU.Task
 
         throw new LogAsErrorException($"Could not find a chrome snapshot folder under {baseUrl}, " +
                                         $"for branch positions {version.branch_base_position} to " +
-                                        $"{branchPosition}, for version {version.version}.");
+                                        $"{branchPosition}, for version {version.version}. " +
+                                        "A fixed version+url can be set in eng/testing/ProvisioningVersions.props .");
     }
 
     private async Task<ChromeVersionSpec> GetChromeVersionAsync()

--- a/src/tasks/WasmBuildTasks/GetChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/GetChromeVersions.cs
@@ -22,7 +22,7 @@ public class GetChromeVersions : MBU.Task
     private const string s_allJsonUrl = "http://omahaproxy.appspot.com/all.json";
     private const string s_snapshotBaseUrl = $"https://storage.googleapis.com/chromium-browser-snapshots";
     private const int s_versionCheckThresholdDays = 3;
-    private const int s_numBranchPositionsToTry = 30;
+    private const int s_numBranchPositionsToTry = 50;
     private static readonly HttpClient s_httpClient = new();
 
     public string Channel { get; set; } = "stable";


### PR DESCRIPTION
note: this affects only the library tests, and *not* the perf runs (which use a fixed v8 version).