### PR TITLE
Make metadata reader smaller

### DIFF
--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryReaderGen.cs
@@ -16,7 +16,7 @@ class MdBinaryReaderGen : CsWriter
 
     public void EmitSource()
     {
-        WriteLine("#pragma warning disable 649");
+        WriteLine("#pragma warning disable 649, SA1121, IDE0036, SA1129");
         WriteLine();
 
         WriteLine("using System;");

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryWriterGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryWriterGen.cs
@@ -16,12 +16,16 @@ class MdBinaryWriterGen : CsWriter
 
     public void EmitSource()
     {
-        WriteLine("#pragma warning disable 649");
+        WriteLine("#pragma warning disable 649, SA1121, IDE0036, SA1129");
         WriteLine();
 
+        WriteLine("using System;");
+        WriteLine("using System.IO;");
         WriteLine("using System.Collections.Generic;");
         WriteLine("using System.Reflection;");
+        WriteLine("using Internal.LowLevelLinq;");
         WriteLine("using Internal.NativeFormat;");
+        WriteLine("using Debug = System.Diagnostics.Debug;");
         WriteLine();
 
         OpenScope("namespace Internal.Metadata.NativeFormat.Writer");

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/ReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/ReaderGen.cs
@@ -23,9 +23,14 @@ class ReaderGen : CsWriter
         WriteLine("#pragma warning disable CA1066 // IEquatable<T> implementations aren't used");
         WriteLine("#pragma warning disable CA1822");
         WriteLine("#pragma warning disable IDE0059");
+        WriteLine("#pragma warning disable SA1121");
+        WriteLine("#pragma warning disable IDE0036, SA1129");
         WriteLine();
 
+        WriteLine("using System;");
         WriteLine("using System.Reflection;");
+        WriteLine("using System.Collections.Generic;");
+        WriteLine("using System.Runtime.CompilerServices;");
         WriteLine("using Internal.NativeFormat;");
         WriteLine();
 
@@ -263,7 +268,7 @@ class ReaderGen : CsWriter
             if (record.Name == "ConstantStringValue")
             {
                 WriteLine("if (IsNull(handle))");
-                WriteLine("    return default(ConstantStringValue);");
+                WriteLine("    return new ConstantStringValue();");
             }
             WriteLine($"{record.Name} record;");
             WriteLine("record._reader = this;");

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/ReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/ReaderGen.cs
@@ -28,6 +28,7 @@ class ReaderGen : CsWriter
         WriteLine();
 
         WriteLine("using System;");
+        WriteLine("using System.Diagnostics;");
         WriteLine("using System.Reflection;");
         WriteLine("using System.Collections.Generic;");
         WriteLine("using System.Runtime.CompilerServices;");
@@ -138,8 +139,7 @@ class ReaderGen : CsWriter
 
         OpenScope($"internal {handleName}(int value)");
         WriteLine("HandleType hType = (HandleType)(value >> 24);");
-        WriteLine($"if (!(hType == 0 || hType == HandleType.{record.Name} || hType == HandleType.Null))");
-        WriteLine("    throw new ArgumentException();");
+        WriteLine($"Debug.Assert(hType == 0 || hType == HandleType.{record.Name} || hType == HandleType.Null);");
         WriteLine($"_value = (value & 0x00FFFFFF) | (((int)HandleType.{record.Name}) << 24);");
         WriteLine("_Validate();");
         CloseScope();

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -274,7 +274,7 @@ class SchemaDef
         (
             from primitiveType in PrimitiveTypes select
                 new RecordDef(
-                    name: "Constant" + primitiveType.Name + "Value",
+                    name: "Constant" + primitiveType.TypeName + "Value",
                     members: new MemberDef[] {
                         new MemberDef(name: "Value", typeName: primitiveType.Name,
                             flags: primitiveType.CustomCompare ? MemberDefFlags.CustomCompare : 0)
@@ -309,9 +309,9 @@ class SchemaDef
         (
             from primitiveType in PrimitiveTypes select
                 new RecordDef(
-                    name: "Constant" + primitiveType.Name + "Array",
+                    name: "Constant" + primitiveType.TypeName + "Array",
                     members: new MemberDef[] {
-                        new MemberDef(name: "Value", typeName: primitiveType.Name,
+                        new MemberDef(name: "Value", typeName: primitiveType.TypeName,
                             flags: MemberDefFlags.Array | (primitiveType.CustomCompare ? MemberDefFlags.CustomCompare : 0))
                     }
                 )
@@ -759,10 +759,10 @@ class SchemaDef
     public static readonly string[] TypeNamesWithCollectionTypes =
         RecordSchema.SelectMany(r =>
             from member in r.Members
-            let memberName = member.Name as string
-            where memberName != null &&
+            let memberTypeName = member.TypeName as string
+            where memberTypeName != null &&
                 (member.Flags & MemberDefFlags.Collection) != 0 &&
-                !PrimitiveTypes.Any(pt => pt.Name == memberName)
-            select memberName
+                !PrimitiveTypes.Any(pt => pt.TypeName == memberTypeName)
+            select memberTypeName
         ).Concat(new[] { "ScopeDefinition" }).Distinct().ToArray();
 }

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/WriterGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/WriterGen.cs
@@ -10,13 +10,18 @@ class WriterGen : CsWriter
 
     public void EmitSource()
     {
-        WriteLine("#pragma warning disable 649");
+        WriteLine("#pragma warning disable 649, SA1121, IDE0036, SA1129");
         WriteLine();
 
+        WriteLine("using System;");
+        WriteLine("using System.IO;");
         WriteLine("using System.Collections.Generic;");
         WriteLine("using System.Reflection;");
         WriteLine("using System.Threading;");
+        WriteLine("using Internal.LowLevelLinq;");
+        WriteLine("using Internal.Metadata.NativeFormat.Writer;");
         WriteLine("using Internal.NativeFormat;");
+        WriteLine("using HandleType = Internal.Metadata.NativeFormat.HandleType;");
         WriteLine("using Debug = System.Diagnostics.Debug;");
         WriteLine();
 
@@ -59,8 +64,8 @@ class WriterGen : CsWriter
         }
         CloseScope("Visit");
 
-        OpenScope("public sealed override bool Equals(object obj)");
-        WriteLine("if (ReferenceEquals(this, obj)) return true;");
+        OpenScope("public override sealed bool Equals(Object obj)");
+        WriteLine("if (Object.ReferenceEquals(this, obj)) return true;");
         WriteLine($"var other = obj as {record.Name};");
         WriteLine("if (other == null) return false;");
         if ((record.Flags & RecordDefFlags.ReentrantEquals) != 0)
@@ -89,7 +94,7 @@ class WriterGen : CsWriter
             else
             if ((member.Flags & (MemberDefFlags.Map | MemberDefFlags.RecordRef)) != 0)
             {
-                WriteLine($"if (!Equals({member.Name}, other.{member.Name})) return false;");
+                WriteLine($"if (!Object.Equals({member.Name}, other.{member.Name})) return false;");
             }
             else
             if ((member.Flags & MemberDefFlags.CustomCompare) != 0)
@@ -108,7 +113,7 @@ class WriterGen : CsWriter
             WriteLine("finally");
             WriteLine("{");
             WriteLine("    var popped = _equalsReentrancyGuard.Value.Pop();");
-            WriteLine("    Debug.Assert(ReferenceEquals(other, popped));");
+            WriteLine("    Debug.Assert(Object.ReferenceEquals(other, popped));");
             WriteLine("}");
         }
         WriteLine("return true;");
@@ -116,7 +121,7 @@ class WriterGen : CsWriter
         if ((record.Flags & RecordDefFlags.ReentrantEquals) != 0)
             WriteLine("private ThreadLocal<ReentrancyGuardStack> _equalsReentrancyGuard;");
 
-        OpenScope("public sealed override int GetHashCode()");
+        OpenScope("public override sealed int GetHashCode()");
         WriteLine("if (_hash != 0)");
         WriteLine("    return _hash;");
         WriteLine("EnterGetHashCode();");

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/MdBinaryReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/MdBinaryReaderGen.cs
@@ -3,10 +3,14 @@
 
 // NOTE: This is a generated file - do not manually edit!
 
-#pragma warning disable 649
+#pragma warning disable 649, SA1121, IDE0036, SA1129
 
+using System;
+using System.IO;
+using System.Collections.Generic;
 using System.Reflection;
 using Internal.NativeFormat;
+using Debug = System.Diagnostics.Debug;
 
 namespace Internal.Metadata.NativeFormat
 {

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -13,6 +13,7 @@
 #pragma warning disable IDE0036, SA1129
 
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -119,8 +120,7 @@ namespace Internal.Metadata.NativeFormat
         internal ArraySignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ArraySignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ArraySignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ArraySignature) << 24);
             _Validate();
         }
@@ -235,8 +235,7 @@ namespace Internal.Metadata.NativeFormat
         internal ByReferenceSignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ByReferenceSignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ByReferenceSignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ByReferenceSignature) << 24);
             _Validate();
         }
