### PR TITLE
Fix TargetOS value `linux` instead of `Unix`

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -30,7 +30,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     <TargetOS Condition="$(RuntimeIdentifier.StartsWith('win'))">windows</TargetOS>
     <TargetOS Condition="$(RuntimeIdentifier.StartsWith('osx'))">osx</TargetOS>
     <TargetOS Condition="$(RuntimeIdentifier.StartsWith('freebsd'))">freebsd</TargetOS>
-    <TargetOS Condition="$(RuntimeIdentifier.StartsWith('linux-musl')) OR $(RuntimeIdentifier.StartsWith('alpine'))">linux-musl</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == ''">linux</TargetOS>
     <NativeDebugSymbols Condition="$(DebugSymbols) == 'true' or ($(DebugType) != 'none' and $(DebugType) != '')">true</NativeDebugSymbols>
     <!-- Workaround for https://github.com/dotnet/runtimelab/issues/771 -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -27,9 +27,11 @@ The .NET Foundation licenses this file to you under the MIT license.
     <IlcFrameworkNativePath Condition="'$(IlcPath)' != '' and '$(IlcFrameworkNativePath)' == ''">$(IlcPath)\framework\</IlcFrameworkNativePath>
     <IlcFrameworkNativePath Condition="'$(IlcFrameworkNativePath)' == '' and '$(IlcFrameworkPath)' != ''">$(IlcFrameworkPath)</IlcFrameworkNativePath>
     <IlcMibcPath Condition="'$(IlcPath)' != '' and '$(IlcMibcPath)' == ''">$(IlcPath)\mibc\</IlcMibcPath>
-    <TargetOS Condition="'$([MSBuild]::IsOSPlatform(Windows))' == 'true'">windows</TargetOS>
-    <TargetOS Condition="'$([MSBuild]::IsOSPlatform(OSX))' == 'true'">osx</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == ''">$(OS)</TargetOS>
+    <TargetOS Condition="$(RuntimeIdentifier.StartsWith('win'))">windows</TargetOS>
+    <TargetOS Condition="$(RuntimeIdentifier.StartsWith('osx'))">osx</TargetOS>
+    <TargetOS Condition="$(RuntimeIdentifier.StartsWith('freebsd'))">freebsd</TargetOS>
+    <TargetOS Condition="$(RuntimeIdentifier.StartsWith('linux-musl')) OR $(RuntimeIdentifier.StartsWith('alpine'))">linux-musl</TargetOS>
+    <TargetOS Condition="'$(TargetOS)' == ''">linux</TargetOS>
     <NativeDebugSymbols Condition="$(DebugSymbols) == 'true' or ($(DebugType) != 'none' and $(DebugType) != '')">true</NativeDebugSymbols>
     <!-- Workaround for https://github.com/dotnet/runtimelab/issues/771 -->
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>


### PR DESCRIPTION
Regression from https://github.com/dotnet/runtime/commit/4ece8f0e73c72271b3e4afa95bfeb7d28ec50869 (see `src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets`).

Daily build of SDK (`8.0.100-alpha.1.23068.3`) is failing with:

```sh
$  dotnet publish -o dist -p:PublishAot=true
...
  foo -> /foo/bin/Debug/net8.0/linux-arm64/foo.dll
  Generating native code
  Unhandled exception. System.CommandLine.CommandLineException: Target OS 'Unix' is not supported
     at System.CommandLine.Helpers.GetTargetOS(String) in /_/src/coreclr/tools/Common/CommandLineHelpers.cs:line 82
     at System.CommandLine.Argument`1.<>c__DisplayClass5_0.<.ctor>b__1(ArgumentResult, Object& )
     at System.CommandLine.Parsing.ArgumentResult.Convert(Argument)
     at System.CommandLine.Parsing.ArgumentResult.GetArgumentConversionResult()
     at System.CommandLine.Parsing.ParseResultVisitor.ValidateAndConvertArgumentResult(ArgumentResult)
     at System.CommandLine.Parsing.ParseResultVisitor.ValidateAndConvertOptionResult(OptionResult)
     at System.CommandLine.Parsing.ParseResultVisitor.Stop()
     at System.CommandLine.Parsing.Parser.Parse(IReadOnlyList`1, String )
     at ILCompiler.Program.Main(String[]) in /_/src/coreclr/tools/aot/ILCompiler/Program.cs:line 672
  Aborted
/root/.nuget/packages/microsoft.dotnet.ilcompiler/8.0.0-alpha.1.23067.2/build/Microsoft.NETCore.Native.targets(281,5): error MSB3073: The command ""/root/.nuget/packages/runtime.linux-arm64.microsoft.dotnet.ilcompiler/8.0.0-alpha.1.23067.2/tools/ilc" @"obj/Debug/net8.0/linux-arm64/native/foo.ilc.rsp"" exited with code 134. [/foo/foo.csproj]
```

copied this block: https://github.com/am11/runtime/blob/feature/nativeaot/build-integration2/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets#L5-L8 plus [a line](https://github.com/dotnet/runtime/pull/80323/files#diff-49438f70de24dbf3d1ae33807787838aee977e2c5486e7309a54b63119f44d02R7) from @Thefrank's PR.