### PR TITLE
Fix for issue #80350 tracking runtime deficiencies in the presence of static virtual method reabstraction

### DIFF
--- a/src/tests/Loader/classloader/StaticVirtualMethods/DiamondShape/svm_diamondshape.il
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/DiamondShape/svm_diamondshape.il
@@ -232,7 +232,7 @@
 .class interface private abstract auto ansi I4Reabstract
        implements I4
 {
-  .method private hidebysig abstract
+  .method private hidebysig virtual abstract
           static int32  Func(int32 a) cil managed
   {
     .override method int32 I1::Func(int32)

--- a/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_80350.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_80350.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+// This regression test tracks the issue where implementation of a static virtual method
+// on a derived type is not found when there is a re-abstraction of the same method
+// higher in inheritance hierarchy.
+
+class Test1 : I2
+{
+
+    static int Main()
+    {
+        string result = Test<Test1>();
+        const string expectedResult = "Test1.M1";
+        Console.WriteLine("Expected {0}, found {1}: {2}", expectedResult, result, expectedResult == result ? "match" : "mismatch");
+        return result == expectedResult ? 100 : 101;
+    }
+
+    static string Test<i1>() where i1 : I1
+    {
+        return i1.M1();
+    }
+
+    static string I1.M1()
+    {
+        return "Test1.M1";
+    }
+}
+
+public interface I1
+{
+    static abstract string M1();
+}
+
+public interface I2 : I1
+{
+    static abstract string I1.M1();
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_80350.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_80350.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1525,6 +1525,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/CompatibleWithTest/**">
             <Issue>Doesn't pass after LLVM AOT compilation.</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/DiamondShape/**">
+            <Issue>https://github.com/dotnet/runtime/issues/80350</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/StaticVirtualMethods/InterfaceVariance/**">
             <Issue>Static virtual methods are not yet implemented in the Mono runtime.</Issue>
         </ExcludeList>


### PR DESCRIPTION
This change fixes the issue

https://github.com/dotnet/runtime/issues/80350

that uncovered several inconsistencies in the CoreCLR runtime
w.r.t. static virtual methods. In particular, reabstraction (declaring
an abstract explicit override of a static virtual method in a derived
interface) turned out to be causing runtime issues. As part of
the change I'm also fixing the reabstraction unit test
svm_diamondshape as it turns out Roslyn emits the method flags
in a slightly different manner than I originally expected in the
hand-written IL test.

Thanks

Tomas

P.S. This PR would be normally an obvious adept for nominating @davidwrighton as the reviewer. As David is on parental leave right now, I am designating a larger reviewer group to get more pairs of eyes to see the change and also ideally proliferate CoreCLR typesystem knowledge to improve our agility the next time David's not available.