### PR TITLE
Add tests for exercising certificates with platform provider keys

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/CngPlatformProviderKey.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/CngPlatformProviderKey.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace Test.Cryptography
+{
+    internal sealed class CngPlatformProviderKey : IDisposable
+    {
+        public CngPlatformProviderKey(
+            CngAlgorithm algorithm,
+            string keySuffix = null,
+            [CallerMemberName] string testName = null,
+            params CngProperty[] additionalParameters)
+        {
+            CngKeyCreationParameters cngCreationParameters = new CngKeyCreationParameters
+            {
+                Provider = CngProvider.MicrosoftPlatformCryptoProvider,
+                KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
+            };
+
+            foreach (CngProperty parameter in additionalParameters)
+            {
+                cngCreationParameters.Parameters.Add(parameter);
+            }
+
+            Key = CngKey.Create(algorithm, $"{testName}{algorithm.Algorithm}{keySuffix}", cngCreationParameters);
+        }
+
+        internal CngKey Key { get; }
+
+        public void Dispose()
+        {
+            Key.Delete();
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
@@ -193,39 +193,14 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void PlatformCryptoProvider_DeriveKeyMaterial()
         {
-            CngKey key1 = null;
-            CngKey key2 = null;
-
-            try
+            using (CngPlatformProviderKey platformKey1 = new CngPlatformProviderKey(CngAlgorithm.ECDiffieHellmanP256, "key1"))
+            using (CngPlatformProviderKey platformKey2 = new CngPlatformProviderKey(CngAlgorithm.ECDiffieHellmanP256, "key2"))
+            using (ECDiffieHellmanCng ecdhCng1 = new ECDiffieHellmanCng(platformKey1.Key))
+            using (ECDiffieHellmanCng ecdhCng2 = new ECDiffieHellmanCng(platformKey2.Key))
             {
-                CngKeyCreationParameters cngCreationParameters = new CngKeyCreationParameters
-                {
-                    Provider = CngProvider.MicrosoftPlatformCryptoProvider,
-                    KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
-                };
-
-                key1 = CngKey.Create(
-                    CngAlgorithm.ECDiffieHellmanP256,
-                    $"{nameof(PlatformCryptoProvider_DeriveKeyMaterial)}{nameof(key1)}",
-                    cngCreationParameters);
-
-                key2 = CngKey.Create(
-                    CngAlgorithm.ECDiffieHellmanP256,
-                    $"{nameof(PlatformCryptoProvider_DeriveKeyMaterial)}{nameof(key2)}",
-                    cngCreationParameters);
-
-                using (ECDiffieHellmanCng ecdhCng1 = new ECDiffieHellmanCng(key1))
-                using (ECDiffieHellmanCng ecdhCng2 = new ECDiffieHellmanCng(key2))
-                {
-                    byte[] derivedKey1 = ecdhCng1.DeriveKeyMaterial(key2);
-                    byte[] derivedKey2 = ecdhCng2.DeriveKeyMaterial(key1);
-                    Assert.Equal(derivedKey1, derivedKey2);
-                }
-            }
-            finally
-            {
-                key1?.Delete();
-                key2?.Delete();
+                byte[] derivedKey1 = ecdhCng1.DeriveKeyMaterial(platformKey2.Key);
+                byte[] derivedKey2 = ecdhCng2.DeriveKeyMaterial(platformKey1.Key);
+                Assert.Equal(derivedKey1, derivedKey2);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -42,6 +42,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\ECDiffieHellman\ECDiffieHellmanFactory.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs"
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\CngPlatformProviderKey.cs"
+             Link="CommonTest\System\Security\Cryptography\CngPlatformProviderKey.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs"
              Link="CommonTest\System\Security\Cryptography\CryptoUtils.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -201,6 +201,8 @@
              Link="CommonTest\System\Security\Cryptography\509Certificates\RevocationResponder.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs"
              Link="CommonTest\System\Security\Cryptography\ByteUtils.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\CngPlatformProviderKey.cs"
+             Link="CommonTest\System\Security\Cryptography\CngPlatformProviderKey.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\CryptoUtils.cs"
              Link="CommonTest\System\Security\Cryptography\CryptoUtils.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\PlatformSupport.cs"

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -627,7 +627,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 key = CngKey.Create(
                     CngAlgorithm.Rsa,
-                    nameof(MicrosoftPlatformCryptoProvider_EcdsaKey),
+                    nameof(MicrosoftPlatformCryptoProvider_RsaKey),
                     cngCreationParameters);
 
                 using (RSACng rsa = new RSACng(key))

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -573,7 +573,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
-        public static void MicrosoftPlatformCryptoProvider_EcdsaKey()
+        public static void CreateCertificate_MicrosoftPlatformCryptoProvider_EcdsaKey()
         {
              CngKey key = null;
 
@@ -587,7 +587,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 key = CngKey.Create(
                     CngAlgorithm.ECDsaP384,
-                    nameof(MicrosoftPlatformCryptoProvider_EcdsaKey),
+                    nameof(CreateCertificate_MicrosoftPlatformCryptoProvider_EcdsaKey),
                     cngCreationParameters);
 
                 using (ECDsaCng ecdsa = new ECDsaCng(key))
@@ -613,7 +613,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
-        public static void MicrosoftPlatformCryptoProvider_RsaKey()
+        public static void CreateCertificate_MicrosoftPlatformCryptoProvider_RsaKey()
         {
              CngKey key = null;
 
@@ -627,7 +627,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 key = CngKey.Create(
                     CngAlgorithm.Rsa,
-                    nameof(MicrosoftPlatformCryptoProvider_RsaKey),
+                    nameof(CreateCertificate_MicrosoftPlatformCryptoProvider_RsaKey),
                     cngCreationParameters);
 
                 using (RSACng rsa = new RSACng(key))

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -575,39 +575,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void CreateCertificate_MicrosoftPlatformCryptoProvider_EcdsaKey()
         {
-             CngKey key = null;
-
-            try
+            using (CngPlatformProviderKey platformKey = new CngPlatformProviderKey(CngAlgorithm.ECDsaP384))
+            using (ECDsaCng ecdsa = new ECDsaCng(platformKey.Key))
             {
-                CngKeyCreationParameters cngCreationParameters = new CngKeyCreationParameters
+                CertificateRequest req = new CertificateRequest("CN=potato", ecdsa, HashAlgorithmName.SHA256);
+
+                using (X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow))
+                using (ECDsa certKey = cert.GetECDsaPrivateKey())
                 {
-                    Provider = CngProvider.MicrosoftPlatformCryptoProvider,
-                    KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
-                };
-
-                key = CngKey.Create(
-                    CngAlgorithm.ECDsaP384,
-                    nameof(CreateCertificate_MicrosoftPlatformCryptoProvider_EcdsaKey),
-                    cngCreationParameters);
-
-                using (ECDsaCng ecdsa = new ECDsaCng(key))
-                {
-                    CertificateRequest req = new CertificateRequest("CN=potato", ecdsa, HashAlgorithmName.SHA256);
-
-                    using (X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow))
-                    using (ECDsa certKey = cert.GetECDsaPrivateKey())
-                    {
-                        Assert.NotNull(certKey);
-                        byte[] data = new byte[] { 12, 11, 02, 08, 25, 14, 11, 18, 16 };
-                        byte[] signature = certKey.SignData(data, HashAlgorithmName.SHA256);
-                        bool valid = ecdsa.VerifyData(data, signature, HashAlgorithmName.SHA256);
-                        Assert.True(valid, "valid signature");
-                    }
+                    Assert.NotNull(certKey);
+                    byte[] data = new byte[] { 12, 11, 02, 08, 25, 14, 11, 18, 16 };
+                    byte[] signature = certKey.SignData(data, HashAlgorithmName.SHA256);
+                    bool valid = ecdsa.VerifyData(data, signature, HashAlgorithmName.SHA256);
+                    Assert.True(valid, "valid signature");
                 }
-            }
-            finally
-            {
-                key?.Delete();
             }
         }
 
@@ -615,39 +596,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [OuterLoop("Hardware backed key generation takes several seconds.")]
         public static void CreateCertificate_MicrosoftPlatformCryptoProvider_RsaKey()
         {
-             CngKey key = null;
-
-            try
+            using (CngPlatformProviderKey platformKey = new CngPlatformProviderKey(CngAlgorithm.Rsa))
+            using (RSACng rsa = new RSACng(platformKey.Key))
             {
-                CngKeyCreationParameters cngCreationParameters = new CngKeyCreationParameters
+                CertificateRequest req = new CertificateRequest("CN=potato", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+                using (X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow))
+                using (RSA certKey = cert.GetRSAPrivateKey())
                 {
-                    Provider = CngProvider.MicrosoftPlatformCryptoProvider,
-                    KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
-                };
-
-                key = CngKey.Create(
-                    CngAlgorithm.Rsa,
-                    nameof(CreateCertificate_MicrosoftPlatformCryptoProvider_RsaKey),
-                    cngCreationParameters);
-
-                using (RSACng rsa = new RSACng(key))
-                {
-                    CertificateRequest req = new CertificateRequest("CN=potato", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-
-                    using (X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow))
-                    using (RSA certKey = cert.GetRSAPrivateKey())
-                    {
-                        Assert.NotNull(certKey);
-                        byte[] data = new byte[] { 12, 11, 02, 08, 25, 14, 11, 18, 16 };
-                        byte[] signature = certKey.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-                        bool valid = rsa.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-                        Assert.True(valid, "valid signature");
-                    }
+                    Assert.NotNull(certKey);
+                    byte[] data = new byte[] { 12, 11, 02, 08, 25, 14, 11, 18, 16 };
+                    byte[] signature = certKey.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                    bool valid = rsa.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                    Assert.True(valid, "valid signature");
                 }
-            }
-            finally
-            {
-                key?.Delete();
             }
         }
 


### PR DESCRIPTION
With #77801, #77809, and #80457, we can now correctly issue and use an `X509Certificate2` with a key backed by a Platform Provider TPM key, both for RSA and ECDSA.

Let's add a test that does and end-to-end test and then I think we can close it.

Closes #75971