### PR TITLE
[Android] Add NetworkChange implementation using PeriodicTimer

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -176,6 +176,9 @@
     <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.ProtocolStatistics.cs" Link="Common\Interop\BSD\System.Native\Interop.ProtocolStatistics.cs" />
     <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.TcpConnectionInfo.cs" Link="Common\Interop\BSD\System.Native\Interop.TcpConnectionInfo.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
+    <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.Android.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos'">
     <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.OSX.cs" />
     <!-- OSX Common -->
@@ -188,7 +191,7 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'freebsd'">
     <Compile Include="$(CommonPath)Interop\FreeBSD\Interop.Libraries.cs" Link="Common\Interop\FreeBSD\Interop.Libraries.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'linux' or '$(TargetPlatformIdentifier)' == 'android' or '$(TargetPlatformIdentifier)' == 'freebsd'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'linux' or '$(TargetPlatformIdentifier)' == 'freebsd'">
     <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.NetworkChange.cs" Link="Common\Interop\Unix\System.Native\Interop.NetworkChange.cs" />
   </ItemGroup>

--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -153,8 +153,9 @@
     <Compile Include="System\Net\NetworkInformation\AndroidIPInterfaceProperties.cs" />
     <Compile Include="System\Net\NetworkInformation\AndroidIPv4InterfaceProperties.cs" />
     <Compile Include="System\Net\NetworkInformation\AndroidIPv6InterfaceProperties.cs" />
-    <Compile Include="System\Net\NetworkInformation\NetworkInterfacePal.Android.cs" />
     <Compile Include="System\Net\NetworkInformation\AndroidNetworkInterface.cs" />
+    <Compile Include="System\Net\NetworkInformation\NetworkInterfacePal.Android.cs" />
+    <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.Android.cs" />
   </ItemGroup>
   <!-- OSX -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos' or '$(TargetPlatformIdentifier)' == 'freebsd'">
@@ -175,9 +176,6 @@
     <!-- BSD Common -->
     <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.ProtocolStatistics.cs" Link="Common\Interop\BSD\System.Native\Interop.ProtocolStatistics.cs" />
     <Compile Include="$(CommonPath)Interop\BSD\System.Native\Interop.TcpConnectionInfo.cs" Link="Common\Interop\BSD\System.Native\Interop.TcpConnectionInfo.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
-    <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.Android.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos'">
     <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.OSX.cs" />

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Android.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Android.cs
@@ -111,7 +111,7 @@ namespace System.Net.NetworkInformation
             Debug.Assert(s_loopTask is null);
 
             s_cancellationTokenSource = new CancellationTokenSource();
-            s_loopTask = Task.Run(() => PeriodicallyCheckIfAddressChanged(s_cancellationTokenSource.Token));
+            s_loopTask = Task.Run(() => PeriodicallyCheckIfNetworkChanged(s_cancellationTokenSource.Token));
         }
 
         private static void StopLoop()
@@ -126,7 +126,7 @@ namespace System.Net.NetworkInformation
             s_lastIpAddresses = null;
         }
 
-        private static async Task PeriodicallyCheckIfAddressChanged(CancellationToken cancellationToken)
+        private static async Task PeriodicallyCheckIfNetworkChanged(CancellationToken cancellationToken)
         {
             using var timer = new PeriodicTimer(s_timerInterval);
 
@@ -135,7 +135,7 @@ namespace System.Net.NetworkInformation
                 while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false)
                     && !cancellationToken.IsCancellationRequested)
                 {
-                    CheckIfAddressChanged();
+                    CheckIfNetworkChanged();
                 }
             }
             catch (OperationCanceledException)
@@ -143,12 +143,12 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        private static void CheckIfAddressChanged()
+        private static void CheckIfNetworkChanged()
         {
             var newAddresses = GetIPAddresses();
-            if (s_lastIpAddresses is IPAddress[] oldAddresses && AddressesChanged(oldAddresses, newAddresses))
+            if (s_lastIpAddresses is IPAddress[] oldAddresses && NetworkChanged(oldAddresses, newAddresses))
             {
-                OnAddressChanged();
+                OnNetworkChanged();
             }
 
             s_lastIpAddresses = newAddresses;
@@ -171,7 +171,7 @@ namespace System.Net.NetworkInformation
             return addresses.ToArray();
         }
 
-        private static bool AddressesChanged(IPAddress[] oldAddresses, IPAddress[] newAddresses)
+        private static bool NetworkChanged(IPAddress[] oldAddresses, IPAddress[] newAddresses)
         {
             if (oldAddresses.Length != newAddresses.Length)
             {
@@ -189,7 +189,7 @@ namespace System.Net.NetworkInformation
             return false;
         }
 
-        private static void OnAddressChanged()
+        private static void OnNetworkChanged()
         {
             Dictionary<NetworkAddressChangedEventHandler, ExecutionContext?>? addressChangedSubscribers = null;
             Dictionary<NetworkAvailabilityChangedEventHandler, ExecutionContext?>? availabilityChangedSubscribers = null;


### PR DESCRIPTION
We can't use netlink sockets to monitor network changes on Android anymore due to changes to permissions in recent Android versions. There doesn't seem to be a native Android API that could be used to implement the `NetworkChange` API in .NET. Instead, this PR implements the functionality using `PeriodicTimer` and manually diffing the IP addresses of all network interfaces. The period is set to 2s to limit the impact on battery life of mobile devices.

Ref #77822