### PR TITLE
Removing old variable debug info tracking system

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -701,33 +701,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     void genSetScopeInfoUsingVariableRanges();
 #endif // USING_VARIABLE_LIVE_RANGE
 
-#ifdef USING_SCOPE_INFO
-    void genSetScopeInfoUsingsiScope();
-
-/*
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XX                                                                           XX
-XX                           ScopeInfo                                       XX
-XX                                                                           XX
-XX  Keeps track of the scopes during code-generation.                        XX
-XX  This is used to translate the local-variable debugging information       XX
-XX  from IL offsets to native code offsets.                                  XX
-XX                                                                           XX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-*/
-
-/*****************************************************************************/
-/*****************************************************************************
- *                              ScopeInfo
- *
- * This class is called during code gen at block-boundaries, and when the
- * set of live variables changes. It keeps track of the scope of the variables
- * in terms of the native code PC.
- */
-
-#endif // USING_SCOPE_INFO
 public:
     void siInit();
     void checkICodeDebugInfo();
@@ -747,165 +720,23 @@ protected:
 
     IL_OFFSET siLastEndOffs; // IL offset of the (exclusive) end of the last block processed
 
-#ifdef USING_SCOPE_INFO
-
-public:
-    // Closes the "ScopeInfo" of the tracked variables that has become dead.
-    virtual void siUpdate();
-
-    void siCheckVarScope(unsigned varNum, IL_OFFSET offs);
-
-    void siCloseAllOpenScopes();
-
-#ifdef DEBUG
-    void siDispOpenScopes();
-#endif
-
-    /**************************************************************************
-     *                          PROTECTED
-     *************************************************************************/
-
-protected:
-    struct siScope
-    {
-        emitLocation scStartLoc; // emitter location of start of scope
-        emitLocation scEndLoc;   // emitter location of end of scope
-
-        unsigned scVarNum; // index into lvaTable
-        unsigned scLVnum;  // 'which' in eeGetLVinfo()
-
-        unsigned scStackLevel; // Only for stk-vars
-
-        siScope* scPrev;
-        siScope* scNext;
-    };
-
-    // Returns a "siVarLoc" instance representing the place where the variable lives base on
-    // varDsc and scope description.
-    CodeGenInterface::siVarLoc getSiVarLoc(const LclVarDsc* varDsc, const siScope* scope) const;
-
-    siScope siOpenScopeList, siScopeList, *siOpenScopeLast, *siScopeLast;
-
-    unsigned siScopeCnt;
-
-    VARSET_TP siLastLife; // Life at last call to siUpdate()
-
-    // Tracks the last entry for each tracked register variable
-
-    siScope** siLatestTrackedScopes;
-
-    // Functions
-
-    siScope* siNewScope(unsigned LVnum, unsigned varNum);
-
-    void siRemoveFromOpenScopeList(siScope* scope);
-
-    void siEndTrackedScope(unsigned varIndex);
-
-    void siEndScope(unsigned varNum);
-
-    void siEndScope(siScope* scope);
-
-#ifdef DEBUG
-    bool siVerifyLocalVarTab();
-#endif
-
-#ifdef LATE_DISASM
-public:
-    /* virtual */
-    const char* siRegVarName(size_t offs, size_t size, unsigned reg);
-
-    /* virtual */
-    const char* siStackVarName(size_t offs, size_t size, unsigned reg, unsigned stkOffs);
-#endif // LATE_DISASM
-
-/*
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XX                                                                           XX
-XX                          PrologScopeInfo                                  XX
-XX                                                                           XX
-XX We need special handling in the prolog block, as the parameter variables  XX
-XX may not be in the same position described by genLclVarTable - they all    XX
-XX start out on the stack                                                    XX
-XX                                                                           XX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-*/
-#endif // USING_SCOPE_INFO
+    /*
+    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    XX                                                                           XX
+    XX                          PrologScopeInfo                                  XX
+    XX                                                                           XX
+    XX We need special handling in the prolog block, as the parameter variables  XX
+    XX may not be in the same position described by genLclVarTable - they all    XX
+    XX start out on the stack                                                    XX
+    XX                                                                           XX
+    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    */
 public:
     void psiBegProlog();
 
     void psiEndProlog();
-
-#ifdef USING_SCOPE_INFO
-    void psiAdjustStackLevel(unsigned size);
-
-    // For EBP-frames, the parameters are accessed via ESP on entry to the function,
-    // but via EBP right after a "mov ebp,esp" instruction.
-    void psiMoveESPtoEBP();
-
-    // Close previous psiScope and open a new one on the location described by the registers.
-    void psiMoveToReg(unsigned varNum, regNumber reg = REG_NA, regNumber otherReg = REG_NA);
-
-    // Search the open "psiScope" of the "varNum" parameter, close it and open
-    // a new one using "LclVarDsc" fields.
-    void psiMoveToStack(unsigned varNum);
-
-    /**************************************************************************
-     *                          PROTECTED
-     *************************************************************************/
-
-protected:
-    struct psiScope
-    {
-        emitLocation scStartLoc; // emitter location of start of scope
-        emitLocation scEndLoc;   // emitter location of end of scope
-
-        unsigned scSlotNum; // index into lclVarTab
-        unsigned scLVnum;   // 'which' in eeGetLVinfo()
-
-        bool scRegister;
-
-        union {
-            struct
-            {
-                regNumberSmall scRegNum;
-
-                // Used for:
-                //  - "other half" of long var on architectures with 32 bit size registers - x86.
-                //  - for System V structs it stores the second register
-                //    used to pass a register passed struct.
-                regNumberSmall scOtherReg;
-            } u1;
-
-            struct
-            {
-                regNumberSmall scBaseReg;
-                NATIVE_OFFSET  scOffset;
-            } u2;
-        };
-
-        psiScope* scPrev;
-        psiScope* scNext;
-
-        // Returns a "siVarLoc" instance representing the place where the variable lives base on
-        // psiScope properties.
-        CodeGenInterface::siVarLoc getSiVarLoc() const;
-    };
-
-    psiScope psiOpenScopeList, psiScopeList, *psiOpenScopeLast, *psiScopeLast;
-
-    unsigned psiScopeCnt;
-
-    // Implementation Functions
-
-    psiScope* psiNewPrologScope(unsigned LVnum, unsigned slotNum);
-
-    void psiEndPrologScope(psiScope* scope);
-
-    void psiSetScopeOffset(psiScope* newScope, const LclVarDsc* lclVarDsc) const;
-#endif // USING_SCOPE_INFO
 
     NATIVE_OFFSET psiGetVarStackOffset(const LclVarDsc* lclVarDsc) const;
 

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -696,10 +696,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                          siVarLoc*      varLoc);
 
     void genSetScopeInfo();
-#ifdef USING_VARIABLE_LIVE_RANGE
     // Send VariableLiveRanges as debug info to the debugger
     void genSetScopeInfoUsingVariableRanges();
-#endif // USING_VARIABLE_LIVE_RANGE
 
 public:
     void siInit();

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1898,12 +1898,6 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
     }
 
     compiler->unwindAllocStack(frameSize);
-#ifdef USING_SCOPE_INFO
-    if (!doubleAlignOrFramePointerUsed())
-    {
-        psiAdjustStackLevel(frameSize);
-    }
-#endif // USING_SCOPE_INFO
 }
 
 void CodeGen::genPushFltRegs(regMaskTP regMask)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -727,9 +727,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming dead\n", varNum);
         }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
         codeGen->getVariableLiveKeeper()->siEndVariableLiveRange(varNum);