@@ -350,8 +349,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantBooleanArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantBooleanArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantBooleanArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantBooleanArray) << 24);
             _Validate();
         }
@@ -465,8 +463,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantBooleanValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantBooleanValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantBooleanValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantBooleanValue) << 24);
             _Validate();
         }
@@ -592,8 +589,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantBoxedEnumValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantBoxedEnumValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantBoxedEnumValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantBoxedEnumValue) << 24);
             _Validate();
         }
@@ -707,8 +703,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantByteArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantByteArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantByteArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantByteArray) << 24);
             _Validate();
         }
@@ -822,8 +817,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantByteValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantByteValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantByteValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantByteValue) << 24);
             _Validate();
         }
@@ -937,8 +931,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantCharArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantCharArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantCharArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantCharArray) << 24);
             _Validate();
         }
@@ -1052,8 +1045,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantCharValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantCharValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantCharValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantCharValue) << 24);
             _Validate();
         }
@@ -1167,8 +1159,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantDoubleArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantDoubleArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantDoubleArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantDoubleArray) << 24);
             _Validate();
         }
@@ -1282,8 +1273,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantDoubleValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantDoubleValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantDoubleValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantDoubleValue) << 24);
             _Validate();
         }
@@ -1407,8 +1397,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantEnumArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantEnumArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantEnumArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantEnumArray) << 24);
             _Validate();
         }
@@ -1522,8 +1511,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantHandleArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantHandleArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantHandleArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantHandleArray) << 24);
             _Validate();
         }
@@ -1637,8 +1625,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantInt16ArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantInt16Array || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantInt16Array || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantInt16Array) << 24);
             _Validate();
         }
@@ -1752,8 +1739,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantInt16ValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantInt16Value || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantInt16Value || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantInt16Value) << 24);
             _Validate();
         }
@@ -1867,8 +1853,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantInt32ArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantInt32Array || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantInt32Array || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantInt32Array) << 24);
             _Validate();
         }
@@ -1982,8 +1967,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantInt32ValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantInt32Value || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantInt32Value || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantInt32Value) << 24);
             _Validate();
         }
@@ -2097,8 +2081,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantInt64ArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantInt64Array || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantInt64Array || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantInt64Array) << 24);
             _Validate();
         }
@@ -2212,8 +2195,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantInt64ValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantInt64Value || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantInt64Value || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantInt64Value) << 24);
             _Validate();
         }
@@ -2317,8 +2299,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantReferenceValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantReferenceValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantReferenceValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantReferenceValue) << 24);
             _Validate();
         }
@@ -2432,8 +2413,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantSByteArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantSByteArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantSByteArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantSByteArray) << 24);
             _Validate();
         }
@@ -2547,8 +2527,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantSByteValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantSByteValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantSByteValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantSByteValue) << 24);
             _Validate();
         }
@@ -2662,8 +2641,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantSingleArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantSingleArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantSingleArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantSingleArray) << 24);
             _Validate();
         }
