### PR TITLE
Updating stind_ref.il test to actually use stind_ref

### DIFF
--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_ref.il
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/stind_ref.il
@@ -12,16 +12,23 @@
 .method public static	int32 main() {
 .entrypoint
 .maxstack		2
-.locals	(class stind_ref)
-	newobj	instance	void stind_ref::stind_ref()
-	stloc	0
-	ldloca		0
-	ldind.ref
-	ldloc	0
-	ceq
-	brfalse		FAIL
-	ldc.i4 100
-	ret
+.locals	(class stind_ref, class stind_ref&)
+    newobj	instance	void stind_ref::stind_ref()
+    stloc.0
+    ldloca.s 0
+    stloc.1
+    ldloc.1
+    ldnull
+    stind.ref
+    ldloc.1
+    ldloc.0
+    stind.ref
+    ldloc.0
+    ldloc.1
+    ldind.ref
+    bne.un.s FAIL
+    ldc.i4.s 100
+    ret
 FAIL:
 	ldc.i4	0x0
 	ret


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/78867

Straight-forward change. Sets the value by address to `null` then sets it back to the original value.