### PR TITLE
Set FieldSeq in CreateSpan for field handle

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2241,8 +2241,10 @@ GenTree* Compiler::impCreateSpanIntrinsic(CORINFO_SIG_INFO* sig)
     impPopStack();
 
     // Turn count and pointer value into constants.
-    GenTree* lengthValue  = gtNewIconNode(count, TYP_INT);
-    GenTree* pointerValue = gtNewIconHandleNode((size_t)data, GTF_ICON_CONST_PTR);
+    GenTree*  lengthValue = gtNewIconNode(count, TYP_INT);
+    FieldSeq* fldSeq =
+        GetFieldSeqStore()->Create(fieldToken, (ssize_t)data, FieldSeq::FieldKind::SimpleStaticKnownAddress);
+    GenTree* pointerValue = gtNewIconHandleNode((size_t)data, GTF_ICON_STATIC_HDL, fldSeq);
 
     // Construct ReadOnlySpan<T> to return.
     CORINFO_CLASS_HANDLE spanHnd     = sig->retTypeClass;


### PR DESCRIPTION
Fixes this codegen:
```csharp
int ConstRva()
{
    ReadOnlySpan<int> RVA = new [] { 1, 2, 3, 4, 5 };
    return RVA[3];
}
```
to produce "return 4".

Because previously `CreateSpan` intrisnsic (that Roslyn emits for this syntax) didn't properly propagate FieldSeq for the field so the corresponding VN optimization wasn't able to fold RVA[const] (it only worked for bytes where CreateSpan is not emitted).

PTAL @SingleAccretion @jakobbotsch @dotnet/jit-contrib 