### PR TITLE
[JIT] - TP Emitter improvement - Using 'FORCEINLINE' on 'emitAllocAnyInstr'

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1435,7 +1435,7 @@ size_t emitter::emitGenEpilogLst(size_t (*fp)(void*, unsigned), void* cp)
  *  The following series of methods allocates instruction descriptors.
  */
 
-void* emitter::emitAllocAnyInstr(size_t sz, emitAttr opsz)
+FORCEINLINE void* emitter::emitAllocAnyInstr(size_t sz, emitAttr opsz)
 {
     instrDesc* id;
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2247,7 +2247,7 @@ private:
     // The emitters themselves use emitNewXXX, which might be thin wrappers over the emitAllocXXX functions.
     //
 
-    __forceinline void* emitAllocAnyInstr(size_t sz, emitAttr attr);
+    FORCEINLINE void* emitAllocAnyInstr(size_t sz, emitAttr attr);
 
     instrDesc* emitAllocInstr(emitAttr attr)
     {

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2247,7 +2247,7 @@ private:
     // The emitters themselves use emitNewXXX, which might be thin wrappers over the emitAllocXXX functions.
     //
 
-    void* emitAllocAnyInstr(size_t sz, emitAttr attr);
+    __forceinline void* emitAllocAnyInstr(size_t sz, emitAttr attr);
 
     instrDesc* emitAllocInstr(emitAttr attr)
     {


### PR DESCRIPTION
At the moment, this may or may not be an improvement if `emitAllocAnyInstr` already gets inlined from PGO. Will need to investigate further.