### PR TITLE
Fix regex analyzers category to be "Performance" rather than "GeneratedRegex"

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/DiagnosticDescriptors.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/DiagnosticDescriptors.cs
@@ -8,7 +8,7 @@ namespace System.Text.RegularExpressions.Generator
 {
     internal static class DiagnosticDescriptors
     {
-        private const string Category = "GeneratedRegex";
+        private const string Category = "Performance";
 
         public static DiagnosticDescriptor InvalidGeneratedRegexAttribute { get; } = new DiagnosticDescriptor(
             id: "SYSLIB1040",


### PR DESCRIPTION
<img width="336" alt="image" src="https://user-images.githubusercontent.com/2642209/213723773-578d9f39-77d6-4f6d-8fab-0500836f89c0.png">
