### PR TITLE
[mono][loader] Set status on success

### DIFF
--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2024,6 +2024,8 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 		mono_image_fixup_vtable (image);
 #endif
 
+	*status = MONO_IMAGE_OK;
+
 	mono_assembly_invoke_load_hook_internal (req->alc, ass);
 
 	MONO_PROFILER_RAISE (assembly_loaded, (ass));


### PR DESCRIPTION
Emebedders that call `mono_assembly_load_from_full` may observe a non-NULL return value and an uninitialized MonoImageOpenStatus, which may lead to incorrect diagnostics in code like:

```
MonoImageOpenStatus status;
MonoAssembly *assembly = mono_assembly_load_from_full (image, name, status, refonly);
if (!assembly || status != MONO_IMAGE_OK) {
   fprintf(stderr, "Failure due to: %s\n", mono_image_strerror (status));
   abort();
}
```
Which will print `Failure due to: Internal error`

Addresses https://github.com/xamarin/xamarin-android/issues/7658