### PR TITLE
Fix Configuration to ensure calling the property setters.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -262,7 +262,10 @@ namespace Microsoft.Extensions.Configuration
                 config.GetSection(GetPropertyName(property)),
                 options);
 
-            if (propertyBindingPoint.HasNewValue)
+            // For property binding, there are some cases when HasNewValue is not set in BindingPoint while a non-null Value inside that object can be retrieved from the property getter.
+            // As example, when binding a property which not having a configuration entry matching this property and the getter can initialize the Value.
+            // It is important to call the property setter as the setters can have a logic adjusting the Value.
+            if (!propertyBindingPoint.IsReadOnly && propertyBindingPoint.Value is not null)
             {
                 property.SetValue(instance, propertyBindingPoint.Value);
             }
@@ -383,14 +386,6 @@ namespace Microsoft.Extensions.Configuration
                         BindProperties(bindingPoint.Value, config, options);
                     }
                 }
-            }
-
-            if (!bindingPoint.HasNewValue && !bindingPoint.IsReadOnly && bindingPoint.Value is not null)
-            {
-                // For property binding, there are some cases when HasNewValue is not set in BindingPoint while a non-null Value inside that object can be retrieved
-                // from the property getter. As example, when binding a property which not having a configuration entry matching this property and the getter can initialize the Value.
-                // It is important to set the HasNewValue to true at this time to force the property setter to run. The reason is the setters can have a logic adjusting the Value.
-                bindingPoint.SetValue(bindingPoint.Value);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -384,6 +384,14 @@ namespace Microsoft.Extensions.Configuration
                     }
                 }
             }
+
+            if (!bindingPoint.HasNewValue && !bindingPoint.IsReadOnly && bindingPoint.Value is not null)
+            {
+                // For property binding, there are some cases when HasNewValue is not set in BindingPoint while a non-null Value inside that object can be retrieved
+                // from the property getter. As example, when binding a property which not having a configuration entry matching this property and the getter can initialize the Value.
+                // It is important to set the HasNewValue to true at this time to force the property setter to run. The reason is the setters can have a logic adjusting the Value.
+                bindingPoint.SetValue(bindingPoint.Value);
+            }
         }
 
         [RequiresDynamicCode(DynamicCodeWarningMessage)]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Microsoft.Extensions.Configuration.Binder.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Microsoft.Extensions.Configuration.Binder.Tests.csproj
@@ -10,13 +10,14 @@
              Link="Common\ConfigurationProviderExtensions.cs" />
     <Compile Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration\tests\Common\TestStreamHelpers.cs"
              Link="Common\TestStreamHelpers.cs" />
-    <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" /> 
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
 
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration\src\Microsoft.Extensions.Configuration.csproj" SkipUseReferenceAssembly="true" />
+    <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration.Json\src\Microsoft.Extensions.Configuration.Json.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.FileProviders.Abstractions\src\Microsoft.Extensions.FileProviders.Abstractions.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="..\src\Microsoft.Extensions.Configuration.Binder.csproj" SkipUseReferenceAssembly="true" />
   </ItemGroup>


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/79904

When performing the configuration property binding, we need to ensure calling the property setter (if the property has a setter). The reason is the apps can decide having some logic adjusting the property value inside the setter. This is a fix to a regression introduced in 7.0 release. 