### PR TITLE
Ignore the property with JsonIgnore when generating source code

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -667,6 +667,19 @@ namespace {@namespace}
 
                 List<PropertyGenerationSpec> properties = typeGenerationSpec.PropertyGenSpecList!;
 
+                if (typeGenerationSpec.CtorParamGenSpecArray != null)
+                {
+                    properties = properties
+                        .Where(prop => prop.DefaultIgnoreCondition != JsonIgnoreCondition.Always ||
+                                       typeGenerationSpec.CtorParamGenSpecArray.Any(
+                                           ctorPara => prop.ClrName.Equals(ctorPara.ParameterInfo.Name, StringComparison.OrdinalIgnoreCase)))
+                        .ToList();
+                }
+                else
+                {
+                    properties = properties.Where(prop => prop.DefaultIgnoreCondition != JsonIgnoreCondition.Always).ToList();
+                }
+
                 int propCount = properties.Count;
 
                 string propertyArrayInstantiationValue = propCount == 0


### PR DESCRIPTION
Ignore the property with JsonIgnore attribute when generating property info.
If the property is bind with parameter in constructor, we keep generating the property info.