-#endif // USING_VARIABLE_LIVE_RANGE
     }
 
     VarSetOps::Iter bornIter(this, bornSet);
@@ -773,9 +771,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming live\n", varNum);
         }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
         codeGen->getVariableLiveKeeper()->siStartVariableLiveRange(varDsc, varNum);
-#endif // USING_VARIABLE_LIVE_RANGE
     }
 }
 
@@ -6752,9 +6748,7 @@ void CodeGen::genSetScopeInfo()
 
     unsigned varsLocationsCount = 0;
 
-#ifdef USING_VARIABLE_LIVE_RANGE
     varsLocationsCount = (unsigned int)varLiveKeeper->getLiveRangesCount();
-#endif // USING_VARIABLE_LIVE_RANGE
 
     if (varsLocationsCount == 0)
     {
@@ -6777,19 +6771,15 @@ void CodeGen::genSetScopeInfo()
     }
 #endif
 
-#ifdef USING_VARIABLE_LIVE_RANGE
     // We can have one of both flags defined, both, or none. Specially if we need to compare both
     // both results. But we cannot report both to the debugger, since there would be overlapping
     // intervals, and may not indicate the same variable location.
 
     genSetScopeInfoUsingVariableRanges();
 
-#endif // USING_VARIABLE_LIVE_RANGE
-
     compiler->eeSetLVdone();
 }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
 //------------------------------------------------------------------------
 // genSetScopeInfoUsingVariableRanges: Call "genSetScopeInfo" with the
 //  "VariableLiveRanges" created for the arguments, special arguments and
@@ -6882,7 +6872,6 @@ void CodeGen::genSetScopeInfoUsingVariableRanges()
 
     compiler->eeVarsCount = liveRangeIndex;
 }
-#endif // USING_VARIABLE_LIVE_RANGE
 
 //------------------------------------------------------------------------
 // genSetScopeInfo: Record scope information for debug info
@@ -8268,10 +8257,8 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
                 genUpdateVarReg(varDsc, treeNode);
 
-#ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
                 varLiveKeeper->siUpdateVariableLiveRange(varDsc, lcl->GetLclNum());
-#endif // USING_VARIABLE_LIVE_RANGE
 
                 // The new location is going live
                 genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
@@ -8336,10 +8323,8 @@ regNumber CodeGen::genRegCopy(GenTree* treeNode, unsigned multiRegIndex)
                 gcInfo.gcMarkRegSetNpt(genRegMask(sourceReg));
                 genUpdateVarReg(fieldVarDsc, treeNode);
 
-#ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
                 varLiveKeeper->siUpdateVariableLiveRange(fieldVarDsc, fieldVarNum);
-#endif // USING_VARIABLE_LIVE_RANGE
 
                 // The new location is going live
                 genUpdateRegLife(fieldVarDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
@@ -8414,7 +8399,6 @@ unsigned CodeGenInterface::getCurrentStackLevel() const
     return genStackLevel;
 }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
 #ifdef DEBUG
 //------------------------------------------------------------------------
 //                      VariableLiveRanges dumpers
@@ -9222,7 +9206,6 @@ void CodeGenInterface::VariableLiveKeeper::dumpLvaVariableLiveRanges() const
     }
 }
 #endif // DEBUG
-#endif // USING_VARIABLE_LIVE_RANGE
 
 //-----------------------------------------------------------------------------
 // genPoisonFrame: Generate code that places a recognizable value into address exposed variables.

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -25,14 +25,8 @@
 #include "treelifeupdater.h"
 #include "emit.h"
 
-#if 0
-// Enable USING_SCOPE_INFO flag to use psiScope/siScope info to report variables' locations.
-#define USING_SCOPE_INFO
-#endif
 #if 1
 // Enable USING_VARIABLE_LIVE_RANGE flag to use VariableLiveRange info to report variables' locations.
-// Note: if both USING_SCOPE_INFO and USING_VARIABLE_LIVE_RANGE are defined, then USING_SCOPE_INFO
-// information is reported to the debugger.
 #define USING_VARIABLE_LIVE_RANGE
 #endif
 
@@ -396,10 +390,6 @@ private:
     bool m_cgFullPtrRegMap;
 
 public:
-#ifdef USING_SCOPE_INFO
-    virtual void siUpdate() = 0;
-#endif // USING_SCOPE_INFO
-
     /* These are the different addressing modes used to access a local var.
      * The JIT has to report the location of the locals back to the EE
      * for debugging purposes.

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -25,11 +25,6 @@
 #include "treelifeupdater.h"
 #include "emit.h"
 
-#if 1
-// Enable USING_VARIABLE_LIVE_RANGE flag to use VariableLiveRange info to report variables' locations.
-#define USING_VARIABLE_LIVE_RANGE
-#endif
-
 // Forward reference types
 
 class CodeGenInterface;
@@ -555,7 +550,6 @@ protected:
     unsigned genStackLevel;
 
 public:
-#ifdef USING_VARIABLE_LIVE_RANGE
     //--------------------------------------------
     //
     // VariableLiveKeeper: Holds an array of "VariableLiveDescriptor", one for each variable
@@ -749,7 +743,6 @@ public:
 
 protected:
     VariableLiveKeeper* varLiveKeeper; // Used to manage VariableLiveRanges of variables
-#endif                                 // USING_VARIABLE_LIVE_RANGE
 
 #ifdef LATE_DISASM
 public:

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -565,20 +565,6 @@ void CodeGen::genCodeForBBlist()
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {
             siEndBlock(block);
-
-#ifdef USING_SCOPE_INFO
-            if (isLastBlockProcessed && siOpenScopeList.scNext)
-            {
-                /* This assert no longer holds, because we may insert a throw
-                   block to demarcate the end of a try or finally region when they
-                   are at the end of the method.  It would be nice if we could fix
-                   our code so that this throw block will no longer be necessary. */
-
-                // noway_assert(block->bbCodeOffsEnd != compiler->info.compILCodeSize);
-
-                siCloseAllOpenScopes();
-            }
-#endif // USING_SCOPE_INFO
         }
 
         SubtractStackLevel(savedStkLvl);

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -827,14 +827,14 @@ void CodeGen::genCodeForBBlist()
         }
 #endif
 
+#if defined(DEBUG)
         if (compiler->verbose)
         {
             varLiveKeeper->dumpBlockVariableLiveRanges(block);
         }
-
-        INDEBUG(compiler->compCurBB = nullptr);
-
-    } //------------------ END-FOR each block of the method -------------------
+        compiler->compCurBB = nullptr;
+#endif // defined(DEBUG)
+    }  //------------------ END-FOR each block of the method -------------------
 
     // There could be variables alive at this point. For example see lvaKeepAliveAndReportThis.
     // This call is for cleaning the GC refs

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -827,13 +827,13 @@ void CodeGen::genCodeForBBlist()
         }
 #endif
 
-#if defined(DEBUG)
+#ifdef DEBUG
         if (compiler->verbose)
         {
             varLiveKeeper->dumpBlockVariableLiveRanges(block);
         }
         compiler->compCurBB = nullptr;
-#endif // defined(DEBUG)
+#endif // DEBUG
     }  //------------------ END-FOR each block of the method -------------------
 
     // There could be variables alive at this point. For example see lvaKeepAliveAndReportThis.

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -86,9 +86,7 @@ void CodeGen::genInitialize()
         siInit();
     }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
     initializeVariableLiveKeeper();
