### PR TITLE
Disable hardware intrinsics tests under gcstress for macOS-arm64 and arm32

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_r.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
     <NumberOfStripesToUseInStress>20</NumberOfStripesToUseInStress>
+    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'OSX'">true</GCStressIncompatible>
+    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <MergedWrapperProjectReference Include="*/**/*.csproj" Exclude="**/*_ro.csproj" />

--- a/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/HardwareIntrinsics_ro.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
     <NumberOfStripesToUseInStress>20</NumberOfStripesToUseInStress>
+    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'OSX'">true</GCStressIncompatible>
+    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <MergedWrapperProjectReference Include="Arm/**/*_ro.csproj" />


### PR DESCRIPTION
These are currently hitting timeouts.

Related: #78323