### PR TITLE
Update manually the cecil version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -84,13 +84,13 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>5618b2d243ccdeb5c7e50a298b33b13036b4351b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.23053.1">
+    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.23060.1">
       <Uri>https://github.com/dotnet/cecil</Uri>
-      <Sha>61a57d143fc06e69123307e2d5fb2bb9ab1230ef</Sha>
+      <Sha>2941911af1e028ec4b508cbb8c326003089bc610</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cecil.Pdb" Version="0.11.4-alpha.23053.1">
+    <Dependency Name="Microsoft.DotNet.Cecil.Pdb" Version="0.11.4-alpha.23060.1">
       <Uri>https://github.com/dotnet/cecil</Uri>
-      <Sha>61a57d143fc06e69123307e2d5fb2bb9ab1230ef</Sha>
+      <Sha>2941911af1e028ec4b508cbb8c326003089bc610</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -214,8 +214,8 @@
     <MicrosoftNETILLinkTasksVersion>7.0.100-1.22606.1</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>
     <!-- Mono Cecil -->
-    <MicrosoftDotNetCecilVersion>0.11.4-alpha.23053.1</MicrosoftDotNetCecilVersion>
-    <MicrosoftDotNetCecilPdbVersion>0.11.4-alpha.23053.1</MicrosoftDotNetCecilPdbVersion>
+    <MicrosoftDotNetCecilVersion>0.11.4-alpha.23060.1</MicrosoftDotNetCecilVersion>
+    <MicrosoftDotNetCecilPdbVersion>0.11.4-alpha.23060.1</MicrosoftDotNetCecilPdbVersion>
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>8.0.0-alpha.1.23056.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->


### PR DESCRIPTION
The current version has a bug that prevents the illink package to generate valid IL.
The Microsoft.NET.ILLink.Tasks package is blocking runtime to SDK flow
There is a PR https://github.com/dotnet/runtime/pull/80429 that updates the cecil dependency into runtime but its blocked due to failures (there is 10 different repos trying to be updated at the same time)