### PR TITLE
Allow forced building of mobile manifest pkgs, outside mobile builds

### DIFF
--- a/src/mono/nuget/mono-packages.proj
+++ b/src/mono/nuget/mono-packages.proj
@@ -14,7 +14,7 @@
     <ProjectReference Include="Microsoft.NET.Runtime.iOS.Sample.Mono\Microsoft.NET.Runtime.iOS.Sample.Mono.pkgproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetsMobile)' == 'true'">
+  <ItemGroup Condition="'$(TargetsMobile)' == 'true' or '$(ForceBuildMobileManifests)' == 'true'">
     <ProjectReference Include="Microsoft.NET.Workload.Mono.Toolchain.Manifest\Microsoft.NET.Workload.Mono.Toolchain.Manifest.pkgproj" />
     <ProjectReference Include="Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest\Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest.pkgproj" />
     <ProjectReference Include="Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest\Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest.pkgproj" />


### PR DESCRIPTION
We may need to build our manifests separately from our mobile packages, this change allows us to force the build