### PR TITLE
Improve logging of GC ref map mismatches

### DIFF
--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -2153,18 +2153,11 @@ bool CheckGCRefMapEqual(PTR_BYTE pGCRefMap, MethodDesc* pMD, bool isDispatchCell
         invalidGCRefMap = true;
     }
 #endif
-    while (!decoderNew.AtEnd() || !decoderExisting.AtEnd())
+    while (!invalidGCRefMap && !(decoderNew.AtEnd() && decoderExisting.AtEnd()))
     {
-        if (decoderNew.AtEnd() != decoderExisting.AtEnd())
-        {
-            invalidGCRefMap = true;
-            break;
-        }
-        if (decoderNew.CurrentPos() != decoderExisting.CurrentPos())
-        {
-            invalidGCRefMap = true;
-        }
-        if (decoderNew.ReadToken() != decoderExisting.ReadToken())
+        if (decoderNew.AtEnd() != decoderExisting.AtEnd() ||
+            decoderNew.CurrentPos() != decoderExisting.CurrentPos() ||
+            decoderNew.ReadToken() != decoderExisting.ReadToken())
         {
             invalidGCRefMap = true;
         }

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -2107,6 +2107,7 @@ static void DumpGCRefMap(const char *name, BYTE *address)
 
                 case GCREFMAP_VASIG_COOKIE:
                     printf("V(");
+                    break;
 
                 default:
                     // Not implemented

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -2063,14 +2063,14 @@ void FakeGcScanRoots(MetaSig& msig, ArgIterator& argit, MethodDesc * pMD, BYTE *
 }
 
 #ifdef _DEBUG
-static void DumpGCRefMap(const wchar_t* name, BYTE *address)
+static void DumpGCRefMap(const char *name, BYTE *address)
 {
     GCRefMapDecoder decoder(address);
 
-    wprintf(L"%s GC ref map: ", name);
+    printf("%s GC ref map: ", name);
 #if TARGET_X86
     uint32_t stackPop = decoder.ReadStackPop();
-    wprintf(L"POP(0x%x)", stackPop);
+    printf("POP(0x%x)", stackPop);
 #endif
 
     int previousToken = GCREFMAP_SKIP;
@@ -2082,7 +2082,7 @@ static void DumpGCRefMap(const wchar_t* name, BYTE *address)
         {
             if (previousToken != GCREFMAP_SKIP)
             {
-                wprintf(L") ");
+                printf(") ");
             }
             switch (token)
             {
@@ -2090,23 +2090,23 @@ static void DumpGCRefMap(const wchar_t* name, BYTE *address)
                     break;
 
                 case GCREFMAP_REF:
-                    wprintf(L"R(");
+                    printf("R(");
                     break;
 
                 case GCREFMAP_INTERIOR:
-                    wprintf(L"I(");
+                    printf("I(");
                     break;
 
                 case GCREFMAP_METHOD_PARAM:
-                    wprintf(L"M(");
+                    printf("M(");
                     break;
 
                 case GCREFMAP_TYPE_PARAM:
-                    wprintf(L"T(");
+                    printf("T(");
                     break;
 
                 case GCREFMAP_VASIG_COOKIE:
-                    wprintf(L"V(");
+                    printf("V(");
 
                 default:
                     // Not implemented
@@ -2115,19 +2115,19 @@ static void DumpGCRefMap(const wchar_t* name, BYTE *address)
         }
         else if (token != GCREFMAP_SKIP)
         {
-            wprintf(L" ");
+            printf(" ");
         }
         if (token != GCREFMAP_SKIP)
         {
-            wprintf(L"%02x", OffsetFromGCRefMapPos(pos));
+            printf("%02x", OffsetFromGCRefMapPos(pos));
         }
         previousToken = token;
     }
     if (previousToken != GCREFMAP_SKIP)
     {
-        wprintf(L")");
+        printf(")");
     }
-    wprintf(L"\n");
+    printf("\n");
 }
 #endif
 
@@ -2171,9 +2171,9 @@ bool CheckGCRefMapEqual(PTR_BYTE pGCRefMap, MethodDesc* pMD, bool isDispatchCell
     }
     if (invalidGCRefMap)
     {
-        wprintf(L"GC ref map mismatch detected for method: %S::%S\n", pMD->GetMethodTable()->GetDebugClassName(), pMD->GetName());
-        DumpGCRefMap(L"  Runtime", (BYTE *)pBlob);
-        DumpGCRefMap(L"Crossgen2", pGCRefMap);
+        printf("GC ref map mismatch detected for method: %s::%s\n", pMD->GetMethodTable()->GetDebugClassName(), pMD->GetName());
+        DumpGCRefMap("  Runtime", (BYTE *)pBlob);
+        DumpGCRefMap("Crossgen2", pGCRefMap);
         _ASSERTE(false);
     }
 #endif


### PR DESCRIPTION
As part of investigation of the GC refmap mismatch I'm fixing with

https://github.com/dotnet/runtime/pull/80218

I have improved CoreCLR runtime behavior in the presence of GC refmap mismatches by adding debug-only logic to dump both the GC ref map emitted by Crossgen2 and the one calculated by the native runtime. The dump format matches the way R2RDump outputs GC ref maps next to method import cells in the R2R file.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 

C:\git\runtime>C:\triage\wpf\bin\Debug\net7.0-windows\win-arm64\publish\wpf.exe
GC ref map mismatch detected for method: System.Windows.Media.PathGeometry::GetPathBoundsAsRB
  Runtime GC ref map: I(70) R(78) I(80)
Crossgen2 GC ref map: I(68 70) R(78) I(80)

Assert failure(PID 12596 [0x00003134], Thread: 9568 [0x2560]): false

CORECLR! CheckGCRefMapEqual + 0x1DC (0x00007fff`e66fa72c)
CORECLR! ExternalMethodFixupWorker + 0xA98 (0x00007fff`e681b3c8)
CORECLR! DelayLoad_MethodCall + 0x58 (0x00007fff`e6581a18)
PRESENTATIONCORE! <no symbol> + 0x0 (0x00007fff`e401ecac)
PRESENTATIONCORE! <no symbol> + 0x0 (0x00007fff`e401eaa4)
PRESENTATIONFRAMEWORK! <no symbol> + 0x0 (0x00007fff`dbd34db4)
PRESENTATIONFRAMEWORK! <no symbol> + 0x0 (0x00007fff`dbd33d6c)
PRESENTATIONFRAMEWORK! <no symbol> + 0x0 (0x00007fff`dbc9a85c)
PRESENTATIONCORE! <no symbol> + 0x0 (0x00007fff`e3ecde14)
PRESENTATIONFRAMEWORK! <no symbol> + 0x0 (0x00007fff`dc13ce5c)
    File: C:\git\runtime\src\coreclr\vm\frames.cpp Line: 2177
    Image: C:\triage\wpf\bin\Debug\net7.0-windows\win-arm64\publish\wpf.exe
