### PR TITLE
[6.0] Disable GetProviderNames_AssertProperties test

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
@@ -90,6 +90,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/80475")]
         public void GetProviderNames_AssertProperties()
         {
             const string Prefix = "win:";


### PR DESCRIPTION
Addresses: https://github.com/dotnet/runtime/issues/80475
