### PR TITLE
Fix small buffer handling with the Platform Crypto Provider

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.ErrorCode.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.ErrorCode.cs
@@ -20,6 +20,12 @@ internal static partial class Interop
             NTE_NO_MORE_ITEMS = unchecked((int)0x8009002a),
             E_FAIL = unchecked((int)0x80004005),
             STATUS_UNSUCCESSFUL = unchecked((int)0xC0000001),
+            TPMAPI_E_BUFFER_TOO_SMALL = unchecked((int)0x80290406),
         }
+    }
+
+    internal static bool IsBufferTooSmall(this NCrypt.ErrorCode errorCode)
+    {
+        return errorCode is NCrypt.ErrorCode.NTE_BUFFER_TOO_SMALL or NCrypt.ErrorCode.TPMAPI_E_BUFFER_TOO_SMALL;
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.ErrorCode.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.ErrorCode.cs
@@ -11,6 +11,7 @@ internal static partial class Interop
         internal enum ErrorCode : int
         {
             ERROR_SUCCESS = 0,
+            E_FAIL = unchecked((int)0x80004005),
             NTE_BAD_SIGNATURE = unchecked((int)0x80090006),
             NTE_NOT_FOUND = unchecked((int)0x80090011),
             NTE_BAD_KEYSET = unchecked((int)0x80090016),
@@ -18,9 +19,8 @@ internal static partial class Interop
             NTE_BUFFER_TOO_SMALL = unchecked((int)0x80090028),
             NTE_NOT_SUPPORTED = unchecked((int)0x80090029),
             NTE_NO_MORE_ITEMS = unchecked((int)0x8009002a),
-            E_FAIL = unchecked((int)0x80004005),
-            STATUS_UNSUCCESSFUL = unchecked((int)0xC0000001),
             TPM_E_PCP_BUFFER_TOO_SMALL = unchecked((int)0x80290406),
+            STATUS_UNSUCCESSFUL = unchecked((int)0xC0000001),
         }
     }
 

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.ErrorCode.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.ErrorCode.cs
@@ -20,12 +20,12 @@ internal static partial class Interop
             NTE_NO_MORE_ITEMS = unchecked((int)0x8009002a),
             E_FAIL = unchecked((int)0x80004005),
             STATUS_UNSUCCESSFUL = unchecked((int)0xC0000001),
-            TPMAPI_E_BUFFER_TOO_SMALL = unchecked((int)0x80290406),
+            TPM_E_PCP_BUFFER_TOO_SMALL = unchecked((int)0x80290406),
         }
     }
 
     internal static bool IsBufferTooSmall(this NCrypt.ErrorCode errorCode)
     {
-        return errorCode is NCrypt.ErrorCode.NTE_BUFFER_TOO_SMALL or NCrypt.ErrorCode.TPMAPI_E_BUFFER_TOO_SMALL;
+        return errorCode is NCrypt.ErrorCode.NTE_BUFFER_TOO_SMALL or NCrypt.ErrorCode.TPM_E_PCP_BUFFER_TOO_SMALL;
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveKeyMaterial.cs
+++ b/src/libraries/Common/src/Interop/Windows/NCrypt/Interop.NCryptDeriveKeyMaterial.cs
@@ -140,7 +140,7 @@ internal static partial class Interop
                     out int keySize,
                     flags);
 
-                if (error != ErrorCode.ERROR_SUCCESS && error != ErrorCode.NTE_BUFFER_TOO_SMALL)
+                if (error != ErrorCode.ERROR_SUCCESS && !error.IsBufferTooSmall())
                 {
                     throw error.ToCryptographicException();
                 }

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.EncryptDecrypt.cs
@@ -219,7 +219,7 @@ namespace System.Security.Cryptography
                 }
             }
 
