### PR TITLE
Make sure we specify arguments only when the test ask for it

### DIFF
--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -992,7 +992,12 @@ public class ReliabilityFramework
 
                         try
                         {
-                            daTest.EntryPointMethod.Invoke(null, new object[] { (daTest.Arguments == null) ? new string[0] : daTest.GetSplitArguments() });
+                            object[] parameters = null;
+                            if (daTest.EntryPointMethod.GetParameters().Length == 1)
+                            {
+                                parameters = new object[] { (daTest.Arguments == null) ? new string[0] : daTest.GetSplitArguments() };
+                            }
+                            daTest.EntryPointMethod.Invoke(null, parameters);
                         }
                         catch (Exception e)
                         {

--- a/src/tests/GC/Stress/Framework/ReliabilityTest.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityTest.cs
@@ -48,7 +48,11 @@ public class TestAssemblyLoadContext : AssemblyLoadContext
     public int ExecuteAssembly(string path, string[] args)
     {
         Assembly assembly = LoadFromAssemblyPath(Path.Combine(_applicationBase, path));
-        object[] actualArgs = new object[] { args != null ? args : new string[0] };
+        object[] actualArgs = null;
+        if (assembly.EntryPoint.GetParameters().Length == 1)
+        {
+            actualArgs = new object[] { args != null ? args : new string[0] };
+        }
         return (int)assembly.EntryPoint.Invoke(null, actualArgs);
     }
 


### PR DESCRIPTION
In the reliability framework test, we use reflection to invoke the main method.

There are some test cases where the `string[]` argument is absent in the main method, and therefore the reflection call will fail.

This change detects the situation and make sure we supply the right number of arguments to the reflection call.