### PR TITLE
Rename `SafeSecKeyRefHandle`

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ecc.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ecc.cs
@@ -14,20 +14,20 @@ internal static partial class Interop
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_EccGenerateKey(
             int keySizeInBits,
-            out SafeSecKeyRefHandle pPublicKey,
-            out SafeSecKeyRefHandle pPrivateKey,
+            out SafeSecKeyHandle pPublicKey,
+            out SafeSecKeyHandle pPrivateKey,
             out SafeCFErrorHandle pErrorOut);
 
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_EccGetKeySizeInBits")]
-        internal static partial int EccGetKeySizeInBits(SafeSecKeyRefHandle publicKey);
+        internal static partial int EccGetKeySizeInBits(SafeSecKeyHandle publicKey);
 
         internal static void EccGenerateKey(
             int keySizeInBits,
-            out SafeSecKeyRefHandle pPublicKey,
-            out SafeSecKeyRefHandle pPrivateKey)
+            out SafeSecKeyHandle pPublicKey,
+            out SafeSecKeyHandle pPrivateKey)
         {
-            SafeSecKeyRefHandle publicKey;
-            SafeSecKeyRefHandle privateKey;
+            SafeSecKeyHandle publicKey;
+            SafeSecKeyHandle privateKey;
             SafeCFErrorHandle error;
 
             int result = AppleCryptoNative_EccGenerateKey(

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.KeyAgree.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.KeyAgree.cs
@@ -14,14 +14,14 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_EcdhKeyAgree(
-            SafeSecKeyRefHandle privateKey,
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle privateKey,
+            SafeSecKeyHandle publicKey,
             out SafeCFDataHandle cfDataOut,
             out SafeCFErrorHandle cfErrorOut);
 
         internal static byte[]? EcdhKeyAgree(
-            SafeSecKeyRefHandle privateKey,
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle privateKey,
+            SafeSecKeyHandle publicKey,
             Span<byte> opportunisticDestination,
             out int bytesWritten)
         {

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.macOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.macOS.cs
@@ -101,7 +101,7 @@ internal static partial class Interop
         internal static SafeKeychainHandle SecKeychainItemCopyKeychain(SafeKeychainItemHandle item)
             => SecKeychainItemCopyKeychain((SafeHandle)item);
 
-        internal static SafeKeychainHandle SecKeychainItemCopyKeychain(SafeSecKeyRefHandle item)
+        internal static SafeKeychainHandle SecKeychainItemCopyKeychain(SafeSecKeyHandle item)
             => SecKeychainItemCopyKeychain((SafeHandle)item);
 
         internal static SafeKeychainHandle SecKeychainItemCopyKeychain(IntPtr item)

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.RSA.cs
@@ -15,13 +15,13 @@ internal static partial class Interop
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_RsaGenerateKey(
             int keySizeInBits,
-            out SafeSecKeyRefHandle pPublicKey,
-            out SafeSecKeyRefHandle pPrivateKey,
+            out SafeSecKeyHandle pPublicKey,
+            out SafeSecKeyHandle pPrivateKey,
             out SafeCFErrorHandle pErrorOut);
 
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_RsaSignaturePrimitive(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             ref byte pbData,
             int cbData,
             out SafeCFDataHandle pDataOut,
@@ -29,7 +29,7 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_RsaVerificationPrimitive(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ref byte pbData,
             int cbData,
             out SafeCFDataHandle pDataOut,
@@ -37,7 +37,7 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_RsaEncryptionPrimitive(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ref byte pbData,
             int cbData,
             out SafeCFDataHandle pDataOut,
@@ -45,7 +45,7 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptOaep")]
         private static partial int RsaEncryptOaep(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
@@ -54,7 +54,7 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaEncryptPkcs")]
         private static partial int RsaEncryptPkcs(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
@@ -62,7 +62,7 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptOaep")]
         private static partial int RsaDecryptOaep(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> pbData,
             int cbData,
             PAL_HashAlgorithm mgfAlgorithm,
@@ -71,7 +71,7 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_RsaDecryptPkcs")]
         private static partial int RsaDecryptPkcs(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> pbData,
             int cbData,
             out SafeCFDataHandle pEncryptedOut,
@@ -79,11 +79,11 @@ internal static partial class Interop
 
         internal static void RsaGenerateKey(
             int keySizeInBits,
-            out SafeSecKeyRefHandle pPublicKey,
-            out SafeSecKeyRefHandle pPrivateKey)
+            out SafeSecKeyHandle pPublicKey,
+            out SafeSecKeyHandle pPrivateKey)
         {
-            SafeSecKeyRefHandle publicKey;
-            SafeSecKeyRefHandle privateKey;
+            SafeSecKeyHandle publicKey;
+            SafeSecKeyHandle privateKey;
             SafeCFErrorHandle error;
 
             int result = AppleCryptoNative_RsaGenerateKey(
@@ -116,7 +116,7 @@ internal static partial class Interop
         }
 
         internal static byte[] RsaEncrypt(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             byte[] data,
             RSAEncryptionPadding padding)
         {
@@ -142,7 +142,7 @@ internal static partial class Interop
         }
 
         internal static bool TryRsaEncrypt(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             RSAEncryptionPadding padding,
@@ -162,7 +162,7 @@ internal static partial class Interop
         }
 
         internal static byte[] RsaDecrypt(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             byte[] data,
             RSAEncryptionPadding padding)
         {
@@ -188,7 +188,7 @@ internal static partial class Interop
         }
 
         internal static bool TryRsaDecrypt(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             RSAEncryptionPadding padding,
@@ -229,7 +229,7 @@ internal static partial class Interop
         }
 
         internal static bool TryRsaEncryptionPrimitive(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             out int bytesWritten)
@@ -245,7 +245,7 @@ internal static partial class Interop
         }
 
         internal static bool TryRsaSignaturePrimitive(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             out int bytesWritten)
@@ -261,7 +261,7 @@ internal static partial class Interop
         }
 
         internal static bool TryRsaVerificationPrimitive(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> source,
             Span<byte> destination,
             out int bytesWritten)

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKey.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKey.cs
@@ -24,7 +24,7 @@ internal static partial class Interop
         }
 
         [LibraryImport(Libraries.AppleCryptoNative)]
-        private static partial ulong AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SafeSecKeyRefHandle publicKey);
+        private static partial ulong AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(SafeSecKeyHandle publicKey);
 
         private delegate int SecKeyTransform(ReadOnlySpan<byte> source, out SafeCFDataHandle outputHandle, out SafeCFErrorHandle errorHandle);
 
@@ -80,7 +80,7 @@ internal static partial class Interop
             }
         }
 
-        internal static int GetSimpleKeySizeInBits(SafeSecKeyRefHandle publicKey)
+        internal static int GetSimpleKeySizeInBits(SafeSecKeyHandle publicKey)
         {
             ulong keySizeInBytes = AppleCryptoNative_SecKeyGetSimpleKeySizeInBytes(publicKey);
 
@@ -90,7 +90,7 @@ internal static partial class Interop
             }
         }
 
-        internal static unsafe SafeSecKeyRefHandle CreateDataKey(
+        internal static unsafe SafeSecKeyHandle CreateDataKey(
             ReadOnlySpan<byte> keyData,
             PAL_KeyAlgorithm keyAlgorithm,
             bool isPublic)
@@ -102,7 +102,7 @@ internal static partial class Interop
                     keyData.Length,
                     keyAlgorithm,
                     isPublic ? 1 : 0,
-                    out SafeSecKeyRefHandle dataKey,
+                    out SafeSecKeyHandle dataKey,
                     out SafeCFErrorHandle errorHandle);
 
                 using (errorHandle)
@@ -122,7 +122,7 @@ internal static partial class Interop
         }
 
         internal static bool TrySecKeyCopyExternalRepresentation(
-            SafeSecKeyRefHandle key,
+            SafeSecKeyHandle key,
             out byte[] externalRepresentation)
         {
             const int errSecPassphraseRequired = -25260;
@@ -160,25 +160,25 @@ internal static partial class Interop
             int cbKey,
             PAL_KeyAlgorithm keyAlgorithm,
             int isPublic,
-            out SafeSecKeyRefHandle pDataKey,
+            out SafeSecKeyHandle pDataKey,
             out SafeCFErrorHandle pErrorOut);
 
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static unsafe partial int AppleCryptoNative_SecKeyCopyExternalRepresentation(
-            SafeSecKeyRefHandle key,
+            SafeSecKeyHandle key,
             out SafeCFDataHandle pDataOut,
             out SafeCFErrorHandle pErrorOut);
 
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_SecKeyCopyPublicKey")]
-        internal static unsafe partial SafeSecKeyRefHandle CopyPublicKey(SafeSecKeyRefHandle privateKey);
+        internal static unsafe partial SafeSecKeyHandle CopyPublicKey(SafeSecKeyHandle privateKey);
     }
 }
 
 namespace System.Security.Cryptography.Apple
 {
-    internal sealed class SafeSecKeyRefHandle : SafeHandle
+    internal sealed class SafeSecKeyHandle : SafeHandle
     {
-        public SafeSecKeyRefHandle()
+        public SafeSecKeyHandle()
             : base(IntPtr.Zero, ownsHandle: true)
         {
         }
@@ -194,7 +194,7 @@ namespace System.Security.Cryptography.Apple
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && SafeHandleCache<SafeSecKeyRefHandle>.IsCachedInvalidHandle(this))
+            if (disposing && SafeHandleCache<SafeSecKeyHandle>.IsCachedInvalidHandle(this))
             {
                 return;
             }
@@ -202,8 +202,8 @@ namespace System.Security.Cryptography.Apple
             base.Dispose(disposing);
         }
 
