### PR TITLE
Build tools subset to generate artifacts

### DIFF
--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -65,9 +65,9 @@ jobs:
 
       variables:
         - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        - _subset: libs+libs.tests
+        - _subset: tools+libs+libs.tests
         - ${{ if and(eq(parameters.runTests, false), eq(parameters.useHelix, false)) }}:
-          - _subset: libs
+          - _subset: tools+libs
         - _buildAction: ''
         - _additionalBuildArguments: ''
         - ${{ parameters.variables }}


### PR DESCRIPTION
Build the tools along with the libraries to produce the illink packages in the artifacts folder during the runtime official build.
The following [build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2083643&view=results) tests that the build does not break and that the [intermediate artifacts](https://dev.azure.com/dnceng/internal/_build/results?buildId=2083643&view=artifacts&pathAsName=false&type=publishedArtifacts) are generated, including the illink package Microsoft.NET.ILLink.Tasks.8.0.0-alpha.1.23059.11.nupkg