### PR TITLE
Strip all symbols on macOS as well

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -399,7 +399,7 @@ function(strip_symbols targetName outputFilename)
         message(FATAL_ERROR "strip not found")
       endif()
 
-      set(strip_command ${STRIP} -no_code_signature_warning -x ${strip_source_file})
+      set(strip_command ${STRIP} -no_code_signature_warning -S ${strip_source_file})
 
       # codesign release build
       string(TOLOWER "${CMAKE_BUILD_TYPE}" LOWERCASE_CMAKE_BUILD_TYPE)

--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -399,7 +399,7 @@ function(strip_symbols targetName outputFilename)
         message(FATAL_ERROR "strip not found")
       endif()
 
-      set(strip_command ${STRIP} -no_code_signature_warning -S ${strip_source_file})
+      set(strip_command ${STRIP} -no_code_signature_warning -x ${strip_source_file})
 
       # codesign release build
       string(TOLOWER "${CMAKE_BUILD_TYPE}" LOWERCASE_CMAKE_BUILD_TYPE)

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -344,6 +344,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <_IgnoreLinkerWarnings>false</_IgnoreLinkerWarnings>
       <_IgnoreLinkerWarnings Condition="'$(TargetOS)' == 'osx'">true</_IgnoreLinkerWarnings>
+      <StripFlag Condition="'$(TargetOS)' == 'osx' and '$(NativeLib)' == 'Shared'">-x</StripFlag> <!-- keep global symbols in dylib -->
     </PropertyGroup>
 
     <Exec Command="&quot;$(CppLinker)&quot; @(CustomLinkerArg, ' ')" Condition="'$(TargetOS)' != 'windows' and '$(NativeLib)' != 'Static'" IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)" />
@@ -364,10 +365,10 @@ The .NET Foundation licenses this file to you under the MIT license.
         &quot;$(ObjCopyName)&quot; --strip-debug --strip-unneeded &quot;$(NativeBinary)&quot; &amp;&amp;
         &quot;$(ObjCopyName)&quot; --add-gnu-debuglink=&quot;$(NativeBinary)$(NativeSymbolExt)&quot; &quot;$(NativeBinary)&quot;" />
 
-    <Exec Condition="'$(StripSymbols)' == 'true' and '$(TargetOS)' == 'osx'"
+    <Exec Condition="'$(StripSymbols)' == 'true' and '$(TargetOS)' == 'osx' and '$(NativeLib)' != 'Static'"
       Command="
         dsymutil $(DsymUtilOptions) &quot;$(NativeBinary)&quot; &amp;&amp;
-        strip -no_code_signature_warning -S &quot;$(NativeBinary)&quot;" />
+        strip -no_code_signature_warning $(StripFlag) &quot;$(NativeBinary)&quot;" />
   </Target>
 
   <Target Name="CreateLib"


### PR DESCRIPTION
On non-Darwin Unix, we are stripping all symbols from release binaries.
On Darwin, we are stripping only the Debug symbols (with `-S`).

Removing `-S` from Darwin branchs aligns the behavior with other Unices. With MVC template app (net8.0), `StripSymbols=true` is producing 184M release binary on osx-arm64; with this PR, it shrinks down to 75M.

Thanks to @neon-sunset for pointing it out and sharing repro: https://github.com/dotnet/runtime/issues/80416#issuecomment-1376827491

I have tested it on macOS, which (does not use `.gnu_debuglink` but instead) uses UUID to match the symbol file and that UUID is preserved:

```sh
# using @neon-sunset's repro

$ otool -l dist/http-bench | grep ' uuid '
    uuid B585F7F9-DB0C-3900-95E2-954BD1DB3DF1
$ otool -l dist/http-bench.dwarf | grep ' uuid '
    uuid B585F7F9-DB0C-3900-95E2-954BD1DB3DF1

$ lldb dist/http-bench

# lookup a symbol which is known to exist.
(lldb) image lookup -vn RedhawkGCInterface::BulkEnumGcObjRef
# nothing! because all symbols were stripped and no symbol file is loaded yet.
# note: in main branch it finds the symbol with partial information (which is totally unnecessary)

# load the symbol file.
(lldb) target symbols add dist/http-bench.dwarf
symbol file '/Users/am11/projects/http-bench/dist/http-bench.dwarf' has been added to '/Users/am11/projects/http-bench/dist/http-bench'

# try again
(lldb) image lookup -vn RedhawkGCInterface::BulkEnumGcObjRef
1 match found in /Users/am11/projects/http-bench/dist/http-bench:
        Address: http-bench[0x000000010000fe94] (http-bench.__TEXT.__text + 51072)
        Summary: http-bench`RedhawkGCInterface::BulkEnumGcObjRef(RtuObjectRef*, unsigned int, void*, void*) at gcrhenv.cpp:421:5
         Module: file = "/Users/am11/projects/http-bench/dist/http-bench", arch = "arm64"
    CompileUnit: id = {0x0000000e}, file = "/Users/runner/work/1/s/src/coreclr/nativeaot/Runtime/gcrhenv.cpp", language = "c++11"
       Function: id = {0x001ed804}, name = "RedhawkGCInterface::BulkEnumGcObjRef(RtuObjectRef*, unsigned int, void*, void*)", mangled = "_ZN18RedhawkGCInterface16BulkEnumGcObjRefEP12RtuObjectRefjPvS2_", range = [0x000000010000fe94-0x000000010000fe98)
       FuncType: id = {0x001ed804}, byte-size = 0, decl = gcrhinterface.h:117, compiler_type = "void (PTR_RtuObjectRef, uint32_t, void *, void *)"
         Blocks: id = {0x001ed804}, range = [0x10000fe94-0x10000fe98)
      LineEntry: [0x000000010000fe94-0x000000010000fe98): /Users/runner/work/1/s/src/coreclr/nativeaot/Runtime/gcrhenv.cpp:421:5
         Symbol: id = {0x000000a0}, range = [0x000000010000fe94-0x000000010000fe98), name="RedhawkGCInterface::BulkEnumGcObjRef(RtuObjectRef*, unsigned int, void*, void*)", mangled="_ZN18RedhawkGCInterface16BulkEnumGcObjRefEP12RtuObjectRefjPvS2_"
       Variable: id = {0x001ed81b}, name = "pRefs", type = "PTR_RtuObjectRef", location = DW_OP_reg0 W0, decl = gcrhenv.cpp:419
       Variable: id = {0x001ed82a}, name = "cRefs", type = "uint32_t", location = DW_OP_reg1 W1, decl = gcrhenv.cpp:419
       Variable: id = {0x001ed839}, name = "pfnEnumCallback", type = "void *", location = DW_OP_reg2 W2, decl = gcrhenv.cpp:419
       Variable: id = {0x001ed848}, name = "pvCallbackData", type = "void *", location = DW_OP_reg3 W3, decl = gcrhenv.cpp:419
```