### PR TITLE
Improve StringComparer.OrdinalIgnoreCase.Compare perf

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/StringComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/StringComparer.cs
@@ -318,7 +318,7 @@ namespace System
 
             if (_ignoreCase)
             {
-                return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+                return System.Globalization.Ordinal.CompareStringIgnoreCase(ref x.GetRawStringData(), x.Length, ref y.GetRawStringData(), y.Length);
             }
 
             return string.CompareOrdinal(x, y);
@@ -418,7 +418,25 @@ namespace System
         {
         }
 
-        public override int Compare(string? x, string? y) => string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+        public override int Compare(string? x, string? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x == null)
+            {
+                return -1;
+            }
+
+            if (y == null)
+            {
+                return 1;
+            }
+
+            return System.Globalization.Ordinal.CompareStringIgnoreCase(ref x.GetRawStringData(), x.Length, ref y.GetRawStringData(), y.Length);
+        }
 
         public override bool Equals(string? x, string? y)
         {


### PR DESCRIPTION
Give OrdinalComparer's Compare method the same treatment as its Equals method.

|  Method |         Toolchain | Length |      Mean |     Error |    StdDev | Ratio |
|-------- |------------------ |------- |----------:|----------:|----------:|------:|
| Compare | \main\corerun.exe |      1 |  5.427 ns | 0.1309 ns | 0.1286 ns |  1.00 |
| Compare |   \pr\corerun.exe |      1 |  3.218 ns | 0.0150 ns | 0.0133 ns |  0.59 |
|         |                   |        |           |           |           |       |
| Compare | \main\corerun.exe |      8 |  9.612 ns | 0.0561 ns | 0.0469 ns |  1.00 |
| Compare |   \pr\corerun.exe |      8 |  6.864 ns | 0.0292 ns | 0.0259 ns |  0.71 |
|         |                   |        |           |           |           |       |
| Compare | \main\corerun.exe |     16 | 13.942 ns | 0.0572 ns | 0.0507 ns |  1.00 |
| Compare |   \pr\corerun.exe |     16 | 11.009 ns | 0.2097 ns | 0.1859 ns |  0.79 |
|         |                   |        |           |           |           |       |
| Compare | \main\corerun.exe |     32 | 23.097 ns | 0.0385 ns | 0.0300 ns |  1.00 |
| Compare |   \pr\corerun.exe |     32 | 20.088 ns | 0.0599 ns | 0.0500 ns |  0.87 |
|         |                   |        |           |           |           |       |
| Compare | \main\corerun.exe |     64 | 40.654 ns | 0.1745 ns | 0.1632 ns |  1.00 |
| Compare |   \pr\corerun.exe |     64 | 39.504 ns | 0.4239 ns | 0.3965 ns |  0.97 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Linq;

[MemoryDiagnoser]
public partial class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private string _a, _b;

    [Params(1, 8, 16, 32, 64)]
    public int Length { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        _a = string.Concat(Enumerable.Repeat('a', Length));
        _b = _a[0..^1] + "b";
    }

    [Benchmark]
    public int Compare() => StringComparer.OrdinalIgnoreCase.Compare(_a, _b);
}
```