### PR TITLE
Avoid losing messages for memory-mapped stress log

### DIFF
--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -596,14 +596,14 @@ struct StressLogChunk
 
     void * operator new (size_t size) throw()
     {
-        if (IsInCantAllocStressLogRegion ())
-        {
-            return NULL;
-        }
 #ifdef MEMORY_MAPPED_STRESSLOG
         if (s_memoryMapped)
             return StressLog::AllocMemoryMapped(size);
 #endif //MEMORY_MAPPED_STRESSLOG
+        if (IsInCantAllocStressLogRegion ())
+        {
+            return NULL;
+        }
 #ifdef HOST_WINDOWS
         _ASSERTE(s_LogChunkHeap);
         return HeapAlloc(s_LogChunkHeap, 0, size);

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -645,6 +645,12 @@ void StressLog::ThreadDetach() {
 
 BOOL StressLog::AllowNewChunk (LONG numChunksInCurThread)
 {
+#ifdef MEMORY_MAPPED_STRESSLOG
+    if (StressLogChunk::s_memoryMapped)
+    {
+        return TRUE;
+    }
+#endif
     _ASSERTE (numChunksInCurThread <= theLog.totalChunk);
     DWORD perThreadLimit = theLog.MaxSizePerThread;
 


### PR DESCRIPTION
It is noticed that even when having a huge memory-mapped file, there are often cases where we missed messages.

- We were in the `CantAllocStressLogRegion`, or
- We hit the per thread stress log message count limit

Neither case matters for the memory-mapped file, so I simply lifted the restrictions.

