### PR TITLE
Inline resource strings in the compiler

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
@@ -163,15 +163,16 @@ namespace System.Diagnostics
             {
                 // Passing a default string for "at" in case SR.UsingResourceKeys() is true
                 // as this is a special case and we don't want to have "Word_At" on stack traces.
-                string word_At = SR.GetResourceString(nameof(SR.Word_At), defaultString: "at");
+                string word_At = SR.UsingResourceKeys() ? "at" : SR.Word_At;
                 builder.Append("   ").Append(word_At).Append(' ');
                 builder.AppendLine(DeveloperExperience.Default.CreateStackTraceString(_ipAddress, _needFileInfo));
             }
             if (_isLastFrameFromForeignExceptionStackTrace)
             {
                 // Passing default for Exception_EndStackTraceFromPreviousThrow in case SR.UsingResourceKeys is set.
-                builder.AppendLine(SR.GetResourceString(nameof(SR.Exception_EndStackTraceFromPreviousThrow),
-                    defaultString: "--- End of stack trace from previous location ---"));
+                builder.AppendLine(SR.UsingResourceKeys() ?
+                    "--- End of stack trace from previous location ---" :
+                    SR.Exception_EndStackTraceFromPreviousThrow);
             }
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
@@ -41,7 +41,9 @@ namespace ILCompiler.DependencyAnalysis
             if (!resourceName.EndsWith(".resources", StringComparison.Ordinal))
                 return false;
 
