### PR TITLE
Vectorize Enumerable.Range(...).ToArray()

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -82,17 +82,16 @@ namespace System.Linq
                 return _end - 1;
             }
 
-            // Destination *must* be non-empty and exactly match the range length
+            // Destination *must* be non-empty and match the range length
             private void InitializeSpan(Span<int> destination)
             {
                 if (destination.Length < Vector<int>.Count * 2)
                 {
-                    int end = _end;
-                    ref int pos = ref MemoryMarshal.GetReference(destination);
-                    for (int cur = _start; cur < end; cur++)
+                    int cur = _start;
+                    for (int i = 0; i < destination.Length; i++)
                     {
-                        pos = cur;
-                        pos = ref Unsafe.Add(ref pos, 1);
+                        destination[i] = cur;
+                        cur++;
                     }
                 }
                 else

--- a/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -83,7 +83,6 @@ namespace System.Linq
             }
 
             // Destination *must* be non-empty and exactly match the range length
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void InitializeSpan(Span<int> destination)
             {
                 if (destination.Length < Vector<int>.Count * 2)

--- a/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -87,15 +87,13 @@ namespace System.Linq
             // Destination *must* be non-empty and exactly match the range length
             private void InitializeSpan(Span<int> destination)
             {
-                Debug.Assert((_end - _start) == destination.Length);
-
                 if (destination.Length < Vector<int>.Count * 2)
                 {
-                    int end = _start + _end;
+                    int end = _end;
                     ref int pos = ref MemoryMarshal.GetReference(destination);
-                    for (int num = _start; num < end; num++)
+                    for (int cur = _start; cur < end; cur++)
                     {
-                        pos = num;
+                        pos = cur;
                         pos = ref Unsafe.Add(ref pos, 1);
                     }
                 }

--- a/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -20,8 +20,7 @@ namespace System.Linq
 
             public int[] ToArray()
             {
-                int[] array = GC.AllocateUninitializedArray<int>(_end - _start);
-
+                int[] array = new int[_end - _start];
                 InitializeSpan(array);
                 return array;
             }
@@ -85,6 +84,7 @@ namespace System.Linq
             }
 
             // Destination *must* be non-empty and exactly match the range length
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void InitializeSpan(Span<int> destination)
             {
                 if (destination.Length < Vector<int>.Count * 2)


### PR DESCRIPTION
Loop body is almost the same to what LLVM produces for Rust's `let vec: Vec<i32> = (0..count).collect()` with `x86-64-v3` target except the unroll factor it chooses is 4 while here we pick 2 instead because it saturates store throughput on Zen 3 anyways and has much smaller codegen size.

NB: on ARM64 it emits a pair of `str`s vs LLVM's single `stp` but I'm not sure if that's an optimization .NET can do today out of two adjacent `Unsafe.WriteUnaligned`.

Codegen (.NET 8 daily build + FullPGO):
```assembly
; BenchFixture.Enumerable2+RangeIterator.InitializeSpanCore(System.Span`1<Int32>)
       vzeroupper
       mov       rax,[rdx]
       mov       edx,[rdx+8]
       mov       r8d,edx
       sar       r8d,1F
       and       r8d,0F
       add       r8d,edx
       and       r8d,0FFFFFFF0
       mov       r9d,edx
       sub       r9d,r8d
       vmovupd   ymm0,[7FFDC3F91140]
       vpbroadcastd ymm1,dword ptr [rcx+8]
       mov       r8,1457FC040C8
       mov       r8,[r8]
       vpaddd    ymm1,ymm1,[r8+8]
       vpaddd    ymm2,ymm1,[7FFDC3F91160]
       mov       r8d,edx
       sub       r8d,r9d
       movsxd    r8,r8d
       lea       r8,[rax+r8*4]
       cmp       rax,r8
       je        short M03_L01
       nop       dword ptr [rax]
M03_L00:
       vmovupd   [rax],ymm1
       vmovupd   [rax+20],ymm2
       vpaddd    ymm1,ymm1,ymm0
       vpaddd    ymm2,ymm2,ymm0
       add       rax,40
       cmp       rax,r8
       jne       short M03_L00
M03_L01:
       sub       edx,r9d
       mov       r8d,[rcx+8]
       add       edx,r8d
       add       r8d,[rcx+0C]
       cmp       edx,r8d
       jge       short M03_L03
M03_L02:
       mov       [rax],edx
       add       rax,4
       inc       edx
       cmp       edx,r8d
       jl        short M03_L02
M03_L03:
       vzeroupper
       ret
; Total bytes of code 158
```

This is a port of https://github.com/neon-sunset/RangeExtensions/blob/main/RangeExtensions/RangeEnumerable.ICollection.cs#L144 except it doesn't need to support bi-directional scenario.
