### PR TITLE
Disable onelocbuild in official builds

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -38,12 +38,15 @@ extends:
       #
       # Localization build
       #
-      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-        - template: /eng/common/templates/job/onelocbuild.yml
-          parameters:
-            MirrorRepo: runtime
-            LclSource: lclFilesfromPackage
-            LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
+
+      # TODO: Re-enable when https://github.com/dotnet/runtime/issues/80729 is fixed.
+
+      #- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      #  - template: /eng/common/templates/job/onelocbuild.yml
+      #    parameters:
+      #      MirrorRepo: runtime
+      #      LclSource: lclFilesfromPackage
+      #      LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
 
       #
       # Source Index Build


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/80729

Unblocks failing official builds until we have a fix for the OneLoc failure when uploading assets.