### PR TITLE
[release/6.0] Fix parsing the output of ping on Samsung phones

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -15,6 +15,8 @@ namespace System.Net.NetworkInformation
 {
     public partial class Ping
     {
+        private static char[] s_ttlExceededAddressSeparators = new[] { ' ', ':' };
+
         private Process GetPingProcess(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
             bool isIpv4 = address.AddressFamily == AddressFamily.InterNetwork;
@@ -123,9 +125,11 @@ namespace System.Net.NetworkInformation
                 return false;
             }
 
-            // look for address in "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
+            // look for address in:
+            // - "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
+            // - "From 172.21.64.1: icmp_seq=1 Time to live exceeded"
             int addressStart = stdout.IndexOf("From ", StringComparison.Ordinal) + 5;
-            int addressLength = stdout.IndexOf(' ', Math.Max(addressStart, 0)) - addressStart;
+            int addressLength = stdout.IndexOfAny(s_ttlExceededAddressSeparators, Math.Max(addressStart, 0)) - addressStart;
             IPAddress? address;
             if (addressStart < 5 || addressLength <= 0 || !IPAddress.TryParse(stdout.AsSpan(addressStart, addressLength), out address))
             {

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -45,15 +45,15 @@ namespace System.Net.NetworkInformation
             using (Process p = GetPingProcess(address, buffer, timeout, options))
             {
                 p.Start();
-                if (!p.WaitForExit(timeout) || p.ExitCode == 1 || p.ExitCode == 2)
+                if (!p.WaitForExit(timeout))
                 {
                     return CreatePingReply(IPStatus.TimedOut);
                 }
 
                 try
                 {
-                    string output = p.StandardOutput.ReadToEnd();
-                    return ParsePingUtilityOutput(address, output);
+                    string stdout = p.StandardOutput.ReadToEnd();
+                    return ParsePingUtilityOutput(address, p.ExitCode, stdout);
                 }
                 catch (Exception)
                 {
@@ -82,16 +82,10 @@ namespace System.Net.NetworkInformation
                     return CreatePingReply(IPStatus.TimedOut);
                 }
 
-                if (p.ExitCode == 1 || p.ExitCode == 2)
-                {
-                    // Throw timeout for known failure return codes from ping functions.
-                    return CreatePingReply(IPStatus.TimedOut);
-                }
-
                 try
                 {
-                    string output = await p.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
-                    return ParsePingUtilityOutput(address, output);
+                    string stdout = await p.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+                    return ParsePingUtilityOutput(address, p.ExitCode, stdout);
                 }
                 catch (Exception)
                 {
@@ -101,15 +95,47 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        private PingReply ParsePingUtilityOutput(IPAddress address, string output)
+        private static PingReply ParsePingUtilityOutput(IPAddress address, int exitCode, string stdout)
         {
-            long rtt = UnixCommandLinePing.ParseRoundTripTime(output);
-            return new PingReply(
-                address,
-                null, // Ping utility cannot accommodate these, return null to indicate they were ignored.
-                IPStatus.Success,
-                rtt,
-                Array.Empty<byte>()); // Ping utility doesn't deliver this info.
+            // Throw timeout for known failure return codes from ping functions.
+            if (exitCode == 1 || exitCode == 2)
+            {
+                // TTL exceeded may have occured
+                if (TryParseTtlExceeded(stdout, out PingReply? reply))
+                {
+                    return reply!;
+                }
+
+                // otherwise assume timeout
+                return CreatePingReply(IPStatus.TimedOut);
+            }
+
+            // On success, report RTT
+            long rtt = UnixCommandLinePing.ParseRoundTripTime(stdout);
+            return CreatePingReply(IPStatus.Success, address, rtt);
+        }
+
+        private static bool TryParseTtlExceeded(string stdout, out PingReply? reply)
+        {
+            reply = null;
+            if (!stdout.Contains("Time to live exceeded", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // look for address in "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
+            int addressStart = stdout.IndexOf("From ", StringComparison.Ordinal) + 5;
+            int addressLength = stdout.IndexOf(' ', Math.Max(addressStart, 0)) - addressStart;
+            IPAddress? address;
+            if (addressStart < 5 || addressLength <= 0 || !IPAddress.TryParse(stdout.AsSpan(addressStart, addressLength), out address))
+            {
+                // failed to parse source address (which in case of TTL is different than the original
+                // destination address), fallback to all 0
+                address = new IPAddress(0);
+            }
+
+            reply = CreatePingReply(IPStatus.TimeExceeded, address);
+            return true;
         }
     }
 }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -15,8 +15,6 @@ namespace System.Net.NetworkInformation
 {
     public partial class Ping
     {
-        private static char[] s_ttlExceededAddressSeparators = new[] { ' ', ':' };
-
         private Process GetPingProcess(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
         {
             bool isIpv4 = address.AddressFamily == AddressFamily.InterNetwork;
@@ -129,7 +127,7 @@ namespace System.Net.NetworkInformation
             // - "From 172.21.64.1 icmp_seq=1 Time to live exceeded"
             // - "From 172.21.64.1: icmp_seq=1 Time to live exceeded"
             int addressStart = stdout.IndexOf("From ", StringComparison.Ordinal) + 5;
-            int addressLength = stdout.IndexOfAny(s_ttlExceededAddressSeparators, Math.Max(addressStart, 0)) - addressStart;
+            int addressLength = stdout.AsSpan(Math.Max(addressStart, 0)).IndexOfAny(' ', ':');
             IPAddress? address;
             if (addressStart < 5 || addressLength <= 0 || !IPAddress.TryParse(stdout.AsSpan(addressStart, addressLength), out address))
             {

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -29,8 +29,8 @@ namespace System.Net.NetworkInformation
             bool ipv4 = address.AddressFamily == AddressFamily.InterNetwork;
             bool sendIpHeader = ipv4 && options != null && SendIpHeader;
 
-             if (sendIpHeader)
-             {
+            if (sendIpHeader)
+            {
                 iph.VersionAndLength = 0x45;
                 // On OSX this strangely must be host byte order.
                 iph.TotalLength = (ushort)(sizeof(IpHeader) + checked(sizeof(IcmpHeader) +  buffer.Length));
@@ -42,7 +42,7 @@ namespace System.Net.NetworkInformation
 #pragma warning restore 618
                 // No need to fill in SourceAddress or checksum.
                 // If left blank, kernel will fill it in - at least on OSX.
-             }
+            }
 
             return new SocketConfig(
                 new IPEndPoint(address, 0), timeout, options,
@@ -260,11 +260,11 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        private static PingReply CreatePingReply(IPStatus status)
+        private static PingReply CreatePingReply(IPStatus status, IPAddress? address = null, long rtt = 0)
         {
             // Documentation indicates that you should only pay attention to the IPStatus value when
             // its value is not "Success", but the rest of these values match that of the Windows implementation.
-            return new PingReply(new IPAddress(0), null, status, 0, Array.Empty<byte>());
+            return new PingReply(address ?? new IPAddress(0), null, status, rtt, Array.Empty<byte>());
         }
 
 #if DEBUG


### PR DESCRIPTION
Backport of #80133 and (older 7.0 fix) #65312 to release/6.0

Fixes #78990

Unlike in #80502, we need to backport #65312 that wasn't originally backported to 6.0.

## Customer Impact

Some Android installations contain a ping utility that produces slightly different output when TTL is exceeded from what our code expects. This seems to be the case at least on Samsung phones. This PR updates the parser to account for this variation.

## Testing

- Manual testing on a Samsung phone (API 31) and on Android emulators of various API levels.
- CI - Android emulator (API 29)

## Risk

Low.
