### PR TITLE
Append version to RID only with valid characters

### DIFF
--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -842,8 +842,13 @@ pal::string_t pal::get_current_os_rid_platform()
                     size_t pos = line.find(strVersionID);
                     if ((pos != std::string::npos) && (pos == 0))
                     {
-                        valVersionID.append(line.substr(11));
-                        fFoundVersion = true;
+                        pal::string_t version = line.substr(11);
+                        // check if version characters are valid (quotes are trimmed at a later stage)
+                        if (version.find_first_not_of("0123456789.\"'") == std::string::npos)
+                        {
+                            valVersionID.append(version);
+                            fFoundVersion = true;
+                        }
                     }
                 }
 

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -844,7 +844,7 @@ pal::string_t pal::get_current_os_rid_platform()
                     {
                         pal::string_t version = line.substr(11);
                         // check if version characters are valid (quotes are trimmed at a later stage)
-                        if (version.find_first_not_of("0123456789.\"'") == std::string::npos)
+                        if (!version.empty() && version.find_first_not_of("0123456789.\"'") == std::string::npos)
                         {
                             valVersionID.append(version);
                             fFoundVersion = true;


### PR DESCRIPTION
On some distros with [rolling release model](https://en.wikipedia.org/wiki/Rolling_release), `VERSION_ID` is set to a sentinel indicating their versioning model. Arch Linux is one of those distros with `VERSION_ID=TEMPLATE_VERSION_ID` line in `/etc/os-release`.

This makes assembly launched with `dotnet`, `dotnet exec` or `dotnet run` unable to function properly, when corehost is built with non-portable flag set: https://github.com/archlinux/svntogit-community/blob/ca544978888af3d305f8ef5051622ff1d04b102c/dotnet-core/trunk/PKGBUILD#L128 (dotnet/source-build recommended) and assembly has a dependency on package with native runtime assets.

Fix is to validate that string contains valid characters (not necessarily conforming to any particular versioning standard), before inserting version into the RID string.