### PR TITLE
Remove dead code relating to switching AppDomains in CCWs

### DIFF
--- a/src/coreclr/vm/stdinterfaces.h
+++ b/src/coreclr/vm/stdinterfaces.h
@@ -15,19 +15,7 @@
 #endif // FEATURE_COMINTEROP
 
 #include "dispex.h"
-#include "weakreference.h"
 #include "common.h"
-
-// Until the Windows SDK is updated, just hard-code the INoMarshal IID
-#ifndef __INoMarshal_INTERFACE_DEFINED__
-DEFINE_GUID(IID_INoMarshal,0xecc8691b,0xc1db,0x4dc0,0x85,0x5e,0x65,0xf6,0xc5,0x51,0xaf,0x49);
-MIDL_INTERFACE("ecc8691b-c1db-4dc0-855e-65f6c551af49")
-INoMarshal : public IUnknown
-{
-public:
-};
-#endif // !__INoMarshal_INTERFACE_DEFINED__
-
 
 class Assembly;
 class Module;
@@ -114,42 +102,23 @@ enum ComClassType
     enum_Last,
 };
 
+// IUNKNOWN wrappers
 
-//-------------------------------------------------------------------------
-// IProvideClassInfo methods
-HRESULT __stdcall ClassInfo_GetClassInfo_Wrapper(IUnknown* pUnk,
-                         ITypeInfo** ppTI); //Address of output variable that receives the type info.
+// prototypes IUnknown methods
+HRESULT __stdcall   Unknown_QueryInterface(IUnknown* pUnk, REFIID riid, void** ppv);
 
-// ---------------------------------------------------------------------------
-//  Interface ISupportsErrorInfo
+ULONG __stdcall     Unknown_AddRef(IUnknown* pUnk);
+ULONG __stdcall     Unknown_Release(IUnknown* pUnk);
+ULONG __stdcall     Unknown_AddRefInner(IUnknown* pUnk);
+ULONG __stdcall     Unknown_ReleaseInner(IUnknown* pUnk);
 
-// %%Function: SupportsErroInfo_IntfSupportsErrorInfo,
-// ---------------------------------------------------------------------------
-HRESULT __stdcall
-SupportsErroInfo_IntfSupportsErrorInfo_Wrapper(IUnknown* pUnk, REFIID riid);
+// for std interfaces such as IProvideClassInfo
+HRESULT __stdcall   Unknown_QueryInterface_IErrorInfo(IUnknown* pUnk, REFIID riid, void** ppv);
+ULONG __stdcall     Unknown_AddRefSpecial(IUnknown* pUnk);
+ULONG __stdcall     Unknown_ReleaseSpecial(IUnknown* pUnk);
+ULONG __stdcall     Unknown_ReleaseSpecial_IErrorInfo(IUnknown* pUnk);
 
-// ---------------------------------------------------------------------------
-//  Interface IErrorInfo
-
-// %%Function: ErrorInfo_GetDescription,
-HRESULT __stdcall ErrorInfo_GetDescription_Wrapper(IUnknown* pUnk, BSTR* pbstrDescription);
-
-// %%Function: ErrorInfo_GetGUID,
-HRESULT __stdcall ErrorInfo_GetGUID_Wrapper(IUnknown* pUnk, GUID* pguid);
-
-// %%Function: ErrorInfo_GetHelpContext,
-HRESULT _stdcall ErrorInfo_GetHelpContext_Wrapper(IUnknown* pUnk, DWORD* pdwHelpCtxt);
-
-// %%Function: ErrorInfo_GetHelpFile,
-HRESULT __stdcall ErrorInfo_GetHelpFile_Wrapper(IUnknown* pUnk, BSTR* pbstrHelpFile);
-
-// %%Function: ErrorInfo_GetSource,
-HRESULT __stdcall ErrorInfo_GetSource_Wrapper(IUnknown* pUnk, BSTR* pbstrSource);
-
-//------------------------------------------------------------------------------------------
-//      IDispatch methods for COM+ objects. These methods dispatch to the appropriate
-//      implementation based on the flags of the class that implements them.
-
+// IDISPATCH wrappers
 
 // %%Function: IDispatch::GetTypeInfoCount
 HRESULT __stdcall   Dispatch_GetTypeInfoCount_Wrapper (
@@ -207,200 +176,6 @@ HRESULT __stdcall   InternalDispatchImpl_Invoke_Wrapper (
                                     EXCEPINFO *pexcepinfo,
                                     unsigned int *puArgErr
                                     );
-
-//------------------------------------------------------------------------------------------
-//      IDispatchEx methods for COM+ objects
-
-
-// %%Function: IDispatchEx::GetTypeInfoCount
-HRESULT __stdcall   DispatchEx_GetTypeInfoCount_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    unsigned int *pctinfo);
-
-
-//  %%Function: IDispatch::GetTypeInfo
-HRESULT __stdcall   DispatchEx_GetTypeInfo_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    unsigned int itinfo,
-                                    LCID lcid,
-                                    ITypeInfo **pptinfo);
-
-// IDispatchEx::GetIDsofNames
-HRESULT __stdcall   DispatchEx_GetIDsOfNames_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    REFIID riid,
-                                    _In_reads_(cNames) OLECHAR **rgszNames,
-                                    unsigned int cNames,
-                                    LCID lcid,
-                                    DISPID *rgdispid);
-
-// IDispatchEx::Invoke
-HRESULT __stdcall   DispatchEx_Invoke_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    DISPID dispidMember,
-                                    REFIID riid,
-                                    LCID lcid,
-                                    unsigned short wFlags,
-                                    DISPPARAMS *pdispparams,
-                                    VARIANT *pvarResult,
-                                    EXCEPINFO *pexcepinfo,
-                                    unsigned int *puArgErr);
-
-// IDispatchEx::DeleteMemberByDispID
-HRESULT __stdcall   DispatchEx_DeleteMemberByDispID_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    DISPID id);
-
-// IDispatchEx::DeleteMemberByName
-HRESULT __stdcall   DispatchEx_DeleteMemberByName_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    BSTR bstrName,
-                                    DWORD grfdex);
-
-
-// IDispatchEx::GetDispID
-HRESULT __stdcall   DispatchEx_GetDispID_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    BSTR bstrName,
-                                    DWORD grfdex,
-                                    DISPID *pid);
-
-
-// IDispatchEx::GetMemberName
-HRESULT __stdcall   DispatchEx_GetMemberName_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    DISPID id,
-                                    BSTR *pbstrName);
-
-// IDispatchEx::GetMemberProperties
-HRESULT __stdcall   DispatchEx_GetMemberProperties_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    DISPID id,
-                                    DWORD grfdexFetch,
-                                    DWORD *pgrfdex);
-
-// IDispatchEx::GetNameSpaceParent
-HRESULT __stdcall   DispatchEx_GetNameSpaceParent_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    IUnknown **ppunk);
-
-// IDispatchEx::GetNextDispID
-HRESULT __stdcall   DispatchEx_GetNextDispID_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    DWORD grfdex,
-                                    DISPID id,
-                                    DISPID *pid);
-
-// IDispatchEx::InvokeEx
-HRESULT __stdcall   DispatchEx_InvokeEx_Wrapper (
-                                    IDispatchEx* pDisp,
-                                    DISPID id,
-                                    LCID lcid,
-                                    WORD wFlags,
-                                    DISPPARAMS *pdp,
-                                    VARIANT *pVarRes,
-                                    EXCEPINFO *pei,
-                                    IServiceProvider *pspCaller);
-
-//------------------------------------------------------------------------------------------
-//      IMarshal methods for COM+ objects
-
-HRESULT __stdcall Marshal_GetUnmarshalClass_Wrapper (
-                                    IMarshal* pMarsh,
-                                    REFIID riid, void * pv, ULONG dwDestContext,
-                                    void * pvDestContext, ULONG mshlflags,
-                                    LPCLSID pclsid);
-
-HRESULT __stdcall Marshal_GetMarshalSizeMax_Wrapper (
-                                    IMarshal* pMarsh,
-                                    REFIID riid, void * pv, ULONG dwDestContext,
-                                    void * pvDestContext, ULONG mshlflags,
-                                    ULONG * pSize);
-
-HRESULT __stdcall Marshal_MarshalInterface_Wrapper (
-                                    IMarshal* pMarsh,
-                                    LPSTREAM pStm, REFIID riid, void * pv,
-                                    ULONG dwDestContext, LPVOID pvDestContext,
-                                    ULONG mshlflags);
-
-HRESULT __stdcall Marshal_UnmarshalInterface_Wrapper (
-                                    IMarshal* pMarsh,
-                                    LPSTREAM pStm, REFIID riid,
-                                    void ** ppvObj);
-
-HRESULT __stdcall Marshal_ReleaseMarshalData_Wrapper (IMarshal* pMarsh, LPSTREAM pStm);
-
-HRESULT __stdcall Marshal_DisconnectObject_Wrapper (IMarshal* pMarsh, ULONG dwReserved);
-
-
-//------------------------------------------------------------------------------------------
-//      IConnectionPointContainer methods for COM+ objects
-
-interface IEnumConnectionPoints;
-
-HRESULT __stdcall ConnectionPointContainer_EnumConnectionPoints_Wrapper(IUnknown* pUnk,
-                                    IEnumConnectionPoints **ppEnum);
-
-HRESULT __stdcall ConnectionPointContainer_FindConnectionPoint_Wrapper(IUnknown* pUnk,
-                                    REFIID riid,
-                                    IConnectionPoint **ppCP);
-
-
-//------------------------------------------------------------------------------------------
-//      IObjectSafety methods for COM+ objects
-
-interface IObjectSafety;
-
-HRESULT __stdcall ObjectSafety_GetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk,
-                                                         REFIID riid,
-                                                         DWORD *pdwSupportedOptions,
-                                                         DWORD *pdwEnabledOptions);
-
-HRESULT __stdcall ObjectSafety_SetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk,
-                                                         REFIID riid,
-                                                         DWORD dwOptionSetMask,
-                                                         DWORD dwEnabledOptions);
-
-// IUNKNOWN wrappers
-
-// prototypes IUnknown methods
-HRESULT __stdcall   Unknown_QueryInterface(IUnknown* pUnk, REFIID riid, void** ppv);
-
-ULONG __stdcall     Unknown_AddRef(IUnknown* pUnk);
-ULONG __stdcall     Unknown_Release(IUnknown* pUnk);
-ULONG __stdcall     Unknown_AddRefInner(IUnknown* pUnk);
-ULONG __stdcall     Unknown_ReleaseInner(IUnknown* pUnk);
-
-// for std interfaces such as IProvideClassInfo
-HRESULT __stdcall   Unknown_QueryInterface_IErrorInfo(IUnknown* pUnk, REFIID riid, void** ppv);
-ULONG __stdcall     Unknown_AddRefSpecial(IUnknown* pUnk);
-ULONG __stdcall     Unknown_ReleaseSpecial(IUnknown* pUnk);
-ULONG __stdcall     Unknown_ReleaseSpecial_IErrorInfo(IUnknown* pUnk);
-
-
-// special idispatch methods
-
-HRESULT __stdcall
-InternalDispatchImpl_GetIDsOfNames (
-    IDispatch* pDisp,
-    REFIID riid,
-    _In_reads_(cNames) OLECHAR **rgszNames,
-    unsigned int cNames,
-    LCID lcid,
-    DISPID *rgdispid);
-
-
-HRESULT __stdcall
-InternalDispatchImpl_Invoke (
-    IDispatch* pDisp,
-    DISPID dispidMember,
-    REFIID riid,
-    LCID lcid,
-    unsigned short wFlags,
-    DISPPARAMS *pdispparams,
-    VARIANT *pvarResult,
-    EXCEPINFO *pexcepinfo,
-    unsigned int *puArgErr);
 
 //------------------------------------------------------------------------------------------
 // Helper to get the current IErrorInfo if the specified interface supports it.

--- a/src/coreclr/vm/stdinterfaces.h
+++ b/src/coreclr/vm/stdinterfaces.h
@@ -21,8 +21,6 @@ class Assembly;
 class Module;
 class MethodTable;
 
-typedef HRESULT (__stdcall* PCOMFN)(void);
-
 //------------------------------------------------------------------------------------------
 // HRESULT's returned by GetITypeInfoForEEClass.
 #define S_USEIUNKNOWN   (HRESULT)2

--- a/src/coreclr/vm/stdinterfaces_wrapper.cpp
+++ b/src/coreclr/vm/stdinterfaces_wrapper.cpp
@@ -39,274 +39,26 @@
 #include "stdinterfaces_internal.h"
 #include "interoputil.inl"
 
-
-interface IEnumConnectionPoints;
+struct IEnumConnectionPoints;
 
 // IUnknown is part of IDispatch
 // Common vtables for well-known COM interfaces
 // shared by all COM+ callable wrappers.
 
