### PR TITLE
Remove the second type parameter from CastingConverter

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/CastingConverter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Reflection;
 
 namespace System.Text.Json.Serialization.Converters
@@ -9,18 +10,18 @@ namespace System.Text.Json.Serialization.Converters
     /// <summary>
     /// Converter wrapper which casts SourceType into TargetType
     /// </summary>
-    internal sealed class CastingConverter<T, TSource> : JsonConverter<T>
+    internal sealed class CastingConverter<T> : JsonConverter<T>
     {
-        private readonly JsonConverter<TSource> _sourceConverter;
+        private readonly JsonConverter _sourceConverter;
         internal override Type? KeyType => _sourceConverter.KeyType;
         internal override Type? ElementType => _sourceConverter.ElementType;
 
         public override bool HandleNull { get; }
         internal override bool SupportsCreateObjectDelegate => _sourceConverter.SupportsCreateObjectDelegate;
 
-        internal CastingConverter(JsonConverter<TSource> sourceConverter)
+        internal CastingConverter(JsonConverter sourceConverter, bool handleNull, bool handleNullOnRead, bool handleNullOnWrite)
         {
-            Debug.Assert(typeof(T).IsInSubtypeRelationshipWith(typeof(TSource)));
+            Debug.Assert(typeof(T).IsInSubtypeRelationshipWith(sourceConverter.TypeToConvert));
             Debug.Assert(sourceConverter.SourceConverterForCastingConverter is null, "casting converters should not be layered.");
 
             _sourceConverter = sourceConverter;
@@ -30,83 +31,45 @@ namespace System.Text.Json.Serialization.Converters
             CanBePolymorphic = sourceConverter.CanBePolymorphic;
 
             // Ensure HandleNull values reflect the exact configuration of the source converter
-            HandleNullOnRead = sourceConverter.HandleNullOnRead;
-            HandleNullOnWrite = sourceConverter.HandleNullOnWrite;
-            HandleNull = sourceConverter.HandleNull;
+            HandleNullOnRead = handleNullOnRead;
+            HandleNullOnWrite = handleNullOnWrite;
+            HandleNull = handleNull;
         }
 
         internal override JsonConverter? SourceConverterForCastingConverter => _sourceConverter;
 
         public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            => CastOnRead(_sourceConverter.Read(ref reader, typeToConvert, options));
+            => JsonSerializer.UnboxOnRead<T>(_sourceConverter.ReadAsObject(ref reader, typeToConvert, options));
 
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
-            => _sourceConverter.Write(writer, CastOnWrite(value), options);
+            => _sourceConverter.WriteAsObject(writer, value, options);
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out T? value)
         {
-            bool result = _sourceConverter.OnTryRead(ref reader, typeToConvert, options, ref state, out TSource? sourceValue);
-            value = CastOnRead(sourceValue);
+            bool result = _sourceConverter.OnTryReadAsObject(ref reader, typeToConvert, options, ref state, out object? sourceValue);
+            value = JsonSerializer.UnboxOnRead<T>(sourceValue);
             return result;
         }
 
         internal override bool OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
-            => _sourceConverter.OnTryWrite(writer, CastOnWrite(value), options, ref state);
+            => _sourceConverter.OnTryWriteAsObject(writer, value, options, ref state);
 
         public override T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            => CastOnRead(_sourceConverter.ReadAsPropertyName(ref reader, typeToConvert, options));
+            => JsonSerializer.UnboxOnRead<T>(_sourceConverter.ReadAsPropertyNameAsObject(ref reader, typeToConvert, options))!;
 
         internal override T ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            => CastOnRead(_sourceConverter.ReadAsPropertyNameCore(ref reader, typeToConvert, options));
+            => JsonSerializer.UnboxOnRead<T>(_sourceConverter.ReadAsPropertyNameCoreAsObject(ref reader, typeToConvert, options))!;
 
         public override void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
-            => _sourceConverter.WriteAsPropertyName(writer, CastOnWrite(value), options);
+            => _sourceConverter.WriteAsPropertyNameAsObject(writer, value, options);
 
         internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, T value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)
-            => _sourceConverter.WriteAsPropertyNameCore(writer, CastOnWrite(value), options, isWritingExtensionDataProperty);
+            => _sourceConverter.WriteAsPropertyNameCoreAsObject(writer, value, options, isWritingExtensionDataProperty);
 
         internal override T ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)
-            => CastOnRead(_sourceConverter.ReadNumberWithCustomHandling(ref reader, handling, options));
+            => JsonSerializer.UnboxOnRead<T>(_sourceConverter.ReadNumberWithCustomHandlingAsObject(ref reader, handling, options))!;
 
         internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, T value, JsonNumberHandling handling)
