### PR TITLE
Fix duplicate asset because of "Build tools subset to generate artifacts"

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
+++ b/src/tools/illink/src/ILLink.Tasks/ILLink.Tasks.csproj
@@ -12,7 +12,6 @@
     <Nullable>disable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.NET.ILLink.Tasks</PackageId>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- TODO: Enable when the package shipped stable with .NET 8. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <!-- NU5128: This package doesn't contain any lib or ref assemblies because it's a tooling package.


### PR DESCRIPTION
https://github.com/dotnet/runtime/commit/a1bfa04fde6da39370bdb3d7ec9b4a1684444bc0 broke official builds because the illink package was uploaded in every leg instead of just on windows_x64

I first wanted to revert the change but decided to fix it instead as the fix is straightforward. Setting `GeneratePackageOnBuild` results in the package being created and published in every RID leg. The [dnceng public asset promotion pipeline](https://dev.azure.com/dnceng/internal/_build/results?buildId=2085232&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=c7a8693b-2f9c-5ea8-c909-cde9405ac2e1) doesn't allow duplicate assets and hence the official build failed.

Unfortunately we don't have any CI protection for that and we actually hit that issue multiple times in the past cc @mmitche.

Resolving the issue by removing the `GeneratePackageOnBuild` setting and instead letting packaging.targets define it when `BuildAllConfigurations=true` is passed in (which is only true in an official build for windows-x64).