### PR TITLE
[release/6.0] Allow retaining the original casing for known header values

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -8,6 +8,12 @@ namespace System.Net.Http
     /// </summary>
     internal static class GlobalHttpSettings
     {
+        // Switch to disable ignore-case matching for known header values. Enabled by default.
+        public static bool IgnoreCaseForKnownHeaderValues { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
+            "System.Net.Http.IgnoreCaseForKnownHeaderValues",
+            "DOTNET_SYSTEM_NET_HTTP_IGNORECASEFORKNOWNHEADERVALUES",
+            true);
+
         internal static class DiagnosticsHandler
         {
             public static bool EnableActivityPropagation { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -132,7 +132,9 @@ namespace System.Net.Http.Headers
                 {
                     for (int i = 0; i < knownValues.Length; i++)
                     {
-                        if (ByteArrayHelpers.EqualsOrdinalAsciiIgnoreCase(knownValues[i], headerValue))
+                        if (GlobalHttpSettings.IgnoreCaseForKnownHeaderValues
+                            ? ByteArrayHelpers.EqualsOrdinalAsciiIgnoreCase(knownValues[i], headerValue)
+                            : ByteArrayHelpers.EqualsOrdinalAscii(knownValues[i], headerValue))
                         {
                             return knownValues[i];
                         }
@@ -239,9 +241,17 @@ namespace System.Net.Http.Headers
 
             Debug.Assert(candidate is null || candidate.Length == contentTypeValue.Length);
 
-            return candidate != null && ByteArrayHelpers.EqualsOrdinalAsciiIgnoreCase(candidate, contentTypeValue) ?
-                candidate :
-                null;
+            if (candidate is not null)
+            {
+                if (GlobalHttpSettings.IgnoreCaseForKnownHeaderValues
+                    ? ByteArrayHelpers.EqualsOrdinalAsciiIgnoreCase(candidate, contentTypeValue)
+                    : ByteArrayHelpers.EqualsOrdinalAscii(candidate, contentTypeValue))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
         }
 
         private static bool TryDecodeUtf8(ReadOnlySpan<byte> input, [NotNullWhen(true)] out string? decoded)

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -78,6 +78,8 @@
          Link="ProductionCode\System\Net\Http\EmptyReadStream.cs" />
     <Compile Include="..\..\src\System\Net\Http\FormUrlEncodedContent.cs"
              Link="ProductionCode\System\Net\Http\FormUrlEncodedContent.cs" />
+    <Compile Include="..\..\src\System\Net\Http\GlobalHttpSettings.cs"
+             Link="ProductionCode\System\Net\Http\GlobalHttpSettings.cs" />
     <Compile Include="..\..\src\System\Net\Http\HeaderEncodingSelector.cs"
              Link="ProductionCode\System\Net\Http\HeaderEncodingSelector.cs" />
     <Compile Include="..\..\src\System\Net\Http\Headers\AltSvcHeaderParser.cs"


### PR DESCRIPTION
Backport of #64702 to release/6.0, gated behind an AppContext switch.

## Customer Impact

Starting with [.NET Core 2.1](https://github.com/dotnet/corefx/pull/23186) and later expanded in [.NET 5.0](https://github.com/dotnet/runtime/pull/35694), we introduced a performance optimization where we avoid allocating strings for common well-known header values.
We did this in a case-insensitive manner, so if the server sent us `Connection: close` or `Connection: CLOSE`, they would both be exposed to the user as `close`.

As services are migrating from Framework to Core, this represents a change in behavior that can't be avoided as the optimization is taking place lower in the stack before the information is exposed to the user.
Clients running different versions of .NET may therefore not agree on the exact response provided by the server, which can break scenarios such as signature validation.

We stopped doing case-insensitive matching in [.NET 7.0](https://github.com/dotnet/runtime/pull/64702), and this PR brings the option to do the same on the 6.0 LTS release to unblock migration.

## Testing

I added a targeted test to verify the expected behavior is observed if the `AppContext` switch is set.
The customer validated the new behavior using a private build of `System.Net.Http`.

## Risk

Practically zero. The change in behavior is hidden behind an `AppContext` switch.