### PR TITLE
Fix overwriting of superpmi log file

### DIFF
--- a/src/coreclr/scripts/superpmi-diffs.proj
+++ b/src/coreclr/scripts/superpmi-diffs.proj
@@ -68,7 +68,7 @@
     <HelixWorkItem Include="@(SPMI_Partition)">
       <Command>$(WorkItemCommand) -arch %(HelixWorkItem.Architecture) -platform %(HelixWorkItem.Platform)</Command>
       <Timeout>$(WorkItemTimeout)</Timeout>
-      <DownloadFilesFromResults>superpmi_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).log;superpmi_download_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).log;superpmi_diff_summary_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).md;superpmi_tpdiff_summary_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).md;Asmdiffs_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).zip</DownloadFilesFromResults>
+      <DownloadFilesFromResults>superpmi_asmdiffs_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).log;superpmi_tpdiff_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).log;superpmi_download_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).log;superpmi_diff_summary_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).md;superpmi_tpdiff_summary_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).md;Asmdiffs_%(HelixWorkItem.Platform)_%(HelixWorkItem.Architecture).zip</DownloadFilesFromResults>
     </HelixWorkItem>
   </ItemGroup>
   </Project>

--- a/src/coreclr/scripts/superpmi_diffs.py
+++ b/src/coreclr/scripts/superpmi_diffs.py
@@ -196,7 +196,8 @@ def main(main_args):
         ], _exit_on_fail=True)
 
     print("Running superpmi.py asmdiffs")
-    log_file = os.path.join(log_directory, "superpmi_{}_{}.log".format(platform_name, arch_name))
+
+    log_file = os.path.join(log_directory, "superpmi_asmdiffs_{}_{}.log".format(platform_name, arch_name))
 
     overall_md_asmdiffs_summary_file = os.path.join(spmi_location, "diff_summary.md")
     if os.path.isfile(overall_md_asmdiffs_summary_file):
@@ -224,6 +225,8 @@ def main(main_args):
         failed = True
 
     print("Running superpmi.py tpdiff")
+
+    log_file = os.path.join(log_directory, "superpmi_tpdiff_{}_{}.log".format(platform_name, arch_name))
 
     overall_md_tpdiff_summary_file = os.path.join(spmi_location, "tpdiff_summary.md")
     if os.path.isfile(overall_md_tpdiff_summary_file):


### PR DESCRIPTION
The invocation of "tpdiff" was overwriting the log file generated by superpmi.py of the asmdiffs run. Use a unique log file for each invocation.

run-superpmi-diffs-job.yml is already configured to copy all `superpmi_*.log` files to the output, so these new names will get saved.