### PR TITLE
HttpClientFactory should not hold onto exceptions indefinitely

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -115,9 +115,12 @@ namespace Microsoft.Extensions.Http
         {
             ThrowHelper.ThrowIfNull(name);
 
+            // Refactor the StartHandlerEntryTimer to be based on the name instead of the ActiveHandlerTrackingEntry
+            // And start the timer just before the handler is created.
+            // This will ensure that any exception that might be thrown during the initialzation of the Lazy object
+            // will not persist throughout the lifetime of the application
+            StartHandlerEntryTimer(name);
             ActiveHandlerTrackingEntry entry = _activeHandlers.GetOrAdd(name, _entryFactory).Value;
-
-            StartHandlerEntryTimer(entry);
 
             return entry.Handler;
         }

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/HttpClientHandlerDependencyInjectionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/HttpClientHandlerDependencyInjectionTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Moq;
+
+using Xunit;
+
+namespace HttpClientHandlerDependencyInjection
+{
+    public class HttpClientHandlerFactoryDependencyInjectionTests
+    {
+        string nextFunctionInput = "throw";
+
+        [Fact]
+        public void Demonstrate_That_ExceptionsInHttpFactoriesPersist_Incorrectly()
+        {
+            var myException = new Exception("The one and only exception");
+            var mockHandlerFactory = new Mock<IHandlerFactory>();
+            mockHandlerFactory
+                .Setup(mock => mock.Create("throw"))
+                .Callback(() => nextFunctionInput = "don't throw")
+                .Throws(myException);
+
+            mockHandlerFactory
+                .Setup(mock => mock.Create("don't throw"))
+                .Returns(new HttpClientHandler());
+
+            var services = GetServiceCollection(mockHandlerFactory.Object);
+            var a = services.GetService<IHttpClientFactory>();
+
+            // Should throw on the first call
+            var act = () => a.CreateClient("myClient");
+            var exFromFirstCall = act.Should().Throw<Exception>().Which;
+
+            mockHandlerFactory.Verify(mock => mock.Create("throw"), Times.Once);
+
+            // Wait 1 second -- It's the minimum handler lifetime possible
+            Thread.Sleep(1001);
+
+            // The following code fails, but should not.
+            // The client that is created is a part of a lazy initialization
+            // The ActiveHandlerTrackingEntry is incorrectly caching the exception indefinitely (https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs#L118)
+            // The entry timer is not being started due to the exception (https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs#L120)
+            ////var client = a.CreateClient("myClient");
+            ////mockHandlerFactory.Verify(mock => mock.Create("don't throw"), Times.Once);
+            ////client.Should().BeOfType<HttpClientHandler>();
+
+            // The following code succeeds, but should not
+            var act2 = () => a.CreateClient("myClient");
+            var exception = act2.Should().Throw<Exception>("The one and only exception").Which;
+            exception.Should().Be(exFromFirstCall);
+        }
+
+        private IServiceProvider GetServiceCollection(IHandlerFactory handlerFactory)
+        {
+            var services = new ServiceCollection();
+            services.AddHttpClient("myClient")
+           .ConfigurePrimaryHttpMessageHandler((p) =>
+           {
+               return handlerFactory.Create(nextFunctionInput);
+           })
+           .SetHandlerLifetime(TimeSpan.FromSeconds(1)); // Minimum timespan is 1 second
+
+            return services.BuildServiceProvider();
+        }
+
+        public interface IHandlerFactory
+        {
+            HttpClientHandler Create(string toDo);
+        }
+    }
+}


### PR DESCRIPTION
# Summary
This PR is not meant to be merged, it's merely a demonstration of the issue that I'm reporting. The test code runs and demonstrates the issue well. The production code is incomplete, but shows a potential path to fixing the issue.

The problem is that DefaultHttpClientFactory doesn't handle the case where an factory throws an exception well.

Typically, an HttpClientHandler will be recycled after two minutes (https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientBuilderExtensions.cs#L499), but, in the case where the building of the handler throws an exception, the exception will be cached indefinitely. 

In the definition of a Lazy object:
```
Exception caching When you use factory methods, exceptions are cached. That is, if the factory method throws an exception the first time a thread tries to access the [Value](https://learn.microsoft.com/en-us/dotnet/api/system.lazy-1.value?view=net-7.0) property of the [Lazy<T>](https://learn.microsoft.com/en-us/dotnet/api/system.lazy-1?view=net-7.0) object, the same exception is thrown on every subsequent attempt.
```

This Lazy object is accessed in the `CreateHandler` method https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs#L118 , and immediately after it is accessed, the code will start a timer with the `StartHandlerEntry` timer. So, if line 118 throws an exception, a timer will never be set, and there will never be an attempt to re-initialize the object and the handler will be indefinitely in a bad state and irrecoverable.

# Example scenario
As an example of how this might occur, consider a factory which takes runtime configuration as input. The runtime configuration changes to a bad state, causing an exception in the handler. The runtime configuration is then updated to a good state, but the factory will never be called again, so the application must be restarted to clear the Lazy object from memory.

# Proposed solutions
1. One solution is to ensure that the HandlerTimer is set before the factory is called. This will ensure that even if exceptions occur, we will always try to re-initialize it after the two-minute default. In the current implementation, the timer depends on the ActiveHandlerTrackingEntry, so this would require a bit of a re-write in the way the timers are handled. (See the code in the PR https://github.com/dotnet/runtime/compare/main...amittleider:runtime:HttpClientFactory_ExceptionsPersist?expand=1#diff-940dba6ffc5ae548fca7105241869c1a78442c04b968f129ce645407022e83cbR118 . This code doesn't compile, but it helps to illustrate the proposal).
2. Another solution would be to make a new type of Lazy object that has a timer pre-built in. Like this, there is no need to handle timers at all within the DefaultHttpClientFactory.

# Issue link
https://github.com/dotnet/runtime/issues/80605