### PR TITLE
JIT: Check return type compatibility for method GDVs

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2369,9 +2369,13 @@ public:
     GenTreeCall* gtNewCallNode(gtCallTypes           callType,
                                CORINFO_METHOD_HANDLE handle,
                                var_types             type,
+                               CORINFO_CLASS_HANDLE  retClsHandle,
                                const DebugInfo&      di = DebugInfo());
 
-    GenTreeCall* gtNewIndCallNode(GenTree* addr, var_types type, const DebugInfo& di = DebugInfo());
+    GenTreeCall* gtNewIndCallNode(GenTree*             addr,
+                                  var_types            type,
+                                  CORINFO_CLASS_HANDLE retClsHandle,
+                                  const DebugInfo&     di = DebugInfo());
 
     GenTreeCall* gtNewHelperCallNode(
         unsigned helper, var_types type, GenTree* arg1 = nullptr, GenTree* arg2 = nullptr, GenTree* arg3 = nullptr);
@@ -3669,7 +3673,7 @@ protected:
 
     CORINFO_CLASS_HANDLE impGetSpecialIntrinsicExactReturnType(GenTreeCall* call);
 
-    GenTree* impFixupCallStructReturn(GenTreeCall* call, CORINFO_CLASS_HANDLE retClsHnd);
+    GenTree* impFixupCallStructReturn(GenTreeCall* call);
 
     GenTree* impFixupStructReturnType(GenTree* op);
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -999,7 +999,7 @@ inline GenTreeCall* Compiler::gtNewHelperCallNode(
     unsigned helper, var_types type, GenTree* arg1, GenTree* arg2, GenTree* arg3)
 {
     GenTreeFlags flags  = s_helperCallProperties.NoThrow((CorInfoHelpFunc)helper) ? GTF_EMPTY : GTF_EXCEPT;
-    GenTreeCall* result = gtNewCallNode(CT_HELPER, eeFindHelper(helper), type);
+    GenTreeCall* result = gtNewCallNode(CT_HELPER, eeFindHelper(helper), type, NO_CLASS_HANDLE);
     result->gtFlags |= flags;
 
 #if DEBUG

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7305,14 +7305,18 @@ GenTreeLclVar* Compiler::gtNewStoreLclVar(unsigned dstLclNum, GenTree* src)
     return store;
 }
 
-GenTreeCall* Compiler::gtNewIndCallNode(GenTree* addr, var_types type, const DebugInfo& di)
+GenTreeCall* Compiler::gtNewIndCallNode(GenTree*             addr,
+                                        var_types            type,
+                                        CORINFO_CLASS_HANDLE retClsHandle,
+                                        const DebugInfo&     di)
 {
-    return gtNewCallNode(CT_INDIRECT, (CORINFO_METHOD_HANDLE)addr, type, di);
+    return gtNewCallNode(CT_INDIRECT, (CORINFO_METHOD_HANDLE)addr, type, retClsHandle, di);
 }
 
 GenTreeCall* Compiler::gtNewCallNode(gtCallTypes           callType,
                                      CORINFO_METHOD_HANDLE callHnd,
                                      var_types             type,
+                                     CORINFO_CLASS_HANDLE  retClsHandle,
                                      const DebugInfo&      di)
 {
     GenTreeCall* node = new (this, GT_CALL) GenTreeCall(genActualType(type));
@@ -7326,7 +7330,7 @@ GenTreeCall* Compiler::gtNewCallNode(gtCallTypes           callType,
     node->gtCallMethHnd = callHnd;
     INDEBUG(node->callSig = nullptr;)
     node->tailCallInfo    = nullptr;
-    node->gtRetClsHnd     = nullptr;
+    node->gtRetClsHnd     = varTypeIsStruct(type) ? retClsHandle : NO_CLASS_HANDLE;
     node->gtControlExpr   = nullptr;
     node->gtCallMoreFlags = GTF_CALL_M_EMPTY;
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1578,7 +1578,7 @@ GenTree* Compiler::impFixupCallStructReturn(GenTreeCall* call)
     }
 
 #if FEATURE_MULTIREG_RET
-    call->InitializeStructReturnType(this, retClsHnd, call->GetUnmanagedCallConv());
+    call->InitializeStructReturnType(this, call->gtRetClsHnd, call->GetUnmanagedCallConv());
     const ReturnTypeDesc* retTypeDesc = call->GetReturnTypeDesc();
     const unsigned        retRegCount = retTypeDesc->GetReturnRegCount();
 #else  // !FEATURE_MULTIREG_RET
@@ -1631,7 +1631,7 @@ GenTree* Compiler::impFixupCallStructReturn(GenTreeCall* call)
         // No need to assign a multi-reg struct to a local var if:
         //  - It is a tail call or
         //  - The call is marked for in-lining later
-        return impAssignMultiRegTypeToVar(call, retClsHnd DEBUGARG(call->GetUnmanagedCallConv()));
+        return impAssignMultiRegTypeToVar(call, call->gtRetClsHnd DEBUGARG(call->GetUnmanagedCallConv()));
     }
     return call;
 #endif // FEATURE_MULTIREG_RET

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7092,7 +7092,8 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
                                                       CORINFO_METHOD_HANDLE callTargetStubHnd,
                                                       CORINFO_METHOD_HANDLE dispatcherHnd)
 {
-    GenTreeCall* callDispatcherNode = gtNewCallNode(CT_USER_FUNC, dispatcherHnd, TYP_VOID, fgMorphStmt->GetDebugInfo());
+    GenTreeCall* callDispatcherNode =
+        gtNewCallNode(CT_USER_FUNC, dispatcherHnd, TYP_VOID, NO_CLASS_HANDLE, fgMorphStmt->GetDebugInfo());
     // The dispatcher has signature
     // void DispatchTailCalls(void* callersRetAddrSlot, void* callTarget, ref byte retValue)
 

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -150,7 +150,7 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
     BlockRange().Remove(treeFirstNode, tree);
 
     // Create the call node
-    GenTreeCall* call = comp->gtNewCallNode(CT_USER_FUNC, callHnd, tree->gtType);
+    GenTreeCall* call = comp->gtNewCallNode(CT_USER_FUNC, callHnd, tree->gtType, NO_CLASS_HANDLE);
 
     if (arg2 != nullptr)
     {


### PR DESCRIPTION
For method GDV we need to check that a GDV candidate is a reasonable guess to avoid the JIT blowing up while trying to inline the candidate. This was missing a check for the return type.

Noticed this while trying to reproduce #77141.

Also refactor `impImportCall` a bit to make this work. The GDV determination happens before we have saved the return type class handle into the `GenTreeCall` instance. To resolve this unify
the cases where we need to use the call site's signature over the method def's signature, and then ensure `GenTreeCall` instances always have valid class handles.