### PR TITLE
JIT: build pred lists before inlining

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4407,6 +4407,23 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_IMPORTATION, &Compiler::fgImport);
 
+    // If this is a failed inline attempt, we're done.
+    //
+    if (compIsForInlining() && compInlineResult->IsFailure())
+    {
+#ifdef FEATURE_JIT_METHOD_PERF
+        if (pCompJitTimer != nullptr)
+        {
+#if MEASURE_CLRAPI_CALLS
+            EndPhase(PHASE_CLR_API);
+#endif
+            pCompJitTimer->Terminate(this, CompTimeSummaryInfo::s_compTimeSummary, false);
+        }
+#endif
+
+        return;
+    }
+
     // If instrumenting, add block and class probes.
     //
     if (compileFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR))

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2759,12 +2759,19 @@ static volatile int bbTraverseLabel = 1;
 
 void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRefs /* = true  */)
 {
-#ifdef DEBUG
     if (verbose)
     {
-        printf("*************** In fgDebugCheckBBlist\n");
+        JITDUMP("*************** In fgDebugCheckBBlist\n");
     }
-#endif // DEBUG
+
+    // Don't bother checking a failed inlinee; we may have bailed
+    // out in the middle of importation.
+    //
+    if (compIsForInlining() && compInlineResult->IsFailure())
+    {
+        JITDUMP("... failed inline attempt, no checking needed\n");
+        return;
+    }
 
     fgDebugCheckBlockLinks();
     fgFirstBBisScratch();

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2974,6 +2974,12 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
         assert(genReturnBB->GetFirstLIRNode() != nullptr || genReturnBB->bbStmtList != nullptr);
     }
 
+    // If this is an inlinee, we're done checking.
+    if (compIsForInlining())
+    {
+        return;
+    }
+
     // The general encoder/decoder (currently) only reports "this" as a generics context as a stack location,
     // so we mark info.compThisArg as lvAddrTaken to ensure that it is not enregistered. Otherwise, it should
     // not be address-taken.  This variable determines if the address-taken-ness of "thisArg" is "OK".

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -810,16 +810,22 @@ void Compiler::fgComputePreds()
         }
     }
 
-    for (EHblkDsc* const ehDsc : EHClauses(this))
+    // Add artifical ref counts to the entry of filters and handlers.
+    // We don't inline methods with EH, so this is only relevant to the root method.
+    //
+    if (!compIsForInlining())
     {
-        if (ehDsc->HasFilter())
+        for (EHblkDsc* const ehDsc : EHClauses(this))
         {
-            // The first block of a filter has an artificial extra refcount.
-            ehDsc->ebdFilter->bbRefs++;
-        }
+            if (ehDsc->HasFilter())
+            {
+                // The first block of a filter has an artificial extra refcount.
+                ehDsc->ebdFilter->bbRefs++;
+            }
 
-        // The first block of a handler has an artificial extra refcount.
-        ehDsc->ebdHndBeg->bbRefs++;
+            // The first block of a handler has an artificial extra refcount.
+            ehDsc->ebdHndBeg->bbRefs++;
+        }
     }
 
     fgModified         = false;


### PR DESCRIPTION
Move pred list building up a bit further. Note that this impacts both the root method and all inlinees, since we run a number of the initial phases on both.

Since inlinees build their basic blocks and flow edges in the root compiler's memory pool, the only work required to unify the pred lists for a successful inline is to get things right at the boundaries. And for failed inlines there is no cross-referencing so we can just let the new pred lists leak away (like we alredy do for the inlinee blocks).

Contributes towards #80193.