### PR TITLE
[mono][aot] Skip codegen of non-generic methods in dedup-include mode.

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -12996,11 +12996,6 @@ mono_llvm_create_aot_module (MonoAssembly *assembly, const char *global_prefix, 
 	gboolean llvm_only = (flags & LLVM_MODULE_FLAG_LLVM_ONLY) ? 1 : 0;
 	gboolean interp = (flags & LLVM_MODULE_FLAG_INTERP) ? 1 : 0;
 
-	/* Delete previous module */
-	g_hash_table_destroy (module->plt_entries);
-	if (module->lmodule)
-		LLVMDisposeModule (module->lmodule);
-
 	memset (module, 0, sizeof (aot_module));
 
 	module->lmodule = LLVMModuleCreateWithName ("aot");
@@ -13139,6 +13134,16 @@ mono_llvm_create_aot_module (MonoAssembly *assembly, const char *global_prefix, 
 		LLVMSetLinkage (module->sentinel_exception, LLVMExternalLinkage);
 		mono_llvm_set_is_constant (module->sentinel_exception);
 	}
+}
+
+void
+mono_llvm_free_aot_module (void)
+{
+	MonoLLVMModule *module = &aot_module;
+
+	g_hash_table_destroy (module->plt_entries);
+	if (module->lmodule)
+		LLVMDisposeModule (module->lmodule);
 }
 
 void

--- a/src/mono/mono/mini/mini-llvm.h
+++ b/src/mono/mono/mini/mini-llvm.h
@@ -23,6 +23,7 @@ void mono_llvm_init                     (gboolean enable_jit);
 void mono_llvm_emit_method              (MonoCompile *cfg);
 void mono_llvm_emit_call                (MonoCompile *cfg, MonoCallInst *call);
 void mono_llvm_create_aot_module        (MonoAssembly *assembly, const char *global_prefix, int initial_got_size, LLVMModuleFlags flags);
+void mono_llvm_free_aot_module          (void);
 void mono_llvm_emit_aot_module          (const char *filename, const char *cu_name);
 void mono_llvm_emit_aot_file_info       (MonoAotFileInfo *info, gboolean has_jitted_code);
 gpointer mono_llvm_emit_aot_data        (const char *symbol, guint8 *data, int data_len);

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1269,6 +1269,8 @@ typedef enum {
 	JIT_FLAG_SELF_INIT = (1 << 11),
 	/* Assume code memory is exec only */
 	JIT_FLAG_CODE_EXEC_ONLY = (1 << 12),
+	/* Stop before code generation */
+	JIT_FLAG_SKIP_CODEGEN = (1 << 13),
 } JitFlags;
 
 /* Bit-fields in the MonoBasicBlock.region */


### PR DESCRIPTION
These methods are just AOTed to collect the generic instances etc. referenced by them, so its ok to skip the code generation pass for them.

Also free the LLVM image properly after AOT.