### PR TITLE
retrieve method symbol only once in logging source gen parser

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -188,318 +188,318 @@ namespace Microsoft.Extensions.Logging.Generators
                                         break;
                                     }
 
-                                        var lm = new LoggerMethod
+                                    var lm = new LoggerMethod
+                                    {
+                                        Name = logMethodSymbol.Name,
+                                        Level = level,
+                                        Message = message,
+                                        EventId = eventId,
+                                        EventName = eventName,
+                                        IsExtensionMethod = logMethodSymbol.IsExtensionMethod,
+                                        Modifiers = method.Modifiers.ToString(),
+                                        SkipEnabledCheck = skipEnabledCheck
+                                    };
+
+                                    ExtractTemplates(message, lm.TemplateMap, lm.TemplateList);
+
+                                    bool keepMethod = true;   // whether or not we want to keep the method definition or if it's got errors making it so we should discard it instead
+                                    if (lm.Name[0] == '_')
+                                    {
+                                        // can't have logging method names that start with _ since that can lead to conflicting symbol names
+                                        // because the generated symbols start with _
+                                        Diag(DiagnosticDescriptors.InvalidLoggingMethodName, method.Identifier.GetLocation());
+                                        keepMethod = false;
+                                    }
+
+                                    if (!logMethodSymbol.ReturnsVoid)
+                                    {
+                                        // logging methods must return void
+                                        Diag(DiagnosticDescriptors.LoggingMethodMustReturnVoid, method.ReturnType.GetLocation());
+                                        keepMethod = false;
+                                    }
+
+                                    if (method.Arity > 0)
+                                    {
+                                        // we don't currently support generic methods
+                                        Diag(DiagnosticDescriptors.LoggingMethodIsGeneric, method.Identifier.GetLocation());
+                                        keepMethod = false;
+                                    }
+
+                                    bool isStatic = false;
+                                    bool isPartial = false;
+                                    foreach (SyntaxToken mod in method.Modifiers)
+                                    {
+                                        if (mod.IsKind(SyntaxKind.PartialKeyword))
                                         {
-                                            Name = logMethodSymbol.Name,
-                                            Level = level,
-                                            Message = message,
-                                            EventId = eventId,
-                                            EventName = eventName,
-                                            IsExtensionMethod = logMethodSymbol.IsExtensionMethod,
-                                            Modifiers = method.Modifiers.ToString(),
-                                            SkipEnabledCheck = skipEnabledCheck
+                                            isPartial = true;
+                                        }
+                                        else if (mod.IsKind(SyntaxKind.StaticKeyword))
+                                        {
+                                            isStatic = true;
+                                        }
+                                    }
+
+                                    if (!isPartial)
+                                    {
+                                        Diag(DiagnosticDescriptors.LoggingMethodMustBePartial, method.GetLocation());
+                                        keepMethod = false;
+                                    }
+
+                                    CSharpSyntaxNode? methodBody = method.Body as CSharpSyntaxNode ?? method.ExpressionBody;
+                                    if (methodBody != null)
+                                    {
+                                        Diag(DiagnosticDescriptors.LoggingMethodHasBody, methodBody.GetLocation());
+                                        keepMethod = false;
+                                    }
+
+                                    // ensure there are no duplicate ids.
+                                    if (ids.Contains(lm.EventId))
+                                    {
+                                        Diag(DiagnosticDescriptors.ShouldntReuseEventIds, ma.GetLocation(), lm.EventId, classDec.Identifier.Text);
+                                    }
+                                    else
+                                    {
+                                        _ = ids.Add(lm.EventId);
+                                    }
+
+                                    string msg = lm.Message;
+                                    if (msg.StartsWith("INFORMATION:", StringComparison.OrdinalIgnoreCase)
+                                        || msg.StartsWith("INFO:", StringComparison.OrdinalIgnoreCase)
+                                        || msg.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase)
+                                        || msg.StartsWith("WARN:", StringComparison.OrdinalIgnoreCase)
+                                        || msg.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase)
+                                        || msg.StartsWith("ERR:", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        Diag(DiagnosticDescriptors.RedundantQualifierInMessage, ma.GetLocation(), method.Identifier.ToString());
+                                    }
+
+                                    bool foundLogger = false;
+                                    bool foundException = false;
+                                    bool foundLogLevel = level != null;
+                                    foreach (IParameterSymbol paramSymbol in logMethodSymbol.Parameters)
+                                    {
+                                        string paramName = paramSymbol.Name;
+                                        bool needsAtSign = false;
+                                        if (paramSymbol.DeclaringSyntaxReferences.Length > 0)
+                                        {
+                                            ParameterSyntax paramSyntax = paramSymbol.DeclaringSyntaxReferences[0].GetSyntax(_cancellationToken) as ParameterSyntax;
+                                            if (paramSyntax != null && !string.IsNullOrEmpty(paramSyntax.Identifier.Text))
+                                            {
+                                                needsAtSign = paramSyntax.Identifier.Text[0] == '@';
+                                            }
+                                        }
+                                        if (string.IsNullOrWhiteSpace(paramName))
+                                        {
+                                            // semantic problem, just bail quietly
+                                            keepMethod = false;
+                                            break;
+                                        }
+
+                                        ITypeSymbol paramTypeSymbol = paramSymbol!.Type;
+                                        if (paramTypeSymbol is IErrorTypeSymbol)
+                                        {
+                                            // semantic problem, just bail quietly
+                                            keepMethod = false;
+                                            break;
+                                        }
+
+                                        string? qualifier = null;
+                                        if (paramSymbol.RefKind == RefKind.In)
+                                        {
+                                            qualifier = "in";
+                                        }
+                                        else if (paramSymbol.RefKind == RefKind.Ref)
+                                        {
+                                            qualifier = "ref";
+                                        }
+                                        string typeName = paramTypeSymbol.ToDisplayString(
+                                            SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
+                                                SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier));
+
+                                        var lp = new LoggerParameter
+                                        {
+                                            Name = paramName,
+                                            Type = typeName,
+                                            Qualifier = qualifier,
+                                            CodeName = needsAtSign ? "@" + paramName : paramName,
+                                            IsLogger = !foundLogger && IsBaseOrIdentity(paramTypeSymbol!, loggerSymbol),
+                                            IsException = !foundException && IsBaseOrIdentity(paramTypeSymbol!, exceptionSymbol),
+                                            IsLogLevel = !foundLogLevel && IsBaseOrIdentity(paramTypeSymbol!, logLevelSymbol),
+                                            IsEnumerable = IsBaseOrIdentity(paramTypeSymbol!, enumerableSymbol) && !IsBaseOrIdentity(paramTypeSymbol!, stringSymbol),
                                         };
 
