### PR TITLE
[release/7.0] Fix delegate allocation in CachingContext.GetOrAddJsonTypeInfo

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -8,7 +8,8 @@
     <NoWarn>CS8969</NoWarn>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>
-    <ServicingVersion>1</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>2</ServicingVersion>
     <!-- This library has been annotated to be AOT safe -->
     <EnableAOTAnalyzer>true</EnableAOTAnalyzer>
     <PackageDescription>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -141,10 +141,13 @@ namespace System.Text.Json
         internal sealed class CachingContext
         {
             private readonly ConcurrentDictionary<Type, JsonTypeInfo?> _jsonTypeInfoCache = new();
+            private readonly Func<Type, JsonTypeInfo?> _jsonTypeInfoFactory;
 
             public CachingContext(JsonSerializerOptions options)
             {
                 Options = options;
+
+                _jsonTypeInfoFactory = options.GetTypeInfoNoCaching;
             }
 
             public JsonSerializerOptions Options { get; }
@@ -152,7 +155,8 @@ namespace System.Text.Json
             // If changing please ensure that src/ILLink.Descriptors.LibraryBuild.xml is up-to-date.
             public int Count => _jsonTypeInfoCache.Count;
 
-            public JsonTypeInfo? GetOrAddJsonTypeInfo(Type type) => _jsonTypeInfoCache.GetOrAdd(type, Options.GetTypeInfoNoCaching);
+            public JsonTypeInfo? GetOrAddJsonTypeInfo(Type type) => _jsonTypeInfoCache.GetOrAdd(type, _jsonTypeInfoFactory);
+
             public bool TryGetJsonTypeInfo(Type type, [NotNullWhen(true)] out JsonTypeInfo? typeInfo) => _jsonTypeInfoCache.TryGetValue(type, out typeInfo);
 
             public void Clear()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -146,8 +146,7 @@ namespace System.Text.Json
             public CachingContext(JsonSerializerOptions options)
             {
                 Options = options;
-
-                _jsonTypeInfoFactory = options.GetTypeInfoNoCaching;
+                _jsonTypeInfoFactory = Options.GetTypeInfoNoCaching;
             }
 
             public JsonSerializerOptions Options { get; }


### PR DESCRIPTION
Fixes #80430.

## Customer Impact

Fixes a customer reported performance regression in STJ's metadata caching implementation, which will a allocate a new delegate on every metadata lookup operation. This becomes particularly noticeable when serializing object graphs containing many polymorphic values, for example large non-generic collections.

## Testing

N/A.

## Risk

Low. It is a small change that caches the metadata factory delegate in a field.