### PR TITLE
remove draft UUID section superseded by RFC 4122

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -405,25 +405,6 @@ BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
 HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
 
-License notice for Algorithm from Internet Draft document "UUIDs and GUIDs"
----------------------------------------------------------------------------
-
-Copyright (c) 1990- 1993, 1996 Open Software Foundation, Inc.
-Copyright (c) 1989 by Hewlett-Packard Company, Palo Alto, Ca. &
-Digital Equipment Corporation, Maynard, Mass.
-To anyone who acknowledges that this file is provided "AS IS"
-without any express or implied warranty: permission to use, copy,
-modify, and distribute this file for any purpose is hereby
-granted without fee, provided that the above copyright notices and
-this notice appears in all source code copies, and that none of
-the names of Open Software Foundation, Inc., Hewlett-Packard
-Company, or Digital Equipment Corporation be used in advertising
-or publicity pertaining to distribution of the software without
-specific, written prior permission.  Neither Open Software
-Foundation, Inc., Hewlett-Packard Company, Microsoft, nor Digital Equipment
-Corporation makes any representations about the suitability of
-this software for any purpose.
-
 Copyright(C) The Internet Society 1997. All Rights Reserved.
 
 This document and translations of it may be copied and furnished to others,


### PR DESCRIPTION
TPN contains a reference to an IETF draft as well as the final RFC. This needs to be clarified for downstream FOSS licensing scans by removing the draft reference. 