### PR TITLE
Make GetAssemblyName test more robust.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -3090,7 +3090,7 @@ namespace System.Reflection.Metadata.Tests
 
             if (PlatformDetection.HasAssemblyFiles)
             {
-                Assembly a = typeof(MetadataReaderTests).Assembly;
+                Assembly a = typeof(MetadataReader).Assembly;
                 AssemblyName name = MetadataReader.GetAssemblyName(AssemblyPathHelper.GetAssemblyLocation(a));
                 Assert.Equal(new AssemblyName(a.FullName).ToString(), name.ToString());
 


### PR DESCRIPTION
Fixes: #80863