### PR TITLE
Remove incorrect assert from UnixEvent::Wait

### DIFF
--- a/src/coreclr/gc/unix/events.cpp
+++ b/src/coreclr/gc/unix/events.cpp
@@ -174,8 +174,6 @@ public:
 #else // HAVE_CLOCK_GETTIME_NSEC_NP
                 st = pthread_cond_timedwait(&m_condition, &m_mutex, &endTime);
 #endif // HAVE_CLOCK_GETTIME_NSEC_NP
-                // Verify that if the wait timed out, the event was not set
-                assert((st != ETIMEDOUT) || !m_state);
             }
 
             if (st != 0)

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -256,8 +256,6 @@ public:
 #else // HAVE_CLOCK_GETTIME_NSEC_NP
                 st = pthread_cond_timedwait(&m_condition, &m_mutex, &endTime);
 #endif // HAVE_CLOCK_GETTIME_NSEC_NP
-                // Verify that if the wait timed out, the event was not set
-                ASSERT((st != ETIMEDOUT) || !m_state);
             }
 
             if (st != 0)


### PR DESCRIPTION
There is an incorrect assert checking that when `pthread_cond_timedwait` timeouts, the event is not set. That assumption is incorrect, according to the `pthread_cond_timedwait` documentation.

It fired in one of the CI runs recently.

Close #80166