### PR TITLE
JIT: Fix GC hole for Armv8.1 Atomics

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -1425,6 +1425,7 @@ emitter::insFormat emitter::emitInsFormat(instruction ins)
 #define WID 16
 #define LNG 32
 #define NRW 64
+#define WR2 128 // writes operand 2 instead of 1
 
 // clang-format off
 /*static*/ const BYTE CodeGenInterface::instInfo[] =
@@ -1536,6 +1537,19 @@ bool emitter::emitInsIsVectorWide(instruction ins)
         return false;
 }
 
+//------------------------------------------------------------------------
+// emitInsDestIsOp2: Returns true if the instruction is one of the special
+// cases that has its destination register as the second register operand
+// instead of the first.
+//
+bool emitter::emitInsDestIsOp2(instruction ins)
+{
+    if (ins < ArrLen(CodeGenInterface::instInfo))
+        return (CodeGenInterface::instInfo[ins] & WR2) != 0;
+    else
+        return false;
+}
+
 #undef LD
 #undef ST
 #undef CMP
@@ -1543,6 +1557,7 @@ bool emitter::emitInsIsVectorWide(instruction ins)
 #undef WID
 #undef LNG
 #undef NRW
+#undef WR2
 
 /*****************************************************************************
  *
@@ -10729,6 +10744,24 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             code |= insEncodeReg_Rt(id->idReg2());             // ttttt
             code |= insEncodeReg_Rn(id->idReg3());             // nnnnn
             dst += emitOutput_Instr(dst, code);
+
+            // Some instructions with this encoding return their result in the
+            // second operand register instead of the first so we special case
+            // the GC update here and skip the common path down below.
+            if (emitInsDestIsOp2(ins))
+            {
+                if (id->idGCref() != GCT_NONE)
+                {
+                    emitGCregLiveUpd(id->idGCref(), id->idReg2(), dst);
+                }
+                else
+                {
+                    emitGCregDeadUpd(id->idReg2(), dst);
+                }
+
+                goto SKIP_GC_UPDATE;
+            }
+
             break;
 
         case IF_LS_3F: // LS_3F   .Q.........mmmmm ....ssnnnnnttttt      Vt Rn Rm
@@ -11638,6 +11671,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     if (emitInsMayWriteToGCReg(id)) // True if "id->idIns()" writes to a register than can hold GC ref.
     {
         // We assume that "idReg1" is the primary destination register for all instructions
+        assert(!emitInsDestIsOp2(ins));
         if (id->idGCref() != GCT_NONE)
         {
             emitGCregLiveUpd(id->idGCref(), id->idReg1(), dst);
@@ -11662,6 +11696,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         }
     }
 
+SKIP_GC_UPDATE:
     // Now we determine if the instruction has written to a (local variable) stack location, and either written a GC
     // ref or overwritten one.
     if (emitInsWritesToLclVarStackLoc(id) || emitInsWritesToLclVarStackLocPair(id))

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -82,6 +82,7 @@ bool emitInsIsVectorRightShift(instruction ins);
 bool emitInsIsVectorLong(instruction ins);
 bool emitInsIsVectorNarrow(instruction ins);
 bool emitInsIsVectorWide(instruction ins);
+bool emitInsDestIsOp2(instruction ins);
 emitAttr emitInsTargetRegSize(instrDesc* id);
 emitAttr emitInsLoadStoreSize(instrDesc* id);
 

--- a/src/coreclr/jit/instrsarm64.h
+++ b/src/coreclr/jit/instrsarm64.h
@@ -1172,100 +1172,100 @@ INST1(casal,       "casal",        LD|ST,  IF_LS_3E,  0x88E0FC00)
 INST1(casl,        "casl",         LD|ST,  IF_LS_3E,  0x88A0FC00)
                                    //  casl    Rm, Rt, [Xn]         LS_3E  1X001000101mmmmm 111111nnnnnttttt   88A0 FC00   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddb,      "ldaddb",       LD|ST,  IF_LS_3E,  0x38200000)
+INST1(ldaddb,      "ldaddb",   WR2|LD|ST,  IF_LS_3E,  0x38200000)
                                    //  ldaddb   Wm, Wt, [Xn]        LS_3E  00111000001mmmmm 000000nnnnnttttt   3820 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddab,     "ldaddab",      LD|ST,  IF_LS_3E,  0x38A00000)
+INST1(ldaddab,     "ldaddab",  WR2|LD|ST,  IF_LS_3E,  0x38A00000)
                                    //  ldaddab  Wm, Wt, [Xn]        LS_3E  00111000101mmmmm 000000nnnnnttttt   38A0 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddalb,    "ldaddalb",     LD|ST,  IF_LS_3E,  0x38E00000)
+INST1(ldaddalb,    "ldaddalb", WR2|LD|ST,  IF_LS_3E,  0x38E00000)
                                    //  ldaddalb Wm, Wt, [Xn]        LS_3E  00111000111mmmmm 000000nnnnnttttt   38E0 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddlb,     "ldaddlb",      LD|ST,  IF_LS_3E,  0x38600000)
+INST1(ldaddlb,     "ldaddlb",  WR2|LD|ST,  IF_LS_3E,  0x38600000)
                                    //  ldaddlb  Wm, Wt, [Xn]        LS_3E  00111000011mmmmm 000000nnnnnttttt   3860 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddh,      "ldaddh",       LD|ST,  IF_LS_3E,  0x78200000)
+INST1(ldaddh,      "ldaddh",   WR2|LD|ST,  IF_LS_3E,  0x78200000)
                                    //  ldaddh   Wm, Wt, [Xn]        LS_3E  01111000001mmmmm 000000nnnnnttttt   7820 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddah,     "ldaddah",      LD|ST,  IF_LS_3E,  0x78A00000)
+INST1(ldaddah,     "ldaddah",  WR2|LD|ST,  IF_LS_3E,  0x78A00000)
                                    //  ldaddah  Wm, Wt, [Xn]        LS_3E  01111000101mmmmm 000000nnnnnttttt   78A0 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddalh,    "ldaddalh",     LD|ST,  IF_LS_3E,  0x78E00000)
+INST1(ldaddalh,    "ldaddalh", WR2|LD|ST,  IF_LS_3E,  0x78E00000)
                                    //  ldaddalh Wm, Wt, [Xn]        LS_3E  01111000111mmmmm 000000nnnnnttttt   78E0 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddlh,     "ldaddlh",      LD|ST,  IF_LS_3E,  0x78600000)
+INST1(ldaddlh,     "ldaddlh",  WR2|LD|ST,  IF_LS_3E,  0x78600000)
                                    //  ldaddlh  Wm, Wt, [Xn]        LS_3E  01111000011mmmmm 000000nnnnnttttt   7860 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldadd,       "ldadd",        LD|ST,  IF_LS_3E,  0xB8200000)
+INST1(ldadd,       "ldadd",    WR2|LD|ST,  IF_LS_3E,  0xB8200000)
                                    //  ldadd    Rm, Rt, [Xn]        LS_3E  1X111000001mmmmm 000000nnnnnttttt   B820 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldadda,      "ldadda",       LD|ST,  IF_LS_3E,  0xB8A00000)
+INST1(ldadda,      "ldadda",   WR2|LD|ST,  IF_LS_3E,  0xB8A00000)
                                    //  ldadda   Rm, Rt, [Xn]        LS_3E  1X111000101mmmmm 000000nnnnnttttt   B8A0 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddal,     "ldaddal",      LD|ST,  IF_LS_3E,  0xB8E00000)
+INST1(ldaddal,     "ldaddal",  WR2|LD|ST,  IF_LS_3E,  0xB8E00000)
                                    //  ldaddal  Rm, Rt, [Xn]        LS_3E  1X111000111mmmmm 000000nnnnnttttt   B8E0 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldclral,     "ldclral",      LD|ST,  IF_LS_3E,  0xB8E01000)
+INST1(ldclral,     "ldclral",  WR2|LD|ST,  IF_LS_3E,  0xB8E01000)
                                    //  ldclral  Rm, Rt, [Xn]        LS_3E  1X111000111mmmmm 000100nnnnnttttt   B8E0 1000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldsetal,     "ldsetal",      LD|ST,  IF_LS_3E,  0xB8E03000)
+INST1(ldsetal,     "ldsetal",  WR2|LD|ST,  IF_LS_3E,  0xB8E03000)
                                    //  ldsetal  Rm, Rt, [Xn]        LS_3E  1X111000111mmmmm 001100nnnnnttttt   B8E0 3000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(ldaddl,      "ldaddl",       LD|ST,  IF_LS_3E,  0xB8600000)
+INST1(ldaddl,      "ldaddl",   WR2|LD|ST,  IF_LS_3E,  0xB8600000)
                                    //  ldaddl   Rm, Rt, [Xn]        LS_3E  1X111000011mmmmm 000000nnnnnttttt   B860 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(staddb,      "staddb",       ST,     IF_LS_3E,  0x38200000)
+INST1(staddb,      "staddb",   WR2|ST,     IF_LS_3E,  0x38200000)
                                    //  staddb   Wm, [Xn]            LS_3E  00111000001mmmmm 000000nnnnnttttt   3820 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(staddlb,     "staddlb",      ST,     IF_LS_3E,  0x38600000)
+INST1(staddlb,     "staddlb",  WR2|ST,     IF_LS_3E,  0x38600000)
                                    //  staddlb  Wm, [Xn]            LS_3E  00111000011mmmmm 000000nnnnnttttt   3860 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(staddh,      "staddh",       ST,     IF_LS_3E,  0x78200000)
+INST1(staddh,      "staddh",   WR2|ST,     IF_LS_3E,  0x78200000)
                                    //  staddh   Wm, [Xn]            LS_3E  01111000001mmmmm 000000nnnnnttttt   7820 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(staddlh,     "staddlh",      ST,     IF_LS_3E,  0x78600000)
+INST1(staddlh,     "staddlh",  WR2|ST,     IF_LS_3E,  0x78600000)
                                    //  staddlh  Wm, [Xn]            LS_3E  01111000011mmmmm 000000nnnnnttttt   7860 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(stadd,       "stadd",        ST,     IF_LS_3E,  0xB8200000)
+INST1(stadd,       "stadd",    WR2|ST,     IF_LS_3E,  0xB8200000)
                                    //  stadd    Rm, [Xn]            LS_3E  1X111000001mmmmm 000000nnnnnttttt   B820 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(staddl,      "staddl",       ST,     IF_LS_3E,  0xB8600000)
+INST1(staddl,      "staddl",   WR2|ST,     IF_LS_3E,  0xB8600000)
                                    //  staddl   Rm, [Xn]            LS_3E  1X111000011mmmmm 000000nnnnnttttt   B860 0000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swpb,        "swpb",         LD|ST,  IF_LS_3E,  0x38208000)
+INST1(swpb,        "swpb",     WR2|LD|ST,  IF_LS_3E,  0x38208000)
                                    //  swpb    Wm, Wt, [Xn]         LS_3E  00111000001mmmmm 100000nnnnnttttt   3820 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swpab,       "swpab",        LD|ST,  IF_LS_3E,  0x38A08000)
+INST1(swpab,       "swpab",    WR2|LD|ST,  IF_LS_3E,  0x38A08000)
                                    //  swpab   Wm, Wt, [Xn]         LS_3E  00111000101mmmmm 100000nnnnnttttt   38A0 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swpalb,      "swpalb",       LD|ST,  IF_LS_3E,  0x38E08000)
+INST1(swpalb,      "swpalb",   WR2|LD|ST,  IF_LS_3E,  0x38E08000)
                                    //  swpalb  Wm, Wt, [Xn]         LS_3E  00111000111mmmmm 100000nnnnnttttt   38E0 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swplb,       "swplb",        LD|ST,  IF_LS_3E,  0x38608000)
+INST1(swplb,       "swplb",    WR2|LD|ST,  IF_LS_3E,  0x38608000)
                                    //  swplb   Wm, Wt, [Xn]         LS_3E  00111000011mmmmm 100000nnnnnttttt   3860 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swph,        "swph",         LD|ST,  IF_LS_3E,  0x78208000)
+INST1(swph,        "swph",     WR2|LD|ST,  IF_LS_3E,  0x78208000)
                                    //  swph    Wm, Wt, [Xn]         LS_3E  01111000001mmmmm 100000nnnnnttttt   7820 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swpah,       "swpah",        LD|ST,  IF_LS_3E,  0x78A08000)
+INST1(swpah,       "swpah",    WR2|LD|ST,  IF_LS_3E,  0x78A08000)
                                    //  swpah   Wm, Wt, [Xn]         LS_3E  01111000101mmmmm 100000nnnnnttttt   78A0 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swpalh,      "swpalh",       LD|ST,  IF_LS_3E,  0x78E08000)
+INST1(swpalh,      "swpalh",   WR2|LD|ST,  IF_LS_3E,  0x78E08000)
                                    //  swpalh  Wm, Wt, [Xn]         LS_3E  01111000111mmmmm 100000nnnnnttttt   78E0 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swplh,       "swplh",        LD|ST,  IF_LS_3E,  0x78608000)
+INST1(swplh,       "swplh",    WR2|LD|ST,  IF_LS_3E,  0x78608000)
                                    //  swplh   Wm, Wt, [Xn]         LS_3E  01111000011mmmmm 100000nnnnnttttt   7860 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swp,         "swp",          LD|ST,  IF_LS_3E,  0xB8208000)
+INST1(swp,         "swp",      WR2|LD|ST,  IF_LS_3E,  0xB8208000)
                                    //  swp     Rm, Rt, [Xn]         LS_3E  1X111000001mmmmm 100000nnnnnttttt   B820 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swpa,        "swpa",         LD|ST,  IF_LS_3E,  0xB8A08000)
+INST1(swpa,        "swpa",     WR2|LD|ST,  IF_LS_3E,  0xB8A08000)
                                    //  swpa    Rm, Rt, [Xn]         LS_3E  1X111000101mmmmm 100000nnnnnttttt   B8A0 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swpal,       "swpal",        LD|ST,  IF_LS_3E,  0xB8E08000)
+INST1(swpal,       "swpal",    WR2|LD|ST,  IF_LS_3E,  0xB8E08000)
                                    //  swpal   Rm, Rt, [Xn]         LS_3E  1X111000111mmmmm 100000nnnnnttttt   B8E0 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
-INST1(swpl,        "swpl",         LD|ST,  IF_LS_3E,  0xB8608000)
+INST1(swpl,        "swpl",     WR2|LD|ST,  IF_LS_3E,  0xB8608000)
                                    //  swpl    Rm, Rt, [Xn]         LS_3E  1X111000011mmmmm 100000nnnnnttttt   B860 8000   Rm Rt Rn ARMv8.1 LSE Atomics
 
 INST1(adr,         "adr",          0,      IF_DI_1E,  0x10000000)


### PR DESCRIPTION
Unlike seemingly all other ARM instructions, the set of instructions marked by this PR actually write their result in the second operand register instead of the first. This means we were incorrectly updating GC info when emitting these instructions.

Fix #79431
Fix #80582
Fix #80584
Fix #80585
Fix #80586
Fix #80587
Fix #80588

I have not checked all the above issues, but I think it is likely they are all this underlying problem. We can reopen them if they keep reproing in GC stress.

Some more context in the investigation: https://github.com/dotnet/runtime/issues/79431#issuecomment-1385522143