### PR TITLE
Suppress warnings for taking address of TypedReference

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -56,7 +56,9 @@ namespace System
             // reference to TypedReference is banned, so have to pass result as pointer
             unsafe
             {
+#pragma warning disable CS8500 // Takes a pointer to a managed type
                 FCallGetNextArg(&result);
+#pragma warning restore CS8500
             }
             return result;
         }
@@ -92,7 +94,9 @@ namespace System
                 // reference to TypedReference is banned, so have to pass result as pointer
                 unsafe
                 {
+#pragma warning disable CS8500 // Takes a pointer to a managed type
                     InternalGetNextArg(&result, rth.GetRuntimeType());
+#pragma warning restore CS8500
                 }
                 return result;
             }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
@@ -172,7 +172,9 @@ namespace System.Reflection
                 throw new ArgumentException(SR.Arg_TypedReference_Null);
 
             // Passing TypedReference by reference is easier to make correct in native code
+#pragma warning disable CS8500 // Takes a pointer to a managed type
             return RuntimeFieldHandle.GetValueDirect(this, (RuntimeType)FieldType, &obj, (RuntimeType?)DeclaringType);
+#pragma warning restore CS8500
         }
 
         [DebuggerStepThrough]
@@ -227,7 +229,9 @@ namespace System.Reflection
                 throw new ArgumentException(SR.Arg_TypedReference_Null);
 
             // Passing TypedReference by reference is easier to make correct in native code
+#pragma warning disable CS8500 // Takes a pointer to a managed type
             RuntimeFieldHandle.SetValueDirect(this, (RuntimeType)FieldType, &obj, value, (RuntimeType?)DeclaringType);
+#pragma warning restore CS8500
         }
 
         public override RuntimeFieldHandle FieldHandle => new RuntimeFieldHandle(this);

--- a/src/libraries/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TypedReference.cs
@@ -53,7 +53,9 @@ namespace System
             // reference to TypedReference is banned, so have to pass result as pointer
             unsafe
             {
+#pragma warning disable CS8500 // Takes a pointer to a managed type
                 InternalMakeTypedReference(&result, target, fields, targetType);
+#pragma warning restore CS8500
             }
             return result;
         }


### PR DESCRIPTION
Relates to compiler change: https://github.com/dotnet/roslyn/pull/66328
Tagging @AaronRobinsonMSFT to confirm those suppressions are okay.