### PR TITLE
Increase superpmi-replay x64 parallelism

### DIFF
--- a/src/coreclr/scripts/superpmi-replay.proj
+++ b/src/coreclr/scripts/superpmi-replay.proj
@@ -52,21 +52,24 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Architecture)' == 'x64'">
-    <!-- Use 2 partitions for each run on an x64 machine -->
-    <SPMI_Partition Include="win-x64-1" Platform="windows" Architecture="x64" Partition="1" PartitionCount="2"/>
-    <SPMI_Partition Include="win-x64-2" Platform="windows" Architecture="x64" Partition="2" PartitionCount="2"/>
-    <SPMI_Partition Include="win-arm64-1" Platform="windows" Architecture="arm64" Partition="1" PartitionCount="2"/>
-    <SPMI_Partition Include="win-arm64-2" Platform="windows" Architecture="arm64" Partition="2" PartitionCount="2"/>
-    <SPMI_Partition Include="unix-x64-1" Platform="linux" Architecture="x64" Partition="1" PartitionCount="2"/>
-    <SPMI_Partition Include="unix-x64-2" Platform="linux" Architecture="x64" Partition="2" PartitionCount="2"/>
-    <SPMI_Partition Include="linux-arm64-1" Platform="linux" Architecture="arm64" Partition="1" PartitionCount="2"/>
-    <SPMI_Partition Include="linux-arm64-2" Platform="linux" Architecture="arm64" Partition="2" PartitionCount="2"/>
-    <SPMI_Partition Include="osx-arm64-1" Platform="osx" Architecture="arm64" Partition="1" PartitionCount="2"/>
-    <SPMI_Partition Include="osx-arm64-2" Platform="osx" Architecture="arm64" Partition="2" PartitionCount="2"/>
+    <SPMI_Partition Include="win-x64-1" Platform="windows" Architecture="x64" Partition="1" PartitionCount="3"/>
+    <SPMI_Partition Include="win-x64-2" Platform="windows" Architecture="x64" Partition="2" PartitionCount="3"/>
+    <SPMI_Partition Include="win-x64-3" Platform="windows" Architecture="x64" Partition="3" PartitionCount="3"/>
+    <SPMI_Partition Include="win-arm64-1" Platform="windows" Architecture="arm64" Partition="1" PartitionCount="3"/>
+    <SPMI_Partition Include="win-arm64-2" Platform="windows" Architecture="arm64" Partition="2" PartitionCount="3"/>
+    <SPMI_Partition Include="win-arm64-3" Platform="windows" Architecture="arm64" Partition="3" PartitionCount="3"/>
+    <SPMI_Partition Include="unix-x64-1" Platform="linux" Architecture="x64" Partition="1" PartitionCount="3"/>
+    <SPMI_Partition Include="unix-x64-2" Platform="linux" Architecture="x64" Partition="2" PartitionCount="3"/>
+    <SPMI_Partition Include="unix-x64-3" Platform="linux" Architecture="x64" Partition="3" PartitionCount="3"/>
+    <SPMI_Partition Include="linux-arm64-1" Platform="linux" Architecture="arm64" Partition="1" PartitionCount="3"/>
+    <SPMI_Partition Include="linux-arm64-2" Platform="linux" Architecture="arm64" Partition="2" PartitionCount="3"/>
+    <SPMI_Partition Include="linux-arm64-3" Platform="linux" Architecture="arm64" Partition="3" PartitionCount="3"/>
+    <SPMI_Partition Include="osx-arm64-1" Platform="osx" Architecture="arm64" Partition="1" PartitionCount="3"/>
+    <SPMI_Partition Include="osx-arm64-2" Platform="osx" Architecture="arm64" Partition="2" PartitionCount="3"/>
+    <SPMI_Partition Include="osx-arm64-3" Platform="osx" Architecture="arm64" Partition="3" PartitionCount="3"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(Architecture)' == 'x86'">
-    <!-- The x86 machine replays are slower than x64, so use 3 partitions for each run on x86 -->
     <SPMI_Partition Include="win-x86-1" Platform="windows" Architecture="x86" Partition="1" PartitionCount="3"/>
     <SPMI_Partition Include="win-x86-2" Platform="windows" Architecture="x86" Partition="2" PartitionCount="3"/>
     <SPMI_Partition Include="win-x86-3" Platform="windows" Architecture="x86" Partition="3" PartitionCount="3"/>


### PR DESCRIPTION
Increase partitions per platform from 2 to 3 for x64 runs to reduce overall run time.