### PR TITLE
Fix build invocation on Windows without os param

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -130,7 +130,9 @@ if ($subset -eq 'help') {
 }
 
 # Lower-case the passed in OS string.
-$os = $os.ToLowerInvariant()
+if ($os) {
+  $os = $os.ToLowerInvariant()
+}
 
 if ($vs) {
   $archToOpen = $arch[0]


### PR DESCRIPTION
Regressed with https://github.com/dotnet/runtime/commit/2ca7cf7140ebfaa8e34732b529c194416b122e89