@@ -2777,8 +2755,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantSingleValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantSingleValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantSingleValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantSingleValue) << 24);
             _Validate();
         }
@@ -2893,8 +2870,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantStringArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantStringArray || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantStringArray || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantStringArray) << 24);
             _Validate();
         }
@@ -3008,8 +2984,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantStringValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantStringValue || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantStringValue || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantStringValue) << 24);
             _Validate();
         }
@@ -3123,8 +3098,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantUInt16ArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantUInt16Array || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantUInt16Array || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantUInt16Array) << 24);
             _Validate();
         }
@@ -3238,8 +3212,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantUInt16ValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantUInt16Value || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantUInt16Value || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantUInt16Value) << 24);
             _Validate();
         }
@@ -3353,8 +3326,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantUInt32ArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantUInt32Array || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantUInt32Array || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantUInt32Array) << 24);
             _Validate();
         }
@@ -3468,8 +3440,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantUInt32ValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantUInt32Value || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantUInt32Value || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantUInt32Value) << 24);
             _Validate();
         }
@@ -3583,8 +3554,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantUInt64ArrayHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantUInt64Array || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantUInt64Array || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantUInt64Array) << 24);
             _Validate();
         }
@@ -3698,8 +3668,7 @@ namespace Internal.Metadata.NativeFormat
         internal ConstantUInt64ValueHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ConstantUInt64Value || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ConstantUInt64Value || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ConstantUInt64Value) << 24);
             _Validate();
         }
@@ -3835,8 +3804,7 @@ namespace Internal.Metadata.NativeFormat
         internal CustomAttributeHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.CustomAttribute || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.CustomAttribute || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.CustomAttribute) << 24);
             _Validate();
         }
@@ -3991,8 +3959,7 @@ namespace Internal.Metadata.NativeFormat
         internal EventHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.Event || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.Event || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.Event) << 24);
             _Validate();
         }
@@ -4157,8 +4124,7 @@ namespace Internal.Metadata.NativeFormat
         internal FieldHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.Field || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.Field || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.Field) << 24);
             _Validate();
         }
@@ -4273,8 +4239,7 @@ namespace Internal.Metadata.NativeFormat
         internal FieldSignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.FieldSignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.FieldSignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.FieldSignature) << 24);
             _Validate();
         }
@@ -4388,8 +4353,7 @@ namespace Internal.Metadata.NativeFormat
         internal FunctionPointerSignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.FunctionPointerSignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.FunctionPointerSignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.FunctionPointerSignature) << 24);
             _Validate();
         }
@@ -4554,8 +4518,7 @@ namespace Internal.Metadata.NativeFormat
         internal GenericParameterHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.GenericParameter || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.GenericParameter || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.GenericParameter) << 24);
             _Validate();
         }
@@ -4691,8 +4654,7 @@ namespace Internal.Metadata.NativeFormat
         internal MemberReferenceHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.MemberReference || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.MemberReference || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.MemberReference) << 24);
             _Validate();
         }
@@ -4866,8 +4828,7 @@ namespace Internal.Metadata.NativeFormat
         internal MethodHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.Method || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.Method || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.Method) << 24);
             _Validate();
         }
@@ -4993,8 +4954,7 @@ namespace Internal.Metadata.NativeFormat
         internal MethodInstantiationHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.MethodInstantiation || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.MethodInstantiation || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.MethodInstantiation) << 24);
             _Validate();
         }
@@ -5118,8 +5078,7 @@ namespace Internal.Metadata.NativeFormat
         internal MethodSemanticsHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.MethodSemantics || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.MethodSemantics || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.MethodSemantics) << 24);
             _Validate();
         }
@@ -5276,8 +5235,7 @@ namespace Internal.Metadata.NativeFormat
         internal MethodSignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.MethodSignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.MethodSignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.MethodSignature) << 24);
             _Validate();
         }
@@ -5391,8 +5349,7 @@ namespace Internal.Metadata.NativeFormat
         internal MethodTypeVariableSignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.MethodTypeVariableSignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.MethodTypeVariableSignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.MethodTypeVariableSignature) << 24);
             _Validate();
         }
@@ -5528,8 +5485,7 @@ namespace Internal.Metadata.NativeFormat
         internal ModifiedTypeHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ModifiedType || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ModifiedType || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ModifiedType) << 24);
             _Validate();
         }
@@ -5675,8 +5631,7 @@ namespace Internal.Metadata.NativeFormat
         internal NamedArgumentHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.NamedArgument || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.NamedArgument || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.NamedArgument) << 24);
             _Validate();
         }
@@ -5831,8 +5786,7 @@ namespace Internal.Metadata.NativeFormat
         internal NamespaceDefinitionHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.NamespaceDefinition || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.NamespaceDefinition || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.NamespaceDefinition) << 24);
             _Validate();
         }
@@ -5957,8 +5911,7 @@ namespace Internal.Metadata.NativeFormat
         internal NamespaceReferenceHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.NamespaceReference || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.NamespaceReference || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.NamespaceReference) << 24);
             _Validate();
         }
@@ -6113,8 +6066,7 @@ namespace Internal.Metadata.NativeFormat
         internal ParameterHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.Parameter || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.Parameter || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.Parameter) << 24);
             _Validate();
         }
@@ -6229,8 +6181,7 @@ namespace Internal.Metadata.NativeFormat
         internal PointerSignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.PointerSignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.PointerSignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.PointerSignature) << 24);
             _Validate();
         }
@@ -6395,8 +6346,7 @@ namespace Internal.Metadata.NativeFormat
         internal PropertyHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.Property || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.Property || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.Property) << 24);
             _Validate();
         }
@@ -6532,8 +6482,7 @@ namespace Internal.Metadata.NativeFormat
         internal PropertySignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.PropertySignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.PropertySignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.PropertySignature) << 24);
             _Validate();
         }
