### PR TITLE
[webcil] Minor cleanups

### DIFF
--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1460,8 +1460,8 @@ bundled_assembly_match (const char *bundled_name, const char *name)
 		return TRUE;
 	/* if they want a .dll and we have the matching .webcil, return it */
 	if (g_str_has_suffix (bundled_name, ".webcil") && g_str_has_suffix (name, ".dll")) {
-		size_t bprefix = strlen (bundled_name) - 7;
-		size_t nprefix = strlen (name) - 4;
+		size_t bprefix = strlen (bundled_name) - strlen (".webcil");
+		size_t nprefix = strlen (name) - strlen (".dll");
 		if (bprefix == nprefix && strncmp (bundled_name, name, bprefix) == 0)
 			return TRUE;
 	}

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -1105,7 +1105,7 @@ bsymfile_match (BundledSymfile *bsymfile, const char *assembly_name)
 #ifdef ENABLE_WEBCIL
 	const char *p = strstr (assembly_name, ".webcil");
 	/* if assembly_name ends with .webcil, check if aname matches, with a .dll extension instead */
-	if (p && *(p + 7) == 0) {
+	if (p && *(p + strlen(".webcil")) == 0) {
 		size_t n = p - assembly_name;
 		if (!strncmp (bsymfile->aname, assembly_name, n)
 			&& !strcmp (bsymfile->aname + n, ".dll"))

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -134,8 +134,11 @@ mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, c
 #ifdef ENABLE_WEBCIL
 			else {
 				/* /path/foo.dll -> /path/foo.webcil */
-				size_t n = strlen (fullpath) - 4;
-				char *fullpath2 = g_malloc (n + 8);
+				size_t n = strlen (fullpath);
+				if (n < strlen(".dll"))
+					continue;
+				n -= strlen(".dll");
+				char *fullpath2 = g_malloc (n + strlen(".webcil") + 1);
 				g_strlcpy (fullpath2, fullpath, n + 1);
 				g_strlcpy (fullpath2 + n, ".webcil", 8);
 				if (g_file_test (fullpath2, G_FILE_TEST_IS_REGULAR)) {

--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -19,6 +19,7 @@
     <_ServeMimeTypes>$(_ServeMimeTypes) --mime .mjs=text/javascript</_ServeMimeTypes>
     <_ServeMimeTypes>$(_ServeMimeTypes) --mime .cjs=text/javascript</_ServeMimeTypes>
     <_ServeMimeTypes>$(_ServeMimeTypes) --mime .js=text/javascript</_ServeMimeTypes>
+    <_ServeMimeTypes>$(_ServeMimeTypes) --mime .webcil=application/octet-stream</_ServeMimeTypes>
   </PropertyGroup>
 
   <Target Name="BuildSampleInTree"

--- a/src/mono/sample/wasm/simple-server/Program.cs
+++ b/src/mono/sample/wasm/simple-server/Program.cs
@@ -156,6 +156,8 @@ namespace HttpServer
                 string? contentType = null;
                 if (path.EndsWith(".wasm"))
                     contentType = "application/wasm";
+                if (path.EndsWith(".webcil"))
+                    contentType = "application/octet-stream";
                 if (path.EndsWith(".json"))
                     contentType = "application/json";
                 if (path.EndsWith(".js") || path.EndsWith(".mjs") || path.EndsWith(".cjs"))

--- a/src/mono/wasm/host/WebServerStartup.cs
+++ b/src/mono/wasm/host/WebServerStartup.cs
@@ -82,7 +82,7 @@ internal sealed class WebServerStartup
         provider.Mappings[".cjs"] = "text/javascript";
         provider.Mappings[".mjs"] = "text/javascript";
 
-        foreach (string extn in new string[] { ".dll", ".pdb", ".dat", ".blat" })
+        foreach (string extn in new string[] { ".dll", ".pdb", ".dat", ".blat", ".webcil" })
         {
             provider.Mappings[extn] = "application/octet-stream";
         }

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -199,7 +199,10 @@ public class WasmAppBuilder : Task
                 webcilWriter.ConvertToWebcil();
                 var finalWebcil = Path.Combine(asmRootPath, Path.ChangeExtension(Path.GetFileName(assembly), ".webcil"));
                 if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
-                    _fileWrites.Add(finalWebcil);
+                    Log.LogMessage(MessageImportance.Low, $"Generated {finalWebcil} .");
+                else
+                    Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");
+                _fileWrites.Add(finalWebcil);
             }
             else
             {
@@ -285,8 +288,11 @@ public class WasmAppBuilder : Task
                     var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: fullPath, outputPath: tmpWebcil, logger: Log);
                     webcilWriter.ConvertToWebcil();
                     var finalWebcil = Path.Combine(directory, Path.ChangeExtension(name, ".webcil"));
-                    if (Utils.CopyIfDifferent (tmpWebcil, finalWebcil, useHash: true))
-                        _fileWrites.Add (finalWebcil);
+                    if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
+                        Log.LogMessage(MessageImportance.Low, $"Generated {finalWebcil} .");
+                    else
+                        Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");
+                    _fileWrites.Add(finalWebcil);
                     config.Assets.Add(new SatelliteAssemblyEntry(finalWebcil, culture));
                 }
                 else

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -198,7 +198,8 @@ public class WasmAppBuilder : Task
                 var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: assembly, outputPath: tmpWebcil, logger: Log);
                 webcilWriter.ConvertToWebcil();
                 var finalWebcil = Path.ChangeExtension(assembly, ".webcil");
-                FileCopyChecked(tmpWebcil, Path.Combine(asmRootPath, Path.GetFileName(finalWebcil)), "Assemblies");
+                if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
+                    _fileWrites.Add(finalWebcil);
             }
             else
             {
@@ -284,7 +285,8 @@ public class WasmAppBuilder : Task
                     var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: fullPath, outputPath: tmpWebcil, logger: Log);
                     webcilWriter.ConvertToWebcil();
                     var finalWebcil = Path.ChangeExtension(name, ".webcil");
