### PR TITLE
Fix multiple dumps from being generated

### DIFF
--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -294,22 +294,6 @@ void SEHCleanupSignals()
     }
 }
 
-/*++
-Function :
-    SEHCleanupAbort()
-
-    Restore default SIGABORT signal handlers
-
-    (no parameters, no return value)
---*/
-void SEHCleanupAbort()
-{
-    if (g_registered_signal_handlers)
-    {
-        restore_signal(SIGABRT, &g_previous_sigabrt);
-    }
-}
-
 /* internal function definitions **********************************************/
 
 /*++

--- a/src/coreclr/pal/src/include/pal/signal.hpp
+++ b/src/coreclr/pal/src/include/pal/signal.hpp
@@ -117,14 +117,4 @@ Function :
 --*/
 void SEHCleanupSignals();
 
-/*++
-Function :
-    SEHCleanupAbort()
-
-    Restore default SIGABORT signal handlers
-
-    (no parameters, no return value)
---*/
-void SEHCleanupAbort();
-
 #endif /* _PAL_SIGNAL_HPP_ */

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2436,8 +2436,9 @@ PROCAbort(int signal)
 
     PROCCreateCrashDumpIfEnabled(signal);
 
-    // Restore the SIGABORT handler to prevent recursion
-    SEHCleanupAbort();
+    // Restore all signals; the SIGABORT handler to prevent recursion and
+    // the others to prevent multiple core dumps from being generated.
+    SEHCleanupSignals();
 
     // Abort the process after waiting for the core dump to complete
     abort();


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/78956

After a core dump is generated because of a unhandled managed exception abort() is called but a SIGSEGV is generated in libpthread.so which is caught by the runtime and a second core dump is generated. The fix is to uninstall/uninitialize all the signal handlers, not just SIGABORT.