### PR TITLE
Make some tests use single-file publish instead of bundler API

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -20,9 +20,7 @@ namespace AppHost.Bundle.Tests
         [Fact]
         public void SelfContained_SingleFile_APITests()
         {
-            var fixture = sharedTestState.TestFixture.Copy();
-            var singleFile = BundleSelfContainedApp(fixture);
-
+            string singleFile = BundleHelper.GetHostPath(sharedTestState.PublishedSingleFile);
             Command.Create(singleFile, "fullyqualifiedname codebase appcontext cmdlineargs executing_assembly_location basedirectory")
                 .CaptureStdErr()
                 .CaptureStdOut()
@@ -88,10 +86,9 @@ namespace AppHost.Bundle.Tests
         [Fact]
         public void AppContext_Native_Search_Dirs_Contains_Bundle_Dir()
         {
-            var fixture = sharedTestState.TestFixture.Copy();
-            Bundler bundler = BundleSelfContainedApp(fixture, out string singleFile);
-            string extractionDir = BundleHelper.GetExtractionDir(fixture, bundler).Name;
-            string bundleDir = BundleHelper.GetBundleDir(fixture).FullName;
+            string singleFile = BundleHelper.GetHostPath(sharedTestState.PublishedSingleFile);
+            string extractionRoot = BundleHelper.GetExtractionRootPath(sharedTestState.PublishedSingleFile);
+            string bundleDir = BundleHelper.GetPublishPath(sharedTestState.PublishedSingleFile);
 
             // If we don't extract anything to disk, the extraction dir shouldn't
             // appear in the native search dirs.
@@ -101,7 +98,7 @@ namespace AppHost.Bundle.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining(bundleDir)
-                .And.NotHaveStdOutContaining(extractionDir);
+                .And.NotHaveStdOutContaining(extractionRoot);
         }
 
         [Fact]

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileSharedState.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileSharedState.cs
@@ -6,6 +6,8 @@ using System.IO;
 using Microsoft.DotNet;
 using Microsoft.DotNet.CoreSetup.Test;
 using Xunit;
+
+using BundleTests.Helpers;
 using static AppHost.Bundle.Tests.BundleTestBase;
 
 namespace AppHost.Bundle.Tests
@@ -13,6 +15,8 @@ namespace AppHost.Bundle.Tests
     public class SingleFileSharedState : SharedTestStateBase, IDisposable
     {
         public TestProjectFixture TestFixture { get; set; }
+
+        public TestProjectFixture PublishedSingleFile { get; set; }
 
         public SingleFileSharedState()
         {
@@ -22,6 +26,23 @@ namespace AppHost.Bundle.Tests
                 string mockCoreClrPath = Path.Combine(RepoDirectories.Artifacts, "corehost_test",
                     RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr"));
                 TestFixture = PreparePublishedSelfContainedTestProject("SingleFileApiTests", $"/p:AddFile={mockCoreClrPath}");
+
+                var singleFileHost = Path.Combine(
+                    RepoDirectories.HostArtifacts,
+                    RuntimeInformationExtensions.GetExeFileNameForCurrentPlatform("singlefilehost"));
+
+                // This uses the repo's SDK to publish single file using the live-built singlefilehost,
+                // such that the publish directory is the real scenario, rather than manually constructed
+                // via the bundler API and copying files around. This does mean that the bundler used is
+                // the version from the SDK.
+                PublishedSingleFile = new TestProjectFixture("SingleFileApiTests", RepoDirectories);
+                PublishedSingleFile
+                    .EnsureRestoredForRid(PublishedSingleFile.CurrentRid)
+                    .PublishProject(runtime: PublishedSingleFile.CurrentRid,
+                                    outputDirectory: BundleHelper.GetPublishPath(PublishedSingleFile),
+                                    selfContained: true,
+                                    singleFile: true,
+                                    extraArgs: new[] { $"/p:AddFile={mockCoreClrPath}", $"/p:SingleFileHostSourcePath={singleFileHost}" });
             }
             catch (Exception e) when (TestUtils.FailFast(e)) // Fail fast to gather a crash dump
             {
@@ -32,6 +53,7 @@ namespace AppHost.Bundle.Tests
         public void Dispose()
         {
             TestFixture.Dispose();
+            PublishedSingleFile.Dispose();
         }
     }
 }


### PR DESCRIPTION
All the single-file tests publish the application as non-single-file and then use the `Bundler` API to construct a single-file application. Unlike in the product where the SDK determines what to try to bundle or not , the tests try to bundle everything in the publish directory and then copy over any files that were excluded:

https://github.com/dotnet/runtime/blob/67743295d05777ce3701135afbbdb473d4fb4436/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs#L151-L152

https://github.com/dotnet/runtime/blob/67743295d05777ce3701135afbbdb473d4fb4436/src/installer/tests/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs#L167-L175

As a result, the tests end up with extra files (for example, native runtime and host files in self-contained scenarios) in the constructed bundle directory, which can cause them to miss real product issues.

This change switches a basic self-contained single-file test to go through `PublishSingleFile=true` rather than manually constructing a bundle. It will use the live-built `singlefilehost`, but the SDK's bundler (`Microsoft.NET.HostModel`).

This is not trying to touch any of the broader issues with single-file testing. It is just targeting the immediate problem of 'none of these tests run the single-file host the way the product would'.