### PR TITLE
[release/6.0] [mono][debugger] Fix Debugger.Break() behavior when running on release mode

### DIFF
--- a/src/mono/mono/component/debugger-stub.c
+++ b/src/mono/mono/component/debugger-stub.c
@@ -155,7 +155,8 @@ stub_debugger_end_exception_filter (MonoException *exc, MonoContext *ctx, MonoCo
 static void
 stub_debugger_user_break (void)
 {
-	G_BREAKPOINT ();
+	if (get_mini_debug_options ()->native_debugger_break)
+		G_BREAKPOINT ();
 }
 
 static void


### PR DESCRIPTION
Backport of #79822 to release/6.0

/cc @thaystg

## Customer Impact
When the customer application has a Debugger.Break it was crashing the app when running on release mode.
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1675269

## Testing
Manually tested.

## Risk
Low risk, only calling raise(SIGTRAP) when native debugging option is enabled.