-        public static SafeSecKeyRefHandle InvalidHandle =>
-            SafeHandleCache<SafeSecKeyRefHandle>.GetInvalidHandle(
-                () => new SafeSecKeyRefHandle());
+        public static SafeSecKeyHandle InvalidHandle =>
+            SafeHandleCache<SafeSecKeyHandle>.GetInvalidHandle(
+                () => new SafeSecKeyHandle());
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKey.macOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SecKey.macOS.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         private static int AppleCryptoNative_SecKeyImportEphemeral(
             ReadOnlySpan<byte> pbKeyBlob,
             int isPrivateKey,
-            out SafeSecKeyRefHandle ppKeyOut,
+            out SafeSecKeyHandle ppKeyOut,
             out int pOSStatus) =>
             AppleCryptoNative_SecKeyImportEphemeral(
                 ref MemoryMarshal.GetReference(pbKeyBlob),
@@ -31,14 +31,14 @@ internal static partial class Interop
             ref byte pbKeyBlob,
             int cbKeyBlob,
             int isPrivateKey,
-            out SafeSecKeyRefHandle ppKeyOut,
+            out SafeSecKeyHandle ppKeyOut,
             out int pOSStatus);
 
-        internal static SafeSecKeyRefHandle ImportEphemeralKey(ReadOnlySpan<byte> keyBlob, bool hasPrivateKey)
+        internal static SafeSecKeyHandle ImportEphemeralKey(ReadOnlySpan<byte> keyBlob, bool hasPrivateKey)
         {
             Debug.Assert(keyBlob != null);
 
-            SafeSecKeyRefHandle keyHandle;
+            SafeSecKeyHandle keyHandle;
             int osStatus;
 
             int ret = AppleCryptoNative_SecKeyImportEphemeral(
@@ -66,14 +66,14 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_SecKeyExport(
-            SafeSecKeyRefHandle? key,
+            SafeSecKeyHandle? key,
             int exportPrivate,
             SafeCreateHandle cfExportPassphrase,
             out SafeCFDataHandle cfDataOut,
             out int pOSStatus);
 
         internal static SafeCFDataHandle SecKeyExportData(
-            SafeSecKeyRefHandle? key,
+            SafeSecKeyHandle? key,
             bool exportPrivate,
             ReadOnlySpan<char> password)
         {
@@ -119,7 +119,7 @@ internal static partial class Interop
         }
 
         internal static byte[] SecKeyExport(
-            SafeSecKeyRefHandle? key,
+            SafeSecKeyHandle? key,
             bool exportPrivate,
             string password)
         {

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SignVerify.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.SignVerify.cs
@@ -23,7 +23,7 @@ internal static partial class Interop
         }
 
         private static unsafe int AppleCryptoNative_SecKeyVerifySignature(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> dataHash,
             ReadOnlySpan<byte> signature,
             PAL_HashAlgorithm hashAlgorithm,
@@ -47,7 +47,7 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static unsafe partial int AppleCryptoNative_SecKeyVerifySignature(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             byte* pbDataHash,
             int cbDataHash,
             byte* pbSignature,
@@ -57,7 +57,7 @@ internal static partial class Interop
             out SafeCFErrorHandle pErrorOut);
 
         private static unsafe int AppleCryptoNative_SecKeyCreateSignature(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             ReadOnlySpan<byte> dataHash,
             PAL_HashAlgorithm hashAlgorithm,
             PAL_SignatureAlgorithm signatureAlgorithm,
@@ -79,7 +79,7 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static unsafe partial int AppleCryptoNative_SecKeyCreateSignature(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             byte* pbDataHash,
             int cbDataHash,
             PAL_HashAlgorithm hashAlgorithm,
@@ -88,7 +88,7 @@ internal static partial class Interop
             out SafeCFErrorHandle pErrorOut);
 
         internal static bool VerifySignature(
-            SafeSecKeyRefHandle publicKey,
+            SafeSecKeyHandle publicKey,
             ReadOnlySpan<byte> dataHash,
             ReadOnlySpan<byte> signature,
             PAL_HashAlgorithm hashAlgorithm,
@@ -125,7 +125,7 @@ internal static partial class Interop
         }
 
         private static SafeCFDataHandle NativeCreateSignature(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             ReadOnlySpan<byte> dataHash,
             PAL_HashAlgorithm hashAlgorithm,
             PAL_SignatureAlgorithm signatureAlgorithm)
@@ -156,7 +156,7 @@ internal static partial class Interop
         }
 
         internal static byte[] CreateSignature(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             ReadOnlySpan<byte> dataHash,
             PAL_HashAlgorithm hashAlgorithm,
             PAL_SignatureAlgorithm signatureAlgorithm)
@@ -168,7 +168,7 @@ internal static partial class Interop
         }
 
         internal static bool TryCreateSignature(
-            SafeSecKeyRefHandle privateKey,
+            SafeSecKeyHandle privateKey,
             ReadOnlySpan<byte> dataHash,
             Span<byte> destination,
             PAL_HashAlgorithm hashAlgorithm,

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
@@ -26,7 +26,7 @@ internal static partial class Interop
             out SafeCFStringHandle cfSubjectSummaryOut);
 
         [LibraryImport(Libraries.AppleCryptoNative)]
-        private static partial int AppleCryptoNative_X509GetPublicKey(SafeSecCertificateHandle cert, out SafeSecKeyRefHandle publicKey, out int pOSStatus);
+        private static partial int AppleCryptoNative_X509GetPublicKey(SafeSecCertificateHandle cert, out SafeSecKeyHandle publicKey, out int pOSStatus);
 
         internal static X509ContentType X509GetContentType(ReadOnlySpan<byte> data)
             => X509GetContentType(ref MemoryMarshal.GetReference(data), data.Length);
@@ -42,7 +42,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_X509CopyPrivateKeyFromIdentity(
             SafeSecIdentityHandle identity,
-            out SafeSecKeyRefHandle key);
+            out SafeSecKeyHandle key);
 
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_X509DemuxAndRetainHandle(
@@ -102,9 +102,9 @@ internal static partial class Interop
             throw new CryptographicException();
         }
 
-        internal static SafeSecKeyRefHandle X509GetPrivateKeyFromIdentity(SafeSecIdentityHandle identity)
+        internal static SafeSecKeyHandle X509GetPrivateKeyFromIdentity(SafeSecIdentityHandle identity)
         {
-            SafeSecKeyRefHandle key;
+            SafeSecKeyHandle key;
             int osStatus = AppleCryptoNative_X509CopyPrivateKeyFromIdentity(identity, out key);
 
             if (osStatus != 0)
@@ -122,9 +122,9 @@ internal static partial class Interop
             return key;
         }
 
-        internal static SafeSecKeyRefHandle X509GetPublicKey(SafeSecCertificateHandle cert)
+        internal static SafeSecKeyHandle X509GetPublicKey(SafeSecCertificateHandle cert)
         {
-            SafeSecKeyRefHandle publicKey;
+            SafeSecKeyHandle publicKey;
             int osStatus;
             int ret = AppleCryptoNative_X509GetPublicKey(cert, out publicKey, out osStatus);
 

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.macOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.macOS.cs
@@ -73,7 +73,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.AppleCryptoNative)]
         private static partial int AppleCryptoNative_X509CopyWithPrivateKey(
             SafeSecCertificateHandle certHandle,
-            SafeSecKeyRefHandle privateKeyHandle,
+            SafeSecKeyHandle privateKeyHandle,
             SafeKeychainHandle targetKeychain,
             out SafeSecIdentityHandle pIdentityHandleOut,
             out int pOSStatus);
