### PR TITLE
Add the DbgDisablePagemapUse environment variable to control pagemap usage

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "createdump.h"
-#include <clrconfignocache.h>
 
 // This is for the PAL_VirtualUnwindOutOfProc read memory adapter.
 CrashInfo* g_crashInfo;

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -52,6 +52,7 @@ typedef int T_CONTEXT;
 #include <releaseholder.h>
 #ifdef HOST_UNIX
 #include <dumpcommon.h>
+#include <clrconfignocache.h>
 #include <unistd.h>
 #include <signal.h>
 #include <sys/types.h>


### PR DESCRIPTION
The default is currently opt-in. "DOTNET_DbgDisablePagemapUse=0" needs to be set to enable the pagemap checking feature. It is opt-in because it is breaking createdump testing against 8.0.