### PR TITLE
Fix dynamic class zeroing

### DIFF
--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -96,9 +96,9 @@ struct ThreadLocalModule
             LIMITED_METHOD_CONTRACT;
         }
 
-        LOADERHANDLE        m_hGCStatics;
-        LOADERHANDLE        m_hNonGCStatics;
-        PTR_LoaderAllocator m_pLoaderAllocator;
+        LOADERHANDLE        m_hGCStatics = NULL;
+        LOADERHANDLE        m_hNonGCStatics = NULL;
+        PTR_LoaderAllocator m_pLoaderAllocator = NULL;
     };
     typedef DPTR(CollectibleDynamicEntry) PTR_CollectibleDynamicEntry;
 


### PR DESCRIPTION
Recent change in the `ThreadLocalModule::AllocateDynamicClass` has accidentally removed zeroing for new  `CollectibleDynamicEntry` instances. That leads to crashes when running code in an unloadable context.
It got exposed by weekly coreclr test runs with the `runincontext` option.

This change fixes that.