### PR TITLE
JIT: Add a stress mode that poisons implicit byrefs

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -10181,8 +10181,8 @@ void Compiler::EnregisterStats::RecordLocal(const LclVarDsc* varDsc)
                     m_dispatchRetBuf++;
                     break;
 
-                case AddressExposedReason::STRESS_WRITE_IMPLICIT_BYREFS:
-                    m_stressWriteImplicitByrefs++;
+                case AddressExposedReason::STRESS_POISON_IMPLICIT_BYREFS:
+                    m_stressPoisonImplicitByrefs++;
                     break;
 
                 default:
@@ -10280,6 +10280,6 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
     PRINT_STATS(m_osrExposed, m_addrExposed);
     PRINT_STATS(m_stressLclFld, m_addrExposed);
     PRINT_STATS(m_dispatchRetBuf, m_addrExposed);
-    PRINT_STATS(m_stressWriteImplicitByrefs, m_addrExposed);
+    PRINT_STATS(m_stressPoisonImplicitByrefs, m_addrExposed);
 }
 #endif // TRACK_ENREG_STATS

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1775,6 +1775,8 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
 
     // set this early so we can use it without relying on random memory values
     verbose = compIsForInlining() ? impInlineInfo->InlinerCompiler->verbose : false;
+
+    compPoisoningAnyImplicitByrefs = false;
 #endif
 
 #if defined(DEBUG) || defined(LATE_DISASM) || DUMP_FLOWGRAPHS || DUMP_GC_TABLES
@@ -10179,6 +10181,10 @@ void Compiler::EnregisterStats::RecordLocal(const LclVarDsc* varDsc)
                     m_dispatchRetBuf++;
                     break;
 
+                case AddressExposedReason::STRESS_WRITE_IMPLICIT_BYREFS:
+                    m_stressWriteImplicitByrefs++;
+                    break;
+
                 default:
                     unreached();
                     break;
@@ -10274,5 +10280,6 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
     PRINT_STATS(m_osrExposed, m_addrExposed);
     PRINT_STATS(m_stressLclFld, m_addrExposed);
     PRINT_STATS(m_dispatchRetBuf, m_addrExposed);
+    PRINT_STATS(m_stressWriteImplicitByrefs, m_addrExposed);
 }
 #endif // TRACK_ENREG_STATS

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -467,14 +467,14 @@ enum class DoNotEnregisterReason
 enum class AddressExposedReason
 {
     NONE,
-    PARENT_EXPOSED,               // This is a promoted field but the parent is exposed.
-    TOO_CONSERVATIVE,             // Were marked as exposed to be conservative, fix these places.
-    ESCAPE_ADDRESS,               // The address is escaping, for example, passed as call argument.
-    WIDE_INDIR,                   // We access via indirection with wider type.
-    OSR_EXPOSED,                  // It was exposed in the original method, osr has to repeat it.
-    STRESS_LCL_FLD,               // Stress mode replaces localVar with localFld and makes them addrExposed.
-    DISPATCH_RET_BUF,             // Caller return buffer dispatch.
-    STRESS_WRITE_IMPLICIT_BYREFS, // This is an implicit byref we want to poison.
+    PARENT_EXPOSED,                // This is a promoted field but the parent is exposed.
+    TOO_CONSERVATIVE,              // Were marked as exposed to be conservative, fix these places.
+    ESCAPE_ADDRESS,                // The address is escaping, for example, passed as call argument.
+    WIDE_INDIR,                    // We access via indirection with wider type.
+    OSR_EXPOSED,                   // It was exposed in the original method, osr has to repeat it.
+    STRESS_LCL_FLD,                // Stress mode replaces localVar with localFld and makes them addrExposed.
+    DISPATCH_RET_BUF,              // Caller return buffer dispatch.
+    STRESS_POISON_IMPLICIT_BYREFS, // This is an implicit byref we want to poison.
 };
 
 #endif // DEBUG
@@ -10141,7 +10141,7 @@ public:
         unsigned m_stressLclFld;
         unsigned m_dispatchRetBuf;
         unsigned m_wideIndir;
-        unsigned m_stressWriteImplicitByrefs;
+        unsigned m_stressPoisonImplicitByrefs;
 
     public:
         void RecordLocal(const LclVarDsc* varDsc);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6985,7 +6985,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
             case CEE_RET:
                 prefixFlags &= ~PREFIX_TAILCALL; // ret without call before it
