### PR TITLE
Fix embedded coreclr detection in corhost.cpp

### DIFF
--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -14,6 +14,7 @@
 #include <utilcode.h>
 #include <corhost.h>
 #include <configuration.h>
+#include "../../vm/ceemain.h"
 #ifdef FEATURE_GDBJIT
 #include "../../vm/gdbjithelpers.h"
 #endif // FEATURE_GDBJIT
@@ -26,12 +27,6 @@
 
 // Holder for const wide strings
 typedef NewArrayHolder<const WCHAR> ConstWStringHolder;
-
-// Specifies whether coreclr is embedded or standalone
-extern bool g_coreclr_embedded;
-
-// Specifies whether hostpolicy is embedded in executable or standalone
-extern bool g_hostpolicy_embedded;
 
 // Holder for array of wide strings
 class ConstWStringArrayHolder : public NewArrayHolder<LPCWSTR>

--- a/src/coreclr/vm/ceemain.h
+++ b/src/coreclr/vm/ceemain.h
@@ -54,5 +54,10 @@ INT32 GetLatchedExitCode (void);
 // Stronger than IsGCHeapInitialized
 BOOL IsGarbageCollectorFullyInitialized();
 
+// Specifies whether coreclr is embedded or standalone
+extern bool g_coreclr_embedded;
+
+// Specifies whether hostpolicy is embedded in executable or standalone
+extern bool g_hostpolicy_embedded;
 
 #endif

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -630,23 +630,26 @@ HRESULT CorHost2::CreateAppDomainWithManager(
             sAppPaths));
     }
 
-#if defined(TARGET_UNIX) && !defined(CORECLR_EMBEDDED)
-    // Check if the current code is executing in the single file host or in libcoreclr.so. The libSystem.Native is linked
-    // into the single file host, so we need to check only when this code is in libcoreclr.so.
-    // Preload the libSystem.Native.so/dylib to detect possible problems with loading it early
-    EX_TRY
+#if defined(TARGET_UNIX)
+    if (!g_coreclr_embedded)
     {
-        NativeLibrary::LoadLibraryByName(W("libSystem.Native"), SystemDomain::SystemAssembly(), FALSE, 0, TRUE);
+        // Check if the current code is executing in the single file host or in libcoreclr.so. The libSystem.Native is linked
+        // into the single file host, so we need to check only when this code is in libcoreclr.so.
+        // Preload the libSystem.Native.so/dylib to detect possible problems with loading it early
+        EX_TRY
+        {
+            NativeLibrary::LoadLibraryByName(W("libSystem.Native"), SystemDomain::SystemAssembly(), FALSE, 0, TRUE);
+        }
+        EX_HOOK
+        {
+            Exception *ex = GET_EXCEPTION();
+            SString err;
+            ex->GetMessage(err);
+            LogErrorToHost("Error message: %s", err.GetUTF8());
+        }
+        EX_END_HOOK;
     }
-    EX_HOOK
-    {
-        Exception *ex = GET_EXCEPTION();
-        SString err;
-        ex->GetMessage(err);
-        LogErrorToHost("Error message: %s", err.GetUTF8());
-    }
-    EX_END_HOOK;
-#endif // TARGET_UNIX && !CORECLR_EMBEDDED
+#endif // TARGET_UNIX
 
     *pAppDomainID=DefaultADID;
 


### PR DESCRIPTION
The `CORECLR_EMBEDDED` define that is used in corhost.cpp to detect whether the current host has coreclr and some other native libraries embedded or not doesn't work. The reason is that corhost.cpp is not compiled separately for the cases of embedded and non-embedded coreclr.

The proper way is to check the `g_coreclr_embedded` global variable that is defined in the ceemain.cpp, which is compiled separately for those two cases.

While we could also make the corhost.cpp build twice, it would be a waste of time.