@@ -6657,8 +6606,7 @@ namespace Internal.Metadata.NativeFormat
         internal QualifiedFieldHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.QualifiedField || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.QualifiedField || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.QualifiedField) << 24);
             _Validate();
         }
@@ -6782,8 +6730,7 @@ namespace Internal.Metadata.NativeFormat
         internal QualifiedMethodHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.QualifiedMethod || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.QualifiedMethod || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.QualifiedMethod) << 24);
             _Validate();
         }
@@ -6898,8 +6845,7 @@ namespace Internal.Metadata.NativeFormat
         internal SZArraySignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.SZArraySignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.SZArraySignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.SZArraySignature) << 24);
             _Validate();
         }
@@ -7163,8 +7109,7 @@ namespace Internal.Metadata.NativeFormat
         internal ScopeDefinitionHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ScopeDefinition || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ScopeDefinition || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ScopeDefinition) << 24);
             _Validate();
         }
@@ -7348,8 +7293,7 @@ namespace Internal.Metadata.NativeFormat
         internal ScopeReferenceHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.ScopeReference || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.ScopeReference || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.ScopeReference) << 24);
             _Validate();
         }
@@ -7605,8 +7549,7 @@ namespace Internal.Metadata.NativeFormat
         internal TypeDefinitionHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.TypeDefinition || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.TypeDefinition || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.TypeDefinition) << 24);
             _Validate();
         }
@@ -7740,8 +7683,7 @@ namespace Internal.Metadata.NativeFormat
         internal TypeForwarderHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.TypeForwarder || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.TypeForwarder || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.TypeForwarder) << 24);
             _Validate();
         }
@@ -7867,8 +7809,7 @@ namespace Internal.Metadata.NativeFormat
         internal TypeInstantiationSignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.TypeInstantiationSignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.TypeInstantiationSignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.TypeInstantiationSignature) << 24);
             _Validate();
         }
@@ -7993,8 +7934,7 @@ namespace Internal.Metadata.NativeFormat
         internal TypeReferenceHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.TypeReference || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.TypeReference || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.TypeReference) << 24);
             _Validate();
         }
@@ -8109,8 +8049,7 @@ namespace Internal.Metadata.NativeFormat
         internal TypeSpecificationHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.TypeSpecification || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.TypeSpecification || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.TypeSpecification) << 24);
             _Validate();
         }
@@ -8224,8 +8163,7 @@ namespace Internal.Metadata.NativeFormat
         internal TypeVariableSignatureHandle(int value)
         {
             HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.TypeVariableSignature || hType == HandleType.Null))
-                throw new ArgumentException();
+            Debug.Assert(hType == 0 || hType == HandleType.TypeVariableSignature || hType == HandleType.Null);
             _value = (value & 0x00FFFFFF) | (((int)HandleType.TypeVariableSignature) << 24);
             _Validate();
         }

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -9,6 +9,8 @@
 #pragma warning disable CA1066 // IEquatable<T> implementations aren't used
 #pragma warning disable CA1822
 #pragma warning disable IDE0059
+#pragma warning disable SA1121
+#pragma warning disable IDE0036, SA1129
 
 using System;
 using System.Reflection;
@@ -10700,7 +10702,7 @@ namespace Internal.Metadata.NativeFormat
         public ConstantStringValue GetConstantStringValue(ConstantStringValueHandle handle)
         {
             if (IsNull(handle))
-                return default(ConstantStringValue);
+                return new ConstantStringValue();
             ConstantStringValue record;
             record._reader = this;
             record._handle = handle;

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
@@ -3,11 +3,15 @@
 
 // NOTE: This is a generated file - do not manually edit!
 
-#pragma warning disable 649
+#pragma warning disable 649, SA1121, IDE0036, SA1129
 
+using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Reflection;
+using Internal.LowLevelLinq;
 using Internal.NativeFormat;
+using Debug = System.Diagnostics.Debug;
 
 namespace Internal.Metadata.NativeFormat.Writer
 {

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
@@ -3,12 +3,17 @@
 
 // NOTE: This is a generated file - do not manually edit!
 
-#pragma warning disable 649
+#pragma warning disable 649, SA1121, IDE0036, SA1129
 
+using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
+using Internal.LowLevelLinq;
+using Internal.Metadata.NativeFormat.Writer;
 using Internal.NativeFormat;
+using HandleType = Internal.Metadata.NativeFormat.HandleType;
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.Metadata.NativeFormat.Writer
@@ -28,19 +33,19 @@ namespace Internal.Metadata.NativeFormat.Writer
             ElementType = visitor.Visit(this, ElementType);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ArraySignature;
             if (other == null) return false;
-            if (!Equals(ElementType, other.ElementType)) return false;
+            if (!Object.Equals(ElementType, other.ElementType)) return false;
             if (Rank != other.Rank) return false;
             if (!Sizes.SequenceEqual(other.Sizes)) return false;
             if (!LowerBounds.SequenceEqual(other.LowerBounds)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -101,8 +106,8 @@ namespace Internal.Metadata.NativeFormat.Writer
 
         public MetadataRecord ElementType;
         public int Rank;
-        public int[] Sizes;
-        public int[] LowerBounds;
+        public Int32[] Sizes;
+        public Int32[] LowerBounds;
     } // ArraySignature
 
     public partial class ByReferenceSignature : MetadataRecord
@@ -120,16 +125,16 @@ namespace Internal.Metadata.NativeFormat.Writer
             Type = visitor.Visit(this, Type);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ByReferenceSignature;
             if (other == null) return false;
-            if (!Equals(Type, other.Type)) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -187,16 +192,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantBooleanArray;
             if (other == null) return false;
             if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -239,7 +244,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public bool[] Value;
+        public Boolean[] Value;
     } // ConstantBooleanArray
 
     public partial class ConstantBooleanValue : MetadataRecord
@@ -256,16 +261,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantBooleanValue;
             if (other == null) return false;
             if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -321,17 +326,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             Type = visitor.Visit(this, Type);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantBoxedEnumValue;
             if (other == null) return false;
-            if (!Equals(Value, other.Value)) return false;
-            if (!Equals(Type, other.Type)) return false;
+            if (!Object.Equals(Value, other.Value)) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -401,16 +406,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantByteArray;
             if (other == null) return false;
             if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -453,7 +458,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public byte[] Value;
+        public Byte[] Value;
     } // ConstantByteArray
 
     public partial class ConstantByteValue : MetadataRecord