-            => _sourceConverter.WriteNumberWithCustomHandling(writer, CastOnWrite(value), handling);
-
-        private static T CastOnRead(TSource? source)
-        {
-            if (default(T) is null && default(TSource) is null && source is null)
-            {
-                return default!;
-            }
-
-            if (source is T t)
-            {
-                return t;
-            }
-
-            HandleFailure(source);
-            return default!;
-
-            static void HandleFailure(TSource? source)
-            {
-                if (source is null)
-                {
-                    ThrowHelper.ThrowInvalidOperationException_DeserializeUnableToAssignNull(typeof(T));
-                }
-                else
-                {
-                    ThrowHelper.ThrowInvalidCastException_DeserializeUnableToAssignValue(typeof(TSource), typeof(T));
-                }
-            }
-        }
-
-        private static TSource CastOnWrite(T source)
-        {
-            if (default(TSource) is not null && default(T) is null && source is null)
-            {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(typeof(TSource));
-            }
-
-            return (TSource)(object?)source!;
-        }
+            => _sourceConverter.WriteNumberWithCustomHandlingAsObject(writer, value, handling);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -166,7 +166,7 @@ namespace System.Text.Json.Serialization
                     ResolvePolymorphicConverter(jsonTypeInfo, ref state) is JsonConverter polymorphicConverter)
                 {
                     Debug.Assert(!IsValueType);
-                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, options, ref state, out object? objectResult);
+                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, polymorphicConverter.TypeToConvert, options, ref state, out object? objectResult);
                     value = (TCollection)objectResult!;
                     state.ExitPolymorphicConverter(success);
                     return success;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -190,7 +190,7 @@ namespace System.Text.Json.Serialization
                     ResolvePolymorphicConverter(jsonTypeInfo, ref state) is JsonConverter polymorphicConverter)
                 {
                     Debug.Assert(!IsValueType);
-                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, options, ref state, out object? objectResult);
+                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, polymorphicConverter.TypeToConvert, options, ref state, out object? objectResult);
                     value = (TDictionary)objectResult!;
                     state.ExitPolymorphicConverter(success);
                     return success;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -107,7 +107,7 @@ namespace System.Text.Json.Serialization.Converters
                     ResolvePolymorphicConverter(jsonTypeInfo, ref state) is JsonConverter polymorphicConverter)
                 {
                     Debug.Assert(!IsValueType);
-                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, options, ref state, out object? objectResult);
+                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, polymorphicConverter.TypeToConvert, options, ref state, out object? objectResult);
                     value = (T)objectResult!;
                     state.ExitPolymorphicConverter(success);
                     return success;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Converters
             Debug.Assert(jsonParameterInfo.ShouldDeserialize);
             Debug.Assert(jsonParameterInfo.Options != null);
 
-            bool success = jsonParameterInfo.ConverterBase.TryReadAsObject(ref reader, jsonParameterInfo.Options!, ref state, out object? arg);
+            bool success = jsonParameterInfo.ConverterBase.TryReadAsObject(ref reader, TypeToConvert, jsonParameterInfo.Options!, ref state, out object? arg);
 
             if (success && !(arg == null && jsonParameterInfo.IgnoreNullTokensOnRead))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -137,7 +137,7 @@ namespace System.Text.Json.Serialization.Converters
                     ResolvePolymorphicConverter(jsonTypeInfo, ref state) is JsonConverter polymorphicConverter)
                 {
                     Debug.Assert(!IsValueType);
-                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, options, ref state, out object? objectResult);
+                    bool success = polymorphicConverter.OnTryReadAsObject(ref reader, polymorphicConverter.TypeToConvert, options, ref state, out object? objectResult);
                     value = (T)objectResult!;
                     state.ExitPolymorphicConverter(success);
                     return success;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -110,6 +110,11 @@ namespace System.Text.Json.Serialization
 
         internal abstract JsonConverter<TTarget> CreateCastingConverter<TTarget>();
 
+        /// <summary>
+        /// Set if this converter is itself a casting converter.
+        /// </summary>
+        internal virtual JsonConverter? SourceConverterForCastingConverter => null;
+
         internal abstract Type? ElementType { get; }
 
         internal abstract Type? KeyType { get; }
@@ -138,15 +143,20 @@ namespace System.Text.Json.Serialization
         // This is used internally to quickly determine the type being converted for JsonConverter<T>.
         internal abstract Type TypeToConvert { get; }
 
