### PR TITLE
Don't try to build FunctionalTests test assets as tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -532,6 +532,11 @@
   </ItemGroup>
 
   <ItemGroup>
+      <!-- FunctionalTests TestAssets are not, themselves, tests. -->
+      <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\TestAssets\**\*.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
     <GrpcTestProject Include="$(RepoRoot)\src\tests\FunctionalTests\Android\Device_Emulator\gRPC\Android.Device_Emulator.gRPC.Test.csproj" />
   </ItemGroup>


### PR DESCRIPTION
They are just assemblies that can be referenced by other tests, not standalone tests, themselves.

Follow-up to #80391 to address apparent failures on the Android runtime-extra-platforms legs