### PR TITLE
[browser] benchmark fix aggressive trimming

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Browser.cs
+++ b/src/mono/sample/wasm/browser-bench/Browser.cs
@@ -5,6 +5,8 @@ namespace Sample
 {
     public partial class Test
     {
+        internal const string AssemblyName = "Wasm.Browser.Bench.Sample";
+
         public static int Main(string[] args)
         {
             return 0;

--- a/src/mono/sample/wasm/browser-bench/Console/Console.cs
+++ b/src/mono/sample/wasm/browser-bench/Console/Console.cs
@@ -11,6 +11,7 @@ namespace Sample
 {
     public partial class Test
     {
+        internal const string AssemblyName = "Wasm.Console.Bench.Sample";
         static string tasksArg;
 
         static List<string> ProcessArguments(string[] args)

--- a/src/mono/sample/wasm/browser-bench/JSInterop.cs
+++ b/src/mono/sample/wasm/browser-bench/JSInterop.cs
@@ -25,9 +25,9 @@ namespace Sample
         public JSInteropTask()
         {
             measurements = new Measurement[] {
-                // new LegacyExportIntMeasurement(),
+                new LegacyExportIntMeasurement(),
                 new JSExportIntMeasurement(),
-                // new LegacyExportStringMeasurement(),
+                new LegacyExportStringMeasurement(),
                 new JSExportStringMeasurement(),
                 new JSImportIntMeasurement(),
                 new JSImportStringMeasurement(),

--- a/src/mono/sample/wasm/browser-bench/JSInterop.cs
+++ b/src/mono/sample/wasm/browser-bench/JSInterop.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices.JavaScript;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Sample
 {
@@ -41,6 +42,8 @@ namespace Sample
         {
             public override int InitialSamples => 3;
             public override string Name => "LegacyExportInt";
+            // because of the aggressive trimming of methods reachable via JS legacy bind_static_method
+            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "Sample.ImportsExportsHelper", "Wasm.Browser.Bench.Sample")]
             public override void RunStep()
             {
                 ImportsExportsHelper.RunLegacyExportInt(10000);
@@ -61,6 +64,9 @@ namespace Sample
         {
             public override int InitialSamples => 3;
             public override string Name => "LegacyExportString";
+
+            // because of the aggressive trimming of methods reachable via JS legacy bind_static_method
+            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "Sample.ImportsExportsHelper", "Wasm.Browser.Bench.Sample")]
             public override void RunStep()
             {
                 ImportsExportsHelper.RunLegacyExportString(10000);

--- a/src/mono/sample/wasm/browser-bench/JSInterop.cs
+++ b/src/mono/sample/wasm/browser-bench/JSInterop.cs
@@ -43,7 +43,7 @@ namespace Sample
             public override int InitialSamples => 3;
             public override string Name => "LegacyExportInt";
             // because of the aggressive trimming of methods reachable via JS legacy bind_static_method
-            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "Sample.ImportsExportsHelper", "Wasm.Browser.Bench.Sample")]
+            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "Sample.ImportsExportsHelper", Test.AssemblyName)]
             public override void RunStep()
             {
                 ImportsExportsHelper.RunLegacyExportInt(10000);
@@ -66,7 +66,7 @@ namespace Sample
             public override string Name => "LegacyExportString";
 
             // because of the aggressive trimming of methods reachable via JS legacy bind_static_method
-            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "Sample.ImportsExportsHelper", "Wasm.Browser.Bench.Sample")]
+            [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, "Sample.ImportsExportsHelper", Test.AssemblyName)]
             public override void RunStep()
             {
                 ImportsExportsHelper.RunLegacyExportString(10000);

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -70,10 +70,10 @@ class MainApp {
         setTasks = exports.Sample.Test.SetTasks;
         getFullJsonResults = exports.Sample.Test.GetFullJsonResults;
 
-        // legacyExportTargetInt = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetInt");
-        // jsExportTargetInt = exports.Sample.ImportsExportsHelper.JSExportTargetInt;
-        // legacyExportTargetString = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetString");
-        // jsExportTargetString = exports.Sample.ImportsExportsHelper.JSExportTargetString;
+        legacyExportTargetInt = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetInt");
+        jsExportTargetInt = exports.Sample.ImportsExportsHelper.JSExportTargetInt;
+        legacyExportTargetString = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetString");
+        jsExportTargetString = exports.Sample.ImportsExportsHelper.JSExportTargetString;
 
         setModuleImports("main.js", {
             Sample: {


### PR DESCRIPTION
to fix
```
Uncaught Error: Could not find method: LegacyExportTargetInt
    Ni http://localhost:8270/dotnet.js:5
    mi http://localhost:8270/dotnet.js:5
    init http://localhost:8270/main.js:73
    async* http://localhost:8270/main.js:188```