### PR TITLE
Solve recently introduce ASCII regression

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
@@ -193,8 +193,7 @@ namespace System.Text
             {
                 // Unrecognized fallback mechanism - count chars manually.
 
-                int firstNonAsciiIndex = Ascii.GetIndexOfFirstNonAsciiChar(new ReadOnlySpan<char>(pChars, charsLength));
-                byteCount = firstNonAsciiIndex < 0 ? charsLength : firstNonAsciiIndex;
+                byteCount = (int)Ascii.GetIndexOfFirstNonAsciiChar(pChars, (uint)charsLength);
             }
 
             charsConsumed = byteCount;
@@ -513,8 +512,7 @@ namespace System.Text
             {
                 // Unrecognized fallback mechanism - count bytes manually.
 
-                int indexOfFirstNonAscii = Ascii.GetIndexOfFirstNonAsciiByte(new ReadOnlySpan<byte>(pBytes, bytesLength));
-                charCount = indexOfFirstNonAscii < 0 ? bytesLength : indexOfFirstNonAscii;
+                charCount = (int)Ascii.GetIndexOfFirstNonAsciiByte(pBytes, (uint)bytesLength);
             }
 
             bytesConsumed = charCount;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
@@ -354,8 +354,10 @@ namespace System.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetBytesCommon
         private protected sealed override unsafe int GetBytesFast(char* pChars, int charsLength, byte* pBytes, int bytesLength, out int charsConsumed)
         {
-            Ascii.FromUtf16(new ReadOnlySpan<char>(pChars, charsLength), new Span<byte>(pBytes, bytesLength), out charsConsumed);
-            return charsConsumed;
+            int bytesWritten = (int)Ascii.NarrowUtf16ToAscii(pChars, pBytes, (uint)Math.Min(charsLength, bytesLength));
+
+            charsConsumed = bytesWritten;
+            return bytesWritten;
         }
 
         private protected sealed override unsafe int GetBytesWithFallback(ReadOnlySpan<char> chars, int originalCharsLength, Span<byte> bytes, int originalBytesLength, EncoderNLS? encoder)
