### PR TITLE
Fix timeout in regex source generated test

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1283,6 +1283,7 @@ namespace System.Text.RegularExpressions.Tests
             }, ((int)engine).ToString(CultureInfo.InvariantCulture)).Dispose();
         }
 
+#if NET7_0_OR_GREATER
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void Match_InstanceMethods_DefaultTimeout_SourceGenerated_Throws()
         {
@@ -1305,6 +1306,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [GeneratedRegex(@"^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@(([0-9a-zA-Z])+([-\w]*[0-9a-zA-Z])*\.)+[a-zA-Z]{2,9})$")]
         private static partial Regex Match_InstanceMethods_DefaultTimeout_SourceGenerated_ThrowsImpl();
+#endif
 
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [InlineData(RegexOptions.None)]

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1255,28 +1255,56 @@ namespace System.Text.RegularExpressions.Tests
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/67886", RuntimeTestModes.JitMinOpts)]
         public void Match_InstanceMethods_DefaultTimeout_Throws(RegexEngine engine)
         {
-            if (RegexHelpers.IsNonBacktracking(engine))
+            if (RegexHelpers.IsNonBacktracking(engine) ||
+                engine == RegexEngine.SourceGenerated)
             {
-                // Test relies on backtracking triggering timeout checks
+                // Disabled for non-backtracking: the test relies on backtracking triggering timeout checks due to runaway backtracking.
+                // Disabled for source-generated: the default timeout can't be set before invoking Roslyn because Roslyn itself
+                // uses regexes that would then be subject to the timeout, and the default can't be set after invoking Roslyn because
+                // the regexes used by Roslyn will have baked the read default value in such that changes to it via SetData won't be
+                // observed. It's covered by the Match_InstanceMethods_DefaultTimeout_SourceGenerated_Throws test below.
                 return;
             }
 
             RemoteExecutor.Invoke(async engineString =>
             {
+                AppDomain.CurrentDomain.SetData(RegexHelpers.DefaultMatchTimeout_ConfigKeyName, TimeSpan.FromMilliseconds(100));
+
                 RegexEngine engine = (RegexEngine)int.Parse(engineString, CultureInfo.InvariantCulture);
 
                 const string Pattern = @"^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@(([0-9a-zA-Z])+([-\w]*[0-9a-zA-Z])*\.)+[a-zA-Z]{2,9})$";
+                Regex r = await RegexHelpers.GetRegexAsync(engine, Pattern);
                 string input = new string('a', 50) + "@a.a";
 
-                AppDomain.CurrentDomain.SetData(RegexHelpers.DefaultMatchTimeout_ConfigKeyName, TimeSpan.FromMilliseconds(100));
-
-                Regex r = await RegexHelpers.GetRegexAsync(engine, Pattern);
                 Assert.Throws<RegexMatchTimeoutException>(() => r.Match(input));
                 Assert.Throws<RegexMatchTimeoutException>(() => r.IsMatch(input));
                 Assert.Throws<RegexMatchTimeoutException>(() => r.Matches(input).Count);
 
             }, ((int)engine).ToString(CultureInfo.InvariantCulture)).Dispose();
         }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void Match_InstanceMethods_DefaultTimeout_SourceGenerated_Throws()
+        {
+            // Version of Match_InstanceMethods_DefaultTimeout_Throws that uses the source generator at
+            // compile time rather than at run time.  As such, this will be using a version of the source
+            // generator that's not live with the rest of the src but rather is part of the SDK being
+            // used to build the test.
+            RemoteExecutor.Invoke(() =>
+            {
+                AppDomain.CurrentDomain.SetData(RegexHelpers.DefaultMatchTimeout_ConfigKeyName, TimeSpan.FromMilliseconds(100));
+
+                Regex r = Match_InstanceMethods_DefaultTimeout_SourceGenerated_ThrowsImpl();
+                string input = new string('a', 50) + "@a.a";
+
+                Assert.Throws<RegexMatchTimeoutException>(() => r.Match(input));
+                Assert.Throws<RegexMatchTimeoutException>(() => r.IsMatch(input));
+                Assert.Throws<RegexMatchTimeoutException>(() => r.Matches(input).Count);
+            }).Dispose();
+        }
+
+        [GeneratedRegex(@"^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@(([0-9a-zA-Z])+([-\w]*[0-9a-zA-Z])*\.)+[a-zA-Z]{2,9})$")]
+        private static partial Regex Match_InstanceMethods_DefaultTimeout_SourceGenerated_ThrowsImpl();
 
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [InlineData(RegexOptions.None)]


### PR DESCRIPTION
The test is using Roslyn to dynamically emit a Regex with the source generator, as we do throughout the test suite.  However, this test is about validating the default static regex timeout, and the Roslyn code itself uses a regex.  To work around this, this PR splits off the source generated test into its own dedicated one that doesn't rely on Roslyn.

Fixes https://github.com/dotnet/runtime/issues/77814