@@ -82,7 +82,7 @@ internal static partial class Interop
         private static partial int AppleCryptoNative_X509MoveToKeychain(
             SafeSecCertificateHandle certHandle,
             SafeKeychainHandle targetKeychain,
-            SafeSecKeyRefHandle privateKeyHandle,
+            SafeSecKeyHandle privateKeyHandle,
             out SafeSecIdentityHandle pIdentityHandleOut,
             out int pOSStatus);
 
@@ -251,7 +251,7 @@ internal static partial class Interop
 
         internal static SafeSecIdentityHandle X509CopyWithPrivateKey(
             SafeSecCertificateHandle certHandle,
-            SafeSecKeyRefHandle privateKeyHandle,
+            SafeSecKeyHandle privateKeyHandle,
             SafeKeychainHandle targetKeychain)
         {
             SafeSecIdentityHandle identityHandle;
@@ -284,7 +284,7 @@ internal static partial class Interop
         internal static SafeSecIdentityHandle? X509MoveToKeychain(
             SafeSecCertificateHandle cert,
             SafeKeychainHandle targetKeychain,
-            SafeSecKeyRefHandle? privateKey)
+            SafeSecKeyHandle? privateKey)
         {
             SafeSecIdentityHandle identityHandle;
             int osStatus;
@@ -292,7 +292,7 @@ internal static partial class Interop
             int result = AppleCryptoNative_X509MoveToKeychain(
                 cert,
                 targetKeychain,
-                privateKey ?? SafeSecKeyRefHandle.InvalidHandle,
+                privateKey ?? SafeSecKeyHandle.InvalidHandle,
                 out identityHandle,
                 out osStatus);
 

--- a/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -24,12 +24,12 @@ namespace System.Security.Cryptography
                 base.KeySize = keySize;
             }
 