-// All Com+ created vtables have well known IUnknown methods, which is used to identify
-// the type of the interface
-// For e.g. all com+ created tear-offs have the same QI method in their IUnknown portion
-//          Unknown_QueryInterface is the QI method for all the tear-offs created from COM+
-//
-//  Tearoff interfaces created for std. interfaces such as IProvideClassInfo, IErrorInfo etc.
-//  have the AddRef & Release function point to Unknown_AddRefSpecial & Unknown_ReleaseSpecial
-//
-//  Inner unknown, or the original unknown for a wrapper has
-//  AddRef & Release point to a Unknown_AddRefInner & Unknown_ReleaseInner
-
-// global inner Unknown vtable
-const StdInterfaceDesc<3> g_InnerUnknown =
+namespace
 {
-    enum_InnerUnknown,
+    inline BOOL CanCallRuntimeInterfaceImplementations()
     {
-        (UINT_PTR*)Unknown_QueryInterface,
-        (UINT_PTR*)Unknown_AddRefInner,             // special addref to distinguish inner unk
-        (UINT_PTR*)Unknown_ReleaseInner,            // special release to distinguish inner unknown
+        LIMITED_METHOD_CONTRACT;
+        // If we are finalizing all alive objects, or after this stage, we do not allow
+        // a thread to enter EE.
+        return !((g_fEEShutDown & ShutDown_Finalize2) || g_fForbidEnterEE);
     }
-};
-
-// global IProvideClassInfo vtable
-const StdInterfaceDesc<4> g_IProvideClassInfo =
-{
-    enum_IProvideClassInfo,
-    {
-        (UINT_PTR*)Unknown_QueryInterface,          // don't change this
-        (UINT_PTR*)Unknown_AddRefSpecial,           // special addref for std. interface
-        (UINT_PTR*)Unknown_ReleaseSpecial,          // special release for std. interface
-        (UINT_PTR*)ClassInfo_GetClassInfo_Wrapper   // GetClassInfo
-    }
-};
-
-// global IMarshal vtable
-const StdInterfaceDesc<9> g_IMarshal =
-{
-    enum_IMarshal,
-    {
-        (UINT_PTR*)Unknown_QueryInterface,
-        (UINT_PTR*)Unknown_AddRefSpecial,
-        (UINT_PTR*)Unknown_ReleaseSpecial,
-        (UINT_PTR*)Marshal_GetUnmarshalClass_Wrapper,
-        (UINT_PTR*)Marshal_GetMarshalSizeMax_Wrapper,
-        (UINT_PTR*)Marshal_MarshalInterface_Wrapper,
-        (UINT_PTR*)Marshal_UnmarshalInterface_Wrapper,
-        (UINT_PTR*)Marshal_ReleaseMarshalData_Wrapper,
-        (UINT_PTR*)Marshal_DisconnectObject_Wrapper
-    }
-};
-
-// global ISupportsErrorInfo vtable
-const StdInterfaceDesc<4> g_ISupportsErrorInfo =
-{
-    enum_ISupportsErrorInfo,
-    {
-        (UINT_PTR*)Unknown_QueryInterface,
-        (UINT_PTR*)Unknown_AddRefSpecial,
-        (UINT_PTR*)Unknown_ReleaseSpecial,
-        (UINT_PTR*)SupportsErroInfo_IntfSupportsErrorInfo_Wrapper
-    }
-};
-
-// global IErrorInfo vtable
-const StdInterfaceDesc<8> g_IErrorInfo =
-{
-    enum_IErrorInfo,
-    {
-        (UINT_PTR*)Unknown_QueryInterface_IErrorInfo,
-        (UINT_PTR*)Unknown_AddRefSpecial,
-        (UINT_PTR*)Unknown_ReleaseSpecial_IErrorInfo,
-        (UINT_PTR*)ErrorInfo_GetGUID_Wrapper,
-        (UINT_PTR*)ErrorInfo_GetSource_Wrapper,
-        (UINT_PTR*)ErrorInfo_GetDescription_Wrapper,
-        (UINT_PTR*)ErrorInfo_GetHelpFile_Wrapper,
-        (UINT_PTR*)ErrorInfo_GetHelpContext_Wrapper
-    }
-};
-
-// global IConnectionPointContainer vtable
-const StdInterfaceDesc<5> g_IConnectionPointContainer =
-{
-    enum_IConnectionPointContainer,
-    {
-        (UINT_PTR*)Unknown_QueryInterface,
-        (UINT_PTR*)Unknown_AddRefSpecial,
-        (UINT_PTR*)Unknown_ReleaseSpecial,
-        (UINT_PTR*)ConnectionPointContainer_EnumConnectionPoints_Wrapper,
-        (UINT_PTR*)ConnectionPointContainer_FindConnectionPoint_Wrapper
-    }
-};
-
-// global IObjectSafety vtable
-const StdInterfaceDesc<5> g_IObjectSafety =
-{
-    enum_IObjectSafety,
-    {
-        (UINT_PTR*)Unknown_QueryInterface,
-        (UINT_PTR*)Unknown_AddRefSpecial,
-        (UINT_PTR*)Unknown_ReleaseSpecial,
-        (UINT_PTR*)ObjectSafety_GetInterfaceSafetyOptions_Wrapper,
-        (UINT_PTR*)ObjectSafety_SetInterfaceSafetyOptions_Wrapper
-    }
-};
-
-// global IDispatchEx vtable
-const StdInterfaceDesc<15> g_IDispatchEx =
-{
-    enum_IDispatchEx,
-    {
-        (UINT_PTR*)Unknown_QueryInterface,
-        (UINT_PTR*)Unknown_AddRefSpecial,
-        (UINT_PTR*)Unknown_ReleaseSpecial,
-        (UINT_PTR*)DispatchEx_GetTypeInfoCount_Wrapper,
-        (UINT_PTR*)DispatchEx_GetTypeInfo_Wrapper,
-        (UINT_PTR*)DispatchEx_GetIDsOfNames_Wrapper,
-        (UINT_PTR*)DispatchEx_Invoke_Wrapper,
-        (UINT_PTR*)DispatchEx_GetDispID_Wrapper,
-        (UINT_PTR*)DispatchEx_InvokeEx_Wrapper,
-        (UINT_PTR*)DispatchEx_DeleteMemberByName_Wrapper,
-        (UINT_PTR*)DispatchEx_DeleteMemberByDispID_Wrapper,
-        (UINT_PTR*)DispatchEx_GetMemberProperties_Wrapper,
-        (UINT_PTR*)DispatchEx_GetMemberName_Wrapper,
-        (UINT_PTR*)DispatchEx_GetNextDispID_Wrapper,
-        (UINT_PTR*)DispatchEx_GetNameSpaceParent_Wrapper
-    }
-};
-
-// global IAgileObject vtable
-const StdInterfaceDesc<3> g_IAgileObject =
-{
-    enum_IAgileObject,
-    {
-        (UINT_PTR*)Unknown_QueryInterface,
-        (UINT_PTR*)Unknown_AddRefSpecial,
-        (UINT_PTR*)Unknown_ReleaseSpecial
-    }
-};
-
-// Generic helper to check if AppDomain matches and perform a DoCallBack otherwise
-inline BOOL IsCurrentDomainValid(ComCallWrapper* pWrap, Thread* pThread)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_ANY;
-        PRECONDITION(CheckPointer(pWrap));
-        PRECONDITION(CheckPointer(pThread));
-    }
-    CONTRACTL_END;
-
-    _ASSERTE(pWrap != NULL);
-    PREFIX_ASSUME(pWrap != NULL);
-
-    // If we are finalizing all alive objects, or after this stage, we do not allow
-    // a thread to enter EE.
-    if ((g_fEEShutDown & ShutDown_Finalize2) || g_fForbidEnterEE)
-        return FALSE;
-
-    return TRUE;
-}
-
-BOOL IsCurrentDomainValid(ComCallWrapper* pWrap)
-{
-    CONTRACTL { NOTHROW; GC_TRIGGERS; MODE_ANY; } CONTRACTL_END;
-
-    return IsCurrentDomainValid(pWrap, GetThread());
-}
-
-struct AppDomainSwitchToPreemptiveHelperArgs
-{
-    ADCallBackFcnType pRealCallback;
-    void* pRealArgs;
-};
-
-VOID __stdcall AppDomainSwitchToPreemptiveHelper(LPVOID pv)
-{
-    AppDomainSwitchToPreemptiveHelperArgs* pArgs = (AppDomainSwitchToPreemptiveHelperArgs*)pv;
-
-    CONTRACTL
-    {
-        GC_TRIGGERS;
-        MODE_ANY;
-        PRECONDITION(CheckPointer(pv));
-
-        VOID __stdcall Dispatch_Invoke_CallBack(LPVOID ptr);
-        if (pArgs->pRealCallback == Dispatch_Invoke_CallBack) THROWS; else NOTHROW;
-    }
-    CONTRACTL_END;
-
-    GCX_PREEMP();
-    pArgs->pRealCallback(pArgs->pRealArgs);
-}
-
-VOID AppDomainDoCallBack(ComCallWrapper* pWrap, ADCallBackFcnType pTarget, LPVOID pArgs, HRESULT* phr)
-{
-    CONTRACTL
-    {
-        DISABLED(NOTHROW);
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pWrap));
-        PRECONDITION(CheckPointer(pTarget));
-        PRECONDITION(CheckPointer(pArgs));
-        PRECONDITION(CheckPointer(phr));
-    }
-    CONTRACTL_END;
-
-    // If we are finalizing all alive objects, or after this stage, we do not allow
-    // a thread to enter EE.
-    if ((g_fEEShutDown & ShutDown_Finalize2) || g_fForbidEnterEE)
-    {
-        *phr = E_FAIL;
-        return;
-    }
-
-    BEGIN_EXTERNAL_ENTRYPOINT(phr)
-    {
-        // make the call directly not forgetting to switch to preemptive GC mode
-        GCX_PREEMP();
-        ((ADCallBackFcnType)pTarget)(pArgs);
-    }
-    END_EXTERNAL_ENTRYPOINT;
 }
 
 //-------------------------------------------------------------------------
 // IUnknown methods
 
-struct QIArgs
-{
-    ComCallWrapper* pWrap;
-    IUnknown* pUnk;
-    const IID* riid;
-    void**  ppv;
-    HRESULT* hr;
-};
-
-VOID __stdcall Unknown_QueryInterface_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    QIArgs* pArgs = (QIArgs*)ptr;
-
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Unknown_QueryInterface_Internal(pArgs->pWrap, pArgs->pUnk, *pArgs->riid, pArgs->ppv);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Unknown_QueryInterface_CallBack, pArgs, pArgs->hr);;
-    }
-}
 
 HRESULT __stdcall Unknown_QueryInterface(IUnknown* pUnk, REFIID riid, void** ppv)
 {
@@ -322,26 +74,12 @@ HRESULT __stdcall Unknown_QueryInterface(IUnknown* pUnk, REFIID riid, void** ppv
     }
     CONTRACTL_END;
 
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pUnk);
-    if (IsCurrentDomainValid(pWrap, GET_THREAD()))
-    {
-        return Unknown_QueryInterface_Internal(pWrap, pUnk, riid, ppv);
-    }
-    else
-    {
-        HRESULT hr = S_OK;
-        QIArgs args = {pWrap, pUnk, &riid, ppv, &hr};
-        Unknown_QueryInterface_CallBack(&args);
-        return hr;
-    }
-}
+    if (!CanCallRuntimeInterfaceImplementations())
+        return E_FAIL;
 
-struct AddRefReleaseArgs
-{
-    IUnknown* pUnk;
-    ULONG* pLong;
-    HRESULT* hr;
-};
+    ComCallWrapper* pWrap = MapIUnknownToWrapper(pUnk);
+    return Unknown_QueryInterface_Internal(pWrap, pUnk, riid, ppv);
+}
 
 ULONG __stdcall Unknown_AddRef(IUnknown* pUnk)
 {
@@ -509,405 +247,12 @@ ULONG __stdcall Unknown_ReleaseSpecial_IErrorInfo(IUnknown* pUnk)
     return Unknown_ReleaseSpecial_IErrorInfo_Internal(pUnk);
 }
 
