### PR TITLE
[mono][interp] Properly initialize fields of LocalValue

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -8673,6 +8673,8 @@ interp_fold_unop (TransformData *td, LocalValue *local_defs, InterpInst *ins)
 	}
 
 	local_ref_count [sreg]--;
+	result.ins = ins;
+	result.ref_count = 0;
 	local_defs [dreg] = result;
 
 	return ins;
@@ -8850,6 +8852,8 @@ interp_fold_binop (TransformData *td, LocalValue *local_defs, InterpInst *ins, g
 
 	local_ref_count [sreg1]--;
 	local_ref_count [sreg2]--;
+	result.ins = ins;
+	result.ref_count = 0;
 	local_defs [dreg] = result;
 	return ins;
 }


### PR DESCRIPTION
We were storing uninitialized values. Bug caught with valgrind, hopefully fixes some real crashes.