### PR TITLE
Disable a couple of coreclr test for unloadability testing

### DIFF
--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetUnix.csproj
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests_TargetUnix.csproj
@@ -4,6 +4,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- There is a Windows and a non-Windows version of this test to allow it to be compiled for all targets -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' == 'true'">true</CLRTestTargetUnsupported>
+    <!-- The test has a static variable holding an instance of an object from the unloadable context -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GlobalInstance.cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M01/b08046cs/b08046cs.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M01/b08046cs/b08046cs.csproj
@@ -3,6 +3,9 @@
     <!-- Needed for Environment.Exit -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <OutputType>Exe</OutputType>
+    <!-- System.Text.EncodingHelper.GetSupportedConsoleEncoding in different assembly from System.Console.get_OutputEncoding,
+     tries to load the assembly System.Text.EncodingHelper after the ALC unload started -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/opt/Remainder/IntRemainder.csproj
+++ b/src/tests/JIT/opt/Remainder/IntRemainder.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-  </PropertyGroup>
+    <!-- The test checks the generated code for a method that accesses statics.
+         In unloadable context the helper to access those is different, so the
+         test fails -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+</PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>

--- a/src/tests/profiler/multiple/multiple.csproj
+++ b/src/tests/profiler/multiple/multiple.csproj
@@ -5,6 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- This test provides no value for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The System.Net.Sockets.SocketAsyncEngine.EventLoop on Unix is running forever
+     inside of the unloadable AssemblyLoadContext, preventing its unload -->
+    <UnloadabilityIncompatible Condition="'$(TargetsWindows)' != 'true'">true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
There are four tests that are failing because of various incompatibilities of the tests with unloadability. This change disables them for the unloadability testing.