-
             RET:
                 if (!impReturnInstruction(prefixFlags, opcode))
                 {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11215,6 +11215,13 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
 // impPoisonImplicitByrefsBeforeReturn:
 //   Spill the stack and insert IR that poisons all implicit byrefs.
 //
+// Remarks:
+//   The memory pointed to by implicit byrefs is owned by the callee but
+//   usually exists on the caller's frame (or on the heap for some reflection
+//   invoke scenarios). This function helps catch situations where the caller
+//   reads from the memory after the invocation, for example due to a bug in
+//   the JIT's own last-use copy elision for implicit byrefs.
+//
 void Compiler::impPoisonImplicitByrefsBeforeReturn()
 {
     bool spilled = false;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11231,7 +11231,7 @@ void Compiler::impPoisonImplicitByrefsBeforeReturn()
         {
             for (unsigned level = 0; level < verCurrentState.esStackDepth; level++)
             {
-                impSpillStackEntry(level, BAD_VAR_NUM DEBUGARG(true) DEBUGARG("Stress writing byrefs before return"));
+                impSpillStackEntry(level, BAD_VAR_NUM DEBUGARG(true) DEBUGARG("Stress poisoning byrefs before return"));
             }
 
             spilled = true;
@@ -11239,7 +11239,7 @@ void Compiler::impPoisonImplicitByrefsBeforeReturn()
 
         LclVarDsc* dsc = lvaGetDesc(lclNum);
         // Be conservative about this local to ensure we do not eliminate the poisoning.
-        lvaSetVarAddrExposed(lclNum, AddressExposedReason::STRESS_WRITE_IMPLICIT_BYREFS);
+        lvaSetVarAddrExposed(lclNum, AddressExposedReason::STRESS_POISON_IMPLICIT_BYREFS);
 
         assert(varTypeIsStruct(dsc));
         ClassLayout* layout = dsc->GetLayout();

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1988,6 +1988,12 @@ bool Compiler::StructPromotionHelper::CanPromoteStructVar(unsigned lclNum)
         return false;
     }
 
+    if (varDsc->IsAddressExposed())
+    {
+        JITDUMP("  struct promotion of V%02u is disabled because it has already been marked address exposed\n", lclNum);
+        return false;
+    }
+
     CORINFO_CLASS_HANDLE typeHnd = varDsc->GetStructHnd();
     assert(typeHnd != NO_CLASS_HANDLE);
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6206,7 +6206,7 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
 
     if (compPoisoningAnyImplicitByrefs)
     {
-        failTailCall("STRESS_WRITE_IMPLICIT_BYREFS has introduced IR after tailcall opportunity, invalidating");
+        failTailCall("STRESS_POISON_IMPLICIT_BYREFS has introduced IR after tailcall opportunity, invalidating");
         return nullptr;
     }
 #endif

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4810,7 +4810,7 @@ GenTree* Compiler::fgMorphExpandImplicitByRefArg(GenTreeLclVarCommon* lclNode)
     {
         if (argNodeType == TYP_STRUCT)
         {
-            newArgNode = gtNewObjNode(argNodeLayout, addrNode);
+            newArgNode = gtNewStructVal(argNodeLayout, addrNode);
         }
         else
         {
@@ -6199,8 +6199,14 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
 #ifdef DEBUG
     if (opts.compGcChecks && (info.compRetType == TYP_REF))
     {
-        failTailCall("COMPlus_JitGCChecks or stress might have interposed a call to CORINFO_HELP_CHECK_OBJ, "
+        failTailCall("DOTNET_JitGCChecks or stress might have interposed a call to CORINFO_HELP_CHECK_OBJ, "
                      "invalidating tailcall opportunity");
+        return nullptr;
+    }
+
+    if (compPoisoningAnyImplicitByrefs)
+    {
+        failTailCall("STRESS_WRITE_IMPLICIT_BYREFS has introduced IR after tailcall opportunity, invalidating");
         return nullptr;
     }
 #endif


### PR DESCRIPTION
This stress mode poisons all implicit byrefs before returns from the method. GC pointers are nulled out and other parts of the structs are filled with 0xcd bytes.

This should help expose incorrectly elided copies in the recently added last-use copy elision optimization.