### PR TITLE
[release/7.0] Use platform runtime check for ProtectedData

### DIFF
--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <AddXamarinPlaceholderFilesToPackage>true</AddXamarinPlaceholderFilesToPackage>
@@ -13,13 +13,11 @@ System.Security.Cryptography.ProtectedData</PackageDescription>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
-    <TargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatformIdentifier>
     <IsPartialFacadeAssembly Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(IsPartialFacadeAssembly)' == 'true'">true</OmitResources>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(IsPartialFacadeAssembly)' != 'true' and '$(TargetPlatformIdentifier)' != 'windows'">SR.PlatformNotSupported_CryptographyProtectedData</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Security\Cryptography\DataProtectionScope.cs" />
     <Compile Include="System\Security\Cryptography\ProtectedData.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\Crypt32\Interop.CryptProtectData.cs"
@@ -42,12 +40,16 @@ System.Security.Cryptography.ProtectedData</PackageDescription>
              Link="Common\System\Security\Cryptography\CryptoThrowHelper.Windows.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0-windows'))">
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"
              Link="Common\DisableRuntimeMarshalling.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Security" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
@@ -4,6 +4,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <AddXamarinPlaceholderFilesToPackage>true</AddXamarinPlaceholderFilesToPackage>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides access to Windows Data Protection Api.
 
 Commonly Used Types:

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs
@@ -16,14 +16,20 @@ namespace System.Security.Cryptography
 
         public static byte[] Protect(byte[] userData, byte[]? optionalEntropy, DataProtectionScope scope)
         {
-            ArgumentNullException.ThrowIfNull(userData);
+            CheckPlatformSupport();
+
+            if (userData is null)
+                throw new ArgumentNullException(nameof(userData));
 
             return ProtectOrUnprotect(userData, optionalEntropy, scope, protect: true);
         }
 
         public static byte[] Unprotect(byte[] encryptedData, byte[]? optionalEntropy, DataProtectionScope scope)
         {
-            ArgumentNullException.ThrowIfNull(encryptedData);
+            CheckPlatformSupport();
+
+            if (encryptedData is null)
+                throw new ArgumentNullException(nameof(encryptedData));
 
             return ProtectOrUnprotect(encryptedData, optionalEntropy, scope, protect: false);
         }
@@ -101,6 +107,14 @@ namespace System.Security.Cryptography
             // CAPI returns a file not found error if the user profile is not yet loaded
             return errorCode == HResults.E_FILENOTFOUND ||
                    errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND;
+        }
+
+        private static void CheckPlatformSupport()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException();
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.ProtectedData/tests/ProtectedDataUnsupportedTests.cs
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/tests/ProtectedDataUnsupportedTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Cryptography;
+
+using Xunit;
+
+namespace System.Security.Cryptography.ProtectedDataTests
+{
+    [PlatformSpecific(~TestPlatforms.Windows)]
+    public static class ProtectedUnsupportedDataTests
+    {
+        [Theory]
+        [InlineData(DataProtectionScope.LocalMachine)]
+        [InlineData(DataProtectionScope.CurrentUser)]
+        public static void Protect_PlatformNotSupported(DataProtectionScope scope)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => ProtectedData.Protect(null, null, scope));
+        }
+
+        [Theory]
+        [InlineData(DataProtectionScope.LocalMachine)]
+        [InlineData(DataProtectionScope.CurrentUser)]
+        public static void Unprotect_PlatformNotSupported(DataProtectionScope scope)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => ProtectedData.Unprotect(null, null, scope));
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/tests/System.Security.Cryptography.ProtectedData.Tests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProtectedDataTests.cs" />
+    <Compile Include="ProtectedDataUnsupportedTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs"
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
   </ItemGroup>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/80158 to release/7.0

# Description

Reported by a customer in https://github.com/dotnet/runtime/issues/78875. The System.Security.Cryptography.ProtectedData package erroneously throws a `PlatformNotSupportedException` on Windows for non .NETCoreApp targets, like UWP, which use the .NETStandard targets.

This changes the package from using target platform identifiers to using runtime checks to determine if the platform is Windows. Using target platform identifiers with .NET Standard was removed in .NET 7, so the checks are now performed at runtime.

# Customer Impact

Customers are unable to use version 7.0.0 of this package on Windows in a UWP project, or other .NET platforms that are not a .NETCoreApp target.

# Regression

This is a regression from the 6.0.x version of the package, which works correctly on Windows with .NET Standard.

# Testing

Manually verified the package contents and that it can be used from a UWP project.

# Risk

Medium-low. The tests verify the code is behaving as-expected both on Windows and non-Windows systems, but the change also simplifies the target framework of the package, which may have unexpected consequences in build-over-build validation tools.

# Package authoring signed off?

Required. This services System.Security.Cryptography.ProtectedData.


IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.