### PR TITLE
Add type loader support for resolving static virtuals

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
@@ -141,6 +141,28 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
+        /// <summary>
+        /// Used for generic static constrained Methods
+        /// </summary>
+        private class GenericStaticConstrainedMethodCell : GenericDictionaryCell
+        {
+            internal DefType ConstraintType;
+            internal InstantiatedMethod ConstrainedMethod;
+            private InstantiatedMethod _resolvedMethod;
+
+            internal override void Prepare(TypeBuilder builder)
+            {
+                _resolvedMethod = TypeLoaderEnvironment.GVMLookupForSlotWorker(ConstraintType, ConstrainedMethod);
+                builder.PrepareMethod(_resolvedMethod);
+            }
+
+            internal override IntPtr Create(TypeBuilder builder)
+            {
+                IntPtr methodDictionary = _resolvedMethod.RuntimeMethodDictionary;
+                return FunctionPointerOps.GetGenericMethodFunctionPointer(_resolvedMethod.FunctionPointer, methodDictionary);
+            }
+        }
+
         private class StaticDataCell : GenericDictionaryCell
         {
             internal StaticDataKind DataKind;
@@ -499,6 +521,23 @@ namespace Internal.Runtime.TypeLoader
                     }
                     break;
 
+                case FixupSignatureKind.GenericStaticConstrainedMethod:
+                    {
+                        TypeDesc constraintType = nativeLayoutInfoLoadContext.GetType(ref parser);
+
+                        NativeParser ldtokenSigParser = parser.GetParserFromRelativeOffset();
+                        MethodDesc constrainedMethod = nativeLayoutInfoLoadContext.GetMethod(ref ldtokenSigParser);
+
+                        TypeLoaderLogger.WriteLine("NonGenericStaticConstrainedMethod: " + constraintType.ToString() + " Method " + constrainedMethod.ToString());
+
+                        cell = new GenericStaticConstrainedMethodCell()
+                        {
+                            ConstraintType = (DefType)constraintType,
+                            ConstrainedMethod = (InstantiatedMethod)constrainedMethod,
+                        };
+                    }
+                    break;
+
                 case FixupSignatureKind.ThreadStaticIndex:
                     {
                         var type = nativeLayoutInfoLoadContext.GetType(ref parser);
@@ -509,7 +548,6 @@ namespace Internal.Runtime.TypeLoader
                     break;
 
                 case FixupSignatureKind.NotYetSupported:
-                case FixupSignatureKind.GenericStaticConstrainedMethod:
                     TypeLoaderLogger.WriteLine("Valid dictionary entry, but not yet supported by the TypeLoader!");
                     throw new TypeBuilder.MissingTemplateException();
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
@@ -528,7 +528,7 @@ namespace Internal.Runtime.TypeLoader
                         NativeParser ldtokenSigParser = parser.GetParserFromRelativeOffset();
                         MethodDesc constrainedMethod = nativeLayoutInfoLoadContext.GetMethod(ref ldtokenSigParser);
 
-                        TypeLoaderLogger.WriteLine("NonGenericStaticConstrainedMethod: " + constraintType.ToString() + " Method " + constrainedMethod.ToString());
+                        TypeLoaderLogger.WriteLine("GenericStaticConstrainedMethod: " + constraintType.ToString() + " Method " + constrainedMethod.ToString());
 
                         cell = new GenericStaticConstrainedMethodCell()
                         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -322,6 +322,11 @@ namespace Internal.Runtime.TypeLoader
                 throw new MissingTemplateException();
             }
 
