### PR TITLE
Suppress more managed TypeReference warnings-as-errors

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/mono/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -63,7 +63,9 @@ namespace System
             TypedReference result = default;
             unsafe
             {
+#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
                 IntGetNextArg(&result);
+#pragma warning restore CS8500
             }
             return result;
         }
@@ -79,7 +81,9 @@ namespace System
             TypedReference result = default;
             unsafe
             {
+#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
                 IntGetNextArgWithType(&result, rth.Value);
+#pragma warning restore CS8500
             }
             return result;
         }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -111,7 +111,9 @@ namespace System.Reflection
             unsafe
             {
                 // Passing TypedReference by reference is easier to make correct in native code
+#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
                 RuntimeFieldHandle.SetValueDirect(this, (RuntimeType)FieldType, &obj, value, (RuntimeType?)DeclaringType);
+#pragma warning restore CS8500
             }
         }
 
@@ -125,7 +127,9 @@ namespace System.Reflection
             unsafe
             {
                 // Passing TypedReference by reference is easier to make correct in native code
+#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
                 return RuntimeFieldHandle.GetValueDirect(this, (RuntimeType)FieldType, &obj, (RuntimeType?)DeclaringType);
+#pragma warning restore CS8500
             }
         }
 

--- a/src/mono/System.Private.CoreLib/src/System/TypedReference.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/TypedReference.Mono.cs
@@ -18,7 +18,9 @@ namespace System
 
         public static unsafe object? ToObject(TypedReference value)
         {
+#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
             return InternalToObject(&value);
+#pragma warning restore CS8500
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
To unblock Roslyn ingestion.