### PR TITLE
Use CompressionLevel.SmallestSize in Bundler

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -101,7 +101,8 @@ namespace Microsoft.NET.HostModel.Bundle
 
                 // We use DeflateStream here.
                 // It uses GZip algorithm, but with a trivial header that does not contain file info.
-                using (DeflateStream compressionStream = new DeflateStream(bundle, CompressionLevel.Optimal, leaveOpen: true))
+                CompressionLevel smallestSize = (CompressionLevel)3;
+                using (DeflateStream compressionStream = new DeflateStream(bundle, Enum.IsDefined(typeof(CompressionLevel), smallestSize) ? smallestSize : CompressionLevel.Optimal, leaveOpen: true))
                 {
                     file.CopyTo(compressionStream);
                 }


### PR DESCRIPTION
Microsoft.NET.HostModel's GenerateBundle currently implements compression via a DeflateStream set to use CompressionLevel.Optimal, which represents a balance between compression speed and ratio.  This changes it to use CompressionLevel.SmallestSize if that value is defined.  This makes bundling take longer, but also removes a bit of the size.  Building the default web app template for Windows, this shaves ~200K off the resulting bundle but also increases publish time by ~3.5 seconds on my machine. I'm not sure if it's worth it, but putting it up just in case folks want to take it; otherwise, please feel free to close.

cc: @eerhardt 