### PR TITLE
[mono][aot] Disable dedup for wrapper with a return type which has a …

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -4453,6 +4453,11 @@ mono_aot_can_dedup (MonoMethod *method)
 			/* Handled using linkonce */
 			return FALSE;
 #endif
+		MonoMethodSignature *sig = mono_method_signature_internal (method);
+		if (sig->ret->has_cmods) {
+			// FIXME:
+			return FALSE;
+		}
 		return TRUE;
 	}
 	default:


### PR DESCRIPTION
…cmod.

The wrappers are not found at runtime in some cases.

Re: https://github.com/dotnet/runtime/issues/79152.