-            internal DSASecurityTransforms(SafeSecKeyRefHandle publicKey)
+            internal DSASecurityTransforms(SafeSecKeyHandle publicKey)
             {
                 SetKey(SecKeyPair.PublicOnly(publicKey));
             }
 
-            internal DSASecurityTransforms(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
+            internal DSASecurityTransforms(SafeSecKeyHandle publicKey, SafeSecKeyHandle privateKey)
             {
                 SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.macOS.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.macOS.cs
@@ -91,12 +91,12 @@ namespace System.Security.Cryptography
 
                 if (hasPrivateKey)
                 {
-                    SafeSecKeyRefHandle privateKey = ImportKey(parameters);
+                    SafeSecKeyHandle privateKey = ImportKey(parameters);
 
                     DSAParameters publicOnly = parameters;
                     publicOnly.X = null;
 
-                    SafeSecKeyRefHandle publicKey;
+                    SafeSecKeyHandle publicKey;
                     try
                     {
                         publicKey = ImportKey(publicOnly);
@@ -111,7 +111,7 @@ namespace System.Security.Cryptography
                 }
                 else
                 {
-                    SafeSecKeyRefHandle publicKey = ImportKey(parameters);
+                    SafeSecKeyHandle publicKey = ImportKey(parameters);
                     SetKey(SecKeyPair.PublicOnly(publicKey));
                 }
             }
@@ -134,7 +134,7 @@ namespace System.Security.Cryptography
                 base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
             }
 
-            private static SafeSecKeyRefHandle ImportKey(DSAParameters parameters)
+            private static SafeSecKeyHandle ImportKey(DSAParameters parameters)
             {
                 AsnWriter keyWriter;
                 bool hasPrivateKey;
@@ -206,7 +206,7 @@ namespace System.Security.Cryptography
                             manager.Memory,
                             out int localRead);
 
-                        SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.ImportEphemeralKey(source.Slice(0, localRead), false);
+                        SafeSecKeyHandle publicKey = Interop.AppleCrypto.ImportEphemeralKey(source.Slice(0, localRead), false);
                         SetKey(SecKeyPair.PublicOnly(publicKey));
 
                         bytesRead = localRead;

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
@@ -17,12 +17,12 @@ namespace System.Security.Cryptography
                 base.KeySize = 521;
             }
 
