### PR TITLE
[NativeAOT] Do not run managed pre-mortem callbacks for GC threads.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -1125,6 +1125,10 @@ FORCEINLINE bool Thread::InlineTryFastReversePInvoke(ReversePInvokeFrame * pFram
         return false; // bad transition
     }
 
+    // this is an ordinary transition to managed code
+    // GC threads should not do that
+    ASSERT(!IsGCSpecial());
+
     // save the previous transition frame
     pFrame->m_savedPInvokeTransitionFrame = m_pTransitionFrame;
 

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -168,7 +168,9 @@ void ThreadStore::DetachCurrentThread()
     }
 
     // Run pre-mortem callbacks while we still can run managed code and not holding locks.
-    if (g_threadExitCallback != NULL)
+    // NOTE: background GC threads are attached/suspendable threads, but should not run ordinary
+    // managed code. Make sure that does not happen here.
+    if (g_threadExitCallback != NULL && !pDetachingThread->IsGCSpecial())
     {
         g_threadExitCallback();
     }


### PR DESCRIPTION
Fixes: #80262

GC threads should not be running managed code. They are too special. Most of the runtime expects that they do not ever run ordinary managed code. For example - even though we can suspend GC threads, we will not scan them for GC roots as a matter of optimization. Managed frames will result in GC holes and all kind of problems.