### PR TITLE
Add suppression for CS8500 to test reflection/regression/github_25697

### DIFF
--- a/src/tests/reflection/regression/github_25697/25697.cs
+++ b/src/tests/reflection/regression/github_25697/25697.cs
@@ -4,8 +4,11 @@
 using System;
 using System.Reflection;
 
+#pragma warning disable CS8500
+
 unsafe class Program
 {
+
     public static void AsTypedReference<T>(ref T value, TypedReference* output)
     {
         *output = __makeref(value);
@@ -27,3 +30,5 @@ unsafe class Program
         return 100;
     }
 }
+
+#pragma warning restore CS8500


### PR DESCRIPTION
Fixes coreclr1 test build break.