### PR TITLE
[wasm] Disable legacy interop measurements

### DIFF
--- a/src/mono/sample/wasm/browser-bench/JSInterop.cs
+++ b/src/mono/sample/wasm/browser-bench/JSInterop.cs
@@ -24,9 +24,9 @@ namespace Sample
         public JSInteropTask()
         {
             measurements = new Measurement[] {
-                new LegacyExportIntMeasurement(),
+                // new LegacyExportIntMeasurement(),
                 new JSExportIntMeasurement(),
-                new LegacyExportStringMeasurement(),
+                // new LegacyExportStringMeasurement(),
                 new JSExportStringMeasurement(),
                 new JSImportIntMeasurement(),
                 new JSImportStringMeasurement(),

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -70,10 +70,10 @@ class MainApp {
         setTasks = exports.Sample.Test.SetTasks;
         getFullJsonResults = exports.Sample.Test.GetFullJsonResults;
 
-        legacyExportTargetInt = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetInt");
-        jsExportTargetInt = exports.Sample.ImportsExportsHelper.JSExportTargetInt;
-        legacyExportTargetString = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetString");
-        jsExportTargetString = exports.Sample.ImportsExportsHelper.JSExportTargetString;
+        // legacyExportTargetInt = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetInt");
+        // jsExportTargetInt = exports.Sample.ImportsExportsHelper.JSExportTargetInt;
+        // legacyExportTargetString = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetString");
+        // jsExportTargetString = exports.Sample.ImportsExportsHelper.JSExportTargetString;
 
         setModuleImports("main.js", {
             Sample: {


### PR DESCRIPTION
Temporarily as they currently don't work