### PR TITLE
Permit CngKey backed ECDH interoperability from different KSPs

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/ECDiffieHellmanCngTests.cs
@@ -191,7 +191,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
         [OuterLoop("Hardware backed key generation takes several seconds.")]
-        public static void PlatformCryptoProvider_DeriveKeyMaterial()
+        public static void PlatformCryptoProvider_DeriveKeyMaterial_CngKey()
         {
             CngKey key1 = null;
             CngKey key2 = null;
@@ -206,12 +206,12 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
                 key1 = CngKey.Create(
                     CngAlgorithm.ECDiffieHellmanP256,
-                    $"{nameof(PlatformCryptoProvider_DeriveKeyMaterial)}{nameof(key1)}",
+                    $"{nameof(PlatformCryptoProvider_DeriveKeyMaterial_CngKey)}{nameof(key1)}",
                     cngCreationParameters);
 
                 key2 = CngKey.Create(
                     CngAlgorithm.ECDiffieHellmanP256,
-                    $"{nameof(PlatformCryptoProvider_DeriveKeyMaterial)}{nameof(key2)}",
+                    $"{nameof(PlatformCryptoProvider_DeriveKeyMaterial_CngKey)}{nameof(key2)}",
                     cngCreationParameters);
 
                 using (ECDiffieHellmanCng ecdhCng1 = new ECDiffieHellmanCng(key1))
@@ -219,6 +219,86 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
                 {
                     byte[] derivedKey1 = ecdhCng1.DeriveKeyMaterial(key2);
                     byte[] derivedKey2 = ecdhCng2.DeriveKeyMaterial(key1);
+                    Assert.Equal(derivedKey1, derivedKey2);
+                }
+            }
+            finally
+            {
+                key1?.Delete();
+                key2?.Delete();
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [OuterLoop("Hardware backed key generation takes several seconds.")]
+        public static void PlatformCryptoProvider_DeriveKeyFromHash()
+        {
+            CngKey key1 = null;
+            CngKey key2 = null;
+
+            try
+            {
+                CngKeyCreationParameters cngCreationParameters = new CngKeyCreationParameters
+                {
+                    Provider = CngProvider.MicrosoftPlatformCryptoProvider,
+                    KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
+                };
+
+                key1 = CngKey.Create(
+                    CngAlgorithm.ECDiffieHellmanP256,
+                    $"{nameof(PlatformCryptoProvider_DeriveKeyFromHash)}{nameof(key1)}",
+                    cngCreationParameters);
+
+                key2 = CngKey.Create(
+                    CngAlgorithm.ECDiffieHellmanP256,
+                    $"{nameof(PlatformCryptoProvider_DeriveKeyFromHash)}{nameof(key2)}",
+                    cngCreationParameters);
+
+                using (ECDiffieHellmanCng ecdhCng1 = new ECDiffieHellmanCng(key1))
+                using (ECDiffieHellmanCng ecdhCng2 = new ECDiffieHellmanCng(key2))
+                {
+                    byte[] derivedKey1 = ecdhCng1.DeriveKeyFromHash(ecdhCng2.PublicKey, HashAlgorithmName.SHA256, new byte[] { 0x00 }, new byte[] { 0xFF });
+                    byte[] derivedKey2 = ecdhCng2.DeriveKeyFromHash(ecdhCng1.PublicKey, HashAlgorithmName.SHA256, new byte[] { 0x00 }, new byte[] { 0xFF });
+                    Assert.Equal(derivedKey1, derivedKey2);
+                }
+            }
+            finally
+            {
+                key1?.Delete();
+                key2?.Delete();
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctional))]
+        [OuterLoop("Hardware backed key generation takes several seconds.")]
+        public static void PlatformCryptoProvider_DeriveKeyMaterial_ECDiffieHellmanPublicKey()
+        {
+            CngKey key1 = null;
+            CngKey key2 = null;
+
+            try
+            {
+                CngKeyCreationParameters cngCreationParameters = new CngKeyCreationParameters
+                {
+                    Provider = CngProvider.MicrosoftPlatformCryptoProvider,
+                    KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey,
+                };
+
+                key1 = CngKey.Create(
+                    CngAlgorithm.ECDiffieHellmanP256,
+                    $"{nameof(PlatformCryptoProvider_DeriveKeyFromHash)}{nameof(key1)}",
+                    cngCreationParameters);
+
+                key2 = CngKey.Create(
+                    CngAlgorithm.ECDiffieHellmanP256,
+                    $"{nameof(PlatformCryptoProvider_DeriveKeyFromHash)}{nameof(key2)}",
+                    cngCreationParameters);
+
+                using (ECDiffieHellmanCng ecdhCng1 = new ECDiffieHellmanCng(key1))
+                using (ECDiffieHellmanCng ecdhCng2 = new ECDiffieHellmanCng(key2))
+                {
+                    byte[] derivedKey1 = ecdhCng1.DeriveKeyMaterial(ecdhCng2.PublicKey);
+                    byte[] derivedKey2 = ecdhCng2.DeriveKeyMaterial(ecdhCng1.PublicKey);
                     Assert.Equal(derivedKey1, derivedKey2);
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCng.Derive.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCng.Derive.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography
 
             if (otherPartyPublicKey is ECDiffieHellmanCngPublicKey otherKey)
             {
-                using (CngKey import = otherKey.Import())
+                using (CngKey import = otherKey.NativeCngKey() ?? otherKey.Import())
                 {
                     return DeriveKeyMaterial(import);
                 }
@@ -101,7 +101,7 @@ namespace System.Security.Cryptography
 
             if (otherPartyPublicKey is ECDiffieHellmanCngPublicKey otherKey)
             {
-                using (CngKey importedKey = otherKey.Import())
+                using (CngKey importedKey = otherKey.NativeCngKey() ?? otherKey.Import())
                 {
                     return DeriveSecretAgreementHandle(importedKey);
                 }


### PR DESCRIPTION
This is a proof-of-concept for fixing ECDiffieHellman that uses CNG keys when performing the exchange with a `ECDiffieHellmanCngPublicKey`.

The original issue is #71009.

Some background, first.

`ECDiffieHellman`, unlike other asymmetric cryptographic types, has a dedicated type called `ECDiffieHellmanCngPublicKey`. The latter type _always_ uses the Microsoft Software Key Storage Provider for the public key. Even if the original `ECDiffieHellman` was created with the right KSP, when the ECDHCngPublicKey is created, it is exported from the current provider, and shoved in to the Microsoft Software Key Storage Provider. That occurs here:

https://github.com/dotnet/runtime/blob/6e1ca642370eefbe49c61a0b3f518772875fbe24/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCngPublicKey.cs#L83-L88

This is problematic when the other party `ECDiffieHellman` is _not_ in the Microsoft Software Key Storage Provider. 

`NCryptSecretAgreement` does not perform cross CNG provider agreement:

> This key and the hPubKey key must come from the same key storage provider.

So cross provider ECDH doesn't work at the CNG level.

To fix this, I originally thought about making an internal implementation of [`Import`](https://github.com/dotnet/runtime/blob/6e1ca642370eefbe49c61a0b3f518772875fbe24/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDiffieHellmanCngPublicKey.cs#L95) that preserves the provider. However, this proved problematic for some providers. The Microsoft Platform Crypto Provider, for example, forbids importing keys. Even public ones. So going from PCP -> Software Provider -> PCP doesn't work.

This lead to me to preserve the CngKey handle itself in the ECDHCngPublicKey. This way, if two `ECDiffieHellmanCng` instances start from the same provider, the provider is preserved.

The original `Import` method does _not_ return this stashed handle. This is intentional, and it hydrates the blob. This is because `Import` is [public](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.ecdiffiehellmancngpublickey.import?view=net-7.0). I would not want this method to start returning a `CngKey` object that is a handle to the original private key. So it continues to use the public blobs.

What this PR does is allow two `ECDiffieHellmanCng` objects to interoperate with each other if they were both constructed from a `CngKey` that are not in the Software Storage Provider.

What this PR does not do is try to further fix "cross" provider interoperability. My general thought here is that our guidance should be `CngKey`s should be from the same provider. This can be a future improvement. The largest barrier to implementing this is any kind of testability. I have no CNG provider that permits imports other than the software one. So testing this would require making blind changes.

@bartonjs apologies for the probably excessive background, and I would appreciate your input if you think I am off the mark on the approach for this one.