-            internal ECDiffieHellmanSecurityTransforms(SafeSecKeyRefHandle publicKey)
+            internal ECDiffieHellmanSecurityTransforms(SafeSecKeyHandle publicKey)
             {
                 KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicOnly(publicKey));
             }
 
-            internal ECDiffieHellmanSecurityTransforms(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
+            internal ECDiffieHellmanSecurityTransforms(SafeSecKeyHandle publicKey, SafeSecKeyHandle privateKey)
             {
                 KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
             }
@@ -175,7 +175,7 @@ namespace System.Security.Cryptography
 
                 try
                 {
-                    SafeSecKeyRefHandle otherPublic = secTransPubKey.KeyHandle;
+                    SafeSecKeyHandle otherPublic = secTransPubKey.KeyHandle;
 
                     if (Interop.AppleCrypto.EccGetKeySizeInBits(otherPublic) != KeySize)
                     {
@@ -184,7 +184,7 @@ namespace System.Security.Cryptography
                             nameof(otherPartyPublicKey));
                     }
 
-                    SafeSecKeyRefHandle? thisPrivate = GetKeys().PrivateKey;
+                    SafeSecKeyHandle? thisPrivate = GetKeys().PrivateKey;
 
                     if (thisPrivate == null)
                     {
@@ -281,7 +281,7 @@ namespace System.Security.Cryptography
                 public override ECParameters ExportParameters() =>
                     _ecc.ExportParameters(includePrivateParameters: false, keySizeInBits: -1);
 
-                internal SafeSecKeyRefHandle KeyHandle =>
+                internal SafeSecKeyHandle KeyHandle =>
                     _ecc.GetOrGenerateKeys(-1).PublicKey;
             }
         }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -18,12 +18,12 @@ namespace System.Security.Cryptography
                 base.KeySize = 521;
             }
 
-            internal ECDsaSecurityTransforms(SafeSecKeyRefHandle publicKey)
+            internal ECDsaSecurityTransforms(SafeSecKeyHandle publicKey)
             {
                 KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicOnly(publicKey));
             }
 
