### PR TITLE
disable SendFileGetsCanceledByDispose on MacOS

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -239,6 +239,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73536", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/80169", TestPlatforms.OSX)]
         public async Task SendFileGetsCanceledByDispose(bool owning)
         {
             // Aborting sync operations for non-owning handles is not supported on Unix.


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/80169.
I have local repro but fix seems more complicated and I don't want failing CI. 

BTW the test is disabled on iOS by  #73374. That is strange as the PR talks about Unix DomainSockets but this is normal TCP. Any thoughts @simonrozsival ? If there is no native `sendfile` we should be able to mimic it in managed code (and track as separate issue)  