### PR TITLE
Don't produce ILLink package in runtime

### DIFF
--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -65,9 +65,9 @@ jobs:
 
       variables:
         - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        - _subset: tools+libs+libs.tests
+        - _subset: libs+libs.tests
         - ${{ if and(eq(parameters.runTests, false), eq(parameters.useHelix, false)) }}:
-          - _subset: tools+libs
+          - _subset: libs
         - _buildAction: ''
         - _additionalBuildArguments: ''
         - ${{ parameters.variables }}


### PR DESCRIPTION
I though https://github.com/dotnet/runtime/pull/80627 would make the runtime not to produce the package but seems like runtime is still producing it. Reverting the change that builds tools along with the libraries to stop producing the Microsoft.NET.ILLink.Tasks package