-            internal ECDsaSecurityTransforms(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
+            internal ECDsaSecurityTransforms(SafeSecKeyHandle publicKey, SafeSecKeyHandle privateKey)
             {
                 KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs
@@ -68,8 +68,8 @@ namespace System.Security.Cryptography
 
         private SecKeyPair GenerateKey(int keySizeInBits)
         {
-            SafeSecKeyRefHandle publicKey;
-            SafeSecKeyRefHandle privateKey;
+            SafeSecKeyHandle publicKey;
+            SafeSecKeyHandle privateKey;
 
             Interop.AppleCrypto.EccGenerateKey(keySizeInBits, out publicKey, out privateKey);
 
@@ -219,13 +219,13 @@ namespace System.Security.Cryptography
                 // match the public key fields and the system determines an integrity failure.
                 //
                 // Public import should go off without a hitch.
-                SafeSecKeyRefHandle privateKey = ImportKey(parameters);
-                SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.CopyPublicKey(privateKey);
+                SafeSecKeyHandle privateKey = ImportKey(parameters);
+                SafeSecKeyHandle publicKey = Interop.AppleCrypto.CopyPublicKey(privateKey);
                 newKeys = SecKeyPair.PublicPrivatePair(publicKey, privateKey);
             }
             else
             {
-                SafeSecKeyRefHandle publicKey = ImportKey(parameters);
+                SafeSecKeyHandle publicKey = ImportKey(parameters);
                 newKeys = SecKeyPair.PublicOnly(publicKey);
             }
 
@@ -242,7 +242,7 @@ namespace System.Security.Cryptography
             return size;
         }
 
-        private static SafeSecKeyRefHandle ImportKey(ECParameters parameters)
+        private static SafeSecKeyHandle ImportKey(ECParameters parameters)
         {
             int fieldSize = parameters.Q!.X!.Length;
 

--- a/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.macOS.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.macOS.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography
 
         private static void ExtractPublicKeyFromPrivateKey(ref ECParameters ecParameters)
         {
-            using (SafeSecKeyRefHandle secPrivateKey = ImportLegacyPrivateKey(ref ecParameters))
+            using (SafeSecKeyHandle secPrivateKey = ImportLegacyPrivateKey(ref ecParameters))
             {
                 const string ExportPassword = "DotnetExportPassphrase";
                 byte[] keyBlob = Interop.AppleCrypto.SecKeyExport(secPrivateKey, exportPrivate: true, password: ExportPassword);
@@ -60,7 +60,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        private static SafeSecKeyRefHandle ImportLegacyPrivateKey(ref ECParameters parameters)
+        private static SafeSecKeyHandle ImportLegacyPrivateKey(ref ECParameters parameters)
         {
             AsnWriter keyWriter = EccKeyFormatHelper.WriteECPrivateKey(parameters);
 

--- a/src/libraries/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -28,12 +28,12 @@ namespace System.Security.Cryptography
                 base.KeySize = keySize;
             }
 
-            internal RSASecurityTransforms(SafeSecKeyRefHandle publicKey)
+            internal RSASecurityTransforms(SafeSecKeyHandle publicKey)
             {
                 SetKey(SecKeyPair.PublicOnly(publicKey));
             }
 
-            internal RSASecurityTransforms(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
+            internal RSASecurityTransforms(SafeSecKeyHandle publicKey, SafeSecKeyHandle privateKey)
             {
                 SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
             }
@@ -152,13 +152,13 @@ namespace System.Security.Cryptography
                     // don't match the public key fields.
                     //
                     // Public import should go off without a hitch.
-                    SafeSecKeyRefHandle privateKey = ImportKey(parameters);
-                    SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.CopyPublicKey(privateKey);
+                    SafeSecKeyHandle privateKey = ImportKey(parameters);
+                    SafeSecKeyHandle publicKey = Interop.AppleCrypto.CopyPublicKey(privateKey);
                     SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
                 }
                 else
                 {
-                    SafeSecKeyRefHandle publicKey = ImportKey(parameters);
+                    SafeSecKeyHandle publicKey = ImportKey(parameters);
                     SetKey(SecKeyPair.PublicOnly(publicKey));
                 }
             }
@@ -176,7 +176,7 @@ namespace System.Security.Cryptography
                             manager.Memory,
                             out int localRead);
 
-                        SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.CreateDataKey(
+                        SafeSecKeyHandle publicKey = Interop.AppleCrypto.CreateDataKey(
                             source.Slice(0, localRead),
                             Interop.AppleCrypto.PAL_KeyAlgorithm.RSA,
                             isPublic: true);
@@ -320,7 +320,7 @@ namespace System.Security.Cryptography
             }
 
             private bool TryDecrypt(
-                SafeSecKeyRefHandle privateKey,
+                SafeSecKeyHandle privateKey,
                 ReadOnlySpan<byte> data,
                 Span<byte> destination,
                 RSAEncryptionPadding padding,
@@ -509,7 +509,7 @@ namespace System.Security.Cryptography
                 }
                 else if (padding.Mode == RSASignaturePaddingMode.Pss)
                 {
-                    SafeSecKeyRefHandle publicKey = GetKeys().PublicKey;
+                    SafeSecKeyHandle publicKey = GetKeys().PublicKey;
 
                     int keySize = KeySize;
                     int rsaSize = RsaPaddingProcessor.BytesRequiredForBitCount(keySize);
@@ -616,8 +616,8 @@ namespace System.Security.Cryptography
                     return current;
                 }
 
-                SafeSecKeyRefHandle publicKey;
-                SafeSecKeyRefHandle privateKey;
+                SafeSecKeyHandle publicKey;
+                SafeSecKeyHandle privateKey;
 
                 Interop.AppleCrypto.RsaGenerateKey(KeySizeValue, out publicKey, out privateKey);
 
@@ -640,7 +640,7 @@ namespace System.Security.Cryptography
                 }
             }
 
