### PR TITLE
Introduce TieredPGO_InstrumentedTierAlwaysOptimized for PGO tests

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -614,6 +614,7 @@ jobs:
             - fullpgo_random_gdv
             - fullpgo_random_gdv_methodprofiling_only
             - fullpgo_random_gdv_edge
+            - fullpgo_methodprofiling_always_optimized
         ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
           longRunningGcTests: true
           scenarios:

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -610,6 +610,9 @@ RETAIL_CONFIG_DWORD_INFO(EXTERNAL_TieredPGO, W("TieredPGO"), 0, "Instrument Tier
 // 0) Instrument all IL-only code, R2R'd code is never instrumented
 // 1) Instrument only hot IL-only and hot R2R code (use optimizations in the instrumented tier for hot R2R and no optimizations for hot IL-only)
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredPGO_InstrumentOnlyHotCode, W("TieredPGO_InstrumentOnlyHotCode"), 1, "Strategy for TieredPGO, see comments in clrconfigvalues.h")
+
+// By default, we only use optimizations in instrumented tiers for hot R2R code only.
+RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredPGO_InstrumentedTierAlwaysOptimized, W("TieredPGO_InstrumentedTierAlwaysOptimized"), 0, "Always use optimizations inside instrumented tiers")
 #endif
 
 ///

--- a/src/coreclr/vm/tieredcompilation.cpp
+++ b/src/coreclr/vm/tieredcompilation.cpp
@@ -302,6 +302,14 @@ void TieredCompilationManager::AsyncPromoteToTier1(
                 // 3) Unoptimized instrumented tier is faster to produce and wire up
                 nextTier = NativeCodeVersion::OptimizationTier0Instrumented;
 
+#if _DEBUG
+                if (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_TieredPGO_InstrumentedTierAlwaysOptimized) != 0)
+                {
+                    // Override that behavior and always use optimizations.
+                    nextTier = NativeCodeVersion::OptimizationTier1Instrumented;
+                }
+#endif
+
                 // NOTE: we might consider using OptimizationTier1Instrumented if the previous Tier0
                 // made it to Tier1-OSR.
             }

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -68,6 +68,7 @@
       DOTNET_JitRandomEdgeCounts;
       DOTNET_JitRandomOnStackReplacement;
       DOTNET_JitRandomlyCollect64BitCounts;
+      DOTNET_TieredPGO_InstrumentedTierAlwaysOptimized;
       DOTNET_JitForceControlFlowGuard;
       DOTNET_JitCFGUseDispatcher;
       RunningIlasmRoundTrip
@@ -212,6 +213,7 @@
     <TestEnvironment Include="defaultpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" />
     <TestEnvironment Include="fullpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0"/>
     <TestEnvironment Include="fullpgo_methodprofiling" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" />
+    <TestEnvironment Include="fullpgo_methodprofiling_always_optimized" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitDelegateProfiling="1" JitVTableProfiling="1" TieredPGO_InstrumentedTierAlwaysOptimized="1" />
     <TestEnvironment Include="fullpgo_random_gdv" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="fullpgo_random_gdv_methodprofiling_only" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitClassProfiling="0" JitDelegateProfiling="1" JitVTableProfiling="1" JitRandomlyCollect64BitCounts="1" />
     <TestEnvironment Include="fullpgo_random_gdv_edge" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomEdgeCounts="1" JitRandomlyCollect64BitCounts="1" />


### PR DESCRIPTION
Currently we use optimizations for instrumented tiers only when we instrument (promote) hot R2R code. For IL-only one we don't do that for various reasons. That quite complicates testing since they require all tests to be prejitted and R2R to be not disabled. `DOTNET_TieredPGO_InstrumentedTierAlwaysOptimized=1` is supposed to increase test coverage for that. Example (let's say the app is not prejitted):

