### PR TITLE
Make it possible to construct StackFrame without MethodBase

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
@@ -47,13 +47,14 @@ namespace System.Diagnostics
 
         private bool TryInitializeMethodBase()
         {
-            if (_noMethodBaseAvailable || _ipAddress == IntPtr.Zero)
+            if (_noMethodBaseAvailable || _ipAddress == IntPtr.Zero || _ipAddress == Exception.EdiSeparator)
                 return false;
 
             if (_method != null)
                 return true;
 
-            IntPtr methodStartAddress = RuntimeImports.RhFindMethodStartAddress(_ipAddress);
+            IntPtr methodStartAddress = _ipAddress - _nativeOffset;
+            Debug.Assert(RuntimeImports.RhFindMethodStartAddress(_ipAddress) == methodStartAddress);
             DeveloperExperience.Default.TryGetMethodBase(methodStartAddress, out _method);
             if (_method == null)
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -29,6 +31,36 @@ namespace System.Diagnostics
         private bool _needFileInfo;
 
         /// <summary>
+        /// Will be true if we attempted to retrieve the associated MethodBase but couldn't.
+        /// </summary>
+        private bool _noMethodBaseAvailable;
+
+        /// <summary>
+        /// Returns the method the frame is executing
+        /// </summary>
+        [RequiresUnreferencedCode("Metadata for the method might be incomplete or removed")]
+        public virtual MethodBase? GetMethod()
+        {
+            TryInitializeMethodBase();
+            return _method;
+        }
+
+        private bool TryInitializeMethodBase()
+        {
+            if (_noMethodBaseAvailable || _ipAddress == IntPtr.Zero)
+                return false;
+
+            IntPtr methodStartAddress = RuntimeImports.RhFindMethodStartAddress(_ipAddress);
+            DeveloperExperience.Default.TryGetMethodBase(methodStartAddress, out MethodBase _method);
+            if (_method == null)
+            {
+                _noMethodBaseAvailable = true;
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
         /// Constructs a StackFrame corresponding to a given IP address.
         /// </summary>
         internal StackFrame(IntPtr ipAddress, bool needFileInfo)
@@ -55,7 +87,6 @@ namespace System.Diagnostics
                 _nativeOffset = (int)((nint)_ipAddress - (nint)methodStartAddress);
 
                 DeveloperExperience.Default.TryGetILOffsetWithinMethod(_ipAddress, out _ilOffset);
-                DeveloperExperience.Default.TryGetMethodBase(methodStartAddress, out _method);
 
                 if (needFileInfo)
                 {
@@ -98,7 +129,7 @@ namespace System.Diagnostics
         /// </summary>
         internal bool HasMethod()
         {
-            return _method != null;
+            return TryInitializeMethodBase();
         }
 
         /// <summary>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
@@ -50,8 +50,11 @@ namespace System.Diagnostics
             if (_noMethodBaseAvailable || _ipAddress == IntPtr.Zero)
                 return false;
 
+            if (_method != null)
+                return true;
+
             IntPtr methodStartAddress = RuntimeImports.RhFindMethodStartAddress(_ipAddress);
-            DeveloperExperience.Default.TryGetMethodBase(methodStartAddress, out MethodBase _method);
+            DeveloperExperience.Default.TryGetMethodBase(methodStartAddress, out _method);
             if (_method == null)
             {
                 _noMethodBaseAvailable = true;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackFrame.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackFrame.cs
@@ -134,6 +134,7 @@ namespace System.Diagnostics
 
         internal bool IsLastFrameFromForeignExceptionStackTrace => _isLastFrameFromForeignExceptionStackTrace;
 
+#if !NATIVEAOT
         /// <summary>
         /// Returns the method the frame is executing
         /// </summary>
@@ -142,6 +143,7 @@ namespace System.Diagnostics
         {
             return _method;
         }
+#endif
 
         /// <summary>
         /// Returns the offset from the start of the native (jitted) code for the


### PR DESCRIPTION
Contributes to #80165.

Resolving a `MethodBase` is a pretty expensive operation and currently even a hello world needs it because of `Exception.ToString()`. This pull request is trying to get `MethodBase` out of the picture when constructing the exception string.

We currently only need `_method` for two things - the public `GetMethod` API, and `StackFrame.ToString`. The `StackFrame.ToString` can already deal with `_method` being null (and that codepath exists solely for NativeAOT). This is the minimal change. We could potentially explore other approaches - leave `MethodBase` always at null, or unshare the `StackFrame` class.

Cc @dotnet/ilc-contrib 