-            if (errorCode == ErrorCode.NTE_BUFFER_TOO_SMALL)
+            if (errorCode.IsBufferTooSmall())
             {
                 CryptographicOperations.ZeroMemory(output);
                 output = new byte[numBytesNeeded];
@@ -265,7 +265,7 @@ namespace System.Security.Cryptography
                     case ErrorCode.ERROR_SUCCESS:
                         bytesWritten = numBytesNeeded;
                         return true;
-                    case ErrorCode.NTE_BUFFER_TOO_SMALL:
+                    case ErrorCode code when code.IsBufferTooSmall():
                         bytesWritten = 0;
                         return false;
                     case ErrorCode.STATUS_UNSUCCESSFUL:

--- a/src/libraries/Common/tests/System/Security/Cryptography/PlatformSupport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/PlatformSupport.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Xunit;
 
@@ -11,10 +12,12 @@ namespace Test.Cryptography
     {
         private static Lazy<bool> s_lazyPlatformCryptoProviderFunctional = new Lazy<bool>(static () =>
         {
-            if (!OperatingSystem.IsWindows())
+#if !NETFRAMEWORK
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return false;
             }
+#endif
 
             CngKey key = null;
 
@@ -25,7 +28,7 @@ namespace Test.Cryptography
                     $"{nameof(PlatformCryptoProviderFunctional)}Key",
                     new CngKeyCreationParameters
                     {
-                        Provider = CngProvider.MicrosoftPlatformCryptoProvider,
+                        Provider = new CngProvider("Microsoft Platform Crypto Provider"),
                         KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
                     });
 

--- a/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
@@ -190,6 +190,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void PlatformCryptoProvider_DeriveKeyMaterial()
         {
             CngKey key1 = null;

--- a/src/libraries/System.Security.Cryptography.Cng/tests/PropertyTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/PropertyTests.cs
@@ -2,42 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.EcDsa.Tests;
+using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.Cng.Tests
 {
     public static class PropertyTests
     {
-        private static Lazy<bool> s_lazyPlatformCryptoProviderFunctional = new Lazy<bool>(static () =>
-        {
-            CngKey key = null;
-
-            try
-            {
-                key = CngKey.Create(
-                    CngAlgorithm.ECDsaP256,
-                    $"{nameof(PlatformCryptoProviderFunctional)}Key",
-                    new CngKeyCreationParameters
-                    {
-                        Provider = CngProvider.MicrosoftPlatformCryptoProvider,
-                        KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
-                    });
-
-                return true;
-            }
-            catch (CryptographicException)
-            {
-                return false;
-            }
-            finally
-            {
-                key?.Delete();
-            }
-        });
-
-        public static bool PlatformCryptoProviderFunctional => s_lazyPlatformCryptoProviderFunctional.Value;
-
-        [ConditionalTheory(nameof(PlatformCryptoProviderFunctional))]
+        [ConditionalTheory(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
         [InlineData("ECDH_P256", 256)]
         [InlineData("ECDH_P384", 384)]
         [InlineData("ECDSA_P256", 256)]
@@ -66,7 +38,7 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        [ConditionalTheory(nameof(PlatformCryptoProviderFunctional))]
+        [ConditionalTheory(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
         [InlineData(1024)]
         [InlineData(2048)]
         [OuterLoop("Hardware backed key generation takes several seconds.")]

--- a/src/libraries/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/RsaCngTests.cs
@@ -128,6 +128,7 @@ namespace System.Security.Cryptography.Cng.Tests
         }
 
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void RSACng_PlatformCryptoProvider_SignHash_Roundtrip()
         {
             CngKey key = null;
@@ -173,6 +174,7 @@ namespace System.Security.Cryptography.Cng.Tests
         }
 
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void RSACng_PlatformCryptoProvider_EncryptDecrypt_Roundtrip()
         {
             CngKey key = null;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngCommon.SignVerify.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngCommon.SignVerify.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography
         public static unsafe byte[] SignHash(this SafeNCryptKeyHandle keyHandle, ReadOnlySpan<byte> hash, AsymmetricPaddingMode paddingMode, void* pPaddingInfo, int estimatedSize)
         {
 #if DEBUG
-            estimatedSize = 2;  // Make sure the NTE_BUFFER_TOO_SMALL and TPMAPI_E_BUFFER_TOO_SMALL scenario gets exercised.
+            estimatedSize = 2;  // Make sure the NTE_BUFFER_TOO_SMALL and TPM_E_PCP_BUFFER_TOO_SMALL scenario gets exercised.
 #endif
             byte[] signature = new byte[estimatedSize];
             int numBytesNeeded;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngCommon.SignVerify.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngCommon.SignVerify.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography
         public static unsafe byte[] SignHash(this SafeNCryptKeyHandle keyHandle, ReadOnlySpan<byte> hash, AsymmetricPaddingMode paddingMode, void* pPaddingInfo, int estimatedSize)
         {
 #if DEBUG
-            estimatedSize = 2;  // Make sure the NTE_BUFFER_TOO_SMALL scenario gets exercised.
+            estimatedSize = 2;  // Make sure the NTE_BUFFER_TOO_SMALL and TPMAPI_E_BUFFER_TOO_SMALL scenario gets exercised.
 #endif
             byte[] signature = new byte[estimatedSize];
             int numBytesNeeded;
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography
                 errorCode = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, out numBytesNeeded, paddingMode);
             }
 
-            if (errorCode == ErrorCode.NTE_BUFFER_TOO_SMALL)
+            if (errorCode.IsBufferTooSmall())
             {
                 signature = new byte[numBytesNeeded];
                 errorCode = Interop.NCrypt.NCryptSignHash(keyHandle, pPaddingInfo, hash, hash.Length, signature, signature.Length, out numBytesNeeded, paddingMode);
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography
                         bytesWritten = numBytesNeeded;
                         return true;
 
-                    case ErrorCode.NTE_BUFFER_TOO_SMALL:
+                    case ErrorCode code when code.IsBufferTooSmall():
                         bytesWritten = 0;
                         return false;
 


### PR DESCRIPTION
When using the Platform Crypto Provider with CNG, it returns different a different error code for "buffer too small".

This means for `Try*` APIs we will throw an exception when we should be returning false. For allocating-return APIs, this would mean we throw instead of returning a right sized buffer.

This change allows handling `TPM_E_PCP_BUFFER_TOO_SMALL` in places we were also handling `NTE_BUFFER_TOO_SMALL`.

Fixes #80444.