-                                        ExtractTemplates(message, lm.TemplateMap, lm.TemplateList);
+                                        foundLogger |= lp.IsLogger;
+                                        foundException |= lp.IsException;
+                                        foundLogLevel |= lp.IsLogLevel;
 
-                                        bool keepMethod = true;   // whether or not we want to keep the method definition or if it's got errors making it so we should discard it instead
-                                        if (lm.Name[0] == '_')
+                                        bool forceAsTemplateParams = false;
+                                        if (lp.IsLogger && lm.TemplateMap.ContainsKey(paramName))
                                         {
-                                            // can't have logging method names that start with _ since that can lead to conflicting symbol names
-                                            // because the generated symbols start with _
-                                            Diag(DiagnosticDescriptors.InvalidLoggingMethodName, method.Identifier.GetLocation());
+                                            Diag(DiagnosticDescriptors.ShouldntMentionLoggerInMessage, paramSymbol.Locations[0], paramName);
+                                            forceAsTemplateParams = true;
+                                        }
+                                        else if (lp.IsException && lm.TemplateMap.ContainsKey(paramName))
+                                        {
+                                            Diag(DiagnosticDescriptors.ShouldntMentionExceptionInMessage, paramSymbol.Locations[0], paramName);
+                                            forceAsTemplateParams = true;
+                                        }
+                                        else if (lp.IsLogLevel && lm.TemplateMap.ContainsKey(paramName))
+                                        {
+                                            Diag(DiagnosticDescriptors.ShouldntMentionLogLevelInMessage, paramSymbol.Locations[0], paramName);
+                                            forceAsTemplateParams = true;
+                                        }
+                                        else if (lp.IsLogLevel && level != null && !lm.TemplateMap.ContainsKey(paramName) && !lm.TemplateMap.ContainsKey(lp.CodeName))
+                                        {
+                                            Diag(DiagnosticDescriptors.ArgumentHasNoCorrespondingTemplate, paramSymbol.Locations[0], paramName);
+                                        }
+                                        else if (lp.IsTemplateParameter && !lm.TemplateMap.ContainsKey(paramName) && !lm.TemplateMap.ContainsKey($"@{paramName}") && !lm.TemplateMap.ContainsKey(lp.CodeName))
+                                        {
+                                            Diag(DiagnosticDescriptors.ArgumentHasNoCorrespondingTemplate, paramSymbol.Locations[0], paramName);
+                                        }
+
+                                        if (paramName[0] == '_')
+                                        {
+                                            // can't have logging method parameter names that start with _ since that can lead to conflicting symbol names
+                                            // because all generated symbols start with _
+                                            Diag(DiagnosticDescriptors.InvalidLoggingMethodParameterName, paramSymbol.Locations[0]);
+                                        }
+
+                                        lm.AllParameters.Add(lp);
+                                        if (lp.IsTemplateParameter || forceAsTemplateParams)
+                                        {
+                                            lm.TemplateParameters.Add(lp);
+                                        }
+                                    }
+
+                                    if (keepMethod)
+                                    {
+                                        if (isStatic && !foundLogger)
+                                        {
+                                            Diag(DiagnosticDescriptors.MissingLoggerArgument, method.GetLocation(), lm.Name);
                                             keepMethod = false;
                                         }
-
-                                        if (!logMethodSymbol.ReturnsVoid)
+                                        else if (!isStatic && foundLogger)
                                         {
-                                            // logging methods must return void
-                                            Diag(DiagnosticDescriptors.LoggingMethodMustReturnVoid, method.ReturnType.GetLocation());
-                                            keepMethod = false;
+                                            Diag(DiagnosticDescriptors.LoggingMethodShouldBeStatic, method.GetLocation());
                                         }
-
-                                        if (method.Arity > 0)
+                                        else if (!isStatic && !foundLogger)
                                         {
-                                            // we don't currently support generic methods
-                                            Diag(DiagnosticDescriptors.LoggingMethodIsGeneric, method.Identifier.GetLocation());
-                                            keepMethod = false;
-                                        }
-
-                                        bool isStatic = false;
-                                        bool isPartial = false;
-                                        foreach (SyntaxToken mod in method.Modifiers)
-                                        {
-                                            if (mod.IsKind(SyntaxKind.PartialKeyword))
+                                            if (loggerField == null)
                                             {
-                                                isPartial = true;
-                                            }
-                                            else if (mod.IsKind(SyntaxKind.StaticKeyword))
-                                            {
-                                                isStatic = true;
-                                            }
-                                        }
-
-                                        if (!isPartial)
-                                        {
-                                            Diag(DiagnosticDescriptors.LoggingMethodMustBePartial, method.GetLocation());
-                                            keepMethod = false;
-                                        }
-
-                                        CSharpSyntaxNode? methodBody = method.Body as CSharpSyntaxNode ?? method.ExpressionBody;
-                                        if (methodBody != null)
-                                        {
-                                            Diag(DiagnosticDescriptors.LoggingMethodHasBody, methodBody.GetLocation());
-                                            keepMethod = false;
-                                        }
-
-                                        // ensure there are no duplicate ids.
-                                        if (ids.Contains(lm.EventId))
-                                        {
-                                            Diag(DiagnosticDescriptors.ShouldntReuseEventIds, ma.GetLocation(), lm.EventId, classDec.Identifier.Text);
-                                        }
-                                        else
-                                        {
-                                            _ = ids.Add(lm.EventId);
-                                        }
-
-                                        string msg = lm.Message;
-                                        if (msg.StartsWith("INFORMATION:", StringComparison.OrdinalIgnoreCase)
-                                            || msg.StartsWith("INFO:", StringComparison.OrdinalIgnoreCase)
-                                            || msg.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase)
-                                            || msg.StartsWith("WARN:", StringComparison.OrdinalIgnoreCase)
-                                            || msg.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase)
-                                            || msg.StartsWith("ERR:", StringComparison.OrdinalIgnoreCase))
-                                        {
-                                            Diag(DiagnosticDescriptors.RedundantQualifierInMessage, ma.GetLocation(), method.Identifier.ToString());
-                                        }
-
-                                        bool foundLogger = false;
-                                        bool foundException = false;
-                                        bool foundLogLevel = level != null;
-                                        foreach (IParameterSymbol paramSymbol in logMethodSymbol.Parameters)
-                                        {
-                                            string paramName = paramSymbol.Name;
-                                            bool needsAtSign = false;
-                                            if (paramSymbol.DeclaringSyntaxReferences.Length > 0)
-                                            {
-                                                ParameterSyntax paramSyntax = paramSymbol.DeclaringSyntaxReferences[0].GetSyntax(_cancellationToken) as ParameterSyntax;
-                                                if (paramSyntax != null && !string.IsNullOrEmpty(paramSyntax.Identifier.Text))
-                                                {
-                                                    needsAtSign = paramSyntax.Identifier.Text[0] == '@';
-                                                }
-                                            }
-                                            if (string.IsNullOrWhiteSpace(paramName))
-                                            {
-                                                // semantic problem, just bail quietly
-                                                keepMethod = false;
-                                                break;
+                                                (loggerField, multipleLoggerFields) = FindLoggerField(sm, classDec, loggerSymbol);
                                             }
 
-                                            ITypeSymbol paramTypeSymbol = paramSymbol!.Type;
-                                            if (paramTypeSymbol is IErrorTypeSymbol)
+                                            if (multipleLoggerFields)
                                             {
-                                                // semantic problem, just bail quietly
-                                                keepMethod = false;
-                                                break;
-                                            }
-
-                                            string? qualifier = null;
-                                            if (paramSymbol.RefKind == RefKind.In)
-                                            {
-                                                qualifier = "in";
-                                            }
-                                            else if (paramSymbol.RefKind == RefKind.Ref)
-                                            {
-                                                qualifier = "ref";
-                                            }
-                                            string typeName = paramTypeSymbol.ToDisplayString(
-                                                SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
-                                                    SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier));
-
-                                            var lp = new LoggerParameter
-                                            {
-                                                Name = paramName,
-                                                Type = typeName,
-                                                Qualifier = qualifier,
-                                                CodeName = needsAtSign ? "@" + paramName : paramName,
-                                                IsLogger = !foundLogger && IsBaseOrIdentity(paramTypeSymbol!, loggerSymbol),
-                                                IsException = !foundException && IsBaseOrIdentity(paramTypeSymbol!, exceptionSymbol),
-                                                IsLogLevel = !foundLogLevel && IsBaseOrIdentity(paramTypeSymbol!, logLevelSymbol),
-                                                IsEnumerable = IsBaseOrIdentity(paramTypeSymbol!, enumerableSymbol) && !IsBaseOrIdentity(paramTypeSymbol!, stringSymbol),
-                                            };
-
-                                            foundLogger |= lp.IsLogger;
-                                            foundException |= lp.IsException;
-                                            foundLogLevel |= lp.IsLogLevel;
-
-                                            bool forceAsTemplateParams = false;
-                                            if (lp.IsLogger && lm.TemplateMap.ContainsKey(paramName))
-                                            {
-                                                Diag(DiagnosticDescriptors.ShouldntMentionLoggerInMessage, paramSymbol.Locations[0], paramName);
-                                                forceAsTemplateParams = true;
-                                            }
-                                            else if (lp.IsException && lm.TemplateMap.ContainsKey(paramName))
-                                            {
-                                                Diag(DiagnosticDescriptors.ShouldntMentionExceptionInMessage, paramSymbol.Locations[0], paramName);
-                                                forceAsTemplateParams = true;
-                                            }
-                                            else if (lp.IsLogLevel && lm.TemplateMap.ContainsKey(paramName))
-                                            {
-                                                Diag(DiagnosticDescriptors.ShouldntMentionLogLevelInMessage, paramSymbol.Locations[0], paramName);
-                                                forceAsTemplateParams = true;
-                                            }
-                                            else if (lp.IsLogLevel && level != null && !lm.TemplateMap.ContainsKey(paramName) && !lm.TemplateMap.ContainsKey(lp.CodeName))
-                                            {
-                                                Diag(DiagnosticDescriptors.ArgumentHasNoCorrespondingTemplate, paramSymbol.Locations[0], paramName);
-                                            }
-                                            else if (lp.IsTemplateParameter && !lm.TemplateMap.ContainsKey(paramName) && !lm.TemplateMap.ContainsKey($"@{paramName}") && !lm.TemplateMap.ContainsKey(lp.CodeName))
-                                            {
-                                                Diag(DiagnosticDescriptors.ArgumentHasNoCorrespondingTemplate, paramSymbol.Locations[0], paramName);
-                                            }
-
-                                            if (paramName[0] == '_')
-                                            {
-                                                // can't have logging method parameter names that start with _ since that can lead to conflicting symbol names
-                                                // because all generated symbols start with _
-                                                Diag(DiagnosticDescriptors.InvalidLoggingMethodParameterName, paramSymbol.Locations[0]);
-                                            }
-
-                                            lm.AllParameters.Add(lp);
-                                            if (lp.IsTemplateParameter || forceAsTemplateParams)
-                                            {
-                                                lm.TemplateParameters.Add(lp);
-                                            }
-                                        }
-
-                                        if (keepMethod)
-                                        {
-                                            if (isStatic && !foundLogger)
-                                            {
-                                                Diag(DiagnosticDescriptors.MissingLoggerArgument, method.GetLocation(), lm.Name);
+                                                Diag(DiagnosticDescriptors.MultipleLoggerFields, method.GetLocation(), classDec.Identifier.Text);
                                                 keepMethod = false;
                                             }
-                                            else if (!isStatic && foundLogger)
+                                            else if (loggerField == null)
                                             {
-                                                Diag(DiagnosticDescriptors.LoggingMethodShouldBeStatic, method.GetLocation());
-                                            }
-                                            else if (!isStatic && !foundLogger)
-                                            {
-                                                if (loggerField == null)
-                                                {
-                                                    (loggerField, multipleLoggerFields) = FindLoggerField(sm, classDec, loggerSymbol);
-                                                }
-
-                                                if (multipleLoggerFields)
-                                                {
-                                                    Diag(DiagnosticDescriptors.MultipleLoggerFields, method.GetLocation(), classDec.Identifier.Text);
-                                                    keepMethod = false;
-                                                }
-                                                else if (loggerField == null)
-                                                {
-                                                    Diag(DiagnosticDescriptors.MissingLoggerField, method.GetLocation(), classDec.Identifier.Text);
-                                                    keepMethod = false;
-                                                }
-                                                else
-                                                {
-                                                    lm.LoggerField = loggerField;
-                                                }
-                                            }
-
-                                            if (level == null && !foundLogLevel)
-                                            {
-                                                Diag(DiagnosticDescriptors.MissingLogLevel, method.GetLocation());
+                                                Diag(DiagnosticDescriptors.MissingLoggerField, method.GetLocation(), classDec.Identifier.Text);
                                                 keepMethod = false;
                                             }
-
-                                            foreach (KeyValuePair<string, string> t in lm.TemplateMap)
+                                            else
                                             {
-                                                bool found = false;
-                                                foreach (LoggerParameter p in lm.AllParameters)
-                                                {
-                                                    if (t.Key.Equals(p.Name, StringComparison.OrdinalIgnoreCase) ||
-                                                        t.Key.Equals(p.CodeName, StringComparison.OrdinalIgnoreCase) ||
-                                                        t.Key[0] == '@' && t.Key.Substring(1).Equals(p.CodeName, StringComparison.OrdinalIgnoreCase))
-                                                    {
-                                                        found = true;
-                                                        break;
-                                                    }
-                                                }
-
-                                                if (!found)
-                                                {
-                                                    Diag(DiagnosticDescriptors.TemplateHasNoCorrespondingArgument, ma.GetLocation(), t.Key);
-                                                }
+                                                lm.LoggerField = loggerField;
                                             }
                                         }
 
