### PR TITLE
Assist JIT in eliminating bounds checks

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ReferenceSource/LinkAttributesParser.cs
+++ b/src/coreclr/tools/Common/Compiler/ReferenceSource/LinkAttributesParser.cs
@@ -173,7 +173,7 @@ namespace Mono.Linker.Steps
                     continue;
 
                 bool match = true;
-                for (int ii = 0; match && ii != args.Length; ++ii)
+                for (int ii = 0; match && ii < args.Length; ++ii)
                 {
                     //
                     // No candidates betterness, only exact matches are supported

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/Extensions/NiceIO.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/Extensions/NiceIO.cs
@@ -328,7 +328,7 @@ namespace Mono.Linker.Tests.Extensions
 			if (p._elements.Length != _elements.Length)
 				return false;
 
-			for (var i = 0; i != _elements.Length; i++)
+			for (var i = 0; i < _elements.Length; i++)
 				if (!string.Equals (p._elements[i], _elements[i], PathStringComparison))
 					return false;
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
             if (arguments != null) // null is treated as empty, so not invalid
             {
-                for (int i = 0; i != arguments.Length; ++i)
+                for (int i = 0; i < arguments.Length; ++i)
                 {
                     ValidateBindArgument(arguments[i], $"{paramName}[{i}]");
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             public object CreateInstance(IServiceProvider provider)
             {
-                for (int index = 0; index != _parameters.Length; index++)
+                for (int index = 0; index < _parameters.Length; index++)
                 {
                     if (_parameterValues[index] == null)
                     {

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -160,7 +160,7 @@ namespace System.Collections.Generic
                 {
                     comparer = Comparer; // obtain default if this is null.
                     Array.Sort<TKey, TValue>(keys, values, comparer);
-                    for (int i = 1; i != keys.Length; ++i)
+                    for (int i = 1; i < keys.Length; ++i)
                     {
                         if (comparer.Compare(keys[i - 1], keys[i]) == 0)
                         {

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/AsynchronousChannelMergeEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/AsynchronousChannelMergeEnumerator.cs
@@ -122,7 +122,7 @@ namespace System.Linq.Parallel
             int firstChannelIndex = _channelIndex;
 
             int currChannelIndex;
-            while ((currChannelIndex = _channelIndex) != _channels.Length)
+            while ((currChannelIndex = _channelIndex) < _channels.Length)
             {
                 AsynchronousChannel<T> current = _channels[currChannelIndex];
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/SynchronousChannelMergeEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/SynchronousChannelMergeEnumerator.cs
@@ -84,7 +84,7 @@ namespace System.Linq.Parallel
             }
 
             // If the index has reached the end, we bail.
-            while (_channelIndex != _channels.Length)
+            while (_channelIndex < _channels.Length)
             {
                 SynchronousChannel<T> current = _channels[_channelIndex];
                 Debug.Assert(current != null);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -73,10 +73,10 @@ namespace System.Net.Http.Headers
             int? maxAge = null;
             bool persist = false;
 
-            while (idx != value.Length)
+            while (idx < value.Length)
             {
                 // Skip OWS before semicolon.
-                while (idx != value.Length && IsOptionalWhiteSpace(value[idx])) ++idx;
+                while (idx < value.Length && IsOptionalWhiteSpace(value[idx])) ++idx;
 
                 if (idx == value.Length)
                 {
@@ -102,7 +102,7 @@ namespace System.Net.Http.Headers
                 ++idx;
 
                 // Skip OWS after semicolon / before value.
-                while (idx != value.Length && IsOptionalWhiteSpace(value[idx])) ++idx;
+                while (idx < value.Length && IsOptionalWhiteSpace(value[idx])) ++idx;
 
                 // Get the parameter key length.
                 int tokenLength = HttpRuleParser.GetTokenLength(value, idx);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Number.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Number.cs
@@ -61,7 +61,7 @@ namespace System.Buffers.Text
             int maxDigitCount = digits.Length - 1;
 
             // Throw away any leading zeroes
-            while (srcIndex != source.Length)
+            while (srcIndex < source.Length)
             {
                 c = source[srcIndex];
                 if (c != '0')
@@ -79,7 +79,7 @@ namespace System.Buffers.Text
             int startIndexNonLeadingDigitsBeforeDecimal = srcIndex;
 
             int hasNonZeroTail = 0;
-            while (srcIndex != source.Length)
+            while (srcIndex < source.Length)
             {
                 c = source[srcIndex];
                 int value = (byte)(c - (byte)('0'));
@@ -134,7 +134,7 @@ namespace System.Buffers.Text
                 srcIndex++;
                 int startIndexDigitsAfterDecimal = srcIndex;
 
-                while (srcIndex != source.Length)
+                while (srcIndex < source.Length)
                 {
                     c = source[srcIndex];
                     int value = (byte)(c - (byte)('0'));
@@ -268,7 +268,7 @@ namespace System.Buffers.Text
                 // continue eating digits from there
                 srcIndex += 10;
 
-                while (srcIndex != source.Length)
+                while (srcIndex < source.Length)
                 {
                     c = source[srcIndex];
                     int value = (byte)(c - (byte)('0'));

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Number.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Number.cs
@@ -44,7 +44,7 @@ namespace System.Buffers.Text
 
                 case Utf8Constants.Plus:
                     srcIndex++;
-                    if (srcIndex == source.Length)
+                    if (srcIndex >= source.Length)
                     {
                         bytesConsumed = 0;
                         return false;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.TimeSpan.BigG.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.TimeSpan.BigG.cs
@@ -9,7 +9,7 @@ namespace System.Buffers.Text
         {
             int srcIndex = 0;
             byte c = default;
-            while (srcIndex != source.Length)
+            while (srcIndex < source.Length)
             {
                 c = source[srcIndex];
                 if (!(c == ' ' || c == '\t'))

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.TimeSpan.cs
@@ -75,7 +75,7 @@ namespace System.Buffers.Text
             uint fraction = digit;
             int digitCount = 1;
 
-            while (srcIndex != source.Length)
+            while (srcIndex < source.Length)
             {
                 digit = source[srcIndex] - 48u; // '0'
                 if (digit > 9)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.TimeSpanSplitter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.TimeSpanSplitter.cs
@@ -38,7 +38,7 @@ namespace System.Buffers.Text
                 byte c = default;
 
                 // Unlike many other data types, TimeSpan allow leading whitespace.
-                while (srcIndex != source.Length)
+                while (srcIndex < source.Length)
                 {
                     c = source[srcIndex];
                     if (!(c == ' ' || c == '\t'))

--- a/src/tools/illink/test/Mono.Linker.Tests/Extensions/NiceIO.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/Extensions/NiceIO.cs
@@ -326,7 +326,7 @@ namespace Mono.Linker.Tests.Extensions
 			if (p._elements.Length != _elements.Length)
 				return false;
 
-			for (var i = 0; i != _elements.Length; i++)
+			for (var i = 0; i < _elements.Length; i++)
 				if (!string.Equals (p._elements[i], _elements[i], PathStringComparison))
 					return false;
 


### PR DESCRIPTION
Follow-up: #81001.

Change condition in loops from `index != T.Length` to `index < T.Length` where T:

* `U[]`
* `string`
* `Span<U>`
* `ReadOnlySpan<U>`

cc: @stephentoub