### PR TITLE
Restore Advance when reading float/double with XmlBufferReader.

### DIFF
--- a/src/libraries/Common/tests/System/Runtime/Serialization/DataContractSerializerHelper.cs
+++ b/src/libraries/Common/tests/System/Runtime/Serialization/DataContractSerializerHelper.cs
@@ -3,10 +3,8 @@
 
 using System.IO;
 using System.Reflection;
-using System.Reflection.PortableExecutable;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Xml;
-using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 using Xunit;
 
 namespace System.Runtime.Serialization.Tests

--- a/src/libraries/Common/tests/System/Runtime/Serialization/DataContractSerializerHelper.cs
+++ b/src/libraries/Common/tests/System/Runtime/Serialization/DataContractSerializerHelper.cs
@@ -3,15 +3,17 @@
 
 using System.IO;
 using System.Reflection;
+using System.Reflection.PortableExecutable;
 using System.Runtime.Serialization.Formatters.Binary;
-
+using System.Xml;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 using Xunit;
 
 namespace System.Runtime.Serialization.Tests
 {
     public static class DataContractSerializerHelper
     {
-        internal static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
+        internal static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false, bool verifyBinaryRoundTrip = true)
         {
             DataContractSerializer dcs;
             if (serializerFactory != null)
@@ -23,6 +25,7 @@ namespace System.Runtime.Serialization.Tests
                 dcs = (settings != null) ? new DataContractSerializer(typeof(T), settings) : new DataContractSerializer(typeof(T));
             }
 
+            T deserialized;
             using (MemoryStream ms = new MemoryStream())
             {
                 dcs.WriteObject(ms, value);
@@ -38,9 +41,37 @@ namespace System.Runtime.Serialization.Tests
                 }
 
                 ms.Position = 0;
-                T deserialized = (T)dcs.ReadObject(ms);
+                deserialized = (T)dcs.ReadObject(ms);
+            }
 
-                return deserialized;
+            if (verifyBinaryRoundTrip)
+            {
+                RoundTripBinarySerialization<T>(value, settings, serializerFactory);
+            }
+
+            return deserialized;
+        }
+
+        internal static T RoundTripBinarySerialization<T>(T value, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null)
+        {
+            DataContractSerializer dcs;
+            if (serializerFactory != null)
+            {
+                dcs = serializerFactory();
+            }
+            else
+            {
+                dcs = (settings != null) ? new DataContractSerializer(typeof(T), settings) : new DataContractSerializer(typeof(T));
+            }
+
+            using (MemoryStream ms = new MemoryStream())
+            using (XmlDictionaryWriter binWriter = XmlDictionaryWriter.CreateBinaryWriter(ms))
+            {
+                dcs.WriteObject(binWriter, value);
+                binWriter.Flush();
+                ms.Position = 0;
+                XmlDictionaryReader binReader = XmlDictionaryReader.CreateBinaryReader(ms, XmlDictionaryReaderQuotas.Max);
+                return (T)dcs.ReadObject(binReader);
             }
         }
     }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -373,10 +373,18 @@ namespace System.Xml
             => BitConverter.IsLittleEndian ? ReadRawBytes<long>() : BinaryPrimitives.ReverseEndianness(ReadRawBytes<long>());
 
         public float ReadSingle()
-            => BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(sizeof(float), out int offset).AsSpan(offset, sizeof(float)));
+        {
+            float f = BinaryPrimitives.ReadSingleLittleEndian(GetBuffer(sizeof(float), out int offset).AsSpan(offset, sizeof(float)));
+            Advance(sizeof(float));
+            return f;
+        }
 
         public double ReadDouble()
-            => BinaryPrimitives.ReadDoubleLittleEndian(GetBuffer(sizeof(double), out int offset).AsSpan(offset, sizeof(double)));
+        {
+            double d = BinaryPrimitives.ReadDoubleLittleEndian(GetBuffer(sizeof(double), out int offset).AsSpan(offset, sizeof(double)));
+            Advance(sizeof(double));
+            return d;
+        }
 
         public decimal ReadDecimal()
         {


### PR DESCRIPTION
Bring back buffer advance when reading float/double in XmlBufferReader.

Towards the end of 7.0, we took a change (#73332) to improve the performance of XmlDictionaryReader. This change both brought to light some Big-Endian issues in DCS, as well as obscured the fact that some methods for reading double/single with XmlBufferReader required intentional advancing of the buffer after reading. A later change to fix the Big-Endian-ness (#74599) missed those advances.

(#74599 was recently manually backported to 6.0 as well, but as 6.0 did not have the perf change that obscured the calls to Advance, they were not lost in that backport.)

- [ ] Backport to 7.0

Fix #78913
