### PR TITLE
[HTTP/3] Improved Alt-Svc upgrade test to ignore an externally caused error

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -795,6 +795,11 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal(HttpStatusCode.OK, responseA.StatusCode);
                     Assert.NotEqual(3, responseA.Version.Major);
                 }
+                catch (TimeoutException ex)
+                {
+                    _output.WriteLine($"Unable to establish non-H/3 connection to {uri}: {ex}");
+                    return;
+                }
                 catch (HttpRequestException ex) when
                     (ex.InnerException is SocketException se &&
                     (se.SocketErrorCode == SocketError.NetworkUnreachable || se.SocketErrorCode == SocketError.HostUnreachable || se.SocketErrorCode == SocketError.ConnectionRefused))


### PR DESCRIPTION
Test made more reliable by eating `TimeoutException` as well.
Fixes #80125