-
-//-------------------------------------------------------------------------
-// IProvideClassInfo methods
-
-struct GetClassInfoArgs
-{
-    IUnknown* pUnk;
-    ITypeInfo** ppTI; //Address of output variable that receives the type info.
-    HRESULT* hr;
-};
-
-VOID __stdcall ClassInfo_GetClassInfo_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetClassInfoArgs* pArgs = (GetClassInfoArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ClassInfo_GetClassInfo(pArgs->pUnk, pArgs->ppTI);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ClassInfo_GetClassInfo_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall ClassInfo_GetClassInfo_Wrapper(IUnknown* pUnk, ITypeInfo** ppTI)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(ppTI, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetClassInfoArgs args = {pUnk, ppTI, &hr};
-    ClassInfo_GetClassInfo_CallBack(&args);
-    return hr;
-}
-
-
-// ---------------------------------------------------------------------------
-//  Interface ISupportsErrorInfo
-
-struct IntfSupportsErrorInfoArgs
-{
-    IUnknown* pUnk;
-    const IID* riid;
-    HRESULT* hr;
-};
-
-VOID __stdcall SupportsErroInfo_IntfSupportsErrorInfo_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    IntfSupportsErrorInfoArgs* pArgs = (IntfSupportsErrorInfoArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = SupportsErroInfo_IntfSupportsErrorInfo(pArgs->pUnk, *pArgs->riid);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, SupportsErroInfo_IntfSupportsErrorInfo_CallBack, pArgs, pArgs->hr);;
-    }
-}
-
-HRESULT __stdcall
-SupportsErroInfo_IntfSupportsErrorInfo_Wrapper(IUnknown* pUnk, REFIID riid)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    IntfSupportsErrorInfoArgs args = {pUnk, &riid, &hr};
-    SupportsErroInfo_IntfSupportsErrorInfo_CallBack(&args);
-    return hr;
-}
-
-// ---------------------------------------------------------------------------
-//  Interface IErrorInfo
-
-struct GetDescriptionArgs
-{
-    IUnknown* pUnk;
-    BSTR*   pbstDescription;
-    HRESULT* hr;
-};
-
-VOID __stdcall ErrorInfo_GetDescription_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetDescriptionArgs* pArgs = (GetDescriptionArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ErrorInfo_GetDescription(pArgs->pUnk, pArgs->pbstDescription);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ErrorInfo_GetDescription_CallBack, pArgs, pArgs->hr);;
-    }
-}
-
-HRESULT __stdcall ErrorInfo_GetDescription_Wrapper(IUnknown* pUnk, BSTR* pbstrDescription)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(pbstrDescription, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetDescriptionArgs args = {pUnk, pbstrDescription, &hr};
-    ErrorInfo_GetDescription_CallBack(&args);
-    return hr;
-}
-
-struct GetGUIDArgs
-{
-    IUnknown* pUnk;
-    GUID* pguid;
-    HRESULT* hr;
-};
-
-VOID __stdcall ErrorInfo_GetGUID_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetGUIDArgs* pArgs = (GetGUIDArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ErrorInfo_GetGUID(pArgs->pUnk, pArgs->pguid);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ErrorInfo_GetGUID_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall ErrorInfo_GetGUID_Wrapper(IUnknown* pUnk, GUID* pguid)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(pguid, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetGUIDArgs args = {pUnk, pguid, &hr};
-    ErrorInfo_GetGUID_CallBack(&args);
-    return hr;
-}
-
-struct GetHelpContextArgs
-{
-    IUnknown* pUnk;
-    DWORD* pdwHelpCtxt;
-    HRESULT* hr;
-};
-
-VOID _stdcall ErrorInfo_GetHelpContext_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetHelpContextArgs* pArgs = (GetHelpContextArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ErrorInfo_GetHelpContext(pArgs->pUnk, pArgs->pdwHelpCtxt);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ErrorInfo_GetHelpContext_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT _stdcall ErrorInfo_GetHelpContext_Wrapper(IUnknown* pUnk, DWORD* pdwHelpCtxt)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(pdwHelpCtxt, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetHelpContextArgs args = {pUnk, pdwHelpCtxt, &hr};
-    ErrorInfo_GetHelpContext_CallBack(&args);
-    return hr;
-}
-
-struct GetHelpFileArgs
-{
-    IUnknown* pUnk;
-    BSTR* pbstrHelpFile;
-    HRESULT* hr;
-};
-
-VOID __stdcall ErrorInfo_GetHelpFile_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetHelpFileArgs* pArgs = (GetHelpFileArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ErrorInfo_GetHelpFile(pArgs->pUnk, pArgs->pbstrHelpFile);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ErrorInfo_GetHelpFile_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall ErrorInfo_GetHelpFile_Wrapper(IUnknown* pUnk, BSTR* pbstrHelpFile)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(pbstrHelpFile, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetHelpFileArgs args = {pUnk, pbstrHelpFile, &hr};
-    ErrorInfo_GetHelpFile_CallBack(&args);
-    return hr;
-}
-
-struct GetSourceArgs
-{
-    IUnknown* pUnk;
-    BSTR* pbstrSource;
-    HRESULT* hr;
-};
-
-VOID __stdcall ErrorInfo_GetSource_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetSourceArgs* pArgs = (GetSourceArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ErrorInfo_GetSource(pArgs->pUnk, pArgs->pbstrSource);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ErrorInfo_GetSource_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall ErrorInfo_GetSource_Wrapper(IUnknown* pUnk, BSTR* pbstrSource)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(pbstrSource, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetSourceArgs args = {pUnk, pbstrSource, &hr};
-    ErrorInfo_GetSource_CallBack(&args);
-    return hr;
-}
-
-
 // ---------------------------------------------------------------------------
 //  Interface IDispatch
 //
 //      IDispatch methods for COM+ objects. These methods dispatch's to the
 //      appropriate implementation based on the flags of the class that
 //      implements them.
-
-struct GetTypeInfoCountArgs
-{
-    IDispatch* pUnk;
-    unsigned int *pctinfo;
-    HRESULT* hr;
-};
-
-VOID __stdcall Dispatch_GetTypeInfoCount_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetTypeInfoCountArgs* pArgs = (GetTypeInfoCountArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Dispatch_GetTypeInfoCount(pArgs->pUnk, pArgs->pctinfo);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Dispatch_GetTypeInfoCount_CallBack, pArgs, pArgs->hr);
-    }
-}
 
 HRESULT __stdcall Dispatch_GetTypeInfoCount_Wrapper(IDispatch* pDisp, unsigned int *pctinfo)
 {
@@ -922,43 +267,11 @@ HRESULT __stdcall Dispatch_GetTypeInfoCount_Wrapper(IDispatch* pDisp, unsigned i
         PRECONDITION(CheckPointer(pctinfo, NULL_OK));
     }
     CONTRACTL_END;
+    
+    if (!CanCallRuntimeInterfaceImplementations())
+        return E_FAIL;
 
-    HRESULT hr = S_OK;
-    GetTypeInfoCountArgs args = {pDisp, pctinfo, &hr};
-    Dispatch_GetTypeInfoCount_CallBack(&args);
-    return hr;
-}
-
-struct GetTypeInfoArgs
-{
-    IDispatch* pUnk;
-    unsigned int itinfo;
-    LCID lcid;
-    ITypeInfo **pptinfo;
-    HRESULT* hr;
-};
-
-VOID __stdcall Dispatch_GetTypeInfo_CallBack (LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetTypeInfoArgs* pArgs = (GetTypeInfoArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Dispatch_GetTypeInfo(pArgs->pUnk, pArgs->itinfo, pArgs->lcid, pArgs->pptinfo);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Dispatch_GetTypeInfo_CallBack, pArgs, pArgs->hr);
-    }
+    return Dispatch_GetTypeInfoCount(pDisp, pctinfo);
 }
 
 HRESULT __stdcall Dispatch_GetTypeInfo_Wrapper(IDispatch* pDisp, unsigned int itinfo, LCID lcid, ITypeInfo **pptinfo)
@@ -974,50 +287,16 @@ HRESULT __stdcall Dispatch_GetTypeInfo_Wrapper(IDispatch* pDisp, unsigned int it
         PRECONDITION(CheckPointer(pptinfo, NULL_OK));
     }
     CONTRACTL_END;
+    
+    
+    if (!CanCallRuntimeInterfaceImplementations())
+        return E_FAIL;
 
-    HRESULT hr = S_OK;
-    GetTypeInfoArgs args = {pDisp, itinfo, lcid, pptinfo, &hr};
-    Dispatch_GetTypeInfo_CallBack(&args);
-    return hr;
-}
-
-struct GetIDsOfNamesArgs
-{
-    IDispatch* pUnk;
-    const IID* riid;
-    OLECHAR **rgszNames;
-    unsigned int cNames;
-    LCID lcid;
-    DISPID *rgdispid;
-    HRESULT* hr;
-};
-
-VOID __stdcall Dispatch_GetIDsOfNames_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetIDsOfNamesArgs* pArgs = (GetIDsOfNamesArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Dispatch_GetIDsOfNames(pArgs->pUnk, *pArgs->riid, pArgs->rgszNames,
-                                    pArgs->cNames, pArgs->lcid, pArgs->rgdispid);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Dispatch_GetIDsOfNames_CallBack, pArgs, pArgs->hr);
-    }
+    return Dispatch_GetTypeInfo(pDisp, itinfo, lcid, pptinfo);
 }
 
 HRESULT __stdcall Dispatch_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
-                               unsigned int cNames, LCID lcid, DISPID *rgdispid)
+                                unsigned int cNames, LCID lcid, DISPID *rgdispid)
 {
     SetupForComCallHR();
 
@@ -1031,39 +310,15 @@ HRESULT __stdcall Dispatch_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFIID riid, 
         PRECONDITION(CheckPointer(rgdispid, NULL_OK));
     }
     CONTRACTL_END;
+    
+    if (!CanCallRuntimeInterfaceImplementations())
+        return E_FAIL;
 
-    HRESULT hr = S_OK;
-    GetIDsOfNamesArgs args = {pDisp, &riid, rgszNames, cNames, lcid, rgdispid, &hr};
-    Dispatch_GetIDsOfNames_CallBack(&args);
-    return hr;
-}
-
-VOID __stdcall InternalDispatchImpl_GetIDsOfNames_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetIDsOfNamesArgs* pArgs = (GetIDsOfNamesArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = InternalDispatchImpl_GetIDsOfNames(pArgs->pUnk, *pArgs->riid, pArgs->rgszNames,
-                                                          pArgs->cNames, pArgs->lcid, pArgs->rgdispid);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, InternalDispatchImpl_GetIDsOfNames_CallBack, pArgs, pArgs->hr);
-    }
+    return Dispatch_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
 }
 
 HRESULT __stdcall InternalDispatchImpl_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
-                                           unsigned int cNames, LCID lcid, DISPID *rgdispid)
+                                            unsigned int cNames, LCID lcid, DISPID *rgdispid)
 {
     SetupForComCallHR();
 
@@ -1077,50 +332,11 @@ HRESULT __stdcall InternalDispatchImpl_GetIDsOfNames_Wrapper(IDispatch* pDisp, R
         PRECONDITION(CheckPointer(rgdispid, NULL_OK));
     }
     CONTRACTL_END;
+    
+    if (!CanCallRuntimeInterfaceImplementations())
+        return E_FAIL;
 
-    HRESULT hr = S_OK;
-    GetIDsOfNamesArgs args = {pDisp, &riid, rgszNames, cNames, lcid, rgdispid, &hr};
-    InternalDispatchImpl_GetIDsOfNames_CallBack(&args);
-    return hr;
-}
-
-struct InvokeArgs
-{
-    IDispatch* pUnk;
-    DISPID dispidMember;
-    const IID* riid;
-    LCID lcid;
-    unsigned short wFlags;
-    DISPPARAMS *pdispparams;
-    VARIANT *pvarResult;
-    EXCEPINFO *pexcepinfo;
-    unsigned int *puArgErr;
-    HRESULT* hr;
-};
-
-VOID __stdcall Dispatch_Invoke_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        THROWS; // Dispatch_Invoke can throw
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    InvokeArgs* pArgs = (InvokeArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Dispatch_Invoke(pArgs->pUnk, pArgs->dispidMember, *pArgs->riid,
-                                    pArgs->lcid, pArgs->wFlags, pArgs->pdispparams, pArgs->pvarResult,
-                                    pArgs->pexcepinfo, pArgs->puArgErr);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Dispatch_Invoke_CallBack, pArgs, pArgs->hr);
-    }
+    return InternalDispatchImpl_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
 }
 
 HRESULT __stdcall Dispatch_Invoke_Wrapper(IDispatch* pDisp, DISPID dispidMember, REFIID riid, LCID lcid, unsigned short wFlags,
@@ -1142,37 +358,12 @@ HRESULT __stdcall Dispatch_Invoke_Wrapper(IDispatch* pDisp, DISPID dispidMember,
         PRECONDITION(CheckPointer(puArgErr, NULL_OK));
     }
     CONTRACTL_END;
+    
+    
+    if (!CanCallRuntimeInterfaceImplementations())
+        return E_FAIL;
 
-    InvokeArgs args = {pDisp, dispidMember, &riid, lcid, wFlags, pdispparams,
-                       pvarResult, pexcepinfo, puArgErr, &hrRetVal};
-    Dispatch_Invoke_CallBack(&args);
-
-    return hrRetVal;
-}
-
-VOID __stdcall InternalDispatchImpl_Invoke_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    InvokeArgs* pArgs = (InvokeArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = InternalDispatchImpl_Invoke(pArgs->pUnk, pArgs->dispidMember, *pArgs->riid,
-                                    pArgs->lcid, pArgs->wFlags, pArgs->pdispparams, pArgs->pvarResult,
-                                    pArgs->pexcepinfo, pArgs->puArgErr);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, InternalDispatchImpl_Invoke_CallBack, pArgs, pArgs->hr);
-    }
+    return Dispatch_Invoke(pDisp, dispidMember, riid, lcid, wFlags, pdispparams, pvarResult, pexcepinfo, puArgErr);
 }
 
 HRESULT __stdcall InternalDispatchImpl_Invoke_Wrapper(IDispatch* pDisp, DISPID dispidMember, REFIID riid, LCID lcid,
@@ -1193,1220 +384,775 @@ HRESULT __stdcall InternalDispatchImpl_Invoke_Wrapper(IDispatch* pDisp, DISPID d
         PRECONDITION(CheckPointer(puArgErr, NULL_OK));
     }
     CONTRACTL_END;
+    
+    
+    if (!CanCallRuntimeInterfaceImplementations())
+        return E_FAIL;
 
-    HRESULT hr = S_OK;
-    InvokeArgs args = {pDisp, dispidMember, &riid, lcid, wFlags, pdispparams,
-                       pvarResult, pexcepinfo, puArgErr, &hr};
-    InternalDispatchImpl_Invoke_CallBack(&args);
-    return hr;
+    return InternalDispatchImpl_Invoke(pDisp, dispidMember, riid, lcid, wFlags, pdispparams, pvarResult, pexcepinfo, puArgErr);
 }
 
