### PR TITLE
Optimize "new DateTime(<const args>)" via improvements in JIT VN

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3227,13 +3227,10 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
 
     if (conValTree != nullptr)
     {
-        if (tree->OperIs(GT_LCL_VAR))
+        if (!optIsProfitableToSubstitute(tree, block, conValTree))
         {
-            if (!optIsProfitableToSubstitute(tree->AsLclVar(), block, conValTree))
-            {
-                // Not profitable to substitute
-                return nullptr;
-            }
+            // Not profitable to substitute
+            return nullptr;
         }
 
         // Were able to optimize.
@@ -3259,26 +3256,34 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
 }
 
 //------------------------------------------------------------------------------
-// optIsProfitableToSubstitute: Checks if value worth substituting to lcl location
+// optIsProfitableToSubstitute: Checks if value worth substituting to dest
 //
 // Arguments:
-//    lcl       - lcl to replace with value if profitable
-//    lclBlock  - Basic block lcl located in
-//    value     - value we plan to substitute to lcl
+//    dest      - destination to substitute value to
+//    destBlock - Basic block of destination
+//    value     - value we plan to substitute
 //
 // Returns:
 //    False if it's likely not profitable to do substitution, True otherwise
 //
-bool Compiler::optIsProfitableToSubstitute(GenTreeLclVarCommon* lcl, BasicBlock* lclBlock, GenTree* value)
+bool Compiler::optIsProfitableToSubstitute(GenTree* dest, BasicBlock* destBlock, GenTree* value)
 {
+    // Giving up on these kinds of handles demonstrated size improvements
+    if (!value->IsIntegralConst(0) && value->IsIconHandle(GTF_ICON_STATIC_HDL, GTF_ICON_CLASS_HDL))
+    {
+        return false;
+    }
+
     // A simple heuristic: If the constant is defined outside of a loop (not far from its head)
     // and is used inside it - don't propagate.
 
     // TODO: Extend on more kinds of trees
-    if (!value->OperIs(GT_CNS_VEC, GT_CNS_DBL))
+    if (!value->OperIs(GT_CNS_VEC, GT_CNS_DBL) || !dest->IsLocal())
     {
         return true;
     }
+
+    const GenTreeLclVarCommon* lcl = dest->AsLclVarCommon();
 
     gtPrepareCost(value);
 
@@ -3294,11 +3299,11 @@ bool Compiler::optIsProfitableToSubstitute(GenTreeLclVarCommon* lcl, BasicBlock*
                 // NOTE: this currently does not take "a float living across a call" case into account
                 // where we might end up with spill/restore on ABIs without callee-saved registers
                 const weight_t defBlockWeight = defBlock->getBBWeight(this);
-                const weight_t lclblockWeight = lclBlock->getBBWeight(this);
+                const weight_t lclblockWeight = destBlock->getBBWeight(this);
 
                 if ((defBlockWeight > 0) && ((lclblockWeight / defBlockWeight) >= BB_LOOP_WEIGHT_SCALE))
                 {
-                    JITDUMP("Constant propagation inside loop " FMT_BB " is not profitable\n", lclBlock->bbNum);
+                    JITDUMP("Constant propagation inside loop " FMT_BB " is not profitable\n", destBlock->bbNum);
                     return false;
                 }
             }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3278,12 +3278,12 @@ bool Compiler::optIsProfitableToSubstitute(GenTree* dest, BasicBlock* destBlock,
     // and is used inside it - don't propagate.
 
     // TODO: Extend on more kinds of trees
-    if (!value->OperIs(GT_CNS_VEC, GT_CNS_DBL) || !dest->IsLocal())
+    if (!value->OperIs(GT_CNS_VEC, GT_CNS_DBL) || !dest->OperIs(GT_LCL_VAR))
     {
         return true;
     }
 
-    const GenTreeLclVarCommon* lcl = dest->AsLclVarCommon();
+    const GenTreeLclVar* lcl = dest->AsLclVar();
 
     gtPrepareCost(value);
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3269,7 +3269,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
 bool Compiler::optIsProfitableToSubstitute(GenTree* dest, BasicBlock* destBlock, GenTree* value)
 {
     // Giving up on these kinds of handles demonstrated size improvements
-    if (!value->IsIntegralConst(0) && value->IsIconHandle(GTF_ICON_STATIC_HDL, GTF_ICON_CLASS_HDL))
+    if (value->IsIconHandle(GTF_ICON_STATIC_HDL, GTF_ICON_CLASS_HDL))
     {
         return false;
     }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7471,7 +7471,7 @@ public:
     GenTree* optConstantAssertionProp(AssertionDsc*        curAssertion,
                                       GenTreeLclVarCommon* tree,
                                       Statement* stmt DEBUGARG(AssertionIndex index));
-    bool optIsProfitableToSubstitute(GenTreeLclVarCommon* lcl, BasicBlock* lclBlock, GenTree* value);
+    bool optIsProfitableToSubstitute(GenTree* dest, BasicBlock* destBlock, GenTree* value);
     bool optZeroObjAssertionProp(GenTree* tree, ASSERT_VALARG_TP assertions);
 
     // Assertion propagation functions.

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8578,12 +8578,13 @@ static bool GetStaticFieldSeqAndAddress(ValueNumStore* vnStore, GenTree* tree, s
         ValueNum op1vn = op1->gtVNPair.GetLiberal();
         ValueNum op2vn = op2->gtVNPair.GetLiberal();
 
-        if (op1->gtVNPair.BothEqual() && !vnStore->IsVNHandle(op1vn) && varTypeIsIntegral(vnStore->TypeOfVN(op1vn)))
+        if (op1->gtVNPair.BothEqual() && vnStore->IsVNConstant(op1vn) && !vnStore->IsVNHandle(op1vn) &&
+            varTypeIsIntegral(vnStore->TypeOfVN(op1vn)))
         {
             val += vnStore->CoercedConstantValue<ssize_t>(op1vn);
             tree = op2;
         }
-        else if (op2->gtVNPair.BothEqual() && !vnStore->IsVNHandle(op2vn) &&
+        else if (op2->gtVNPair.BothEqual() && vnStore->IsVNConstant(op2vn) && !vnStore->IsVNHandle(op2vn) &&
                  varTypeIsIntegral(vnStore->TypeOfVN(op2vn)))
         {
             val += vnStore->CoercedConstantValue<ssize_t>(op2vn);

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -463,12 +463,12 @@ public:
         m_embeddedToCompileTimeHandleMap.AddOrUpdate(embeddedHandle, compileTimeHandle);
     }
 
-    void AddToFieldAddressToFieldSeqMap(ssize_t fldAddr, FieldSeq* fldSeq)
+    void AddToFieldAddressToFieldSeqMap(ValueNum fldAddr, FieldSeq* fldSeq)
     {
         m_fieldAddressToFieldSeqMap.AddOrUpdate(fldAddr, fldSeq);
     }
 
-    FieldSeq* GetFieldSeqFromAddress(ssize_t fldAddr)
+    FieldSeq* GetFieldSeqFromAddress(ValueNum fldAddr)
     {
         FieldSeq* fldSeq;
         if (m_fieldAddressToFieldSeqMap.TryGetValue(fldAddr, &fldSeq))
@@ -1438,7 +1438,7 @@ private:
     typedef SmallHashTable<ssize_t, ssize_t> EmbeddedToCompileTimeHandleMap;
     EmbeddedToCompileTimeHandleMap m_embeddedToCompileTimeHandleMap;
 
-    typedef SmallHashTable<ssize_t, FieldSeq*> FieldAddressToFieldSeqMap;
+    typedef SmallHashTable<ValueNum, FieldSeq*> FieldAddressToFieldSeqMap;
     FieldAddressToFieldSeqMap m_fieldAddressToFieldSeqMap;
 
     struct LargePrimitiveKeyFuncsFloat : public JitLargePrimitiveKeyFuncs<float>

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -463,6 +463,21 @@ public:
         m_embeddedToCompileTimeHandleMap.AddOrUpdate(embeddedHandle, compileTimeHandle);
     }
 
+    void AddToFieldAddressToFieldSeqMap(ssize_t fldAddr, FieldSeq* fldSeq)
+    {
+        m_fieldAddressToFieldSeqMap.AddOrUpdate(fldAddr, fldSeq);
+    }
+
+    FieldSeq* GetFieldSeqFromAddress(ssize_t fldAddr)
+    {
+        FieldSeq* fldSeq;
+        if (m_fieldAddressToFieldSeqMap.TryGetValue(fldAddr, &fldSeq))
+        {
+            return fldSeq;
+        }
+        return nullptr;
+    }
+
     // And the single constant for an object reference type.
     static ValueNum VNForNull()
     {
@@ -1422,6 +1437,9 @@ private:
 
     typedef SmallHashTable<ssize_t, ssize_t> EmbeddedToCompileTimeHandleMap;
     EmbeddedToCompileTimeHandleMap m_embeddedToCompileTimeHandleMap;
+
+    typedef SmallHashTable<ssize_t, FieldSeq*> FieldAddressToFieldSeqMap;
+    FieldAddressToFieldSeqMap m_fieldAddressToFieldSeqMap;
 
     struct LargePrimitiveKeyFuncsFloat : public JitLargePrimitiveKeyFuncs<float>
     {


### PR DESCRIPTION
This PR is the last missing piece to fold `new DateTime(2023, 1, 22)` call into just a constant in JIT. While there is not much value in folding `DateTime` specifically, the PR(s) improves constant folding in JIT around RVA fields for a general case and makes it more robust. Just look at this screenshot (click to zoom):

![image](https://user-images.githubusercontent.com/523221/213939205-567c6b86-0dfa-4828-907b-89d26f1bbbae.png)

All of that code is inlined and folded including "array" accesses to those `ReadOnlySpan<>` fields during JIT compilation into `Test()` method on the left-top.

Previous codegen for `Test()`:
```asm
; Method ConsoleApp1.Program:Test():System.DateTime:this
G_M15270_IG01:              ;; offset=0000H
       4883EC28             sub      rsp, 40
G_M15270_IG02:              ;; offset=0004H
       48B8F82AE494FB7F0000 mov      rax, 0x7FFB94E42AF8      ; static handle
       8B5004               mov      edx, dword ptr [rax+04H]
       8B00                 mov      eax, dword ptr [rax]
       2BD0                 sub      edx, eax
       83FA16               cmp      edx, 22
       7218                 jb       SHORT G_M15270_IG04
       05ED440B00           add      eax, 0xB44ED
       48BA00C0692AC9000000 mov      rdx, 0xC92A69C000
       480FAFC2             imul     rax, rdx
G_M15270_IG03:              ;; offset=002DH
       4883C428             add      rsp, 40
       C3                   ret      
G_M15270_IG04:              ;; offset=0032H
       FF15B88E0B00         call     [System.ThrowHelper:ThrowArgumentOutOfRange_BadYearMonthDay()]
       CC                   int3     
; Total bytes of code: 57
```

What this PR does specifically is:
1) Don't add implicit VN cast for `nint -> byref` operations on top of ICON handles (thanks to @SingleAccretion for idea). This leads to a slight size regression because JIT now recognizes more places it can propagate constants to 
2) Don't propagate certain types of handles to fix size regressions introduced by ^
3) Add ability to obtain a `FieldSeq*` for given address via a side hashmap since we don't encode FieldSeq into a VN.

SPMI diffs are expected not to catch some improvements due to new VM calls (contexts) to fold RVAs

_Just-for-fun_ retrospective of PRs helped to fold all of that 🙂:

- https://github.com/dotnet/runtime/pull/79461 (and corresponding Roslyn PR) allowed us to rely on `ROS<>` for truly constant arrays
- https://github.com/dotnet/runtime/pull/61079 - added `RuntimeHelpers.CreateSpan` API and intrinsified it in JIT
- https://github.com/dotnet/runtime/pull/80622 - fixed that intrinsic to keep `FieldSeq*`
- https://github.com/dotnet/runtime/pull/78783 + https://github.com/dotnet/runtime/pull/78961 - implemented general constant folding for RVA
- https://github.com/dotnet/runtime/pull/80888 - this single-line PR is important too, it allowed to get rid of dead branches early, without it we would have `GT_PHI` nodes in VN phase (wouldn't be able to fold).