### PR TITLE
Remove System.Security.Permissions from S.C.CM.

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
@@ -1383,9 +1383,6 @@ namespace System.Configuration.Internal
         public virtual string GetConfigPathFromLocationSubPath(string configPath, string locationSubPath) { throw null; }
         public virtual System.Type GetConfigType(string typeName, bool throwOnError) { throw null; }
         public virtual string GetConfigTypeName(System.Type t) { throw null; }
-#pragma warning disable SYSLIB0003
-        public virtual void GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord configRecord, out System.Security.PermissionSet permissionSet, out bool isHostReady) { throw null; }
-#pragma warning restore SYSLIB0003
         public virtual string GetStreamName(string configPath) { throw null; }
         public virtual string GetStreamNameForConfigSource(string streamName, string configSource) { throw null; }
         public virtual object GetStreamVersion(string streamName) { throw null; }
@@ -1473,9 +1470,6 @@ namespace System.Configuration.Internal
         string GetConfigPathFromLocationSubPath(string configPath, string locationSubPath);
         System.Type GetConfigType(string typeName, bool throwOnError);
         string GetConfigTypeName(System.Type t);
-#pragma warning disable SYSLIB0003
-        void GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord configRecord, out System.Security.PermissionSet permissionSet, out bool isHostReady);
-#pragma warning restore SYSLIB0003
         string GetStreamName(string configPath);
         string GetStreamNameForConfigSource(string streamName, string configSource);
         object GetStreamVersion(string streamName);

--- a/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj
@@ -12,11 +12,8 @@
     <Compile Include="System.Configuration.ConfigurationManager.netframework.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Permissions\ref\System.Security.Permissions.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Permissions\ref\System.Security.Permissions.csproj" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/CompatibilitySuppressions.xml
@@ -2,6 +2,30 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/net462/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/net6.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/net6.0/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/net7.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/net7.0/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.Configuration.Internal.DelegatingConfigHost.get_HasLocalConfig</Target>
     <Left>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Left>
     <Right>lib/net462/System.Configuration.ConfigurationManager.dll</Right>
@@ -23,6 +47,30 @@
     <Target>M:System.Configuration.Internal.DelegatingConfigHost.RefreshConfigPaths</Target>
     <Left>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Left>
     <Right>lib/net462/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Configuration.Internal.DelegatingConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/net462/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Configuration.Internal.DelegatingConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Configuration.Internal.DelegatingConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/net6.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/net6.0/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Configuration.Internal.DelegatingConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/net7.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/net7.0/System.Configuration.ConfigurationManager.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/CompatibilitySuppressions.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
+    <Left>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Left>
+    <Right>lib/net462/System.Configuration.ConfigurationManager.dll</Right>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.Configuration.Internal.IInternalConfigHost.GetRestrictedPermissions(System.Configuration.Internal.IInternalConfigRecord, out System.Security.PermissionSet, out bool)</Target>
     <Left>lib/netstandard2.0/System.Configuration.ConfigurationManager.dll</Left>

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System.Configuration.ConfigurationManager.csproj
@@ -273,7 +273,7 @@
   </ItemGroup>
 
   <!-- Since this package is compatible with .NETStandard, it must also ensure its .NETFramework and .NETCoreApp behavior is compatible with its .NETStandard behavior.-->
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Permissions\src\System.Security.Permissions.csproj" />
   </ItemGroup>
 

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/DelegatingConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/DelegatingConfigHost.cs
@@ -231,12 +231,5 @@ namespace System.Configuration.Internal
 
         public virtual IDisposable Impersonate() => new DummyDisposable();
 
-#if NETFRAMEWORK // Obsolete: CAS (.NET Framework only)
-        public virtual void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady)
-        {
-            permissionSet = new PermissionSet(null);
-            isHostReady = true;
-        }
-#endif
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/DelegatingConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/DelegatingConfigHost.cs
@@ -231,12 +231,12 @@ namespace System.Configuration.Internal
 
         public virtual IDisposable Impersonate() => new DummyDisposable();
 
-#pragma warning disable SYSLIB0003 // Obsolete: CAS
+#if NETFRAMEWORK // Obsolete: CAS (.NET Framework only)
         public virtual void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady)
         {
             permissionSet = new PermissionSet(null);
             isHostReady = true;
         }
-#pragma warning restore SYSLIB0003 // Obsolete: CAS
+#endif
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/IInternalConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/IInternalConfigHost.cs
@@ -103,8 +103,5 @@ namespace System.Configuration.Internal
 
         IDisposable Impersonate();
 
-#if NETFRAMEWORK // Obsolete: CAS (.NET Framework only)
-        void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady);
-#endif
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/IInternalConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/IInternalConfigHost.cs
@@ -103,8 +103,8 @@ namespace System.Configuration.Internal
 
         IDisposable Impersonate();
 
-#pragma warning disable SYSLIB0003 // Obsolete: CAS
+#if NETFRAMEWORK // Obsolete: CAS (.NET Framework only)
         void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady);
-#pragma warning restore SYSLIB0003 // Obsolete: CAS
+#endif
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/InternalConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/InternalConfigHost.cs
@@ -304,12 +304,5 @@ namespace System.Configuration.Internal
 
         public IDisposable Impersonate() => new DummyDisposable();
 
-#if NETFRAMEWORK
-        public void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady)
-        {
-            permissionSet = new PermissionSet(null);
-            isHostReady = true;
-        }
-#endif
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/InternalConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/Internal/InternalConfigHost.cs
@@ -304,12 +304,12 @@ namespace System.Configuration.Internal
 
         public IDisposable Impersonate() => new DummyDisposable();
 
-#pragma warning disable SYSLIB0003
+#if NETFRAMEWORK
         public void GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady)
         {
             permissionSet = new PermissionSet(null);
             isHostReady = true;
         }
-#pragma warning restore SYSLIB0003
+#endif
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/TypeUtilTests.cs
@@ -314,12 +314,12 @@ namespace System.ConfigurationTests
                 throw new NotImplementedException();
             }
 
-#pragma warning disable SYSLIB0003 // Obsolete: CAS
+#if NETFRAMEWORK // Obsolete: CAS (.NET Framework only)
             void IInternalConfigHost.GetRestrictedPermissions(IInternalConfigRecord configRecord, out PermissionSet permissionSet, out bool isHostReady)
             {
                 throw new NotImplementedException();
             }
-#pragma warning restore SYSLIB0003 // Obsolete: CAS
+#endif
         }
     }
 }


### PR DESCRIPTION
This removes System.Security.Permissions from S.C.CM for non-.NET Framework targets. For .NET Framework targets nothing changes. This is because CAS is only implemented in .NET Framework and as such should only be used in .NET Framework to remove the chance that in .NET Core/5+ and .NET Standard that System.Drawing.Common is loaded outside of a windows environment which since .NET 6 is made to throw PNSE everywhere which is not desired for people using cross platform dependencies that just so happens to depend on S.C.CM.

Contributes to #64592

Note: I consider changes in the internal namespace to be an implementation detail and any possibly breaking change being an acceptable change as it is marked ``internal`` in the name meaning that users outside of this repository should not be using it and if they are the namespace should imply that it can have breaking changes at any time. With that excluded in my mind from public ABI, I have determined this change (part of #64592) is trivial. For S.DS the change to remove S.S.P is non-trivial as it breaks public ABI and so needs to go through api-review (and approval) for that breaking change to land in .NET 8.

After that, I do not see much of any codebases in dotnet/runtime using S.S.P anymore (outside of the .NET Framework targets for them).