### PR TITLE
[mono][aot] Extend Mono.ValueTuple to 7 arguments.

### DIFF
--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -610,6 +610,8 @@
 		<type fullname="Mono.ValueTuple`3" preserve="fields"/>
 		<type fullname="Mono.ValueTuple`4" preserve="fields"/>
 		<type fullname="Mono.ValueTuple`5" preserve="fields"/>
+		<type fullname="Mono.ValueTuple`6" preserve="fields"/>
+		<type fullname="Mono.ValueTuple`7" preserve="fields"/>
 		<!-- aot-compiler.c -->
 		<type fullname="Mono.I8Enum" preserve="fields"/>
 		<type fullname="Mono.UI8Enum" preserve="fields"/>

--- a/src/mono/System.Private.CoreLib/src/Mono/RuntimeStructs.cs
+++ b/src/mono/System.Private.CoreLib/src/Mono/RuntimeStructs.cs
@@ -118,6 +118,27 @@ namespace Mono
         public T5 Item5;
     }
 
+    internal struct ValueTuple<T1, T2, T3, T4, T5, T6>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+    }
+
+    internal struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+    }
+
     internal enum I8Enum : byte
     {
     }

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -1148,6 +1148,8 @@ static GENERATE_GET_CLASS_WITH_CACHE (valuetuple_2, "Mono", "ValueTuple`2");
 static GENERATE_GET_CLASS_WITH_CACHE (valuetuple_3, "Mono", "ValueTuple`3");
 static GENERATE_GET_CLASS_WITH_CACHE (valuetuple_4, "Mono", "ValueTuple`4");
 static GENERATE_GET_CLASS_WITH_CACHE (valuetuple_5, "Mono", "ValueTuple`5");
+static GENERATE_GET_CLASS_WITH_CACHE (valuetuple_6, "Mono", "ValueTuple`6");
+static GENERATE_GET_CLASS_WITH_CACHE (valuetuple_7, "Mono", "ValueTuple`7");
 
 static MonoType*
 get_wrapper_shared_type (MonoType *t);
@@ -1187,7 +1189,6 @@ get_wrapper_shared_vtype (MonoType *t)
 	gpointer iter = NULL;
 	MonoClassField *field;
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
-
 		if (field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA))
 			continue;
 		MonoType *ftype = get_wrapper_shared_type_full (field->type, TRUE);
@@ -1213,11 +1214,11 @@ get_wrapper_shared_vtype (MonoType *t)
 		for (int i = 0; i < findex; ++i)
 			args [i] = m_class_get_byval_arg (mono_get_int64_class ());
 	} else {
-		if (findex > 5)
+		if (findex > 7)
 			return NULL;
 	}
 #else
-	if (findex > 5)
+	if (findex > 7)
 		return NULL;
 #endif
 
@@ -1239,6 +1240,12 @@ get_wrapper_shared_vtype (MonoType *t)
 		break;
 	case 5:
 		tuple_class = mono_class_get_valuetuple_5_class ();
+		break;
+	case 6:
+		tuple_class = mono_class_get_valuetuple_6_class ();
+		break;
+	case 7:
+		tuple_class = mono_class_get_valuetuple_7_class ();
 		break;
 	default:
 		g_assert_not_reached ();


### PR DESCRIPTION
This fixes a crash in the System.Text.RegularExpression tests on wasm+aot.