### PR TITLE
NativeAOT: Don't check time budget in inliner when --Ot is set

### DIFF
--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -488,8 +488,13 @@ bool DefaultPolicy::BudgetCheck() const
     // The strategy tracks the amout of inlining done so far,
     // so it performs the actual check.
     //
-    InlineStrategy* strategy   = m_RootCompiler->m_inlineStrategy;
-    const bool      overBudget = strategy->BudgetCheck(EstimatedTotalILSize());
+    InlineStrategy* strategy = m_RootCompiler->m_inlineStrategy;
+
+    const bool preferSpeed = m_RootCompiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_SPEED_OPT);
+    const bool isAot       = m_RootCompiler->opts.IsReadyToRun();
+
+    // Ignore time budget for AOT + PreferSpeed, otherwise check if we run out of it.
+    const bool overBudget = !(isAot && preferSpeed) && strategy->BudgetCheck(EstimatedTotalILSize());
 
     if (overBudget)
     {

--- a/src/coreclr/jit/inlinepolicy.cpp
+++ b/src/coreclr/jit/inlinepolicy.cpp
@@ -490,11 +490,11 @@ bool DefaultPolicy::BudgetCheck() const
     //
     InlineStrategy* strategy = m_RootCompiler->m_inlineStrategy;
 
-    const bool preferSpeed = m_RootCompiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_SPEED_OPT);
-    const bool isAot       = m_RootCompiler->opts.IsReadyToRun();
+    const bool isPrejit   = m_RootCompiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT);
+    const bool isSpeedOpt = m_RootCompiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_SPEED_OPT);
 
     // Ignore time budget for AOT + PreferSpeed, otherwise check if we run out of it.
-    const bool overBudget = !(isAot && preferSpeed) && strategy->BudgetCheck(EstimatedTotalILSize());
+    const bool overBudget = !(isPrejit && isSpeedOpt) && strategy->BudgetCheck(EstimatedTotalILSize());
 
     if (overBudget)
     {


### PR DESCRIPTION
For AOT + "PreferSpeed" (which is `--Ot`) we can afford more time to spend in the inliner and process more methods. We don't currently have jit-diff tools for NativeAOT (I'm trying to implement it) so I can't share the exact diffs for Hello World but from what I see it found a couple of methods where it previously gave up due to "ran out of time budget" e.g. inlined a couple of `System.String:FillStringChecked` - +2Kb for the object file.

Note: we still have that depth limitation so we won't stuck in the inliner forever anyway.

