### PR TITLE
Avoid unobserved ReadAheadTask exceptions in HttpConnection

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -50,7 +50,7 @@ namespace System.Net.Http
         private static Task<HttpResponseMessage> InnerSendAsync(HttpRequestMessage request, bool async, bool isProxyAuth, HttpConnectionPool pool, HttpConnection connection, CancellationToken cancellationToken)
         {
             return isProxyAuth ?
-                connection.SendAsyncCore(request, async, cancellationToken) :
+                connection.SendAsync(request, async, cancellationToken) :
                 pool.SendWithNtProxyAuthAsync(connection, request, async, cancellationToken);
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -47,6 +47,7 @@ namespace System.Net.Http
         private readonly TransportContext? _transportContext;
 
         private HttpRequestMessage? _currentRequest;
+        private bool _lastRequestWasAsync;
         private ArrayBuffer _writeBuffer;
         private int _allowedReadLineBytes;
 
@@ -54,8 +55,11 @@ namespace System.Net.Http
         [ThreadStatic]
         private static string[]? t_headerValues;
 
-        private ValueTask<int>? _readAheadTask;
-        private int _readAheadTaskLock; // 0 == free, 1 == held
+        private const int ReadAheadTask_NotStarted = 0;
+        private const int ReadAheadTask_Started = 1;
+        private const int ReadAheadTask_CompletionReserved = 2;
+        private int _readAheadTaskStatus;
+        private ValueTask<int> _readAheadTask;
         private ArrayBuffer _readBuffer;
 
         private long _idleSinceTickCount;
@@ -87,6 +91,7 @@ namespace System.Net.Http
             _readBuffer = new ArrayBuffer(InitialReadBufferSize, usePool: false);
 
             _idleSinceTickCount = Environment.TickCount64;
+            _lastRequestWasAsync = true;
 
             if (HttpTelemetry.Log.IsEnabled())
             {
@@ -101,14 +106,14 @@ namespace System.Net.Http
 
         public override void Dispose() => Dispose(disposing: true);
 
-        private void Dispose(bool disposing)
+        private void Dispose(bool disposing, bool fromReadAheadTask = false)
         {
             // Ensure we're only disposed once.  Dispose could be called concurrently, for example,
             // if the request and the response were running concurrently and both incurred an exception.
             int previousValue = Interlocked.Exchange(ref _disposed, Status_Disposed);
             if (previousValue != Status_Disposed)
             {
-                if (NetEventSource.Log.IsEnabled()) Trace("Connection closing.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Connection closing. {nameof(fromReadAheadTask)}={fromReadAheadTask}");
 
                 // Only decrement the connection count if we counted this connection
                 if (HttpTelemetry.Log.IsEnabled() && previousValue == Status_NotDisposedAndTrackedByTelemetry)
@@ -118,26 +123,19 @@ namespace System.Net.Http
 
                 if (!_detachedFromPool)
                 {
-                    _pool.InvalidateHttp11Connection(this, disposing);
+                    _pool.InvalidateHttp11Connection(this, fromReadAheadTask);
                 }
 
                 if (disposing)
                 {
                     GC.SuppressFinalize(this);
                     _stream.Dispose();
-
-                    // Eat any exceptions from the read-ahead task.  We don't need to log, as we expect
-                    // failures from this task due to closing the connection while a read is in progress.
-                    ValueTask<int>? readAheadTask = ConsumeReadAheadTask();
-                    if (readAheadTask != null)
-                    {
-                        IgnoreExceptions(readAheadTask.GetValueOrDefault());
-                    }
                 }
             }
         }
 
-        /// <summary>Prepare an idle connection to be used for a new request.</summary>
+        /// <summary>Prepare an idle connection to be used for a new request.
+        /// The caller MUST call SendAsync afterwards if this method returns true.</summary>
         /// <param name="async">Indicates whether the coming request will be sync or async.</param>
         /// <returns>True if connection can be used, false if it is invalid due to a timeout or receiving EOF or unexpected data.</returns>
         public bool PrepareForReuse(bool async)
@@ -149,9 +147,9 @@ namespace System.Net.Http
 
             // We may already have a read-ahead task if we did a previous scavenge and haven't used the connection since.
             // If the read-ahead task is completed, then we've received either EOF or erroneous data the connection, so it's not usable.
-            if (_readAheadTask is not null)
+            if (ReadAheadTaskHasStarted())
             {
-                return !_readAheadTask.Value.IsCompleted;
+                return TryOwnReadAheadTaskCompletion();
             }
 
             // Check to see if we've received anything on the connection; if we have, that's
@@ -175,18 +173,92 @@ namespace System.Net.Http
             {
                 // Perform an async read on the stream, since we're going to need to read from it
                 // anyway, and in doing so we can avoid the extra syscall.
+                EnsureReadAheadTaskHasStarted(useZeroByteRead: false);
+
+                return TryOwnReadAheadTaskCompletion();
+            }
+        }
+
+        private bool ReadAheadTaskHasStarted() =>
+            Volatile.Read(ref _readAheadTaskStatus) != ReadAheadTask_NotStarted;
+
+        private bool CanOwnReadAheadTaskCompletion() =>
+            Volatile.Read(ref _readAheadTaskStatus) == ReadAheadTask_Started;
+
+        private bool TryOwnReadAheadTaskCompletion() =>
+            Interlocked.CompareExchange(ref _readAheadTaskStatus, ReadAheadTask_CompletionReserved, ReadAheadTask_Started) == ReadAheadTask_Started;
+
+        private void EnsureReadAheadTaskHasStarted(bool useZeroByteRead)
+        {
+            if (Interlocked.CompareExchange(ref _readAheadTaskStatus, ReadAheadTask_Started, ReadAheadTask_NotStarted) == ReadAheadTask_NotStarted)
+            {
+                Debug.Assert(_readAheadTask == default);
+
+#pragma warning disable CA2012 // we're very careful to ensure the ValueTask is only consumed once, even though it's stored into a field
+                if (useZeroByteRead)
+                {
+                    // Avoid capturing the ExecutionContext in the read-ahead task to avoid
+                    // artificially extending the lifetime of unrelated AsyncLocals.
+                    bool restoreFlow = false;
+                    try
+                    {
+                        if (!ExecutionContext.IsFlowSuppressed())
+                        {
+                            ExecutionContext.SuppressFlow();
+                            restoreFlow = true;
+                        }
+
+                        _readAheadTask = ReadAheadWithZeroByteReadAsync();
+                    }
+                    finally
+                    {
+                        if (restoreFlow)
+                        {
+                            ExecutionContext.RestoreFlow();
+                        }
+                    }
+                }
+                else
+                {
+                    // We should only get here from PrepareForReuse, which means we're about to call
+                    // SendAsync that will observe any exception thrown by this read.
+                    _readAheadTask = _stream.ReadAsync(_readBuffer.AvailableMemory);
+                }
+#pragma warning restore CA2012
+            }
+
+            async ValueTask<int> ReadAheadWithZeroByteReadAsync()
+            {
+                Debug.Assert(_readAheadTask == default);
+                Debug.Assert(_readBuffer.ActiveLength == 0);
+
                 try
                 {
-#pragma warning disable CA2012 // we're very careful to ensure the ValueTask is only consumed once, even though it's stored into a field
-                    _readAheadTask = _stream.ReadAsync(_readBuffer.AvailableMemory);
-#pragma warning restore CA2012
-                    return !_readAheadTask.Value.IsCompleted;
+                    // Issue a zero-byte read.
+                    // If the underlying stream supports it, this will not complete until the stream has data available,
+                    // which will avoid pinning the connection's read buffer (and possibly allow us to release it to the buffer pool in the future, if desired).
+                    // If not, it will complete immediately.
+                    await _stream.ReadAsync(Memory<byte>.Empty).ConfigureAwait(false);
+
+                    // We don't know for sure that the stream actually has data available, so we need to issue a real read now.
+                    int read = await _stream.ReadAsync(_readBuffer.AvailableMemory).ConfigureAwait(false);
+
+                    if (TryOwnReadAheadTaskCompletion())
+                    {
+                        if (NetEventSource.Log.IsEnabled()) Trace("Read-ahead task observed data before the request was sent.");
+
+                        Dispose(disposing: true, fromReadAheadTask: true);
+                    }
+
+                    return read;
                 }
-                catch (Exception error)
+                catch (Exception error) when (TryOwnReadAheadTaskCompletion())
                 {
-                    // If reading throws, eat the error and don't reuse the connection.
                     if (NetEventSource.Log.IsEnabled()) Trace($"Error performing read ahead: {error}");
-                    return false;
+
+                    Dispose(disposing: true, fromReadAheadTask: true);
+
+                    return 0;
                 }
             }
         }
@@ -200,28 +272,11 @@ namespace System.Net.Http
                 return false;
             }
 
