### PR TITLE
JIT: fix jit stress failures in `fgSetBlockOrder`

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4692,8 +4692,6 @@ bool Compiler::optReachWithoutCall(BasicBlock* topBB, BasicBlock* botBB)
     // When we can determine this, then we can set BBF_GC_SAFE_POINT for
     // those helpers too.
 
-    noway_assert(topBB->bbNum <= botBB->bbNum);
-
     // We can always check topBB and botBB for any gc safe points and early out
 
     if ((topBB->bbFlags | botBB->bbFlags) & BBF_GC_SAFE_POINT)
@@ -4708,6 +4706,8 @@ bool Compiler::optReachWithoutCall(BasicBlock* topBB, BasicBlock* botBB)
         // return a conservative answer of true when we don't have the dominator sets
         return true;
     }
+
+    noway_assert(topBB->bbNum <= botBB->bbNum);
 
     BasicBlock* curBB = topBB;
     for (;;)


### PR DESCRIPTION
Defer asserting that bbNums are ordered until we know if we're optimizing (and hence have computed dominators).

Fixes #80974.