### PR TITLE
[NativeAOT] correctly initalize CONTEXT before failing fast

### DIFF
--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -90,9 +90,18 @@ COOP_PINVOKE_HELPER(int32_t, RhGetModuleFileName, (HANDLE moduleHandle, _Out_ co
 
 COOP_PINVOKE_HELPER(void, RhpCopyContextFromExInfo, (void * pOSContext, int32_t cbOSContext, PAL_LIMITED_CONTEXT * pPalContext))
 {
-    UNREFERENCED_PARAMETER(cbOSContext);
     ASSERT((size_t)cbOSContext >= sizeof(CONTEXT));
+    memset(pOSContext, 0, cbOSContext);
     CONTEXT* pContext = (CONTEXT *)pOSContext;
+
+#ifndef HOST_WASM
+    if (TryPopulateControlSegmentRegisters(pContext))
+    {
+        pContext->ContextFlags |= CONTEXT_CONTROL;
+    }
+    pContext->ContextFlags |= CONTEXT_INTEGER;
+#endif
+
 #if defined(UNIX_AMD64_ABI)
     pContext->Rip = pPalContext->IP;
     pContext->Rsp = pPalContext->Rsp;

--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -94,15 +94,11 @@ COOP_PINVOKE_HELPER(void, RhpCopyContextFromExInfo, (void * pOSContext, int32_t 
     memset(pOSContext, 0, cbOSContext);
     CONTEXT* pContext = (CONTEXT *)pOSContext;
 
-#ifndef HOST_WASM
-    if (TryPopulateControlSegmentRegisters(pContext))
-    {
-        pContext->ContextFlags |= CONTEXT_CONTROL;
-    }
-    pContext->ContextFlags |= CONTEXT_INTEGER;
-#endif
+    // Fill in CONTEXT_CONTROL registers that were not captured in PAL_LIMITED_CONTEXT.
+    PopulateControlSegmentRegisters(pContext);
 
 #if defined(UNIX_AMD64_ABI)
+    pContext->ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
     pContext->Rip = pPalContext->IP;
     pContext->Rsp = pPalContext->Rsp;
     pContext->Rbp = pPalContext->Rbp;
@@ -114,6 +110,7 @@ COOP_PINVOKE_HELPER(void, RhpCopyContextFromExInfo, (void * pOSContext, int32_t 
     pContext->R14 = pPalContext->R14;
     pContext->R15 = pPalContext->R15;
 #elif defined(HOST_AMD64)
+    pContext->ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
     pContext->Rip = pPalContext->IP;
     pContext->Rsp = pPalContext->Rsp;
     pContext->Rbp = pPalContext->Rbp;
@@ -126,6 +123,7 @@ COOP_PINVOKE_HELPER(void, RhpCopyContextFromExInfo, (void * pOSContext, int32_t 
     pContext->R14 = pPalContext->R14;
     pContext->R15 = pPalContext->R15;
 #elif defined(HOST_X86)
+    pContext->ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
     pContext->Eip = pPalContext->IP;
     pContext->Esp = pPalContext->Rsp;
     pContext->Ebp = pPalContext->Rbp;
@@ -134,6 +132,7 @@ COOP_PINVOKE_HELPER(void, RhpCopyContextFromExInfo, (void * pOSContext, int32_t 
     pContext->Eax = pPalContext->Rax;
     pContext->Ebx = pPalContext->Rbx;
 #elif defined(HOST_ARM)
+    pContext->ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
     pContext->R0  = pPalContext->R0;
     pContext->R4  = pPalContext->R4;
     pContext->R5  = pPalContext->R5;
@@ -147,6 +146,7 @@ COOP_PINVOKE_HELPER(void, RhpCopyContextFromExInfo, (void * pOSContext, int32_t 
     pContext->Lr  = pPalContext->LR;
     pContext->Pc  = pPalContext->IP;
 #elif defined(HOST_ARM64)
+    pContext->ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
     pContext->X0 = pPalContext->X0;
     pContext->X1 = pPalContext->X1;
     // TODO: Copy registers X2-X7 when we start supporting HVA's

--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -636,7 +636,7 @@ REDHAWK_PALIMPORT void REDHAWK_PALAPI PalRestoreContext(CONTEXT * pCtx);
 // For platforms that have segment registers in the CONTEXT_CONTROL set that
 // are not saved in PAL_LIMITED_CONTEXT, this captures them from the current
 // thread and saves them in `pContext`.
-// This function returns true if the current plateform has no such registers or
+// This function returns true if the current platform has no such registers or
 // if the registers are successfully saved in `pContext`.
 // Other false is returned.
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext);

--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -112,6 +112,11 @@ struct FILETIME
 
 #ifdef HOST_AMD64
 
+#define CONTEXT_AMD64   0x00100000L
+
+#define CONTEXT_CONTROL         (CONTEXT_AMD64 | 0x00000001L)
+#define CONTEXT_INTEGER         (CONTEXT_AMD64 | 0x00000002L)
+
 typedef struct DECLSPEC_ALIGN(16) _XSAVE_FORMAT {
     uint16_t  ControlWord;
     uint16_t  StatusWord;
@@ -232,6 +237,11 @@ typedef struct DECLSPEC_ALIGN(16) _CONTEXT {
 } CONTEXT, *PCONTEXT;
 #elif defined(HOST_ARM)
 
+#define CONTEXT_ARM   0x00200000L
+
+#define CONTEXT_CONTROL (CONTEXT_ARM | 0x1L)
+#define CONTEXT_INTEGER (CONTEXT_ARM | 0x2L)
+
 #define ARM_MAX_BREAKPOINTS     8
 #define ARM_MAX_WATCHPOINTS     1
 
@@ -275,6 +285,12 @@ typedef struct DECLSPEC_ALIGN(8) _CONTEXT {
 } CONTEXT, *PCONTEXT;
 
 #elif defined(HOST_X86)
+
+#define CONTEXT_i386    0x00010000L
+
+#define CONTEXT_CONTROL         (CONTEXT_i386 | 0x00000001L) // SS:SP, CS:IP, FLAGS, BP
+#define CONTEXT_INTEGER         (CONTEXT_i386 | 0x00000002L) // AX, BX, CX, DX, SI, DI
+
 #define SIZE_OF_80387_REGISTERS      80
 #define MAXIMUM_SUPPORTED_EXTENSION  512
 
@@ -328,6 +344,11 @@ typedef struct _CONTEXT {
 #include "poppack.h"
 
 #elif defined(HOST_ARM64)
+
+#define CONTEXT_ARM64   0x00400000L
+
+#define CONTEXT_CONTROL (CONTEXT_ARM64 | 0x1L)
+#define CONTEXT_INTEGER (CONTEXT_ARM64 | 0x2L)
 
 // Specify the number of breakpoints and watchpoints that the OS
 // will track. Architecturally, ARM64 supports up to 16. In practice,
@@ -484,8 +505,6 @@ typedef enum _EXCEPTION_DISPOSITION {
 //#endif // !DACCESS_COMPILE
 #endif // !_INC_WINDOWS
 
-
-
 #ifndef DACCESS_COMPILE
 #ifndef _INC_WINDOWS
 
@@ -613,6 +632,14 @@ REDHAWK_PALIMPORT CONTEXT* PalAllocateCompleteOSContext(_Out_ uint8_t** contextB
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalGetCompleteThreadContext(HANDLE hThread, _Out_ CONTEXT * pCtx);
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI PalSetThreadContext(HANDLE hThread, _Out_ CONTEXT * pCtx);
 REDHAWK_PALIMPORT void REDHAWK_PALAPI PalRestoreContext(CONTEXT * pCtx);
+
+// For platforms that have segment registers in the CONTEXT_CONTROL set that
+// are not saved in PAL_LIMITED_CONTEXT, this captures them from the current
+// thread and saves them in `pContext`.
+// This function returns true if the current plateform has no such registers or
+// if the registers are successfully saved in `pContext`.
+// Other false is returned.
+REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext);
 
 REDHAWK_PALIMPORT int32_t REDHAWK_PALAPI PalGetProcessCpuCount();
 

--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -505,6 +505,8 @@ typedef enum _EXCEPTION_DISPOSITION {
 //#endif // !DACCESS_COMPILE
 #endif // !_INC_WINDOWS
 
+
+
 #ifndef DACCESS_COMPILE
 #ifndef _INC_WINDOWS
 
@@ -636,10 +638,7 @@ REDHAWK_PALIMPORT void REDHAWK_PALAPI PalRestoreContext(CONTEXT * pCtx);
 // For platforms that have segment registers in the CONTEXT_CONTROL set that
 // are not saved in PAL_LIMITED_CONTEXT, this captures them from the current
 // thread and saves them in `pContext`.
-// This function returns true if the current platform has no such registers or
-// if the registers are successfully saved in `pContext`.
-// Other false is returned.
-REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext);
+REDHAWK_PALIMPORT void REDHAWK_PALAPI PopulateControlSegmentRegisters(CONTEXT* pContext);
 
 REDHAWK_PALIMPORT int32_t REDHAWK_PALAPI PalGetProcessCpuCount();
 

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1071,7 +1071,8 @@ extern "C" int32_t _stricmp(const char *string1, const char *string2)
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext)
 {
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
-    // TODO: attempt to fill in SegCs and SegSs
+    // Currently the CONTEXT is only used on Windows for RaiseFailFastException.
+    // So we punt on filling in SegCs and SegSs for now.
     return false;
 #else
     return true;

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1068,14 +1068,11 @@ extern "C" int32_t _stricmp(const char *string1, const char *string2)
     return strcasecmp(string1, string2);
 }
 
-REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext)
+REDHAWK_PALIMPORT void REDHAWK_PALAPI PopulateControlSegmentRegisters(CONTEXT* pContext)
 {
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
     // Currently the CONTEXT is only used on Windows for RaiseFailFastException.
     // So we punt on filling in SegCs and SegSs for now.
-    return false;
-#else
-    return true;
 #endif
 }
 

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1068,6 +1068,16 @@ extern "C" int32_t _stricmp(const char *string1, const char *string2)
     return strcasecmp(string1, string2);
 }
 
+REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext)
+{
+#if defined(TARGET_X86) || defined(TARGET_AMD64)
+    // TODO: attempt to fill in SegCs and SegSs
+    return false;
+#else
+    return true;
+#endif
+}
+
 uint32_t g_RhNumberOfProcessors;
 
 REDHAWK_PALEXPORT int32_t PalGetProcessCpuCount()

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -446,6 +446,27 @@ REDHAWK_PALEXPORT void REDHAWK_PALAPI PalRestoreContext(CONTEXT * pCtx)
     RtlRestoreContext(pCtx, NULL);
 }
 
+REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext)
+{
+#if defined(TARGET_X86) || defined(TARGET_AMD64)
+    HANDLE hThread = GetCurrentThread();
+
+    CONTEXT ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.ContextFlags = CONTEXT_CONTROL;
+
+    if (!GetThreadContext(hThread, &ctx))
+    {
+        return false;
+    }
+
+    pContext->SegCs = ctx.SegCs;
+    pContext->SegSs = ctx.SegSs;
+#endif //defined(TARGET_X86) || defined(TARGET_AMD64)
+
+    return true;
+}
+
 static PalHijackCallback g_pHijackCallback;
 
 #ifdef FEATURE_SPECIAL_USER_MODE_APC

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -449,16 +449,9 @@ REDHAWK_PALEXPORT void REDHAWK_PALAPI PalRestoreContext(CONTEXT * pCtx)
 REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext)
 {
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
-    HANDLE hThread = GetCurrentThread();
-
     CONTEXT ctx;
-    memset(&ctx, 0, sizeof(ctx));
-    ctx.ContextFlags = CONTEXT_CONTROL;
 
-    if (!GetThreadContext(hThread, &ctx))
-    {
-        return false;
-    }
+    RtlCaptureContext(&ctx);
 
     pContext->SegCs = ctx.SegCs;
     pContext->SegSs = ctx.SegSs;

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -446,7 +446,7 @@ REDHAWK_PALEXPORT void REDHAWK_PALAPI PalRestoreContext(CONTEXT * pCtx)
     RtlRestoreContext(pCtx, NULL);
 }
 
-REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT* pContext)
+REDHAWK_PALIMPORT void REDHAWK_PALAPI PopulateControlSegmentRegisters(CONTEXT* pContext)
 {
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
     CONTEXT ctx;
@@ -456,8 +456,6 @@ REDHAWK_PALIMPORT bool REDHAWK_PALAPI TryPopulateControlSegmentRegisters(CONTEXT
     pContext->SegCs = ctx.SegCs;
     pContext->SegSs = ctx.SegSs;
 #endif //defined(TARGET_X86) || defined(TARGET_AMD64)
-
-    return true;
 }
 
 static PalHijackCallback g_pHijackCallback;


### PR DESCRIPTION
### Short Explanation

Basically the `CONTEXT` structure is not being initalized properly before calling `RaiseFailFastException`.

### Long Explanation

Consider this program:

```csharp
using System;
using System.Globalization;

static class Program
{
    static void FillStack(byte value)
    {
        Span<byte> bytes = stackalloc byte[1024 * 16];
        bytes.Fill(value);
    }

    static void Main(string[] args)
    {
        if (args.Length != 0)
        {
            byte fillValue = byte.Parse(args[0], NumberStyles.HexNumber);
            AppDomain.CurrentDomain.UnhandledException += (_,_) => FillStack(fillValue);
        }
        throw new Exception();
    }
}
```

On NativeAOT on Windows, the last act of a process that throws an unhanded exception is to call `RaiseFailFastException` [here](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeExceptionHelpers.cs#L279). The instruction pointer and `CONTEXT` structure passed to `RaiseFailFastException` point at the function that raised the unhanded exception. If you have a debugger like Visual Studio attached after when `RaiseFailFastException` is called, you will see a call stack pointing to the faulting function.

Depending on what argument  you pass to the program, you get different call stacks.

If you pass `0` you get:

```
 	ntdll.dll!NtRaiseException()	Unknown
 	KernelBase.dll!RaiseFailFastException()	Unknown
 	reproNative.exe!S_P_CoreLib_Interop_Kernel32__RaiseFailFastException_0()	Unknown
>	reproNative.exe!S_P_CoreLib_Interop_Kernel32__RaiseFailFastException() Line 46	Unknown
 	reproNative.exe!S_P_CoreLib_System_RuntimeExceptionHelpers__FailFast_1() Line 279	Unknown
 	reproNative.exe!S_P_CoreLib_System_RuntimeExceptionHelpers__RuntimeFailFast() Line 219	Unknown
 	reproNative.exe!S_P_CoreLib_System_Runtime_EH__UnhandledExceptionFailFastViaClasslib() Line 205	Unknown
 	reproNative.exe!S_P_CoreLib_System_Runtime_EH__DispatchEx() Line 650	Unknown
 	reproNative.exe!S_P_CoreLib_System_Runtime_EH__RhThrowEx() Line 572	Unknown
 	reproNative.exe!RhpThrowEx() Line 190	Unknown
 	reproNative.exe!repro_Program__Main() Line 24	Unknown
 	reproNative.exe!repro__Module___MainMethodWrapper()	Unknown
 	reproNative.exe!repro__Module___StartupCodeMain()	Unknown
 	reproNative.exe!wmain(int argc, wchar_t * * argv) Line 216	C++
 	reproNative.exe!invoke_main() Line 91	C++
 	reproNative.exe!__scrt_common_main_seh() Line 288	C++
 	reproNative.exe!__scrt_common_main() Line 331	C++
 	reproNative.exe!wmainCRTStartup(void * __formal) Line 17	C++
 	kernel32.dll!BaseThreadInitThunk()	Unknown
 	ntdll.dll!RtlUserThreadStart()	Unknown
```

That's less than ideal as it does not directly point at the faulting function.

If you pass `ff` you get garbage:

```
 	00000000f2d49ff1()	Unknown
 	000001ed07011578()	Unknown
 	000001ed07011548()	Unknown
>	reproNative.exe!repro_Program___c__DisplayClass1_0___Main_b__0() Line 22	Unknown
```

After this PR is merged, the call stack correctly points at the faulting function:

```
>	reproNative.exe!repro_Program__Main() Line 24	Unknown
 	reproNative.exe!repro__Module___MainMethodWrapper()	Unknown
 	reproNative.exe!repro__Module___StartupCodeMain()	Unknown
 	reproNative.exe!wmain(int argc, wchar_t * * argv) Line 216	C++
 	reproNative.exe!invoke_main() Line 91	C++
 	reproNative.exe!__scrt_common_main_seh() Line 288	C++
 	reproNative.exe!__scrt_common_main() Line 331	C++
 	reproNative.exe!wmainCRTStartup(void * __formal) Line 17	C++
 	kernel32.dll!BaseThreadInitThunk()	Unknown
 	ntdll.dll!RtlUserThreadStart()	Unknown
```

### TODO before merging:

* [ ] ~AMD64: capture `CS`, `SS`, and `RFLAGS` into `PAL_LIMITED_CONTEXT` when throwing and exception~
* [ ] ~AMD64: restore `CS`, `SS`, and `RFLAGS` in `RhpCopyContextFromExInfo`~
* [x] In `RhpCopyContextFromExInfo`, capture the `CS` and `SS` segment registers from the current thread and stuff them into the `CONTEXT`.
