### PR TITLE
Implement new `ComWrappers` APIs

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -39,11 +39,11 @@ namespace System.Runtime.InteropServices
         /// understand the COM object may have apartment affinity and therefore if the current thread is not
         /// in the correct apartment or the COM object is not a proxy this call may fail.
         /// </remarks>
-        public static unsafe bool TryGetComInstance(object obj, out void* unknown)
+        public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown)
         {
             if (obj == null)
             {
-                unknown = null;
+                unknown = IntPtr.Zero;
                 return false;
             }
 
@@ -52,7 +52,7 @@ namespace System.Runtime.InteropServices
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetComInstance")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static partial bool TryGetComInstanceInternal(ObjectHandleOnStack wrapperMaybe, out void* externalComObject);
+        private static partial bool TryGetComInstanceInternal(ObjectHandleOnStack wrapperMaybe, out IntPtr externalComObject);
 
         /// <summary>
         /// Given a COM object, determine if it is a ComWrappers created
@@ -61,10 +61,10 @@ namespace System.Runtime.InteropServices
         /// <param name="unknown">An unmanaged wrapper</param>
         /// <param name="obj">A managed object</param>
         /// <returns>True if the wrapper was resolved to a managed object, otherwise false.</returns>
-        public static unsafe bool TryGetObject(void* unknown, [NotNullWhen(true)] out object? obj)
+        public static unsafe bool TryGetObject(IntPtr unknown, [NotNullWhen(true)] out object? obj)
         {
             obj = null;
-            if (unknown == null)
+            if (unknown == IntPtr.Zero)
             {
                 return false;
             }
@@ -74,7 +74,7 @@ namespace System.Runtime.InteropServices
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetObject")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static partial bool TryGetObjectInternal(void* wrapperMaybe, ObjectHandleOnStack instance);
+        private static partial bool TryGetObjectInternal(IntPtr wrapperMaybe, ObjectHandleOnStack instance);
 
         /// <summary>
         /// ABI for function dispatch of a COM interface.

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -26,7 +26,7 @@ namespace System.Runtime.InteropServices
     public abstract partial class ComWrappers
     {
         /// <summary>
-        /// Given a managed object, determine if it is a ComWrappers created
+        /// Given a managed object, determine if it is a <see cref="ComWrappers" />-created
         /// managed wrapper and if so, return the wrapped unmanaged pointer.
         /// </summary>
         /// <param name="obj">A managed wrapper</param>
@@ -34,10 +34,10 @@ namespace System.Runtime.InteropServices
         /// <returns>True if the wrapper was resolved to an external COM object, otherwise false.</returns>
         /// <remarks>
         /// If a COM object is returned, the caller is expected to call Release() on the object.
-        /// This can be done through an API like Marshal.Release(). Since this API is required to interact
-        /// directly with the external COM object, QueryInterface(), it is important for the caller to
-        /// understand the COM object may have apartment affinity and therefore if the current thread is not
-        /// in the correct apartment or the COM object is not a proxy this call may fail.
+        /// This can be done through an API like <see cref="Marshal.Release(IntPtr)"/>.
+        /// Since this API is required to interact directly with the external COM object, QueryInterface(),
+        /// it is important for the caller to understand the COM object may have apartment affinity and therefore
+        /// if the current thread is not in the correct apartment or the COM object is not a proxy this call may fail.
         /// </remarks>
         public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown)
         {
@@ -55,7 +55,7 @@ namespace System.Runtime.InteropServices
         private static partial bool TryGetComInstanceInternal(ObjectHandleOnStack wrapperMaybe, out IntPtr externalComObject);
 
         /// <summary>
-        /// Given a COM object, determine if it is a ComWrappers created
+        /// Given a COM object, determine if it is a <see cref="ComWrappers" />-created
         /// unmanaged wrapper and if so, return the wrapped managed object.
         /// </summary>
         /// <param name="unknown">An unmanaged wrapper</param>

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.InteropServices
     /// <summary>
     /// Class for managing wrappers of COM IUnknown types.
     /// </summary>
-    public abstract unsafe partial class ComWrappers
+    public abstract partial class ComWrappers
     {
         /// <summary>
         /// Given a managed object, determine if it is a ComWrappers created

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
@@ -60,7 +61,7 @@ namespace System.Runtime.InteropServices
         /// <param name="unknown">An unmanaged wrapper</param>
         /// <param name="obj">A managed object</param>
         /// <returns>True if the wrapper was resolved to a managed object, otherwise false.</returns>
-        public static unsafe bool TryGetObject(void* unknown, out object? obj)
+        public static unsafe bool TryGetObject(void* unknown, [NotNullWhen(true)] out object? obj)
         {
             obj = null;
             if (unknown == null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -28,8 +28,8 @@ namespace System.Runtime.InteropServices
         /// Given a managed object, determine if it is a ComWrappers created
         /// managed wrapper and if so, return the wrapped unmanaged pointer.
         /// </summary>
-        /// <param name="wrapperMaybe">A managed wrapper</param>
-        /// <param name="externalComObject">An unmanaged COM object</param>
+        /// <param name="obj">A managed wrapper</param>
+        /// <param name="unknown">An unmanaged COM object</param>
         /// <returns>True if the wrapper was resolved to an external COM object, otherwise false.</returns>
         /// <remarks>
         /// If a COM object is returned, the caller is expected to call Release() on the object.
@@ -38,15 +38,15 @@ namespace System.Runtime.InteropServices
         /// understand the COM object may have apartment affinity and therefore if the current thread is not
         /// in the correct apartment or the COM object is not a proxy this call may fail.
         /// </remarks>
-        public static unsafe bool TryGetComInstance(object wrapperMaybe, out void* externalComObject)
+        public static unsafe bool TryGetComInstance(object obj, out void* unknown)
         {
-            if (wrapperMaybe == null)
+            if (obj == null)
             {
-                externalComObject = null;
+                unknown = null;
                 return false;
             }
 
-            return TryGetComInstanceInternal(ObjectHandleOnStack.Create(ref wrapperMaybe), out externalComObject);
+            return TryGetComInstanceInternal(ObjectHandleOnStack.Create(ref obj), out unknown);
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetComInstance")]
@@ -57,18 +57,18 @@ namespace System.Runtime.InteropServices
         /// Given a COM object, determine if it is a ComWrappers created
         /// unmanaged wrapper and if so, return the wrapped managed object.
         /// </summary>
-        /// <param name="wrapperMaybe"></param>
-        /// <param name="instance"></param>
+        /// <param name="unknown">An unmanaged wrapper</param>
+        /// <param name="obj">A managed object</param>
         /// <returns>True if the wrapper was resolved to a managed object, otherwise false.</returns>
-        public static unsafe bool TryGetObject(void* wrapperMaybe, out object? instance)
+        public static unsafe bool TryGetObject(void* unknown, out object? obj)
         {
-            instance = null;
-            if (wrapperMaybe == null)
+            obj = null;
+            if (unknown == null)
             {
                 return false;
             }
 
-            return TryGetObjectInternal(wrapperMaybe, ObjectHandleOnStack.Create(ref instance));
+            return TryGetObjectInternal(unknown, ObjectHandleOnStack.Create(ref obj));
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetObject")]
@@ -375,7 +375,7 @@ namespace System.Runtime.InteropServices
         /// <param name="fpQueryInterface">Function pointer to QueryInterface.</param>
         /// <param name="fpAddRef">Function pointer to AddRef.</param>
         /// <param name="fpRelease">Function pointer to Release.</param>
-        protected static void GetIUnknownImpl(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease)
+        public static void GetIUnknownImpl(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease)
             => GetIUnknownImplInternal(out fpQueryInterface, out fpAddRef, out fpRelease);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_GetIUnknownImpl")]

--- a/src/coreclr/interop/comwrappers.cpp
+++ b/src/coreclr/interop/comwrappers.cpp
@@ -340,6 +340,8 @@ namespace
 
 namespace
 {
+    // This IID represents an internal interface we define to tag any ManagedObjectWrappers we create.
+    // This interface type and GUID do not correspond to any public interface; it is an internal implementation detail.
     // 5c13e51c-4f32-4726-a3fd-f3edd63da3a0
     const GUID IID_TaggedImpl = { 0x5c13e51c, 0x4f32, 0x4726, { 0xa3, 0xfd, 0xf3, 0xed, 0xd6, 0x3d, 0xa3, 0xa0 } };
 

--- a/src/coreclr/interop/comwrappers.cpp
+++ b/src/coreclr/interop/comwrappers.cpp
@@ -403,7 +403,7 @@ ManagedObjectWrapper* ManagedObjectWrapper::MapFromIUnknown(_In_ IUnknown* pUnk)
         // handled by the DAC logic and that is by-design.
         ComHolder<ITaggedImpl> implMaybe;
         if (S_OK != pUnk->QueryInterface(IID_TaggedImpl, (void**)&implMaybe)
-            || S_OK != implMaybe->IsCurrentVersion(&ITaggedImpl_IsCurrentVersion))
+            || S_OK != implMaybe->IsCurrentVersion((void*)&ITaggedImpl_IsCurrentVersion))
         {
             return nullptr;
         }

--- a/src/coreclr/interop/comwrappers.cpp
+++ b/src/coreclr/interop/comwrappers.cpp
@@ -377,7 +377,7 @@ ManagedObjectWrapper* ManagedObjectWrapper::MapFromIUnknown(_In_ IUnknown* pUnk)
 {
     _ASSERTE(pUnk != nullptr);
 
-    // If the first Vtable entry is part of the ManagedObjectWrapper IUnknown impl,
+    // If the first Vtable entry is part of a ManagedObjectWrapper impl,
     // we know how to interpret the IUnknown.
     void** vtable = *reinterpret_cast<void***>(pUnk);
     if (*vtable != ManagedObjectWrapper_IUnknownImpl.QueryInterface

--- a/src/coreclr/interop/comwrappers.hpp
+++ b/src/coreclr/interop/comwrappers.hpp
@@ -76,6 +76,13 @@ public: // static
     // into a ManagedObjectWrapper, otherwise null.
     static ManagedObjectWrapper* MapFromIUnknown(_In_ IUnknown* pUnk);
 
+    // Convert the IUnknown if the instance is a ManagedObjectWrapper
+    // into a ManagedObjectWrapper, otherwise null. This API provides
+    // a stronger guarantee than MapFromIUnknown(), but does so by
+    // performing a QueryInterface() which may not always be possible.
+    // See implementation for more details.
+    static ManagedObjectWrapper* MapFromIUnknownWithQueryInterface(_In_ IUnknown* pUnk);
+
     // Create a ManagedObjectWrapper instance
     static HRESULT Create(
         _In_ InteropLib::Com::CreateComInterfaceFlags flags,

--- a/src/coreclr/interop/interoplib.cpp
+++ b/src/coreclr/interop/interoplib.cpp
@@ -46,7 +46,7 @@ namespace InteropLib
 
         void DestroyWrapperForObject(_In_ void* wrapperMaybe) noexcept
         {
-            ManagedObjectWrapper* wrapper = ManagedObjectWrapper::MapFromIUnknown(static_cast<IUnknown*>(wrapperMaybe));
+            ManagedObjectWrapper* wrapper = ManagedObjectWrapper::MapFromIUnknownWithQueryInterface(static_cast<IUnknown*>(wrapperMaybe));
 
             // A caller should not be destroying a wrapper without knowing if the wrapper is valid.
             _ASSERTE(wrapper != nullptr);

--- a/src/coreclr/interop/interoplib.cpp
+++ b/src/coreclr/interop/interoplib.cpp
@@ -69,7 +69,7 @@ namespace InteropLib
             *object = nullptr;
 
             // Attempt to get the managed object wrapper.
-            ManagedObjectWrapper *mow = ManagedObjectWrapper::MapFromIUnknown(wrapper);
+            ManagedObjectWrapper *mow = ManagedObjectWrapper::MapFromIUnknownWithQueryInterface(wrapper);
             if (mow == nullptr)
                 return E_INVALIDARG;
 
@@ -79,7 +79,7 @@ namespace InteropLib
 
         HRESULT MarkComActivated(_In_ IUnknown* wrapperMaybe) noexcept
         {
-            ManagedObjectWrapper* wrapper = ManagedObjectWrapper::MapFromIUnknown(wrapperMaybe);
+            ManagedObjectWrapper* wrapper = ManagedObjectWrapper::MapFromIUnknownWithQueryInterface(wrapperMaybe);
             if (wrapper == nullptr)
                 return E_INVALIDARG;
 
@@ -89,7 +89,7 @@ namespace InteropLib
 
         HRESULT IsComActivated(_In_ IUnknown* wrapperMaybe) noexcept
         {
-            ManagedObjectWrapper* wrapper = ManagedObjectWrapper::MapFromIUnknown(wrapperMaybe);
+            ManagedObjectWrapper* wrapper = ManagedObjectWrapper::MapFromIUnknownWithQueryInterface(wrapperMaybe);
             if (wrapper == nullptr)
                 return E_INVALIDARG;
 
@@ -162,7 +162,7 @@ namespace InteropLib
 
             result->Context = wrapperContext->GetRuntimeContext();
             result->FromTrackerRuntime = (wrapperContext->GetReferenceTracker() != nullptr);
-            result->ManagedObjectWrapper = (ManagedObjectWrapper::MapFromIUnknown(external) != nullptr);
+            result->ManagedObjectWrapper = (ManagedObjectWrapper::MapFromIUnknownWithQueryInterface(external) != nullptr);
             return S_OK;
         }
 

--- a/src/coreclr/interop/referencetrackertypes.hpp
+++ b/src/coreclr/interop/referencetrackertypes.hpp
@@ -9,7 +9,7 @@
 // Documentation found at https://docs.microsoft.com/windows/win32/api/windows.ui.xaml.hosting.referencetracker/
 
 // 64bd43f8-bfee-4ec4-b7eb-2935158dae21
-const GUID IID_IReferenceTrackerTarget = { 0x64bd43f8, 0xbfee, 0x4ec4, { 0xb7, 0xeb, 0x29, 0x35, 0x15, 0x8d, 0xae, 0x21} };
+const GUID IID_IReferenceTrackerTarget = { 0x64bd43f8, 0xbfee, 0x4ec4, { 0xb7, 0xeb, 0x29, 0x35, 0x15, 0x8d, 0xae, 0x21 } };
 
 class DECLSPEC_UUID("64bd43f8-bfee-4ec4-b7eb-2935158dae21") IReferenceTrackerTarget : public IUnknown
 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -35,6 +35,16 @@ namespace System.Runtime.InteropServices
         private readonly Dictionary<IntPtr, GCHandle> _rcwCache = new Dictionary<IntPtr, GCHandle>();
         private readonly ConditionalWeakTable<object, NativeObjectWrapper> _rcwTable = new ConditionalWeakTable<object, NativeObjectWrapper>();
 
+        public static unsafe bool TryGetComInstance(object wrapperMaybe, out void* externalComObject)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static unsafe bool TryGetObject(void* wrapperMaybe, out object? instance)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         /// <summary>
         /// ABI for function dispatch of a COM interface.
         /// </summary>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -37,29 +37,28 @@ namespace System.Runtime.InteropServices
         private readonly Lock _lock = new Lock();
         private readonly Dictionary<IntPtr, GCHandle> _rcwCache = new Dictionary<IntPtr, GCHandle>();
 
-        public static unsafe bool TryGetComInstance(object obj, out void* unknown)
+        public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown)
         {
-            unknown = null;
+            unknown = IntPtr.Zero;
             if (obj == null
                 || !s_rcwTable.TryGetValue(obj, out NativeObjectWrapper? wrapper))
             {
                 return false;
             }
 
-            Marshal.QueryInterface(wrapper._externalComObject, ref IID_IUnknown, out nint pUnk);
-            unknown = (void*)pUnk;
+            Marshal.QueryInterface(wrapper._externalComObject, ref IID_IUnknown, out unknown);
             return true;
         }
 
-        public static unsafe bool TryGetObject(void* unknown, [NotNullWhen(true)] out object? obj)
+        public static unsafe bool TryGetObject(IntPtr unknown, [NotNullWhen(true)] out object? obj)
         {
             obj = null;
-            if (unknown == null)
+            if (unknown == IntPtr.Zero)
             {
                 return false;
             }
 
-            ComInterfaceDispatch* comInterfaceDispatch = TryGetComInterfaceDispatch((nint)unknown);
+            ComInterfaceDispatch* comInterfaceDispatch = TryGetComInterfaceDispatch(unknown);
             if (comInterfaceDispatch == null)
             {
                 return false;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Threading;
@@ -50,7 +51,7 @@ namespace System.Runtime.InteropServices
             return true;
         }
 
-        public static unsafe bool TryGetObject(void* unknown, out object? obj)
+        public static unsafe bool TryGetObject(void* unknown, [NotNullWhen(true)] out object? obj)
         {
             obj = null;
             if (unknown == null)

--- a/src/coreclr/vm/interoplibinterface.h
+++ b/src/coreclr/vm/interoplibinterface.h
@@ -48,6 +48,14 @@ extern "C" void QCALLTYPE ComWrappers_GetIUnknownImpl(
     _Out_ void** fpAddRef,
     _Out_ void** fpRelease);
 
+extern "C" BOOL QCALLTYPE ComWrappers_TryGetComInstance(
+    _In_ QCall::ObjectHandleOnStack wrapperMaybe,
+    _Out_ void** externalComObject);
+
+extern "C" BOOL QCALLTYPE ComWrappers_TryGetObject(
+    _In_ void* wrapperMaybe,
+    _Inout_ QCall::ObjectHandleOnStack instance);
+
 extern "C" BOOL QCALLTYPE ComWrappers_TryGetOrCreateComInterfaceForObject(
     _In_ QCall::ObjectHandleOnStack comWrappersImpl,
     _In_ INT64 wrapperId,
@@ -63,6 +71,7 @@ extern "C" BOOL QCALLTYPE ComWrappers_TryGetOrCreateObjectForComInstance(
     _In_ INT32 flags,
     _In_ QCall::ObjectHandleOnStack wrapperMaybe,
     _Inout_ QCall::ObjectHandleOnStack retValue);
+
 // Native QCall for the ComWrappers managed type to indicate a global instance
 // is registered for marshalling. This should be set if the private static member
 // representing the global instance for marshalling on ComWrappers is non-null.

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -1579,7 +1579,7 @@ extern "C" BOOL QCALLTYPE ComWrappers_TryGetObject(
     _ASSERTE(hr == S_OK);
 
     InteropLib::OBJECTHANDLE handle;
-    if (InteropLib::Com::GetObjectForWrapper(identity, &handle) ==  S_OK)
+    if (InteropLib::Com::GetObjectForWrapper(identity, &handle) == S_OK)
     {
         // Switch to Cooperative mode since object references
         // are being manipulated.

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -822,16 +822,32 @@ namespace
         bool uniqueInstance = !!(flags & CreateObjectFlags::CreateObjectFlags_UniqueInstance);
         if (!uniqueInstance)
         {
-            // Query the external object cache
-            ExtObjCxtCache::LockHolder lock(cache);
-            extObjCxt = cache->Find(cacheKey);
+            bool objectFound = false;
+            {
+                // Query the external object cache
+                ExtObjCxtCache::LockHolder lock(cache);
+                extObjCxt = cache->Find(cacheKey);
+
+                objectFound = extObjCxt != NULL;
+                if (objectFound && extObjCxt->IsSet(ExternalObjectContext::Flags_Detached))
+                {
+                    // If an EOC has been found but is marked detached, then we will remove it from the
+                    // cache here instead of letting the GC do it later and pretend like it wasn't found.
+                    STRESS_LOG1(LF_INTEROP, LL_INFO10, "Detached EOC requested: 0x%p\n", extObjCxt);
+                    cache->Remove(extObjCxt);
+                    extObjCxt->MarkNotInCache();
+                    extObjCxt = NULL;
+                }
+            }
 
             // If is no object found in the cache, check if the object COM instance is actually the CCW
             // representing a managed object. If the user passed the Unwrap flag, COM instances that are
             // actually CCWs should be unwrapped to the original managed object to allow for round
             // tripping object -> COM instance -> object.
-            if (extObjCxt == NULL && (flags & CreateObjectFlags::CreateObjectFlags_Unwrap))
+            if (!objectFound && (flags & CreateObjectFlags::CreateObjectFlags_Unwrap))
             {
+                GCX_PREEMP();
+
                 // If the COM instance is a CCW that is not COM-activated, use the object of that wrapper object.
                 InteropLib::OBJECTHANDLE handleLocal;
                 if (InteropLib::Com::GetObjectForWrapper(identity, &handleLocal) ==  S_OK
@@ -839,15 +855,6 @@ namespace
                 {
                     handle = handleLocal;
                 }
-            }
-            else if (extObjCxt != NULL && extObjCxt->IsSet(ExternalObjectContext::Flags_Detached))
-            {
-                // If an EOC has been found but is marked detached, then we will remove it from the
-                // cache here instead of letting the GC do it later and pretend like it wasn't found.
-                STRESS_LOG1(LF_INTEROP, LL_INFO10, "Detached EOC requested: 0x%p\n", extObjCxt);
-                cache->Remove(extObjCxt);
-                extObjCxt->MarkNotInCache();
-                extObjCxt = NULL;
             }
         }
 
@@ -1670,15 +1677,19 @@ void ComWrappersNative::MarkWrapperAsComActivated(_In_ IUnknown* wrapperMaybe)
 {
     CONTRACTL
     {
-        NOTHROW;
-        MODE_ANY;
+        THROWS;
+        GC_TRIGGERS;
+        MODE_COOPERATIVE;
         PRECONDITION(wrapperMaybe != NULL);
     }
     CONTRACTL_END;
 
-    // The IUnknown may or may not represent a wrapper, so E_INVALIDARG is okay here.
-    HRESULT hr = InteropLib::Com::MarkComActivated(wrapperMaybe);
-    _ASSERTE(SUCCEEDED(hr) || hr == E_INVALIDARG);
+    {
+        GCX_PREEMP();
+        // The IUnknown may or may not represent a wrapper, so E_INVALIDARG is okay here.
+        HRESULT hr = InteropLib::Com::MarkComActivated(wrapperMaybe);
+        _ASSERTE(SUCCEEDED(hr) || hr == E_INVALIDARG);
+    }
 }
 
 extern "C" void QCALLTYPE ComWrappers_SetGlobalInstanceRegisteredForMarshalling(INT64 id)

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -1573,8 +1573,13 @@ extern "C" BOOL QCALLTYPE ComWrappers_TryGetObject(
 
     BEGIN_QCALL;
 
+    // Determine the true identity of the object
+    SafeComHolder<IUnknown> identity;
+    HRESULT hr = ((IUnknown*)wrapperMaybe)->QueryInterface(IID_IUnknown, &identity);
+    _ASSERTE(hr == S_OK);
+
     InteropLib::OBJECTHANDLE handle;
-    if (InteropLib::Com::GetObjectForWrapper((IUnknown*)wrapperMaybe, &handle) ==  S_OK)
+    if (InteropLib::Com::GetObjectForWrapper(identity, &handle) ==  S_OK)
     {
         // Switch to Cooperative mode since object references
         // are being manipulated.

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -254,6 +254,8 @@ static const Entry s_QCall[] =
     DllImportEntry(ReflectionSerialization_GetUninitializedObject)
 #if defined(FEATURE_COMWRAPPERS)
     DllImportEntry(ComWrappers_GetIUnknownImpl)
+    DllImportEntry(ComWrappers_TryGetComInstance)
+    DllImportEntry(ComWrappers_TryGetObject)
     DllImportEntry(ComWrappers_TryGetOrCreateComInterfaceForObject)
     DllImportEntry(ComWrappers_TryGetOrCreateObjectForComInstance)
     DllImportEntry(ComWrappers_SetGlobalInstanceRegisteredForMarshalling)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
@@ -8,6 +8,16 @@ namespace System.Runtime.InteropServices
 {
     public abstract partial class ComWrappers
     {
+        public static unsafe bool TryGetComInstance(object wrapperMaybe, out void* externalComObject)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static unsafe bool TryGetObject(void* wrapperMaybe, out object? instance)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public partial struct ComInterfaceDispatch
         {
             public static unsafe T GetInstance<T>(ComInterfaceDispatch* dispatchPtr) where T : class

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 
 namespace System.Runtime.InteropServices
@@ -13,7 +14,7 @@ namespace System.Runtime.InteropServices
             throw new PlatformNotSupportedException();
         }
 
-        public static unsafe bool TryGetObject(void* unknown, out object? obj)
+        public static unsafe bool TryGetObject(void* unknown, [NotNullWhen(true)] out object? obj)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
@@ -9,12 +9,12 @@ namespace System.Runtime.InteropServices
 {
     public abstract partial class ComWrappers
     {
-        public static unsafe bool TryGetComInstance(object obj, out void* unknown)
+        public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown)
         {
             throw new PlatformNotSupportedException();
         }
 
-        public static unsafe bool TryGetObject(void* unknown, [NotNullWhen(true)] out object? obj)
+        public static unsafe bool TryGetObject(IntPtr unknown, [NotNullWhen(true)] out object? obj)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
@@ -8,12 +8,12 @@ namespace System.Runtime.InteropServices
 {
     public abstract partial class ComWrappers
     {
-        public static unsafe bool TryGetComInstance(object wrapperMaybe, out void* externalComObject)
+        public static unsafe bool TryGetComInstance(object obj, out void* unknown)
         {
             throw new PlatformNotSupportedException();
         }
 
-        public static unsafe bool TryGetObject(void* wrapperMaybe, out object? instance)
+        public static unsafe bool TryGetObject(void* unknown, out object? obj)
         {
             throw new PlatformNotSupportedException();
         }
@@ -57,7 +57,7 @@ namespace System.Runtime.InteropServices
             throw new PlatformNotSupportedException();
         }
 
-        protected static void GetIUnknownImpl(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease)
+        public static void GetIUnknownImpl(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -552,8 +552,8 @@ namespace System.Runtime.InteropServices
     [System.CLSCompliantAttribute(false)]
     public abstract class ComWrappers
     {
-        public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown) { throw null; }
-        public static unsafe bool TryGetObject(IntPtr unknown, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? obj) { throw null; }
+        public static unsafe bool TryGetComInstance(object obj, out System.IntPtr unknown) { throw null; }
+        public static unsafe bool TryGetObject(System.IntPtr unknown, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? obj) { throw null; }
         public struct ComInterfaceEntry
         {
             public System.Guid IID;

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -552,8 +552,8 @@ namespace System.Runtime.InteropServices
     [System.CLSCompliantAttribute(false)]
     public abstract class ComWrappers
     {
-        public static unsafe bool TryGetComInstance(object obj, out void* unknown) { throw null; }
-        public static unsafe bool TryGetObject(void* unknown, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? obj) { throw null; }
+        public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown) { throw null; }
+        public static unsafe bool TryGetObject(IntPtr unknown, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? obj) { throw null; }
         public struct ComInterfaceEntry
         {
             public System.Guid IID;

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -552,6 +552,8 @@ namespace System.Runtime.InteropServices
     [System.CLSCompliantAttribute(false)]
     public abstract class ComWrappers
     {
+        public static unsafe bool TryGetComInstance(object wrapperMaybe, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out void* externalComObject) { throw null; }
+        public static unsafe bool TryGetObject(void* wrapperMaybe, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? instance) { throw null; }
         public struct ComInterfaceEntry
         {
             public System.Guid IID;

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -552,8 +552,8 @@ namespace System.Runtime.InteropServices
     [System.CLSCompliantAttribute(false)]
     public abstract class ComWrappers
     {
-        public static unsafe bool TryGetComInstance(object wrapperMaybe, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out void* externalComObject) { throw null; }
-        public static unsafe bool TryGetObject(void* wrapperMaybe, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? instance) { throw null; }
+        public static unsafe bool TryGetComInstance(object obj, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out void* unknown) { throw null; }
+        public static unsafe bool TryGetObject(void* unknown, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? obj) { throw null; }
         public struct ComInterfaceEntry
         {
             public System.Guid IID;
@@ -574,7 +574,7 @@ namespace System.Runtime.InteropServices
         public static void RegisterForTrackerSupport(ComWrappers instance) { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static void RegisterForMarshalling(ComWrappers instance) { }
-        protected static void GetIUnknownImpl(out System.IntPtr fpQueryInterface, out System.IntPtr fpAddRef, out System.IntPtr fpRelease) { throw null; }
+        public static void GetIUnknownImpl(out System.IntPtr fpQueryInterface, out System.IntPtr fpAddRef, out System.IntPtr fpRelease) { throw null; }
     }
     [System.FlagsAttribute]
     public enum CreateComInterfaceFlags

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -552,7 +552,7 @@ namespace System.Runtime.InteropServices
     [System.CLSCompliantAttribute(false)]
     public abstract class ComWrappers
     {
-        public static unsafe bool TryGetComInstance(object obj, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out void* unknown) { throw null; }
+        public static unsafe bool TryGetComInstance(object obj, out void* unknown) { throw null; }
         public static unsafe bool TryGetObject(void* unknown, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out object? obj) { throw null; }
         public struct ComInterfaceEntry
         {

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -253,6 +253,9 @@ namespace ComWrappersTests
             Assert.Equal(0, Marshal.QueryInterface(unmanagedObj, ref IID_IUnknown, out IntPtr unmanagedObjIUnknown));
             var unmanagedWrapper = cw.GetOrCreateObjectForComInstance(unmanagedObj, CreateObjectFlags.None);
 
+            // Also allocate a unique instance to validate looking from an uncached instance
+            var unmanagedWrapperUnique = cw.GetOrCreateObjectForComInstance(unmanagedObj, CreateObjectFlags.UniqueInstance);
+
             // Verify TryGetObject
             Assert.True(ComWrappers.TryGetObject(managedWrapper, out object managedObjOther));
             Assert.Equal(managedObj, managedObjOther);
@@ -263,8 +266,11 @@ namespace ComWrappersTests
             // Verify TryGetComInstance
             Assert.False(ComWrappers.TryGetComInstance(managedObj, out IntPtr _));
             Assert.True(ComWrappers.TryGetComInstance(unmanagedWrapper, out IntPtr unmanagedObjOther));
+            Assert.True(ComWrappers.TryGetComInstance(unmanagedWrapperUnique, out IntPtr unmanagedObjOtherUnique));
             Assert.Equal(unmanagedObjIUnknown, unmanagedObjOther);
+            Assert.Equal(unmanagedObjIUnknown, unmanagedObjOtherUnique);
             Marshal.Release(unmanagedObjOther);
+            Marshal.Release(unmanagedObjOtherUnique);
 
             // Release unmanaged resources
             int count = Marshal.Release(managedWrapper);

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -17,34 +17,65 @@ namespace ComWrappersTests
     {
         class TestComWrappers : ComWrappers
         {
+            private static IntPtr fpQueryInterface = default;
+            private static IntPtr fpAddRef = default;
+            private static IntPtr fpRelease = default;
+            private static IntPtr fpWrappedQueryInterface = default;
+
+            static TestComWrappers()
+            {
+                ComWrappers.GetIUnknownImpl(out fpQueryInterface, out fpAddRef, out fpRelease);
+                fpWrappedQueryInterface = MockReferenceTrackerRuntime.WrapQueryInterface(fpQueryInterface);
+            }
+
             protected unsafe override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
             {
-                IntPtr fpQueryInterface = default;
-                IntPtr fpAddRef = default;
-                IntPtr fpRelease = default;
-                ComWrappers.GetIUnknownImpl(out fpQueryInterface, out fpAddRef, out fpRelease);
-
                 ComInterfaceEntry* entryRaw = null;
                 count = 0;
                 if (obj is Test)
                 {
-                    var vtbl = new ITestVtbl()
+                    // If the caller is requesting an IUnknown definition we supply 2 vtables
+                    count = flags.HasFlag(CreateComInterfaceFlags.CallerDefinedIUnknown) ? 2 : 1;
+                    entryRaw = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(ComInterfaceEntry) * count);
+
+                    int index = 0;
+                    if (flags.HasFlag(CreateComInterfaceFlags.CallerDefinedIUnknown))
                     {
-                        IUnknownImpl = new IUnknownVtbl()
+                        // This IUnknown wraps the QueryInterface to validate proper detection
+                        // of ComWrappers created managed object wrappers.
+                        var vtbl = new IUnknownVtbl()
                         {
-                            QueryInterface = fpQueryInterface,
+                            QueryInterface = fpWrappedQueryInterface,
                             AddRef = fpAddRef,
                             Release = fpRelease
-                        },
-                        SetValue = Marshal.GetFunctionPointerForDelegate(ITestVtbl.pSetValue)
-                    };
-                    var vtblRaw = RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(ITestVtbl));
-                    Marshal.StructureToPtr(vtbl, vtblRaw, false);
+                        };
 
-                    entryRaw = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(ComInterfaceEntry));
-                    entryRaw->IID = typeof(ITest).GUID;
-                    entryRaw->Vtable = vtblRaw;
-                    count = 1;
+                        var vtblRaw = RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(IUnknownVtbl));
+                        Marshal.StructureToPtr(vtbl, vtblRaw, false);
+
+                        entryRaw[index].IID = IUnknownVtbl.IID_IUnknown;
+                        entryRaw[index].Vtable = vtblRaw;
+                        index++;
+                    }
+
+                    {
+                        var vtbl = new ITestVtbl()
+                        {
+                            IUnknownImpl = new IUnknownVtbl()
+                            {
+                                QueryInterface = fpQueryInterface,
+                                AddRef = fpAddRef,
+                                Release = fpRelease
+                            },
+                            SetValue = Marshal.GetFunctionPointerForDelegate(ITestVtbl.pSetValue)
+                        };
+                        var vtblRaw = RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ITestVtbl), sizeof(ITestVtbl));
+                        Marshal.StructureToPtr(vtbl, vtblRaw, false);
+
+                        entryRaw[index].IID = typeof(ITest).GUID;
+                        entryRaw[index].Vtable = vtblRaw;
+                        index++;
+                    }
                 }
 
                 return entryRaw;
@@ -208,15 +239,22 @@ namespace ComWrappersTests
             IntPtr managedWrapper = cw.GetOrCreateComInterfaceForObject(managedObj, CreateComInterfaceFlags.None);
             Assert.NotEqual(IntPtr.Zero, managedWrapper);
 
+            // Allocate wrapper with user defined IUnknown
+            var cwAlt = new TestComWrappers();
+            IntPtr managedWrapper2 = cwAlt.GetOrCreateComInterfaceForObject(managedObj, CreateComInterfaceFlags.CallerDefinedIUnknown);
+            Assert.NotEqual(IntPtr.Zero, managedWrapper2);
+
             // Create a wrapper for the unmanaged instance
             IntPtr unmanagedObj = MockReferenceTrackerRuntime.CreateTrackerObject();
-            Guid IID_IUnknown = new Guid("00000000-0000-0000-C000-000000000046");
+            Guid IID_IUnknown = IUnknownVtbl.IID_IUnknown;
             Assert.Equal(0, Marshal.QueryInterface(unmanagedObj, ref IID_IUnknown, out IntPtr unmanagedObjIUnknown));
             var unmanagedWrapper = cw.GetOrCreateObjectForComInstance(unmanagedObj, CreateObjectFlags.None);
 
             // Verify TryGetObject
             Assert.True(ComWrappers.TryGetObject((void*)managedWrapper, out object managedObjOther));
             Assert.Equal(managedObj, managedObjOther);
+            Assert.True(ComWrappers.TryGetObject((void*)managedWrapper2, out object managedObjOther2));
+            Assert.Equal(managedObj, managedObjOther2);
             Assert.False(ComWrappers.TryGetObject((void*)unmanagedObj, out object _));
 
             // Verify TryGetComInstance
@@ -227,6 +265,8 @@ namespace ComWrappersTests
 
             // Release unmanaged resources
             int count = Marshal.Release(managedWrapper);
+            Assert.Equal(0, count);
+            count = Marshal.Release(managedWrapper2);
             Assert.Equal(0, count);
             Marshal.Release(unmanagedObj);
             Marshal.Release(unmanagedObjIUnknown);

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -239,7 +239,10 @@ namespace ComWrappersTests
             IntPtr managedWrapper = cw.GetOrCreateComInterfaceForObject(managedObj, CreateComInterfaceFlags.None);
             Assert.NotEqual(IntPtr.Zero, managedWrapper);
 
-            // Allocate wrapper with user defined IUnknown
+            // Allocate wrapper with user defined IUnknown.
+            // Using a new ComWrappers instance because
+            // a native wrapper for a managed object is associated
+            // with its allocating ComWrappers instance.
             var cwAlt = new TestComWrappers();
             IntPtr managedWrapper2 = cwAlt.GetOrCreateComInterfaceForObject(managedObj, CreateComInterfaceFlags.CallerDefinedIUnknown);
             Assert.NotEqual(IntPtr.Zero, managedWrapper2);

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -228,7 +228,7 @@ namespace ComWrappersTests
             Assert.NotEqual(trackerObj1, trackerObj3);
         }
 
-        static unsafe void ValidateMappingAPIs()
+        static void ValidateMappingAPIs()
         {
             Console.WriteLine($"Running {nameof(ValidateMappingAPIs)}...");
 
@@ -254,17 +254,17 @@ namespace ComWrappersTests
             var unmanagedWrapper = cw.GetOrCreateObjectForComInstance(unmanagedObj, CreateObjectFlags.None);
 
             // Verify TryGetObject
-            Assert.True(ComWrappers.TryGetObject((void*)managedWrapper, out object managedObjOther));
+            Assert.True(ComWrappers.TryGetObject(managedWrapper, out object managedObjOther));
             Assert.Equal(managedObj, managedObjOther);
-            Assert.True(ComWrappers.TryGetObject((void*)managedWrapper2, out object managedObjOther2));
+            Assert.True(ComWrappers.TryGetObject(managedWrapper2, out object managedObjOther2));
             Assert.Equal(managedObj, managedObjOther2);
-            Assert.False(ComWrappers.TryGetObject((void*)unmanagedObj, out object _));
+            Assert.False(ComWrappers.TryGetObject(unmanagedObj, out object _));
 
             // Verify TryGetComInstance
-            Assert.False(ComWrappers.TryGetComInstance(managedObj, out void* _));
-            Assert.True(ComWrappers.TryGetComInstance(unmanagedWrapper, out void* unmanagedObjOther));
-            Assert.Equal(unmanagedObjIUnknown, (IntPtr)unmanagedObjOther);
-            Marshal.Release((IntPtr)unmanagedObjOther);
+            Assert.False(ComWrappers.TryGetComInstance(managedObj, out IntPtr _));
+            Assert.True(ComWrappers.TryGetComInstance(unmanagedWrapper, out IntPtr unmanagedObjOther));
+            Assert.Equal(unmanagedObjIUnknown, unmanagedObjOther);
+            Marshal.Release(unmanagedObjOther);
 
             // Release unmanaged resources
             int count = Marshal.Release(managedWrapper);

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -94,7 +94,12 @@ namespace ComWrappersTests.Common
 
         public static IntPtr CreateTrackerObject()
         {
-            return CreateTrackerObject(IntPtr.Zero, out IntPtr _);
+            IntPtr result = CreateTrackerObject(IntPtr.Zero, out IntPtr inner);
+            if (inner != IntPtr.Zero)
+            {
+                Marshal.Release(inner);
+            }
+            return result;
         }
 
         public static IntPtr CreateTrackerObject(IntPtr outer, out IntPtr inner)

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -53,6 +53,8 @@ namespace ComWrappersTests.Common
 
     public struct IUnknownVtbl
     {
+        public static Guid IID_IUnknown = new Guid("00000000-0000-0000-C000-000000000046");
+
         public IntPtr QueryInterface;
         public IntPtr AddRef;
         public IntPtr Release;
@@ -162,6 +164,12 @@ namespace ComWrappersTests.Common
         [SuppressGCTransition]
         [DllImport(nameof(MockReferenceTrackerRuntime))]
         extern public static byte IsTrackerObjectConnected(IntPtr instance);
+
+        // API used to wrap a QueryInterface(). This is used for testing
+        // scenarios where triggering off of the QueryInterface() slot is
+        // done by the runtime.
+        [DllImport(nameof(MockReferenceTrackerRuntime))]
+        extern public static IntPtr WrapQueryInterface(IntPtr queryInterface);
     }
 
     [Guid("42951130-245C-485E-B60B-4ED4254256F8")]

--- a/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
+++ b/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
@@ -581,6 +581,25 @@ extern "C" DLL_EXPORT LONG STDMETHODCALLTYPE TrackerTarget_ReleaseFromReferenceT
     return (LONG)target->ReleaseFromReferenceTracker();
 }
 
+namespace
+{
+    using QueryInterface_t = HRESULT(STDMETHODCALLTYPE*)(void*,GUID*,void**);
+    QueryInterface_t _qiToWrap;
+
+    HRESULT STDMETHODCALLTYPE QueryInterfaceWrapper(void* _this, GUID* riid, void** ppvObject)
+    {
+        if (_qiToWrap == nullptr)
+            return E_UNEXPECTED;
+        return _qiToWrap(_this, riid, ppvObject);
+    }
+}
+
+extern "C" DLL_EXPORT void* WrapQueryInterface(QueryInterface_t qiToWrap)
+{
+    _qiToWrap = qiToWrap;
+    return (void*)&QueryInterfaceWrapper;
+}
+
 extern "C" DLL_EXPORT int STDMETHODCALLTYPE UpdateTestObjectAsIUnknown(IUnknown *obj, int i, IUnknown **out)
 {
     if (obj == nullptr)

--- a/src/tests/Interop/common/xplatform.h
+++ b/src/tests/Interop/common/xplatform.h
@@ -33,6 +33,7 @@
 #define S_FALSE         _HRESULT_TYPEDEF_(0x00000001L)
 #define E_OUTOFMEMORY   _HRESULT_TYPEDEF_(0x8007000EL)
 #define E_NOTIMPL       _HRESULT_TYPEDEF_(0x80004001L)
+#define E_UNEXPECTED    _HRESULT_TYPEDEF_(0x8000FFFFL)
 
 // Declaring a handle dummy struct for HSTRING the same way DECLARE_HANDLE does.
 typedef struct HSTRING__{


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/79674
Fixes https://github.com/dotnet/runtime/issues/79679
Fixes https://github.com/dotnet/runtime/issues/80451

This also adds support in NativeAOT.
NativeAOT support for `ICustomQueryInterface` for `ComWrappers`
was also added.

/cc @dotnet/interop-contrib 