-#endif //  USING_VARIABLE_LIVE_RANGE
 
     genPendingCallLabel = nullptr;
 
@@ -555,12 +553,10 @@ void CodeGen::genCodeForBBlist()
             isLastBlockProcessed = (block->bbNext->bbNext == nullptr);
         }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
         if (compiler->opts.compDbgInfo && isLastBlockProcessed)
         {
             varLiveKeeper->siEndAllVariableLiveRange(compiler->compCurLife);
         }
-#endif // USING_VARIABLE_LIVE_RANGE
 
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {
@@ -831,12 +827,10 @@ void CodeGen::genCodeForBBlist()
         }
 #endif
 
-#if defined(DEBUG) && defined(USING_VARIABLE_LIVE_RANGE)
         if (compiler->verbose)
         {
             varLiveKeeper->dumpBlockVariableLiveRanges(block);
         }
-#endif // defined(DEBUG) && defined(USING_VARIABLE_LIVE_RANGE)
 
         INDEBUG(compiler->compCurBB = nullptr);
 
@@ -955,14 +949,12 @@ void CodeGen::genSpillVar(GenTree* tree)
         assert((varDsc->IsAlwaysAliveInMemory()) && ((tree->gtFlags & GTF_VAR_DEF) != 0));
     }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
     if (needsSpill)
     {
         // We need this after "lvRegNum" has change because now we are sure that varDsc->lvIsInReg() is false.
         // "SiVarLoc" constructor uses the "LclVarDsc" of the variable.
         varLiveKeeper->siUpdateVariableLiveRange(varDsc, varNum);
     }
-#endif // USING_VARIABLE_LIVE_RANGE
 }
 
 //------------------------------------------------------------------------
@@ -1077,7 +1069,6 @@ void CodeGen::genUnspillLocal(
     {
         varDsc->SetRegNum(regNum);
 
-#ifdef USING_VARIABLE_LIVE_RANGE
         // We want "VariableLiveRange" inclusive on the beginning and exclusive on the ending.
         // For that we shouldn't report an update of the variable location if is becoming dead
         // on the same native offset.
@@ -1086,7 +1077,6 @@ void CodeGen::genUnspillLocal(
             // Report the home change for this variable
             varLiveKeeper->siUpdateVariableLiveRange(varDsc, varNum);
         }
-#endif // USING_VARIABLE_LIVE_RANGE
 
         if (!varDsc->IsAlwaysAliveInMemory())
         {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -2128,9 +2128,6 @@ void CodeGen::genEstablishFramePointer(int delta, bool reportUnwindData)
     if (delta == 0)
     {
         GetEmitter()->emitIns_Mov(INS_mov, EA_PTRSIZE, REG_FPBASE, REG_SPBASE, /* canSkip */ false);
-#ifdef USING_SCOPE_INFO
-        psiMoveESPtoEBP();
-#endif // USING_SCOPE_INFO
     }
     else
     {
@@ -2242,13 +2239,6 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
             *pInitRegZeroed = false;
         }
     }
-
-#ifdef USING_SCOPE_INFO
-    if (!doubleAlignOrFramePointerUsed())
-    {
-        psiAdjustStackLevel(frameSize);
-    }
-#endif // USING_SCOPE_INFO
 }
 
 //------------------------------------------------------------------------
@@ -9563,12 +9553,6 @@ void CodeGen::genPushCalleeSavedRegisters()
         {
             inst_RV(INS_push, reg, TYP_REF);
             compiler->unwindPush(reg);
-#ifdef USING_SCOPE_INFO
-            if (!doubleAlignOrFramePointerUsed())
-            {
-                psiAdjustStackLevel(REGSIZE_BYTES);
-            }
-#endif // USING_SCOPE_INFO
             rsPushRegs &= ~regBit;
         }
     }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1332,7 +1332,6 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             varDsc->SetRegNum(newRegNum);
             count++;
 
-#ifdef USING_VARIABLE_LIVE_RANGE
             BasicBlock* prevReportedBlock = bb->bbPrev;
             if (bb->bbPrev != nullptr && bb->bbPrev->isBBCallAlwaysPairTail())
             {
@@ -1351,7 +1350,6 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
                 // "getInVarToRegMap"
                 compiler->codeGen->getVariableLiveKeeper()->siUpdateVariableLiveRange(varDsc, varNum);
             }
-#endif // USING_VARIABLE_LIVE_RANGE
         }
         else if (newRegNum != REG_STK)
         {

--- a/src/coreclr/jit/scopeinfo.cpp
+++ b/src/coreclr/jit/scopeinfo.cpp
@@ -578,268 +578,6 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
 }
 #endif
 
