### PR TITLE
Handle Span<T>.Length and ReadOnlySpan<T>.Length as intrinsic

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2812,6 +2812,37 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 break;
             }
 
+            case NI_System_Span_get_Length:
+            case NI_System_ReadOnlySpan_get_Length:
+            {
+                assert(sig->sigInst.classInstCount == 1);
+                assert(sig->numArgs == 0);
+
+                CORINFO_CLASS_HANDLE spanElemHnd = sig->sigInst.classInst[0];
+                const unsigned       elemSize    = info.compCompHnd->getClassSize(spanElemHnd);
+                assert(elemSize > 0);
+
+                const bool isReadOnly = (ni == NI_System_ReadOnlySpan_get_Length);
+
+                JITDUMP("\nimpIntrinsic: Expanding %sSpan<T>.get_Length, T=%s, sizeof(T)=%u\n",
+                        isReadOnly ? "ReadOnly" : "", eeGetClassName(spanElemHnd), elemSize);
+
+                GenTree* ptrToSpan = impPopStack().val;
+
+#if defined(DEBUG)
+                if (verbose)
+                {
+                    printf("with ptr-to-span\n");
+                    gtDispTree(ptrToSpan);
+                }
+#endif // defined(DEBUG)
+
+                CORINFO_FIELD_HANDLE lengthHnd    = info.compCompHnd->getFieldInClass(clsHnd, 1);
+                const unsigned       lengthOffset = info.compCompHnd->getFieldOffset(lengthHnd);
+
+                return gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
+            }
+
             case NI_System_RuntimeTypeHandle_GetValueInternal:
             {
                 GenTree* op1 = impStackTop(0).val;
@@ -7230,6 +7261,10 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                 {
                     result = NI_System_ReadOnlySpan_get_Item;
                 }
+                else if (strcmp(methodName, "get_Length") == 0)
+                {
+                    result = NI_System_ReadOnlySpan_get_Length;
+                }
             }
             else if (strcmp(className, "RuntimeType") == 0)
             {
@@ -7250,6 +7285,10 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                 if (strcmp(methodName, "get_Item") == 0)
                 {
                     result = NI_System_Span_get_Item;
+                }
+                else if (strcmp(methodName, "get_Length") == 0)
+                {
+                    result = NI_System_Span_get_Length;
                 }
             }
             else if (strcmp(className, "String") == 0)

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -101,7 +101,9 @@ enum NamedIntrinsic : unsigned short
     NI_System_String_op_Implicit,
     NI_System_String_StartsWith,
     NI_System_Span_get_Item,
+    NI_System_Span_get_Length,
     NI_System_ReadOnlySpan_get_Item,
+    NI_System_ReadOnlySpan_get_Length,
 
     NI_System_MemoryExtensions_AsSpan,
     NI_System_MemoryExtensions_Equals,

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -157,6 +157,7 @@ namespace System
         /// </summary>
         public int Length
         {
+            [Intrinsic]
             [NonVersionable]
             get => _length;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -163,6 +163,7 @@ namespace System
         /// </summary>
         public int Length
         {
+            [Intrinsic]
             [NonVersionable]
             get => _length;
         }


### PR DESCRIPTION
This marks `Span<T>.Length` and `ROSpan<T>.Length` as intrinsic and directly handles them as part of importation.

This does not update `fgbasic` to take into account that comparisons against the value feed bounds checks (`LDLEN` does `PushArrayLen` which tracks `SLOT_ARRAYLEN` which in turn enables `CALLEE_ARG_FEEDS_RANGE_CHECK`).

This likewise does not enable the handling to track that the length is always positive. However, this is the first step required to do both of those work items as later PRs.