### PR TITLE
[mono] Fixed getting namespace names of array types.

### DIFF
--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -1474,6 +1474,8 @@ namespace System.Reflection.Tests
         [InlineData(typeof(int), "System")]
         [InlineData(typeof(TI_BaseClass[]), "System.Reflection.Tests")]
         [InlineData(typeof(TI_BaseClass.PublicNestedClass1[]), "System.Reflection.Tests")]
+        [InlineData(typeof(TI_BaseClass.PublicNestedClass1[][]), "System.Reflection.Tests")]
+        [InlineData(typeof(TI_Struct*), "System.Reflection.Tests")]
         public void Namespace(Type type, string expected)
         {
             Assert.Equal(expected, type.GetTypeInfo().Namespace);
@@ -1862,6 +1864,10 @@ namespace System.Reflection.Tests
             [FieldOffset(1)]
             public short y;
         }
+    }
+    public struct TI_Struct
+    {
+        public int _field;
     }
     public class TI_BaseClass
     {

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -1474,7 +1474,6 @@ namespace System.Reflection.Tests
         [InlineData(typeof(int), "System")]
         [InlineData(typeof(TI_BaseClass[]), "System.Reflection.Tests")]
         [InlineData(typeof(TI_BaseClass.PublicNestedClass1[]), "System.Reflection.Tests")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/42633", TestRuntimes.Mono)]
         public void Namespace(Type type, string expected)
         {
             Assert.Equal(expected, type.GetTypeInfo().Namespace);

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2926,6 +2926,7 @@ ves_icall_RuntimeType_GetNamespace (MonoQCallTypeHandle type_handle, MonoObjectH
 {
 	MonoType *type = type_handle.type;
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
+	klass = m_class_get_element_class(klass);
 
 	MonoClass *klass_nested_in;
 	while ((klass_nested_in = m_class_get_nested_in (klass)))

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2928,7 +2928,8 @@ ves_icall_RuntimeType_GetNamespace (MonoQCallTypeHandle type_handle, MonoObjectH
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
 	
 	MonoClass *elem;
-	while (klass != (elem = m_class_get_element_class (klass)))
+	while (!m_class_is_enumtype (klass) && 
+		(klass != (elem = m_class_get_element_class (klass))))
 		klass = elem;
 
 	MonoClass *klass_nested_in;

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2926,7 +2926,10 @@ ves_icall_RuntimeType_GetNamespace (MonoQCallTypeHandle type_handle, MonoObjectH
 {
 	MonoType *type = type_handle.type;
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
-	klass = m_class_get_element_class (klass);
+	
+	MonoClass *elem;
+	while (klass != (elem = m_class_get_element_class (klass)))
+		klass = elem;
 
 	MonoClass *klass_nested_in;
 	while ((klass_nested_in = m_class_get_nested_in (klass)))

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2929,6 +2929,7 @@ ves_icall_RuntimeType_GetNamespace (MonoQCallTypeHandle type_handle, MonoObjectH
 	
 	MonoClass *elem;
 	while (!m_class_is_enumtype (klass) && 
+		!mono_class_is_nullable (klass) &&
 		(klass != (elem = m_class_get_element_class (klass))))
 		klass = elem;
 

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2926,7 +2926,7 @@ ves_icall_RuntimeType_GetNamespace (MonoQCallTypeHandle type_handle, MonoObjectH
 {
 	MonoType *type = type_handle.type;
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
-	klass = m_class_get_element_class(klass);
+	klass = m_class_get_element_class (klass);
 
 	MonoClass *klass_nested_in;
 	while ((klass_nested_in = m_class_get_nested_in (klass)))


### PR DESCRIPTION
Fixes `Type.Namespace` on nested array types. Addresses #42633.