-#ifdef USING_SCOPE_INFO
-//------------------------------------------------------------------------
-// getSiVarLoc: Returns a "siVarLoc" instance representing the place where the variable
-// is given its description, "baseReg", and "offset" (if needed).
-//
-// Arguments:
-//    varDsc    - a "LclVarDsc *" to the variable it is desired to build the "siVarLoc".
-//    scope   - a "siScope" Scope info of the variable.
-//
-// Return Value:
-//    A "siVarLoc" filled with the correct case struct fields for the variable, which could live
-//    in a register, an stack position, or a combination of both.
-//
-// Notes:
-//    Called for each siScope in siScopeList when "genSetScopeInfo".
-CodeGenInterface::siVarLoc CodeGen::getSiVarLoc(const LclVarDsc* varDsc, const siScope* scope) const
-{
-    // For stack vars, find the base register, and offset
-
-    regNumber baseReg;
-    signed    offset = varDsc->GetStackOffset();
-
-    if (!varDsc->lvFramePointerBased)
-    {
-        baseReg = REG_SPBASE;
-        offset += scope->scStackLevel;
-    }
-    else
-    {
-        baseReg = REG_FPBASE;
-    }
-
-    return CodeGenInterface::siVarLoc(varDsc, baseReg, offset, isFramePointerUsed());
-}
-
-//------------------------------------------------------------------------
-// getSiVarLoc: Creates a "CodegenInterface::siVarLoc" instance from using the properties
-// of the "psiScope" instance.
-//
-// Notes:
-//    Called for every psiScope in "psiScopeList" codegen.h
-CodeGenInterface::siVarLoc CodeGen::psiScope::getSiVarLoc() const
-{
-    CodeGenInterface::siVarLoc varLoc;
-
-    if (scRegister)
-    {
-        varLoc.vlType       = VLT_REG;
-        varLoc.vlReg.vlrReg = (regNumber)u1.scRegNum;
-    }
-    else
-    {
-        varLoc.vlType           = VLT_STK;
-        varLoc.vlStk.vlsBaseReg = (regNumber)u2.scBaseReg;
-        varLoc.vlStk.vlsOffset  = u2.scOffset;
-    }
-
-    return varLoc;
-}
-
-/*============================================================================
- *
- *              Implementation for ScopeInfo
- *
- *
- * Whenever a variable comes into scope, add it to the list.
- * When a varDsc goes dead, end its previous scope entry, and make a new one
- * which is unavailable.
- * When a varDsc goes live, end its previous un-available entry (if any) and
- * set its new entry as available.
- *
- *============================================================================
- */
-
-/*****************************************************************************
- *                      siNewScope
- *
- * Creates a new scope and adds it to the Open scope list.
- */
-
-CodeGen::siScope* CodeGen::siNewScope(unsigned LVnum, unsigned varNum)
-{
-    bool     tracked  = compiler->lvaTable[varNum].lvTracked;
-    unsigned varIndex = compiler->lvaTable[varNum].lvVarIndex;
-
-    if (tracked)
-    {
-        siEndTrackedScope(varIndex);
-    }
-
-    siScope* newScope = compiler->getAllocator(CMK_SiScope).allocate<siScope>(1);
-
-    newScope->scStartLoc.CaptureLocation(GetEmitter());
-    assert(newScope->scStartLoc.Valid());
-
-    newScope->scEndLoc.Init();
-
-    newScope->scLVnum      = LVnum;
-    newScope->scVarNum     = varNum;
-    newScope->scNext       = nullptr;
-    newScope->scStackLevel = genStackLevel; // used only by stack vars
-
-    siOpenScopeLast->scNext = newScope;
-    newScope->scPrev        = siOpenScopeLast;
-    siOpenScopeLast         = newScope;
-
-    if (tracked)
-    {
-        siLatestTrackedScopes[varIndex] = newScope;
-    }
-
-    return newScope;
-}
-
-/*****************************************************************************
- *                          siRemoveFromOpenScopeList
- *
- * Removes a scope from the open-scope list and puts it into the done-scope list
- */
-
-void CodeGen::siRemoveFromOpenScopeList(CodeGen::siScope* scope)
-{
-    assert(scope);
-    assert(scope->scEndLoc.Valid());
-
-    // Remove from open-scope list
-
-    scope->scPrev->scNext = scope->scNext;
-    if (scope->scNext)
-    {
-        scope->scNext->scPrev = scope->scPrev;
-    }
-    else
-    {
-        siOpenScopeLast = scope->scPrev;
-    }
-
-    // Add to the finished scope list. (Try to) filter out scopes of length 0.
-
-    if (scope->scStartLoc != scope->scEndLoc)
-    {
-        siScopeLast->scNext = scope;
-        siScopeLast         = scope;
-        siScopeCnt++;
-    }
-}
-
-/*----------------------------------------------------------------------------
- * These functions end scopes given different types of parameters
- *----------------------------------------------------------------------------
- */
-
-/*****************************************************************************
- * For tracked vars, we don't need to search for the scope in the list as we
- * have a pointer to the open scopes of all tracked variables.
- */
-
-void CodeGen::siEndTrackedScope(unsigned varIndex)
-{
-    siScope* scope = siLatestTrackedScopes[varIndex];
-    if (!scope)
-    {
-        return;
-    }
-
-    scope->scEndLoc.CaptureLocation(GetEmitter());
-    assert(scope->scEndLoc.Valid());
-
-    siRemoveFromOpenScopeList(scope);
-
-    siLatestTrackedScopes[varIndex] = nullptr;
-}
-
-/*****************************************************************************
- * If we don't know that the variable is tracked, this function handles both
- * cases.
- */
-
-void CodeGen::siEndScope(unsigned varNum)
-{
-    for (siScope* scope = siOpenScopeList.scNext; scope; scope = scope->scNext)
-    {
-        if (scope->scVarNum == varNum)
-        {
-            siEndScope(scope);
-            return;
-        }
-    }
-
-    JITDUMP("siEndScope: Failed to end scope for V%02u\n", varNum);
-
-    // At this point, we probably have a bad LocalVarTab
-    if (compiler->opts.compDbgCode)
-    {
-        JITDUMP("...checking var tab validity\n");
-
-        // Note the following assert is saying that we expect
-        // the VM supplied info to be invalid...
-        assert(!siVerifyLocalVarTab());
-
-        compiler->opts.compScopeInfo = false;
-    }
-}
-
-/*****************************************************************************
- * If we have a handle to the siScope structure, we handle ending this scope
- * differently than if we just had a variable number. This saves us searching
- * the open-scope list again.
- */
-
-void CodeGen::siEndScope(siScope* scope)
-{
-    scope->scEndLoc.CaptureLocation(GetEmitter());
-    assert(scope->scEndLoc.Valid());
-
-    siRemoveFromOpenScopeList(scope);
-
-    LclVarDsc& lclVarDsc1 = compiler->lvaTable[scope->scVarNum];
-    if (lclVarDsc1.lvTracked)
-    {
-        siLatestTrackedScopes[lclVarDsc1.lvVarIndex] = nullptr;
-    }
-}
-
-/*****************************************************************************
- *                      siVerifyLocalVarTab
- *
- * Checks the LocalVarTab for consistency. The VM may not have properly
- * verified the LocalVariableTable.
- */
-
-#ifdef DEBUG
-
-bool CodeGen::siVerifyLocalVarTab()
-{
-    // No entries with overlapping lives should have the same slot.
-
-    for (unsigned i = 0; i < compiler->info.compVarScopesCount; i++)
-    {
-        for (unsigned j = i + 1; j < compiler->info.compVarScopesCount; j++)
-        {
-            unsigned slot1 = compiler->info.compVarScopes[i].vsdVarNum;
-            unsigned beg1  = compiler->info.compVarScopes[i].vsdLifeBeg;
-            unsigned end1  = compiler->info.compVarScopes[i].vsdLifeEnd;
-
-            unsigned slot2 = compiler->info.compVarScopes[j].vsdVarNum;
-            unsigned beg2  = compiler->info.compVarScopes[j].vsdLifeBeg;
-            unsigned end2  = compiler->info.compVarScopes[j].vsdLifeEnd;
-
-            if (slot1 == slot2 && (end1 > beg2 && beg1 < end2))
-            {
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
-#endif // DEBUG
-#endif // USING_SCOPE_INFO
-
 /*============================================================================
  *           INTERFACE (public) Functions for ScopeInfo
  *============================================================================
@@ -894,33 +632,6 @@ void CodeGen::siInit()
 
     siLastEndOffs = 0;
 
-#ifdef USING_SCOPE_INFO
-    siOpenScopeList.scNext = nullptr;
-    siOpenScopeLast        = &siOpenScopeList;
-    siScopeLast            = &siScopeList;
-
-    siScopeCnt = 0;
-
-    VarSetOps::AssignNoCopy(compiler, siLastLife, VarSetOps::MakeEmpty(compiler));
-
-    if (compiler->info.compVarScopesCount == 0)
-    {
-        siLatestTrackedScopes = nullptr;
-    }
-    else
-    {
-        unsigned scopeCount = compiler->lvaTrackedCount;
-
-        if (scopeCount == 0)
-        {
-            siLatestTrackedScopes = nullptr;
-        }
-        else
-        {
-            siLatestTrackedScopes = new (compiler->getAllocator(CMK_SiScope)) siScope* [scopeCount] {};
-        }
-    }
-#endif // USING_SCOPE_INFO
     compiler->compResetScopeLists();
 }
 
@@ -984,42 +695,10 @@ void CodeGen::siBeginBlock(BasicBlock* block)
     //
     // Note: we can improve on this some day -- if there are any tracked
     // locals, untracked locals will fail to be reported.
-    if (compiler->lvaTrackedCount > 0)
-    {
-#ifdef USING_SCOPE_INFO
-        // End scope of variables which are not live for this block
-        siUpdate();
-
-        // Check that vars which are live on entry have an open scope
-        VarSetOps::Iter iter(compiler, block->bbLiveIn);
-        unsigned        varIndex = 0;
-        while (iter.NextElem(&varIndex))
-        {
-            unsigned   varNum = compiler->lvaTrackedIndexToLclNum(varIndex);
-            LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
-            // lvRefCnt may go down to 0 after liveness-analysis.
-            // So we need to check if this tracked variable is actually used.
-            if (!varDsc->lvIsInReg() && !varDsc->lvOnFrame)
-            {
-                assert(varDsc->lvRefCnt() == 0);
-                continue;
-            }
-
-            siCheckVarScope(varNum, beginOffs);
-        }
-#endif
-    }
-    else
+    if (compiler->lvaTrackedCount <= 0)
     {
         siOpenScopesForNonTrackedVars(block, siLastEndOffs);
     }
-
-#if defined(USING_SCOPE_INFO) && defined(DEBUG)
-    if (verbose)
-    {
-        siDispOpenScopes();
-    }
-#endif // defined(USING_SCOPE_INFO) && defined(DEBUG)
 }
 
 //------------------------------------------------------------------------
@@ -1102,23 +781,9 @@ void CodeGen::siOpenScopesForNonTrackedVars(const BasicBlock* block, unsigned in
                 JITDUMP("Scope info: opening scope, LVnum=%u [%03X..%03X)\n", varScope->vsdLVnum, varScope->vsdLifeBeg,
                         varScope->vsdLifeEnd);
 
-#ifdef USING_SCOPE_INFO
-                siNewScope(varScope->vsdLVnum, varScope->vsdVarNum);
-#endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
                 varLiveKeeper->siStartVariableLiveRange(lclVarDsc, varScope->vsdVarNum);
 #endif // USING_VARIABLE_LIVE_RANGE
-
-#if defined(DEBUG) && defined(USING_SCOPE_INFO)
-                if (VERBOSE)
-                {
-                    printf("Scope info: >> new scope, VarNum=%u, tracked? %s, VarIndex=%u, bbLiveIn=%s ",
-                           varScope->vsdVarNum, lclVarDsc->lvTracked ? "yes" : "no", lclVarDsc->lvVarIndex,
-                           VarSetOps::ToString(compiler, block->bbLiveIn));
-                    dumpConvertedVarSet(compiler, block->bbLiveIn);
-                    printf("\n");
-                }
-#endif // defined(DEBUG) && defined(USING_SCOPE_INFO)
 
                 INDEBUG(assert(!lclVarDsc->lvTracked ||
                                VarSetOps::IsMember(compiler, block->bbLiveIn, lclVarDsc->lvVarIndex)));
@@ -1150,15 +815,6 @@ void CodeGen::siEndBlock(BasicBlock* block)
     }
 #endif // FEATURE_EH_FUNCLETS
 
-#if defined(USING_SCOPE_INFO) && defined(DEBUG)
-    if (verbose)
-    {
-        printf("\nScope info: end block " FMT_BB ", IL range ", block->bbNum);
-        block->dspBlockILRange();
-        printf("\n");
-    }
-#endif // defined(USING_SCOPE_INFO) && defined(DEBUG)
-
     unsigned endOffs = block->bbCodeOffsEnd;
 
     if (endOffs == BAD_IL_OFFSET)
@@ -1167,303 +823,8 @@ void CodeGen::siEndBlock(BasicBlock* block)
         return;
     }
 
-#ifdef USING_SCOPE_INFO
-    // If non-debuggable code, find all scopes which end over this block
-    // and close them. For debuggable code, scopes will only end on block
-    // boundaries.
-
-    VarScopeDsc* varScope;
-    while ((varScope = compiler->compGetNextExitScope(endOffs, !compiler->opts.compDbgCode)) != nullptr)
-    {
-        // brace-matching editor workaround for following line: (
-        JITDUMP("Scope info: ending scope, LVnum=%u [%03X..%03X)\n", varScope->vsdLVnum, varScope->vsdLifeBeg,
-                varScope->vsdLifeEnd);
-
-        unsigned         varNum     = varScope->vsdVarNum;
-        const LclVarDsc* lclVarDsc1 = compiler->lvaGetDesc(varNum);
-
-        if (lclVarDsc1->lvTracked)
-        {
-            siEndTrackedScope(lclVarDsc1->lvVarIndex);
-        }
-        else
-        {
-            siEndScope(varNum);
-        }
-    }
-#endif // USING_SCOPE_INFO
-
     siLastEndOffs = endOffs;
-
-#if defined(USING_SCOPE_INFO) && defined(DEBUG)
-    if (verbose)
-    {
-        siDispOpenScopes();
-    }
-#endif // defined(USING_SCOPE_INFO) && defined(DEBUG)
 }
-
-#ifdef USING_SCOPE_INFO
-//------------------------------------------------------------------------
-// siUpdate: Closes the "ScopeInfo" of the tracked variables that has become dead.
-//
-// Notes:
-//    Called at the start of basic blocks, and during code-gen of a block,
-//    for non-debuggable code, whenever the life of any tracked variable changes
-//    and the appropriate code has been generated. For debuggable code, variables are
-//    live over their entire scope, and so they go live or dead only on
-//    block boundaries.
-void CodeGen::siUpdate()
-{
-    if (!compiler->opts.compScopeInfo)
-    {
-        return;
-    }
-
-    if (compiler->opts.compDbgCode)
-    {
-        return;
-    }
-
-    if (compiler->info.compVarScopesCount == 0)
-    {
-        return;
-    }
-
-#if defined(FEATURE_EH_FUNCLETS)
-    if (siInFuncletRegion)
-    {
-        return;
-    }
-#endif // FEATURE_EH_FUNCLETS
-
-    VARSET_TP killed(VarSetOps::Diff(compiler, siLastLife, compiler->compCurLife));
-    assert(VarSetOps::IsSubset(compiler, killed, compiler->lvaTrackedVars));
-
-    VarSetOps::Iter iter(compiler, killed);
-    unsigned        varIndex = 0;
-    while (iter.NextElem(&varIndex))
-    {
-        assert(compiler->lvaGetDescByTrackedIndex(varIndex)->lvTracked);
-        siEndTrackedScope(varIndex);
-    }
-
-    VarSetOps::Assign(compiler, siLastLife, compiler->compCurLife);
-}
-
-/*****************************************************************************
- *                          siCheckVarScope
- *
- * For non-debuggable code, whenever we come across a GenTree which is an
- * assignment to a local variable, this function is called to check if the
- * variable has an open scope. Also, check if it has the correct LVnum.
- */
-
-void CodeGen::siCheckVarScope(unsigned varNum, IL_OFFSET offs)
-{
-    assert(compiler->opts.compScopeInfo && !compiler->opts.compDbgCode && (compiler->info.compVarScopesCount > 0));
-
-#if defined(FEATURE_EH_FUNCLETS)
-    if (siInFuncletRegion)
-    {
-        return;
-    }
-#endif // FEATURE_EH_FUNCLETS
-
-    if (offs == BAD_IL_OFFSET)
-    {
-        return;
-    }
-
-    siScope*   scope;
-    LclVarDsc* lclVarDsc1 = compiler->lvaGetDesc(varNum);
-
-    // If there is an open scope corresponding to varNum, find it
-
-    if (lclVarDsc1->lvTracked)
-    {
-        scope = siLatestTrackedScopes[lclVarDsc1->lvVarIndex];
-    }
-    else
-    {
-        for (scope = siOpenScopeList.scNext; scope; scope = scope->scNext)
-        {
-            if (scope->scVarNum == varNum)
-            {
-                break;
-            }
-        }
-    }
-
-    // Look up the compiler->info.compVarScopes[] to find the local var info for (varNum->lvSlotNum, offs)
-    VarScopeDsc* varScope = compiler->compFindLocalVar(varNum, offs);
-    if (varScope == nullptr)
-    {
-        return;
-    }
-
-    // If the currently open scope does not have the correct LVnum, close it
-    // and create a new scope with this new LVnum
-
-    if (scope)
-    {
-        if (scope->scLVnum != varScope->vsdLVnum)
-        {
-            siEndScope(scope);
-            siNewScope(varScope->vsdLVnum, varScope->vsdVarNum);
-        }
-    }
-    else
-    {
-        siNewScope(varScope->vsdLVnum, varScope->vsdVarNum);
-    }
-}
-
-/*****************************************************************************
- *                          siCloseAllOpenScopes
- *
- * For unreachable code, or optimized code with blocks reordered, there may be
- * scopes left open at the end. Simply close them.
- */
-
-void CodeGen::siCloseAllOpenScopes()
-{
-    assert(siOpenScopeList.scNext);
-
-    while (siOpenScopeList.scNext)
-    {
-        siEndScope(siOpenScopeList.scNext);
-    }
-}
-
-/*****************************************************************************
- *                          siDispOpenScopes
- *
- * Displays all the vars on the open-scope list
- */
-
-#ifdef DEBUG
-
-void CodeGen::siDispOpenScopes()
-{
-    assert(compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0));
-
-    printf("Scope info: open scopes =\n");
-
-    if (siOpenScopeList.scNext == nullptr)
-    {
-        printf("   <none>\n");
-    }
-    else
-    {
-        for (siScope* scope = siOpenScopeList.scNext; scope != nullptr; scope = scope->scNext)
-        {
-            VarScopeDsc* localVars = compiler->info.compVarScopes;
-
-            for (unsigned i = 0; i < compiler->info.compVarScopesCount; i++, localVars++)
-            {
-                if (localVars->vsdLVnum == scope->scLVnum)
-                {
-                    const char* name = compiler->VarNameToStr(localVars->vsdName);
-                    // brace-matching editor workaround for following line: (
-                    printf("   %u (%s) [%03X..%03X)\n", localVars->vsdLVnum, name == nullptr ? "UNKNOWN" : name,
-                           localVars->vsdLifeBeg, localVars->vsdLifeEnd);
-                    break;
-                }
-            }
-        }
-    }
-}
-
-#endif // DEBUG
-
-/*============================================================================
- *
- *              Implementation for PrologScopeInfo
- *
- *============================================================================
- */
-
-/*****************************************************************************
- *                      psiNewPrologScope
- *
- * Creates a new scope and adds it to the Open scope list.
- */
-
-CodeGen::psiScope* CodeGen::psiNewPrologScope(unsigned LVnum, unsigned slotNum)
-{
-    psiScope* newScope = compiler->getAllocator(CMK_SiScope).allocate<psiScope>(1);
-
-    newScope->scStartLoc.CaptureLocation(GetEmitter());
-    assert(newScope->scStartLoc.Valid());
-
-    newScope->scEndLoc.Init();
-
-    newScope->scLVnum   = LVnum;
-    newScope->scSlotNum = slotNum;
-
-    newScope->scNext         = nullptr;
-    psiOpenScopeLast->scNext = newScope;
-    newScope->scPrev         = psiOpenScopeLast;
-    psiOpenScopeLast         = newScope;
-
-    return newScope;
-}
-
-/*****************************************************************************
- *                          psiEndPrologScope
- *
- * Remove the scope from the Open-scope list and add it to the finished-scopes
- * list if its length is non-zero
- */
-
-void CodeGen::psiEndPrologScope(psiScope* scope)
-{
-    scope->scEndLoc.CaptureLocation(GetEmitter());
-    assert(scope->scEndLoc.Valid());
-
-    // Remove from open-scope list
-    scope->scPrev->scNext = scope->scNext;
-    if (scope->scNext)
-    {
-        scope->scNext->scPrev = scope->scPrev;
-    }
-    else
-    {
-        psiOpenScopeLast = scope->scPrev;
-    }
-
-    // Add to the finished scope list.
-    // If the length is zero, it means that the prolog is empty. In that case,
-    // CodeGen::genSetScopeInfo will report the liveness of all arguments
-    // as spanning the first instruction in the method, so that they can
-    // at least be inspected on entry to the method.
-    if (scope->scStartLoc != scope->scEndLoc || scope->scStartLoc.IsOffsetZero())
-    {
-        psiScopeLast->scNext = scope;
-        psiScopeLast         = scope;
-        psiScopeCnt++;
-    }
-}
-
-/*============================================================================
- *           INTERFACE (protected) Functions for PrologScopeInfo
- *============================================================================
- */
-
-//------------------------------------------------------------------------
-// psiSetScopeOffset: Set the offset of the newScope to the offset of the LslVar
-//
-// Arguments:
-//    'newScope'  the new scope object whose offset is to be set to the lclVarDsc offset.
-//    'lclVarDsc' is an op that will now be contained by its parent.
-void CodeGen::psiSetScopeOffset(psiScope* newScope, const LclVarDsc* lclVarDsc) const
-{
-    newScope->scRegister   = false;
-    newScope->u2.scBaseReg = REG_SPBASE;
-    newScope->u2.scOffset  = psiGetVarStackOffset(lclVarDsc);
-}
-#endif // USING_SCOPE_INFO
 
 //------------------------------------------------------------------------
 // psiGetVarStackOffset: Return the offset of the lclVarDsc on the stack.
@@ -1511,13 +872,6 @@ void CodeGen::psiBegProlog()
 {
     assert(compiler->compGeneratingProlog);
 
-#ifdef USING_SCOPE_INFO
-    psiOpenScopeList.scNext = nullptr;
-    psiOpenScopeLast        = &psiOpenScopeList;
-    psiScopeLast            = &psiScopeList;
-    psiScopeCnt             = 0;
-#endif // USING_SCOPE_INFO
-
     compiler->compResetScopeLists();
 
     VarScopeDsc* varScope;
@@ -1529,9 +883,6 @@ void CodeGen::psiBegProlog()
         {
             continue;
         }
-#ifdef USING_SCOPE_INFO
-        psiScope* newScope = psiNewPrologScope(varScope->vsdLVnum, varScope->vsdVarNum);
-#endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
         siVarLoc varLocation;
 #endif // USING_VARIABLE_LIVE_RANGE
@@ -1573,11 +924,6 @@ void CodeGen::psiBegProlog()
                         assert(genMapRegNumToRegArgNum((nCnt == 0 ? regNum : otherRegNum), regType) != (unsigned)-1);
 #endif // DEBUG
                     }
-#ifdef USING_SCOPE_INFO
-                    newScope->scRegister    = true;
-                    newScope->u1.scRegNum   = (regNumberSmall)regNum;
-                    newScope->u1.scOtherReg = (regNumberSmall)otherRegNum;
-#endif // USING_SCOPE_INFO
 
 #ifdef USING_VARIABLE_LIVE_RANGE
                     varLocation.storeVariableInRegisters(regNum, otherRegNum);
@@ -1586,9 +932,6 @@ void CodeGen::psiBegProlog()
                 else
                 {
 // Stack passed argument. Get the offset from the  caller's frame.
-#ifdef USING_SCOPE_INFO
-                    psiSetScopeOffset(newScope, lclVarDsc);
-#endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
                     varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
 #endif // USING_VARIABLE_LIVE_RANGE
@@ -1634,11 +977,6 @@ void CodeGen::psiBegProlog()
 #endif
                 assert(genMapRegNumToRegArgNum(lclVarDsc->GetArgReg(), regType) != (unsigned)-1);
 #endif // DEBUG
-
-#ifdef USING_SCOPE_INFO
-                newScope->scRegister  = true;
-                newScope->u1.scRegNum = (regNumberSmall)lclVarDsc->GetArgReg();
-#endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
                 varLocation.storeVariableInRegisters(lclVarDsc->GetArgReg(), REG_NA);
 #endif // USING_VARIABLE_LIVE_RANGE
@@ -1646,9 +984,6 @@ void CodeGen::psiBegProlog()
         }
         else
         {
-#ifdef USING_SCOPE_INFO
-            psiSetScopeOffset(newScope, lclVarDsc);
-#endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
             varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
 #endif // USING_VARIABLE_LIVE_RANGE
@@ -1671,233 +1006,7 @@ void CodeGen::psiBegProlog()
 void CodeGen::psiEndProlog()
 {
     assert(compiler->compGeneratingProlog);
-#ifdef USING_SCOPE_INFO
-    for (psiScope* scope = psiOpenScopeList.scNext; scope; scope = psiOpenScopeList.scNext)
-    {
-        psiEndPrologScope(scope);
-    }
-#endif
-
 #ifdef USING_VARIABLE_LIVE_RANGE
     varLiveKeeper->psiClosePrologVariableRanges();
 #endif // USING_VARIABLE_LIVE_RANGE
 }
-
-#ifdef USING_SCOPE_INFO
-
-/*****************************************************************************
- Enable this macro to get accurate prolog information for every instruction
- in the prolog. However, this is overkill as nobody steps through the
- disassembly of the prolog. Even if they do they will not expect rich debug info.
-
- We still report all the arguments at the very start of the method so that
- the user can see the arguments at the very start of the method (offset=0).
-
- Disabling this decreased the debug maps in CoreLib by 10% (01/2003)
- */
-
-#if 0
-#define ACCURATE_PROLOG_DEBUG_INFO
-#endif
-
-/*****************************************************************************
- *                          psiAdjustStackLevel
- *
- * When ESP changes, all scopes relative to ESP have to be updated.
- */
-
-void CodeGen::psiAdjustStackLevel(unsigned size)
-{
-    if (!compiler->opts.compScopeInfo || (compiler->info.compVarScopesCount == 0))
-    {
-        return;
-    }
-
-    assert(compiler->compGeneratingProlog);
-
-#ifdef ACCURATE_PROLOG_DEBUG_INFO
-
-    psiScope* scope;
-
-    // walk the list backwards
-    // Works as psiEndPrologScope does not change scPrev
-    for (scope = psiOpenScopeLast; scope != &psiOpenScopeList; scope = scope->scPrev)
-    {
-        if (scope->scRegister)
-        {
-            assert(compiler->lvaTable[scope->scSlotNum].lvIsRegArg);
-            continue;
-        }
-        assert(scope->u2.scBaseReg == REG_SPBASE);
-
-        psiScope* newScope     = psiNewPrologScope(scope->scLVnum, scope->scSlotNum);
-        newScope->scRegister   = false;
-        newScope->u2.scBaseReg = REG_SPBASE;
-        newScope->u2.scOffset  = scope->u2.scOffset + size;
-
-        psiEndPrologScope(scope);
-    }
-
-#endif // ACCURATE_PROLOG_DEBUG_INFO
-}
-
-/*****************************************************************************
- *                          psiMoveESPtoEBP
- *
- * For EBP-frames, the parameters are accessed via ESP on entry to the function,
- * but via EBP right after a "mov ebp,esp" instruction
- */
-
-void CodeGen::psiMoveESPtoEBP()
-{
-    if (!compiler->opts.compScopeInfo || (compiler->info.compVarScopesCount == 0))
-    {
-        return;
-    }
-
-    assert(compiler->compGeneratingProlog);
-    assert(doubleAlignOrFramePointerUsed());
-
-#ifdef ACCURATE_PROLOG_DEBUG_INFO
-
-    psiScope* scope;
-
-    // walk the list backwards
-    // Works as psiEndPrologScope does not change scPrev
-    for (scope = psiOpenScopeLast; scope != &psiOpenScopeList; scope = scope->scPrev)
-    {
-        if (scope->scRegister)
-        {
-            assert(compiler->lvaTable[scope->scSlotNum].lvIsRegArg);
-            continue;
-        }
-        assert(scope->u2.scBaseReg == REG_SPBASE);
-
-        psiScope* newScope     = psiNewPrologScope(scope->scLVnum, scope->scSlotNum);
-        newScope->scRegister   = false;
-        newScope->u2.scBaseReg = REG_FPBASE;
-        newScope->u2.scOffset  = scope->u2.scOffset;
-
-        psiEndPrologScope(scope);
-    }
-
-#endif // ACCURATE_PROLOG_DEBUG_INFO
-}
-
-/*****************************************************************************
- *                          psiMoveToReg
- *
- * Called when a parameter is loaded into its assigned register from the stack,
- * or when parameters are moved around due to circular dependency.
- * If reg != REG_NA, then the parameter is being moved into its assigned
- * register, else it may be being moved to a temp register.
- */
-
-void CodeGen::psiMoveToReg(unsigned varNum, regNumber reg, regNumber otherReg)
-{
-    assert(compiler->compGeneratingProlog);
-
-    if (!compiler->opts.compScopeInfo)
-    {
-        return;
-    }
-
-    if (compiler->info.compVarScopesCount == 0)
-    {
-        return;
-    }
-
-    assert((int)varNum >= 0); // It's not a spill temp number.
-    assert(compiler->lvaTable[varNum].lvIsInReg());
-
-#ifdef ACCURATE_PROLOG_DEBUG_INFO
-
-    /* If reg!=REG_NA, the parameter is part of a cirular dependency, and is
-     * being moved through temp register "reg".
-     * If reg==REG_NA, it is being moved to its assigned register.
-     */
-    if (reg == REG_NA)
-    {
-        // Grab the assigned registers.
-
-        reg      = compiler->lvaTable[varNum].GetRegNum();
-        otherReg = compiler->lvaTable[varNum].GetOtherReg();
-    }
-
-    psiScope* scope;
-
-    // walk the list backwards
-    // Works as psiEndPrologScope does not change scPrev
-    for (scope = psiOpenScopeLast; scope != &psiOpenScopeList; scope = scope->scPrev)
-    {
-        if (scope->scSlotNum != compiler->lvaTable[varNum].lvSlotNum)
-            continue;
-
-        psiScope* newScope      = psiNewPrologScope(scope->scLVnum, scope->scSlotNum);
-        newScope->scRegister    = true;
-        newScope->u1.scRegNum   = reg;
-        newScope->u1.scOtherReg = otherReg;
-
-        psiEndPrologScope(scope);
-        return;
-    }
-
-    // May happen if a parameter does not have an entry in the LocalVarTab
-    // But assert() just in case it is because of something else.
-    assert(varNum == compiler->info.compRetBuffArg ||
-           !"Parameter scope not found (Assert doesnt always indicate error)");
-
-#endif // ACCURATE_PROLOG_DEBUG_INFO
-}
-
-/*****************************************************************************
- *                      CodeGen::psiMoveToStack
- *
- * A incoming register-argument is being moved to its final home on the stack
- * (ie. all adjustments to {F/S}PBASE have been made
- */
-
-void CodeGen::psiMoveToStack(unsigned varNum)
-{
-    if (!compiler->opts.compScopeInfo || (compiler->info.compVarScopesCount == 0))
-    {
-        return;
-    }
-
-    assert(compiler->compGeneratingProlog);
-    assert(compiler->lvaTable[varNum].lvIsRegArg);
-    assert(!compiler->lvaTable[varNum].lvRegister);
-
-#ifdef ACCURATE_PROLOG_DEBUG_INFO
-
-    psiScope* scope;
-
-    // walk the list backwards
-    // Works as psiEndPrologScope does not change scPrev
-    for (scope = psiOpenScopeLast; scope != &psiOpenScopeList; scope = scope->scPrev)
-    {
-        if (scope->scSlotNum != compiler->lvaTable[varNum].lvSlotNum)
-            continue;
-
-        /* The param must be currently sitting in the register in which it
-           was passed in */
-        assert(scope->scRegister);
-        assert(scope->u1.scRegNum == compiler->lvaTable[varNum].GetArgReg());
-
-        psiScope* newScope     = psiNewPrologScope(scope->scLVnum, scope->scSlotNum);
-        newScope->scRegister   = false;
-        newScope->u2.scBaseReg = (compiler->lvaTable[varNum].lvFramePointerBased) ? REG_FPBASE : REG_SPBASE;
-        newScope->u2.scOffset  = compiler->lvaTable[varNum].GetStackOffset();
-
-        psiEndPrologScope(scope);
-        return;
-    }
-
-    // May happen if a parameter does not have an entry in the LocalVarTab
-    // But assert() just in case it is because of something else.
-    assert(varNum == compiler->info.compRetBuffArg ||
-           !"Parameter scope not found (Assert doesnt always indicate error)");
-
-#endif // ACCURATE_PROLOG_DEBUG_INFO
-}
-#endif // USING_SCOPE_INFO

--- a/src/coreclr/jit/scopeinfo.cpp
+++ b/src/coreclr/jit/scopeinfo.cpp
@@ -781,9 +781,7 @@ void CodeGen::siOpenScopesForNonTrackedVars(const BasicBlock* block, unsigned in
                 JITDUMP("Scope info: opening scope, LVnum=%u [%03X..%03X)\n", varScope->vsdLVnum, varScope->vsdLifeBeg,
                         varScope->vsdLifeEnd);
 
-#ifdef USING_VARIABLE_LIVE_RANGE
                 varLiveKeeper->siStartVariableLiveRange(lclVarDsc, varScope->vsdVarNum);
-#endif // USING_VARIABLE_LIVE_RANGE
 
                 INDEBUG(assert(!lclVarDsc->lvTracked ||
                                VarSetOps::IsMember(compiler, block->bbLiveIn, lclVarDsc->lvVarIndex)));
@@ -883,9 +881,7 @@ void CodeGen::psiBegProlog()
         {
             continue;
         }
-#ifdef USING_VARIABLE_LIVE_RANGE
         siVarLoc varLocation;
-#endif // USING_VARIABLE_LIVE_RANGE
 
         if (lclVarDsc->lvIsRegArg)
         {
@@ -925,16 +921,12 @@ void CodeGen::psiBegProlog()
 #endif // DEBUG
                     }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
                     varLocation.storeVariableInRegisters(regNum, otherRegNum);
-#endif // USING_VARIABLE_LIVE_RANGE
                 }
                 else
                 {
-// Stack passed argument. Get the offset from the  caller's frame.
-#ifdef USING_VARIABLE_LIVE_RANGE
+                    // Stack passed argument. Get the offset from the  caller's frame.
                     varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
-#endif // USING_VARIABLE_LIVE_RANGE
                 }
 
                 isStructHandled = true;
@@ -977,22 +969,16 @@ void CodeGen::psiBegProlog()
 #endif
                 assert(genMapRegNumToRegArgNum(lclVarDsc->GetArgReg(), regType) != (unsigned)-1);
 #endif // DEBUG
-#ifdef USING_VARIABLE_LIVE_RANGE
                 varLocation.storeVariableInRegisters(lclVarDsc->GetArgReg(), REG_NA);
-#endif // USING_VARIABLE_LIVE_RANGE
             }
         }
         else
         {
-#ifdef USING_VARIABLE_LIVE_RANGE
             varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
-#endif // USING_VARIABLE_LIVE_RANGE
         }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
         // Start a VariableLiveRange for this LclVarDsc on the built location
         varLiveKeeper->psiStartVariableLiveRange(varLocation, varScope->vsdVarNum);
-#endif // USING_VARIABLE_LIVE_RANGE
     }
 }
 
