### PR TITLE
[browser][http] Fix blocking of streaming response and abort

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1080,11 +1080,20 @@ namespace System.Net.Http.Functional.Tests
 
                         // Various forms of reading
                         var buffer = new byte[1];
+                        var buffer2 = new byte[2];
 
                         if (PlatformDetection.IsBrowser)
                         {
 #if !NETFRAMEWORK
-                            Assert.Equal('h', await responseStream.ReadByteAsync());
+                            if(slowChunks)
+                            {
+                                Assert.Equal(1, await responseStream.ReadAsync(new Memory<byte>(buffer2)));
+                                Assert.Equal((byte)'h', buffer2[0]);
+                            }
+                            else
+                            {
+                                Assert.Equal('h', await responseStream.ReadByteAsync());
+                            }
                             Assert.Equal('e', await responseStream.ReadByteAsync());
                             Assert.Equal(1, await responseStream.ReadAsync(new Memory<byte>(buffer)));
                             Assert.Equal((byte)'l', buffer[0]);
@@ -1190,9 +1199,7 @@ namespace System.Net.Http.Functional.Tests
                                 await connection.SendResponseBodyAsync("1\r\nh\r\n", false);
                                 await Task.Delay(100);
                                 await connection.SendResponseBodyAsync("2\r\nel\r\n", false);
-                                await Task.Delay(100);
                                 await connection.SendResponseBodyAsync("8\r\nlo world\r\n", false);
-                                await Task.Delay(100);
                                 await connection.SendResponseBodyAsync("0\r\n\r\n", true);
                             }
                             else

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1004,6 +1004,12 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
+            if (enableWasmStreaming && !PlatformDetection.IsBrowser)
+            {
+                // enableWasmStreaming makes only sense on Browser platform
+                return;
+            }
+
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
@@ -1194,7 +1200,7 @@ namespace System.Net.Http.Functional.Tests
                     {
                         case true:
                             await connection.SendResponseAsync(HttpStatusCode.OK, headers: new HttpHeaderData[] { new HttpHeaderData("Transfer-Encoding", "chunked") }, isFinal: false);
-                            if(slowChunks)
+                            if(PlatformDetection.IsBrowser && slowChunks)
                             {
                                 await connection.SendResponseBodyAsync("1\r\nh\r\n", false);
                                 await Task.Delay(100);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1188,8 +1188,11 @@ namespace System.Net.Http.Functional.Tests
                             if(slowChunks)
                             {
                                 await connection.SendResponseBodyAsync("1\r\nh\r\n", false);
+                                await Task.Delay(100);
                                 await connection.SendResponseBodyAsync("2\r\nel\r\n", false);
+                                await Task.Delay(100);
                                 await connection.SendResponseBodyAsync("8\r\nlo world\r\n", false);
+                                await Task.Delay(100);
                                 await connection.SendResponseBodyAsync("0\r\n\r\n", true);
                             }
                             else

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -106,7 +106,7 @@ export function http_wasm_get_response_bytes(res: ResponseExtension, view: Span)
     return bytes_read;
 }
 
-export async function http_wasm_get_streamed_response_bytes(res: ResponseExtension, bufferPtr: VoidPtr, bufferLength: number): Promise<number> {
+export function http_wasm_get_streamed_response_bytes(res: ResponseExtension, bufferPtr: VoidPtr, bufferLength: number): Promise<number> {
     // the bufferPtr is pinned by the caller
     const view = new Span(bufferPtr, bufferLength, MemoryViewType.Byte);
     return wrap_as_cancelable_promise(async () => {

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -117,6 +117,7 @@ export async function http_wasm_get_streamed_response_bytes(res: ResponseExtensi
             res.__source_offset = 0;
         }
         if (res.__chunk.done) {
+            res.__reader = undefined;
             return 0;
         }
 

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { wrap_as_cancelable_promise } from "./cancelable-promise";
+import { Module } from "./imports";
 import { MemoryViewType, Span } from "./marshal";
 import { mono_assert } from "./types";
 import { VoidPtr } from "./types/emscripten";
@@ -21,8 +22,11 @@ export function http_wasm_abort_request(abort_controller: AbortController): void
 export function http_wasm_abort_response(res: ResponseExtension): void {
     res.__abort_controller.abort();
     if (res.__reader) {
-        res.__reader.cancel().catch(() => {
-            //we ignore the error
+        res.__reader.cancel().catch((err) => {
+            if (err && err.name !== "AbortError") {
+                Module.printErr("MONO_WASM: Error in http_wasm_abort_response: " + err);
+            }
+            // otherwise, it's expected
         });
     }
 }

--- a/src/mono/wasm/runtime/http.ts
+++ b/src/mono/wasm/runtime/http.ts
@@ -21,7 +21,9 @@ export function http_wasm_abort_request(abort_controller: AbortController): void
 export function http_wasm_abort_response(res: ResponseExtension): void {
     res.__abort_controller.abort();
     if (res.__reader) {
-        res.__reader.cancel();
+        res.__reader.cancel().catch(() => {
+            //we ignore the error
+        });
     }
 }
 
@@ -104,38 +106,32 @@ export async function http_wasm_get_streamed_response_bytes(res: ResponseExtensi
     // the bufferPtr is pinned by the caller
     const view = new Span(bufferPtr, bufferLength, MemoryViewType.Byte);
     return wrap_as_cancelable_promise(async () => {
-        if (!res.__chunk && res.body) {
+        if (!res.body) {
+            return 0;
+        }
+        if (!res.__reader) {
             res.__reader = res.body.getReader();
+        }
+        if (!res.__chunk) {
             res.__chunk = await res.__reader.read();
             res.__source_offset = 0;
         }
-
-        let target_offset = 0;
-        let bytes_read = 0;
-        // loop until end of browser stream or end of C# buffer
-        while (res.__reader && res.__chunk && !res.__chunk.done) {
-            const remaining_source = res.__chunk.value.byteLength - res.__source_offset;
-            if (remaining_source === 0) {
-                res.__chunk = await res.__reader.read();
-                res.__source_offset = 0;
-                continue;// are we done yet
-            }
-
-            const remaining_target = view.byteLength - target_offset;
-            const bytes_copied = Math.min(remaining_source, remaining_target);
-            const source_view = res.__chunk.value.subarray(res.__source_offset, res.__source_offset + bytes_copied);
-
-            // copy available bytes
-            view.set(source_view, target_offset);
-            target_offset += bytes_copied;
-            bytes_read += bytes_copied;
-            res.__source_offset += bytes_copied;
-
-            if (target_offset == view.byteLength) {
-                return bytes_read;
-            }
+        if (res.__chunk.done) {
+            return 0;
         }
-        return bytes_read;
+
+        const remaining_source = res.__chunk.value.byteLength - res.__source_offset;
+        mono_assert(remaining_source > 0, "expected remaining_source to be greater than 0");
+
+        const bytes_copied = Math.min(remaining_source, view.byteLength);
+        const source_view = res.__chunk.value.subarray(res.__source_offset, bytes_copied);
+        view.set(source_view, 0);
+        res.__source_offset += bytes_copied;
+        if (remaining_source == bytes_copied) {
+            res.__chunk = undefined;
+        }
+
+        return bytes_copied;
     });
 }
 


### PR DESCRIPTION
- return bytes of streaming response as soon as available
- fix unhandled error in reader.cancel() promise
- return cancelable promise from `http_wasm_get_streamed_response_bytes`
- unit test for slowly streamed chunks
- unit test for streaming and default cancellation

Fixes https://github.com/dotnet/runtime/issues/79238
Fixes https://github.com/dotnet/runtime/issues/80696

Should be merged back to Net7