-            // TODO: we should grab this name from the SR class
+            // Make a guess at the name of the resource Arcade tooling generated for the resource
+            // strings.
+            // https://github.com/dotnet/runtime/issues/81385 tracks not having to guess this.
             string simpleName = module.Assembly.GetName().Name;
             string resourceName1 = $"{simpleName}.Strings.resources";
             string resourceName2 = $"FxResources.{simpleName}.SR.resources";

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
@@ -18,6 +18,10 @@ namespace ILCompiler.DependencyAnalysis
     {
         private readonly EcmaModule _module;
 
+        public const string ResourceAccessorTypeName = "SR";
+        public const string ResourceAccessorTypeNamespace = "System";
+        public const string ResourceAccessorGetStringMethodName = "GetResourceString";
+
         public InlineableStringsResourceNode(EcmaModule module)
         {
             _module = module;
@@ -43,17 +47,17 @@ namespace ILCompiler.DependencyAnalysis
             if (resourceName != resourceName1 && resourceName != resourceName2)
                 return false;
 
-            MetadataType srType = module.GetType("System", "SR", throwIfNotFound: false);
+            MetadataType srType = module.GetType(ResourceAccessorTypeNamespace, ResourceAccessorTypeName, throwIfNotFound: false);
             if (srType == null)
                 return false;
 
-            return srType.GetMethod("GetResourceString", null) != null;
+            return srType.GetMethod(ResourceAccessorGetStringMethodName, null) != null;
         }
 
         public static void AddDependenciesDueToResourceStringUse(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            if (method.Name == "GetResourceString" && method.OwningType is MetadataType mdType
-                && mdType.Name == "SR" && mdType.Namespace == "System")
+            if (method.Name == ResourceAccessorGetStringMethodName && method.OwningType is MetadataType mdType
+                && mdType.Name == ResourceAccessorTypeName && mdType.Namespace == ResourceAccessorTypeNamespace)
             {
                 dependencies ??= new DependencyList();
                 dependencies.Add(factory.InlineableStringResource((EcmaModule)mdType.Module), "Using the System.SR class");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a resource blob used by the SR class in the BCL.
+    /// If this node is present in the graph, it means we were not able to optimize its use away
+    /// and the blob has to be generated.
+    /// </summary>
+    internal sealed class InlineableStringsResourceNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly EcmaModule _module;
+
+        public InlineableStringsResourceNode(EcmaModule module)
+        {
+            _module = module;
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+
+        public override bool HasDynamicDependencies => false;
+
+        public override bool HasConditionalStaticDependencies => false;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public static bool IsInlineableStringsResource(EcmaModule module, string resourceName)
+        {
+            if (!resourceName.EndsWith(".resources"))
+                return false;
+
+            // TODO: we should grab this name from the SR class
+            string resourceName1 = $"{module.Assembly.GetName().Name}.Strings.resources";
+            string resourceName2 = $"FxResources.{module.Assembly.GetName().Name}.SR.resources";
+
+            if (resourceName != resourceName1 && resourceName != resourceName2)
+                return false;
+
+            MetadataType srType = module.GetType("System", "SR", throwIfNotFound: false);
+            if (srType == null)
+                return false;
+
+            return srType.GetMethod("GetResourceString", null) != null;
+        }
+
+        public static void AddDependenciesDueToResourceStringUse(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            if (method.Name == "GetResourceString" && method.OwningType is MetadataType mdType
+                && mdType.Name == "SR" && mdType.Namespace == "System")
+            {
+                dependencies ??= new DependencyList();
+                dependencies.Add(factory.InlineableStringResource((EcmaModule)mdType.Module), "Using the System.SR class");
+            }
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+        protected override string GetName(NodeFactory context)
+            => $"String resources for {_module.Assembly.GetName().Name}";
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
@@ -37,12 +37,13 @@ namespace ILCompiler.DependencyAnalysis
 
         public static bool IsInlineableStringsResource(EcmaModule module, string resourceName)
         {
-            if (!resourceName.EndsWith(".resources"))
+            if (!resourceName.EndsWith(".resources", StringComparison.Ordinal))
                 return false;
 
             // TODO: we should grab this name from the SR class
-            string resourceName1 = $"{module.Assembly.GetName().Name}.Strings.resources";
-            string resourceName2 = $"FxResources.{module.Assembly.GetName().Name}.SR.resources";
+            string simpleName = module.Assembly.GetName().Name;
+            string resourceName1 = $"{simpleName}.Strings.resources";
+            string resourceName2 = $"FxResources.{simpleName}.SR.resources";
 
             if (resourceName != resourceName1 && resourceName != resourceName2)
                 return false;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysisFramework;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -462,6 +462,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new ModuleMetadataNode(module);
             });
 
+            _inlineableStringResources = new NodeCache<EcmaModule, InlineableStringsResourceNode>(module =>
+            {
+                return new InlineableStringsResourceNode(module);
+            });
+
             _customAttributesWithMetadata = new NodeCache<ReflectableCustomAttribute, CustomAttributeMetadataNode>(ca =>
             {
                 return new CustomAttributeMetadataNode(ca);
@@ -1137,6 +1142,12 @@ namespace ILCompiler.DependencyAnalysis
             // in the dependency graph otherwise.
             Debug.Assert(MetadataManager is UsageBasedMetadataManager);
             return _modulesWithMetadata.GetOrAdd(module);
+        }
+
+        private NodeCache<EcmaModule, InlineableStringsResourceNode> _inlineableStringResources;
+        internal InlineableStringsResourceNode InlineableStringResource(EcmaModule module)
+        {
+            return _inlineableStringResources.GetOrAdd(module);
         }
 
         private NodeCache<ReflectableCustomAttribute, CustomAttributeMetadataNode> _customAttributesWithMetadata;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ResourceDataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ResourceDataNode.cs
@@ -98,7 +98,7 @@ namespace ILCompiler.DependencyAnalysis
                             string resourceName = module.MetadataReader.GetString(resource.Name);
 
                             // Check if emitting the manifest resource is blocked by policy.
-                            if (factory.MetadataManager.IsManifestResourceBlocked(module, resourceName))
+                            if (factory.MetadataManager.IsManifestResourceBlocked(factory, module, resourceName))
                                 continue;
 
                             string assemblyName = module.GetName().FullName;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -393,6 +393,7 @@
     <Compile Include="Compiler\DependencyAnalysis\FieldRvaDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GenericStaticBaseInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IndirectionExtensions.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\InlineableStringsResourceNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellSectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodExceptionHandlingInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ModuleInitializerListNode.cs" />

--- a/src/libraries/Common/src/System/SR.cs
+++ b/src/libraries/Common/src/System/SR.cs
@@ -13,7 +13,7 @@ namespace System
         // by default it returns the value of System.Resources.UseSystemResourceKeys AppContext switch or false if not specified.
         // Native code generators can replace the value this returns based on user input at the time of native code generation.
         // The Linker is also capable of replacing the value of this method when the application is being trimmed.
-        private static bool UsingResourceKeys() => s_usingResourceKeys;
+        internal static bool UsingResourceKeys() => s_usingResourceKeys;
 
         internal static string GetResourceString(string resourceKey)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingData.cs
@@ -237,41 +237,6 @@ namespace System.Text
             56
         };
 
-        //
-        // EnglishNames is the concatenation of the English names for each codepage.
-        // It is used in retrieving the value for System.Text.Encoding.EncodingName
-        // given System.Text.Encoding.CodePage.
-        // This is done rather than using a large readonly array of strings to avoid
-        // generating a large amount of code in the static constructor.
-        //
-        private const string EnglishNames =
-            "Unicode" + // 1200
-            "Unicode (Big-Endian)" + // 1201
-            "Unicode (UTF-32)" + // 12000
-            "Unicode (UTF-32 Big-Endian)" + // 12001
-            "US-ASCII" + // 20127
-            "Western European (ISO)" + // 28591
-            "Unicode (UTF-7)" + // 65000
-            "Unicode (UTF-8)"; // 65001
-
-        //
-        // EnglishNameIndices contains the start index of each code page's English
-        // name in the string EnglishNames. It is indexed by an index into
-        // MappedCodePages.
-        //
-        private static ReadOnlySpan<int> EnglishNameIndices => new int[]
-        {
-            0, // Unicode (1200)
-            7, // Unicode (Big-Endian) (1201)
-            27, // Unicode (UTF-32) (12000)
-            43, // Unicode (UTF-32 Big-Endian) (12001)
-            70, // US-ASCII (20127)
-            78, // Western European (ISO) (28591)
-            100, // Unicode (UTF-7) (65000)
-            115, // Unicode (UTF-8) (65001)
-            130
-        };
-
         // redeclaring these constants here for readability below
         private const uint MIMECONTF_MAILNEWS = Encoding.MIMECONTF_MAILNEWS;
         private const uint MIMECONTF_BROWSER = Encoding.MIMECONTF_BROWSER;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -124,7 +124,7 @@ namespace System.Text
                 arrayEncodingInfo[arrayEncodingInfoIdx++] = new EncodingInfo(
                     codePage,
                     webNames[webNameIndices[i]..webNameIndices[i + 1]],
-                    GetDisplayName(codePage, i)
+                    GetDisplayName(codePage)
                     );
             }
 
@@ -151,7 +151,7 @@ namespace System.Text
                     if (codePage != Encoding.CodePageUTF7 || LocalAppContextSwitches.EnableUnsafeUTF7Encoding)
                     {
                         encodingInfoList[codePage] = new EncodingInfo(codePage, webNames[webNameIndices[i]..webNameIndices[i + 1]],
-                                                                                GetDisplayName(codePage, i));
+                                                                                GetDisplayName(codePage));
                     }
                 }
             }
