### PR TITLE
Fix indexing of correlated diagnostic binaries

### DIFF
--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -22,6 +22,7 @@ stages:
       pool:
         name: NetCore1ESPool-Internal
         demands: ImageOverride -equals 1es-windows-2022
+      symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
 
 # Stages-based publishing entry point
 - template: /eng/common/templates/post-build/post-build.yml


### PR DESCRIPTION
Since https://github.com/dotnet/runtime/commit/66af85735dc40dc7aa257329c91e790b7418b429 it looks like the runtime is not creating the clr <-> dac correlation index in symbol servers. `publishInstallersAndChecksums` is no longer needed, so skip passing that to the in-stage publish.