-// ---------------------------------------------------------------------------
-//  Interface IDispatchEx
-
-struct GetTypeInfoCountExArgs
+namespace
 {
-    IDispatchEx* pUnk;
-    unsigned int *pctinfo;
-    HRESULT* hr;
+    //-------------------------------------------------------------------------
+    // IProvideClassInfo methods
+
+    HRESULT __stdcall ClassInfo_GetClassInfo_Wrapper(IUnknown* pUnk, ITypeInfo** ppTI)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(ppTI, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ClassInfo_GetClassInfo(pUnk, ppTI);
+    }
+
+
+    // ---------------------------------------------------------------------------
+    //  Interface ISupportsErrorInfo
+
+    HRESULT __stdcall
+    SupportsErroInfo_IntfSupportsErrorInfo_Wrapper(IUnknown* pUnk, REFIID riid)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return SupportsErroInfo_IntfSupportsErrorInfo(pUnk, riid);
+    }
+
+    // ---------------------------------------------------------------------------
+    //  Interface IErrorInfo
+    HRESULT __stdcall ErrorInfo_GetDescription_Wrapper(IUnknown* pUnk, BSTR* pbstrDescription)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(pbstrDescription, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ErrorInfo_GetDescription(pUnk, pbstrDescription);
+    }
+
+    HRESULT __stdcall ErrorInfo_GetGUID_Wrapper(IUnknown* pUnk, GUID* pguid)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(pguid, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ErrorInfo_GetGUID(pUnk, pguid);
+    }
+
+    HRESULT _stdcall ErrorInfo_GetHelpContext_Wrapper(IUnknown* pUnk, DWORD* pdwHelpCtxt)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(pdwHelpCtxt, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ErrorInfo_GetHelpContext(pUnk, pdwHelpCtxt);
+    }
+
+    HRESULT __stdcall ErrorInfo_GetHelpFile_Wrapper(IUnknown* pUnk, BSTR* pbstrHelpFile)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(pbstrHelpFile, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ErrorInfo_GetHelpFile(pUnk, pbstrHelpFile);
+    }
+
+    HRESULT __stdcall ErrorInfo_GetSource_Wrapper(IUnknown* pUnk, BSTR* pbstrSource)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(pbstrSource, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ErrorInfo_GetSource(pUnk, pbstrSource);
+    }
+
+    // ---------------------------------------------------------------------------
+    //  Interface IDispatchEx
+
+    HRESULT __stdcall DispatchEx_GetTypeInfoCount_Wrapper(IDispatchEx* pDisp, unsigned int *pctinfo)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(pctinfo, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_GetTypeInfoCount(pDisp, pctinfo);
+    }
+
+    HRESULT __stdcall DispatchEx_GetTypeInfo_Wrapper(IDispatchEx* pDisp, unsigned int itinfo, LCID lcid, ITypeInfo **pptinfo)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(pptinfo, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_GetTypeInfo(pDisp, itinfo, lcid, pptinfo);
+    }
+
+    HRESULT __stdcall DispatchEx_GetIDsOfNames_Wrapper(IDispatchEx* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
+                                     unsigned int cNames, LCID lcid, DISPID *rgdispid)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(rgszNames, NULL_OK));
+            PRECONDITION(CheckPointer(rgdispid, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
+    }
+
+    HRESULT __stdcall DispatchEx_Invoke_Wrapper(IDispatchEx* pDisp, DISPID dispidMember, REFIID riid, LCID lcid,
+                              unsigned short wFlags, DISPPARAMS *pdispparams, VARIANT *pvarResult,
+                              EXCEPINFO *pexcepinfo, unsigned int *puArgErr)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(pdispparams, NULL_OK));
+            PRECONDITION(CheckPointer(pvarResult, NULL_OK));
+            PRECONDITION(CheckPointer(pexcepinfo, NULL_OK));
+            PRECONDITION(CheckPointer(puArgErr, NULL_OK));
+        }
+        CONTRACTL_END;
+
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_Invoke(pDisp, dispidMember, riid, lcid, wFlags, pdispparams, pvarResult, pexcepinfo, puArgErr);
+    }
+
+    HRESULT __stdcall DispatchEx_DeleteMemberByDispID_Wrapper(IDispatchEx* pDisp, DISPID id)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_DeleteMemberByDispID(pDisp, id);
+    }
+
+    HRESULT __stdcall DispatchEx_DeleteMemberByName_Wrapper(IDispatchEx* pDisp, BSTR bstrName, DWORD grfdex)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+        }
+        CONTRACTL_END;
+
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_DeleteMemberByName(pDisp, bstrName, grfdex);
+    }
+
+    HRESULT __stdcall DispatchEx_GetMemberName_Wrapper(IDispatchEx* pDisp, DISPID id, BSTR *pbstrName)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(pbstrName, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_GetMemberName(pDisp, id, pbstrName);
+    }
+
+
+    HRESULT __stdcall DispatchEx_GetDispID_Wrapper(IDispatchEx* pDisp, BSTR bstrName, DWORD grfdex, DISPID *pid)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(pid, NULL_OK));
+        }
+        CONTRACTL_END;
+
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_GetDispID(pDisp, bstrName, grfdex, pid);
+    }
+
+    HRESULT __stdcall DispatchEx_GetMemberProperties_Wrapper(IDispatchEx* pDisp, DISPID id, DWORD grfdexFetch, DWORD *pgrfdex)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(pgrfdex, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_GetMemberProperties(pDisp, id, grfdexFetch, pgrfdex);
+    }
+
+    HRESULT __stdcall DispatchEx_GetNameSpaceParent_Wrapper(IDispatchEx* pDisp, IUnknown **ppunk)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(ppunk, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_GetNameSpaceParent(pDisp, ppunk);
+    }
+
+    HRESULT __stdcall DispatchEx_GetNextDispID_Wrapper(IDispatchEx* pDisp, DWORD grfdex, DISPID id, DISPID *pid)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(pid, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_GetNextDispID(pDisp, grfdex, id, pid);
+    }
+
+    HRESULT __stdcall DispatchEx_InvokeEx_Wrapper(IDispatchEx* pDisp, DISPID id, LCID lcid, WORD wFlags, DISPPARAMS *pdp,
+                                VARIANT *pVarRes, EXCEPINFO *pei, IServiceProvider *pspCaller)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pDisp));
+            PRECONDITION(CheckPointer(pdp, NULL_OK));
+            PRECONDITION(CheckPointer(pVarRes, NULL_OK));
+            PRECONDITION(CheckPointer(pei, NULL_OK));
+            PRECONDITION(CheckPointer(pspCaller, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return DispatchEx_InvokeEx(pDisp, id, lcid, wFlags, pdp, pVarRes, pei, pspCaller);
+    }
+
+    // ---------------------------------------------------------------------------
+    //  Interface IMarshal
+
+    HRESULT __stdcall Marshal_GetUnmarshalClass_Wrapper(IMarshal* pMarsh, REFIID riid, void * pv, ULONG dwDestContext,
+                                      void * pvDestContext, ULONG mshlflags, LPCLSID pclsid)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pMarsh));
+            PRECONDITION(CheckPointer(pv, NULL_OK));
+            PRECONDITION(CheckPointer(pvDestContext, NULL_OK));
+            PRECONDITION(CheckPointer(pclsid, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return Marshal_GetUnmarshalClass(pMarsh, riid, pv, dwDestContext, pvDestContext, mshlflags, pclsid);
+    }
+
+    HRESULT __stdcall Marshal_GetMarshalSizeMax_Wrapper(IMarshal* pMarsh, REFIID riid, void * pv, ULONG dwDestContext,
+                                      void * pvDestContext, ULONG mshlflags, ULONG * pSize)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pMarsh));
+            PRECONDITION(CheckPointer(pv, NULL_OK));
+            PRECONDITION(CheckPointer(pvDestContext, NULL_OK));
+            PRECONDITION(CheckPointer(pSize, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return Marshal_GetMarshalSizeMax(pMarsh, riid, pv, dwDestContext, pvDestContext, mshlflags, pSize);
+    }
+
+    HRESULT __stdcall Marshal_MarshalInterface_Wrapper(IMarshal* pMarsh, LPSTREAM pStm, REFIID riid, void * pv,
+                                     ULONG dwDestContext, LPVOID pvDestContext, ULONG mshlflags)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pMarsh));
+            PRECONDITION(CheckPointer(pv, NULL_OK));
+            PRECONDITION(CheckPointer(pvDestContext, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return Marshal_MarshalInterface(pMarsh, pStm, riid, pv, dwDestContext, pvDestContext, mshlflags);
+    }
+
+    HRESULT __stdcall Marshal_UnmarshalInterface_Wrapper(IMarshal* pMarsh, LPSTREAM pStm, REFIID riid, void ** ppvObj)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pMarsh));
+            PRECONDITION(CheckPointer(pStm, NULL_OK));
+            PRECONDITION(CheckPointer(ppvObj, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return Marshal_UnmarshalInterface(pMarsh, pStm, riid, ppvObj);
+    }
+
+    HRESULT __stdcall Marshal_ReleaseMarshalData_Wrapper(IMarshal* pMarsh, LPSTREAM pStm)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pMarsh));
+            PRECONDITION(CheckPointer(pStm, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return Marshal_ReleaseMarshalData(pMarsh, pStm);
+    }
+
+    HRESULT __stdcall Marshal_DisconnectObject_Wrapper(IMarshal* pMarsh, ULONG dwReserved)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pMarsh));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return Marshal_DisconnectObject(pMarsh, dwReserved);
+    }
+
+    // ---------------------------------------------------------------------------
+    //  Interface IConnectionPointContainer
+
+    HRESULT __stdcall ConnectionPointContainer_EnumConnectionPoints_Wrapper(IUnknown* pUnk, IEnumConnectionPoints **ppEnum)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(ppEnum, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ConnectionPointContainer_EnumConnectionPoints(pUnk, ppEnum);
+    }
+
+    HRESULT __stdcall ConnectionPointContainer_FindConnectionPoint_Wrapper(IUnknown* pUnk, REFIID riid, IConnectionPoint **ppCP)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(ppCP, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ConnectionPointContainer_FindConnectionPoint(pUnk, riid, ppCP);
+    }
+
+
+    //------------------------------------------------------------------------------------------
+    //      IObjectSafety methods for COM+ objects
+
+    HRESULT __stdcall ObjectSafety_GetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk, REFIID riid,
+                                                   DWORD *pdwSupportedOptions, DWORD *pdwEnabledOptions)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+            PRECONDITION(CheckPointer(pdwSupportedOptions, NULL_OK));
+            PRECONDITION(CheckPointer(pdwEnabledOptions, NULL_OK));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ObjectSafety_GetInterfaceSafetyOptions(pUnk, riid, pdwSupportedOptions, pdwEnabledOptions);
+    }
+
+    HRESULT __stdcall ObjectSafety_SetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk, REFIID riid,
+                                                   DWORD dwOptionSetMask, DWORD dwEnabledOptions)
+    {
+        SetupForComCallHR();
+
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_TRIGGERS;
+            MODE_PREEMPTIVE;
+            PRECONDITION(CheckPointer(pUnk));
+        }
+        CONTRACTL_END;
+    
+        if (!CanCallRuntimeInterfaceImplementations())
+            return E_FAIL;
+
+        return ObjectSafety_SetInterfaceSafetyOptions(pUnk, riid, dwOptionSetMask, dwEnabledOptions);
+    }
+}
+
+// All Com+ created vtables have well known IUnknown methods, which is used to identify
+// the type of the interface
+// For e.g. all com+ created tear-offs have the same QI method in their IUnknown portion
+//          Unknown_QueryInterface is the QI method for all the tear-offs created from COM+
+//
+//  Tearoff interfaces created for std. interfaces such as IProvideClassInfo, IErrorInfo etc.
+//  have the AddRef & Release function point to Unknown_AddRefSpecial & Unknown_ReleaseSpecial
+//
+//  Inner unknown, or the original unknown for a wrapper has
+//  AddRef & Release point to a Unknown_AddRefInner & Unknown_ReleaseInner
+
+// global inner Unknown vtable
+const StdInterfaceDesc<3> g_InnerUnknown =
+{
+    enum_InnerUnknown,
+    {
+        (UINT_PTR*)Unknown_QueryInterface,
+        (UINT_PTR*)Unknown_AddRefInner,             // special addref to distinguish inner unk
+        (UINT_PTR*)Unknown_ReleaseInner,            // special release to distinguish inner unknown
+    }
 };
 
-VOID __stdcall DispatchEx_GetTypeInfoCount_CallBack (LPVOID ptr)
+// global IProvideClassInfo vtable
+const StdInterfaceDesc<4> g_IProvideClassInfo =
 {
-    CONTRACTL
+    enum_IProvideClassInfo,
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
+        (UINT_PTR*)Unknown_QueryInterface,          // don't change this
+        (UINT_PTR*)Unknown_AddRefSpecial,           // special addref for std. interface
+        (UINT_PTR*)Unknown_ReleaseSpecial,          // special release for std. interface
+        (UINT_PTR*)ClassInfo_GetClassInfo_Wrapper   // GetClassInfo
     }
