### PR TITLE
[Android] Add an AzDO pipeline to run tests on emulators running all supported Android API levels

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
@@ -7,6 +7,7 @@ parameters:
   isExtraPlatformsBuild: false
   isAndroidEmulatorOnlyBuild: false
   isRollingBuild: false
+  allApiLevels: false
 
 jobs:
 
@@ -39,6 +40,7 @@ jobs:
       runtimeVariant: minijit
       buildArgs: -s mono+libs -c $(_BuildConfig)
       timeoutInMinutes: 240
+      allApiLevels: ${{ parameters.allApiLevels }}
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
       extraStepsParameters:
@@ -75,6 +77,7 @@ jobs:
       runtimeVariant: monointerpreter
       buildArgs: -s mono+libs -c $(_BuildConfig)
       timeoutInMinutes: 240
+      allApiLevels: ${{ parameters.allApiLevels }}
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
       extraStepsParameters:
@@ -106,6 +109,7 @@ jobs:
       isExtraPlatforms: ${{ parameters.isExtraPlatformsBuild }}
       buildArgs: -s mono+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg)
       timeoutInMinutes: 180
+      allApiLevels: ${{ parameters.allApiLevels }}
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -104,6 +104,18 @@ jobs:
     # Android
     - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
       - Ubuntu.1804.Amd64.Android.29.Open
+      - ${{ if eq(parameters.jobParameters.allApiLevels, true) }}:
+        - Ubuntu.1804.Amd64.Android.21.Open
+        - Ubuntu.1804.Amd64.Android.22.Open
+        - Ubuntu.1804.Amd64.Android.23.Open
+        - Ubuntu.1804.Amd64.Android.24.Open
+        - Ubuntu.1804.Amd64.Android.25.Open
+        - Ubuntu.1804.Amd64.Android.26.Open
+        - Ubuntu.1804.Amd64.Android.27.Open
+        - Ubuntu.1804.Amd64.Android.28.Open
+        - Ubuntu.1804.Amd64.Android.30.Open
+        - Ubuntu.1804.Amd64.Android.31.Open
+        - Ubuntu.1804.Amd64.Android.32.Open
     - ${{ if in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm64') }}:
       - Windows.10.Amd64.Android.Open
 

--- a/eng/pipelines/runtime-androidemulator-all-api-levels.yml
+++ b/eng/pipelines/runtime-androidemulator-all-api-levels.yml
@@ -1,0 +1,29 @@
+# This is a wrapper yml for `runtime-extra-platforms-androidemulator.yml`,
+# which has all the Android jobs. This file is essentially so we can have
+# point the pipeline in azdo UI to this.
+
+trigger: none
+
+schedules:
+  - cron: "0 4 * * Mon" # run at 4:00 (UTC) on every Monday
+    displayName: Run tests on all Android API levels
+    branches:
+      include:
+      - main
+    always: true
+
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
+      - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+        parameters:
+          isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+          isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
+          isRollingBuild: ${{ variables.isRollingBuild }}
+          allApiLevels: true

--- a/eng/pipelines/runtime-androidemulator-all-api-levels.yml
+++ b/eng/pipelines/runtime-androidemulator-all-api-levels.yml
@@ -1,0 +1,29 @@
+# This is a wrapper yml for `runtime-extra-platforms-androidemulator.yml`,
+# which has all the Android jobs. This file is essentially so we can have
+# point the pipeline in azdo UI to this.
+
+trigger: none
+
+schedules:
+  - cron: "0 4 * * 1" # run at 4:00 (UTC) on every Monday
+    displayName: Run tests on all Android API levels
+    branches:
+      include:
+      - main
+    always: true
+
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
+      - template: /eng/pipelines/extra-platforms/runtime-extra-platforms-androidemulator.yml
+        parameters:
+          isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
+          isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
+          isRollingBuild: ${{ variables.isRollingBuild }}
+          allApiLevels: true

--- a/eng/pipelines/runtime-androidemulator.yml
+++ b/eng/pipelines/runtime-androidemulator.yml
@@ -1,9 +1,16 @@
 # This is a wrapper yml for `runtime-extra-platforms-androidemulator.yml`,
-# which has all the wasm jobs. This file is essentially so we can have
-# point the pipeline in azdo UI to this, and thus avoid any scheduled
-# triggers
+# which has all the Android jobs. This file is essentially so we can have
+# point the pipeline in azdo UI to this.
 
 trigger: none
+
+schedules:
+  - cron: "0 4 * * Mon" # run at 4:00 (UTC) on every Monday
+    displayName: Run tests on all Android API levels
+    branches:
+      include:
+      - main
+    always: true
 
 variables:
   - template: /eng/pipelines/common/variables.yml
@@ -19,3 +26,4 @@ extends:
           isExtraPlatformsBuild: ${{ variables.isExtraPlatformsBuild }}
           isAndroidEmulatorOnlyBuild: ${{ variables.isAndroidEmulatorOnlyBuild }}
           isRollingBuild: ${{ variables.isRollingBuild }}
+          allApiLevels: true


### PR DESCRIPTION
We support Android API 21+ but we only run runtime and library tests on devices and emulators running API 29. This PR will add a separate pipeline that'll run once a week on all the API levels currently available in helix (21-32).