### PR TITLE
Remove uses of `TypeInfo` from the reflection stack

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/ConstructorPolicies.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/ConstructorPolicies.cs
@@ -19,9 +19,9 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Reflection implementation")]
-        public sealed override IEnumerable<ConstructorInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        public sealed override IEnumerable<ConstructorInfo> GetDeclaredMembers(Type type)
         {
-            return typeInfo.DeclaredConstructors;
+            return type.GetConstructors(DeclaredOnlyLookup);
         }
 
         public sealed override IEnumerable<ConstructorInfo> CoreGetDeclaredMembers(RuntimeTypeInfo type, NameFilter? optionalNameFilter, RuntimeTypeInfo reflectedType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/EventPolicies.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/EventPolicies.cs
@@ -19,9 +19,9 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Reflection implementation")]
-        public sealed override IEnumerable<EventInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        public sealed override IEnumerable<EventInfo> GetDeclaredMembers(Type type)
         {
-            return typeInfo.DeclaredEvents;
+            return type.GetEvents(DeclaredOnlyLookup);
         }
 
         public sealed override IEnumerable<EventInfo> CoreGetDeclaredMembers(RuntimeTypeInfo type, NameFilter? optionalNameFilter, RuntimeTypeInfo reflectedType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/FieldPolicies.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/FieldPolicies.cs
@@ -19,9 +19,9 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Reflection implementation")]
-        public sealed override IEnumerable<FieldInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        public sealed override IEnumerable<FieldInfo> GetDeclaredMembers(Type type)
         {
-            return typeInfo.DeclaredFields;
+            return type.GetFields(DeclaredOnlyLookup);
         }
 
         public sealed override IEnumerable<FieldInfo> CoreGetDeclaredMembers(RuntimeTypeInfo type, NameFilter? optionalNameFilter, RuntimeTypeInfo reflectedType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/MemberPolicies.cs
@@ -25,9 +25,9 @@ namespace System.Reflection.Runtime.BindingFlagSupport
         //=================================================================================================================
 
         //
-        // Returns all of the directly declared members on the given TypeInfo.
+        // Returns all of the directly declared members on the given Type.
         //
-        public abstract IEnumerable<M> GetDeclaredMembers(TypeInfo typeInfo);
+        public abstract IEnumerable<M> GetDeclaredMembers(Type type);
 
         //
         // Returns all of the directly declared members on the given TypeInfo whose name matches optionalNameFilter. If optionalNameFilter is null,
@@ -188,6 +188,8 @@ namespace System.Reflection.Runtime.BindingFlagSupport
             // Either way, we can trust Reflection's result here.
             return false;
         }
+
+        protected const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
         //
         // This returns a fixed value from 0 to MemberIndex.Count-1 with each possible type of M

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/MethodPolicies.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/MethodPolicies.cs
@@ -19,9 +19,9 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Reflection implementation")]
-        public sealed override IEnumerable<MethodInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        public sealed override IEnumerable<MethodInfo> GetDeclaredMembers(Type type)
         {
-            return typeInfo.DeclaredMethods;
+            return type.GetMethods(DeclaredOnlyLookup);
         }
 
         public sealed override IEnumerable<MethodInfo> CoreGetDeclaredMembers(RuntimeTypeInfo type, NameFilter? optionalNameFilter, RuntimeTypeInfo reflectedType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/NestedTypePolicies.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/NestedTypePolicies.cs
@@ -29,9 +29,9 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Reflection implementation")]
-        public sealed override IEnumerable<Type> GetDeclaredMembers(TypeInfo typeInfo)
+        public sealed override IEnumerable<Type> GetDeclaredMembers(Type type)
         {
-            return typeInfo.DeclaredNestedTypes;
+            return type.GetNestedTypes(DeclaredOnlyLookup);
         }
 
         public sealed override IEnumerable<Type> CoreGetDeclaredMembers(RuntimeTypeInfo type, NameFilter? optionalNameFilter, RuntimeTypeInfo reflectedType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/PropertyPolicies.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/PropertyPolicies.cs
@@ -19,9 +19,9 @@ namespace System.Reflection.Runtime.BindingFlagSupport
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Reflection implementation")]
-        public sealed override IEnumerable<PropertyInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        public sealed override IEnumerable<PropertyInfo> GetDeclaredMembers(Type type)
         {
-            return typeInfo.DeclaredProperties;
+            return type.GetProperties(DeclaredOnlyLookup);
         }
 
         public sealed override IEnumerable<PropertyInfo> CoreGetDeclaredMembers(RuntimeTypeInfo type, NameFilter? optionalNameFilter, RuntimeTypeInfo reflectedType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/Shared.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/BindingFlagSupport/Shared.cs
@@ -156,16 +156,16 @@ namespace System.Reflection.Runtime.BindingFlagSupport
                 return null;
             }
             string name = member.Name;
-            TypeInfo typeInfo = member.DeclaringType.GetTypeInfo();
+            Type type = member.DeclaringType!;
             for (;;)
             {
-                Type? baseType = typeInfo.BaseType;
+                Type? baseType = type.BaseType;
                 if (baseType == null)
                 {
                     return null;
                 }
-                typeInfo = baseType.GetTypeInfo();
-                foreach (M candidate in policies.GetDeclaredMembers(typeInfo))
+                type = baseType;
+                foreach (M candidate in policies.GetDeclaredMembers(type))
                 {
                     if (candidate.Name != name)
                     {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/TypeResolver.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/TypeResolver.NativeFormat.cs
@@ -185,13 +185,13 @@ namespace System.Reflection.Runtime.General
             if (outerTypeInfo != null)
             {
                 // It was a nested type. We've already resolved the containing type recursively - just find the nested among its direct children.
-                TypeInfo? resolvedTypeInfo = outerTypeInfo.GetDeclaredNestedType(name);
-                if (resolvedTypeInfo == null)
+                Type? resolvedType = outerTypeInfo.GetNestedType(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                if (resolvedType == null)
                 {
                     exception = Helpers.CreateTypeLoadException(outerTypeInfo.FullName + "+" + name, outerTypeInfo.Assembly);
                     return null;
                 }
-                return resolvedTypeInfo.CastToRuntimeTypeInfo();
+                return resolvedType.CastToRuntimeTypeInfo();
             }
 
 

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -333,9 +333,9 @@ namespace Internal.Reflection.Execution
                 return true;
             }
 
-            TypeInfo typeDefinition = Type.GetTypeFromHandle(genericTypeDefinitionHandle).GetTypeInfo();
+            Type typeDefinition = Type.GetTypeFromHandle(genericTypeDefinitionHandle);
 
-            TypeInfo[] typeArguments = new TypeInfo[genericTypeArgumentHandles.Length];
+            Type[] typeArguments = new Type[genericTypeArgumentHandles.Length];
             for (int i = 0; i < genericTypeArgumentHandles.Length; i++)
             {
                 // Early out if one of the arguments is a generic definition.
@@ -345,7 +345,7 @@ namespace Internal.Reflection.Execution
                 if (RuntimeAugments.IsGenericTypeDefinition(genericTypeArgumentHandles[i]))
                     return false;
 
-                typeArguments[i] = Type.GetTypeFromHandle(genericTypeArgumentHandles[i]).GetTypeInfo();
+                typeArguments[i] = Type.GetTypeFromHandle(genericTypeArgumentHandles[i]);
             }
 
             ConstraintValidator.EnsureSatisfiesClassConstraints(typeDefinition, typeArguments);
@@ -1144,7 +1144,7 @@ namespace Internal.Reflection.Execution
 
                         if (parameterType.IsByRef)
                             result.Add(parameterType.GetElementType().TypeHandle);
-                        else if (parameterType.GetTypeInfo().IsEnum && !parameters[i].HasDefaultValue)
+                        else if (parameterType.IsEnum && !parameters[i].HasDefaultValue)
                             result.Add(Enum.GetUnderlyingType(parameterType).TypeHandle);
                         else
                             result.Add(parameterType.TypeHandle);

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
@@ -35,8 +35,8 @@ namespace Internal.Reflection.Execution
                 resourceName = methodBase.IsConstructedGenericMethod ? SR.MakeGenericMethod_NoMetadata : SR.Object_NotInvokable;
                 if (methodBase is ConstructorInfo)
                 {
-                    TypeInfo declaringTypeInfo = methodBase.DeclaringType.GetTypeInfo();
-                    if (typeof(Delegate).GetTypeInfo().IsAssignableFrom(declaringTypeInfo))
+                    Type declaringType = methodBase.DeclaringType;
+                    if (typeof(Delegate).IsAssignableFrom(declaringType))
                         throw new PlatformNotSupportedException(SR.PlatformNotSupported_CannotInvokeDelegateCtor);
                 }
             }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/80165.

Not aware of a good reason to keep using it. Removes `TypeDelegator` from apps that don't use it. Saves 7 kB (but also stepping stone for the larger savings later).

Cc @dotnet/ilc-contrib