### PR TITLE
Disable user mapper for SslStream on Windows

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -260,12 +260,9 @@ namespace System.Net.Security
             else
             {
                 direction = Interop.SspiCli.CredentialUse.SECPKG_CRED_INBOUND;
-                flags = Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_SEND_AUX_RECORD;
-
-                if (authOptions.CertificateContext?.Trust?._sendTrustInHandshake == true)
-                {
-                    flags |= Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_CRED_NO_SYSTEM_MAPPER;
-                }
+                flags =
+                    Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_SEND_AUX_RECORD |
+                    Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_CRED_NO_SYSTEM_MAPPER;
             }
 
             EncryptionPolicy policy = authOptions.EncryptionPolicy;


### PR DESCRIPTION
This is small perf improvement on Windows server connected to AD. Schannel by default (for legacy reasons) tries to resolve user identity by querying AD with provided client certificate. That allows to get user identity and/or server can impersonate the client. This would work _if_  we use QuerySecurityContextToken function to retrieve it. (https://learn.microsoft.com/en-us/windows/win32/secauthn/mapping-certificates) But we don't (and caller cannot either) so this is complete waste. 

The existing code was attempt to suppress it for the new scenario (as this also changes advertised CAs) and this change will just make it default. This can be re-visited in future if we want to support the scenario (windows only)  

cc: @Tratcher @mconnew 

fixes #78350