### PR TITLE
Fix bug introduced by page bitmap removal

### DIFF
--- a/src/coreclr/pal/src/map/virtual.cpp
+++ b/src/coreclr/pal/src/map/virtual.cpp
@@ -768,7 +768,7 @@ VIRTUALCommitMemory(
     madvise((void *) StartBoundary, MemSize, MADV_DODUMP);
 #endif
 
-    pRetVal = (void *) (pInformation->startBoundary);
+    pRetVal = (void *) StartBoundary;
     goto done;
 
 error:


### PR DESCRIPTION
The page bitmap removal in PAL that was made recently has introduced a subtle bug when the `VIRTUALCommitMemory` was returning incorrect address when a region of memory was reserved and later a smaller subset of that region that didn't start at the beginning of the reserved region was committed. It was returning the address of the originally reserved region.

While we have not hit any issues in the main branch, a backport of this change has caused CI failures on macOS due to the issue.