### PR TITLE
cleaning unused method in logging source generator Parser

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -671,21 +671,6 @@ namespace Microsoft.Extensions.Logging.Generators
                 return findIndex == -1 ? endIndex : findIndex;
             }
 
-            private string GetStringExpression(SemanticModel sm, SyntaxNode expr)
-            {
-                Optional<object?> optional = sm.GetConstantValue(expr, _cancellationToken);
-                if (optional.HasValue)
-                {
-                    object o = optional.Value;
-                    if (o != null)
-                    {
-                        return o.ToString();
-                    }
-                }
-
-                return string.Empty;
-            }
-
             private static object GetItem(TypedConstant arg) => arg.Kind == TypedConstantKind.Array ? arg.Values : arg.Value;
         }
 


### PR DESCRIPTION
Removing an unused method that was introduced in #52018 for Logging Source Generator Parser, but not used since then.