### PR TITLE
Generate fewer templates for generic virtual methods

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
@@ -110,21 +110,10 @@ namespace Internal.Runtime.TypeLoader
 
         internal unsafe IntPtr ResolveGenericVirtualMethodTarget(RuntimeTypeHandle type, RuntimeMethodHandle slot)
         {
-            RuntimeTypeHandle declaringTypeHandle;
-            MethodNameAndSignature nameAndSignature;
-            RuntimeTypeHandle[] genericMethodArgs;
-            if (!TryGetRuntimeMethodHandleComponents(slot, out declaringTypeHandle, out nameAndSignature, out genericMethodArgs))
-            {
-                Debug.Assert(false);
-                return IntPtr.Zero;
-            }
-
             TypeSystemContext context = TypeSystemContextFactory.Create();
-
             DefType targetType = (DefType)context.ResolveRuntimeTypeHandle(type);
-            DefType declaringType = (DefType)context.ResolveRuntimeTypeHandle(declaringTypeHandle);
-            Instantiation methodInstantiation = context.ResolveRuntimeTypeHandles(genericMethodArgs);
-            InstantiatedMethod slotMethod = (InstantiatedMethod)context.ResolveGenericMethodInstantiation(false, declaringType, nameAndSignature, methodInstantiation, IntPtr.Zero, false);
+
+            InstantiatedMethod slotMethod = (InstantiatedMethod)GetMethodDescForRuntimeMethodHandle(context, slot);
 
             InstantiatedMethod result = GVMLookupForSlotWorker(targetType, slotMethod);
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
@@ -330,12 +330,20 @@ namespace Internal.Runtime.TypeLoader
             return GetRuntimeMethodHandleForComponents(declaringTypeHandle, nameAsIntPtr, methodSignature, genericMethodArgs);
         }
 
+        public MethodDesc GetMethodDescForRuntimeMethodHandle(TypeSystemContext context, RuntimeMethodHandle runtimeMethodHandle)
+        {
+            return runtimeMethodHandle.IsDynamic() ?
+                GetMethodDescForDynamicRuntimeMethodHandle(context, runtimeMethodHandle) :
+                GetMethodDescForStaticRuntimeMethodHandle(context, runtimeMethodHandle);
+        }
+
         public bool TryGetRuntimeMethodHandleComponents(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodArgs)
         {
             return runtimeMethodHandle.IsDynamic() ?
                 TryGetDynamicRuntimeMethodHandleComponents(runtimeMethodHandle, out declaringTypeHandle, out nameAndSignature, out genericMethodArgs) :
                 TryGetStaticRuntimeMethodHandleComponents(runtimeMethodHandle, out declaringTypeHandle, out nameAndSignature, out genericMethodArgs);
         }
+
         private unsafe bool TryGetDynamicRuntimeMethodHandleComponents(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodArgs)
         {
             IntPtr runtimeMethodHandleValue = *(IntPtr*)&runtimeMethodHandle;
@@ -378,12 +386,56 @@ namespace Internal.Runtime.TypeLoader
 
             return true;
         }
+        public MethodDesc GetMethodDescForDynamicRuntimeMethodHandle(TypeSystemContext context, RuntimeMethodHandle runtimeMethodHandle)
+        {
+            bool success = TryGetDynamicRuntimeMethodHandleComponents(runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle,
+                out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodArgs);
+            Debug.Assert(success);
+
+            DefType type = (DefType)context.ResolveRuntimeTypeHandle(declaringTypeHandle);
+
+            if (genericMethodArgs != null)
+            {
+                Instantiation methodInst = context.ResolveRuntimeTypeHandles(genericMethodArgs);
+                return context.ResolveGenericMethodInstantiation(unboxingStub: false, type, nameAndSignature, methodInst, default, default);
+            }
+
+            return context.ResolveRuntimeMethod(unboxingStub: false, type, nameAndSignature, default, default);
+        }
+
         private unsafe bool TryGetStaticRuntimeMethodHandleComponents(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodArgs)
         {
             declaringTypeHandle = default(RuntimeTypeHandle);
             nameAndSignature = null;
             genericMethodArgs = null;
 
+            TypeSystemContext context = TypeSystemContextFactory.Create();
+
+            MethodDesc parsedMethod = GetMethodDescForStaticRuntimeMethodHandle(context, runtimeMethodHandle);
+
+            if (!EnsureTypeHandleForType(parsedMethod.OwningType))
+                return false;
+
+            declaringTypeHandle = parsedMethod.OwningType.RuntimeTypeHandle;
+            nameAndSignature = parsedMethod.NameAndSignature;
+            if (!parsedMethod.IsMethodDefinition && parsedMethod.Instantiation.Length > 0)
+            {
+                genericMethodArgs = new RuntimeTypeHandle[parsedMethod.Instantiation.Length];
+                for (int i = 0; i < parsedMethod.Instantiation.Length; ++i)
+                {
+                    if (!EnsureTypeHandleForType(parsedMethod.Instantiation[i]))
+                        return false;
+
+                    genericMethodArgs[i] = parsedMethod.Instantiation[i].RuntimeTypeHandle;
+                }
+            }
+
+            TypeSystemContextFactory.Recycle(context);
+            return true;
+        }
+
+        public unsafe MethodDesc GetMethodDescForStaticRuntimeMethodHandle(TypeSystemContext context, RuntimeMethodHandle runtimeMethodHandle)
+        {
             // Make sure it's not a dynamically allocated RuntimeMethodHandle before we attempt to use it to parse native layout data
             Debug.Assert(((*(IntPtr*)&runtimeMethodHandle).ToInt64() & 0x1) == 0);
 
@@ -400,7 +452,7 @@ namespace Internal.Runtime.TypeLoader
                 (uint)nativeLayoutInfoSignatureData[1].ToInt32());
 
             RuntimeSignature remainingSignature;
