### PR TITLE
Ignore stale PGO data in impCastClassOrIsInstToTree

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5784,14 +5784,18 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                     if ((info.compCompHnd->compareTypesForCast(likelyCls, pResolvedToken->hClass) ==
                          TypeCompareState::Must))
                     {
-                        assert((info.compCompHnd->getClassAttribs(likelyCls) &
-                                (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) == 0);
-                        JITDUMP("Adding \"is %s (%X)\" check as a fast path for %s using PGO data.\n",
-                                eeGetClassName(likelyCls), likelyCls, isCastClass ? "castclass" : "isinst");
+                        bool isAbstract = (info.compCompHnd->getClassAttribs(likelyCls) &
+                                           (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) == 0;
+                        // If it's abstract it means we most likely deal with a stale PGO data so bail out.
+                        if (!isAbstract)
+                        {
+                            JITDUMP("Adding \"is %s (%X)\" check as a fast path for %s using PGO data.\n",
+                                    eeGetClassName(likelyCls), likelyCls, isCastClass ? "castclass" : "isinst");
 
-                        canExpandInline = true;
-                        partialExpand   = true;
-                        exactCls        = likelyCls;
+                            canExpandInline = true;
+                            partialExpand   = true;
+                            exactCls        = likelyCls;
+                        }
                     }
                 }
             }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5785,7 +5785,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                          TypeCompareState::Must))
                     {
                         bool isAbstract = (info.compCompHnd->getClassAttribs(likelyCls) &
-                                           (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) == 0;
+                                           (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) != 0;
                         // If it's abstract it means we most likely deal with a stale PGO data so bail out.
                         if (!isAbstract)
                         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/79625

Steps to reproduce:
Collect static PGO for this (with `DOTNET_JitProfileCasts=1`) e.g. via `DOTNET_WritePGOData=1`
```csharp
public class ClassA
{
}

public class ClassB : ClassA
{
}

internal class Program
{
    static void Main()
    {
        for (int i = 0; i < 100; i++)
        {
            Foo(new ClassA());
            Thread.Sleep(16);
        }
    }


    [MethodImpl(MethodImplOptions.NoInlining)]
    static bool Foo(object o) => o is ClassA;
}
```
Then apply this patch to the C# code:
```diff
-public class ClassA
+public abstract class ClassA
{
}

public class ClassB : ClassA
{
}

internal class Program
{
    static void Main()
    {
        for (int i = 0; i < 100; i++)
        {
-           Foo(new ClassA());
+           Foo(new ClassB());
            Thread.Sleep(16);
        }
    }


    [MethodImpl(MethodImplOptions.NoInlining)]
    static bool Foo(object o) => o is ClassA;
}
```
And run with `DOTNET_ReadPGOData=1`. Assert will be fired.