@@ -625,7 +627,7 @@ namespace System.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetCharsCommon
         private protected sealed override unsafe int GetCharsFast(byte* pBytes, int bytesLength, char* pChars, int charsLength, out int bytesConsumed)
         {
-            Ascii.ToUtf16(new ReadOnlySpan<byte>(pBytes, bytesLength), new Span<char>(pChars, charsLength), out bytesConsumed);
+            bytesConsumed = (int)Ascii.WidenAsciiToUtf16(pBytes, pChars, (uint)Math.Min(charsLength, bytesLength));
             return bytesConsumed;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1152,7 +1152,7 @@ namespace System.Text
         /// or once <paramref name="elementCount"/> elements have been converted. Returns the total number
         /// of elements that were able to be converted.
         /// </summary>
-        private static unsafe nuint NarrowUtf16ToAscii(char* pUtf16Buffer, byte* pAsciiBuffer, nuint elementCount)
+        internal static unsafe nuint NarrowUtf16ToAscii(char* pUtf16Buffer, byte* pAsciiBuffer, nuint elementCount)
         {
             nuint currentOffset = 0;
 
@@ -1576,7 +1576,7 @@ namespace System.Text
         /// or once <paramref name="elementCount"/> elements have been converted. Returns the total number
         /// of elements that were able to be converted.
         /// </summary>
-        private static unsafe nuint WidenAsciiToUtf16(byte* pAsciiBuffer, char* pUtf16Buffer, nuint elementCount)
+        internal static unsafe nuint WidenAsciiToUtf16(byte* pAsciiBuffer, char* pUtf16Buffer, nuint elementCount)
         {
             // Intrinsified in mono interpreter
             nuint currentOffset = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -81,7 +81,7 @@ namespace System.Text
         /// </summary>
         /// <returns>An ASCII byte is defined as 0x00 - 0x7F, inclusive.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe nuint GetIndexOfFirstNonAsciiByte(byte* pBuffer, nuint bufferLength)
+        internal static unsafe nuint GetIndexOfFirstNonAsciiByte(byte* pBuffer, nuint bufferLength)
         {
             // If SSE2 is supported, use those specific intrinsics instead of the generic vectorized
             // code below. This has two benefits: (a) we can take advantage of specific instructions like
@@ -617,7 +617,7 @@ namespace System.Text
         /// </summary>
         /// <returns>An ASCII char is defined as 0x0000 - 0x007F, inclusive.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe nuint GetIndexOfFirstNonAsciiChar(char* pBuffer, nuint bufferLength /* in chars */)
+        internal static unsafe nuint GetIndexOfFirstNonAsciiChar(char* pBuffer, nuint bufferLength /* in chars */)
         {
             // If SSE2/ASIMD is supported, use those specific intrinsics instead of the generic vectorized
             // code below. This has two benefits: (a) we can take advantage of specific instructions like

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -9,56 +9,26 @@ namespace System.Text
     public static partial class Ascii
     {
         /// <summary>
-        /// Returns the index of the first non-ASCII byte in a buffer.
-        /// </summary>
-        /// <param name="buffer">The buffer to scan.</param>
-        /// <returns>The index in <paramref name="buffer"/> where the first non-ASCII
-        /// byte appears, or -1 if the buffer contains only ASCII bytes.</returns>
-        private static unsafe int GetIndexOfFirstNonAsciiByte(ReadOnlySpan<byte> buffer)
-        {
-            if (buffer.IsEmpty)
-            {
-                return -1;
-            }
-
-            nuint bufferLength = (uint)buffer.Length;
-            fixed (byte* pBuffer = &MemoryMarshal.GetReference(buffer))
-            {
-                nuint idxOfFirstNonAsciiElement = GetIndexOfFirstNonAsciiByte(pBuffer, bufferLength);
-                Debug.Assert(idxOfFirstNonAsciiElement <= bufferLength);
-                return (idxOfFirstNonAsciiElement == bufferLength) ? -1 : (int)idxOfFirstNonAsciiElement;
-            }
-        }
-
-        /// <summary>
-        /// Returns the index of the first non-ASCII char in a buffer.
-        /// </summary>
-        /// <param name="buffer">The buffer to scan.</param>
-        /// <returns>The index in <paramref name="buffer"/> where the first non-ASCII
-        /// char appears, or -1 if the buffer contains only ASCII char.</returns>
-        private static unsafe int GetIndexOfFirstNonAsciiChar(ReadOnlySpan<char> buffer)
-        {
-            if (buffer.IsEmpty)
-            {
-                return -1;
-            }
-
-            nuint bufferLength = (uint)buffer.Length;
-            fixed (char* pBuffer = &MemoryMarshal.GetReference(buffer))
-            {
-                nuint idxOfFirstNonAsciiElement = GetIndexOfFirstNonAsciiChar(pBuffer, bufferLength);
-                Debug.Assert(idxOfFirstNonAsciiElement <= bufferLength);
-                return (idxOfFirstNonAsciiElement == bufferLength) ? -1 : (int)idxOfFirstNonAsciiElement;
-            }
-        }
-
-        /// <summary>
         /// Determines whether the provided value contains only ASCII bytes.
         /// </summary>
         /// <param name="value">The value to inspect.</param>
         /// <returns>True if <paramref name="value"/> contains only ASCII bytes or is
         /// empty; False otherwise.</returns>
-        public static unsafe bool IsValid(ReadOnlySpan<byte> value) => GetIndexOfFirstNonAsciiByte(value) < 0;
+        public static unsafe bool IsValid(ReadOnlySpan<byte> value)
+        {
+            if (value.IsEmpty)
+            {
+                return true;
+            }
+
+            nuint bufferLength = (uint)value.Length;
+            fixed (byte* pBuffer = &MemoryMarshal.GetReference(value))
+            {
+                nuint idxOfFirstNonAsciiElement = GetIndexOfFirstNonAsciiByte(pBuffer, bufferLength);
+                Debug.Assert(idxOfFirstNonAsciiElement <= bufferLength);
+                return idxOfFirstNonAsciiElement == bufferLength;
+            }
+        }
 
         /// <summary>
         /// Determines whether the provided value contains only ASCII chars.
@@ -66,7 +36,21 @@ namespace System.Text
         /// <param name="value">The value to inspect.</param>
         /// <returns>True if <paramref name="value"/> contains only ASCII chars or is
         /// empty; False otherwise.</returns>
-        public static unsafe bool IsValid(ReadOnlySpan<char> value) => GetIndexOfFirstNonAsciiChar(value) < 0;
+        public static unsafe bool IsValid(ReadOnlySpan<char> value)
+        {
+            if (value.IsEmpty)
+            {
+                return true;
+            }
+
+            nuint bufferLength = (uint)value.Length;
+            fixed (char* pBuffer = &MemoryMarshal.GetReference(value))
+            {
+                nuint idxOfFirstNonAsciiElement = GetIndexOfFirstNonAsciiChar(pBuffer, bufferLength);
+                Debug.Assert(idxOfFirstNonAsciiElement <= bufferLength);
+                return idxOfFirstNonAsciiElement == bufferLength;
+            }
+        }
 
         /// <summary>
         /// Determines whether the provided value is ASCII byte.

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -14,7 +14,7 @@ namespace System.Text
         /// <param name="buffer">The buffer to scan.</param>
         /// <returns>The index in <paramref name="buffer"/> where the first non-ASCII
         /// byte appears, or -1 if the buffer contains only ASCII bytes.</returns>
-        internal static unsafe int GetIndexOfFirstNonAsciiByte(ReadOnlySpan<byte> buffer)
+        private static unsafe int GetIndexOfFirstNonAsciiByte(ReadOnlySpan<byte> buffer)
         {
             if (buffer.IsEmpty)
             {
@@ -36,7 +36,7 @@ namespace System.Text
         /// <param name="buffer">The buffer to scan.</param>
         /// <returns>The index in <paramref name="buffer"/> where the first non-ASCII
         /// char appears, or -1 if the buffer contains only ASCII char.</returns>
-        internal static unsafe int GetIndexOfFirstNonAsciiChar(ReadOnlySpan<char> buffer)
+        private static unsafe int GetIndexOfFirstNonAsciiChar(ReadOnlySpan<char> buffer)
         {
             if (buffer.IsEmpty)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -29,8 +29,7 @@ namespace System.Text.Unicode
             // First, we'll handle the common case of all-ASCII. If this is able to
             // consume the entire buffer, we'll skip the remainder of this method's logic.
 
-            int firstNonAsciiIndex = Ascii.GetIndexOfFirstNonAsciiChar(new ReadOnlySpan<char>(pInputBuffer, inputLength));
-            int numAsciiCharsConsumedJustNow = firstNonAsciiIndex < 0 ? inputLength : firstNonAsciiIndex;
+            int numAsciiCharsConsumedJustNow = (int)Ascii.GetIndexOfFirstNonAsciiChar(pInputBuffer, (uint)inputLength);
             Debug.Assert(0 <= numAsciiCharsConsumedJustNow && numAsciiCharsConsumedJustNow <= inputLength);
 
             pInputBuffer += (uint)numAsciiCharsConsumedJustNow;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -26,23 +26,25 @@ namespace System.Text.Unicode
             Debug.Assert(pOutputBuffer != null || outputCharsRemaining == 0, "Destination length must be zero if destination buffer pointer is null.");
 
             // First, try vectorized conversion.
-            OperationStatus status = Ascii.ToUtf16(new ReadOnlySpan<byte>(pInputBuffer, inputLength), new Span<char>(pOutputBuffer, outputCharsRemaining), out int bytesConsumed);
-
-            pInputBuffer += bytesConsumed;
-            pOutputBuffer += bytesConsumed;
-
-            // Quick check - did we just end up consuming the entire input buffer?
-            // If so, short-circuit the remainder of the method.
-
-            if (status == OperationStatus.Done)
             {
-                pInputBufferRemaining = pInputBuffer;
-                pOutputBufferRemaining = pOutputBuffer;
-                return OperationStatus.Done;
-            }
+                nuint numElementsConverted = Ascii.WidenAsciiToUtf16(pInputBuffer, pOutputBuffer, (uint)Math.Min(inputLength, outputCharsRemaining));
 
-            inputLength -= bytesConsumed;
-            outputCharsRemaining -= bytesConsumed;
+                pInputBuffer += numElementsConverted;
+                pOutputBuffer += numElementsConverted;
+
+                // Quick check - did we just end up consuming the entire input buffer?
+                // If so, short-circuit the remainder of the method.
+
+                if ((int)numElementsConverted == inputLength)
+                {
+                    pInputBufferRemaining = pInputBuffer;
+                    pOutputBufferRemaining = pOutputBuffer;
+                    return OperationStatus.Done;
+                }
+
+                inputLength -= (int)numElementsConverted;
+                outputCharsRemaining -= (int)numElementsConverted;
+            }
 
             if (inputLength < sizeof(uint))
             {
@@ -846,23 +848,23 @@ namespace System.Text.Unicode
             // First, try vectorized conversion.
 
             {
-                OperationStatus status = Ascii.FromUtf16(new ReadOnlySpan<char>(pInputBuffer, inputLength), new Span<byte>(pOutputBuffer, outputBytesRemaining), out int charsConsumed);
+                nuint numElementsConverted = Ascii.NarrowUtf16ToAscii(pInputBuffer, pOutputBuffer, (uint)Math.Min(inputLength, outputBytesRemaining));
 
-                pInputBuffer += charsConsumed;
-                pOutputBuffer += charsConsumed;
+                pInputBuffer += numElementsConverted;
+                pOutputBuffer += numElementsConverted;
 
                 // Quick check - did we just end up consuming the entire input buffer?
                 // If so, short-circuit the remainder of the method.
 
-                if (status == OperationStatus.Done)
+                if ((int)numElementsConverted == inputLength)
                 {
                     pInputBufferRemaining = pInputBuffer;
                     pOutputBufferRemaining = pOutputBuffer;
                     return OperationStatus.Done;
                 }
 
-                inputLength -= charsConsumed;
-                outputBytesRemaining -= charsConsumed;
+                inputLength -= (int)numElementsConverted;
+                outputBytesRemaining -= (int)numElementsConverted;
             }
 
             if (inputLength < CharsPerDWord)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -27,18 +27,19 @@ namespace System.Text.Unicode
             Debug.Assert(pInputBuffer != null || inputLength == 0, "Input length must be zero if input buffer pointer is null.");
 
             // First, try to drain off as many ASCII bytes as we can from the beginning.
-            int indexOfFirstNonAscii = Ascii.GetIndexOfFirstNonAsciiByte(new ReadOnlySpan<byte>(pInputBuffer, inputLength));
+            nuint numAsciiBytesCounted = Ascii.GetIndexOfFirstNonAsciiByte(pInputBuffer, (uint)inputLength);
+            pInputBuffer += numAsciiBytesCounted;
+
             // Quick check - did we just end up consuming the entire input buffer?
             // If so, short-circuit the remainder of the method.
-            if (indexOfFirstNonAscii < 0)
+
+            inputLength -= (int)numAsciiBytesCounted;
+            if (inputLength == 0)
             {
                 utf16CodeUnitCountAdjustment = 0;
                 scalarCountAdjustment = 0;
-                return pInputBuffer + inputLength;
+                return pInputBuffer;
             }
-
-            pInputBuffer += indexOfFirstNonAscii;
-            inputLength -= indexOfFirstNonAscii;
 
 #if DEBUG
             // Keep these around for final validation at the end of the method.


### PR DESCRIPTION
One of the goals I had in #75012 was to replace the usage of internal helpers with new public API calls.

Initially we wanted to make `Ascii.GetIndexOfFirstNonAsciiChar` public, but at the end we decided to keep it internal.

Here I am removing the redundant call to `Ascii.GetIndexOfFirstNonAsciiChar(ROS)` with a call to the helper method that accepts a pointer and the length. What we get is one less method call, one less span creation and pinning.

fixes #80247