### PR TITLE
Fix alloc/dealloc mismatches and some buffer overruns found by ASAN

### DIFF
--- a/src/coreclr/ilasm/asmman.hpp
+++ b/src/coreclr/ilasm/asmman.hpp
@@ -209,7 +209,7 @@ public:
 	~AsmMan()
 	{
 		if(m_pAssembly) delete m_pAssembly;
-		if(m_szScopeName) delete m_szScopeName;
+		if(m_szScopeName) delete[] m_szScopeName;
 		if(m_pGUID) delete m_pGUID;
 	};
 	void	SetErrorReporter(ErrorReporter* rpt) { report = rpt; };

--- a/src/coreclr/md/ceefilegen/pesectionman.cpp
+++ b/src/coreclr/md/ceefilegen/pesectionman.cpp
@@ -257,7 +257,7 @@ HRESULT PESection::addSectReloc(unsigned offset, PESection *relativeTo,
         }
 
         memcpy(relocNew, m_relocStart, sizeof(PESectionReloc)*curLen);
-        delete m_relocStart;
+        delete[] m_relocStart;
         m_relocStart = relocNew;
         m_relocCur = &m_relocStart[curLen];
         m_relocEnd = &m_relocStart[newLen];
@@ -403,7 +403,7 @@ HRESULT PESection::cloneInstance(PESection *destination) {
     newSize = (INT32)(m_relocCur-m_relocStart);
 
     if (newSize>(destination->m_relocEnd - destination->m_relocStart)) {
-        delete destination->m_relocStart;
+        delete[] destination->m_relocStart;
 
         destination->m_relocStart = new (nothrow) PESectionReloc[newSize];
         if (destination->m_relocStart == NULL)

--- a/src/coreclr/md/runtime/mdcolumndescriptors.cpp
+++ b/src/coreclr/md/runtime/mdcolumndescriptors.cpp
@@ -165,9 +165,11 @@ const BYTE CMiniMdBase::s_GenericParamConstraintCol[] = {1,
 };
 #ifdef FEATURE_METADATA_EMIT_PORTABLE_PDB
 // Dummy descriptors to fill the gap to 0x30
-const BYTE CMiniMdBase::s_Dummy1Col[] = { NULL };
-const BYTE CMiniMdBase::s_Dummy2Col[] = { NULL };
-const BYTE CMiniMdBase::s_Dummy3Col[] = { NULL };
+// Our parsing process assumes that each colum def will have at least 1 entry,
+// so add enough bytes for a full table descriptor (1 + sizeof(CMiniColDef) bytes)
+const BYTE CMiniMdBase::s_Dummy1Col[] = { 0, 0, 0, 0 };
+const BYTE CMiniMdBase::s_Dummy2Col[] = { 0, 0, 0, 0 };
+const BYTE CMiniMdBase::s_Dummy3Col[] = { 0, 0, 0, 0 };
 // Actual portable PDB tables descriptors
 const BYTE CMiniMdBase::s_DocumentCol[] = { 2,
   103,0,2, 102,2,2, 103,4,2, 102,6,2,

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -528,7 +528,7 @@ void    ThreadLocalModule::AllocateDynamicClass(MethodTable *pMT)
             // If these allocations fail, we will throw
             if (pMT->Collectible())
             {
-                pDynamicStatics = new CollectibleDynamicEntry();
+                pDynamicStatics = new CollectibleDynamicEntry(pMT->GetLoaderAllocator());
             }
             else
             {
@@ -541,11 +541,6 @@ void    ThreadLocalModule::AllocateDynamicClass(MethodTable *pMT)
             static_assert_no_msg(sizeof(NormalDynamicEntry) % MAX_PRIMITIVE_FIELD_SIZE == 0);
             _ASSERTE(IS_ALIGNED(pDynamicStatics, MAX_PRIMITIVE_FIELD_SIZE));
 #endif
-
-            if (pMT->Collectible())
-            {
-                ((CollectibleDynamicEntry*)pDynamicStatics)->m_pLoaderAllocator = pMT->GetLoaderAllocator();
-            }
 
             // Save the DynamicEntry in the DynamicClassTable
             m_pDynamicClassTable[dwID].m_pDynamicEntry = pDynamicStatics;

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -65,7 +65,7 @@ void ThreadLocalBlock::FreeTLM(SIZE_T i, BOOL isThreadShuttingdown)
                     pThreadLocalModule->m_pDynamicClassTable[k].m_pDynamicEntry = NULL;
                 }
             }
-            delete pThreadLocalModule->m_pDynamicClassTable;
+            delete[] pThreadLocalModule->m_pDynamicClassTable;
             pThreadLocalModule->m_pDynamicClassTable = NULL;
         }
 
@@ -525,27 +525,22 @@ void    ThreadLocalModule::AllocateDynamicClass(MethodTable *pMT)
     {
         if (pDynamicStatics == NULL)
         {
-            SIZE_T dynamicEntrySize;
+            // If these allocations fail, we will throw
             if (pMT->Collectible())
             {
-                dynamicEntrySize = sizeof(CollectibleDynamicEntry);
+                pDynamicStatics = new CollectibleDynamicEntry();
             }
             else
             {
-                dynamicEntrySize = DynamicEntry::GetOffsetOfDataBlob() + dwStaticBytes;
+                pDynamicStatics = new({dwStaticBytes}) NormalDynamicEntry();
             }
 
-            // If this allocation fails, we will throw
-            pDynamicStatics = (DynamicEntry*)new BYTE[dynamicEntrySize];
 
 #ifdef FEATURE_64BIT_ALIGNMENT
             // The memory block has be aligned at MAX_PRIMITIVE_FIELD_SIZE to guarantee alignment of statics
             static_assert_no_msg(sizeof(NormalDynamicEntry) % MAX_PRIMITIVE_FIELD_SIZE == 0);
             _ASSERTE(IS_ALIGNED(pDynamicStatics, MAX_PRIMITIVE_FIELD_SIZE));
 #endif
-
-            // Zero out the new DynamicEntry
-            memset((BYTE*)pDynamicStatics, 0, dynamicEntrySize);
 
             if (pMT->Collectible())
             {

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -133,6 +133,18 @@ struct ThreadLocalModule
             SUPPORTS_DAC;
             return dac_cast<PTR_BYTE>(this);
         }
+
+        struct DynamicEntryStaticBytes
+        {
+            DWORD m_bytes;
+        };
+
+        static void* operator new(size_t) = delete;
+
+        static void* operator new(size_t baseSize, DynamicEntryStaticBytes dataBlobSize)
+        {
+            return ::operator new(baseSize + dataBlobSize.m_bytes);
+        }
     };
     typedef DPTR(NormalDynamicEntry) PTR_NormalDynamicEntry;
 


### PR DESCRIPTION
Fix an alloc-dealloc mismatch in ThreadLocalModule and fix some alloc-dealloc mismatches and buffer overruns in ilasm.

Extracted from https://github.com/dotnet/runtime/pull/74623/commits