### PR TITLE
Fix use of span local in WebSocketHandle.ConnectAsync

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -179,9 +179,9 @@ namespace System.Net.WebSockets
 
                 if (options.DangerousDeflateOptions is not null && response.Headers.TryGetValues(HttpKnownHeaderNames.SecWebSocketExtensions, out IEnumerable<string>? extensions))
                 {
-                    foreach (ReadOnlySpan<char> extension in extensions)
+                    foreach (string extension in extensions)
                     {
-                        if (extension.TrimStart().StartsWith(ClientWebSocketDeflateConstants.Extension))
+                        if (extension.AsSpan().TrimStart().StartsWith(ClientWebSocketDeflateConstants.Extension))
                         {
                             negotiatedDeflateOptions = ParseDeflateOptions(extension, options.DangerousDeflateOptions);
                             break;


### PR DESCRIPTION
C# doesn't currently permit ref struct locals in async methods.  A bug allowed one when used as the iteration variable of a foreach,  and that was just fixed by https://github.com/dotnet/roslyn/pull/66264.  We're erroneously using such a local in WebSocketHandle, and it's preventing ingestion of an updated compiler.