-            private static SafeSecKeyRefHandle ImportKey(RSAParameters parameters)
+            private static SafeSecKeyHandle ImportKey(RSAParameters parameters)
             {
                 AsnWriter keyWriter;
                 bool hasPrivateKey;

--- a/src/libraries/Common/src/System/Security/Cryptography/SecKeyPair.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SecKeyPair.cs
@@ -7,10 +7,10 @@ namespace System.Security.Cryptography
 {
     internal sealed class SecKeyPair : IDisposable
     {
-        internal SafeSecKeyRefHandle PublicKey { get; private set; }
-        internal SafeSecKeyRefHandle? PrivateKey { get; private set; }
+        internal SafeSecKeyHandle PublicKey { get; private set; }
+        internal SafeSecKeyHandle? PrivateKey { get; private set; }
 
-        private SecKeyPair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle? privateKey)
+        private SecKeyPair(SafeSecKeyHandle publicKey, SafeSecKeyHandle? privateKey)
         {
             PublicKey = publicKey;
             PrivateKey = privateKey;
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography
             PublicKey = null!;
         }
 
-        internal static SecKeyPair PublicPrivatePair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
+        internal static SecKeyPair PublicPrivatePair(SafeSecKeyHandle publicKey, SafeSecKeyHandle privateKey)
         {
             if (publicKey == null || publicKey.IsInvalid)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(publicKey));
@@ -34,7 +34,7 @@ namespace System.Security.Cryptography
             return new SecKeyPair(publicKey, privateKey);
         }
 
-        internal static SecKeyPair PublicOnly(SafeSecKeyRefHandle publicKey)
+        internal static SecKeyPair PublicOnly(SafeSecKeyHandle publicKey)
         {
             if (publicKey == null || publicKey.IsInvalid)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(publicKey));

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1088,8 +1088,8 @@
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErr.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs" />
-    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs"
-             Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs" />
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKey.cs"
+             Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKey.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SignVerify.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SignVerify.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Symmetric.cs"
@@ -1264,8 +1264,8 @@
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Aead.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.macOS.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.macOS.cs" />
-    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.macOS.cs"
-             Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.macOS.cs" />
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKey.macOS.cs"
+             Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKey.macOS.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509.macOS.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.X509.macOS.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\DSAOpenSsl.cs"

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
@@ -101,13 +101,13 @@ namespace System.Security.Cryptography.X509Certificates
         {
             Debug.Assert(_identityHandle != null);
 
-            using (SafeSecKeyRefHandle key = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle))
+            using (SafeSecKeyHandle key = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle))
             {
                 return ExportPkcs8(key, password);
             }
         }
 
