### PR TITLE
[mono][interp] Fix issue with clearing of unused defs

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -9057,9 +9057,12 @@ retry:
 			if (num_dregs) {
 				// Check if the previous definition of this var was used at all.
 				// If it wasn't we can just clear the instruction
+				//
+				// MINT_MOV_DST_OFF doesn't fully write to the var, so we special case it here
 				if (local_defs [dreg].ins != NULL &&
 						local_defs [dreg].ref_count == 0 &&
-						!td->locals [dreg].indirects) {
+						!td->locals [dreg].indirects &&
+						opcode != MINT_MOV_DST_OFF) {
 					InterpInst *prev_def = local_defs [dreg].ins;
 					if (MINT_NO_SIDE_EFFECTS (prev_def->opcode)) {
 						for (int i = 0; i < mono_interp_op_sregs [prev_def->opcode]; i++)


### PR DESCRIPTION
If within a basic block we have code like `somevar = val1; ...; somevar = val2` and somevar has no indirects and is not used between the two defines, then we can remove the first assignment. However, MINT_SRC_DST_OFF is a special opcode that writes only to a part of a valuetype, even though it has the vt var as a destination. This means we can't clear the previous define, otherwise we lose data in part of the valuetype.

Regression from https://github.com/dotnet/runtime/commit/200a90aae4905567e79aafe49380a899a8f2b0c7

Fixes https://github.com/dotnet/runtime/issues/80141
Fixes https://github.com/dotnet/runtime/issues/80179