### PR TITLE
Use platform runtime check for ProtectedData

### DIFF
--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppPrevious)-windows;$(NetCoreAppPrevious);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <AddXamarinPlaceholderFilesToPackage>true</AddXamarinPlaceholderFilesToPackage>
@@ -13,13 +13,11 @@ System.Security.Cryptography.ProtectedData</PackageDescription>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
-    <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <IsPartialFacadeAssembly Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(IsPartialFacadeAssembly)' == 'true'">true</OmitResources>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(IsPartialFacadeAssembly)' != 'true' and '$(TargetPlatformIdentifier)' != 'windows'">SR.PlatformNotSupported_CryptographyProtectedData</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Security\Cryptography\DataProtectionScope.cs" />
     <Compile Include="System\Security\Cryptography\ProtectedData.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptProtectData.cs"
@@ -42,12 +40,16 @@ System.Security.Cryptography.ProtectedData</PackageDescription>
              Link="Common\System\Security\Cryptography\CryptoThrowHelper.Windows.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0-windows'))">
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"
              Link="Common\DisableRuntimeMarshalling.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Security" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <AddXamarinPlaceholderFilesToPackage>true</AddXamarinPlaceholderFilesToPackage>

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs
@@ -16,14 +16,20 @@ namespace System.Security.Cryptography
 
         public static byte[] Protect(byte[] userData, byte[]? optionalEntropy, DataProtectionScope scope)
         {
-            ArgumentNullException.ThrowIfNull(userData);
+            CheckPlatformSupport();
+
+            if (userData is null)
+                throw new ArgumentNullException(nameof(userData));
 
             return ProtectOrUnprotect(userData, optionalEntropy, scope, protect: true);
         }
 
         public static byte[] Unprotect(byte[] encryptedData, byte[]? optionalEntropy, DataProtectionScope scope)
         {
-            ArgumentNullException.ThrowIfNull(encryptedData);
+            CheckPlatformSupport();
+
+            if (encryptedData is null)
+                throw new ArgumentNullException(nameof(encryptedData));
 
             return ProtectOrUnprotect(encryptedData, optionalEntropy, scope, protect: false);
         }
@@ -61,7 +67,11 @@ namespace System.Security.Cryptography
                             Interop.Crypt32.CryptUnprotectData(in userDataBlob, IntPtr.Zero, ref optionalEntropyBlob, IntPtr.Zero, IntPtr.Zero, flags, out outputBlob);
                         if (!success)
                         {
+#if NET
                             int lastWin32Error = Marshal.GetLastPInvokeError();
+#else
+                            int lastWin32Error = Marshal.GetLastWin32Error();
+#endif
                             if (protect && ErrorMayBeCausedByUnloadedProfile(lastWin32Error))
                                 throw new CryptographicException(SR.Cryptography_DpApi_ProfileMayNotBeLoaded);
                             else
@@ -101,6 +111,14 @@ namespace System.Security.Cryptography
             // CAPI returns a file not found error if the user profile is not yet loaded
             return errorCode == HResults.E_FILENOTFOUND ||
                    errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND;
+        }
+
+        private static void CheckPlatformSupport()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException();
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.ProtectedData/tests/ProtectedDataUnsupportedTests.cs
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/tests/ProtectedDataUnsupportedTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography;
+
+using Xunit;
+
+namespace System.Security.Cryptography.ProtectedDataTests
+{
+    [PlatformSpecific(~TestPlatforms.Windows)]
+    public static class ProtectedUnsupportedDataTests
+    {
+        [Theory]
+        [InlineData(DataProtectionScope.LocalMachine)]
+        [InlineData(DataProtectionScope.CurrentUser)]
+        public static void Protect_PlatformNotSupported(DataProtectionScope scope)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => ProtectedData.Protect(null, null, scope));
+        }
+
+        [Theory]
+        [InlineData(DataProtectionScope.LocalMachine)]
+        [InlineData(DataProtectionScope.CurrentUser)]
+        public static void Unprotect_PlatformNotSupported(DataProtectionScope scope)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => ProtectedData.Unprotect(null, null, scope));
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProtectedDataTests.cs" />
+    <Compile Include="ProtectedDataUnsupportedTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs"
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
   </ItemGroup>


### PR DESCRIPTION
This changes S.S.C.ProtectedData to use runtime checks instead of TPI to determine if that platform is Windows or not.

This fixes an issue where `ProtectedData` does not work on UWP in Windows because UWP is picking up the .NET Standard version. We [removed](https://github.com/dotnet/runtime/pull/64610) .NET Standard 2.0 platform specific target for Windows, which previously allowed this to work in UWP. Since NS2.0-windows is no longer valid, this moves ProtectedData to use a runtime check for all implementations.

Since .NET Standard is being supported again, some refactoring that have since occurred need to be undone, or accounted for, now that we are no longer using `GeneratePlatformNotSupportedAssemblyMessage` for NS2.0. Some of the Common/* sources have been refactored to work off of `Span<T>`. So for .NETStandard we take a dependency on `System.Memory`. We can avoid this if we want to create non-span local copies of those common helpers. I have not deeply investigated how feasible this is.

Lastly, this adds some unit tests to make sure we are correctly throwing PNSE on non-Windows.

Contributes to #78875 