-        internal static unsafe byte[] ExportPkcs8(SafeSecKeyRefHandle key, ReadOnlySpan<char> password)
+        internal static unsafe byte[] ExportPkcs8(SafeSecKeyHandle key, ReadOnlySpan<char> password)
         {
             using (SafeCFDataHandle data = Interop.AppleCrypto.SecKeyExportData(key, exportPrivate: true, password))
             {
@@ -134,7 +134,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        internal AppleCertificatePal? MoveToKeychain(SafeKeychainHandle keychain, SafeSecKeyRefHandle? privateKey)
+        internal AppleCertificatePal? MoveToKeychain(SafeKeychainHandle keychain, SafeSecKeyHandle? privateKey)
         {
             SafeSecIdentityHandle? identity = Interop.AppleCrypto.X509MoveToKeychain(
                 _certHandle,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.macOS.cs
@@ -20,8 +20,8 @@ namespace System.Security.Cryptography.X509Certificates
                 return null;
 
             Debug.Assert(!_identityHandle.IsInvalid);
-            SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
-            SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
+            SafeSecKeyHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
+            SafeSecKeyHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
 
             if (publicKey.IsInvalid)
             {
@@ -80,7 +80,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
 
             using (PinAndClear.Track(ecPrivateKey))
-            using (SafeSecKeyRefHandle privateSecKey = Interop.AppleCrypto.ImportEphemeralKey(ecPrivateKey, true))
+            using (SafeSecKeyHandle privateSecKey = Interop.AppleCrypto.ImportEphemeralKey(ecPrivateKey, true))
             {
                 return CopyWithPrivateKey(privateSecKey);
             }
@@ -115,7 +115,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
 
             using (PinAndClear.Track(ecPrivateKey))
-            using (SafeSecKeyRefHandle privateSecKey = Interop.AppleCrypto.ImportEphemeralKey(ecPrivateKey, true))
+            using (SafeSecKeyHandle privateSecKey = Interop.AppleCrypto.ImportEphemeralKey(ecPrivateKey, true))
             {
                 return CopyWithPrivateKey(privateSecKey);
             }
@@ -133,13 +133,13 @@ namespace System.Security.Cryptography.X509Certificates
             byte[] rsaPrivateKey = privateKey.ExportRSAPrivateKey();
 
             using (PinAndClear.Track(rsaPrivateKey))
-            using (SafeSecKeyRefHandle privateSecKey = Interop.AppleCrypto.ImportEphemeralKey(rsaPrivateKey, true))
+            using (SafeSecKeyHandle privateSecKey = Interop.AppleCrypto.ImportEphemeralKey(rsaPrivateKey, true))
             {
                 return CopyWithPrivateKey(privateSecKey);
             }
         }
 
-        private ICertificatePal CopyWithPrivateKey(SafeSecKeyRefHandle? privateKey)
+        private ICertificatePal CopyWithPrivateKey(SafeSecKeyHandle? privateKey)
         {
             if (privateKey == null)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
@@ -330,8 +330,8 @@ namespace System.Security.Cryptography.X509Certificates
                 return null;
 
             Debug.Assert(!_identityHandle.IsInvalid);
-            SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
-            SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
+            SafeSecKeyHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
+            SafeSecKeyHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
             Debug.Assert(!publicKey.IsInvalid);
 
             return new RSAImplementation.RSASecurityTransforms(publicKey, privateKey);
@@ -343,8 +343,8 @@ namespace System.Security.Cryptography.X509Certificates
                 return null;
 
             Debug.Assert(!_identityHandle.IsInvalid);
-            SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
-            SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
+            SafeSecKeyHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
+            SafeSecKeyHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
             Debug.Assert(!publicKey.IsInvalid);
 
             return new ECDsaImplementation.ECDsaSecurityTransforms(publicKey, privateKey);
@@ -356,8 +356,8 @@ namespace System.Security.Cryptography.X509Certificates
                 return null;
 
             Debug.Assert(!_identityHandle.IsInvalid);
-            SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
-            SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
+            SafeSecKeyHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
+            SafeSecKeyHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
             Debug.Assert(!publicKey.IsInvalid);
 
             return new ECDiffieHellmanImplementation.ECDiffieHellmanSecurityTransforms(publicKey, privateKey);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ApplePkcs12Reader.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ApplePkcs12Reader.macOS.cs
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.X509Certificates
             return key;
         }
 
-        internal static SafeSecKeyRefHandle? GetPrivateKey(AsymmetricAlgorithm? key)
+        internal static SafeSecKeyHandle? GetPrivateKey(AsymmetricAlgorithm? key)
         {
             if (key == null)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.macOS.LoaderPal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.macOS.LoaderPal.cs
@@ -92,10 +92,10 @@ namespace System.Security.Cryptography.X509Certificates
                 foreach (UnixPkcs12Reader.CertAndKey certAndKey in _pkcs12.EnumerateAll())
                 {
                     AppleCertificatePal pal = (AppleCertificatePal)certAndKey.Cert!;
-                    SafeSecKeyRefHandle? safeSecKeyRefHandle =
-                        ApplePkcs12Reader.GetPrivateKey(certAndKey.Key);
 
-                    using (safeSecKeyRefHandle)
+                    SafeSecKeyHandle? privateKey = ApplePkcs12Reader.GetPrivateKey(certAndKey.Key);
+
+                    using (privateKey)
                     {
                         ICertificatePal newPal;
 
@@ -104,17 +104,17 @@ namespace System.Security.Cryptography.X509Certificates
                         //
                         // So, as part of reading this PKCS#12 we now need to write the minimum
                         // PKCS#12 in a normalized form, and ask the OS to import it.
-                        if (!_exportable && safeSecKeyRefHandle != null)
+                        if (!_exportable && privateKey != null)
                         {
                             newPal = AppleCertificatePal.ImportPkcs12NonExportable(
                                 pal,
-                                safeSecKeyRefHandle,
+                                privateKey,
                                 _password,
                                 _keychain);
                         }
                         else
                         {
-                            newPal = pal.MoveToKeychain(_keychain, safeSecKeyRefHandle) ?? pal;
+                            newPal = pal.MoveToKeychain(_keychain, privateKey) ?? pal;
                         }
 
                         X509Certificate2 cert = new X509Certificate2(newPal);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Apple.ECKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Apple.ECKey.cs
@@ -19,7 +19,7 @@ namespace System.Security.Cryptography.X509Certificates
                 return new ECDiffieHellmanImplementation.ECDiffieHellmanSecurityTransforms(DecodeECPublicKey(certificatePal));
             }
 
-            private static SafeSecKeyRefHandle DecodeECPublicKey(ICertificatePal? certificatePal)
+            private static SafeSecKeyHandle DecodeECPublicKey(ICertificatePal? certificatePal)
             {
                 const int errSecInvalidKeyRef = -67712;
                 const int errSecUnsupportedKeySize = -67735;
@@ -28,7 +28,7 @@ namespace System.Security.Cryptography.X509Certificates
                     throw new NotSupportedException(SR.NotSupported_KeyAlgorithm);
 
                 AppleCertificatePal applePal = (AppleCertificatePal)certificatePal;
-                SafeSecKeyRefHandle key = Interop.AppleCrypto.X509GetPublicKey(applePal.CertificateHandle);
+                SafeSecKeyHandle key = Interop.AppleCrypto.X509GetPublicKey(applePal.CertificateHandle);
 
                 // If X509GetPublicKey uses the new SecCertificateCopyKey API it can return an invalid
                 // key reference for unsupported algorithms. This currently happens for the BrainpoolP160r1

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.iOS.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 if (certificatePal is AppleCertificatePal applePal)
                 {
-                    SafeSecKeyRefHandle key = Interop.AppleCrypto.X509GetPublicKey(applePal.CertificateHandle);
+                    SafeSecKeyHandle key = Interop.AppleCrypto.X509GetPublicKey(applePal.CertificateHandle);
                     Debug.Assert(!key.IsInvalid);
                     return new RSAImplementation.RSASecurityTransforms(key);
                 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.macOS.cs
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 if (applePal != null)
                 {
-                    SafeSecKeyRefHandle key = Interop.AppleCrypto.X509GetPublicKey(applePal.CertificateHandle);
+                    SafeSecKeyHandle key = Interop.AppleCrypto.X509GetPublicKey(applePal.CertificateHandle);
 
                     switch (oid.Value)
                     {

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -413,8 +413,8 @@
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecErrMessage.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.macOS.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.macOS.cs" />
-    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs"
-             Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKeyRef.cs" />
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKey.cs"
+             Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.SecKey.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs"
              Link="Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs"


### PR DESCRIPTION
`SafeSecKeyRefHandle` would be better named as `SafeSecKeyHandle`.

This is to be consistent with the other safe handles used for marshalling in Interop, for example `CFStringRef` in our C code becomes `SafeCFStringHandle` in C#.