@@ -1006,7 +992,5 @@ void CodeGen::psiBegProlog()
 void CodeGen::psiEndProlog()
 {
     assert(compiler->compGeneratingProlog);
-#ifdef USING_VARIABLE_LIVE_RANGE
     varLiveKeeper->psiClosePrologVariableRanges();
-#endif // USING_VARIABLE_LIVE_RANGE
 }

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -131,11 +131,9 @@ bool TreeLifeUpdater<ForCodeGen>::UpdateLifeFieldVar(GenTreeLclVar* lclNode, uns
 #endif // DEBUG
             }
 
-#ifdef USING_VARIABLE_LIVE_RANGE
             // For each of the LclVarDsc that are reporting change, variable or fields
             compiler->codeGen->getVariableLiveKeeper()->siStartOrCloseVariableLiveRange(fldVarDsc, fieldVarNum, isBorn,
                                                                                         isDying);
-#endif // USING_VARIABLE_LIVE_RANGE
         }
     }
 
@@ -401,11 +399,8 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree, GenTreeLclVarComm
                 }
 #endif // DEBUG
             }
-
-#ifdef USING_VARIABLE_LIVE_RANGE
             // For each of the LclVarDsc that are reporting change, variable or fields
             compiler->codeGen->getVariableLiveKeeper()->siStartOrCloseVariableLiveRanges(varDeltaSet, isBorn, isDying);
