### PR TITLE
Fix single method compilation for shared generics

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -30,7 +30,7 @@ namespace ILCompiler
 
         public override bool ContainsMethodBody(MethodDesc method, bool unboxingStub)
         {
-            return method == _method;
+            return method == _method || method == _method.GetCanonMethodTarget(CanonicalFormKind.Specific);
         }
 
         public sealed override bool ContainsMethodDictionary(MethodDesc method)


### PR DESCRIPTION
Currently, if you try something like:
```
C#: private static void Problem<T>() { ... }

--singlemethodtypename:"RyuJitReproduction.Program, RyuJitReproduction"
--singlemethodname:"Problem"
--singlemethodgenericarg:"System.Object"
```
with the scanner enabled, the compiler will crash because it won't scan `Problem`, which is in turn caused by the fact addition of roots converts methods to their canonical form while `ContainsMethodBody` expects exact matches (i. e. `Problem<object>` in the above example).

This fix makes `ContainsMethodBody` consider canonical version of the single method to also be included in the compilation.