@@ -470,19 +475,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantByteValue;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -536,19 +538,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantCharArray;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -591,7 +590,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public char[] Value;
+        public Char[] Value;
     } // ConstantCharArray
 
     public partial class ConstantCharValue : MetadataRecord
@@ -608,19 +607,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantCharValue;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -674,19 +670,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantDoubleArray;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value, DoubleComparer.Instance))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value, DoubleComparer.Instance)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -729,7 +722,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public double[] Value;
+        public Double[] Value;
     } // ConstantDoubleArray
 
     public partial class ConstantDoubleValue : MetadataRecord
@@ -746,19 +739,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantDoubleValue;
-            if (other == null)
-                return false;
-            if (!CustomComparer.Equals(Value, other.Value))
-                return false;
+            if (other == null) return false;
+            if (!CustomComparer.Equals(Value, other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -814,21 +804,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             Value = visitor.Visit(this, Value);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantEnumArray;
-            if (other == null)
-                return false;
-            if (!Equals(ElementType, other.ElementType))
-                return false;
-            if (!Equals(Value, other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(ElementType, other.ElementType)) return false;
+            if (!Object.Equals(Value, other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -886,19 +872,16 @@ namespace Internal.Metadata.NativeFormat.Writer
             Value = visitor.Visit(this, Value);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantHandleArray;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -951,19 +934,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantInt16Array;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1006,7 +986,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public short[] Value;
+        public Int16[] Value;
     } // ConstantInt16Array
 
     public partial class ConstantInt16Value : MetadataRecord
@@ -1023,19 +1003,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantInt16Value;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1089,19 +1066,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantInt32Array;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1144,7 +1118,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public int[] Value;
+        public Int32[] Value;
     } // ConstantInt32Array
 
     public partial class ConstantInt32Value : MetadataRecord
@@ -1161,19 +1135,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantInt32Value;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1227,19 +1198,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantInt64Array;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1282,7 +1250,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public long[] Value;
+        public Int64[] Value;
     } // ConstantInt64Array
 
     public partial class ConstantInt64Value : MetadataRecord
@@ -1299,19 +1267,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantInt64Value;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1365,15 +1330,15 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantReferenceValue;
             if (other == null) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1424,19 +1389,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantSByteArray;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1479,7 +1441,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public sbyte[] Value;
+        public SByte[] Value;
     } // ConstantSByteArray
 
     public partial class ConstantSByteValue : MetadataRecord
@@ -1496,19 +1458,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantSByteValue;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1562,19 +1521,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantSingleArray;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value, SingleComparer.Instance))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value, SingleComparer.Instance)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1617,7 +1573,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public float[] Value;
+        public Single[] Value;
     } // ConstantSingleArray
 
     public partial class ConstantSingleValue : MetadataRecord
@@ -1634,19 +1590,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantSingleValue;
-            if (other == null)
-                return false;
-            if (!CustomComparer.Equals(Value, other.Value))
-                return false;
+            if (other == null) return false;
+            if (!CustomComparer.Equals(Value, other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1701,19 +1654,16 @@ namespace Internal.Metadata.NativeFormat.Writer
             Value = visitor.Visit(this, Value);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantStringArray;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1769,19 +1719,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantStringValue;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1841,19 +1788,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantUInt16Array;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1896,7 +1840,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public ushort[] Value;
+        public UInt16[] Value;
     } // ConstantUInt16Array
 
     public partial class ConstantUInt16Value : MetadataRecord
@@ -1913,19 +1857,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantUInt16Value;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -1979,19 +1920,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantUInt32Array;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2034,7 +1972,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public uint[] Value;
+        public UInt32[] Value;
     } // ConstantUInt32Array
 
     public partial class ConstantUInt32Value : MetadataRecord
@@ -2051,19 +1989,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantUInt32Value;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2117,19 +2052,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantUInt64Array;
-            if (other == null)
-                return false;
-            if (!Value.SequenceEqual(other.Value))
-                return false;
+            if (other == null) return false;
+            if (!Value.SequenceEqual(other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2172,7 +2104,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
         } // Handle
 
-        public ulong[] Value;
+        public UInt64[] Value;
     } // ConstantUInt64Array
 
     public partial class ConstantUInt64Value : MetadataRecord
@@ -2189,19 +2121,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ConstantUInt64Value;
-            if (other == null)
-                return false;
-            if (Value != other.Value)
-                return false;
+            if (other == null) return false;
+            if (Value != other.Value) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2263,9 +2192,9 @@ namespace Internal.Metadata.NativeFormat.Writer
             NamedArguments = visitor.Visit(this, NamedArguments);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj)) return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as CustomAttribute;
             if (other == null) return false;
             if (_equalsReentrancyGuard.Value.Contains(other))
