### PR TITLE
[wasm] WBT: Update expected blazor tfm to net8.0 to match the latest sdk

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -84,7 +84,7 @@ public class BuildPublishTests : BuildTestBase
     [Theory]
     [InlineData("Debug")]
     [InlineData("Release")]
-    public void WithDllImportInMainAssembly(string config)
+    public async Task WithDllImportInMainAssembly(string config)
     {
         // Based on https://github.com/dotnet/runtime/issues/59255
         string id = $"blz_dllimp_{config}";
@@ -124,12 +124,12 @@ public class BuildPublishTests : BuildTestBase
         BlazorPublish(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
         CheckNativeFileLinked(forPublish: true);
 
-        // [ActiveIssue("https://github.com/dotnet/runtime/issues/79514")]
-        //await BlazorRun(config, async (page) => {
-            //await page.Locator("text=\"cpp_add\"").ClickAsync();
-            //var txt = await page.Locator("p[role='test']").InnerHTMLAsync();
-            //Assert.Equal("Output: 22", txt);
-        //});
+        await BlazorRun(config, async (page) =>
+        {
+            await page.Locator("text=\"cpp_add\"").ClickAsync();
+            var txt = await page.Locator("p[role='test']").InnerHTMLAsync();
+            Assert.Equal("Output: 22", txt);
+        });
 
         void CheckNativeFileLinked(bool forPublish)
         {

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
@@ -30,7 +30,9 @@ public class MiscTests : BuildTestBase
                                     ? ("<EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>" +
                                         "<EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>")
                                     : string.Empty;
-        AddItemsPropertiesToProject(projectFile, extraProperties: nativeRelink ? string.Empty : "<RunAOTCompilation>true</RunAOTCompilation>");
+        if (!nativeRelink)
+            extraProperties += "<RunAOTCompilation>true</RunAOTCompilation>";
+        AddItemsPropertiesToProject(projectFile, extraProperties: extraProperties);
 
         // build with -p:DeployOnBuild=true, and that will trigger a publish
         (CommandResult res, _) = BuildInternal(id, config, publish: false, setWasmDevel: false, "-p:DeployOnBuild=true");

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
@@ -26,6 +26,10 @@ public class MiscTests : BuildTestBase
     {
         string id = $"blz_deploy_on_build_{config}_{nativeRelink}_{Path.GetRandomFileName()}";
         string projectFile = CreateProjectWithNativeReference(id);
+        string extraProperties = config == "Debug"
+                                    ? ("<EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>" +
+                                        "<EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>")
+                                    : string.Empty;
         AddItemsPropertiesToProject(projectFile, extraProperties: nativeRelink ? string.Empty : "<RunAOTCompilation>true</RunAOTCompilation>");
 
         // build with -p:DeployOnBuild=true, and that will trigger a publish

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/MiscTests.cs
@@ -22,7 +22,6 @@ public class MiscTests : BuildTestBase
     [InlineData("Debug", false)]
     [InlineData("Release", true)]
     [InlineData("Release", false)]
-    //[ActiveIssue("https://github.com/dotnet/runtime/issues/70985", TestPlatforms.Linux)]
     public void NativeBuild_WithDeployOnBuild_UsedByVS(string config, bool nativeRelink)
     {
         string id = $"blz_deploy_on_build_{config}_{nativeRelink}_{Path.GetRandomFileName()}";
@@ -67,7 +66,12 @@ public class MiscTests : BuildTestBase
     {
         string id = $"blz_aot_prj_file_{config}_{Path.GetRandomFileName()}";
         string projectFile = CreateBlazorWasmTemplateProject(id);
-        AddItemsPropertiesToProject(projectFile, extraProperties: "<RunAOTCompilation>true</RunAOTCompilation>");
+
+        string extraProperties = config == "Debug"
+                                    ? ("<EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>" +
+                                        "<EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>")
+                                    : string.Empty;
+        AddItemsPropertiesToProject(projectFile, extraProperties: "<RunAOTCompilation>true</RunAOTCompilation>" + extraProperties);
 
         // No relinking, no AOT
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.FromRuntimePack));

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/NativeRefTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/NativeRefTests.cs
@@ -20,12 +20,15 @@ public class NativeRefTests : BuildTestBase
     [Theory]
     [InlineData("Debug")]
     [InlineData("Release")]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/70985", TestPlatforms.Linux)]
     public void WithNativeReference_AOTInProjectFile(string config)
     {
         string id = $"blz_nativeref_aot_{config}_{Path.GetRandomFileName()}";
         string projectFile = CreateProjectWithNativeReference(id);
-        AddItemsPropertiesToProject(projectFile, extraProperties: "<RunAOTCompilation>true</RunAOTCompilation>");
+        string extraProperties = config == "Debug"
+                                    ? ("<EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>" +
+                                        "<EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>")
+                                    : string.Empty;
+        AddItemsPropertiesToProject(projectFile, extraProperties: "<RunAOTCompilation>true</RunAOTCompilation>" + extraProperties);
 
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
 
@@ -38,11 +41,15 @@ public class NativeRefTests : BuildTestBase
     [Theory]
     [InlineData("Debug")]
     [InlineData("Release")]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/70985", TestPlatforms.Linux)]
     public void WithNativeReference_AOTOnCommandLine(string config)
     {
         string id = $"blz_nativeref_aot_{config}_{Path.GetRandomFileName()}";
-        CreateProjectWithNativeReference(id);
+        string projectFile = CreateProjectWithNativeReference(id);
+        string extraProperties = config == "Debug"
+                                    ? ("<EmccLinkOptimizationFlag>-O1</EmccLinkOptimizationFlag>" +
+                                        "<EmccCompileOptimizationFlag>-O1</EmccCompileOptimizationFlag>")
+                                    : string.Empty;
+        AddItemsPropertiesToProject(projectFile, extraProperties: extraProperties);
 
         BlazorBuild(new BlazorBuildOptions(id, config, NativeFilesType.Relinked));
 

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -29,7 +29,7 @@ namespace Wasm.Build.Tests
     public abstract class BuildTestBase : IClassFixture<SharedBuildPerTestClassFixture>, IDisposable
     {
         public const string DefaultTargetFramework = "net8.0";
-        public const string DefaultTargetFrameworkForBlazor = "net7.0";
+        public const string DefaultTargetFrameworkForBlazor = "net8.0";
         protected static readonly bool s_skipProjectCleanup;
         protected static readonly string s_xharnessRunnerCommand;
         protected string? _projectDir;

--- a/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmTemplateTests.cs
@@ -416,7 +416,6 @@ namespace Wasm.Build.Tests
         }
 
         [ConditionalFact(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/79514")]
         public async Task BlazorRunTest()
         {
             string config = "Debug";


### PR DESCRIPTION
Also, fixes #79514 

- And use `-O1` for some blazor tests when building for `Debug` config.
Fixes #70985 .