### PR TITLE
Remove per-context delegate allocations in netcoreapp targets

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -165,7 +165,7 @@ namespace System.Text.Json
                 Options = options;
                 HashCode = hashCode;
 #if !NETCOREAPP
-                _jsonTypeInfoFactory = options.GetTypeInfoNoCaching;
+                _jsonTypeInfoFactory = Options.GetTypeInfoNoCaching;
 #endif
             }
 


### PR DESCRIPTION
Following up on #80437 this removes delegate allocations altogether in netcoreapp targets.