### PR TITLE
Fix HttpStress & SslStress

### DIFF
--- a/eng/docker/build-docker-sdk.ps1
+++ b/eng/docker/build-docker-sdk.ps1
@@ -9,7 +9,7 @@ Param(
   [switch][Alias('w')]$buildWindowsContainers
 )
 
-$dotNetVersion="7.0"
+$dotNetVersion="8.0"
 $ErrorActionPreference = "Stop"
 
 $REPO_ROOT_DIR=$(git -C "$PSScriptRoot" rev-parse --show-toplevel)

--- a/eng/docker/libraries-sdk.linux.Dockerfile
+++ b/eng/docker/libraries-sdk.linux.Dockerfile
@@ -12,7 +12,7 @@ RUN ./build.sh clr+libs -runtimeconfiguration Release -configuration $CONFIGURAT
 
 FROM $SDK_BASE_IMAGE as target
 
-ARG VERSION=7.0
+ARG VERSION=8.0
 ARG CONFIGURATION=Release
 ENV _DOTNET_INSTALL_CHANNEL="$VERSION.1xx"
 

--- a/eng/docker/libraries-sdk.windows.Dockerfile
+++ b/eng/docker/libraries-sdk.windows.Dockerfile
@@ -5,7 +5,7 @@ FROM $SDK_BASE_IMAGE as target
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=7.0
+ARG VERSION=8.0
 ENV _DOTNET_INSTALL_CHANNEL="$VERSION.1xx"
 ARG CONFIGURATION=Release
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -20,7 +20,7 @@ RUN cd msquic/src/msquic/build/bin/Release && \
     $( ls ./* | cut -d "/" -f 2 | sed -r "s/(.*)/\1=\/usr\/lib\/\1/g" ) && \
     dpkg -i libmsquic_*.deb
 
-ARG VERSION=7.0
+ARG VERSION=8.0
 ARG CONFIGURATION=Release
 
 # Build the stress server

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.ps1
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.ps1
@@ -3,7 +3,7 @@
 ## Usage:
 ## ./build-local.ps1 [StressConfiguration] [LibrariesConfiguration]
 
-$Version="7.0"
+$Version="8.0"
 $RepoRoot="$(git rev-parse --show-toplevel)"
 $DailyDotnetRoot= "./.dotnet-daily"
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.sh
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/build-local.sh
@@ -5,7 +5,7 @@
 ## Usage:
 ## ./build-local.sh [StressConfiguration] [LibrariesConfiguration]
 
-version=7.0
+version=8.0
 repo_root=$(git rev-parse --show-toplevel)
 daily_dotnet_root=./.dotnet-daily
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/windows.Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/windows.Dockerfile
@@ -8,7 +8,7 @@ SHELL ["pwsh", "-Command"]
 WORKDIR /app
 COPY . .
 
-ARG VERSION=7.0
+ARG VERSION=8.0
 ARG CONFIGURATION=Release
 
 RUN dotnet build -c $env:CONFIGURATION `

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Build-Local.ps1
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Build-Local.ps1
@@ -7,7 +7,7 @@
 # In SslStress it's a thin utility to generate a runscript for running the app with the live-built testhost.
 # The main reason to use an equivalent solution in SslStress is consistency with HttpStress.
 
-$Version="7.0"
+$Version="8.0"
 $RepoRoot="$(git rev-parse --show-toplevel)"
 $DailyDotnetRoot= "./.dotnet-daily"
 

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Dockerfile
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . .
 WORKDIR /app/System.Net.Security/tests/StressTests/SslStress
 
-ARG VERSION=7.0
+ARG VERSION=8.0
 ARG CONFIGURATION=Release
 
 RUN dotnet build -c $CONFIGURATION \

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/build-local.sh
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/build-local.sh
@@ -8,7 +8,7 @@
 # In SslStress it's a thin utility to generate a runscript for running the app with the live-built testhost.
 # The main reason to use an equivalent solution in SslStress is consistency with HttpStress.
 
-version=7.0
+version=8.0
 repo_root=$(git rev-parse --show-toplevel)
 
 stress_configuration="Release"

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/windows.Dockerfile
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/windows.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY . .
 WORKDIR /app/System.Net.Security/tests/StressTests/SslStress
 
-ARG VERSION=7.0
+ARG VERSION=8.0
 ARG CONFIGURATION=Release
 
 RUN dotnet build -c $env:CONFIGURATION `


### PR DESCRIPTION
The live-built runtime became 8.0 with #78354, we need to update version settings within the stress infra.

Fixes #80706