### PR TITLE
Target lower glibc for Linux arm64

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -15,9 +15,9 @@ resources:
         ROOTFS_DIR: /crossrootfs/armv6
 
     - container: linux_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-arm64
       env:
-        ROOTFS_DIR: /crossrootfs/arm64
+        ROOTFS_DIR: /crossrootfs
 
     - container: linux_musl_x64
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -711,6 +711,7 @@
       <MonoAotAbi>aarch64-linux-gnu</MonoAotAbi>
       <MonoAotOffsetsFile>$(MonoObjCrossDir)offsets-aarch-linux-gnu.h</MonoAotOffsetsFile>
       <MonoAotOffsetsPrefix>$(MonoCrossDir)/usr/lib/gcc/aarch64-linux-gnu/7</MonoAotOffsetsPrefix>
+      <MonoAotOffsetsPrefix Condition="'$(Platform)' == 'arm64'">$(MonoCrossDir)/usr/lib/gcc/aarch64-linux-gnu/5</MonoAotOffsetsPrefix>
     </PropertyGroup>
 
     <!-- macOS host specific options -->


### PR DESCRIPTION
This uses new cross-build images, added in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/754, that target Ubuntu 16.04. The initial change is only for Linux arm64, to match what we plan to do in .NET 7 (in https://github.com/dotnet/runtime/pull/80866). I'm making the change in 8.0 to get validation of the PGO instrumentation, which happens in official builds, but not in PR jobs.

The new images were published here: https://github.com/dotnet/versions/commit/33968c3c389e47f2e555771be1ceca26ba27055b