### PR TITLE
[mono][wasm] Error out if the linker is not enabled in AOT mode.

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -106,6 +106,9 @@
     <Error Condition="'$(RunAOTCompilation)' == 'true' and '$(_IsEMSDKMissing)' == 'true'"
            Text="$(_EMSDKMissingErrorMessage) Emscripten SDK is required for AOT'ing assemblies." />
 
+    <Error Condition="'$(RunAOTCompilation)' == 'true' and '$(EnableAggressiveTrimming)' != 'true'"
+           Text="EnableAggressiveTrimming=true is required for AOT'ing assemblies." />
+
     <!-- When Building -->
     <PropertyGroup Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
       <!-- build AOT, only if explicitly requested -->


### PR DESCRIPTION
If the linker is not enabled, build times and executable times become prohibitively large.