-            // We may already have a read-ahead task if we did a previous scavenge and haven't used the connection since.
-#pragma warning disable CA2012 // we're very careful to ensure the ValueTask is only consumed once, even though it's stored into a field
-            _readAheadTask ??= ReadAheadWithZeroByteReadAsync();
-#pragma warning restore CA2012
+            Debug.Assert(!_lastRequestWasAsync || ReadAheadTaskHasStarted());
 
-            // If the read-ahead task is completed, then we've received either EOF or erroneous data the connection, so it's not usable.
-            return !_readAheadTask.Value.IsCompleted;
+            EnsureReadAheadTaskHasStarted(useZeroByteRead: true);
 
-            async ValueTask<int> ReadAheadWithZeroByteReadAsync()
-            {
-                Debug.Assert(_readAheadTask is null);
-                Debug.Assert(_readBuffer.ActiveLength == 0);
-
-                // Issue a zero-byte read.
-                // If the underlying stream supports it, this will not complete until the stream has data available,
-                // which will avoid pinning the connection's read buffer (and possibly allow us to release it to the buffer pool in the future, if desired).
-                // If not, it will complete immediately.
-                await _stream.ReadAsync(Memory<byte>.Empty).ConfigureAwait(false);
-
-                // We don't know for sure that the stream actually has data available, so we need to issue a real read now.
-                return await _stream.ReadAsync(_readBuffer.AvailableMemory).ConfigureAwait(false);
-            }
+            return CanOwnReadAheadTaskCompletion();
         }
 
         private bool CheckKeepAliveTimeoutExceeded()
