### PR TITLE
[release/7.0][browser] improve default initial memory size

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -185,7 +185,6 @@
       <_EmccLinkRsp>$(_WasmIntermediateOutputPath)emcc-link.rsp</_EmccLinkRsp>
 
       <EmccInitialHeapSize Condition="'$(EmccInitialHeapSize)' == ''">$(EmccTotalMemory)</EmccInitialHeapSize>
-      <EmccInitialHeapSize Condition="'$(EmccInitialHeapSize)' == ''">536870912</EmccInitialHeapSize>
     </PropertyGroup>
 
     <ItemGroup>
@@ -227,7 +226,6 @@
       <_EmccLDFlags Include="-s ASSERTIONS=$(_EmccAssertionLevelDefault)" Condition="'$(_WasmDevel)' == 'true'" />
       <_EmccLDFlags Include="@(_EmccCommonFlags)" />
       <_EmccLDFlags Include="-Wl,--allow-undefined" />
-      <_EmccLDSFlags Include="-s INITIAL_MEMORY=$(EmccInitialHeapSize)" />
 
       <!-- ILLinker should have removed unused imports, so error for Publish -->
       <_EmccLDSFlags Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" Condition="'$(WasmBuildingForNestedPublish)' != 'true'" />
@@ -374,9 +372,12 @@
       <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>
       <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>
       <_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>
+      <EmccInitialHeapSize Condition="'$(EmccInitialHeapSize)' == '' and '$(_WasmShouldAOT)' != 'true'">16777216</EmccInitialHeapSize>
+      <EmccInitialHeapSize Condition="'$(EmccInitialHeapSize)' == '' and '$(_WasmShouldAOT)' == 'true'">134217728</EmccInitialHeapSize>
 	</PropertyGroup>
     <ItemGroup>
       <!-- order matters -->
+      <_EmccLDSFlags Include="-s INITIAL_MEMORY=$(EmccInitialHeapSize)" />
       <_WasmNativeFileForLinking Include="%(_BitcodeFile.ObjectFile)" />
       <_WasmNativeFileForLinking Include="%(_WasmSourceFileToCompile.ObjectFile)" />
 


### PR DESCRIPTION
Simplified backport of [#80257](https://github.com/dotnet/runtime/pull/80507) to release/7.0

The default value of 512MB for initial memory is too high for mobile devices.
This PR changes the default to 16MB for builds with `wasm-tools` workload and without AOT.
This PR changes the default to 128MB for builds with `wasm-tools` workload and with AOT.

## Customer Impact
Fixes https://github.com/dotnet/runtime/issues/61925
Fixes https://github.com/dotnet/runtime/issues/66313
Fixes https://github.com/dotnet/runtime/issues/79909
Fixes https://github.com/dotnet/runtime/issues/73949

## Workaround 
Adding a property to the customer project file will achieve the same outcome as this PR, 
- for the older releases of Net7 `<EmccInitialHeapSize>16777216</EmccInitialHeapSize>`
- for Net6 `<EmccTotalMemory>16777216</EmccTotalMemory>`

## Testing
   - [x] Manual
   - [x] WBT on CI

## Risk
The fix for Net8 uses more complex logic and we decided to reduce the risk by making backport logic simpler.

This PR makes initial memory for AOT build lower than it was in Net7 so far. 
It may lead to new compilation error similar to:
```
Linking for initial memory $(EmccInitialHeapSize)=134217728 bytes.
...
wasm-ld : error : initial memory too small, 536870912 bytes needed
```
Which could be resolved by adding property into the customer project file.
`<EmccInitialHeapSize>536870912</EmccInitialHeapSize>`

The `EmccInitialHeapSize` value need to be rounded up to 16KB page size.