-#endif // USING_VARIABLE_LIVE_RANGE
         }
     }
 

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -136,10 +136,6 @@ bool TreeLifeUpdater<ForCodeGen>::UpdateLifeFieldVar(GenTreeLclVar* lclNode, uns
             compiler->codeGen->getVariableLiveKeeper()->siStartOrCloseVariableLiveRange(fldVarDsc, fieldVarNum, isBorn,
                                                                                         isDying);
 #endif // USING_VARIABLE_LIVE_RANGE
-
-#ifdef USING_SCOPE_INFO
-            compiler->codeGen->siUpdate();
-#endif // USING_SCOPE_INFO
         }
     }
 
@@ -410,10 +406,6 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree, GenTreeLclVarComm
             // For each of the LclVarDsc that are reporting change, variable or fields
             compiler->codeGen->getVariableLiveKeeper()->siStartOrCloseVariableLiveRanges(varDeltaSet, isBorn, isDying);
 #endif // USING_VARIABLE_LIVE_RANGE
-
-#ifdef USING_SCOPE_INFO
-            compiler->codeGen->siUpdate();
-#endif // USING_SCOPE_INFO
         }
     }
 


### PR DESCRIPTION
Variable live range was added on 2019, replaced scope info in 2020, and has shipped in the last versions of .Net. This pr first removes all ScopeInfo code and then the preprocessing flag used to enable variable live range. The name ScopeInfo is still there with the same meaning, what changed was the underlying tracking structure.