### PR TITLE
Fix GC hole in newly added test

### DIFF
--- a/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
+++ b/src/tests/Interop/MarshalAPI/FunctionPointer/FunctionPointer.cs
@@ -76,6 +76,7 @@ public partial class FunctionPtr
             IntPtr ptr = Marshal.GetFunctionPointerForDelegate(d);
             DelegateToFillOutPtr OutPtrDelegate = Marshal.GetDelegateForFunctionPointer<DelegateToFillOutPtr>(ptr);
             OutPtrDelegate(&outVar);
+            GC.KeepAlive(d);
         }
         Assert.Equal(expectedValue, outVar);
     }


### PR DESCRIPTION
GC stress is red after 78ccdaeeb4ccc5d0eff36b2eadc5e1cb07403fcd due to a delegate not being kept alive.

cc @giritrivedi