### PR TITLE
[release/7.0] Target lower glibc for Linux arm64

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -107,7 +107,7 @@ jobs:
           platforms: ${{ parameters.platforms }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs/arm64'
+        crossrootfsDir: '/crossrootfs'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl x64

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -107,7 +107,7 @@ jobs:
           platforms: ${{ parameters.platforms }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        crossrootfsDir: '/crossrootfs'
+        crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl x64

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -95,7 +95,7 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       container:
         ${{ if eq(parameters.container, '') }}:
-          image: ubuntu-18.04-cross-arm64-20220427171722-6e40d49
+          image: ubuntu-20.04-cross-arm64-20230119134401-944d64e
         ${{ if ne(parameters.container, '') }}:
           image: ${{ parameters.container }}
         registry: mcr

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -95,7 +95,7 @@ jobs:
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       container:
         ${{ if eq(parameters.container, '') }}:
-          image: ubuntu-20.04-cross-arm64-20230119134401-944d64e
+          image: ubuntu-20.04-cross-arm64-20230201170357-8b7d579
         ${{ if ne(parameters.container, '') }}:
           image: ${{ parameters.container }}
         registry: mcr

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -632,6 +632,7 @@
       <MonoAotAbi>aarch64-linux-gnu</MonoAotAbi>
       <MonoAotOffsetsFile>$(MonoObjCrossDir)offsets-aarch-linux-gnu.h</MonoAotOffsetsFile>
       <MonoAotOffsetsPrefix>$(MonoCrossDir)/usr/lib/gcc/aarch64-linux-gnu/7</MonoAotOffsetsPrefix>
+      <MonoAotOffsetsPrefix Condition="'$(Platform)' == 'arm64'">$(MonoCrossDir)/usr/lib/gcc/aarch64-linux-gnu/5</MonoAotOffsetsPrefix>
     </PropertyGroup>
 
     <!-- macOS host specific options -->


### PR DESCRIPTION
This uses new cross-build images, added in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/754, that target Ubuntu 16.04. It should address the .NET 7 part of https://github.com/dotnet/runtime/issues/69361.

Same change was made in .NET 8 here: https://github.com/dotnet/runtime/pull/80939.

~The new images were published here: https://github.com/dotnet/versions/commit/33968c3c389e47f2e555771be1ceca26ba27055b~
Updated to https://github.com/dotnet/versions/commit/f2e8ed1f925ad712b94b3baed9969b0ed4d32676.

## Customer Impact
Allows .NET Linux arm64 to run on Amazon Linux 2 by lowering the glibc version requirement to 2.23. Fixes the .NET 7 part of https://github.com/dotnet/runtime/issues/69361. Customers were hitting the following when using .NET Linux arm64 for AWS Lambda functions:
```
Failed to load /var/task/libcoreclr.so, error: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /var/task/libcoreclr.so)
```
AWS tracking issue: https://github.com/aws/aws-lambda-dotnet/issues/1310

## Testing
- Ci testing
- Local validation that build succeeds with pgo instrumentation (using cross-compiled LLVM profiler library)
- Manual validation of glibc symbol versions in the native build output
- Handed a ci build to partners who validated it was working as expected for their scenarios on Amazon Linux 2 (see https://github.com/dotnet/runtime/issues/69361#issuecomment-1399036337)
- Same fix was applied in .NET 8 and is rolling out as part of of preview 1

## Risk
Low to medium. Any risk is limited to Linux arm64. This is a change in the version of a fundamental dependency, but testing gives confidence that the fix is functionally good. Building with PGO instrumentation has been validated. Collection of PGO data, and validation of the perf characteristics of PGO-optimized builds using the resulting data, has not been manually tested, but the fix has gone through the .NET 8 official build process successfully, suggesting that it passes any automated PGO validation we have.