@@ -231,21 +286,6 @@ namespace System.Net.Http
             // If _keepAliveTimeoutSeconds is 0, no timeout has been set.
             return _keepAliveTimeoutSeconds != 0 &&
                 GetIdleTicks(Environment.TickCount64) >= _keepAliveTimeoutSeconds * 1000;
-        }
-
-        private ValueTask<int>? ConsumeReadAheadTask()
-        {
-            if (Interlocked.CompareExchange(ref _readAheadTaskLock, 1, 0) == 0)
-            {
-                ValueTask<int>? t = _readAheadTask;
-                _readAheadTask = null;
-                Volatile.Write(ref _readAheadTaskLock, 0);
-                return t;
-            }
-
-            // We couldn't get the lock, which means it must already be held
-            // by someone else who will consume the task.
-            return null;
         }
 
         public override long GetIdleTicks(long nowTicks) => nowTicks - _idleSinceTickCount;
@@ -489,15 +529,17 @@ namespace System.Net.Http
                 throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
         }
 
-        public async Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(_currentRequest == null, $"Expected null {nameof(_currentRequest)}.");
             Debug.Assert(_readBuffer.ActiveLength == 0, "Unexpected data in read buffer");
+            Debug.Assert(!ReadAheadTaskHasStarted() || !CanOwnReadAheadTaskCompletion());
 
             TaskCompletionSource<bool>? allowExpect100ToContinue = null;
             Task? sendRequestContentTask = null;
 
             _currentRequest = request;