-    CONTRACTL_END;
-
-    GetTypeInfoCountExArgs* pArgs = (GetTypeInfoCountExArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_GetTypeInfoCount(pArgs->pUnk, pArgs->pctinfo);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_GetTypeInfoCount_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_GetTypeInfoCount_Wrapper(IDispatchEx* pDisp, unsigned int *pctinfo)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(pctinfo, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetTypeInfoCountExArgs args = {pDisp, pctinfo, &hr};
-    DispatchEx_GetTypeInfoCount_CallBack(&args);
-    return hr;
-}
-
-struct GetTypeInfoExArgs
-{
-    IDispatch* pUnk;
-    unsigned int itinfo;
-    LCID lcid;
-    ITypeInfo **pptinfo;
-    HRESULT* hr;
 };
 
-VOID __stdcall DispatchEx_GetTypeInfo_CallBack(LPVOID ptr)
+// global IMarshal vtable
+const StdInterfaceDesc<9> g_IMarshal =
 {
-    CONTRACTL
+    enum_IMarshal,
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
+        (UINT_PTR*)Unknown_QueryInterface,
+        (UINT_PTR*)Unknown_AddRefSpecial,
+        (UINT_PTR*)Unknown_ReleaseSpecial,
+        (UINT_PTR*)Marshal_GetUnmarshalClass_Wrapper,
+        (UINT_PTR*)Marshal_GetMarshalSizeMax_Wrapper,
+        (UINT_PTR*)Marshal_MarshalInterface_Wrapper,
+        (UINT_PTR*)Marshal_UnmarshalInterface_Wrapper,
+        (UINT_PTR*)Marshal_ReleaseMarshalData_Wrapper,
+        (UINT_PTR*)Marshal_DisconnectObject_Wrapper
     }
-    CONTRACTL_END;
-
-    GetTypeInfoExArgs* pArgs = (GetTypeInfoExArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_GetTypeInfo(pArgs->pUnk, pArgs->itinfo, pArgs->lcid, pArgs->pptinfo);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_GetTypeInfo_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_GetTypeInfo_Wrapper(IDispatchEx* pDisp, unsigned int itinfo, LCID lcid, ITypeInfo **pptinfo)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(pptinfo, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetTypeInfoExArgs args = {pDisp, itinfo, lcid, pptinfo, &hr};
-    DispatchEx_GetTypeInfo_CallBack(&args);
-    return hr;
-}
-
-struct GetIDsOfNamesExArgs
-{
-    IDispatchEx* pUnk;
-    const IID* riid;
-    OLECHAR **rgszNames;
-    unsigned int cNames;
-    LCID lcid;
-    DISPID *rgdispid;
-    HRESULT* hr;
 };
 
-VOID __stdcall DispatchEx_GetIDsOfNames_CallBack(LPVOID ptr)
+// global ISupportsErrorInfo vtable
+const StdInterfaceDesc<4> g_ISupportsErrorInfo =
 {
-    CONTRACTL
+    enum_ISupportsErrorInfo,
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
+        (UINT_PTR*)Unknown_QueryInterface,
+        (UINT_PTR*)Unknown_AddRefSpecial,
+        (UINT_PTR*)Unknown_ReleaseSpecial,
+        (UINT_PTR*)SupportsErroInfo_IntfSupportsErrorInfo_Wrapper
     }
-    CONTRACTL_END;
-
-    GetIDsOfNamesExArgs* pArgs = (GetIDsOfNamesExArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_GetIDsOfNames(pArgs->pUnk, *pArgs->riid, pArgs->rgszNames,
-                                    pArgs->cNames, pArgs->lcid, pArgs->rgdispid);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_GetIDsOfNames_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_GetIDsOfNames_Wrapper(IDispatchEx* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
-                                 unsigned int cNames, LCID lcid, DISPID *rgdispid)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(rgszNames, NULL_OK));
-        PRECONDITION(CheckPointer(rgdispid, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetIDsOfNamesExArgs args = {pDisp, &riid, rgszNames, cNames, lcid, rgdispid, &hr};
-    DispatchEx_GetIDsOfNames_CallBack(&args);
-    return hr;
-}
-
-struct DispExInvokeArgs
-{
-    IDispatchEx* pUnk;
-    DISPID dispidMember;
-    const IID* riid;
-    LCID lcid;
-    unsigned short wFlags;
-    DISPPARAMS *pdispparams;
-    VARIANT *pvarResult;
-    EXCEPINFO *pexcepinfo;
-    unsigned int *puArgErr;
-    HRESULT* hr;
 };
 
-VOID __stdcall DispatchEx_Invoke_CallBack(LPVOID ptr)
+// global IErrorInfo vtable
+const StdInterfaceDesc<8> g_IErrorInfo =
 {
-    CONTRACTL
+    enum_IErrorInfo,
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
+        (UINT_PTR*)Unknown_QueryInterface_IErrorInfo,
+        (UINT_PTR*)Unknown_AddRefSpecial,
+        (UINT_PTR*)Unknown_ReleaseSpecial_IErrorInfo,
+        (UINT_PTR*)ErrorInfo_GetGUID_Wrapper,
+        (UINT_PTR*)ErrorInfo_GetSource_Wrapper,
+        (UINT_PTR*)ErrorInfo_GetDescription_Wrapper,
+        (UINT_PTR*)ErrorInfo_GetHelpFile_Wrapper,
+        (UINT_PTR*)ErrorInfo_GetHelpContext_Wrapper
     }
-    CONTRACTL_END;
-
-    DispExInvokeArgs* pArgs = (DispExInvokeArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_Invoke(pArgs->pUnk, pArgs->dispidMember, *pArgs->riid,
-                                    pArgs->lcid, pArgs->wFlags, pArgs->pdispparams, pArgs->pvarResult,
-                                    pArgs->pexcepinfo, pArgs->puArgErr);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_Invoke_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_Invoke_Wrapper(IDispatchEx* pDisp, DISPID dispidMember, REFIID riid, LCID lcid,
-                          unsigned short wFlags, DISPPARAMS *pdispparams, VARIANT *pvarResult,
-                          EXCEPINFO *pexcepinfo, unsigned int *puArgErr)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(pdispparams, NULL_OK));
-        PRECONDITION(CheckPointer(pvarResult, NULL_OK));
-        PRECONDITION(CheckPointer(pexcepinfo, NULL_OK));
-        PRECONDITION(CheckPointer(puArgErr, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    DispExInvokeArgs args = {pDisp, dispidMember, &riid, lcid, wFlags, pdispparams,
-                                pvarResult, pexcepinfo, puArgErr, &hr};
-    DispatchEx_Invoke_CallBack(&args);
-    return hr;
-}
-
-struct DeleteMemberByDispIDArgs
-{
-    IDispatchEx* pDisp;
-    DISPID id;
-    HRESULT* hr;
 };
 
-VOID __stdcall DispatchEx_DeleteMemberByDispID_CallBack(LPVOID ptr)
+// global IConnectionPointContainer vtable
+const StdInterfaceDesc<5> g_IConnectionPointContainer =
 {
-    CONTRACTL
+    enum_IConnectionPointContainer,
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
+        (UINT_PTR*)Unknown_QueryInterface,
+        (UINT_PTR*)Unknown_AddRefSpecial,
+        (UINT_PTR*)Unknown_ReleaseSpecial,
+        (UINT_PTR*)ConnectionPointContainer_EnumConnectionPoints_Wrapper,
+        (UINT_PTR*)ConnectionPointContainer_FindConnectionPoint_Wrapper
     }
-    CONTRACTL_END;
-
-    DeleteMemberByDispIDArgs* pArgs = (DeleteMemberByDispIDArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pDisp);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_DeleteMemberByDispID(pArgs->pDisp, pArgs->id);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_DeleteMemberByDispID_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_DeleteMemberByDispID_Wrapper(IDispatchEx* pDisp, DISPID id)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    DeleteMemberByDispIDArgs args = {pDisp, id, &hr};
-    DispatchEx_DeleteMemberByDispID_CallBack(&args);
-    return hr;
-}
-
-struct DeleteMemberByNameArgs
-{
-    IDispatchEx* pDisp;
-    BSTR bstrName;
-    DWORD grfdex;
-    HRESULT* hr;
 };
 
-VOID __stdcall DispatchEx_DeleteMemberByName_CallBack(LPVOID ptr)
+// global IObjectSafety vtable
+const StdInterfaceDesc<5> g_IObjectSafety =
 {
-    CONTRACTL
+    enum_IObjectSafety,
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
+        (UINT_PTR*)Unknown_QueryInterface,
+        (UINT_PTR*)Unknown_AddRefSpecial,
+        (UINT_PTR*)Unknown_ReleaseSpecial,
+        (UINT_PTR*)ObjectSafety_GetInterfaceSafetyOptions_Wrapper,
+        (UINT_PTR*)ObjectSafety_SetInterfaceSafetyOptions_Wrapper
     }
-    CONTRACTL_END;
-
-    DeleteMemberByNameArgs* pArgs = (DeleteMemberByNameArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pDisp);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_DeleteMemberByName(pArgs->pDisp, pArgs->bstrName, pArgs->grfdex);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_DeleteMemberByName_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_DeleteMemberByName_Wrapper(IDispatchEx* pDisp, BSTR bstrName, DWORD grfdex)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    DeleteMemberByNameArgs args = {pDisp, bstrName, grfdex, &hr};
-    DispatchEx_DeleteMemberByName_CallBack(&args);
-    return hr;
-}
-
-struct GetMemberNameArgs
-{
-    IDispatchEx* pDisp;
-    DISPID id;
-    BSTR *pbstrName;
-    HRESULT* hr;
 };
 
-VOID __stdcall DispatchEx_GetMemberName_CallBack(LPVOID ptr)
+// global IDispatchEx vtable
+const StdInterfaceDesc<15> g_IDispatchEx =
 {
-    CONTRACTL
+    enum_IDispatchEx,
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
+        (UINT_PTR*)Unknown_QueryInterface,
+        (UINT_PTR*)Unknown_AddRefSpecial,
+        (UINT_PTR*)Unknown_ReleaseSpecial,
+        (UINT_PTR*)DispatchEx_GetTypeInfoCount_Wrapper,
+        (UINT_PTR*)DispatchEx_GetTypeInfo_Wrapper,
+        (UINT_PTR*)DispatchEx_GetIDsOfNames_Wrapper,
+        (UINT_PTR*)DispatchEx_Invoke_Wrapper,
+        (UINT_PTR*)DispatchEx_GetDispID_Wrapper,
+        (UINT_PTR*)DispatchEx_InvokeEx_Wrapper,
+        (UINT_PTR*)DispatchEx_DeleteMemberByName_Wrapper,
+        (UINT_PTR*)DispatchEx_DeleteMemberByDispID_Wrapper,
+        (UINT_PTR*)DispatchEx_GetMemberProperties_Wrapper,
+        (UINT_PTR*)DispatchEx_GetMemberName_Wrapper,
+        (UINT_PTR*)DispatchEx_GetNextDispID_Wrapper,
+        (UINT_PTR*)DispatchEx_GetNameSpaceParent_Wrapper
     }
-    CONTRACTL_END;
-
-    GetMemberNameArgs* pArgs = (GetMemberNameArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pDisp);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_GetMemberName(pArgs->pDisp, pArgs->id, pArgs->pbstrName);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_GetMemberName_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_GetMemberName_Wrapper(IDispatchEx* pDisp, DISPID id, BSTR *pbstrName)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(pbstrName, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetMemberNameArgs args = {pDisp, id, pbstrName, &hr};
-    DispatchEx_GetMemberName_CallBack(&args);
-    return hr;
-}
-
-struct GetDispIDArgs
-{
-    IDispatchEx* pDisp;
-    BSTR bstrName;
-    DWORD grfdex;
-    DISPID *pid;
-    HRESULT* hr;
 };
 
-VOID __stdcall DispatchEx_GetDispID_CallBack(LPVOID ptr)
+// global IAgileObject vtable
+const StdInterfaceDesc<3> g_IAgileObject =
 {
-    CONTRACTL
+    enum_IAgileObject,
     {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
+        (UINT_PTR*)Unknown_QueryInterface,
+        (UINT_PTR*)Unknown_AddRefSpecial,
+        (UINT_PTR*)Unknown_ReleaseSpecial
     }
-    CONTRACTL_END;
-
-    GetDispIDArgs* pArgs = (GetDispIDArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pDisp);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_GetDispID(pArgs->pDisp, pArgs->bstrName, pArgs->grfdex, pArgs->pid);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_GetDispID_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_GetDispID_Wrapper(IDispatchEx* pDisp, BSTR bstrName, DWORD grfdex, DISPID *pid)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(pid, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetDispIDArgs args = {pDisp, bstrName, grfdex, pid, &hr};
-    DispatchEx_GetDispID_CallBack(&args);
-    return hr;
-}
-
-struct GetMemberPropertiesArgs
-{
-    IDispatchEx* pDisp;
-    DISPID id;
-    DWORD grfdexFetch;
-    DWORD *pgrfdex;
-    HRESULT* hr;
 };
-
-VOID __stdcall DispatchEx_GetMemberProperties_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetMemberPropertiesArgs* pArgs = (GetMemberPropertiesArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pDisp);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_GetMemberProperties(pArgs->pDisp, pArgs->id, pArgs->grfdexFetch,
-                                    pArgs->pgrfdex);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_GetMemberProperties_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_GetMemberProperties_Wrapper(IDispatchEx* pDisp, DISPID id, DWORD grfdexFetch, DWORD *pgrfdex)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(pgrfdex, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetMemberPropertiesArgs args = {pDisp, id, grfdexFetch, pgrfdex, &hr};
-    DispatchEx_GetMemberProperties_CallBack(&args);
-    return hr;
-}
-
-struct GetNameSpaceParentArgs
-{
-    IDispatchEx* pDisp;
-    IUnknown **ppunk;
-    HRESULT* hr;
-};
-
-VOID __stdcall DispatchEx_GetNameSpaceParent_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetNameSpaceParentArgs* pArgs = (GetNameSpaceParentArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pDisp);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_GetNameSpaceParent(pArgs->pDisp, pArgs->ppunk);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_GetNameSpaceParent_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_GetNameSpaceParent_Wrapper(IDispatchEx* pDisp, IUnknown **ppunk)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(ppunk, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetNameSpaceParentArgs args = {pDisp, ppunk, &hr};
-    DispatchEx_GetNameSpaceParent_CallBack(&args);
-    return hr;
-}
-
-struct GetNextDispIDArgs
-{
-    IDispatchEx* pDisp;
-    DWORD grfdex;
-    DISPID id;
-    DISPID *pid;
-    HRESULT* hr;
-};
-
-VOID __stdcall DispatchEx_GetNextDispID_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetNextDispIDArgs* pArgs = (GetNextDispIDArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pDisp);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_GetNextDispID(pArgs->pDisp, pArgs->grfdex, pArgs->id, pArgs->pid);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_GetNextDispID_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_GetNextDispID_Wrapper(IDispatchEx* pDisp, DWORD grfdex, DISPID id, DISPID *pid)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(pid, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetNextDispIDArgs args = {pDisp, grfdex, id, pid, &hr};
-    DispatchEx_GetNextDispID_CallBack(&args);
-    return hr;
-}
-
-struct DispExInvokeExArgs
-{
-    IDispatchEx* pDisp;
-    DISPID id;
-    LCID lcid;
-    WORD wFlags;
-    DISPPARAMS *pdp;
-    VARIANT *pVarRes;
-    EXCEPINFO *pei;
-    IServiceProvider *pspCaller;
-    HRESULT* hr;
-};
-
-VOID __stdcall DispatchEx_InvokeEx_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    DispExInvokeExArgs* pArgs = (DispExInvokeExArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pDisp);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = DispatchEx_InvokeEx(pArgs->pDisp, pArgs->id,
-                                    pArgs->lcid, pArgs->wFlags, pArgs->pdp, pArgs->pVarRes,
-                                    pArgs->pei, pArgs->pspCaller);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, DispatchEx_InvokeEx_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall DispatchEx_InvokeEx_Wrapper(IDispatchEx* pDisp, DISPID id, LCID lcid, WORD wFlags, DISPPARAMS *pdp,
-                            VARIANT *pVarRes, EXCEPINFO *pei, IServiceProvider *pspCaller)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pDisp));
-        PRECONDITION(CheckPointer(pdp, NULL_OK));
-        PRECONDITION(CheckPointer(pVarRes, NULL_OK));
-        PRECONDITION(CheckPointer(pei, NULL_OK));
-        PRECONDITION(CheckPointer(pspCaller, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    DispExInvokeExArgs args = {pDisp, id, lcid, wFlags, pdp, pVarRes, pei, pspCaller, &hr};
-    DispatchEx_InvokeEx_CallBack(&args);
-    return hr;
-}
-
-// ---------------------------------------------------------------------------
-//  Interface IMarshal
-
-struct GetUnmarshalClassArgs
-{
-    IMarshal* pUnk;
-    const IID* riid;
-    void * pv;
-    ULONG dwDestContext;
-    void * pvDestContext;
-    ULONG mshlflags;
-    LPCLSID pclsid;
-    HRESULT* hr;
-
-};
-
-VOID __stdcall Marshal_GetUnmarshalClass_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetUnmarshalClassArgs* pArgs = (GetUnmarshalClassArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Marshal_GetUnmarshalClass(pArgs->pUnk, *(pArgs->riid), pArgs->pv,
-                                    pArgs->dwDestContext, pArgs->pvDestContext, pArgs->mshlflags,
-                                    pArgs->pclsid);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Marshal_GetUnmarshalClass_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall Marshal_GetUnmarshalClass_Wrapper(IMarshal* pMarsh, REFIID riid, void * pv, ULONG dwDestContext,
-                                  void * pvDestContext, ULONG mshlflags, LPCLSID pclsid)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pMarsh));
-        PRECONDITION(CheckPointer(pv, NULL_OK));
-        PRECONDITION(CheckPointer(pvDestContext, NULL_OK));
-        PRECONDITION(CheckPointer(pclsid, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetUnmarshalClassArgs args = {pMarsh, &riid, pv, dwDestContext, pvDestContext,
-                                        mshlflags, pclsid, &hr};
-    Marshal_GetUnmarshalClass_CallBack(&args);
-    return hr;
-}
-
-struct GetMarshalSizeMaxArgs
-{
-    IMarshal* pUnk;
-    const IID* riid;
-    void * pv;
-    ULONG dwDestContext;
-    void * pvDestContext;
-    ULONG mshlflags;
-    ULONG * pSize;
-    HRESULT* hr;
-
-};
-
-VOID __stdcall Marshal_GetMarshalSizeMax_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetMarshalSizeMaxArgs* pArgs = (GetMarshalSizeMaxArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Marshal_GetMarshalSizeMax(pArgs->pUnk, *(pArgs->riid), pArgs->pv,
-                                    pArgs->dwDestContext, pArgs->pvDestContext, pArgs->mshlflags,
-                                    pArgs->pSize);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Marshal_GetMarshalSizeMax_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-
-HRESULT __stdcall Marshal_GetMarshalSizeMax_Wrapper(IMarshal* pMarsh, REFIID riid, void * pv, ULONG dwDestContext,
-                                  void * pvDestContext, ULONG mshlflags, ULONG * pSize)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pMarsh));
-        PRECONDITION(CheckPointer(pv, NULL_OK));
-        PRECONDITION(CheckPointer(pvDestContext, NULL_OK));
-        PRECONDITION(CheckPointer(pSize, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetMarshalSizeMaxArgs args = {pMarsh, &riid, pv, dwDestContext, pvDestContext,
-                                  mshlflags, pSize, &hr};
-    Marshal_GetMarshalSizeMax_CallBack(&args);
-    return hr;
-}
-
-struct MarshalInterfaceArgs
-{
-    IMarshal* pUnk;
-    LPSTREAM pStm;
-    const IID* riid;
-    void * pv;
-    ULONG dwDestContext;
-    void * pvDestContext;
-    ULONG mshlflags;
-    HRESULT* hr;
-
-};
-
-VOID __stdcall Marshal_MarshalInterface_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    MarshalInterfaceArgs* pArgs = (MarshalInterfaceArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Marshal_MarshalInterface(pArgs->pUnk, pArgs->pStm, *(pArgs->riid), pArgs->pv,
-                                    pArgs->dwDestContext, pArgs->pvDestContext, pArgs->mshlflags);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Marshal_MarshalInterface_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall Marshal_MarshalInterface_Wrapper(IMarshal* pMarsh, LPSTREAM pStm, REFIID riid, void * pv,
-                                 ULONG dwDestContext, LPVOID pvDestContext, ULONG mshlflags)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pMarsh));
-        PRECONDITION(CheckPointer(pv, NULL_OK));
-        PRECONDITION(CheckPointer(pvDestContext, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    MarshalInterfaceArgs args = {pMarsh, pStm, &riid, pv, dwDestContext, pvDestContext,
-                                        mshlflags, &hr};
-    Marshal_MarshalInterface_CallBack(&args);
-    return hr;
-}
-
-struct UnmarshalInterfaceArgs
-{
-    IMarshal* pUnk;
-    LPSTREAM pStm;
-    const IID* riid;
-    void ** ppvObj;
-    HRESULT* hr;
-
-};
-
-VOID __stdcall Marshal_UnmarshalInterface_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    UnmarshalInterfaceArgs* pArgs = (UnmarshalInterfaceArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Marshal_UnmarshalInterface(pArgs->pUnk, pArgs->pStm, *(pArgs->riid), pArgs->ppvObj);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Marshal_UnmarshalInterface_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall Marshal_UnmarshalInterface_Wrapper(IMarshal* pMarsh, LPSTREAM pStm, REFIID riid, void ** ppvObj)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pMarsh));
-        PRECONDITION(CheckPointer(pStm, NULL_OK));
-        PRECONDITION(CheckPointer(ppvObj, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    UnmarshalInterfaceArgs args = {pMarsh, pStm, &riid, ppvObj, &hr};
-    Marshal_UnmarshalInterface_CallBack(&args);
-    return hr;
-}
-
-struct ReleaseMarshalDataArgs
-{
-    IMarshal* pUnk;
-    LPSTREAM pStm;
-    HRESULT* hr;
-
-};
-
-VOID __stdcall Marshal_ReleaseMarshalData_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    ReleaseMarshalDataArgs* pArgs = (ReleaseMarshalDataArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Marshal_ReleaseMarshalData(pArgs->pUnk, pArgs->pStm);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Marshal_ReleaseMarshalData_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall Marshal_ReleaseMarshalData_Wrapper(IMarshal* pMarsh, LPSTREAM pStm)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pMarsh));
-        PRECONDITION(CheckPointer(pStm, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    ReleaseMarshalDataArgs args = {pMarsh, pStm, &hr};
-    Marshal_ReleaseMarshalData_CallBack(&args);
-    return hr;
-}
-
-struct DisconnectObjectArgs
-{
-    IMarshal* pUnk;
-    ULONG dwReserved;
-    HRESULT* hr;
-};
-
-VOID __stdcall Marshal_DisconnectObject_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    DisconnectObjectArgs* pArgs = (DisconnectObjectArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = Marshal_DisconnectObject(pArgs->pUnk, pArgs->dwReserved);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, Marshal_DisconnectObject_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall Marshal_DisconnectObject_Wrapper(IMarshal* pMarsh, ULONG dwReserved)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pMarsh));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    DisconnectObjectArgs args = {pMarsh, dwReserved, &hr};
-    Marshal_DisconnectObject_CallBack(&args);
-    return hr;
-}
-
-// ---------------------------------------------------------------------------
-//  Interface IConnectionPointContainer
-
-struct EnumConnectionPointsArgs
-{
-    IUnknown* pUnk;
-    IEnumConnectionPoints **ppEnum;
-    HRESULT*        hr;
-};
-
-VOID __stdcall ConnectionPointContainer_EnumConnectionPoints_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    EnumConnectionPointsArgs* pArgs = (EnumConnectionPointsArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ConnectionPointContainer_EnumConnectionPoints(pArgs->pUnk, pArgs->ppEnum);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ConnectionPointContainer_EnumConnectionPoints_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall ConnectionPointContainer_EnumConnectionPoints_Wrapper(IUnknown* pUnk, IEnumConnectionPoints **ppEnum)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(ppEnum, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    EnumConnectionPointsArgs args = {pUnk, ppEnum, &hr};
-    ConnectionPointContainer_EnumConnectionPoints_CallBack(&args);
-    return hr;
-}
-
-struct FindConnectionPointArgs
-{
-    IUnknown* pUnk;
-    const IID* riid;
-    IConnectionPoint **ppCP;
-    HRESULT*    hr;
-};
-
-VOID __stdcall ConnectionPointContainer_FindConnectionPoint_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    FindConnectionPointArgs* pArgs = (FindConnectionPointArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ConnectionPointContainer_FindConnectionPoint(pArgs->pUnk, *(pArgs->riid),
-                                                            pArgs->ppCP);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ConnectionPointContainer_FindConnectionPoint_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-HRESULT __stdcall ConnectionPointContainer_FindConnectionPoint_Wrapper(IUnknown* pUnk, REFIID riid, IConnectionPoint **ppCP)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(ppCP, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    FindConnectionPointArgs args = {pUnk, &riid, ppCP, &hr};
-    ConnectionPointContainer_FindConnectionPoint_CallBack(&args);
-    return hr;
-}
-
-
-//------------------------------------------------------------------------------------------
-//      IObjectSafety methods for COM+ objects
-
-struct GetInterfaceSafetyArgs
-{
-    IUnknown* pUnk;
-    const IID* riid;
-    DWORD *pdwSupportedOptions;
-    DWORD *pdwEnabledOptions;
-    HRESULT*    hr;
-};
-
-VOID __stdcall ObjectSafety_GetInterfaceSafetyOptions_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    GetInterfaceSafetyArgs* pArgs = (GetInterfaceSafetyArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ObjectSafety_GetInterfaceSafetyOptions(pArgs->pUnk, *(pArgs->riid),
-                                                              pArgs->pdwSupportedOptions,
-                                                              pArgs->pdwEnabledOptions);
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ObjectSafety_GetInterfaceSafetyOptions_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-
-HRESULT __stdcall ObjectSafety_GetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk, REFIID riid,
-                                               DWORD *pdwSupportedOptions, DWORD *pdwEnabledOptions)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-        PRECONDITION(CheckPointer(pdwSupportedOptions, NULL_OK));
-        PRECONDITION(CheckPointer(pdwEnabledOptions, NULL_OK));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    GetInterfaceSafetyArgs args = {pUnk, &riid, pdwSupportedOptions, pdwEnabledOptions, &hr};
-    ObjectSafety_GetInterfaceSafetyOptions_CallBack(&args);
-    return hr;
-}
-
-struct SetInterfaceSafetyArgs
-{
-    IUnknown* pUnk;
-    const IID* riid;
-    DWORD dwOptionSetMask;
-    DWORD dwEnabledOptions;
-    HRESULT*    hr;
-};
-
-VOID __stdcall ObjectSafety_SetInterfaceSafetyOptions_CallBack(LPVOID ptr)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(ptr));
-    }
-    CONTRACTL_END;
-
-    SetInterfaceSafetyArgs* pArgs = (SetInterfaceSafetyArgs*)ptr;
-    ComCallWrapper* pWrap = MapIUnknownToWrapper(pArgs->pUnk);
-    if (IsCurrentDomainValid(pWrap))
-    {
-        *(pArgs->hr) = ObjectSafety_SetInterfaceSafetyOptions(pArgs->pUnk, *(pArgs->riid),
-                                                              pArgs->dwOptionSetMask,
-                                                              pArgs->dwEnabledOptions
-                                                              );
-    }
-    else
-    {
-        AppDomainDoCallBack(pWrap, ObjectSafety_SetInterfaceSafetyOptions_CallBack, pArgs, pArgs->hr);
-    }
-}
-
-
-HRESULT __stdcall ObjectSafety_SetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk, REFIID riid,
-                                               DWORD dwOptionSetMask, DWORD dwEnabledOptions)
-{
-    SetupForComCallHR();
-
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-        PRECONDITION(CheckPointer(pUnk));
-    }
-    CONTRACTL_END;
-
-    HRESULT hr = S_OK;
-    SetInterfaceSafetyArgs args = {pUnk, &riid, dwOptionSetMask, dwEnabledOptions, &hr};
-    ObjectSafety_SetInterfaceSafetyOptions_CallBack(&args);
-    return hr;
-}