@@ -229,19 +229,32 @@ namespace System.Text
             // All supported code pages have identical header names, and body names.
             string headerName = webName;
             string bodyName = webName;
-            string displayName = GetDisplayName(codePage, index);
+            string displayName = GetDisplayName(codePage);
             uint flags = Flags[index];
 
             return new CodePageDataItem(uiFamilyCodePage, webName, headerName, bodyName, displayName, flags);
         }
 
-        private static string GetDisplayName(int codePage, int englishNameIndex)
+        private static string GetDisplayName(int codePage)
         {
-            string? displayName = SR.GetResourceString("Globalization_cp_" + codePage.ToString());
-            if (string.IsNullOrEmpty(displayName))
-                displayName = EnglishNames[EnglishNameIndices[englishNameIndex]..EnglishNameIndices[englishNameIndex + 1]];
+            return codePage switch
+            {
+                1200 => SR.Globalization_cp_1200,
+                1201 => SR.Globalization_cp_1201,
+                12000 => SR.Globalization_cp_12000,
+                12001 => SR.Globalization_cp_12001,
+                20127 => SR.Globalization_cp_20127,
+                28591 => SR.Globalization_cp_28591,
+                65000 => SR.Globalization_cp_65000,
+                65001 => SR.Globalization_cp_65001,
+                _ => AssertFailAndEmptyString()
+            };
 
-            return displayName;
+            static string AssertFailAndEmptyString()
+            {
+                Debug.Fail("Unexpected code page");
+                return "";
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -237,24 +237,20 @@ namespace System.Text
 
         private static string GetDisplayName(int codePage)
         {
-            return codePage switch
+            switch (codePage)
             {
-                1200 => SR.Globalization_cp_1200,
-                1201 => SR.Globalization_cp_1201,
-                12000 => SR.Globalization_cp_12000,
-                12001 => SR.Globalization_cp_12001,
-                20127 => SR.Globalization_cp_20127,
-                28591 => SR.Globalization_cp_28591,
-                65000 => SR.Globalization_cp_65000,
-                65001 => SR.Globalization_cp_65001,
-                _ => AssertFailAndEmptyString()
+                case 1200: return SR.Globalization_cp_1200;
+                case 1201: return SR.Globalization_cp_1201;
+                case 12000: return SR.Globalization_cp_12000;
+                case 12001: return SR.Globalization_cp_12001;
+                case 20127: return SR.Globalization_cp_20127;
+                case 28591: return SR.Globalization_cp_28591;
+                case 65000: return SR.Globalization_cp_65000;
+                case 65001: return SR.Globalization_cp_65001;
             };
 
-            static string AssertFailAndEmptyString()
-            {
-                Debug.Fail("Unexpected code page");
-                return "";
-            }
+            Debug.Fail("Unexpected code page");
+            return "";
         }
     }
 }

--- a/src/tests/nativeaot/SmokeTests/FrameworkStrings/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/FrameworkStrings/Program.cs
@@ -56,7 +56,6 @@ if (coreLibNames.Length != 0)
 Console.WriteLine("Resources in reflection library:");
 string[] refNames;
 const string reflectionAssembly = "System.Private.Reflection.Execution";
-#if RESOURCE_KEYS
 try
 {
     refNames = System.Reflection.Assembly.Load(reflectionAssembly).GetManifestResourceNames();
@@ -65,9 +64,6 @@ catch (System.IO.FileNotFoundException)
 {
     refNames = Array.Empty<string>();
 }
-#else
-refNames = System.Reflection.Assembly.Load(reflectionAssembly).GetManifestResourceNames();
-#endif
 foreach (var name in refNames)
     Console.WriteLine(name);
 


### PR DESCRIPTION
Contributes to #80165.

Allows getting rid of resource manager.

Cc @dotnet/ilc-contrib 