### PR TITLE
Ensure that we don't root the compilation when using a custom exception marshalling type.

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodIndexData.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodIndexData.cs
@@ -9,23 +9,22 @@ namespace Microsoft.Interop
     /// Contains the data related to a VirtualMethodIndexAttribute, without references to Roslyn symbols.
     /// See <seealso cref="VirtualMethodIndexCompilationData"/> for a type with a reference to the StringMarshallingCustomType
     /// </summary>
-    internal sealed record VirtualMethodIndexData(int Index) : InteropAttributeData
+    internal sealed record VirtualMethodIndexData(
+        int Index,
+        bool ImplicitThisParameter,
+        MarshalDirection Direction,
+        bool ExceptionMarshallingDefined,
+        ExceptionMarshalling ExceptionMarshalling) : InteropAttributeData
     {
-        public bool ImplicitThisParameter { get; init; }
-
-        public MarshalDirection Direction { get; init; }
-
-        public bool ExceptionMarshallingDefined { get; init; }
-
-        public ExceptionMarshalling ExceptionMarshalling { get; init; }
 
         public static VirtualMethodIndexData From(VirtualMethodIndexCompilationData virtualMethodIndex)
-            => new VirtualMethodIndexData(virtualMethodIndex.Index) with
+            => new VirtualMethodIndexData(
+                virtualMethodIndex.Index,
+                virtualMethodIndex.ImplicitThisParameter,
+                virtualMethodIndex.Direction,
+                virtualMethodIndex.ExceptionMarshallingDefined,
+                virtualMethodIndex.ExceptionMarshalling)
             {
-                ImplicitThisParameter = virtualMethodIndex.ImplicitThisParameter,
-                Direction = virtualMethodIndex.Direction,
-                ExceptionMarshallingDefined = virtualMethodIndex.ExceptionMarshallingDefined,
-                ExceptionMarshalling = virtualMethodIndex.ExceptionMarshalling,
                 IsUserDefined = virtualMethodIndex.IsUserDefined,
                 SetLastError = virtualMethodIndex.SetLastError,
                 StringMarshalling = virtualMethodIndex.StringMarshalling

--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodIndexData.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodIndexData.cs
@@ -6,9 +6,37 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.Interop
 {
     /// <summary>
-    /// VirtualMethodIndexAttribute data
+    /// Contains the data related to a VirtualMethodIndexAttribute, without references to Roslyn symbols.
+    /// See <seealso cref="VirtualMethodIndexCompilationData"/> for a type with a reference to the StringMarshallingCustomType
     /// </summary>
-    internal sealed record VirtualMethodIndexData(int Index) : InteropAttributeCompilationData
+    internal sealed record VirtualMethodIndexData(int Index) : InteropAttributeData
+    {
+        public bool ImplicitThisParameter { get; init; }
+
+        public MarshalDirection Direction { get; init; }
+
+        public bool ExceptionMarshallingDefined { get; init; }
+
+        public ExceptionMarshalling ExceptionMarshalling { get; init; }
+
+        public static VirtualMethodIndexData From(VirtualMethodIndexCompilationData virtualMethodIndex)
+            => new VirtualMethodIndexData(virtualMethodIndex.Index) with
+            {
+                ImplicitThisParameter = virtualMethodIndex.ImplicitThisParameter,
+                Direction = virtualMethodIndex.Direction,
+                ExceptionMarshallingDefined = virtualMethodIndex.ExceptionMarshallingDefined,
+                ExceptionMarshalling = virtualMethodIndex.ExceptionMarshalling,
+                IsUserDefined = virtualMethodIndex.IsUserDefined,
+                SetLastError = virtualMethodIndex.SetLastError,
+                StringMarshalling = virtualMethodIndex.StringMarshalling
+            };
+    }
+
+    /// <summary>
+    /// Contains the data related to a VirtualMethodIndexAttribute, with references to Roslyn symbols.
+    /// Use <seealso cref="VirtualMethodIndexData"/> instead when using for incremental compilation state to avoid keeping a compilation alive
+    /// </summary>
+    internal sealed record VirtualMethodIndexCompilationData(int Index) : InteropAttributeCompilationData
     {
         public bool ImplicitThisParameter { get; init; }
 


### PR DESCRIPTION
This is similar to #79051 but for the new VirtualMethodIndex generator.