### PR TITLE
[release/6.0] Backport FileStream finalization fixes

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace System.IO.Tests
 {
-    [Collection(nameof(DisableParallelization))] // make sure no other tests are calling GC.Collect()
+    [Collection("NoParallelTests")]  // make sure no other tests are calling GC.Collect()
     public class FileStream_Dispose : FileSystemTest
     {
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -507,7 +507,12 @@ namespace System.IO
         // _strategy can be null only when ctor has thrown
         protected override void Dispose(bool disposing) => _strategy?.DisposeInternal(disposing);
 
-        public override ValueTask DisposeAsync() => _strategy.DisposeAsync();
+        public async override ValueTask DisposeAsync()
+        {
+            await _strategy.DisposeAsync().ConfigureAwait(false);
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
 
         public override void CopyTo(Stream destination, int bufferSize)
         {
@@ -595,8 +600,6 @@ namespace System.IO
 
         internal ValueTask BaseWriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             => base.WriteAsync(buffer, cancellationToken);
-
-        internal ValueTask BaseDisposeAsync() => base.DisposeAsync();
 
         internal Task BaseCopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             => base.CopyToAsync(destination, bufferSize, cancellationToken);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -147,6 +147,14 @@ namespace System.IO
         {
         }
 
+        ~FileStream()
+        {
+            // Preserved for compatibility since FileStream has defined a
+            // finalizer in past releases and derived classes may depend
+            // on Dispose(false) call.
+            Dispose(false);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="System.IO.FileStream" /> class with the specified path, creation mode, read/write and sharing permission, the access other FileStreams can have to the same file, the buffer size,  additional file options and the allocation size.
         /// </summary>
@@ -496,9 +504,8 @@ namespace System.IO
         /// <param name="value">The byte to write to the stream.</param>
         public override void WriteByte(byte value) => _strategy.WriteByte(value);
 
-        protected override void Dispose(bool disposing) => _strategy.DisposeInternal(disposing);
-
-        internal void DisposeInternal(bool disposing) => Dispose(disposing);
+        // _strategy can be null only when ctor has thrown
+        protected override void Dispose(bool disposing) => _strategy?.DisposeInternal(disposing);
 
         public override ValueTask DisposeAsync() => _strategy.DisposeAsync();
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
@@ -146,7 +146,7 @@ namespace System.IO.Strategies
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             => _fileStream.BaseCopyToAsync(destination, bufferSize, cancellationToken);
 
-        public override ValueTask DisposeAsync() => _fileStream.BaseDisposeAsync();
+        public override ValueTask DisposeAsync() => _strategy.DisposeAsync();
 
         protected sealed override void Dispose(bool disposing) => _strategy.DisposeInternal(disposing);
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/DerivedFileStreamStrategy.cs
@@ -23,14 +23,6 @@ namespace System.IO.Strategies
             _strategy = strategy;
         }
 
-        ~DerivedFileStreamStrategy()
-        {
-            // Preserved for compatibility since FileStream has defined a
-            // finalizer in past releases and derived classes may depend
-            // on Dispose(false) call.
-            _fileStream.DisposeInternal(false);
-        }
-
         public override bool CanRead => _strategy.CanRead;
 
         public override bool CanWrite => _strategy.CanWrite;
@@ -156,14 +148,6 @@ namespace System.IO.Strategies
 
         public override ValueTask DisposeAsync() => _fileStream.BaseDisposeAsync();
 
-        internal override void DisposeInternal(bool disposing)
-        {
-            _strategy.DisposeInternal(disposing);
-
-            if (disposing)
-            {
-                GC.SuppressFinalize(this);
-            }
-        }
+        protected sealed override void Dispose(bool disposing) => _strategy.DisposeInternal(disposing);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamStrategy.cs
@@ -23,6 +23,6 @@ namespace System.IO.Strategies
 
         internal abstract void Flush(bool flushToDisk);
 
-        internal abstract void DisposeInternal(bool disposing);
+        internal void DisposeInternal(bool disposing) => Dispose(disposing);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.cs
@@ -101,10 +101,6 @@ namespace System.IO.Strategies
             }
         }
 
-        ~Net5CompatFileStreamStrategy() => Dispose(false); // mandatory to Flush the write buffer
-
-        internal override void DisposeInternal(bool disposing) => Dispose(disposing);
-
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
             // TODO: https://github.com/dotnet/runtime/issues/27643 (stop doing this synchronous work!!).

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
@@ -148,8 +148,6 @@ namespace System.IO.Strategies
             return ValueTask.CompletedTask;
         }
 
-        internal sealed override void DisposeInternal(bool disposing) => Dispose(disposing);
-
         // this method just disposes everything (no buffer, no need to flush)
         protected sealed override void Dispose(bool disposing)
         {


### PR DESCRIPTION
Backport of #64997 and #65899 to release/6.0

## Customer Impact

Multiple users reported performance issues (#78553, #64741) caused by a lack of proper finalization suppression of the file stream buffering strategy. Users who create a lot of `FileStream` instances (with buffering enabled, which is the default and can't not be controlled application-wide with a single flag) and dispose them properly suffer from having plenty of finalizable objects in the finalizer queue. It leads to performance degradation.

## Testing

Automated tests were added and they are passing. Additional local validation confirmed the leak is gone.

## Risk

The risk is low. The fixes "matured" in main and were released as part of .NET 7 (last fix merged 10 months ago) .

fixes #78553