@@ -2273,20 +2202,20 @@ namespace Internal.Metadata.NativeFormat.Writer
             _equalsReentrancyGuard.Value.Push(other);
             try
             {
-            if (!Equals(Constructor, other.Constructor)) return false;
+            if (!Object.Equals(Constructor, other.Constructor)) return false;
             if (!FixedArguments.SequenceEqual(other.FixedArguments)) return false;
             if (!NamedArguments.SequenceEqual(other.NamedArguments)) return false;
             }
             finally
             {
                 var popped = _equalsReentrancyGuard.Value.Pop();
-                Debug.Assert(ReferenceEquals(other, popped));
+                Debug.Assert(Object.ReferenceEquals(other, popped));
             }
             return true;
         } // Equals
         private ThreadLocal<ReentrancyGuardStack> _equalsReentrancyGuard;
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2398,27 +2327,20 @@ namespace Internal.Metadata.NativeFormat.Writer
             CustomAttributes = visitor.Visit(this, CustomAttributes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as Event;
-            if (other == null)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Equals(Type, other.Type))
-                return false;
-            if (!MethodSemantics.SequenceEqual(other.MethodSemantics))
-                return false;
-            if (!CustomAttributes.SequenceEqual(other.CustomAttributes))
-                return false;
+            if (other == null) return false;
+            if (Flags != other.Flags) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
+            if (!MethodSemantics.SequenceEqual(other.MethodSemantics)) return false;
+            if (!CustomAttributes.SequenceEqual(other.CustomAttributes)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2504,29 +2426,21 @@ namespace Internal.Metadata.NativeFormat.Writer
             CustomAttributes = visitor.Visit(this, CustomAttributes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as Field;
-            if (other == null)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Equals(Signature, other.Signature))
-                return false;
-            if (!Equals(DefaultValue, other.DefaultValue))
-                return false;
-            if (Offset != other.Offset)
-                return false;
-            if (!CustomAttributes.SequenceEqual(other.CustomAttributes))
-                return false;
+            if (other == null) return false;
+            if (Flags != other.Flags) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(Signature, other.Signature)) return false;
+            if (!Object.Equals(DefaultValue, other.DefaultValue)) return false;
+            if (Offset != other.Offset) return false;
+            if (!CustomAttributes.SequenceEqual(other.CustomAttributes)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2635,19 +2549,16 @@ namespace Internal.Metadata.NativeFormat.Writer
             Type = visitor.Visit(this, Type);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as FieldSignature;
-            if (other == null)
-                return false;
-            if (!Equals(Type, other.Type))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2707,19 +2618,16 @@ namespace Internal.Metadata.NativeFormat.Writer
             Signature = visitor.Visit(this, Signature);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as FunctionPointerSignature;
-            if (other == null)
-                return false;
-            if (!Equals(Signature, other.Signature))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Signature, other.Signature)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2776,29 +2684,21 @@ namespace Internal.Metadata.NativeFormat.Writer
             CustomAttributes = visitor.Visit(this, CustomAttributes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as GenericParameter;
-            if (other == null)
-                return false;
-            if (Number != other.Number)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (Kind != other.Kind)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Constraints.SequenceEqual(other.Constraints))
-                return false;
-            if (!CustomAttributes.SequenceEqual(other.CustomAttributes))
-                return false;
+            if (other == null) return false;
+            if (Number != other.Number) return false;
+            if (Flags != other.Flags) return false;
+            if (Kind != other.Kind) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Constraints.SequenceEqual(other.Constraints)) return false;
+            if (!CustomAttributes.SequenceEqual(other.CustomAttributes)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2880,23 +2780,18 @@ namespace Internal.Metadata.NativeFormat.Writer
             Signature = visitor.Visit(this, Signature);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as MemberReference;
-            if (other == null)
-                return false;
-            if (!Equals(Parent, other.Parent))
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Equals(Signature, other.Signature))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Parent, other.Parent)) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(Signature, other.Signature)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -2968,31 +2863,22 @@ namespace Internal.Metadata.NativeFormat.Writer
             CustomAttributes = visitor.Visit(this, CustomAttributes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as Method;
-            if (other == null)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (ImplFlags != other.ImplFlags)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Equals(Signature, other.Signature))
-                return false;
-            if (!Parameters.SequenceEqual(other.Parameters))
-                return false;
-            if (!GenericParameters.SequenceEqual(other.GenericParameters))
-                return false;
-            if (!CustomAttributes.SequenceEqual(other.CustomAttributes))
-                return false;
+            if (other == null) return false;
+            if (Flags != other.Flags) return false;
+            if (ImplFlags != other.ImplFlags) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(Signature, other.Signature)) return false;
+            if (!Parameters.SequenceEqual(other.Parameters)) return false;
+            if (!GenericParameters.SequenceEqual(other.GenericParameters)) return false;
+            if (!CustomAttributes.SequenceEqual(other.CustomAttributes)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3077,21 +2963,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             GenericTypeArguments = visitor.Visit(this, GenericTypeArguments);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as MethodInstantiation;
-            if (other == null)
-                return false;
-            if (!Equals(Method, other.Method))
-                return false;
-            if (!GenericTypeArguments.SequenceEqual(other.GenericTypeArguments))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Method, other.Method)) return false;
+            if (!GenericTypeArguments.SequenceEqual(other.GenericTypeArguments)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3155,21 +3037,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             Method = visitor.Visit(this, Method);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as MethodSemantics;
-            if (other == null)
-                return false;
-            if (Attributes != other.Attributes)
-                return false;
-            if (!Equals(Method, other.Method))
-                return false;
+            if (other == null) return false;
+            if (Attributes != other.Attributes) return false;
+            if (!Object.Equals(Method, other.Method)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3229,27 +3107,20 @@ namespace Internal.Metadata.NativeFormat.Writer
             VarArgParameters = visitor.Visit(this, VarArgParameters);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as MethodSignature;
-            if (other == null)
-                return false;
-            if (CallingConvention != other.CallingConvention)
-                return false;
-            if (GenericParameterCount != other.GenericParameterCount)
-                return false;
-            if (!Equals(ReturnType, other.ReturnType))
-                return false;
-            if (!Parameters.SequenceEqual(other.Parameters))
-                return false;
-            if (!VarArgParameters.SequenceEqual(other.VarArgParameters))
-                return false;
+            if (other == null) return false;
+            if (CallingConvention != other.CallingConvention) return false;
+            if (GenericParameterCount != other.GenericParameterCount) return false;
+            if (!Object.Equals(ReturnType, other.ReturnType)) return false;
+            if (!Parameters.SequenceEqual(other.Parameters)) return false;
+            if (!VarArgParameters.SequenceEqual(other.VarArgParameters)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3342,19 +3213,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as MethodTypeVariableSignature;
-            if (other == null)
-                return false;
-            if (Number != other.Number)
-                return false;
+            if (other == null) return false;
+            if (Number != other.Number) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3410,23 +3278,18 @@ namespace Internal.Metadata.NativeFormat.Writer
             Type = visitor.Visit(this, Type);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ModifiedType;
-            if (other == null)
-                return false;
-            if (IsOptional != other.IsOptional)
-                return false;
-            if (!Equals(ModifierType, other.ModifierType))
-                return false;
-            if (!Equals(Type, other.Type))
-                return false;
+            if (other == null) return false;
+            if (IsOptional != other.IsOptional) return false;
+            if (!Object.Equals(ModifierType, other.ModifierType)) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3498,25 +3361,19 @@ namespace Internal.Metadata.NativeFormat.Writer
             Value = visitor.Visit(this, Value);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as NamedArgument;
-            if (other == null)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Equals(Type, other.Type))
-                return false;
-            if (!Equals(Value, other.Value))
-                return false;
+            if (other == null) return false;
+            if (Flags != other.Flags) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
+            if (!Object.Equals(Value, other.Value)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3621,21 +3478,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             NamespaceDefinitions = visitor.Visit(this, NamespaceDefinitions);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as NamespaceDefinition;
-            if (other == null)
-                return false;
-            if (!Equals(ParentScopeOrNamespace, other.ParentScopeOrNamespace))
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(ParentScopeOrNamespace, other.ParentScopeOrNamespace)) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3703,21 +3556,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             Name = visitor.Visit(this, Name);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as NamespaceReference;
-            if (other == null)
-                return false;
-            if (!Equals(ParentScopeOrNamespace, other.ParentScopeOrNamespace))
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(ParentScopeOrNamespace, other.ParentScopeOrNamespace)) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3780,27 +3629,20 @@ namespace Internal.Metadata.NativeFormat.Writer
             CustomAttributes = visitor.Visit(this, CustomAttributes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as Parameter;
-            if (other == null)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (Sequence != other.Sequence)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Equals(DefaultValue, other.DefaultValue))
-                return false;
-            if (!CustomAttributes.SequenceEqual(other.CustomAttributes))
-                return false;
+            if (other == null) return false;
+            if (Flags != other.Flags) return false;
+            if (Sequence != other.Sequence) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(DefaultValue, other.DefaultValue)) return false;
+            if (!CustomAttributes.SequenceEqual(other.CustomAttributes)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3899,19 +3741,16 @@ namespace Internal.Metadata.NativeFormat.Writer
             Type = visitor.Visit(this, Type);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as PointerSignature;
-            if (other == null)
-                return false;
-            if (!Equals(Type, other.Type))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -3975,29 +3814,21 @@ namespace Internal.Metadata.NativeFormat.Writer
             CustomAttributes = visitor.Visit(this, CustomAttributes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as Property;
-            if (other == null)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Equals(Signature, other.Signature))
-                return false;
-            if (!MethodSemantics.SequenceEqual(other.MethodSemantics))
-                return false;
-            if (!Equals(DefaultValue, other.DefaultValue))
-                return false;
-            if (!CustomAttributes.SequenceEqual(other.CustomAttributes))
-                return false;
+            if (other == null) return false;
+            if (Flags != other.Flags) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(Signature, other.Signature)) return false;
+            if (!MethodSemantics.SequenceEqual(other.MethodSemantics)) return false;
+            if (!Object.Equals(DefaultValue, other.DefaultValue)) return false;
+            if (!CustomAttributes.SequenceEqual(other.CustomAttributes)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4113,23 +3944,18 @@ namespace Internal.Metadata.NativeFormat.Writer
             Parameters = visitor.Visit(this, Parameters);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as PropertySignature;
-            if (other == null)
-                return false;
-            if (CallingConvention != other.CallingConvention)
-                return false;
-            if (!Equals(Type, other.Type))
-                return false;
-            if (!Parameters.SequenceEqual(other.Parameters))
-                return false;
+            if (other == null) return false;
+            if (CallingConvention != other.CallingConvention) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
+            if (!Parameters.SequenceEqual(other.Parameters)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4207,21 +4033,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             EnclosingType = visitor.Visit(this, EnclosingType);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as QualifiedField;
-            if (other == null)
-                return false;
-            if (!Equals(Field, other.Field))
-                return false;
-            if (!Equals(EnclosingType, other.EnclosingType))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Field, other.Field)) return false;
+            if (!Object.Equals(EnclosingType, other.EnclosingType)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4280,21 +4102,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             EnclosingType = visitor.Visit(this, EnclosingType);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as QualifiedMethod;
-            if (other == null)
-                return false;
-            if (!Equals(Method, other.Method))
-                return false;
-            if (!Equals(EnclosingType, other.EnclosingType))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Method, other.Method)) return false;
+            if (!Object.Equals(EnclosingType, other.EnclosingType)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4352,19 +4170,16 @@ namespace Internal.Metadata.NativeFormat.Writer
             ElementType = visitor.Visit(this, ElementType);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as SZArraySignature;
-            if (other == null)
-                return false;
-            if (!Equals(ElementType, other.ElementType))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(ElementType, other.ElementType)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4431,39 +4246,26 @@ namespace Internal.Metadata.NativeFormat.Writer
             ModuleCustomAttributes = visitor.Visit(this, ModuleCustomAttributes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ScopeDefinition;
-            if (other == null)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (HashAlgorithm != other.HashAlgorithm)
-                return false;
-            if (MajorVersion != other.MajorVersion)
-                return false;
-            if (MinorVersion != other.MinorVersion)
-                return false;
-            if (BuildNumber != other.BuildNumber)
-                return false;
-            if (RevisionNumber != other.RevisionNumber)
-                return false;
-            if (!PublicKey.SequenceEqual(other.PublicKey))
-                return false;
-            if (!Equals(Culture, other.Culture))
-                return false;
-            if (!Equals(ModuleName, other.ModuleName))
-                return false;
-            if (!Mvid.SequenceEqual(other.Mvid))
-                return false;
+            if (other == null) return false;
+            if (Flags != other.Flags) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (HashAlgorithm != other.HashAlgorithm) return false;
+            if (MajorVersion != other.MajorVersion) return false;
+            if (MinorVersion != other.MinorVersion) return false;
+            if (BuildNumber != other.BuildNumber) return false;
+            if (RevisionNumber != other.RevisionNumber) return false;
+            if (!PublicKey.SequenceEqual(other.PublicKey)) return false;
+            if (!Object.Equals(Culture, other.Culture)) return false;
+            if (!Object.Equals(ModuleName, other.ModuleName)) return false;
+            if (!Mvid.SequenceEqual(other.Mvid)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4544,14 +4346,14 @@ namespace Internal.Metadata.NativeFormat.Writer
         public ushort MinorVersion;
         public ushort BuildNumber;
         public ushort RevisionNumber;
-        public byte[] PublicKey;
+        public Byte[] PublicKey;
         public ConstantStringValue Culture;
         public NamespaceDefinition RootNamespaceDefinition;
         public QualifiedMethod EntryPoint;
         public TypeDefinition GlobalModuleType;
         public List<CustomAttribute> CustomAttributes = new List<CustomAttribute>();
         public ConstantStringValue ModuleName;
-        public byte[] Mvid;
+        public Byte[] Mvid;
         public List<CustomAttribute> ModuleCustomAttributes = new List<CustomAttribute>();
     } // ScopeDefinition
 
@@ -4571,33 +4373,23 @@ namespace Internal.Metadata.NativeFormat.Writer
             Culture = visitor.Visit(this, Culture);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as ScopeReference;
-            if (other == null)
-                return false;
-            if (Flags != other.Flags)
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (MajorVersion != other.MajorVersion)
-                return false;
-            if (MinorVersion != other.MinorVersion)
-                return false;
-            if (BuildNumber != other.BuildNumber)
-                return false;
-            if (RevisionNumber != other.RevisionNumber)
-                return false;
-            if (!PublicKeyOrToken.SequenceEqual(other.PublicKeyOrToken))
-                return false;
-            if (!Equals(Culture, other.Culture))
-                return false;
+            if (other == null) return false;
+            if (Flags != other.Flags) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (MajorVersion != other.MajorVersion) return false;
+            if (MinorVersion != other.MinorVersion) return false;
+            if (BuildNumber != other.BuildNumber) return false;
+            if (RevisionNumber != other.RevisionNumber) return false;
+            if (!PublicKeyOrToken.SequenceEqual(other.PublicKeyOrToken)) return false;
+            if (!Object.Equals(Culture, other.Culture)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4660,7 +4452,7 @@ namespace Internal.Metadata.NativeFormat.Writer
         public ushort MinorVersion;
         public ushort BuildNumber;
         public ushort RevisionNumber;
-        public byte[] PublicKeyOrToken;
+        public Byte[] PublicKeyOrToken;
         public ConstantStringValue Culture;
     } // ScopeReference
 
@@ -4690,23 +4482,18 @@ namespace Internal.Metadata.NativeFormat.Writer
             CustomAttributes = visitor.Visit(this, CustomAttributes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as TypeDefinition;
-            if (other == null)
-                return false;
-            if (!Equals(NamespaceDefinition, other.NamespaceDefinition))
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!Equals(EnclosingType, other.EnclosingType))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(NamespaceDefinition, other.NamespaceDefinition)) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(EnclosingType, other.EnclosingType)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4801,23 +4588,18 @@ namespace Internal.Metadata.NativeFormat.Writer
             NestedTypes = visitor.Visit(this, NestedTypes);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as TypeForwarder;
-            if (other == null)
-                return false;
-            if (!Equals(Scope, other.Scope))
-                return false;
-            if (!Equals(Name, other.Name))
-                return false;
-            if (!NestedTypes.SequenceEqual(other.NestedTypes))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Scope, other.Scope)) return false;
+            if (!Object.Equals(Name, other.Name)) return false;
+            if (!NestedTypes.SequenceEqual(other.NestedTypes)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4878,21 +4660,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             GenericTypeArguments = visitor.Visit(this, GenericTypeArguments);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as TypeInstantiationSignature;
-            if (other == null)
-                return false;
-            if (!Equals(GenericType, other.GenericType))
-                return false;
-            if (!GenericTypeArguments.SequenceEqual(other.GenericTypeArguments))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(GenericType, other.GenericType)) return false;
+            if (!GenericTypeArguments.SequenceEqual(other.GenericTypeArguments)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -4958,21 +4736,17 @@ namespace Internal.Metadata.NativeFormat.Writer
             TypeName = visitor.Visit(this, TypeName);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as TypeReference;
-            if (other == null)
-                return false;
-            if (!Equals(ParentNamespaceOrType, other.ParentNamespaceOrType))
-                return false;
-            if (!Equals(TypeName, other.TypeName))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(ParentNamespaceOrType, other.ParentNamespaceOrType)) return false;
+            if (!Object.Equals(TypeName, other.TypeName)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -5033,19 +4807,16 @@ namespace Internal.Metadata.NativeFormat.Writer
             Signature = visitor.Visit(this, Signature);
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as TypeSpecification;
-            if (other == null)
-                return false;
-            if (!Equals(Signature, other.Signature))
-                return false;
+            if (other == null) return false;
+            if (!Object.Equals(Signature, other.Signature)) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;
@@ -5110,19 +4881,16 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
         } // Visit
 
-        public sealed override bool Equals(object obj)
+        public override sealed bool Equals(Object obj)
         {
-            if (ReferenceEquals(this, obj))
-                return true;
+            if (Object.ReferenceEquals(this, obj)) return true;
             var other = obj as TypeVariableSignature;
-            if (other == null)
-                return false;
-            if (Number != other.Number)
-                return false;
+            if (other == null) return false;
+            if (Number != other.Number) return false;
             return true;
         } // Equals
 
-        public sealed override int GetHashCode()
+        public override sealed int GetHashCode()
         {
             if (_hash != 0)
                 return _hash;


### PR DESCRIPTION
Saves 13 kB on Hello World.

The first commit undoes the reformatting to the generated code done in #74825. The generator was not properly updated and the generated code is wildly different from what the generator produces and does not build. I tried tweaking the generator but gave up after wasting an hour on it. Added suppressions and moving on with life. Spent a lot more time on this than I thought I would.

Cc @dotnet/ilc-contrib 