### PR TITLE
Jiterpreter opcode updates + implement safepoints

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -8665,4 +8665,11 @@ mono_jiterp_interp_entry (JiterpEntryData *_data, stackval *sp_args, void *res)
 		mono_jiterp_stackval_to_data (type, frame.stack, res);
 }
 
+EMSCRIPTEN_KEEPALIVE void
+mono_jiterp_auto_safepoint (InterpFrame *frame, guint16 *ip)
+{
+	if (G_UNLIKELY (mono_polling_required))
+		do_safepoint (frame, get_context(), ip);
+}
+
 #endif

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -682,6 +682,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_NEWOBJ_VT_INLINED:
 		case MINT_LD_DELEGATE_METHOD_PTR:
 		case MINT_LDTSFLDA:
+		case MINT_SAFEPOINT:
 			return TRACE_CONTINUE;
 
 		case MINT_BR:
@@ -716,7 +717,6 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_RETHROW:
 		case MINT_PROF_EXIT:
 		case MINT_PROF_EXIT_VOID:
-		case MINT_SAFEPOINT:
 			return TRACE_ABORT;
 
 		case MINT_MOV_SRC_OFF:

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -660,6 +660,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_CPOBJ_VT:
 		case MINT_LDOBJ_VT:
 		case MINT_STOBJ_VT:
+		case MINT_CPOBJ_VT_NOREF:
 		case MINT_STRLEN:
 		case MINT_GETCHR:
 		case MINT_GETITEM_SPAN:

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -660,6 +660,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_CPOBJ_VT:
 		case MINT_LDOBJ_VT:
 		case MINT_STOBJ_VT:
+		case MINT_STOBJ_VT_NOREF:
 		case MINT_CPOBJ_VT_NOREF:
 		case MINT_STRLEN:
 		case MINT_GETCHR:

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -117,6 +117,9 @@ typedef struct {
 } JiterpEntryData;
 
 void
+mono_jiterp_auto_safepoint (InterpFrame *frame, guint16 *ip);
+
+void
 mono_jiterp_interp_entry (JiterpEntryData *_data, stackval *sp_args, void *res);
 
 #endif // __MONO_MINI_INTERPRETER_INTERNALS_H__

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -251,6 +251,7 @@ function getTraceImports () {
         ["ldtsflda", "ldtsflda", getRawCwrap("mono_jiterp_ldtsflda")],
         ["conv_ovf", "conv_ovf", getRawCwrap("mono_jiterp_conv_ovf")],
         ["relop_fp", "relop_fp", getRawCwrap("mono_jiterp_relop_fp")],
+        ["safepoint", "safepoint", getRawCwrap("mono_jiterp_auto_safepoint")],
     ];
 
     if (instrumentedMethodNames.length > 0) {
@@ -503,6 +504,12 @@ function generate_wasm (
                 "rhs": WasmValtype.f64,
                 "opcode": WasmValtype.i32,
             }, WasmValtype.i32
+        );
+        builder.defineType(
+            "safepoint", {
+                "frame": WasmValtype.i32,
+                "ip": WasmValtype.i32,
+            }, WasmValtype.void
         );
 
         builder.generateTypeSection();
@@ -885,6 +892,10 @@ function generate_wasm_body (
             case MintOpcode.MINT_SDB_INTR_LOC:
             case MintOpcode.MINT_SDB_SEQ_POINT:
                 is_dead_opcode = true;
+                break;
+
+            case MintOpcode.MINT_SAFEPOINT:
+                append_safepoint(builder, ip);
                 break;
 
             case MintOpcode.MINT_LDLOCA_S:
@@ -2387,11 +2398,10 @@ function emit_branch (
         //  so just return.
         // FIXME: Why is this not a safepoint?
         append_bailout(builder, destination, BailoutReason.BackwardBranch, true);
-    } else if (isSafepoint) {
-        // We set the high bit on our relative displacement so that the interpreter knows
-        //  it needs to perform a safepoint after the trace exits
-        append_bailout(builder, destination, BailoutReason.SafepointBranchTaken, true);
     } else {
+        // Do a safepoint *before* changing our IP, if necessary
+        if (isSafepoint)
+            append_safepoint(builder, ip);
         // Branching is enabled, so set eip and exit the current branch block
         builder.branchTargets.add(destination);
         builder.ip_const(destination);
@@ -2937,6 +2947,13 @@ function append_bailout (builder: WasmBuilder, ip: MintOpcodePtr, reason: Bailou
         builder.callImport("bailout");
     }
     builder.appendU8(WasmOpcode.return_);
+}
+
+function append_safepoint (builder: WasmBuilder, ip: MintOpcodePtr) {
+    builder.local("frame");
+    // Not ip_const, because we can't pass relative IP to do_safepoint
+    builder.i32_const(ip);
+    builder.callImport("safepoint");
 }
 
 const JITERPRETER_TRAINING = 0;

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -917,6 +917,13 @@ function generate_wasm_body (
                 builder.callImport("value_copy");
                 break;
             }
+            case MintOpcode.MINT_CPOBJ_VT_NOREF: {
+                const sizeBytes = getArgU16(ip, 3);
+                append_ldloc(builder, getArgU16(ip, 1), WasmOpcode.i32_load);
+                append_ldloc(builder, getArgU16(ip, 2), WasmOpcode.i32_load);
+                append_memmove_dest_src(builder, sizeBytes);
+                break;
+            }
             case MintOpcode.MINT_LDOBJ_VT: {
                 const size = getArgU16(ip, 3);
                 append_ldloca(builder, getArgU16(ip, 1));


### PR DESCRIPTION
This PR implements some of the new interpreter opcodes (CPOBJ_VT_NOREF and STOBJ_VT_NOREF) while also adding support for doing safepoints without leaving traces. Many safepoint branches don't go backwards (this surprised me!) so we can potentially avoid a bailout if we do the safepoint from inside.

A quick set of test runs shows that this PR reduces the time to run System.Runtime.Tests in interpreter+jiterpreter mode from 141.6sec to 137.3sec. (Note that the jiterpreter is still not enabled by default)