### PR TITLE
Remove presumably-useless? serializability checks

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Collections/EmptyReadOnlyDictionaryInternal.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Collections/EmptyReadOnlyDictionaryInternal.cs
@@ -91,12 +91,6 @@ namespace System.Collections
         {
             ArgumentNullException.ThrowIfNull(key);
 
-            if (!key.GetType().IsSerializable)
-                throw new ArgumentException(SR.Argument_NotSerializable, nameof(key));
-
-            if ((value != null) && (!value.GetType().IsSerializable))
-                throw new ArgumentException(SR.Argument_NotSerializable, nameof(value));
-
             throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Collections/EmptyReadOnlyDictionaryInternal.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Collections/EmptyReadOnlyDictionaryInternal.cs
@@ -68,12 +68,6 @@ namespace System.Collections
             {
                 ArgumentNullException.ThrowIfNull(key);
 
-                if (!key.GetType().IsSerializable)
-                    throw new ArgumentException(SR.Argument_NotSerializable, nameof(key));
-
-                if ((value != null) && (!value.GetType().IsSerializable))
-                    throw new ArgumentException(SR.Argument_NotSerializable, nameof(value));
-
                 throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
             }
         }


### PR DESCRIPTION
Came across this when reading through the code during a debug session. Most of these checks (including the similar ones in `ListDictionaryInternal`) were removed [some time ago](https://github.com/dotnet/runtime/commit/9d1fbf07ccbb709c23e7b3ff7f3aff37378781ee#diff-bd1f3e9b3a41519edd779c3c5d8218dd71638d955a5899d6a255d97d1bdfd70f), but this one wasn't behind a `#if`, so perhaps there's a good reason to keep it around.

Figured I'd file a PR just in case there was interest in cleaning this up. 

From a quick search it appears this may be the last usage of `SR.Argument_NotSerializable`, so possibly that could be removed too if this is accepted.