-                                        if (lc == null)
+                                        if (level == null && !foundLogLevel)
                                         {
-                                            // determine the namespace the class is declared in, if any
-                                            SyntaxNode? potentialNamespaceParent = classDec.Parent;
-                                            while (potentialNamespaceParent != null &&
-                                                   potentialNamespaceParent is not NamespaceDeclarationSyntax
+                                            Diag(DiagnosticDescriptors.MissingLogLevel, method.GetLocation());
+                                            keepMethod = false;
+                                        }
+
+                                        foreach (KeyValuePair<string, string> t in lm.TemplateMap)
+                                        {
+                                            bool found = false;
+                                            foreach (LoggerParameter p in lm.AllParameters)
+                                            {
+                                                if (t.Key.Equals(p.Name, StringComparison.OrdinalIgnoreCase) ||
+                                                    t.Key.Equals(p.CodeName, StringComparison.OrdinalIgnoreCase) ||
+                                                    t.Key[0] == '@' && t.Key.Substring(1).Equals(p.CodeName, StringComparison.OrdinalIgnoreCase))
+                                                {
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+
+                                            if (!found)
+                                            {
+                                                Diag(DiagnosticDescriptors.TemplateHasNoCorrespondingArgument, ma.GetLocation(), t.Key);
+                                            }
+                                        }
+                                    }
+
+                                    if (lc == null)
+                                    {
+                                        // determine the namespace the class is declared in, if any
+                                        SyntaxNode? potentialNamespaceParent = classDec.Parent;
+                                        while (potentialNamespaceParent != null &&
+                                               potentialNamespaceParent is not NamespaceDeclarationSyntax
 #if ROSLYN4_0_OR_GREATER
-                                                   && potentialNamespaceParent is not FileScopedNamespaceDeclarationSyntax
+                                               && potentialNamespaceParent is not FileScopedNamespaceDeclarationSyntax
 #endif
-                                                   )
-                                            {
-                                                potentialNamespaceParent = potentialNamespaceParent.Parent;
-                                            }
+                                               )
+                                        {
+                                            potentialNamespaceParent = potentialNamespaceParent.Parent;
+                                        }
 
 #if ROSLYN4_0_OR_GREATER
-                                            if (potentialNamespaceParent is BaseNamespaceDeclarationSyntax namespaceParent)
+                                        if (potentialNamespaceParent is BaseNamespaceDeclarationSyntax namespaceParent)
 #else
                                             if (potentialNamespaceParent is NamespaceDeclarationSyntax namespaceParent)
 #endif
+                                        {
+                                            nspace = namespaceParent.Name.ToString();
+                                            while (true)
                                             {
-                                                nspace = namespaceParent.Name.ToString();
-                                                while (true)
+                                                namespaceParent = namespaceParent.Parent as NamespaceDeclarationSyntax;
+                                                if (namespaceParent == null)
                                                 {
-                                                    namespaceParent = namespaceParent.Parent as NamespaceDeclarationSyntax;
-                                                    if (namespaceParent == null)
-                                                    {
-                                                        break;
-                                                    }
-
-                                                    nspace = $"{namespaceParent.Name}.{nspace}";
+                                                    break;
                                                 }
+
+                                                nspace = $"{namespaceParent.Name}.{nspace}";
                                             }
                                         }
+                                    }
 
-                                        if (keepMethod)
+                                    if (keepMethod)
+                                    {
+                                        lc ??= new LoggerClass
                                         {
-                                            lc ??= new LoggerClass
+                                            Keyword = classDec.Keyword.ValueText,
+                                            Namespace = nspace,
+                                            Name = classDec.Identifier.ToString() + classDec.TypeParameterList,
+                                            ParentClass = null,
+                                        };
+
+                                        LoggerClass currentLoggerClass = lc;
+                                        var parentLoggerClass = (classDec.Parent as TypeDeclarationSyntax);
+
+                                        static bool IsAllowedKind(SyntaxKind kind) =>
+                                            kind == SyntaxKind.ClassDeclaration ||
+                                            kind == SyntaxKind.StructDeclaration ||
+                                            kind == SyntaxKind.RecordDeclaration;
+
+                                        while (parentLoggerClass != null && IsAllowedKind(parentLoggerClass.Kind()))
+                                        {
+                                            currentLoggerClass.ParentClass = new LoggerClass
                                             {
-                                                Keyword = classDec.Keyword.ValueText,
+                                                Keyword = parentLoggerClass.Keyword.ValueText,
                                                 Namespace = nspace,
-                                                Name = classDec.Identifier.ToString() + classDec.TypeParameterList,
+                                                Name = parentLoggerClass.Identifier.ToString() + parentLoggerClass.TypeParameterList,
                                                 ParentClass = null,
                                             };
 
-                                            LoggerClass currentLoggerClass = lc;
-                                            var parentLoggerClass = (classDec.Parent as TypeDeclarationSyntax);
-
-                                            static bool IsAllowedKind(SyntaxKind kind) =>
-                                                kind == SyntaxKind.ClassDeclaration ||
-                                                kind == SyntaxKind.StructDeclaration ||
-                                                kind == SyntaxKind.RecordDeclaration;
-
-                                            while (parentLoggerClass != null && IsAllowedKind(parentLoggerClass.Kind()))
-                                            {
-                                                currentLoggerClass.ParentClass = new LoggerClass
-                                                {
-                                                    Keyword = parentLoggerClass.Keyword.ValueText,
-                                                    Namespace = nspace,
-                                                    Name = parentLoggerClass.Identifier.ToString() + parentLoggerClass.TypeParameterList,
-                                                    ParentClass = null,
-                                                };
-
-                                                currentLoggerClass = currentLoggerClass.ParentClass;
-                                                parentLoggerClass = (parentLoggerClass.Parent as TypeDeclarationSyntax);
-                                            }
-
-                                            lc.Methods.Add(lm);
+                                            currentLoggerClass = currentLoggerClass.ParentClass;
+                                            parentLoggerClass = (parentLoggerClass.Parent as TypeDeclarationSyntax);
                                         }
+
+                                        lc.Methods.Add(lm);
+                                    }
                                 }
                             }
                         }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -188,8 +188,6 @@ namespace Microsoft.Extensions.Logging.Generators
                                         break;
                                     }
 
