### PR TITLE
Improve jiterpreter heuristic branch handling

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -687,14 +687,14 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 
 		case MINT_BR:
 		case MINT_BR_S:
-			if (*inside_branch_block)
-				return TRACE_CONTINUE;
-
-			return TRACE_ABORT;
-
-		case MINT_THROW:
 		case MINT_LEAVE:
 		case MINT_LEAVE_S:
+			// FIXME: Check for negative displacement
+			*inside_branch_block = TRUE;
+			return TRACE_CONTINUE;
+
+		case MINT_MONO_RETHROW:
+		case MINT_THROW:
 			if (*inside_branch_block)
 				return TRACE_CONTINUE;
 
@@ -708,7 +708,6 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_CALL_HANDLER_S:
 		case MINT_ENDFINALLY:
 		case MINT_RETHROW:
-		case MINT_MONO_RETHROW:
 		case MINT_PROF_EXIT:
 		case MINT_PROF_EXIT_VOID:
 		case MINT_SAFEPOINT:

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -689,7 +689,14 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_BR_S:
 		case MINT_LEAVE:
 		case MINT_LEAVE_S:
-			// FIXME: Check for negative displacement
+			// Detect backwards branches
+			if (ins->info.target_bb->il_offset <= ins->il_offset) {
+				if (*inside_branch_block)
+					return TRACE_CONTINUE;
+				else
+					return TRACE_ABORT;
+			}
+
 			*inside_branch_block = TRUE;
 			return TRACE_CONTINUE;
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -1174,6 +1174,9 @@ function generate_wasm_body (
                 }
                 break;
 
+            // Unlike regular rethrow which will only appear in catch blocks,
+            //  MONO_RETHROW appears to show up in other places, so it's worth conditional bailout
+            case MintOpcode.MINT_MONO_RETHROW:
             case MintOpcode.MINT_THROW:
                 // As above, only abort if this throw happens unconditionally.
                 // Otherwise, it may be in a branch that is unlikely to execute


### PR DESCRIPTION
The current jiterpreter heuristic that rules out trace insertion points doesn't handle branches very accurately. This PR improves its understanding of branches a bit more, raising the number of traces successfully compiled and (in my testing) slightly improving its accuracy as well.