### PR TITLE
Normalize RepoRoot path to improve logs readability

### DIFF
--- a/eng/native/gen-buildsys.cmd
+++ b/eng/native/gen-buildsys.cmd
@@ -11,8 +11,10 @@ if %argC% lss 4 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal enabledelayedexpansion
-set basePath=%~dp0
-set __repoRoot=%~dp0..\..\
+set "basePath=%~dp0"
+set "__repoRoot=%~dp0..\.."
+:: normalize
+for %%i in ("%__repoRoot%") do set "__repoRoot=%%~fi"
 :: remove quotes
 set "basePath=%basePath:"=%"
 :: remove trailing slash
@@ -53,7 +55,7 @@ if /i "%__Arch%" == "wasm" (
                 exit /B 1
             )
 
-            set EMSDK_PATH=%__repoRoot%\src\mono\wasm\emsdk
+            set "EMSDK_PATH=%__repoRoot%\src\mono\wasm\emsdk"
         )
         :: replace backslash with forward slash and append last slash
         set "EMSDK_PATH=!EMSDK_PATH:\=/!"
@@ -69,7 +71,7 @@ if /i "%__Arch%" == "wasm" (
                 exit /B 1
             )
 
-            set WASI_SDK_PATH=%__repoRoot%src\mono\wasi\wasi-sdk
+            set "WASI_SDK_PATH=%__repoRoot%src\mono\wasi\wasi-sdk"
         )
         :: replace backslash with forward slash and append last slash
         set "WASI_SDK_PATH=!WASI_SDK_PATH:\=/!"

--- a/eng/native/gen-buildsys.cmd
+++ b/eng/native/gen-buildsys.cmd
@@ -11,14 +11,9 @@ if %argC% lss 4 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal enabledelayedexpansion
-set "basePath=%~dp0"
 set "__repoRoot=%~dp0..\.."
 :: normalize
 for %%i in ("%__repoRoot%") do set "__repoRoot=%%~fi"
-:: remove quotes
-set "basePath=%basePath:"=%"
-:: remove trailing slash
-if %basePath:~-1%==\ set "basePath=%basePath:~0,-1%"
 
 set __SourceDir=%1
 set __IntermediatesDir=%2

--- a/eng/native/version/copy_version_files.cmd
+++ b/eng/native/version/copy_version_files.cmd
@@ -1,9 +1,11 @@
 @if not defined _echo @echo off
 setlocal EnableDelayedExpansion EnableExtensions
 
-set __VersionFolder=%~dp0
-set __RepoRoot=%~dp0..\..\..
-set __artifactsObjDir=%__RepoRoot%\artifacts\obj
+set "__VersionFolder=%~dp0"
+set "__RepoRoot=%~dp0..\..\.."
+:: normalize
+for %%i in ("%__RepoRoot%") do set "__RepoRoot=%%~fi"
+set "__artifactsObjDir=%__RepoRoot%\artifacts\obj"
 
 for /r "%__VersionFolder%" %%a in (*.h *.rc) do (
     if not exist "%__artifactsObjDir%\%%~nxa" (

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -32,6 +32,8 @@ set "__ProjectDir=%~dp0"
 :: remove trailing slash
 if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
 set "__RepoRootDir=%__ProjectDir%\..\.."
+:: normalize
+for %%i in ("%__RepoRootDir%") do set "__RepoRootDir=%%~fi"
 
 set "__ProjectFilesDir=%__ProjectDir%"
 set "__RootBinDir=%__RepoRootDir%\artifacts"

--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -7,7 +7,10 @@ set "__sourceDir=%~dp0"
 :: remove trailing slash
 if %__sourceDir:~-1%==\ set "__ProjectDir=%__sourceDir:~0,-1%"
 
-set __engNativeDir=%__sourceDir%\..\..\..\eng\native
+set "__RepoRootDir=%__sourceDir%\..\..\.."
+:: normalize
+for %%i in ("%__RepoRootDir%") do set "__RepoRootDir=%%~fi"
+set "__engNativeDir=%__RepoRootDir%\eng\native"
 set __CMakeBinDir=""
 set __IntermediatesDir=""
 set __BuildArch=x64

--- a/src/native/libs/build-native.cmd
+++ b/src/native/libs/build-native.cmd
@@ -3,10 +3,14 @@ setlocal
 
 :SetupArgs
 :: Initialize the args that will be passed to cmake
-set __sourceRootDir=%~dp0
-set __repoRoot=%~dp0..\..\..
-set __engNativeDir=%__repoRoot%\eng\native
-set __artifactsDir=%__repoRoot%\artifacts
+set "__sourceRootDir=%~dp0"
+:: remove trailing slash
+if %__sourceRootDir:~-1%==\ set "__sourceRootDir=%__sourceRootDir:~0,-1%"
+set "__repoRoot=%__sourceRootDir%\..\..\.."
+:: normalize
+for %%i in ("%__repoRoot%") do set "__repoRoot=%%~fi"
+set "__engNativeDir=%__repoRoot%\eng\native"
+set "__artifactsDir=%__repoRoot%\artifacts"
 set __CMakeBinDir=""
 set __IntermediatesDir=""
 set __BuildArch=x64

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -11,7 +11,8 @@ set "__ProjectDir=%~dp0"
 :: remove trailing slash
 if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
 set "__RepoRootDir=%__ProjectDir%\..\.."
-for %%i in ("%__RepoRootDir%") do SET "__RepoRootDir=%%~fi"
+:: normalize
+for %%i in ("%__RepoRootDir%") do set "__RepoRootDir=%%~fi"
 
 set "__TestDir=%__RepoRootDir%\src\tests"
 

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -12,6 +12,8 @@ set __TargetOS=windows
 
 set "__ProjectDir=%~dp0"
 set "__RepoRootDir=%~dp0..\.."
+:: normalize
+for %%i in ("%__RepoRootDir%") do set "__RepoRootDir=%%~fi"
 :: remove trailing slash
 if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
 set "__ProjectFilesDir=%__ProjectDir%"


### PR DESCRIPTION
* Normalize RepoRoot path in various batch scripts.
* Use consistent style in those scripts which is used in build-runtime, src/tests/build and src/tests/run.
* Quote paths.

e.g. before the CI:
```
BUILD: Product binaries are available at D:\a\_work\1\s\src\coreclr\..\..\artifacts\bin\coreclr\windows.x64.Checked
```
PR will normalize that path as:
```
BUILD: Product binaries are available at D:\a\_work\1\s\artifacts\bin\coreclr\windows.x64.Checked
```