### PR TITLE
[release/6.0] Update dotnet host for testing and fix failing globalization test

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -178,13 +178,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>fde6b37e985605d862c070256de7c97e2a3f3342</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="6.0.0-rc.1.21415.6">
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="6.0.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>fde6b37e985605d862c070256de7c97e2a3f3342</Sha>
+      <Sha>1af80ba017f6f7644305e1781d8cc9845a92b5f8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="6.0.0-rc.1.21415.6">
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="6.0.13">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>fde6b37e985605d862c070256de7c97e2a3f3342</Sha>
+      <Sha>1af80ba017f6f7644305e1781d8cc9845a92b5f8</Sha>
     </Dependency>
     <Dependency Name="runtime.native.System.IO.Ports" Version="6.0.0-rc.1.21415.6">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,8 +61,8 @@
     <NuGetBuildTasksPackVersion>6.0.0-preview.1.102</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-alpha.1.20612.4</MicrosoftNETCoreAppRuntimewinx64Version>
-    <MicrosoftNETCoreDotNetHostVersion>6.0.0-rc.1.21415.6</MicrosoftNETCoreDotNetHostVersion>
-    <MicrosoftNETCoreDotNetHostPolicyVersion>6.0.0-rc.1.21415.6</MicrosoftNETCoreDotNetHostPolicyVersion>
+    <MicrosoftNETCoreDotNetHostVersion>6.0.13</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>6.0.13</MicrosoftNETCoreDotNetHostPolicyVersion>
     <MicrosoftExtensionsDependencyModelVersion>6.0.0</MicrosoftExtensionsDependencyModelVersion>
     <!-- CoreClr dependencies -->
     <MicrosoftNETCoreILAsmVersion>6.0.0-rc.1.21415.6</MicrosoftNETCoreILAsmVersion>

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -65,7 +65,11 @@ namespace System.Globalization.Tests
                     return PlatformDetection.IsNlsGlobalization ? new int[] { 12 } : new int[] { 9 };
 
                 case "es-BO":
-                    return (PlatformDetection.IsNlsGlobalization && PlatformDetection.WindowsVersion < 10) ? new int[] { 14 } : new int[] { 1 };
+                    return (PlatformDetection.IsNlsGlobalization && PlatformDetection.WindowsVersion < 10) ? 
+                                new int[] { 14 } : 
+                                // Mac OSX used to return 1 which is the format "-$n". OSX Version 12 (Monterey) started
+                                // to return a different value 12 "$ -n". 
+                                PlatformDetection.IsOSX ? new int[] { 1, 12 } : new int[] { 1 };
 
                 case "fr-CA":
                     return PlatformDetection.IsNlsGlobalization ? new int[] { 15 } : new int[] { 8, 15 };

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -190,7 +190,8 @@ namespace System.Tests
             Version version = Environment.OSVersion.Version;
 
             // verify that the Environment.OSVersion.Version matches the current RID
-            Assert.Contains(version.ToString(2), RuntimeInformation.RuntimeIdentifier);
+            // As of 12.0, only major version numbers are included in the RID
+            Assert.Contains(version.ToString(1), RuntimeInformation.RuntimeIdentifier);
 
             Assert.True(version.Build >= 0, "OSVersion Build should be non-negative");
             Assert.Equal(-1, version.Revision); // Revision is never set on OSX


### PR DESCRIPTION
We changed how we got the OS version in f30e7fa to account for the macOS versioning changes.

The `dotnet` host used for testing was still on a version before that change so the RID it set (which flows through to `RuntimeInformation.RuntimeIdentifier`) was using the old format.
Updating to the latest 6.0.13 and adding the change from 5da4464 so we only check for the major OS version fixes the OSVersion_ValidVersion_OSX test.

This also backports https://github.com/dotnet/runtime/pull/63971 which is necessary to fix a globalization test on macOS 12.

Fixes https://github.com/dotnet/runtime/issues/80252

