### PR TITLE
add unsupported attributes to System.Net.Security

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -218,7 +218,7 @@ internal static class MsQuicConfiguration
     private static QUIC_ALLOWED_CIPHER_SUITE_FLAGS CipherSuitePolicyToFlags(CipherSuitesPolicy cipherSuitesPolicy)
     {
         QUIC_ALLOWED_CIPHER_SUITE_FLAGS flags = QUIC_ALLOWED_CIPHER_SUITE_FLAGS.NONE;
-
+#pragma warning disable CA1416  // not supported on all platforms
         foreach (TlsCipherSuite cipher in cipherSuitesPolicy.AllowedCipherSuites)
         {
             switch (cipher)
@@ -237,6 +237,7 @@ internal static class MsQuicConfiguration
                     // ignore
                     break;
             }
+#pragma warning restore
         }
 
         if (flags == QUIC_ALLOWED_CIPHER_SUITE_FLAGS.NONE)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicy.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicy.cs
@@ -8,6 +8,8 @@ namespace System.Net.Security
     /// <summary>
     /// Specifies allowed cipher suites.
     /// </summary>
+    [UnsupportedOSPlatform("windows")]
+    [UnsupportedOSPlatform("android")]
     public sealed partial class CipherSuitesPolicy
     {
         internal CipherSuitesPolicyPal Pal { get; private set; }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicy.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicy.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 
 namespace System.Net.Security
 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Runtime.Versioning;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -674,6 +674,9 @@ namespace System.Net.Security
 
         public override Task FlushAsync(CancellationToken cancellationToken) => InnerStream.FlushAsync(cancellationToken);
 
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("freebsd")]
         public virtual Task NegotiateClientCertificateAsync(CancellationToken cancellationToken = default)
         {
             ThrowIfExceptionalOrNotAuthenticated();


### PR DESCRIPTION
fixes #57097
The method mentioned are as follow: 

1) `QueryContextClientSpecifiedSpn` powers `NegotiateAuthentication.TargetName`  on server side

https://github.com/dotnet/runtime/blob/19730e5ef332449d1a0d33c2fed1037124634753/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateAuthentication.cs#L218

It seems like the notation is not flexible enough to distinguish client vs server so I'll leave it as is. 

2) `CipherSuitesPolicyPal` supports public `CipherSuitesPolicy`. I added unsupported attributes for Windows and Android. 
The Android is interesting as the class has remark about InitializeSslContext and we throw there but the server seems to be ignored. Can you please clarify @simonrozsival ? And any reason why the class does not throw directly just like Windows? 

3) `QueryContextAssociatedName` was removed in 7.0 by #70720
4) `Renegotiate` is backend for public `NegotiateClientCertificateAsync`. Added SupportedOSPlatform attributes. 
