### PR TITLE
[mono][wasm] Fix an llvm assert.

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -4376,6 +4376,8 @@ emit_wasm_bitoperations_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoM
 	switch (id) {
 		case SN_LeadingZeroCount:
 		case SN_TrailingZeroCount: {
+			if (!MONO_TYPE_IS_PRIMITIVE (fsig->params [0]))
+				return NULL;
 			return emit_wasm_zero_count(cfg, fsig, args, cmethod->klass, id, arg0_type);
 		}
 	}


### PR DESCRIPTION
The assert happened when trying to AOT corlib in debug configuration, on the System.Numerics.BitOperations:LeadingZeroCount (System.Int128) method.