+            if (templateMethod.FunctionPointer != IntPtr.Zero)
+            {
+                nonTemplateMethod.SetFunctionPointer(templateMethod.FunctionPointer, isFunctionPointerUSG: false);
+            }
+
             // Ensure that if this method is non-shareable from a normal canonical perspective, then
             // its template MUST be a universal canonical template method
             Debug.Assert(!method.IsNonSharableMethod || (method.IsNonSharableMethod && templateMethod.IsCanonicalMethod(CanonicalFormKind.Universal)));

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.SignatureParsing.cs
@@ -70,6 +70,16 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
+        public static bool IsStaticMethodSignature(MethodNameAndSignature signature)
+        {
+            Debug.Assert(signature.Signature.IsNativeLayoutSignature);
+            NativeReader reader = GetNativeLayoutInfoReader(signature.Signature);
+            NativeParser parser = new NativeParser(reader, signature.Signature.NativeLayoutOffset);
+
+            MethodCallingConvention callingConvention = (MethodCallingConvention)parser.GetUnsigned();
+            return (callingConvention & MethodCallingConvention.Static) != 0;
+        }
+
         public uint GetGenericArgumentCountFromMethodNameAndSignature(MethodNameAndSignature signature)
         {
             if (signature.Signature.IsNativeLayoutSignature)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -169,16 +169,14 @@ namespace ILCompiler.DependencyAnalysis
                         {
                             Debug.Assert(method.IsVirtual);
 
-                            // Static interface methods don't participate in GVM analysis
-                            if (method.Signature.IsStatic)
-                                continue;
-
                             if (method.HasInstantiation)
                             {
                                 // We found a GVM on one of the implemented interfaces. Find if the type implements this method.
                                 // (Note, do this comparison against the generic definition of the method, not the specific method instantiation
                                 MethodDesc genericDefinition = method.GetMethodDefinition();
-                                MethodDesc slotDecl = _type.ResolveInterfaceMethodTarget(genericDefinition);
+                                MethodDesc slotDecl = genericDefinition.Signature.IsStatic ?
+                                    _type.ResolveInterfaceMethodToStaticVirtualMethodOnType(genericDefinition)
+                                    : _type.ResolveInterfaceMethodTarget(genericDefinition);
                                 if (slotDecl != null)
                                 {
                                     // If the type doesn't introduce this interface method implementation (i.e. the same implementation

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -25,7 +25,12 @@ namespace ILCompiler.DependencyAnalysis
         public GVMDependenciesNode(MethodDesc method)
         {
             Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) == method);
-            Debug.Assert(method.IsVirtual && method.HasInstantiation);
+            Debug.Assert(method.HasInstantiation);
+
+            // This is either a generic virtual method or a MethodImpl for a static interface method.
+            // We can't test for static MethodImpl so at least sanity check it's static and noninterface.
+            Debug.Assert(method.IsVirtual || (method.Signature.IsStatic && !method.OwningType.IsInterface));
+
             _method = method;
         }
 
@@ -56,7 +61,7 @@ namespace ILCompiler.DependencyAnalysis
                         return dependencies;
                     }
 
-                    bool getUnboxingStub = _method.OwningType.IsValueType;
+                    bool getUnboxingStub = _method.OwningType.IsValueType && !_method.Signature.IsStatic;
                     dependencies ??= new DependencyList();
                     dependencies.Add(context.MethodEntrypoint(_method, getUnboxingStub), "GVM Dependency - Canon method");
 
@@ -83,6 +88,14 @@ namespace ILCompiler.DependencyAnalysis
                 if (!methodOwningType.IsInterface &&
                     (methodOwningType.IsSealed() || _method.IsFinal))
                     return false;
+
+                // We model static (non-virtual) methods that are MethodImpls for an static interface method.
+                // But those cannot be overriden (they're not virtual to begin with).
+                if (!methodOwningType.IsInterface && _method.Signature.IsStatic)
+                {
+                    Debug.Assert(!_method.IsVirtual);
+                    return false;
+                }
 
                 return true;
             }
@@ -141,7 +154,9 @@ namespace ILCompiler.DependencyAnalysis
                                 interfaceMethod = context.GetMethodForInstantiatedType(
                                     _method.GetTypicalMethodDefinition(), (InstantiatedType)potentialDefinitionInterfaces[interfaceIndex]);
 
-                            MethodDesc slotDecl = potentialOverrideDefinition.InstantiateAsOpen().ResolveInterfaceMethodTarget(interfaceMethod);
+                            MethodDesc slotDecl = interfaceMethod.Signature.IsStatic ?
+                                potentialOverrideDefinition.InstantiateAsOpen().ResolveInterfaceMethodToStaticVirtualMethodOnType(interfaceMethod)
+                                : potentialOverrideDefinition.InstantiateAsOpen().ResolveInterfaceMethodTarget(interfaceMethod);
                             if (slotDecl == null)
                             {
                                 // The method might be implemented through a default interface method

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -89,7 +89,7 @@ namespace ILCompiler.DependencyAnalysis
                     (methodOwningType.IsSealed() || _method.IsFinal))
                     return false;
 
