### PR TITLE
Fix a build error around the ConstantExpected analyzer

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -1778,7 +1778,7 @@ namespace System.Numerics
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Vector128<float> Permute(Vector128<float> value, byte control)
+        private static Vector128<float> Permute(Vector128<float> value, [ConstantExpected] byte control)
         {
             if (Avx.IsSupported)
             {


### PR DESCRIPTION
This should resolve the error that was cropping up due to https://github.com/dotnet/runtime/pull/80192

Fixes https://github.com/dotnet/runtime/issues/80281 .