-            return GetMethodFromSignatureAndContext(signature, null, null, out declaringTypeHandle, out nameAndSignature, out genericMethodArgs, out remainingSignature);
+            return GetMethodFromSignatureAndContext(context, signature, null, null, out remainingSignature);
         }
         #endregion
     }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -261,50 +261,16 @@ namespace Internal.Runtime.TypeLoader
         // "typeArgs" and "methodArgs" for generic type parameter substitution.  The first field in "signature"
         // must be an encoded method but any data beyond that is user-defined and returned in "remainingSignature"
         //
-        public bool GetMethodFromSignatureAndContext(RuntimeSignature signature, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs, out RuntimeTypeHandle createdType, out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles, out RuntimeSignature remainingSignature)
+        public MethodDesc GetMethodFromSignatureAndContext(TypeSystemContext context, RuntimeSignature signature, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs, out RuntimeSignature remainingSignature)
         {
             NativeReader reader = GetNativeLayoutInfoReader(signature);
             NativeParser parser = new NativeParser(reader, signature.NativeLayoutOffset);
 
-            bool result = GetMethodFromSignatureAndContext(ref parser, new TypeManagerHandle(signature.ModuleHandle), typeArgs, methodArgs, out createdType, out nameAndSignature, out genericMethodTypeArgumentHandles);
+            MethodDesc result = TryParseNativeSignatureWorker(context, new TypeManagerHandle(signature.ModuleHandle), ref parser, typeArgs, methodArgs, true) as MethodDesc;
 
             remainingSignature = RuntimeSignature.CreateFromNativeLayoutSignature(signature, parser.Offset);
 
             return result;
-        }
-
-        internal bool GetMethodFromSignatureAndContext(ref NativeParser parser, TypeManagerHandle moduleHandle, RuntimeTypeHandle[] typeArgs, RuntimeTypeHandle[] methodArgs, out RuntimeTypeHandle createdType, out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodTypeArgumentHandles)
-        {
-            createdType = default(RuntimeTypeHandle);
-            nameAndSignature = null;
-            genericMethodTypeArgumentHandles = null;
-
-            TypeSystemContext context = TypeSystemContextFactory.Create();
-
-            MethodDesc parsedMethod = TryParseNativeSignatureWorker(context, moduleHandle, ref parser, typeArgs, methodArgs, true) as MethodDesc;
-            if (parsedMethod == null)
-                return false;
-
-            if (!EnsureTypeHandleForType(parsedMethod.OwningType))
-                return false;
-
-            createdType = parsedMethod.OwningType.RuntimeTypeHandle;
-            nameAndSignature = parsedMethod.NameAndSignature;
-            if (!parsedMethod.IsMethodDefinition && parsedMethod.Instantiation.Length > 0)
-            {
-                genericMethodTypeArgumentHandles = new RuntimeTypeHandle[parsedMethod.Instantiation.Length];
-                for (int i = 0; i < parsedMethod.Instantiation.Length; ++i)
-                {
-                    if (!EnsureTypeHandleForType(parsedMethod.Instantiation[i]))
-                        return false;
-
-                    genericMethodTypeArgumentHandles[i] = parsedMethod.Instantiation[i].RuntimeTypeHandle;
-                }
-            }
-
-            TypeSystemContextFactory.Recycle(context);
-
-            return true;
         }
 
         //

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -256,15 +256,6 @@ namespace ILCompiler.DependencyAnalysis
 
             dependencies.Add(factory.GVMDependencies(canonMethod), "Potential generic virtual method call");
 
-            // TODO: this should not be needed - we no longer need to materialize RuntimeTypeHandles as part
-            // of the dispatch. Investigate getting rid of this.
-            // Variant generic virtual method calls at runtime might need to build the concrete version of the
-            // type we could be dispatching on to find the appropriate GVM entry.
-            if (_method.OwningType.HasVariance)
-            {
-                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, _method.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific));
-            }
-
             foreach (TypeDesc instArg in canonMethod.Instantiation)
             {
                 dependencies.Add(factory.MaximallyConstructableType(instArg), "Type we need to look up for GVM dispatch");


### PR DESCRIPTION
The only reason left why we needed the extra template was because when we're breaking down a `RuntimeMethodHandle` into components, we were trying to break it down into `RuntimeTypeHandle`s. But what we need is a `MethodDesc`. So shortcut the codepath that computes `MethodDesc`, then breaks it down into various type handles and then get a `MethodDesc` again, and just keep the `MethodDesc` we started with.

Cc @dotnet/ilc-contrib 