-                // We model static (non-virtual) methods that are MethodImpls for an static interface method.
+                // We model static (non-virtual) methods that are MethodImpls for a static interface method.
                 // But those cannot be overriden (they're not virtual to begin with).
                 if (!methodOwningType.IsInterface && _method.Signature.IsStatic)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -738,7 +738,6 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override IMethodNode GetMethodEntrypointNode(NodeFactory factory, out bool unboxingStub)
         {
-            // Only GVM templates need entry points.
             Debug.Assert(NeedsEntrypoint(_method));
             unboxingStub = _method.OwningType.IsValueType && !_method.Signature.IsStatic;
             IMethodNode methodEntryPointNode = factory.MethodEntrypoint(_method, unboxingStub);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -706,8 +706,25 @@ namespace ILCompiler.DependencyAnalysis
     {
         protected override string GetName(NodeFactory factory) => "NativeLayoutTemplateMethodSignatureVertexNode_" + factory.NameMangler.GetMangledMethodName(_method);
 
+        private static bool NeedsEntrypoint(MethodDesc method)
+        {
+            Debug.Assert(method.HasInstantiation);
+
+            // Generic virtual methods need to store information about entrypoint in the template
+            if (method.IsVirtual)
+                return true;
+
+            // MethodImpls for static virtual methods need to store this too
+            // Unfortunately we can't test for "is this a MethodImpl?" here (the method could be a MethodImpl
+            // in a derived class but not in the current class).
+            if (method.Signature.IsStatic && !method.OwningType.IsInterface)
+                return true;
+
+            return false;
+        }
+
         public NativeLayoutTemplateMethodSignatureVertexNode(NodeFactory factory, MethodDesc method)
-            : base(factory, method, MethodEntryFlags.CreateInstantiatedSignature | (method.IsVirtual ? MethodEntryFlags.SaveEntryPoint : 0))
+            : base(factory, method, MethodEntryFlags.CreateInstantiatedSignature | (NeedsEntrypoint(method) ? MethodEntryFlags.SaveEntryPoint : 0))
         {
         }
 
@@ -722,8 +739,8 @@ namespace ILCompiler.DependencyAnalysis
         protected override IMethodNode GetMethodEntrypointNode(NodeFactory factory, out bool unboxingStub)
         {
             // Only GVM templates need entry points.
-            Debug.Assert(_method.IsVirtual);
-            unboxingStub = _method.OwningType.IsValueType;
+            Debug.Assert(NeedsEntrypoint(_method));
+            unboxingStub = _method.OwningType.IsValueType && !_method.Signature.IsStatic;
             IMethodNode methodEntryPointNode = factory.MethodEntrypoint(_method, unboxingStub);
             // Note: We don't set the IsUnboxingStub flag on template methods (all template lookups performed at runtime are performed with this flag not set,
             // since it can't always be conveniently computed for a concrete method before looking up its template)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
@@ -103,10 +103,11 @@ namespace ILCompiler.DependencyAnalysis
             {
                 foreach (var method in iface.GetVirtualMethods())
                 {
-                    if (!method.HasInstantiation || method.Signature.IsStatic)
+                    if (!method.HasInstantiation)
                         continue;
 
-                    MethodDesc slotDecl = type.ResolveInterfaceMethodTarget(method);
+                    MethodDesc slotDecl = method.Signature.IsStatic ?
+                        type.ResolveInterfaceMethodToStaticVirtualMethodOnType(method) : type.ResolveInterfaceMethodTarget(method);
                     if (slotDecl == null)
                     {
                         var resolution = type.ResolveInterfaceMethodToDefaultImplementationOnType(method, out slotDecl);
@@ -143,11 +144,12 @@ namespace ILCompiler.DependencyAnalysis
             {
                 foreach (var method in iface.GetVirtualMethods())
                 {
-                    if (method.Signature.IsStatic || !method.HasInstantiation)
+                    if (!method.HasInstantiation)
                         continue;
 
                     DefaultInterfaceMethodResolution resolution = DefaultInterfaceMethodResolution.None;
-                    MethodDesc slotDecl = _associatedType.ResolveInterfaceMethodTarget(method);
+                    MethodDesc slotDecl = method.Signature.IsStatic ?
+                        _associatedType.ResolveInterfaceMethodToStaticVirtualMethodOnType(method) : _associatedType.ResolveInterfaceMethodTarget(method);
                     if (slotDecl == null)
                     {
                         resolution = _associatedType.ResolveInterfaceMethodToDefaultImplementationOnType(method, out slotDecl);

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -51,6 +51,7 @@ public class Interfaces
         TestMoreConstraints.Run();
         TestSimpleNonGeneric.Run();
         TestSimpleGeneric.Run();
+        TestDynamicStaticGenericVirtualMethods.Run();
 
         return Pass;
     }
@@ -1457,6 +1458,73 @@ public class Interfaces
                 throw new Exception();
             if (CallIndirect<SimpleStruct>(2) != (1236, typeof(IBar<Atom2>)))
                 throw new Exception();
+        }
+    }
+
+    class TestDynamicStaticGenericVirtualMethods
+    {
+        interface IEntry
+        {
+            string Enter1<T>(string cookie) where T : ISimpleCall;
+        }
+
+        interface ISimpleCall
+        {
+            static virtual string Wrap<T>(string cookie) => $"ISimpleCall.Wrap<{typeof(T).Name}>({cookie})";
+        }
+
+        interface ISimpleCallOverride : ISimpleCall
+        {
+            static string ISimpleCall.Wrap<T>(string cookie) => $"ISimpleCallOverride.Wrap<{typeof(T).Name}>({cookie})";
+        }
+
+        interface ISimpleCallGenericOverride<U> : ISimpleCall
+        {
+            static string ISimpleCall.Wrap<T>(string cookie) => $"ISimpleCallGenericOverride<{typeof(U).Name}>.Wrap<{typeof(T).Name}>({cookie})";
+        }
+
+        class SimpleCallClass : ISimpleCall
+        {
+            public static string Wrap<T>(string cookie) => $"SimpleCall.Wrap<{typeof(T).Name}>({cookie})";
+        }
+
+        class SimpleCallGenericClass<U> : ISimpleCall
+        {
+            public static string Wrap<T>(string cookie) => $"SimpleCallGenericClass<{typeof(U).Name}>.Wrap<{typeof(T).Name}>({cookie})";
+        }
+
+        struct SimpleCallStruct<U> : ISimpleCall
+        {
+            public static string Wrap<T>(string cookie) => $"SimpleCallStruct<{typeof(U).Name}>.Wrap<{typeof(T).Name}>({cookie})";
+        }
+
+        class Entry : IEntry
+        {
+            public virtual string Enter1<T>(string cookie) where T : ISimpleCall
+            {
+                return T.Wrap<T>(cookie);
+            }
+        }
+
+        class EnsureVirtualCall : Entry
+        {
+            public override string Enter1<T>(string cookie) => string.Empty;
+        }
+
+        static IEntry s_ensure = new EnsureVirtualCall();
+        static IEntry s_entry = new Entry();
+
+        public static void Run()
+        {
+            // Just to make sure this cannot be devirtualized.
+            s_ensure.Enter1<ISimpleCall>("One");
+
+            //Console.WriteLine(s_entry.Enter1<ISimpleCall>("One"));
+            //Console.WriteLine(s_entry.Enter1<ISimpleCallOverride>("One"));
+            //Console.WriteLine(s_entry.Enter1<ISimpleCallGenericOverride<object>>("One"));
+            Console.WriteLine(s_entry.Enter1<SimpleCallClass>("One"));
+            //Console.WriteLine(s_entry.Enter1<SimpleCallGenericClass<object>>("One"));
+            Console.WriteLine(s_entry.Enter1<SimpleCallStruct<object>>("One"));
         }
     }
 }


### PR DESCRIPTION
Fixes #77070.

The implementation of static virtuals was limited to compile-time resolution in .NET 7. I erroneously believed runtime resolution can only happen with `MakeGenericType`/`MakeGenericMethod` and therefore falls into the general "don't do dynamic code" bucket. But this is also reachable from generic instance virtual method resolution that is also dynamic-like (we don't attempt to precompute all runtime artifacts, only canonical code).

This contains compiler changes to start tracking static virtual method use within type loader templates the same way how we track instance generic virtual method use (i.e. those static virtual uses that happen at compile time are not tracked in this - only the dynamic ones). We also make sure the computed targets get generated into the appropriate table.

The other part of the change is a type loader change to call into the generic virtual method resolution logic when needed.

Cc @dotnet/ilc-contrib 