### PR TITLE
[wasm][debug]Press alt-shift-d and open firefox debug tab attached to the blazor app

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugHost/DebugProxyHost.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/DebugProxyHost.cs
@@ -24,7 +24,7 @@ public static class DebugProxyHost
         {
             RunDevToolsProxyAsync(options, args, loggerFactory, token)
         };
-        if (!options.RunningForBlazor)
+        if (!options.RunningForBlazor || options.IsFirefoxDebugging)
             tasks.Add(RunFirefoxServerLoopAsync(options, args, loggerFactory, token));
 
         Task completedTask = await Task.WhenAny(tasks);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxDebuggerProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxDebuggerProxy.cs
@@ -5,7 +5,9 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,10 +28,13 @@ public class FirefoxDebuggerProxy : DebuggerProxyBase
     {
         if (s_tcpListener is null)
         {
+            //when running from blazor always try to open the same port(which is sent by parameter) to avoid creating a lot of remote debugging connections on firefox
+            if (IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Any(x => x.Port == proxyPort))
+                proxyPort = 0;
             s_tcpListener = new TcpListener(IPAddress.Parse("127.0.0.1"), proxyPort);
             s_tcpListener.Start();
             Console.WriteLine($"Debug proxy for firefox now listening on tcp://{s_tcpListener.LocalEndpoint}." +
-                                (browserPort >= 0 ? $" And expecting firefox at port {browserPort} ." : string.Empty));
+                                (browserPort >= 0 ? $" And expecting firefox at port {browserPort}." : string.Empty));
         }
     }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxDebuggerProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxDebuggerProxy.cs
@@ -28,9 +28,13 @@ public class FirefoxDebuggerProxy : DebuggerProxyBase
     {
         if (s_tcpListener is null)
         {
-            //when running from blazor always try to open the same port(which is sent by parameter) to avoid creating a lot of remote debugging connections on firefox
+            // If there is an existing listener on @proxyPort, then use a new dynamic port.
+            // Blazor always tries to open the same port (specified in @proxyPort) to avoid
+            // creating a lot of remote debugging connections on firefox
             if (IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Any(x => x.Port == proxyPort))
+            {
                 proxyPort = 0;
+            }
             s_tcpListener = new TcpListener(IPAddress.Parse("127.0.0.1"), proxyPort);
             s_tcpListener.Start();
             Console.WriteLine($"Debug proxy for firefox now listening on tcp://{s_tcpListener.LocalEndpoint}." +

--- a/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxDebuggerProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/Firefox/FirefoxDebuggerProxy.cs
@@ -31,7 +31,7 @@ public class FirefoxDebuggerProxy : DebuggerProxyBase
             // If there is an existing listener on @proxyPort, then use a new dynamic port.
             // Blazor always tries to open the same port (specified in @proxyPort) to avoid
             // creating a lot of remote debugging connections on firefox
-            if (IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Any(x => x.Port == proxyPort))
+            if (proxyPort != 0 && IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Any(x => x.Port == proxyPort))
             {
                 proxyPort = 0;
             }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/ProxyOptions.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/ProxyOptions.cs
@@ -28,4 +28,5 @@ public class ProxyOptions
     }
     public string? LogPath { get; set; }
     public bool RunningForBlazor { get; set; }
+    public bool IsFirefoxDebugging { get; set; }
 }


### PR DESCRIPTION
Error if firefox is not opened with remote debugging enabled on port 6000:
![image](https://user-images.githubusercontent.com/4503299/213206922-978f1b64-7795-4485-a213-5739e74f93c8.png)

Error if firefox is opened but about:debugging tab is not opened:
![image](https://user-images.githubusercontent.com/4503299/213206936-819254e4-554c-4f4f-b8fd-e5c01ff98cbc.png)

Debugging working:

https://user-images.githubusercontent.com/4503299/213207844-05aeb947-50f5-4dfe-bc20-b6a0b72827b2.mp4




The goal of this PR is give the customer a similar experience that it have when debugging on chrome/edge, on firefox.

Related to https://github.com/dotnet/aspnetcore/pull/46132

Fixes https://github.com/dotnet/runtime/issues/80043