-                    FileCopyChecked(tmpWebcil, Path.Combine(directory, finalWebcil), "SatelliteAssemblies");
+                    if (Utils.CopyIfDifferent (tmpWebcil, finalWebcil, useHash: true))
+                        _fileWrites.Add (finalWebcil);
                     config.Assets.Add(new SatelliteAssemblyEntry(finalWebcil, culture));
                 }
                 else

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -197,7 +197,7 @@ public class WasmAppBuilder : Task
                 var tmpWebcil = Path.GetTempFileName();
                 var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: assembly, outputPath: tmpWebcil, logger: Log);
                 webcilWriter.ConvertToWebcil();
-                var finalWebcil = Path.ChangeExtension(assembly, ".webcil");
+                var finalWebcil = Path.Combine(asmRootPath, Path.ChangeExtension(assembly, ".webcil"));
                 if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
                     _fileWrites.Add(finalWebcil);
             }
@@ -284,7 +284,7 @@ public class WasmAppBuilder : Task
                     var tmpWebcil = Path.GetTempFileName();
                     var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: fullPath, outputPath: tmpWebcil, logger: Log);
                     webcilWriter.ConvertToWebcil();
-                    var finalWebcil = Path.ChangeExtension(name, ".webcil");
+                    var finalWebcil = Path.Combine(directory, Path.ChangeExtension(name, ".webcil"));
                     if (Utils.CopyIfDifferent (tmpWebcil, finalWebcil, useHash: true))
                         _fileWrites.Add (finalWebcil);
                     config.Assets.Add(new SatelliteAssemblyEntry(finalWebcil, culture));

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -197,7 +197,7 @@ public class WasmAppBuilder : Task
                 var tmpWebcil = Path.GetTempFileName();
                 var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: assembly, outputPath: tmpWebcil, logger: Log);
                 webcilWriter.ConvertToWebcil();
-                var finalWebcil = Path.Combine(asmRootPath, Path.ChangeExtension(assembly, ".webcil"));
+                var finalWebcil = Path.Combine(asmRootPath, Path.ChangeExtension(Path.GetFileName(assembly), ".webcil"));
                 if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
                     _fileWrites.Add(finalWebcil);
             }

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -293,7 +293,7 @@ public class WasmAppBuilder : Task
                     else
                         Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");
                     _fileWrites.Add(finalWebcil);
-                    config.Assets.Add(new SatelliteAssemblyEntry(finalWebcil, culture));
+                    config.Assets.Add(new SatelliteAssemblyEntry(Path.GetFileName(finalWebcil), culture));
                 }
                 else
                 {


### PR DESCRIPTION
Contributes to #80807

1. Use `strlen(LITERAL)` instead of magic constants in C. the compiler will turn them into constants anyway
2. Use `CopyIfDifferent` in WasmAppBuilder when converting webcil.
3. WasmAppHost: explicitly serve .webcil as application/octet-stream
