### PR TITLE
Fix fuzzers for .NET 8 SDK publish

### DIFF
--- a/src/coreclr/scripts/fuzzer_setup.py
+++ b/src/coreclr/scripts/fuzzer_setup.py
@@ -95,14 +95,14 @@ def main(main_args):
     helix_source_prefix = "official"
     creator = ""
 
-    repo_urls = {
-        "Antigen": "https://github.com/kunalspathak/Antigen.git",
-        "Fuzzlyn": "https://github.com/jakobbotsch/Fuzzlyn.git",
+    build_repos = {
+        "Antigen": ("https://github.com/kunalspathak/Antigen.git", "Antigen/Antigen.csproj"),
+        "Fuzzlyn": ("https://github.com/jakobbotsch/Fuzzlyn.git", "Fuzzlyn/Fuzzlyn.csproj"),
     }
 
     # tool_name is verifed in setup_args
-    assert coreclr_args.tool_name in repo_urls
-    repo_url = repo_urls[coreclr_args.tool_name]
+    assert coreclr_args.tool_name in build_repos
+    (repo_url, proj_path) = build_repos[coreclr_args.tool_name]
 
     # create exploratory directory
     print('Copying {} -> {}'.format(scripts_src_directory, coreroot_directory))
@@ -131,7 +131,7 @@ def main(main_args):
                 dotnet_cmd = os.path.join(source_directory, "dotnet.cmd")
                 if not is_windows:
                     dotnet_cmd = os.path.join(source_directory, "dotnet.sh")
-                run_command([dotnet_cmd, "publish", "-c", "Release", "--self-contained", "-r", run_configuration, "-o", publish_dir], _exit_on_fail=True)
+                run_command([dotnet_cmd, "publish", proj_path.replace("/", os.sep), "-c", "Release", "--self-contained", "-r", run_configuration, "-o", publish_dir], _exit_on_fail=True)
 
             dll_name = coreclr_args.tool_name + ".dll"
             if not os.path.exists(path.join(publish_dir, dll_name)):


### PR DESCRIPTION
dotnet publish does not allow publishing of solution files with an output path in the .NET 8 SDK. The pipelines failed today because of it ([Antigen](https://dev.azure.com/dnceng-public/public/_build/results?buildId=138208&view=logs&j=d9ac5510-7b8b-5bd5-21ca-f251aec5107c&t=6137ffab-3221-5920-ccf1-36c3f998c884), [Fuzzlyn](https://dev.azure.com/dnceng-public/public/_build/results?buildId=138207&view=logs&j=d9ac5510-7b8b-5bd5-21ca-f251aec5107c&t=6137ffab-3221-5920-ccf1-36c3f998c884)). This change makes the build scripts specify the project to build.

Context: https://github.com/dotnet/sdk/pull/29065