### PR TITLE
AOT: Handle printing names of generic parameter types

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/JitTypeNameFormatter.cs
+++ b/src/coreclr/tools/Common/JitInterface/JitTypeNameFormatter.cs
@@ -25,7 +25,9 @@ namespace Internal.JitInterface
 
         public override void AppendName(StringBuilder sb, GenericParameterDesc type)
         {
-            Debug.Fail("Unexpected generic parameter type in JitTypeNameFormatter");
+            string prefix = type.Kind == GenericParameterKind.Type ? "!" : "!!";
+            sb.Append(prefix);
+            sb.Append(type.Name);
         }
 
         public override void AppendName(StringBuilder sb, SignatureTypeVariable type)


### PR DESCRIPTION
This case is hittable with tokens representing open generic types that may have their full type names printed as a comment in JIT disasm after e398ba2.