### PR TITLE
Eliminate a bounds check in `NumberBuffer`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Number.NumberBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.NumberBuffer.cs
@@ -83,6 +83,7 @@ namespace System
             }
 #pragma warning restore CA1822
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public byte* GetDigitsPointer()
             {
                 // This is safe to do since we are a ref struct

--- a/src/libraries/System.Private.CoreLib/src/System/Number.NumberBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.NumberBuffer.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System
 {
@@ -85,7 +86,7 @@ namespace System
             public byte* GetDigitsPointer()
             {
                 // This is safe to do since we are a ref struct
-                return (byte*)(Unsafe.AsPointer(ref Digits[0]));
+                return (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(Digits));
             }
 
             //


### PR DESCRIPTION
We check `Debug.Assert(!digits.IsEmpty)` in the ctor.