+            _lastRequestWasAsync = async;
             HttpMethod normalizedMethod = HttpMethod.Normalize(request.Method);
 
             _canRetry = false;
@@ -559,15 +601,19 @@ namespace System.Net.Http
 
                 // When the connection was taken out of the pool, a pre-emptive read was performed
                 // into the read buffer. We need to consume that read prior to issuing another read.
-                ValueTask<int>? t = ConsumeReadAheadTask();
-                if (t != null)
+                if (ReadAheadTaskHasStarted())
                 {
+                    Debug.Assert(_readAheadTask != default);
+                    Debug.Assert(!CanOwnReadAheadTaskCompletion());
+
                     // Handle the pre-emptive read.  For the async==false case, hopefully the read has
                     // already completed and this will be a nop, but if it hasn't, the caller will be forced to block
                     // waiting for the async operation to complete.  We will only hit this case for proxied HTTPS
                     // requests that use a pooled connection, as in that case we don't have a Socket we
                     // can poll and are forced to issue an async read.
-                    ValueTask<int> vt = t.GetValueOrDefault();
+                    ValueTask<int> vt = _readAheadTask;
+                    _readAheadTask = default;
+
                     int bytesRead;
                     if (vt.IsCompleted)
                     {
@@ -586,6 +632,8 @@ namespace System.Net.Http
                     _readBuffer.Commit(bytesRead);
 
                     if (NetEventSource.Log.IsEnabled()) Trace($"Received {bytesRead} bytes.");
+
+                    _readAheadTaskStatus = ReadAheadTask_NotStarted;
                 }
                 else
                 {
@@ -795,6 +843,13 @@ namespace System.Net.Http
                 // Make sure to complete the allowExpect100ToContinue task if it exists.
                 allowExpect100ToContinue?.TrySetResult(false);
 
+                if (_readAheadTask != default)
+                {
+                    Debug.Assert(!CanOwnReadAheadTaskCompletion());
+
+                    LogExceptions(_readAheadTask.AsTask());
+                }
+
                 if (NetEventSource.Log.IsEnabled()) Trace($"Error sending request: {error}");
 
                 // In the rare case where Expect: 100-continue was used and then processing
@@ -837,9 +892,6 @@ namespace System.Net.Http
                 throw;
             }
         }
