### PR TITLE
[Android] Bump target SDK version in Android manifest

### DIFF
--- a/docs/workflow/testing/libraries/testing-android.md
+++ b/docs/workflow/testing/libraries/testing-android.md
@@ -23,9 +23,9 @@ Android SDK and NDK can be automatically installed via the following script:
 set -e
 
 NDK_VER=r23c
-SDK_VER=8092744_latest
+SDK_VER=9123335_latest
 SDK_API_LEVEL=33
-SDK_BUILD_TOOLS=33.0.0
+SDK_BUILD_TOOLS=33.0.1
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     HOST_OS=darwin

--- a/docs/workflow/testing/libraries/testing-android.md
+++ b/docs/workflow/testing/libraries/testing-android.md
@@ -23,9 +23,9 @@ Android SDK and NDK can be automatically installed via the following script:
 set -e
 
 NDK_VER=r23c
-SDK_VER=6200805_latest
-SDK_API_LEVEL=29
-SDK_BUILD_TOOLS=29.0.3
+SDK_VER=8092744_latest
+SDK_API_LEVEL=33
+SDK_BUILD_TOOLS=33.0.0
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     HOST_OS=darwin
@@ -63,7 +63,7 @@ Android Studio offers a convenient UI:
 Before running a build you might want to set the Android SDK and NDK environment variables:
 ```
 export ANDROID_SDK_ROOT=<PATH-TO-ANDROID-SDK>
-export ANDROID_NDK_ROOT=<PATH-TO-ANDROID-NDK>  
+export ANDROID_NDK_ROOT=<PATH-TO-ANDROID-NDK>
 ```
 
 Now we're ready to build everything for Android:

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -302,7 +302,7 @@ namespace System.Diagnostics.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34685", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [InlineData(true), InlineData(false)]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS and tvOS.")]
-        [SkipOnPlatform(TestPlatforms.Android, "Permission denied")]
+        [SkipOnPlatform(TestPlatforms.Android, "Android doesn't allow executing custom shell scripts")]
         public void ProcessStart_UseShellExecute_Executes(bool filenameAsUrl)
         {
             string filename = WriteScriptFile(TestDirectory, GetTestFileName(), returnValue: 42);
@@ -375,7 +375,7 @@ namespace System.Diagnostics.Tests
             nameof(PlatformDetection.IsNotAppSandbox))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34685", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS and tvOS.")]
-        [SkipOnPlatform(TestPlatforms.Android, "Permission denied")]
+        [SkipOnPlatform(TestPlatforms.Android, "Android doesn't allow executing custom shell scripts")]
         public void ProcessStart_UseShellExecute_WorkingDirectory()
         {
             // Create a directory that will ProcessStartInfo.WorkingDirectory

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -302,6 +302,7 @@ namespace System.Diagnostics.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34685", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [InlineData(true), InlineData(false)]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS and tvOS.")]
+        [SkipOnPlatform(TestPlatforms.Android, "Permission denied")]
         public void ProcessStart_UseShellExecute_Executes(bool filenameAsUrl)
         {
             string filename = WriteScriptFile(TestDirectory, GetTestFileName(), returnValue: 42);
@@ -374,6 +375,7 @@ namespace System.Diagnostics.Tests
             nameof(PlatformDetection.IsNotAppSandbox))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34685", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS and tvOS.")]
