### PR TITLE
Set AssemblyName.ProcessorArchitecture for compatibility.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -3091,7 +3091,12 @@ namespace System.Reflection.Metadata.Tests
             if (PlatformDetection.HasAssemblyFiles)
             {
                 Assembly a = typeof(MetadataReaderTests).Assembly;
-                Assert.Equal(new AssemblyName(a.FullName).ToString(), MetadataReader.GetAssemblyName(AssemblyPathHelper.GetAssemblyLocation(a)).ToString());
+                AssemblyName name = MetadataReader.GetAssemblyName(AssemblyPathHelper.GetAssemblyLocation(a));
+                Assert.Equal(new AssemblyName(a.FullName).ToString(), name.ToString());
+
+#pragma warning disable SYSLIB0037 // AssemblyName.ProcessorArchitecture is obsolete
+                Assert.Equal(ProcessorArchitecture.MSIL, name.ProcessorArchitecture);
+#pragma warning restore SYSLIB0037
             }
         }
     }


### PR DESCRIPTION
Fixes: #77697

Computing and setting `ProcessorArchitecture` was unintentionally omitted when `GetAssemblyName(path)` was switched to a managed implementation.

This will need to be backported to 7.0