-        internal abstract bool OnTryReadAsObject(ref Utf8JsonReader reader, JsonSerializerOptions options, scoped ref ReadStack state, out object? value);
-        internal abstract bool TryReadAsObject(ref Utf8JsonReader reader, JsonSerializerOptions options, scoped ref ReadStack state, out object? value);
+        internal abstract object? ReadAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);
+        internal abstract bool OnTryReadAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out object? value);
+        internal abstract bool TryReadAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out object? value);
+        internal abstract object? ReadAsPropertyNameAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);
+        internal abstract object? ReadAsPropertyNameCoreAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);
+        internal abstract object? ReadNumberWithCustomHandlingAsObject(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options);
 
+        internal abstract void WriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options);
+        internal abstract bool OnTryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state);
         internal abstract bool TryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state);
+        internal abstract void WriteAsPropertyNameAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options);
+        internal abstract void WriteAsPropertyNameCoreAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, bool isWritingExtensionDataProperty);
+        internal abstract void WriteNumberWithCustomHandlingAsObject(Utf8JsonWriter writer, object? value, JsonNumberHandling handling);
 
-        /// <summary>
-        /// Loosely-typed WriteToPropertyName() that forwards to strongly-typed WriteToPropertyName().
-        /// </summary>
-        internal abstract void WriteAsPropertyNameCoreAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, bool isWritingExtensionDataProperty);
 
         // Whether a type (ConverterStrategy.Object) is deserialized using a parameterized constructor.
         internal virtual bool ConstructorIsParameterized { get; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -61,8 +61,16 @@ namespace System.Text.Json.Serialization
             return converter;
         }
 
+        internal sealed override object? ReadAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
         internal sealed override bool OnTryReadAsObject(
             ref Utf8JsonReader reader,
+            Type typeToConvert,
             JsonSerializerOptions options,
             scoped ref ReadStack state,
             out object? value)
@@ -74,9 +82,49 @@ namespace System.Text.Json.Serialization
 
         internal sealed override bool TryReadAsObject(
             ref Utf8JsonReader reader,
+            Type typeToConvert,
             JsonSerializerOptions options,
             scoped ref ReadStack state,
             out object? value)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