-
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken) =>
-            SendAsyncCore(request, async, cancellationToken);
 
         private bool MapSendException(Exception exception, CancellationToken cancellationToken, out Exception mappedException)
         {
@@ -1557,7 +1609,7 @@ namespace System.Net.Http
         // Does not throw on EOF. Also assumes there is no buffered data.
         private async ValueTask InitialFillAsync(bool async)
         {
-            Debug.Assert(_readAheadTask == null);
+            Debug.Assert(!ReadAheadTaskHasStarted());
             Debug.Assert(_readBuffer.AvailableLength == _readBuffer.Capacity);
             Debug.Assert(_readBuffer.AvailableLength >= InitialReadBufferSize);
 
@@ -1573,7 +1625,7 @@ namespace System.Net.Http
         // Throws IOException on EOF.  This is only called when we expect more data.
         private async ValueTask FillAsync(bool async)
         {
-            Debug.Assert(_readAheadTask == null);
+            Debug.Assert(_readAheadTask == default);
 
             _readBuffer.EnsureAvailableSpace(1);
 
@@ -1700,7 +1752,7 @@ namespace System.Net.Http
 
             // No data in read buffer.
             // Do an unbuffered read directly against the underlying stream.
-            Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
+            Debug.Assert(_readAheadTask == default, "Read ahead task should have been consumed as part of the headers.");
             int count = _stream.Read(destination);
             if (NetEventSource.Log.IsEnabled()) Trace($"Received {count} bytes.");
             return count;
@@ -1718,7 +1770,7 @@ namespace System.Net.Http
 
             // No data in read buffer.
             // Do an unbuffered read directly against the underlying stream.
-            Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
+            Debug.Assert(_readAheadTask == default, "Read ahead task should have been consumed as part of the headers.");
             int count = await _stream.ReadAsync(destination).ConfigureAwait(false);
             if (NetEventSource.Log.IsEnabled()) Trace($"Received {count} bytes.");
             return count;
@@ -1731,7 +1783,7 @@ namespace System.Net.Http
             if (_readBuffer.ActiveLength == 0)
             {
                 // Do a buffered read directly against the underlying stream.
-                Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
+                Debug.Assert(_readAheadTask == default, "Read ahead task should have been consumed as part of the headers.");
 
                 if (destination.Length == 0)
                 {
@@ -1768,7 +1820,7 @@ namespace System.Net.Http
             if (_readBuffer.ActiveLength == 0)
             {
                 // Do a buffered read directly against the underlying stream.
-                Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
+                Debug.Assert(_readAheadTask == default, "Read ahead task should have been consumed as part of the headers.");
 
                 Debug.Assert(_readBuffer.AvailableLength == _readBuffer.Capacity);
                 int bytesRead = await _stream.ReadAsync(_readBuffer.AvailableMemory).ConfigureAwait(false);
@@ -2025,7 +2077,8 @@ namespace System.Net.Http
         private void ReturnConnectionToPool()
         {
             Debug.Assert(_currentRequest == null, "Connection should no longer be associated with a request.");
-            Debug.Assert(_readAheadTask == null, "Expected a previous initial read to already be consumed.");
+            Debug.Assert(_readAheadTask == default, "Expected a previous initial read to already be consumed.");
+            Debug.Assert(_readAheadTaskStatus == ReadAheadTask_NotStarted, "Expected SendAsync to reset the read-ahead task status.");
             Debug.Assert(_readBuffer.ActiveLength == 0, "Unexpected data in connection read buffer.");
 
             // If we decided not to reuse the connection (either because the server sent Connection: close,
@@ -2045,10 +2098,23 @@ namespace System.Net.Http
             {
                 Debug.Assert(!_detachedFromPool, "Should not be detached from pool unless _connectionClose is true");
 
-                _idleSinceTickCount = Environment.TickCount64;
-
                 // Put connection back in the pool.
                 _pool.RecycleHttp11Connection(this);
+            }
+        }
+
+        // This should be called while holding the lock (mustn't overlap with SendAsync).
+        internal void OnAddingIdleConnectionToPool()
+        {
+            _idleSinceTickCount = Environment.TickCount64;
+
+            // It could be a while until we start serving the next request. Issue a read to
+            // the transport stream so we can quickly react to potential server disconnects.
+            if (_lastRequestWasAsync)
+            {
+                Debug.Assert(!ReadAheadTaskHasStarted());
+
+                EnsureReadAheadTaskHasStarted(useZeroByteRead: true);
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -221,28 +221,9 @@ namespace System.Net.Http
 
                 _readAheadTaskStatus = ReadAheadTask_Started;
 
-                // Avoid capturing the ExecutionContext in the read-ahead task to avoid
-                // artificially extending the lifetime of unrelated AsyncLocals.
-                bool restoreFlow = false;
-                try
-                {
-                    if (!ExecutionContext.IsFlowSuppressed())
-                    {
-                        ExecutionContext.SuppressFlow();
-                        restoreFlow = true;
-                    }
-
 #pragma warning disable CA2012 // we're very careful to ensure the ValueTask is only consumed once, even though it's stored into a field
-                    _readAheadTask = ReadAheadWithZeroByteReadAsync();
+                _readAheadTask = ReadAheadWithZeroByteReadAsync();
 #pragma warning restore CA2012
-                }
-                finally
-                {
-                    if (restoreFlow)
-                    {
-                        ExecutionContext.RestoreFlow();
-                    }
-                }
             }
 
             async ValueTask<int> ReadAheadWithZeroByteReadAsync()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -145,7 +145,7 @@ namespace System.Net.Http
 
             // We may already have a read-ahead task if we did a previous scavenge and haven't used the connection since.
             // If the read-ahead task is completed, then we've received either EOF or erroneous data the connection, so it's not usable.
-            if (ReadAheadTaskHasStarted())
+            if (ReadAheadTaskHasStarted)
             {
                 return TryOwnReadAheadTaskCompletion();
             }
@@ -207,7 +207,7 @@ namespace System.Net.Http
             return !_readAheadTask.IsCompleted;
         }
 
-        private bool ReadAheadTaskHasStarted() =>
+        private bool ReadAheadTaskHasStarted =>
             _readAheadTaskStatus != ReadAheadTask_NotStarted;
 
         private bool TryOwnReadAheadTaskCompletion() =>
@@ -582,7 +582,7 @@ namespace System.Net.Http
 
                 // When the connection was taken out of the pool, a pre-emptive read was performed
                 // into the read buffer. We need to consume that read prior to issuing another read.
-                if (ReadAheadTaskHasStarted())
+                if (ReadAheadTaskHasStarted)
                 {
                     // If the read-ahead task completed synchronously, it would have claimed ownership of its completion,
                     // meaning that PrepareForReuse would have failed, and we wouldn't have called SendAsync.
@@ -1593,7 +1593,7 @@ namespace System.Net.Http
         // Does not throw on EOF. Also assumes there is no buffered data.
         private async ValueTask InitialFillAsync(bool async)
         {
-            Debug.Assert(!ReadAheadTaskHasStarted());
+            Debug.Assert(!ReadAheadTaskHasStarted);
             Debug.Assert(_readBuffer.AvailableLength == _readBuffer.Capacity);
             Debug.Assert(_readBuffer.AvailableLength >= InitialReadBufferSize);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1824,22 +1824,14 @@ namespace System.Net.Http
         /// Called when an HttpConnection from this pool is no longer usable.
         /// Note, this is always called from HttpConnection.Dispose, which is a bit different than how HTTP2 works.
         /// </summary>
-        public void InvalidateHttp11Connection(HttpConnection connection, bool fromReadAheadTask = false)
+        public void InvalidateHttp11Connection(HttpConnection connection, bool disposing = true)
         {
-            // Not locking on SyncObj here as it's expected that we may already be holding the lock in
-            // case we just added an idle connection to the pool and called OnAddingIdleConnectionToPool,
-            // which started a read-ahead that immediately completed, which in turn Disposed and Invalidated
-            // the connection.
-            lock (_availableHttp11Connections)
+            lock (SyncObj)
             {
-                Debug.Assert(_associatedHttp11ConnectionCount > 0, $"{_associatedHttp11ConnectionCount}");
+                Debug.Assert(_associatedHttp11ConnectionCount > 0);
+                Debug.Assert(!disposing || !_availableHttp11Connections.Contains(connection));
 
                 _associatedHttp11ConnectionCount--;
-
-                if (fromReadAheadTask)
-                {
-                    _availableHttp11Connections.Remove(connection);
-                }
 
                 CheckForHttp11ConnectionInjection();
             }
@@ -1945,7 +1937,6 @@ namespace System.Net.Http
                         // Add connection to the pool.
                         added = true;
                         _availableHttp11Connections.Add(connection);
-                        connection.OnAddingIdleConnectionToPool();
                     }
 
                     // If the pool has been disposed of, we will dispose the connection below outside the lock.

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -48,16 +48,20 @@ namespace System.Net.Http.Functional.Tests
             };
 
             TaskScheduler.UnobservedTaskException += eventHandler;
-
-            for (int i = 0; i < 3; i++)
+            try
             {
-                await MakeARequestWithoutDisposingTheHandlerAsync();
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                await Task.Delay(1000);
+                for (int i = 0; i < 3; i++)
+                {
+                    await MakeARequestWithoutDisposingTheHandlerAsync();
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    await Task.Delay(1000);
+                }
             }
-
-            TaskScheduler.UnobservedTaskException -= eventHandler;
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= eventHandler;
+            }
 
             Assert.False(seenUnobservedExceptions);
 


### PR DESCRIPTION
Closes #61256

This change adds synchronization between the read-ahead task and SendAsync to avoid a scenario where we don't observe the task's exception.