+        [SkipOnPlatform(TestPlatforms.Android, "Permission denied")]
         public void ProcessStart_UseShellExecute_WorkingDirectory()
         {
             // Create a directory that will ProcessStartInfo.WorkingDirectory
@@ -2561,7 +2563,7 @@ namespace System.Diagnostics.Tests
             {
                 // returns the username of the owner of the process or null if the username can't be queried.
                 // for services.exe, this will be null.
-                string? servicesUser = Helpers.GetProcessUserName(p); 
+                string? servicesUser = Helpers.GetProcessUserName(p);
 
                 // this isn't really verifying that services.exe is owned by SYSTEM, but we are sure it is not owned by the current user.
                 if (servicesUser != currentProcessUser)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -96,6 +96,7 @@ namespace System.Net.Security.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/70981", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/68206", TestPlatforms.Android)]
         public Task ConnectWithRevocation_WithCallback(bool checkRevocation)
         {
             X509RevocationMode mode = checkRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck;

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -73,6 +73,8 @@ public class AndroidAppBuilderTask : Task
 
     public string? MinApiLevel { get; set; }
 
+    public string? TargetApiLevel { get; set; }
+
     public string? BuildApiLevel { get; set; }
 
     public string? BuildToolsVersion { get; set; }
@@ -106,6 +108,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.AndroidSdk = AndroidSdk;
         apkBuilder.AndroidNdk = AndroidNdk;
         apkBuilder.MinApiLevel = MinApiLevel;
+        apkBuilder.TargetApiLevel = TargetApiLevel;
         apkBuilder.BuildApiLevel = BuildApiLevel;
         apkBuilder.BuildToolsVersion = BuildToolsVersion;
         apkBuilder.StripDebugSymbols = StripDebugSymbols;

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -13,12 +13,14 @@ using Microsoft.Build.Utilities;
 public class ApkBuilder
 {
     private const string DefaultMinApiLevel = "21";
+    private const string DefaultTargetApiLevel = "31";
 
     public string? ProjectName { get; set; }
     public string? AppDir { get; set; }
     public string? AndroidNdk { get; set; }
     public string? AndroidSdk { get; set; }
     public string? MinApiLevel { get; set; }
+    public string? TargetApiLevel { get; set; }
     public string? BuildApiLevel { get; set; }
     public string? BuildToolsVersion { get; set; }
     public string OutputDir { get; set; } = ""!;
@@ -118,14 +120,24 @@ public class ApkBuilder
         if (string.IsNullOrEmpty(MinApiLevel))
             MinApiLevel = DefaultMinApiLevel;
 
-        // make sure BuildApiLevel >= MinApiLevel
+        if (string.IsNullOrEmpty(TargetApiLevel))
+            TargetApiLevel = DefaultTargetApiLevel;
+
+        // make sure BuildApiLevel >= MinApiLevel and BuildApiLevel >= TargetApiLevel
         // only if these api levels are not "preview" (not integers)
-        if (int.TryParse(BuildApiLevel, out int intApi) &&
-            int.TryParse(MinApiLevel, out int intMinApi) &&
-            intApi < intMinApi)
+        if (int.TryParse(BuildApiLevel, out int intApi))
         {
-            throw new ArgumentException($"BuildApiLevel={BuildApiLevel} <= MinApiLevel={MinApiLevel}. " +
-                "Make sure you've downloaded some recent build-tools in Android SDK");
+            if (int.TryParse(MinApiLevel, out int intMinApi) && intApi < intMinApi)
+            {
+                throw new ArgumentException($"BuildApiLevel={BuildApiLevel} < MinApiLevel={MinApiLevel}. " +
+                    "Make sure you've downloaded some recent build-tools in Android SDK");
+            }
+
+            if (int.TryParse(TargetApiLevel, out int intTargetApi) && intApi < intTargetApi)
+            {
+                throw new ArgumentException($"BuildApiLevel={BuildApiLevel} < TargetApiLevel={TargetApiLevel}. " +
+                    "Make sure you've downloaded some recent build-tools in Android SDK");
+            }
         }
 
         string buildToolsFolder = Path.Combine(AndroidSdk, "build-tools", BuildToolsVersion);
@@ -397,7 +409,8 @@ public class ApkBuilder
         File.WriteAllText(Path.Combine(OutputDir, "AndroidManifest.xml"),
             Utils.GetEmbeddedResource("AndroidManifest.xml")
                 .Replace("%PackageName%", packageId)
-                .Replace("%MinSdkLevel%", MinApiLevel));
+                .Replace("%MinSdkLevel%", MinApiLevel)
+                .Replace("%TargetSdkVersion%", TargetApiLevel));
 
         string javaCompilerArgs = $"-d obj -classpath src -bootclasspath {androidJar} -source 1.8 -target 1.8 ";
         Utils.RunProcess(logger, javac, javaCompilerArgs + javaActivityPath, workingDir: OutputDir);

--- a/src/tasks/AndroidAppBuilder/Templates/AndroidManifest.xml
+++ b/src/tasks/AndroidAppBuilder/Templates/AndroidManifest.xml
@@ -3,7 +3,7 @@
           package="%PackageName%"
           a:versionCode="1"
           a:versionName="1.0">
-  <uses-sdk a:minSdkVersion="%MinSdkLevel%" />
+  <uses-sdk a:minSdkVersion="%MinSdkLevel%" a:targetSdkVersion="31" />
   <uses-permission a:name="android.permission.INTERNET"/>
   <uses-permission a:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission a:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/src/tasks/AndroidAppBuilder/Templates/AndroidManifest.xml
+++ b/src/tasks/AndroidAppBuilder/Templates/AndroidManifest.xml
@@ -3,7 +3,7 @@
           package="%PackageName%"
           a:versionCode="1"
           a:versionName="1.0">
-  <uses-sdk a:minSdkVersion="%MinSdkLevel%" a:targetSdkVersion="31" />
+  <uses-sdk a:minSdkVersion="%MinSdkLevel%" a:targetSdkVersion="%TargetSdkVersion%" />
   <uses-permission a:name="android.permission.INTERNET"/>
   <uses-permission a:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission a:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
We should run our tests targeting API 31 which is currently the [Google Play's requirement](https://developer.android.com/google/play/requirements/target-sdk).

It will be necessary to use Android SDK 31+ for local builds. The build process will show an error message instructing the developer to install newer build tools it they're out of date. The CI already uses SDK version 33 (https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/713).