### PR TITLE
Avoid TypeSpec resolution when checking for IsValueType

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/QHandles.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/QHandles.NativeFormat.cs
@@ -75,5 +75,19 @@ namespace System.Reflection.Runtime.General
                 return (_reader != null) && Reader is global::Internal.Metadata.NativeFormat.MetadataReader;
             }
         }
+
+        public bool IsTypeDefinition
+        {
+            get
+            {
+                return _handle.AsHandle().HandleType == HandleType.TypeDefinition;
+            }
+        }
+
+        public QTypeDefinition ToTypeDefinition()
+        {
+            var reader = (MetadataReader)_reader;
+            return new QTypeDefinition(reader, _handle.AsHandle().ToTypeDefinitionHandle(reader));
+        }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/TypeResolver.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/TypeResolver.cs
@@ -45,5 +45,22 @@ namespace System.Reflection.Runtime.General
 
             throw new BadImageFormatException();  // Expected TypeRef, Def or Spec with MetadataReader
         }
+
+        //
+        // Main routine to resolve a typeDef.
+        //
+        internal static RuntimeTypeInfo Resolve(this QTypeDefinition typeDef)
+        {
+            if (typeDef.IsNativeFormatMetadataBased)
+            {
+                return typeDef.NativeFormatHandle.ResolveTypeDefinition(typeDef.NativeFormatReader);
+            }
+
+#if ECMA_METADATA_SUPPORT
+            // TODO: implement
+#endif
+
+            throw new BadImageFormatException();  // Expected TypeRef, Def or Spec with MetadataReader
+        }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.cs
@@ -790,10 +790,37 @@ namespace System.Reflection.Runtime.TypeInfos
         {
             get
             {
+                // We have a very specialized helper to get the base type.
+                // It is not a general purpose base type, but works for the cases we care about.
+                // This avoids bringing in full type resolution support including constructing
+                // generic types.
+                static Type GetLimitedBaseType(RuntimeTypeInfo thisType)
+                {
+                    // If we have a type handle, just use that
+                    RuntimeTypeHandle typeHandle = thisType.InternalTypeHandleIfAvailable;
+                    if (!typeHandle.IsNull())
+                    {
+                        RuntimeTypeHandle baseTypeHandle;
+                        if (ReflectionCoreExecution.ExecutionEnvironment.TryGetBaseType(typeHandle, out baseTypeHandle))
+                            return Type.GetTypeFromHandle(baseTypeHandle);
+                    }
+
+                    // Metadata fallback. We only care about very limited subset of all possibilities.
+                    // The cases that we're interested in will all be definitions, and won't be generic.
+                    Type? baseType = null;
+                    QTypeDefRefOrSpec baseTypeDefOrRefOrSpec = thisType.TypeRefDefOrSpecForBaseType;
+                    if (baseTypeDefOrRefOrSpec.IsTypeDefinition)
+                    {
+                        QTypeDefinition baseTypeDef = baseTypeDefOrRefOrSpec.ToTypeDefinition();
+                        baseType = baseTypeDef.Resolve();
+                    }
+                    return baseType;
+                }
+
                 if (_lazyClassification == 0)
                 {
                     TypeClassification classification = TypeClassification.Computed;
-                    Type baseType = this.BaseType;
+                    Type baseType = GetLimitedBaseType(this);
                     if (baseType != null)
                     {
                         Type enumType = typeof(Enum);

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -2154,6 +2154,9 @@ internal static class ReflectionTest
                 Console.WriteLine(t.IsValueType);
             }
 
+            if (!typeof(G<>).GetGenericArguments()[0].IsValueType)
+                throw new Exception();
+
             static void AssertNoTypeHandle(Type t)
             {
                 RuntimeTypeHandle h = default;
@@ -2185,6 +2188,8 @@ internal static class ReflectionTest
             public Type[] ReferenceTypes;
             public Type[] ValueTypes;
         }
+
+        class G<T> where T : struct { }
     }
 
     class TestEntryPoint
@@ -2192,8 +2197,8 @@ internal static class ReflectionTest
         public static void Run()
         {
             Console.WriteLine(nameof(TestEntryPoint));
-			if (Assembly.GetEntryAssembly().EntryPoint == null)
-				throw new Exception();
+            if (Assembly.GetEntryAssembly().EntryPoint == null)
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
Contributes to #80165.

This creates a much narrower path to get base type of a type that doesn't bring in complete support for token resolution. `IsValueType` and `IsEnum` that call into this are very common.

Also includes a test because the scenario where we wouldn't have a type handle is obscure and we probably didn't have any coverage (even for the previous implementation).

(I have one more reflection fix for #80165 and then I'm done touching the reflection stack.)

Cc @dotnet/ilc-contrib