### PR TITLE
Update cross-arm-alpine image to Ubuntu 22.04 host

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -23,7 +23,7 @@ resources:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode
 
     - container: linux_musl_arm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-arm-alpine
       env:
         ROOTFS_DIR: /crossrootfs/arm
 


### PR DESCRIPTION
cross-arm64-alpine was updated to 22.04 in https://github.com/dotnet/runtime/commit/3eacbaf0f85c6a6dc967cb490480dd256b64e5b0. There were some problems in compiler toolchain installed in the image at the time which is why we didn't updated cross-arm-alpine. Now those are fixed in the latest tags.