### PR TITLE
Don't try to fold ADD(CNS, CNS-handle) in gtWalkOp

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -3869,6 +3869,12 @@ void Compiler::gtWalkOp(GenTree** op1WB, GenTree** op2WB, GenTree* base, bool co
             break;
         }
 
+        // Ignore ADD(CNS, CNS-gc-handle)
+        if (addOp2->TypeIs(TYP_REF) && !addOp2->IsIntegralConst(0))
+        {
+            break;
+        }
+
         // mark it with GTF_ADDRMODE_NO_CSE
         add->gtFlags |= GTF_ADDRMODE_NO_CSE;
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -3870,7 +3870,7 @@ void Compiler::gtWalkOp(GenTree** op1WB, GenTree** op2WB, GenTree* base, bool co
         }
 
         // Ignore ADD(CNS, CNS-gc-handle)
-        if (addOp2->TypeIs(TYP_REF) && !addOp2->IsIntegralConst(0))
+        if (constOnly && addOp2->IsIconHandle(GTF_ICON_OBJ_HDL) && !addOp2->IsIntegralConst(0))
         {
             break;
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/80690

`gtWalkOp` is a bit weird routine that is done after `genCreateAddrMode` to validate that we correctly picked a base address. While `genCreateAddrMode` gives up on `ADD(CNS, CNS-handle)`, `gtWalkOp` used to not. I expect this PR to be zero diff but let's see