### PR TITLE
[wasm] WBT: Add `submit-wbt-helix` make target

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -118,6 +118,18 @@ submit-debugger-tests-helix: build-debugger-tests-helix
 		$(_MSBUILD_WASM_BUILD_ARGS) \
 		$(MSBUILD_ARGS)
 
+submit-wbt-helix:
+	PATH="$(JSVU):$(PATH)" \
+		$(DOTNET) build $(TOP)/src/mono/wasm/Wasm.Build.Tests/ /v:m /p:ArchiveTests=true /t:ArchiveTests $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS) && \
+	EMSDK_PATH=$(EMSDK_PATH) BUILD_REASON=wasm-test SYSTEM_TEAMPROJECT=public BUILD_REPOSITORY_NAME=dotnet/runtime BUILD_SOURCEBRANCH=main \
+		$(TOP)/eng/common/msbuild.sh --ci -restore $(TOP)/src/libraries/sendtohelix.proj \
+		/p:TestRunNamePrefixSuffix=WasmBuildTests /p:HelixBuild=`date "+%Y%m%d.%H%M"` /p:Creator=`whoami` \
+		/bl:$(TOP)/artifacts/log/$(CONFIG)/SendToHelix.binlog -v:m -p:HelixTargetQueue=$(HELIX_TARGET_QUEUE) \
+		/p:RuntimeFlavor=mono /p:TargetRuntimeIdentifier= /p:MonoForceInterpreter= /p:TestScope=innerloop \
+		/p:_Scenarios=buildwasmapps \
+		$(_MSBUILD_WASM_BUILD_ARGS) \
+		$(MSBUILD_ARGS)
+
 submit-tests-helix:
 	echo "\n** This will submit all the available test zip files to helix **\n"
 	EMSDK_PATH=$(EMSDK_PATH) BUILD_REASON=wasm-test SYSTEM_TEAMPROJECT=public BUILD_REPOSITORY_NAME=dotnet/runtime BUILD_SOURCEBRANCH=main \

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -97,7 +97,7 @@ run-tests-%:
 	EMSDK_PATH=$(EMSDK_PATH) PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
 run-build-tests:
-	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/mono/wasm//Wasm.Build.Tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
+	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/mono/wasm/Wasm.Build.Tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)
 
 run-browser-tests-%:
 	PATH="$(GECKODRIVER):$(CHROMEDRIVER):$(PATH)" XHARNESS_COMMAND="test-browser --browser=$(XHARNESS_BROWSER)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) $(MSBUILD_ARGS)

--- a/src/mono/wasm/Wasm.Build.Tests/README.md
+++ b/src/mono/wasm/Wasm.Build.Tests/README.md
@@ -6,9 +6,11 @@ being generated.
 
 - When running locally, it tests against a local workload install (based on `artifacts`)
   - but this can be turned off with `/p:TestUsingWorkloads=false`
-  - in which case, it will run against `emsdk` from `EMSDK_PATH`
+  - in which case, it will run against a sdk that has updated workload
+    manifests for `wasm-tools*`, but does not have the workload installed.
+    Typically installed in `artifacts/bin/dotnet-none`.
 
-- On CI, both workload, and emsdk cases are tested
+- On CI, both workload, and no-workload cases are tested
 
 - Running:
 
@@ -21,7 +23,7 @@ Windows: `.\dotnet.cmd build .\src\mono\wasm\BuildWasmApps\Wasm.Build.Tests\Wasm
 ## Running on helix
 
 The wasm.build.tests are built, and sent as a payload to helix, alongwith
-either emsdk+tasks+targets, or sdk+workload. And on helix the individual unit
+either sdk+no-workload-installed, or sdk+workload. And on helix the individual unit
 tests generate test projects, and build those.
 
 ## About the tests
@@ -57,3 +59,4 @@ For this, the builds get cached using `BuildArgs` as the key.
 ## Useful environment variables
 
 - `SHOW_BUILD_OUTPUT` - will show the build output to the console
+- `SKIP_PROJECT_CLEANUP` - won't remove the temporary project directories generated for the tests


### PR DESCRIPTION
- add a new `submit-wbt-helix` target which can used to submit Wasm.Build.Tests to helix directly from a local dev box
- And update documentation