--- a/src/coreclr/vm/stdinterfaces_wrapper.cpp
+++ b/src/coreclr/vm/stdinterfaces_wrapper.cpp
@@ -47,7 +47,7 @@ struct IEnumConnectionPoints;
 
 namespace
 {
-    inline BOOL CanCallRuntimeInterfaceImplementations()
+    bool CanCallRuntimeInterfaceImplementations()
     {
         LIMITED_METHOD_CONTRACT;
         // If we are finalizing all alive objects, or after this stage, we do not allow
@@ -60,7 +60,7 @@ namespace
 // IUnknown methods
 
 
-HRESULT __stdcall Unknown_QueryInterface(IUnknown* pUnk, REFIID riid, void** ppv)
+HRESULT STDMETHODCALLTYPE Unknown_QueryInterface(IUnknown* pUnk, REFIID riid, void** ppv)
 {
     SetupThreadForComCall(E_OUTOFMEMORY);
 
@@ -81,7 +81,7 @@ HRESULT __stdcall Unknown_QueryInterface(IUnknown* pUnk, REFIID riid, void** ppv
     return Unknown_QueryInterface_Internal(pWrap, pUnk, riid, ppv);
 }
 
-ULONG __stdcall Unknown_AddRef(IUnknown* pUnk)
+ULONG STDMETHODCALLTYPE Unknown_AddRef(IUnknown* pUnk)
 {
     // Ensure the Thread is available for contracts and other users of the Thread, but don't do any of
     // the other "entering managed code" work like checking for reentrancy.
@@ -104,7 +104,7 @@ ULONG __stdcall Unknown_AddRef(IUnknown* pUnk)
     return Unknown_AddRef_Internal(pUnk);
 }
 
-ULONG __stdcall Unknown_Release(IUnknown* pUnk)
+ULONG STDMETHODCALLTYPE Unknown_Release(IUnknown* pUnk)
 {
     // Ensure the Thread is available for contracts and other users of the Thread, but don't do any of
     // the other "entering managed code" work like checking for reentrancy.
@@ -127,7 +127,7 @@ ULONG __stdcall Unknown_Release(IUnknown* pUnk)
     return Unknown_Release_Internal(pUnk);
 }
 
-ULONG __stdcall Unknown_AddRefInner(IUnknown* pUnk)
+ULONG STDMETHODCALLTYPE Unknown_AddRefInner(IUnknown* pUnk)
 {
     // Ensure the Thread is available for contracts and other users of the Thread, but don't do any of
     // the other "entering managed code" work like checking for reentrancy.
@@ -150,7 +150,7 @@ ULONG __stdcall Unknown_AddRefInner(IUnknown* pUnk)
     return Unknown_AddRefInner_Internal(pUnk);
 }
 
-ULONG __stdcall Unknown_ReleaseInner(IUnknown* pUnk)
+ULONG STDMETHODCALLTYPE Unknown_ReleaseInner(IUnknown* pUnk)
 {
     // Ensure the Thread is available for contracts and other users of the Thread, but don't do any of
     // the other "entering managed code" work like checking for reentrancy.
@@ -173,7 +173,7 @@ ULONG __stdcall Unknown_ReleaseInner(IUnknown* pUnk)
     return Unknown_ReleaseInner_Internal(pUnk);
 }
 
-ULONG __stdcall Unknown_AddRefSpecial(IUnknown* pUnk)
+ULONG STDMETHODCALLTYPE Unknown_AddRefSpecial(IUnknown* pUnk)
 {
     // Ensure the Thread is available for contracts and other users of the Thread, but don't do any of
     // the other "entering managed code" work like checking for reentrancy.
@@ -196,7 +196,7 @@ ULONG __stdcall Unknown_AddRefSpecial(IUnknown* pUnk)
     return Unknown_AddRefSpecial_Internal(pUnk);
 }
 
-ULONG __stdcall Unknown_ReleaseSpecial(IUnknown* pUnk)
+ULONG STDMETHODCALLTYPE Unknown_ReleaseSpecial(IUnknown* pUnk)
 {
     // Ensure the Thread is available for contracts and other users of the Thread, but don't do any of
     // the other "entering managed code" work like checking for reentrancy.
@@ -219,7 +219,7 @@ ULONG __stdcall Unknown_ReleaseSpecial(IUnknown* pUnk)
     return Unknown_ReleaseSpecial_Internal(pUnk);
 }
 
-HRESULT __stdcall Unknown_QueryInterface_IErrorInfo(IUnknown* pUnk, REFIID riid, void** ppv)
+HRESULT STDMETHODCALLTYPE Unknown_QueryInterface_IErrorInfo(IUnknown* pUnk, REFIID riid, void** ppv)
 {
     SetupForComCallHR();
 
@@ -233,7 +233,7 @@ HRESULT __stdcall Unknown_QueryInterface_IErrorInfo(IUnknown* pUnk, REFIID riid,
 // Release for IErrorInfo that takes into account that this can be called
 // while holding the loader lock
 // ---------------------------------------------------------------------------
-ULONG __stdcall Unknown_ReleaseSpecial_IErrorInfo(IUnknown* pUnk)
+ULONG STDMETHODCALLTYPE Unknown_ReleaseSpecial_IErrorInfo(IUnknown* pUnk)
 {
     SetupForComCallDWORD();
 
@@ -254,7 +254,7 @@ ULONG __stdcall Unknown_ReleaseSpecial_IErrorInfo(IUnknown* pUnk)
 //      appropriate implementation based on the flags of the class that
 //      implements them.
 
-HRESULT __stdcall Dispatch_GetTypeInfoCount_Wrapper(IDispatch* pDisp, unsigned int *pctinfo)
+HRESULT STDMETHODCALLTYPE Dispatch_GetTypeInfoCount_Wrapper(IDispatch* pDisp, unsigned int *pctinfo)
 {
     SetupForComCallHR();
 
@@ -274,7 +274,7 @@ HRESULT __stdcall Dispatch_GetTypeInfoCount_Wrapper(IDispatch* pDisp, unsigned i
     return Dispatch_GetTypeInfoCount(pDisp, pctinfo);
 }
 
-HRESULT __stdcall Dispatch_GetTypeInfo_Wrapper(IDispatch* pDisp, unsigned int itinfo, LCID lcid, ITypeInfo **pptinfo)
+HRESULT STDMETHODCALLTYPE Dispatch_GetTypeInfo_Wrapper(IDispatch* pDisp, unsigned int itinfo, LCID lcid, ITypeInfo **pptinfo)
 {
     SetupForComCallHR();
 
@@ -295,7 +295,7 @@ HRESULT __stdcall Dispatch_GetTypeInfo_Wrapper(IDispatch* pDisp, unsigned int it
     return Dispatch_GetTypeInfo(pDisp, itinfo, lcid, pptinfo);
 }
 
-HRESULT __stdcall Dispatch_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
+HRESULT STDMETHODCALLTYPE Dispatch_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
                                 unsigned int cNames, LCID lcid, DISPID *rgdispid)
 {
     SetupForComCallHR();
@@ -317,7 +317,7 @@ HRESULT __stdcall Dispatch_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFIID riid, 
     return Dispatch_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
 }
 
-HRESULT __stdcall InternalDispatchImpl_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
+HRESULT STDMETHODCALLTYPE InternalDispatchImpl_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
                                             unsigned int cNames, LCID lcid, DISPID *rgdispid)
 {
     SetupForComCallHR();
@@ -339,7 +339,7 @@ HRESULT __stdcall InternalDispatchImpl_GetIDsOfNames_Wrapper(IDispatch* pDisp, R
     return InternalDispatchImpl_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
 }
 
-HRESULT __stdcall Dispatch_Invoke_Wrapper(IDispatch* pDisp, DISPID dispidMember, REFIID riid, LCID lcid, unsigned short wFlags,
+HRESULT STDMETHODCALLTYPE Dispatch_Invoke_Wrapper(IDispatch* pDisp, DISPID dispidMember, REFIID riid, LCID lcid, unsigned short wFlags,
                         DISPPARAMS *pdispparams, VARIANT *pvarResult, EXCEPINFO *pexcepinfo, unsigned int *puArgErr)
 {
     HRESULT hrRetVal = S_OK;
@@ -366,7 +366,7 @@ HRESULT __stdcall Dispatch_Invoke_Wrapper(IDispatch* pDisp, DISPID dispidMember,
     return Dispatch_Invoke(pDisp, dispidMember, riid, lcid, wFlags, pdispparams, pvarResult, pexcepinfo, puArgErr);
 }
 
-HRESULT __stdcall InternalDispatchImpl_Invoke_Wrapper(IDispatch* pDisp, DISPID dispidMember, REFIID riid, LCID lcid,
+HRESULT STDMETHODCALLTYPE InternalDispatchImpl_Invoke_Wrapper(IDispatch* pDisp, DISPID dispidMember, REFIID riid, LCID lcid,
                                     unsigned short wFlags, DISPPARAMS *pdispparams, VARIANT *pvarResult,
                                     EXCEPINFO *pexcepinfo, unsigned int *puArgErr)
 {
@@ -397,7 +397,7 @@ namespace
     //-------------------------------------------------------------------------
     // IProvideClassInfo methods
 
-    HRESULT __stdcall ClassInfo_GetClassInfo_Wrapper(IUnknown* pUnk, ITypeInfo** ppTI)
+    HRESULT STDMETHODCALLTYPE ClassInfo_GetClassInfo_Wrapper(IUnknown* pUnk, ITypeInfo** ppTI)
     {
         SetupForComCallHR();
 
@@ -421,7 +421,7 @@ namespace
     // ---------------------------------------------------------------------------
     //  Interface ISupportsErrorInfo
 
-    HRESULT __stdcall
+    HRESULT STDMETHODCALLTYPE
     SupportsErroInfo_IntfSupportsErrorInfo_Wrapper(IUnknown* pUnk, REFIID riid)
     {
         SetupForComCallHR();
@@ -443,7 +443,7 @@ namespace
 
     // ---------------------------------------------------------------------------
     //  Interface IErrorInfo
-    HRESULT __stdcall ErrorInfo_GetDescription_Wrapper(IUnknown* pUnk, BSTR* pbstrDescription)
+    HRESULT STDMETHODCALLTYPE ErrorInfo_GetDescription_Wrapper(IUnknown* pUnk, BSTR* pbstrDescription)
     {
         SetupForComCallHR();
 
@@ -463,7 +463,7 @@ namespace
         return ErrorInfo_GetDescription(pUnk, pbstrDescription);
     }
 
-    HRESULT __stdcall ErrorInfo_GetGUID_Wrapper(IUnknown* pUnk, GUID* pguid)
+    HRESULT STDMETHODCALLTYPE ErrorInfo_GetGUID_Wrapper(IUnknown* pUnk, GUID* pguid)
     {
         SetupForComCallHR();
 
@@ -504,7 +504,7 @@ namespace
         return ErrorInfo_GetHelpContext(pUnk, pdwHelpCtxt);
     }
 
-    HRESULT __stdcall ErrorInfo_GetHelpFile_Wrapper(IUnknown* pUnk, BSTR* pbstrHelpFile)
+    HRESULT STDMETHODCALLTYPE ErrorInfo_GetHelpFile_Wrapper(IUnknown* pUnk, BSTR* pbstrHelpFile)
     {
         SetupForComCallHR();
 
@@ -524,7 +524,7 @@ namespace
         return ErrorInfo_GetHelpFile(pUnk, pbstrHelpFile);
     }
 
-    HRESULT __stdcall ErrorInfo_GetSource_Wrapper(IUnknown* pUnk, BSTR* pbstrSource)
+    HRESULT STDMETHODCALLTYPE ErrorInfo_GetSource_Wrapper(IUnknown* pUnk, BSTR* pbstrSource)
     {
         SetupForComCallHR();
 
@@ -547,7 +547,7 @@ namespace
     // ---------------------------------------------------------------------------
     //  Interface IDispatchEx
 
-    HRESULT __stdcall DispatchEx_GetTypeInfoCount_Wrapper(IDispatchEx* pDisp, unsigned int *pctinfo)
+    HRESULT STDMETHODCALLTYPE DispatchEx_GetTypeInfoCount_Wrapper(IDispatchEx* pDisp, unsigned int *pctinfo)
     {
         SetupForComCallHR();
 
@@ -567,7 +567,7 @@ namespace
         return DispatchEx_GetTypeInfoCount(pDisp, pctinfo);
     }
 
-    HRESULT __stdcall DispatchEx_GetTypeInfo_Wrapper(IDispatchEx* pDisp, unsigned int itinfo, LCID lcid, ITypeInfo **pptinfo)
+    HRESULT STDMETHODCALLTYPE DispatchEx_GetTypeInfo_Wrapper(IDispatchEx* pDisp, unsigned int itinfo, LCID lcid, ITypeInfo **pptinfo)
     {
         SetupForComCallHR();
 
@@ -587,7 +587,7 @@ namespace
         return DispatchEx_GetTypeInfo(pDisp, itinfo, lcid, pptinfo);
     }
 
-    HRESULT __stdcall DispatchEx_GetIDsOfNames_Wrapper(IDispatchEx* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
+    HRESULT STDMETHODCALLTYPE DispatchEx_GetIDsOfNames_Wrapper(IDispatchEx* pDisp, REFIID riid, _In_reads_(cNames) OLECHAR **rgszNames,
                                      unsigned int cNames, LCID lcid, DISPID *rgdispid)
     {
         SetupForComCallHR();
@@ -609,7 +609,7 @@ namespace
         return DispatchEx_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
     }
 
-    HRESULT __stdcall DispatchEx_Invoke_Wrapper(IDispatchEx* pDisp, DISPID dispidMember, REFIID riid, LCID lcid,
+    HRESULT STDMETHODCALLTYPE DispatchEx_Invoke_Wrapper(IDispatchEx* pDisp, DISPID dispidMember, REFIID riid, LCID lcid,
                               unsigned short wFlags, DISPPARAMS *pdispparams, VARIANT *pvarResult,
                               EXCEPINFO *pexcepinfo, unsigned int *puArgErr)
     {
@@ -634,7 +634,7 @@ namespace
         return DispatchEx_Invoke(pDisp, dispidMember, riid, lcid, wFlags, pdispparams, pvarResult, pexcepinfo, puArgErr);
     }
 
-    HRESULT __stdcall DispatchEx_DeleteMemberByDispID_Wrapper(IDispatchEx* pDisp, DISPID id)
+    HRESULT STDMETHODCALLTYPE DispatchEx_DeleteMemberByDispID_Wrapper(IDispatchEx* pDisp, DISPID id)
     {
         SetupForComCallHR();
 
@@ -653,7 +653,7 @@ namespace
         return DispatchEx_DeleteMemberByDispID(pDisp, id);
     }
 
-    HRESULT __stdcall DispatchEx_DeleteMemberByName_Wrapper(IDispatchEx* pDisp, BSTR bstrName, DWORD grfdex)
+    HRESULT STDMETHODCALLTYPE DispatchEx_DeleteMemberByName_Wrapper(IDispatchEx* pDisp, BSTR bstrName, DWORD grfdex)
     {
         SetupForComCallHR();
 
@@ -672,7 +672,7 @@ namespace
         return DispatchEx_DeleteMemberByName(pDisp, bstrName, grfdex);
     }
 
-    HRESULT __stdcall DispatchEx_GetMemberName_Wrapper(IDispatchEx* pDisp, DISPID id, BSTR *pbstrName)
+    HRESULT STDMETHODCALLTYPE DispatchEx_GetMemberName_Wrapper(IDispatchEx* pDisp, DISPID id, BSTR *pbstrName)
     {
         SetupForComCallHR();
 
@@ -693,7 +693,7 @@ namespace
     }
 
 
-    HRESULT __stdcall DispatchEx_GetDispID_Wrapper(IDispatchEx* pDisp, BSTR bstrName, DWORD grfdex, DISPID *pid)
+    HRESULT STDMETHODCALLTYPE DispatchEx_GetDispID_Wrapper(IDispatchEx* pDisp, BSTR bstrName, DWORD grfdex, DISPID *pid)
     {
         SetupForComCallHR();
 
@@ -713,7 +713,7 @@ namespace
         return DispatchEx_GetDispID(pDisp, bstrName, grfdex, pid);
     }
 
-    HRESULT __stdcall DispatchEx_GetMemberProperties_Wrapper(IDispatchEx* pDisp, DISPID id, DWORD grfdexFetch, DWORD *pgrfdex)
+    HRESULT STDMETHODCALLTYPE DispatchEx_GetMemberProperties_Wrapper(IDispatchEx* pDisp, DISPID id, DWORD grfdexFetch, DWORD *pgrfdex)
     {
         SetupForComCallHR();
 
@@ -733,7 +733,7 @@ namespace
         return DispatchEx_GetMemberProperties(pDisp, id, grfdexFetch, pgrfdex);
     }
 
-    HRESULT __stdcall DispatchEx_GetNameSpaceParent_Wrapper(IDispatchEx* pDisp, IUnknown **ppunk)
+    HRESULT STDMETHODCALLTYPE DispatchEx_GetNameSpaceParent_Wrapper(IDispatchEx* pDisp, IUnknown **ppunk)
     {
         SetupForComCallHR();
 
@@ -753,7 +753,7 @@ namespace
         return DispatchEx_GetNameSpaceParent(pDisp, ppunk);
     }
 
-    HRESULT __stdcall DispatchEx_GetNextDispID_Wrapper(IDispatchEx* pDisp, DWORD grfdex, DISPID id, DISPID *pid)
+    HRESULT STDMETHODCALLTYPE DispatchEx_GetNextDispID_Wrapper(IDispatchEx* pDisp, DWORD grfdex, DISPID id, DISPID *pid)
     {
         SetupForComCallHR();
 
@@ -773,7 +773,7 @@ namespace
         return DispatchEx_GetNextDispID(pDisp, grfdex, id, pid);
     }
 
-    HRESULT __stdcall DispatchEx_InvokeEx_Wrapper(IDispatchEx* pDisp, DISPID id, LCID lcid, WORD wFlags, DISPPARAMS *pdp,
+    HRESULT STDMETHODCALLTYPE DispatchEx_InvokeEx_Wrapper(IDispatchEx* pDisp, DISPID id, LCID lcid, WORD wFlags, DISPPARAMS *pdp,
                                 VARIANT *pVarRes, EXCEPINFO *pei, IServiceProvider *pspCaller)
     {
         SetupForComCallHR();
@@ -800,7 +800,7 @@ namespace
     // ---------------------------------------------------------------------------
     //  Interface IMarshal
 
-    HRESULT __stdcall Marshal_GetUnmarshalClass_Wrapper(IMarshal* pMarsh, REFIID riid, void * pv, ULONG dwDestContext,
+    HRESULT STDMETHODCALLTYPE Marshal_GetUnmarshalClass_Wrapper(IMarshal* pMarsh, REFIID riid, void * pv, ULONG dwDestContext,
                                       void * pvDestContext, ULONG mshlflags, LPCLSID pclsid)
     {
         SetupForComCallHR();
@@ -823,7 +823,7 @@ namespace
         return Marshal_GetUnmarshalClass(pMarsh, riid, pv, dwDestContext, pvDestContext, mshlflags, pclsid);
     }
 
-    HRESULT __stdcall Marshal_GetMarshalSizeMax_Wrapper(IMarshal* pMarsh, REFIID riid, void * pv, ULONG dwDestContext,
+    HRESULT STDMETHODCALLTYPE Marshal_GetMarshalSizeMax_Wrapper(IMarshal* pMarsh, REFIID riid, void * pv, ULONG dwDestContext,
                                       void * pvDestContext, ULONG mshlflags, ULONG * pSize)
     {
         SetupForComCallHR();
@@ -846,7 +846,7 @@ namespace
         return Marshal_GetMarshalSizeMax(pMarsh, riid, pv, dwDestContext, pvDestContext, mshlflags, pSize);
     }
 
-    HRESULT __stdcall Marshal_MarshalInterface_Wrapper(IMarshal* pMarsh, LPSTREAM pStm, REFIID riid, void * pv,
+    HRESULT STDMETHODCALLTYPE Marshal_MarshalInterface_Wrapper(IMarshal* pMarsh, LPSTREAM pStm, REFIID riid, void * pv,
                                      ULONG dwDestContext, LPVOID pvDestContext, ULONG mshlflags)
     {
         SetupForComCallHR();
@@ -868,7 +868,7 @@ namespace
         return Marshal_MarshalInterface(pMarsh, pStm, riid, pv, dwDestContext, pvDestContext, mshlflags);
     }
 
-    HRESULT __stdcall Marshal_UnmarshalInterface_Wrapper(IMarshal* pMarsh, LPSTREAM pStm, REFIID riid, void ** ppvObj)
+    HRESULT STDMETHODCALLTYPE Marshal_UnmarshalInterface_Wrapper(IMarshal* pMarsh, LPSTREAM pStm, REFIID riid, void ** ppvObj)
     {
         SetupForComCallHR();
 
@@ -889,7 +889,7 @@ namespace
         return Marshal_UnmarshalInterface(pMarsh, pStm, riid, ppvObj);
     }
 
-    HRESULT __stdcall Marshal_ReleaseMarshalData_Wrapper(IMarshal* pMarsh, LPSTREAM pStm)
+    HRESULT STDMETHODCALLTYPE Marshal_ReleaseMarshalData_Wrapper(IMarshal* pMarsh, LPSTREAM pStm)
     {
         SetupForComCallHR();
 
@@ -909,7 +909,7 @@ namespace
         return Marshal_ReleaseMarshalData(pMarsh, pStm);
     }
 
-    HRESULT __stdcall Marshal_DisconnectObject_Wrapper(IMarshal* pMarsh, ULONG dwReserved)
+    HRESULT STDMETHODCALLTYPE Marshal_DisconnectObject_Wrapper(IMarshal* pMarsh, ULONG dwReserved)
     {
         SetupForComCallHR();
 
@@ -931,7 +931,7 @@ namespace
     // ---------------------------------------------------------------------------
     //  Interface IConnectionPointContainer
 
-    HRESULT __stdcall ConnectionPointContainer_EnumConnectionPoints_Wrapper(IUnknown* pUnk, IEnumConnectionPoints **ppEnum)
+    HRESULT STDMETHODCALLTYPE ConnectionPointContainer_EnumConnectionPoints_Wrapper(IUnknown* pUnk, IEnumConnectionPoints **ppEnum)
     {
         SetupForComCallHR();
 
@@ -951,7 +951,7 @@ namespace
         return ConnectionPointContainer_EnumConnectionPoints(pUnk, ppEnum);
     }
 
-    HRESULT __stdcall ConnectionPointContainer_FindConnectionPoint_Wrapper(IUnknown* pUnk, REFIID riid, IConnectionPoint **ppCP)
+    HRESULT STDMETHODCALLTYPE ConnectionPointContainer_FindConnectionPoint_Wrapper(IUnknown* pUnk, REFIID riid, IConnectionPoint **ppCP)
     {
         SetupForComCallHR();
 
@@ -975,7 +975,7 @@ namespace
     //------------------------------------------------------------------------------------------
     //      IObjectSafety methods for COM+ objects
 
-    HRESULT __stdcall ObjectSafety_GetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk, REFIID riid,
+    HRESULT STDMETHODCALLTYPE ObjectSafety_GetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk, REFIID riid,
                                                    DWORD *pdwSupportedOptions, DWORD *pdwEnabledOptions)
     {
         SetupForComCallHR();
@@ -997,7 +997,7 @@ namespace
         return ObjectSafety_GetInterfaceSafetyOptions(pUnk, riid, pdwSupportedOptions, pdwEnabledOptions);
     }
 
-    HRESULT __stdcall ObjectSafety_SetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk, REFIID riid,
+    HRESULT STDMETHODCALLTYPE ObjectSafety_SetInterfaceSafetyOptions_Wrapper(IUnknown* pUnk, REFIID riid,
                                                    DWORD dwOptionSetMask, DWORD dwEnabledOptions)
     {
         SetupForComCallHR();

--- a/src/coreclr/vm/weakreferencenative.h
+++ b/src/coreclr/vm/weakreferencenative.h
@@ -11,6 +11,8 @@
 #ifndef _WEAKREFERENCENATIVE_H
 #define _WEAKREFERENCENATIVE_H
 
+#include "weakreference.h"
+
 #if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS)
 
 class ComAwareWeakReferenceNative


### PR DESCRIPTION
We still had code supporting switching between appdomains in our standard COM interface implementations for CCWs. By this point, it was only checking if the runtime hasn't shut down in a very roundabout manner. Simplify the check to be clearer about what it does and remove what was effectively dead code.

Also, update the standard interface implementations to make many of the wrapper implementations file-scoped to simplify the header and make it clearer where the methods are actually used.

I recommend reviewing with whitespace diffs off (as a lot of the diffs will be from indentation into the anonymous namespace)