### PR TITLE
Remove `CustomAttributeData` usage in IsByRefLike

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -38,6 +38,25 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
             }
         }
 
+        public sealed override bool IsByRefLike
+        {
+            get
+            {
+                // If we have a type handle, ask the runtime
+                RuntimeTypeHandle typeHandle = InternalTypeHandleIfAvailable;
+                if (!typeHandle.IsNull)
+                    return Internal.Runtime.Augments.RuntimeAugments.IsByRefLike(typeHandle);
+
+                // Otherwise fall back to attributes
+                foreach (CustomAttributeHandle cah in _typeDefinition.CustomAttributes)
+                {
+                    if (cah.IsCustomAttributeOfType(_reader, "System.Runtime.CompilerServices", "IsByRefLikeAttribute"))
+                        return true;
+                }
+                return false;
+            }
+        }
+
         protected sealed override Guid? ComputeGuidFromCustomAttributes()
         {
             //

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeBlockedTypeInfo.cs
@@ -60,6 +60,14 @@ namespace System.Reflection.Runtime.TypeInfos
             }
         }
 
+        public sealed override bool IsByRefLike
+        {
+            get
+            {
+                return Internal.Runtime.Augments.RuntimeAugments.IsByRefLike(_typeHandle);
+            }
+        }
+
         public sealed override string FullName
         {
             get

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeClsIdTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeClsIdTypeInfo.cs
@@ -34,6 +34,7 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override string Namespace => BaseType.Namespace;
         public sealed override StructLayoutAttribute StructLayoutAttribute => BaseType.StructLayoutAttribute;
         public sealed override string ToString() => BaseType.ToString();
+        public sealed override bool IsByRefLike => false;
 
         public sealed override IEnumerable<CustomAttributeData> CustomAttributes
         {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeDefinitionTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeDefinitionTypeInfo.cs
@@ -26,22 +26,7 @@ namespace System.Reflection.Runtime.TypeInfos
         public sealed override bool IsGenericTypeParameter => false;
         public sealed override bool IsGenericMethodParameter => false;
 
-        public sealed override bool IsByRefLike
-        {
-            get
-            {
-                RuntimeTypeHandle typeHandle = InternalTypeHandleIfAvailable;
-                if (!typeHandle.IsNull())
-                    return RuntimeAugments.IsByRefLike(typeHandle);
-
-                foreach (CustomAttributeData cad in CustomAttributes)
-                {
-                    if (cad.AttributeType == typeof(IsByRefLikeAttribute))
-                        return true;
-                }
-                return false;
-            }
-        }
+        public abstract override bool IsByRefLike { get; }
 
         // Left unsealed as RuntimeCLSIDTypeInfo has special behavior and needs to override.
         public override bool HasSameMetadataDefinitionAs(MemberInfo other)


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/80165.

Grabbing custom attribute data brings the entire reflection stack (we need properties, constructors, fields, methods).

We ask `IsByRefLike` in type loader constraint validation. Ideally we should be able to get rid of the type loader from a hello world, but that's for later. This is a more efficient implementation either way.

Cc @dotnet/ilc-contrib