### PR TITLE
[release/7.0] [browser] make dynamic import cancelable

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportExportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportExportTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Threading;
 using Xunit;
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
 
@@ -16,6 +17,19 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public unsafe void StructSize()
         {
             Assert.Equal(16, sizeof(JSMarshalerArgument));
+        }
+
+        [Fact]
+        public async Task CancelableImportAsync()
+        {
+            var cts = new CancellationTokenSource();
+            var exTask = Assert.ThrowsAsync<JSException>(async () => await JSHost.ImportAsync("JavaScriptTestHelper", "./JavaScriptTestHelper.mjs", cts.Token));
+            cts.Cancel();
+            var actualEx2 = await exTask;
+            Assert.Equal("OperationCanceledException", actualEx2.Message);
+
+            var actualEx = await Assert.ThrowsAsync<JSException>(async () => await JSHost.ImportAsync("JavaScriptTestHelper", "./JavaScriptTestHelper.mjs", new CancellationToken(true)));
+            Assert.Equal("OperationCanceledException", actualEx.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Backport of #80257 to release/7.0

The underlying dynamic `import()` API of the browser is not cancelable. 

During design of the C# API we added the cancelation token  because we do that on all async methods. 
We also added the C# code which would cancel/abandon the JS promise.
But we forgot to make the JS promise ready for that.
This PR fixes the omission.

It doesn't really cancel the JS download, nor execution of the module as that's not possible. 
But it at least would stop blocking the caller.

## Customer Impact
Fixes customer reported issue https://github.com/dotnet/runtime/issues/80028

## Testing
Unit test

## Risk
Low, new API in Net7
