### PR TITLE
[eventpipe] Perform endian aware serialization of structs and arrays above FireETW layer

### DIFF
--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -281,33 +281,9 @@ def generateWriteEventBody(template, providerName, eventName, runtimeFlavor):
             if template.name in specialCaseSizes and paramName in specialCaseSizes[template.name]:
                 size = "(int)(%s)" % specialCaseSizes[template.name][paramName]
             if runtimeFlavor.mono:
-                pack_list.append("#if BIGENDIAN")
-                pack_list.append("    const uint8_t *valuePtr = %s;" % paramName)
-                pack_list.append("    for (uint32_t i = 0; i < %s; ++i) {" % template.structs[paramName])
-                types = [winTypeToFixedWidthType(t) for t in template.structTypes[paramName]]
-                for t in set(types) - {"UTF8String", "UTF16String"}:
-                    pack_list.append("        %(type)s value_%(type)s;" % {'type': t})
-                if "UTF8String" in types or "UTF16String" in types:
-                    pack_list.append("        size_t value_len;")
-                for t in types:
-                    if t == "UTF8String":
-                        pack_list.append("        value_len = strlen((const char *)valuePtr);")
-                        pack_list.append("        success &= write_buffer_string_utf8_t((const ep_char8_t *)valuePtr, value_len, &buffer, &offset, &size, &fixedBuffer);")
-                        pack_list.append("        valuePtr += value_len + 1;")
-                    elif t == "UTF16String":
-                        pack_list.append("        value_len = strlen((const char *)valuePtr);")
-                        pack_list.append("        success &= write_buffer_string_utf8_to_utf16_t((const ep_char8_t *)valuePtr, value_len, &buffer, &offset, &size, &fixedBuffer);")
-                        pack_list.append("        valuePtr += value_len + 1;")
-                    else:
-                        pack_list.append("        memcpy (&value_%(type)s, valuePtr, sizeof (value_%(type)s));" % {'type': t})
-                        pack_list.append("        valuePtr += sizeof (%s);" % t)
-                        pack_list.append("        success &= write_buffer_%(type)s (value_%(type)s, &buffer, &offset, &size, &fixedBuffer);" % {'type': t})
-                pack_list.append("    }")
-                pack_list.append("#else")
                 pack_list.append(
                     "    success &= write_buffer((const uint8_t *)%s, %s, &buffer, &offset, &size, &fixedBuffer);" %
                     (paramName, size))
-                pack_list.append("#endif // BIGENDIAN")
                 emittedWriteToBuffer = True
             elif runtimeFlavor.coreclr:
                 pack_list.append(
@@ -321,16 +297,9 @@ def generateWriteEventBody(template, providerName, eventName, runtimeFlavor):
             if template.name in specialCaseSizes and paramName in specialCaseSizes[template.name]:
                 size = "(int)(%s)" % specialCaseSizes[template.name][paramName]
             if runtimeFlavor.mono:
-                t = winTypeToFixedWidthType(parameter.winType)
-                pack_list.append("#if BIGENDIAN")
-                pack_list.append("    for (uint32_t i = 0; i < %s; ++i) {" % template.arrays[paramName])
-                pack_list.append("        success &= write_buffer_%(type)s (%(name)s[i], &buffer, &offset, &size, &fixedBuffer);" % {'name': paramName, 'type': t})
-                pack_list.append("    }")
-                pack_list.append("#else")
                 pack_list.append(
                     "    success &= write_buffer((const uint8_t *)%s, %s, &buffer, &offset, &size, &fixedBuffer);" %
                     (paramName, size))
-                pack_list.append("#endif // BIGENDIAN")
                 emittedWriteToBuffer = True
             elif runtimeFlavor.coreclr:
                 pack_list.append(

--- a/src/coreclr/scripts/genEventing.py
+++ b/src/coreclr/scripts/genEventing.py
@@ -188,11 +188,10 @@ class Template:
     def __repr__(self):
         return "<Template " + self.name + ">"
 
-    def __init__(self, templateName, fnPrototypes, dependencies, structSizes, structTypes, arrays):
+    def __init__(self, templateName, fnPrototypes, dependencies, structSizes, arrays):
         self.name = templateName
         self.signature = FunctionSignature()
         self.structs = structSizes
-        self.structTypes = structTypes
         self.arrays = arrays
 
         for variable in fnPrototypes.paramlist:
@@ -274,7 +273,6 @@ def parseTemplateNodes(templateNodes):
 
     for templateNode in templateNodes:
         structCounts = {}
-        structTypes  = {}
         arrays = {}
         templateName    = templateNode.getAttribute('tid')
         var_Dependencies = {}
@@ -339,12 +337,11 @@ def parseTemplateNodes(templateNodes):
             types = [x.attributes['inType'].value for x in structToBeMarshalled.getElementsByTagName("data")]
 
             structCounts[structName] = countVarName
-            structTypes[structName] = types
             var_Dependencies[structName] = [countVarName, structName]
             fnparam_pointer = FunctionParameter("win:Struct", structName, "win:count", countVarName)
             fnPrototypes.append(structName, fnparam_pointer)
 
-        allTemplates[templateName] = Template(templateName, fnPrototypes, var_Dependencies, structCounts, structTypes, arrays)
+        allTemplates[templateName] = Template(templateName, fnPrototypes, var_Dependencies, structCounts, arrays)
 
     return allTemplates
 

--- a/src/native/eventpipe/ep-config.c
+++ b/src/native/eventpipe/ep-config.c
@@ -391,8 +391,8 @@ ep_config_build_event_metadata_event (
 	const ep_char16_t *provider_name_utf16 = ep_provider_get_provider_name_utf16 (provider);
 	const uint8_t *payload_data = ep_event_get_metadata (source_event);
 	uint32_t payload_data_len = ep_event_get_metadata_len (source_event);
-	uint32_t provider_name_len = (uint32_t)((ep_rt_utf16_string_len (provider_name_utf16) + 1) * sizeof (ep_char16_t));
-	uint32_t instance_payload_size = sizeof (metadata_id) + provider_name_len + payload_data_len;
+	uint32_t provider_name_len = (uint32_t)ep_rt_utf16_string_len (provider_name_utf16);
+	uint32_t instance_payload_size = sizeof (metadata_id) + ((provider_name_len + 1) * sizeof (ep_char16_t)) + payload_data_len;
 
 	// Allocate the payload.
 	instance_payload = ep_rt_byte_array_alloc (instance_payload_size);


### PR DESCRIPTION
In the past struct members of payloads were always of primitive types. Since the enablement of the event `BulkType` in commit bfc7359d7e9 struct members may be of array type. On big-endian architectures we need to walk over the whole structure and perform byte swaps accordingly which is done by this fix also for array members.

According to the [manifest](https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/ClrEtwAll.man) there is no event which makes use of nested structures or nested arrays except what is fixed by this patch. Assuming this won't change in the future this patch should be sufficient. Otherwise we might need a more general approach in order to parse and convert arbitrary payloads.

This is basically a follow up to #68648.