-                                    if (logMethodSymbol != null)
-                                    {
                                         var lm = new LoggerMethod
                                         {
                                             Name = logMethodSymbol.Name,
@@ -502,7 +500,6 @@ namespace Microsoft.Extensions.Logging.Generators
 
                                             lc.Methods.Add(lm);
                                         }
-                                    }
                                 }
                             }
                         }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Logging.Generators
                             }
 
                             sm ??= _compilation.GetSemanticModel(classDec.SyntaxTree);
-                            IMethodSymbol logMethodSymbol = sm.GetDeclaredSymbol(method, _cancellationToken) as IMethodSymbol;
+                            IMethodSymbol? logMethodSymbol = sm.GetDeclaredSymbol(method, _cancellationToken);
                             Debug.Assert(logMethodSymbol != null, "log method is present.");
                             (int eventId, int? level, string message, string? eventName, bool skipEnabledCheck) = (-1, null, string.Empty, null, false);
 
@@ -188,17 +188,16 @@ namespace Microsoft.Extensions.Logging.Generators
                                         break;
                                     }
 
-                                    IMethodSymbol? methodSymbol = sm.GetDeclaredSymbol(method, _cancellationToken);
-                                    if (methodSymbol != null)
+                                    if (logMethodSymbol != null)
                                     {
                                         var lm = new LoggerMethod
                                         {
-                                            Name = methodSymbol.Name,
+                                            Name = logMethodSymbol.Name,
                                             Level = level,
                                             Message = message,
                                             EventId = eventId,
                                             EventName = eventName,
-                                            IsExtensionMethod = methodSymbol.IsExtensionMethod,
+                                            IsExtensionMethod = logMethodSymbol.IsExtensionMethod,
                                             Modifiers = method.Modifiers.ToString(),
                                             SkipEnabledCheck = skipEnabledCheck
                                         };
@@ -214,7 +213,7 @@ namespace Microsoft.Extensions.Logging.Generators
                                             keepMethod = false;
                                         }
 
-                                        if (!methodSymbol.ReturnsVoid)
+                                        if (!logMethodSymbol.ReturnsVoid)
                                         {
                                             // logging methods must return void
                                             Diag(DiagnosticDescriptors.LoggingMethodMustReturnVoid, method.ReturnType.GetLocation());
@@ -279,7 +278,7 @@ namespace Microsoft.Extensions.Logging.Generators
                                         bool foundLogger = false;
                                         bool foundException = false;
                                         bool foundLogLevel = level != null;
-                                        foreach (IParameterSymbol paramSymbol in methodSymbol.Parameters)
+                                        foreach (IParameterSymbol paramSymbol in logMethodSymbol.Parameters)
                                         {
                                             string paramName = paramSymbol.Name;
                                             bool needsAtSign = false;


### PR DESCRIPTION
The same logging method symbol was being retrieved twice in the logging source generator Parser.