### PR TITLE
NativeAOT: devirtualize isinst/castclass for monomorphic cases

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5735,6 +5735,9 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
             //
             canExpandInline = true;
             exactCls        = actualImplCls;
+
+            JITDUMP("'%s' interface has a single implementation - '%s', using that to inline isinst/castclass.",
+                    eeGetClassName(pResolvedToken->hClass), eeGetClassName(actualImplCls));
         }
         else if (isCastClass)
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/80828

Luckily, we already have JIT-EE API to get **exact** list of implementations/subclasses for given type.

```csharp
interface IMyInterface{} // this interface has a single implementation

class Program : IMyInterface
{
    static void Main()
    {
        Case1(new Program());
        Case2(new Program());
    }


    [MethodImpl(MethodImplOptions.NoInlining)]
    static bool Case1(object o) => o is IMyInterface;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static IMyInterface Case2(object o) => (IMyInterface)o;
}
```

### Previous NativeAOT codegen:
```asm
; Method Program:Case1(System.Object):bool
       sub      rsp, 40
       mov      rdx, rcx
       lea      rcx, [(reloc)]
       call     CORINFO_HELP_ISINSTANCEOFINTERFACE
       test     rax, rax
       setne    al
       movzx    rax, al
       add      rsp, 40
       ret      
; Total bytes of code: 33


; Method Program:Case2(System.Object):IMyInterface
       sub      rsp, 40
       mov      rdx, rcx
       lea      rcx, [(reloc)]
       call     CORINFO_HELP_CHKCASTINTERFACE
       nop      
       add      rsp, 40
       ret      
; Total bytes of code: 25
```

### New NativeAOT codegen:
```asm
; Method Program:Case1(System.Object):bool
       test     rcx, rcx
       je       SHORT G_M13626_IG05
       lea      rax, [(reloc)]
       cmp      qword ptr [rcx], rax
       je       SHORT G_M13626_IG05
       xor      rcx, rcx
G_M13626_IG05:
       xor      eax, eax
       test     rcx, rcx
       setne    al
       ret      
; Total bytes of code: 28


; Method Program:Case2(System.Object):IMyInterface
       sub      rsp, 40
       mov      rdx, rcx
       mov      rax, rdx
       test     rax, rax
       je       SHORT G_M12806_IG05
       lea      rcx, [(reloc)]
       cmp      qword ptr [rax], rcx
       je       SHORT G_M12806_IG05
       mov      rcx, qword ptr [rsp+20H]
       call     CORINFO_HELP_CHKCASTINTERFACE ;; this is used to throw InvalidCastException only
G_M12806_IG05:
       nop      
       add      rsp, 40
       ret      
; Total bytes of code: 43
```