+        internal sealed override object? ReadAsPropertyNameAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
+        internal sealed override object? ReadAsPropertyNameCoreAsObject(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
+        internal sealed override object? ReadNumberWithCustomHandlingAsObject(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
+        internal sealed override void WriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
+        internal sealed override bool OnTryWriteAsObject(
+            Utf8JsonWriter writer,
+            object? value,
+            JsonSerializerOptions options,
+            ref WriteStack state)
         {
             Debug.Fail("We should never get here.");
 
@@ -94,12 +142,27 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException();
         }
 
+        internal sealed override void WriteAsPropertyNameAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
         internal sealed override Type TypeToConvert => null!;
 
         internal sealed override void WriteAsPropertyNameCoreAsObject(
-            Utf8JsonWriter writer, object value,
+            Utf8JsonWriter writer,
+            object? value,
             JsonSerializerOptions options,
             bool isWritingExtensionDataProperty)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
+        internal sealed override void WriteNumberWithCustomHandlingAsObject(Utf8JsonWriter writer, object? value, JsonNumberHandling handling)
         {
             Debug.Fail("We should never get here.");
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -81,5 +81,52 @@ namespace System.Text.Json
 
         internal static bool IsValidUnmappedMemberHandlingValue(JsonUnmappedMemberHandling handling) =>
             handling is JsonUnmappedMemberHandling.Skip or JsonUnmappedMemberHandling.Disallow;
+
+        [return: NotNullIfNotNull(nameof(value))]
+        internal static T? UnboxOnRead<T>(object? value)
+        {
+            if (value is null)
+            {
+                if (default(T) is not null)
+                {
+                    // Casting null values to a non-nullable struct throws NullReferenceException.
+                    ThrowUnableToCastValue(value);
+                }
+
+                return default;
+            }
+
+            if (value is T typedValue)
+            {
+                return typedValue;
+            }
+
+            ThrowUnableToCastValue(value);
+            return default!;
+
+            static void ThrowUnableToCastValue(object? value)
+            {
+                if (value is null)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_DeserializeUnableToAssignNull(declaredType: typeof(T));
+                }
+                else
+                {
+                    ThrowHelper.ThrowInvalidCastException_DeserializeUnableToAssignValue(typeOfValue: value.GetType(), declaredType: typeof(T));
+                }
+            }
+        }
+
+        [return: NotNullIfNotNull(nameof(value))]
+        internal static T? UnboxOnWrite<T>(object? value)
+        {
+            if (default(T) is not null && value is null)
+            {
+                // Casting null values to a non-nullable struct throws NullReferenceException.
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(typeof(T));
+            }
+
+            return (T?)value;
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
@@ -277,32 +277,13 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         internal sealed override void SerializeAsObject(Utf8JsonWriter writer, object? rootValue, bool isInvokedByPolymorphicConverter = false)
-            => Serialize(writer, UnboxValue(rootValue), rootValue, isInvokedByPolymorphicConverter);
+            => Serialize(writer, JsonSerializer.UnboxOnWrite<T>(rootValue), rootValue, isInvokedByPolymorphicConverter);
 
         internal sealed override Task SerializeAsObjectAsync(Stream utf8Json, object? rootValue, CancellationToken cancellationToken, bool isInvokedByPolymorphicConverter = false)
-            => SerializeAsync(utf8Json, UnboxValue(rootValue), cancellationToken, rootValue, isInvokedByPolymorphicConverter);
+            => SerializeAsync(utf8Json, JsonSerializer.UnboxOnWrite<T>(rootValue), cancellationToken, rootValue, isInvokedByPolymorphicConverter);
 
         internal sealed override void SerializeAsObject(Stream utf8Json, object? rootValue, bool isInvokedByPolymorphicConverter = false)
-            => Serialize(utf8Json, UnboxValue(rootValue), rootValue, isInvokedByPolymorphicConverter);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private T? UnboxValue(object? value)
-        {
-            if (
-#if NETCOREAPP
-                // Treated as a constant by recent versions of the JIT.
-                typeof(T).IsValueType &&
-#else
-                Type.IsValueType &&
-#endif
-                default(T) is not null && value is null)
-            {
-                // Casting null values to a non-nullable struct throws NullReferenceException, replace with JsonException
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(Type);
-            }
-
-            return (T?)value;
-        }
+            => Serialize(utf8Json, JsonSerializer.UnboxOnWrite<T>(rootValue), rootValue, isInvokedByPolymorphicConverter);
 
         // Fast-path serialization in source gen has not been designed with streaming in mind.
         // Even though it's not used in streaming by default, we can sometimes try to turn it on


### PR DESCRIPTION
The `CastingConverter<TSource, TTarget>` class is an internal adapter used for custom converters whose declared type doesn't match that of the serialized member they are being assigned to. The problem with the current implementation is that `CastingConverter` uses two type parameters, which is contributing to a quadratic explosion of generic specializations in NativeAOT:

```
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Text.Json.JsonElement>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Boolean>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Byte>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Char>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.DateOnly>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.DateTime>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.DateTimeOffset>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Decimal>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Double>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Guid>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Int16>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Int32>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Int64>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.SByte>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Single>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.TimeOnly>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.TimeSpan>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.UInt16>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.UInt32>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.UInt64>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.Collections.Generic.KeyValuePair`2<System.__Canon,System.__Canon>>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.__Canon,System.__Canon>.                                                                           384
System.Text.Json.Serialization.Converters.CastingConverter`2<System.Text.Json.JsonElement,System.Collections.Generic.KeyValuePair`2<System.__Canon,System.__Canon>>.                                                                           376
System.Text.Json.Serialization.Converters.CastingConverter`2<System.Text.Json.JsonElement,System.__Canon>.                                                                           376
System.Text.Json.Serialization.Converters.CastingConverter`2<System.Boolean,System.Collections.Generic.KeyValuePair`2<System.__Canon,System.__Canon>>.                                                                           376
System.Text.Json.Serialization.Converters.CastingConverter`2<System.Boolean,System.__Canon>.                                                                           376
System.Text.Json.Serialization.Converters.CastingConverter`2<System.Byte,System.Collections.Generic.KeyValuePair`2<System.__Canon,System.__Canon>>.                                                                           376
System.Text.Json.Serialization.Converters.CastingConverter`2<System.Byte,System.__Canon>.                                                                           376
System.Text.Json.Serialization.Converters.CastingConverter`2<System.Char,System.Collections.Generic.KeyValuePair`2<System.__Canon,System.__Canon>>.                                                                           376
System.Text.Json.Serialization.Converters.CastingConverter`2<System.Char,System.__Canon>.      
```

This PR relaxes the implementation so that `CastingConverter` references and consumes the underlying converter as a weakly typed `JsonConverter` instance. This change can regress runtime performance in certain scenaria due to added boxing/virtual calls, but this should only impact members that are using converters polymorphically -- a relatively rare occurrence.

cc @eerhardt @jkotas