### PR TITLE
Changed handle table scanning so that we would scan all slots for any heap count we may have.

### DIFF
--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -1025,6 +1025,7 @@ struct ScanContext
 {
     Thread* thread_under_crawl;
     int thread_number;
+    int thread_count;
     uintptr_t stack_limit; // Lowest point on the thread stack that the scanning logic is permitted to read
     bool promotion; //TRUE: Promotion, FALSE: Relocation.
     bool concurrent; //TRUE: concurrent scanning
@@ -1042,6 +1043,7 @@ struct ScanContext
 
         thread_under_crawl = 0;
         thread_number = -1;
+        thread_count = -1;
         stack_limit = 0;
         promotion = false;
         concurrent = false;

--- a/src/coreclr/gc/gcscan.cpp
+++ b/src/coreclr/gc/gcscan.cpp
@@ -100,7 +100,7 @@ bool GCScan::GcDhReScan(ScanContext* sc)
 void GCScan::GcWeakPtrScan(int condemned, int max_gen, ScanContext* sc)
 {
     // Clear out weak pointers that are no longer live.
-    Ref_CheckReachable(condemned, max_gen, (uintptr_t)sc);
+    Ref_CheckReachable(condemned, max_gen, sc);
 
     // Clear any secondary objects whose primary object is now definitely dead.
     Ref_ScanDependentHandlesForClearing(condemned, max_gen, sc);
@@ -139,7 +139,7 @@ void GCScan::GcScanSizedRefs(promote_func* fn, int condemned, int max_gen, ScanC
 
 void GCScan::GcShortWeakPtrScan(int condemned, int max_gen, ScanContext* sc)
 {
-    Ref_CheckAlive(condemned, max_gen, (uintptr_t)sc);
+    Ref_CheckAlive(condemned, max_gen, sc);
 }
 
 /*
@@ -220,14 +220,14 @@ void GCScan::GcRuntimeStructuresValid (BOOL bValid)
 
 void GCScan::GcDemote (int condemned, int max_gen, ScanContext* sc)
 {
-    Ref_RejuvenateHandles (condemned, max_gen, (uintptr_t)sc);
+    Ref_RejuvenateHandles (condemned, max_gen, sc);
     if (!IsServerHeap() || sc->thread_number == 0)
         GCToEEInterface::SyncBlockCacheDemote(max_gen);
 }
 
 void GCScan::GcPromotionsGranted (int condemned, int max_gen, ScanContext* sc)
 {
-    Ref_AgeHandles(condemned, max_gen, (uintptr_t)sc);
+    Ref_AgeHandles(condemned, max_gen, sc);
     if (!IsServerHeap() || sc->thread_number == 0)
         GCToEEInterface::SyncBlockCachePromotionsGranted(max_gen);
 }

--- a/src/coreclr/gc/objecthandle.h
+++ b/src/coreclr/gc/objecthandle.h
@@ -105,12 +105,12 @@ void Ref_ScanSizedRefHandles(uint32_t condemned, uint32_t maxgen, ScanContext* s
 void Ref_ScanPointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
 #endif
 
-void Ref_CheckReachable       (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, uintptr_t lp1);
-void Ref_CheckAlive           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, uintptr_t lp1);
+void Ref_CheckReachable       (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, ScanContext* sc);
+void Ref_CheckAlive           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, ScanContext *sc);
 void Ref_ScanHandlesForProfilerAndETW(uint32_t uMaxGeneration, uintptr_t lp1, handle_scan_fn fn);
 void Ref_ScanDependentHandlesForProfilerAndETW(uint32_t uMaxGeneration, ScanContext * SC, handle_scan_fn fn);
-void Ref_AgeHandles           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, uintptr_t lp1);
-void Ref_RejuvenateHandles(uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, uintptr_t lp1);
+void Ref_AgeHandles           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, ScanContext *sc);
+void Ref_RejuvenateHandles(uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, ScanContext *sc);
 
 void Ref_VerifyHandleTable(uint32_t condemned, uint32_t maxgen, ScanContext* sc);
 


### PR DESCRIPTION
This necessitated adding a thread_count field to the scan context so the handle table scanning would be aware of the current number of gc threads.

I also did an unrelated small cleanup where I changed the argument list of a few Ref_xxx function to have a ScanContext * instead of an uintptr_t, to reduce the amount of back-and-forth casting required.

Still thinking about how to reduce the amount of duplicated code...