```csharp
static void Main()
{
    for (int i = 0; i < 100; i++)
    {
        Test(null);
        Thread.Sleep(16);
    }
}

[MethodImpl(MethodImplOptions.NoInlining)]
static void Test(IDisposable d) => d?.Dispose();
```
Instrumented tier for `Test`:
```asm
; Assembly listing for method Program:Test(System.IDisposable)
; Tier-0 compilation
; MinOpts code
; instrumented for collecting profile data
G_M17785_IG01:              ;; offset=0000H
       55                   push     rbp
       4883EC30             sub      rsp, 48
       488D6C2430           lea      rbp, [rsp+30H]
       33C0                 xor      eax, eax
       488945F8             mov      qword ptr [rbp-08H], rax
       488945F0             mov      qword ptr [rbp-10H], rax
       48894D10             mov      gword ptr [rbp+10H], rcx
						;; size=24 bbWeight=1 PerfScore 5.00
G_M17785_IG02:              ;; offset=0018H
       48837D1000           cmp      gword ptr [rbp+10H], 0
       743A                 je       SHORT G_M17785_IG03
       FF053B9B6100         inc      dword ptr [(reloc 0x7ffbad64bb80)]
       488B4D10             mov      rcx, gword ptr [rbp+10H]
       48894DF8             mov      gword ptr [rbp-08H], rcx
       488B4DF8             mov      rcx, gword ptr [rbp-08H]
       48BA88BB64ADFB7F0000 mov      rdx, 0x7FFBAD64BB88
       E8E0F54E5F           call     CORINFO_HELP_CLASSPROFILE32
       488B4DF8             mov      rcx, gword ptr [rbp-08H]
       48894DF0             mov      gword ptr [rbp-10H], rcx
       488B4DF0             mov      rcx, gword ptr [rbp-10H]
       49BB7800D6ACFB7F0000 mov      r11, 0x7FFBACD60078      ; code for System.IDisposable:Dispose():this
       41FF13               call     [r11]System.IDisposable:Dispose():this
						;; size=65 bbWeight=1 PerfScore 16.50
G_M17785_IG03:              ;; offset=0059H
       FF05519B6100         inc      dword ptr [(reloc 0x7ffbad64bbd0)]
						;; size=6 bbWeight=1 PerfScore 3.00
G_M17785_IG04:              ;; offset=005FH
       4883C430             add      rsp, 48
       5D                   pop      rbp
       C3                   ret      
; Total bytes of code 101
```
Instrumented tier for `Test` with `DOTNET_TieredPGO_InstrumentedTierAlwaysOptimized=1`:
```asm
; Assembly listing for method Program:Test(System.IDisposable)
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; Tier-1 compilation
; optimized code
; instrumented for collecting profile data
G_M17785_IG01:              ;; offset=0000H
       56                   push     rsi
       4883EC20             sub      rsp, 32
       488BF1               mov      rsi, rcx
						;; size=8 bbWeight=1 PerfScore 1.50
G_M17785_IG02:              ;; offset=0008H
       FF058A6E6600         inc      dword ptr [(reloc 0x7ffbaa992cc8)]
       4885F6               test     rsi, rsi
       7428                 je       SHORT G_M17785_IG04
						;; size=11 bbWeight=1 PerfScore 4.25
G_M17785_IG03:              ;; offset=0013H
       FF05836E6600         inc      dword ptr [(reloc 0x7ffbaa992ccc)]
       488BCE               mov      rcx, rsi
       48BAD02C99AAFB7F0000 mov      rdx, 0x7FFBAA992CD0
       E8E557525F           call     CORINFO_HELP_CLASSPROFILE32
       488BCE               mov      rcx, rsi
       49BB200105AAFB7F0000 mov      r11, 0x7FFBAA050120      ; code for System.IDisposable:Dispose():this
       41FF13               call     [r11]System.IDisposable:Dispose():this
						;; size=40 bbWeight=0.50 PerfScore 4.00
G_M17785_IG04:              ;; offset=003BH
       FF05A76E6600         inc      dword ptr [(reloc 0x7ffbaa992d18)]
						;; size=6 bbWeight=1 PerfScore 3.00
G_M17785_IG05:              ;; offset=0041H
       4883C420             add      rsp, 32
       5E                   pop      rsi
       C3                   ret      
						;; size=6 bbWeight=1 PerfScore 1.75
; Total bytes of code 71
```
PS: block-based instrumentation ^

cc @AndyAyersMS 