### PR TITLE
Fix Configuration Binding with Instantiated Objects

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -835,9 +835,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            Assert.Equal(2, options.InstantiatedIReadOnlySet.Count);
-            Assert.Equal("Yo1", options.InstantiatedIReadOnlySet.ElementAt(0));
-            Assert.Equal("Yo2", options.InstantiatedIReadOnlySet.ElementAt(1));
+            // Instantiated IReadOnlySet cannot get mutated.
+            Assert.Equal(0, options.InstantiatedIReadOnlySet.Count);
         }
 
         [Fact]
@@ -855,11 +854,10 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            Assert.Equal(4, options.InstantiatedIReadOnlySetWithSomeValues.Count);
+            // Instantiated IReadOnlySet doesn't get mutated.
+            Assert.Equal(2, options.InstantiatedIReadOnlySetWithSomeValues.Count);
             Assert.Equal("existing1", options.InstantiatedIReadOnlySetWithSomeValues.ElementAt(0));
             Assert.Equal("existing2", options.InstantiatedIReadOnlySetWithSomeValues.ElementAt(1));
-            Assert.Equal("Yo1", options.InstantiatedIReadOnlySetWithSomeValues.ElementAt(2));
-            Assert.Equal("Yo2", options.InstantiatedIReadOnlySetWithSomeValues.ElementAt(3));
         }
 
         [Fact]
@@ -932,13 +930,10 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<Foo>()!;
 
-            Assert.Equal(4, options.Items.Count);
+            // Readonly dictionary with instantiated value cannot get mutated by the configuration.
+            Assert.Equal(2, options.Items.Count);
             Assert.Equal(1, options.Items["existing-item1"]);
             Assert.Equal(2, options.Items["existing-item2"]);
-            Assert.Equal(3, options.Items["item3"]);
-            Assert.Equal(4, options.Items["item4"]);
-
-
         }
 
         [Fact]
@@ -956,14 +951,14 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ConfigWithInstantiatedIReadOnlyDictionary>()!;
 
-            Assert.Equal(3, options.Dictionary.Count);
+            // Readonly dictionary with instantiated value cannot be mutated by the configuration
+            Assert.Equal(2, options.Dictionary.Count);
 
             // does not overwrite original
             Assert.Equal(1, ConfigWithInstantiatedIReadOnlyDictionary._existingDictionary["existing-item1"]);
 
-            Assert.Equal(666, options.Dictionary["existing-item1"]);
+            Assert.Equal(1, options.Dictionary["existing-item1"]);
             Assert.Equal(2, options.Dictionary["existing-item2"]);
-            Assert.Equal(3, options.Dictionary["item3"]);
         }
 
         [Fact]
@@ -1027,11 +1022,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var options = config.Get<ComplexOptions>()!;
 
             var resultingDictionary = options.InstantiatedReadOnlyDictionaryWithWithSomeValues;
-            Assert.Equal(4, resultingDictionary.Count);
+
+            // Readonly dictionary with instantiated value cannot be mutated by the configuration.
+            Assert.Equal(2, resultingDictionary.Count);
             Assert.Equal(1, resultingDictionary["existing-item1"]);
             Assert.Equal(2, resultingDictionary["existing-item2"]);
-            Assert.Equal(3, resultingDictionary["item3"]);
-            Assert.Equal(4, resultingDictionary["item4"]);
         }
 
         [Fact]
@@ -1376,9 +1371,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            Assert.Equal(2, options.InstantiatedIEnumerable.Count());
-            Assert.Equal("Yo1", options.InstantiatedIEnumerable.ElementAt(0));
-            Assert.Equal("Yo2", options.InstantiatedIEnumerable.ElementAt(1));
+            // Instantiated readonly IEnumerable which cannot be mutated by the configuration
+            Assert.Equal(0, options.InstantiatedIEnumerable.Count());
         }
 
         [Fact]
@@ -1456,9 +1450,9 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            Assert.Equal(2, options.InstantiatedIReadOnlyCollection.Count);
-            Assert.Equal("Yo1", options.InstantiatedIReadOnlyCollection.ElementAt(0));
-            Assert.Equal("Yo2", options.InstantiatedIReadOnlyCollection.ElementAt(1));
+
+            // Instantiated readonly collection which cannot be mutated by the configuration
+            Assert.Equal(0, options.InstantiatedIReadOnlyCollection.Count);
         }
 
         [Fact]
@@ -1477,9 +1471,8 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            Assert.Equal(2, options.InstantiatedIEnumerable.Count());
-            Assert.Equal("Yo1", options.InstantiatedIEnumerable.ElementAt(0));
-            Assert.Equal("Yo2", options.InstantiatedIEnumerable.ElementAt(1));
+            // Instantiated IEnumerable is a readonly collection which cannot be mutated by the configuration
+            Assert.Equal(0, options.InstantiatedIEnumerable.Count());
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -812,7 +812,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var config = configurationBuilder.Build();
 
-            var options = config.Get<ComplexOptions>()!;
+            var options = config.Get<ComplexOptions>(o => o.ErrorOnUnknownConfiguration = true)!;
 
             Assert.Equal(2, options.ISetNoSetter.Count);
             Assert.Equal("Yo1", options.ISetNoSetter.ElementAt(0));

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -835,8 +835,9 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            // Instantiated IReadOnlySet cannot get mutated.
-            Assert.Equal(0, options.InstantiatedIReadOnlySet.Count);
+            Assert.Equal(2, options.InstantiatedIReadOnlySet.Count);
+            Assert.Equal("Yo1", options.InstantiatedIReadOnlySet.ElementAt(0));
+            Assert.Equal("Yo2", options.InstantiatedIReadOnlySet.ElementAt(1));
         }
 
         [Fact]
@@ -854,10 +855,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            // Instantiated IReadOnlySet doesn't get mutated.
-            Assert.Equal(2, options.InstantiatedIReadOnlySetWithSomeValues.Count);
+            Assert.Equal(4, options.InstantiatedIReadOnlySetWithSomeValues.Count);
             Assert.Equal("existing1", options.InstantiatedIReadOnlySetWithSomeValues.ElementAt(0));
             Assert.Equal("existing2", options.InstantiatedIReadOnlySetWithSomeValues.ElementAt(1));
+            Assert.Equal("Yo1", options.InstantiatedIReadOnlySetWithSomeValues.ElementAt(2));
+            Assert.Equal("Yo2", options.InstantiatedIReadOnlySetWithSomeValues.ElementAt(3));
         }
 
         [Fact]
@@ -930,10 +932,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<Foo>()!;
 
-            // Readonly dictionary with instantiated value cannot get mutated by the configuration.
-            Assert.Equal(2, options.Items.Count);
+            Assert.Equal(4, options.Items.Count);
             Assert.Equal(1, options.Items["existing-item1"]);
             Assert.Equal(2, options.Items["existing-item2"]);
+            Assert.Equal(3, options.Items["item3"]);
+            Assert.Equal(4, options.Items["item4"]);
         }
 
         [Fact]
@@ -952,13 +955,14 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var options = config.Get<ConfigWithInstantiatedIReadOnlyDictionary>()!;
 
             // Readonly dictionary with instantiated value cannot be mutated by the configuration
-            Assert.Equal(2, options.Dictionary.Count);
+            Assert.Equal(3, options.Dictionary.Count);
 
             // does not overwrite original
             Assert.Equal(1, ConfigWithInstantiatedIReadOnlyDictionary._existingDictionary["existing-item1"]);
 
-            Assert.Equal(1, options.Dictionary["existing-item1"]);
+            Assert.Equal(666, options.Dictionary["existing-item1"]);
             Assert.Equal(2, options.Dictionary["existing-item2"]);
+            Assert.Equal(3, options.Dictionary["item3"]);
         }
 
         [Fact]
@@ -1023,10 +1027,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var resultingDictionary = options.InstantiatedReadOnlyDictionaryWithWithSomeValues;
 
-            // Readonly dictionary with instantiated value cannot be mutated by the configuration.
-            Assert.Equal(2, resultingDictionary.Count);
+            Assert.Equal(4, resultingDictionary.Count);
             Assert.Equal(1, resultingDictionary["existing-item1"]);
             Assert.Equal(2, resultingDictionary["existing-item2"]);
+            Assert.Equal(3, resultingDictionary["item3"]);
+            Assert.Equal(4, resultingDictionary["item4"]);
         }
 
         [Fact]
@@ -1371,8 +1376,9 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            // Instantiated readonly IEnumerable which cannot be mutated by the configuration
-            Assert.Equal(0, options.InstantiatedIEnumerable.Count());
+            Assert.Equal(2, options.InstantiatedIEnumerable.Count());
+            Assert.Equal("Yo1", options.InstantiatedIEnumerable.ElementAt(0));
+            Assert.Equal("Yo2", options.InstantiatedIEnumerable.ElementAt(1));
         }
 
         [Fact]
@@ -1450,9 +1456,9 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-
-            // Instantiated readonly collection which cannot be mutated by the configuration
-            Assert.Equal(0, options.InstantiatedIReadOnlyCollection.Count);
+            Assert.Equal(2, options.InstantiatedIReadOnlyCollection.Count);
+            Assert.Equal("Yo1", options.InstantiatedIReadOnlyCollection.ElementAt(0));
+            Assert.Equal("Yo2", options.InstantiatedIReadOnlyCollection.ElementAt(1));
         }
 
         [Fact]
@@ -1471,8 +1477,9 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var options = config.Get<ComplexOptions>()!;
 
-            // Instantiated IEnumerable is a readonly collection which cannot be mutated by the configuration
-            Assert.Equal(0, options.InstantiatedIEnumerable.Count());
+            Assert.Equal(2, options.InstantiatedIEnumerable.Count());
+            Assert.Equal("Yo1", options.InstantiatedIEnumerable.ElementAt(0));
+            Assert.Equal("Yo2", options.InstantiatedIEnumerable.ElementAt(1));
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1832,5 +1832,25 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(2, options.UnInstantiatedIReadOnlyCollection.Count());
             Assert.Equal(new string[] { "r", "e" }, options.UnInstantiatedIReadOnlyCollection);
         }
+
+        [Fact]
+        public void TestMutatingDictionaryValues()
+        {
+            IConfiguration config = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+
+            config["Key:0"] = "NewValue";
+            var dict = new Dictionary<string, string[]>() { { "Key", new[] { "InitialValue" } } };
+
+            Assert.Equal(1, dict["Key"].Length);
+            Assert.Equal("InitialValue", dict["Key"][0]);
+
+            // Binding will accumulate to the values inside the dictionary.
+            config.Bind(dict);
+            Assert.Equal(2, dict["Key"].Length);
+            Assert.Equal("InitialValue", dict["Key"][0]);
+            Assert.Equal("NewValue", dict["Key"][1]);
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1772,7 +1772,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var options = new OptionsWithDifferentCollectionInterfaces();
             config.Bind(options);
 
-            Assert.Equal(3, options.InstantiatedIEnumerable.Count());
+            Assert.True(3 == options.InstantiatedIEnumerable.Count(), $"InstantiatedIEnumerable count is {options.InstantiatedIEnumerable.Count()} .. {options.InstantiatedIEnumerable.ElementAt(options.InstantiatedIEnumerable.Count() - 1)}");
             Assert.Equal("value1", options.InstantiatedIEnumerable.ElementAt(0));
             Assert.Equal("value2", options.InstantiatedIEnumerable.ElementAt(1));
             Assert.Equal("value3", options.InstantiatedIEnumerable.ElementAt(2));
@@ -1781,7 +1781,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(1, options.UnInstantiatedIEnumerable.Count());
             Assert.Equal("value1", options.UnInstantiatedIEnumerable.ElementAt(0));
 
-            Assert.Equal(3, options.InstantiatedIList.Count());
+            Assert.True(3 == options.InstantiatedIList.Count(), $"InstantiatedIList count is {options.InstantiatedIList.Count()} .. {options.InstantiatedIList[options.InstantiatedIList.Count() - 1]}");
             Assert.Equal("value1", options.InstantiatedIList[0]);
             Assert.Equal("value2", options.InstantiatedIList[1]);
             Assert.Equal("value3", options.InstantiatedIList[2]);
@@ -1790,7 +1790,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(1, options.UnInstantiatedIList.Count());
             Assert.Equal("value", options.UnInstantiatedIList[0]);
 
-            Assert.Equal(3, options.InstantiatedIReadOnlyList.Count());
+            Assert.True(3 == options.InstantiatedIReadOnlyList.Count(), $"InstantiatedIReadOnlyList count is {options.InstantiatedIReadOnlyList.Count()} .. {options.InstantiatedIReadOnlyList[options.InstantiatedIReadOnlyList.Count() - 1]}");
             Assert.Equal("value1", options.InstantiatedIReadOnlyList[0]);
             Assert.Equal("value2", options.InstantiatedIReadOnlyList[1]);
             Assert.Equal("value3", options.InstantiatedIReadOnlyList[2]);
@@ -1799,12 +1799,12 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(1, options.UnInstantiatedIReadOnlyList.Count());
             Assert.Equal("value", options.UnInstantiatedIReadOnlyList[0]);
 
-            Assert.Equal(3, options.InstantiatedIDictionary.Count());
+            Assert.True(3 == options.InstantiatedIReadOnlyList.Count(), $"InstantiatedIReadOnlyList count is {options.InstantiatedIReadOnlyList.Count()} .. {options.InstantiatedIReadOnlyList[options.InstantiatedIReadOnlyList.Count() - 1]}");
             Assert.Equal(new string[] { "Key1", "Key2", "Key3" }, options.InstantiatedIDictionary.Keys);
             Assert.Equal(new string[] { "value1", "value2", "value3" }, options.InstantiatedIDictionary.Values);
             Assert.True(options.IsSameInstantiatedIDictionary());
 
-            Assert.Equal(3, options.InstantiatedIReadOnlyDictionary.Count());
+            Assert.True(3 == options.InstantiatedIReadOnlyDictionary.Count(), $"InstantiatedIReadOnlyDictionary count is {options.InstantiatedIReadOnlyDictionary.Count()} .. {options.InstantiatedIReadOnlyDictionary.ElementAt(options.InstantiatedIReadOnlyDictionary.Count() - 1)}");
             Assert.Equal(new string[] { "Key1", "Key2", "Key3" }, options.InstantiatedIReadOnlyDictionary.Keys);
             Assert.Equal(new string[] { "value1", "value2", "value3" }, options.InstantiatedIReadOnlyDictionary.Values);
             Assert.False(options.IsSameInstantiatedIReadOnlyDictionary());
@@ -1813,15 +1813,15 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(new string[] { "Key" }, options.UnInstantiatedIReadOnlyDictionary.Keys);
             Assert.Equal(new string[] { "value" }, options.UnInstantiatedIReadOnlyDictionary.Values);
 
-            Assert.Equal(3, options.InstantiatedISet.Count());
+            Assert.True(3 == options.InstantiatedISet.Count(), $"InstantiatedISet count is {options.InstantiatedISet.Count()} .. {options.InstantiatedISet.ElementAt(options.InstantiatedISet.Count() - 1)}");
             Assert.Equal(new string[] { "a", "b", "C" }, options.InstantiatedISet);
             Assert.True(options.IsSameInstantiatedISet());
 
-            Assert.Equal(3, options.UnInstantiatedISet.Count());
+            Assert.True(3 == options.UnInstantiatedISet.Count(), $"UnInstantiatedISet count is {options.UnInstantiatedISet.Count()} .. {options.UnInstantiatedISet.ElementAt(options.UnInstantiatedISet.Count() - 1)}");
             Assert.Equal(new string[] { "a", "A", "B" }, options.UnInstantiatedISet);
 
 #if NETCOREAPP
-            Assert.Equal(3, options.InstantiatedIReadOnlySet.Count());
+            Assert.True(3 == options.InstantiatedIReadOnlySet.Count(), $"InstantiatedIReadOnlySet count is {options.InstantiatedIReadOnlySet.Count()} .. {options.InstantiatedIReadOnlySet.ElementAt(options.InstantiatedIReadOnlySet.Count() - 1)}");
             Assert.Equal(new string[] { "a", "b", "Z" }, options.InstantiatedIReadOnlySet);
             Assert.False(options.IsSameInstantiatedIReadOnlySet());
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1706,10 +1706,13 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             public ISet<string> InstantiatedISet { get; set; } = s_instantiatedISet;
             public bool IsSameInstantiatedISet() => object.ReferenceEquals(s_instantiatedISet, InstantiatedISet);
 
+#if NETCOREAPP
             private static IReadOnlySet<string> s_instantiatedIReadOnlySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a", "A", "b" };
             public IReadOnlySet<string> InstantiatedIReadOnlySet { get; set; } = s_instantiatedIReadOnlySet;
             public bool IsSameInstantiatedIReadOnlySet() => object.ReferenceEquals(s_instantiatedIReadOnlySet, InstantiatedIReadOnlySet);
 
+            public IReadOnlySet<string> UnInstantiatedIReadOnlySet { get; set; }
+#endif
             private static ICollection<string> s_instantiatedICollection = new List<string> { "a", "b", "c" };
             public ICollection<string> InstantiatedICollection { get; set; } = s_instantiatedICollection;
             public bool IsSameInstantiatedICollection() => object.ReferenceEquals(s_instantiatedICollection, InstantiatedICollection);
@@ -1720,7 +1723,6 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             public IReadOnlyCollection<string> UnInstantiatedIReadOnlyCollection { get; set; }
             public ICollection<string> UnInstantiatedICollection { get; set; }
-            public IReadOnlySet<string> UnInstantiatedIReadOnlySet { get; set; }
             public ISet<string> UnInstantiatedISet { get; set; }
             public IReadOnlyDictionary<string, string> UnInstantiatedIReadOnlyDictionary { get; set; }
             public IEnumerable<string> UnInstantiatedIEnumerable { get; set; }
@@ -1811,13 +1813,14 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(3, options.UnInstantiatedISet.Count());
             Assert.Equal(new string[] { "a", "A", "B" }, options.UnInstantiatedISet);
 
+#if NETCOREAPP
             Assert.Equal(2, options.InstantiatedIReadOnlySet.Count());
             Assert.Equal(new string[] { "a", "b" }, options.InstantiatedIReadOnlySet);
             Assert.True(options.IsSameInstantiatedIReadOnlySet());
 
             Assert.Equal(2, options.UnInstantiatedIReadOnlySet.Count());
             Assert.Equal(new string[] { "y", "z" }, options.UnInstantiatedIReadOnlySet);
-
+#endif
             Assert.Equal(4, options.InstantiatedICollection.Count());
             Assert.Equal(new string[] { "a", "b", "c", "d" }, options.InstantiatedICollection);
             Assert.True(options.IsSameInstantiatedICollection());

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1813,7 +1813,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(new string[] { "Key" }, options.UnInstantiatedIReadOnlyDictionary.Keys);
             Assert.Equal(new string[] { "value" }, options.UnInstantiatedIReadOnlyDictionary.Values);
 
-            Assert.True(3 == options.InstantiatedISet.Count(), $"InstantiatedISet count is {options.InstantiatedISet.Count()} .. {options.InstantiatedISet.ElementAt(options.InstantiatedISet.Count() - 1)}");
+            Assert.True(3 == options.InstantiatedISet.Count(), $"InstantiatedISet count is {options.InstantiatedISet.Count()} .. {string.Join(", ", options.InstantiatedISet)} .. {options.IsSameInstantiatedISet()}");
             Assert.Equal(new string[] { "a", "b", "C" }, options.InstantiatedISet);
             Assert.True(options.IsSameInstantiatedISet());
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1086,14 +1086,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var array = options.AlreadyInitializedIEnumerableInterface.ToArray();
 
-            Assert.Equal(6, array.Length);
+            // Instantiated readonly IEnumerable which cannot be mutated by the configuration
+            Assert.Equal(2, array.Length);
 
             Assert.Equal("This was here too", array[0]);
             Assert.Equal("Don't touch me!", array[1]);
-            Assert.Equal("val0", array[2]);
-            Assert.Equal("val1", array[3]);
-            Assert.Equal("val2", array[4]);
-            Assert.Equal("valx", array[5]);
 
             // the original list hasn't been touched
             Assert.Equal(2, options.ListUsedInIEnumerableFieldAndShouldNotBeTouched.Count);
@@ -1132,12 +1129,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var array = options.AlreadyInitializedCustomListDerivedFromIEnumerable.ToArray();
 
-            Assert.Equal(4, array.Length);
+            // Instantiated IEnumerable is a readonly collection which cannot be mutated by the configuration
+            Assert.Equal(2, array.Length);
 
             Assert.Equal("Item1", array[0]);
             Assert.Equal("Item2", array[1]);
-            Assert.Equal("val0", array[2]);
-            Assert.Equal("val1", array[3]);
         }
 
         [Fact]
@@ -1162,12 +1158,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var array = options.AlreadyInitializedCustomListIndirectlyDerivedFromIEnumerable.ToArray();
 
-            Assert.Equal(4, array.Length);
+            // Instantiated readonly collection/IEnumerable which cannot be mutated by the configuration
+            Assert.Equal(2, array.Length);
 
             Assert.Equal("Item1", array[0]);
             Assert.Equal("Item2", array[1]);
-            Assert.Equal("val0", array[2]);
-            Assert.Equal("val1", array[3]);
         }
 
         [Fact]
@@ -1193,10 +1188,10 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             Assert.Equal(2, array.Length);
 
-            Assert.Equal("overridden!", options.AlreadyInitializedDictionary["existing_key_1"]);
+            Assert.Equal("val_1", options.AlreadyInitializedDictionary["existing_key_1"]);
             Assert.Equal("val_2", options.AlreadyInitializedDictionary["existing_key_2"]);
 
-            Assert.NotEqual(options.AlreadyInitializedDictionary, InitializedCollectionsOptions.ExistingDictionary);
+            Assert.Equal(options.AlreadyInitializedDictionary, InitializedCollectionsOptions.ExistingDictionary);
 
             Assert.Equal("val_1", InitializedCollectionsOptions.ExistingDictionary["existing_key_1"]);
             Assert.Equal("val_2", InitializedCollectionsOptions.ExistingDictionary["existing_key_2"]);
@@ -1678,12 +1673,164 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             private string? v;
             public string? this[string key] { get => v; set => v = value; }
             public bool TryGetValue() { return true; }
-
         }
 
         public class ExtendedDictionary<TKey, TValue> : Dictionary<TKey, TValue>
         {
 
+        }
+
+        private class OptionsWithDifferentCollectionInterfaces
+        {
+            private static IEnumerable<string> s_instantiatedIEnumerable = new List<string> { "value1", "value2" };
+            public bool IsSameInstantiatedIEnumerable() => object.ReferenceEquals(s_instantiatedIEnumerable, InstantiatedIEnumerable);
+            public IEnumerable<string> InstantiatedIEnumerable { get; set; } = s_instantiatedIEnumerable;
+
+            private static IList<string> s_instantiatedIList = new List<string> { "value1", "value2" };
+            public bool IsSameInstantiatedIList() => object.ReferenceEquals(s_instantiatedIList, InstantiatedIList);
+            public IList<string> InstantiatedIList { get; set; } = s_instantiatedIList;
+
+            private static IReadOnlyList<string> s_instantiatedIReadOnlyList = new List<string> { "value1", "value2" };
+            public bool IsSameInstantiatedIReadOnlyList() => object.ReferenceEquals(s_instantiatedIReadOnlyList, InstantiatedIReadOnlyList);
+            public IReadOnlyList<string> InstantiatedIReadOnlyList { get; set; } = s_instantiatedIReadOnlyList;
+
+            private static IDictionary<string, string> s_instantiatedIDictionary = new Dictionary<string, string> { ["Key1"] = "value1", ["Key2"] = "value2" };
+            public IDictionary<string, string> InstantiatedIDictionary { get; set; } = s_instantiatedIDictionary;
+            public bool IsSameInstantiatedIDictionary() => object.ReferenceEquals(s_instantiatedIDictionary, InstantiatedIDictionary);
+
+            private static IReadOnlyDictionary<string, string> s_instantiatedIReadOnlyDictionary = new Dictionary<string, string> { ["Key1"] = "value1", ["Key2"] = "value2" };
+            public IReadOnlyDictionary<string, string> InstantiatedIReadOnlyDictionary { get; set; } = s_instantiatedIReadOnlyDictionary;
+            public bool IsSameInstantiatedIReadOnlyDictionary() => object.ReferenceEquals(s_instantiatedIReadOnlyDictionary, InstantiatedIReadOnlyDictionary);
+
+            private static ISet<string> s_instantiatedISet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a", "A", "b" };
+            public ISet<string> InstantiatedISet { get; set; } = s_instantiatedISet;
+            public bool IsSameInstantiatedISet() => object.ReferenceEquals(s_instantiatedISet, InstantiatedISet);
+
+            private static IReadOnlySet<string> s_instantiatedIReadOnlySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a", "A", "b" };
+            public IReadOnlySet<string> InstantiatedIReadOnlySet { get; set; } = s_instantiatedIReadOnlySet;
+            public bool IsSameInstantiatedIReadOnlySet() => object.ReferenceEquals(s_instantiatedIReadOnlySet, InstantiatedIReadOnlySet);
+
+            private static ICollection<string> s_instantiatedICollection = new List<string> { "a", "b", "c" };
+            public ICollection<string> InstantiatedICollection { get; set; } = s_instantiatedICollection;
+            public bool IsSameInstantiatedICollection() => object.ReferenceEquals(s_instantiatedICollection, InstantiatedICollection);
+
+            private static IReadOnlyCollection<string> s_instantiatedIReadOnlyCollection = new List<string> { "a", "b", "c" };
+            public IReadOnlyCollection<string> InstantiatedIReadOnlyCollection { get; set; } = s_instantiatedIReadOnlyCollection;
+            public bool IsSameInstantiatedIReadOnlyCollection() => object.ReferenceEquals(s_instantiatedIReadOnlyCollection, InstantiatedIReadOnlyCollection);
+
+            public IReadOnlyCollection<string> UnInstantiatedIReadOnlyCollection { get; set; }
+            public ICollection<string> UnInstantiatedICollection { get; set; }
+            public IReadOnlySet<string> UnInstantiatedIReadOnlySet { get; set; }
+            public ISet<string> UnInstantiatedISet { get; set; }
+            public IReadOnlyDictionary<string, string> UnInstantiatedIReadOnlyDictionary { get; set; }
+            public IEnumerable<string> UnInstantiatedIEnumerable { get; set; }
+            public IList<string> UnInstantiatedIList { get; set; }
+            public IReadOnlyList<string> UnInstantiatedIReadOnlyList { get; set; }
+        }
+
+        [Fact]
+        public void TestOptionsWithDifferentCollectionInterfaces()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"InstantiatedIEnumerable:0", "value3"},
+                {"UnInstantiatedIEnumerable:0", "value1"},
+                {"InstantiatedIList:0", "value3"},
+                {"InstantiatedIReadOnlyList:0", "value3"},
+                {"UnInstantiatedIReadOnlyList:0", "value"},
+                {"UnInstantiatedIList:0", "value"},
+                {"InstantiatedIDictionary:Key3", "value3"},
+                {"InstantiatedIReadOnlyDictionary:Key3", "value3"},
+                {"UnInstantiatedIReadOnlyDictionary:Key", "value"},
+                {"InstantiatedISet:0", "B"},
+                {"InstantiatedISet:1", "C"},
+                {"UnInstantiatedISet:0", "a"},
+                {"UnInstantiatedISet:1", "A"},
+                {"UnInstantiatedISet:2", "B"},
+                {"InstantiatedIReadOnlySet:0", "Z"},
+                {"UnInstantiatedIReadOnlySet:0", "y"},
+                {"UnInstantiatedIReadOnlySet:1", "z"},
+                {"InstantiatedICollection:0", "d"},
+                {"UnInstantiatedICollection:0", "t"},
+                {"UnInstantiatedICollection:1", "a"},
+                {"InstantiatedIReadOnlyCollection:0", "d"},
+                {"UnInstantiatedIReadOnlyCollection:0", "r"},
+                {"UnInstantiatedIReadOnlyCollection:1", "e"},
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = new OptionsWithDifferentCollectionInterfaces();
+            config.Bind(options);
+
+            Assert.Equal(2, options.InstantiatedIEnumerable.Count());
+            Assert.Equal("value1", options.InstantiatedIEnumerable.ElementAt(0));
+            Assert.Equal("value2", options.InstantiatedIEnumerable.ElementAt(1));
+            Assert.True(options.IsSameInstantiatedIEnumerable());
+
+            Assert.Equal(1, options.UnInstantiatedIEnumerable.Count());
+            Assert.Equal("value1", options.UnInstantiatedIEnumerable.ElementAt(0));
+
+            Assert.Equal(3, options.InstantiatedIList.Count());
+            Assert.Equal("value1", options.InstantiatedIList[0]);
+            Assert.Equal("value2", options.InstantiatedIList[1]);
+            Assert.Equal("value3", options.InstantiatedIList[2]);
+            Assert.True(options.IsSameInstantiatedIList());
+
+            Assert.Equal(1, options.UnInstantiatedIList.Count());
+            Assert.Equal("value", options.UnInstantiatedIList[0]);
+
+            Assert.Equal(2, options.InstantiatedIReadOnlyList.Count());
+            Assert.Equal("value1", options.InstantiatedIReadOnlyList[0]);
+            Assert.Equal("value2", options.InstantiatedIReadOnlyList[1]);
+            Assert.True(options.IsSameInstantiatedIReadOnlyList());
+
+            Assert.Equal(1, options.UnInstantiatedIReadOnlyList.Count());
+            Assert.Equal("value", options.UnInstantiatedIReadOnlyList[0]);
+
+            Assert.Equal(3, options.InstantiatedIDictionary.Count());
+            Assert.Equal(new string[] { "Key1", "Key2", "Key3" }, options.InstantiatedIDictionary.Keys);
+            Assert.Equal(new string[] { "value1", "value2", "value3" }, options.InstantiatedIDictionary.Values);
+            Assert.True(options.IsSameInstantiatedIDictionary());
+
+            Assert.Equal(2, options.InstantiatedIReadOnlyDictionary.Count());
+            Assert.Equal(new string[] { "Key1", "Key2" }, options.InstantiatedIReadOnlyDictionary.Keys);
+            Assert.Equal(new string[] { "value1", "value2" }, options.InstantiatedIReadOnlyDictionary.Values);
+            Assert.True(options.IsSameInstantiatedIReadOnlyDictionary());
+
+            Assert.Equal(1, options.UnInstantiatedIReadOnlyDictionary.Count());
+            Assert.Equal(new string[] { "Key" }, options.UnInstantiatedIReadOnlyDictionary.Keys);
+            Assert.Equal(new string[] { "value" }, options.UnInstantiatedIReadOnlyDictionary.Values);
+
+            Assert.Equal(3, options.InstantiatedISet.Count());
+            Assert.Equal(new string[] { "a", "b", "C" }, options.InstantiatedISet);
+            Assert.True(options.IsSameInstantiatedISet());
+
+            Assert.Equal(3, options.UnInstantiatedISet.Count());
+            Assert.Equal(new string[] { "a", "A", "B" }, options.UnInstantiatedISet);
+
+            Assert.Equal(2, options.InstantiatedIReadOnlySet.Count());
+            Assert.Equal(new string[] { "a", "b" }, options.InstantiatedIReadOnlySet);
+            Assert.True(options.IsSameInstantiatedIReadOnlySet());
+
+            Assert.Equal(2, options.UnInstantiatedIReadOnlySet.Count());
+            Assert.Equal(new string[] { "y", "z" }, options.UnInstantiatedIReadOnlySet);
+
+            Assert.Equal(4, options.InstantiatedICollection.Count());
+            Assert.Equal(new string[] { "a", "b", "c", "d" }, options.InstantiatedICollection);
+            Assert.True(options.IsSameInstantiatedICollection());
+
+            Assert.Equal(2, options.UnInstantiatedICollection.Count());
+            Assert.Equal(new string[] { "t", "a" }, options.UnInstantiatedICollection);
+
+            Assert.Equal(3, options.InstantiatedIReadOnlyCollection.Count());
+            Assert.Equal(new string[] { "a", "b", "c" }, options.InstantiatedIReadOnlyCollection);
+            Assert.True(options.IsSameInstantiatedIReadOnlyCollection());
+
+            Assert.Equal(2, options.UnInstantiatedIReadOnlyCollection.Count());
+            Assert.Equal(new string[] { "r", "e" }, options.UnInstantiatedIReadOnlyCollection);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationCollectionBindingTests.cs
@@ -1086,11 +1086,14 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var array = options.AlreadyInitializedIEnumerableInterface.ToArray();
 
-            // Instantiated readonly IEnumerable which cannot be mutated by the configuration
-            Assert.Equal(2, array.Length);
+            Assert.Equal(6, array.Length);
 
             Assert.Equal("This was here too", array[0]);
             Assert.Equal("Don't touch me!", array[1]);
+            Assert.Equal("val0", array[2]);
+            Assert.Equal("val1", array[3]);
+            Assert.Equal("val2", array[4]);
+            Assert.Equal("valx", array[5]);
 
             // the original list hasn't been touched
             Assert.Equal(2, options.ListUsedInIEnumerableFieldAndShouldNotBeTouched.Count);
@@ -1129,11 +1132,12 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var array = options.AlreadyInitializedCustomListDerivedFromIEnumerable.ToArray();
 
-            // Instantiated IEnumerable is a readonly collection which cannot be mutated by the configuration
-            Assert.Equal(2, array.Length);
+            Assert.Equal(4, array.Length);
 
             Assert.Equal("Item1", array[0]);
             Assert.Equal("Item2", array[1]);
+            Assert.Equal("val0", array[2]);
+            Assert.Equal("val1", array[3]);
         }
 
         [Fact]
@@ -1158,11 +1162,12 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var array = options.AlreadyInitializedCustomListIndirectlyDerivedFromIEnumerable.ToArray();
 
-            // Instantiated readonly collection/IEnumerable which cannot be mutated by the configuration
-            Assert.Equal(2, array.Length);
+            Assert.Equal(4, array.Length);
 
             Assert.Equal("Item1", array[0]);
             Assert.Equal("Item2", array[1]);
+            Assert.Equal("val0", array[2]);
+            Assert.Equal("val1", array[3]);
         }
 
         [Fact]
@@ -1188,10 +1193,10 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             Assert.Equal(2, array.Length);
 
-            Assert.Equal("val_1", options.AlreadyInitializedDictionary["existing_key_1"]);
+            Assert.Equal("overridden!", options.AlreadyInitializedDictionary["existing_key_1"]);
             Assert.Equal("val_2", options.AlreadyInitializedDictionary["existing_key_2"]);
 
-            Assert.Equal(options.AlreadyInitializedDictionary, InitializedCollectionsOptions.ExistingDictionary);
+            Assert.NotEqual(options.AlreadyInitializedDictionary, InitializedCollectionsOptions.ExistingDictionary);
 
             Assert.Equal("val_1", InitializedCollectionsOptions.ExistingDictionary["existing_key_1"]);
             Assert.Equal("val_2", InitializedCollectionsOptions.ExistingDictionary["existing_key_2"]);
@@ -1767,10 +1772,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var options = new OptionsWithDifferentCollectionInterfaces();
             config.Bind(options);
 
-            Assert.Equal(2, options.InstantiatedIEnumerable.Count());
+            Assert.Equal(3, options.InstantiatedIEnumerable.Count());
             Assert.Equal("value1", options.InstantiatedIEnumerable.ElementAt(0));
             Assert.Equal("value2", options.InstantiatedIEnumerable.ElementAt(1));
-            Assert.True(options.IsSameInstantiatedIEnumerable());
+            Assert.Equal("value3", options.InstantiatedIEnumerable.ElementAt(2));
+            Assert.False(options.IsSameInstantiatedIEnumerable());
 
             Assert.Equal(1, options.UnInstantiatedIEnumerable.Count());
             Assert.Equal("value1", options.UnInstantiatedIEnumerable.ElementAt(0));
@@ -1784,10 +1790,11 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(1, options.UnInstantiatedIList.Count());
             Assert.Equal("value", options.UnInstantiatedIList[0]);
 
-            Assert.Equal(2, options.InstantiatedIReadOnlyList.Count());
+            Assert.Equal(3, options.InstantiatedIReadOnlyList.Count());
             Assert.Equal("value1", options.InstantiatedIReadOnlyList[0]);
             Assert.Equal("value2", options.InstantiatedIReadOnlyList[1]);
-            Assert.True(options.IsSameInstantiatedIReadOnlyList());
+            Assert.Equal("value3", options.InstantiatedIReadOnlyList[2]);
+            Assert.False(options.IsSameInstantiatedIReadOnlyList());
 
             Assert.Equal(1, options.UnInstantiatedIReadOnlyList.Count());
             Assert.Equal("value", options.UnInstantiatedIReadOnlyList[0]);
@@ -1797,10 +1804,10 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(new string[] { "value1", "value2", "value3" }, options.InstantiatedIDictionary.Values);
             Assert.True(options.IsSameInstantiatedIDictionary());
 
-            Assert.Equal(2, options.InstantiatedIReadOnlyDictionary.Count());
-            Assert.Equal(new string[] { "Key1", "Key2" }, options.InstantiatedIReadOnlyDictionary.Keys);
-            Assert.Equal(new string[] { "value1", "value2" }, options.InstantiatedIReadOnlyDictionary.Values);
-            Assert.True(options.IsSameInstantiatedIReadOnlyDictionary());
+            Assert.Equal(3, options.InstantiatedIReadOnlyDictionary.Count());
+            Assert.Equal(new string[] { "Key1", "Key2", "Key3" }, options.InstantiatedIReadOnlyDictionary.Keys);
+            Assert.Equal(new string[] { "value1", "value2", "value3" }, options.InstantiatedIReadOnlyDictionary.Values);
+            Assert.False(options.IsSameInstantiatedIReadOnlyDictionary());
 
             Assert.Equal(1, options.UnInstantiatedIReadOnlyDictionary.Count());
             Assert.Equal(new string[] { "Key" }, options.UnInstantiatedIReadOnlyDictionary.Keys);
@@ -1814,9 +1821,9 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(new string[] { "a", "A", "B" }, options.UnInstantiatedISet);
 
 #if NETCOREAPP
-            Assert.Equal(2, options.InstantiatedIReadOnlySet.Count());
-            Assert.Equal(new string[] { "a", "b" }, options.InstantiatedIReadOnlySet);
-            Assert.True(options.IsSameInstantiatedIReadOnlySet());
+            Assert.Equal(3, options.InstantiatedIReadOnlySet.Count());
+            Assert.Equal(new string[] { "a", "b", "Z" }, options.InstantiatedIReadOnlySet);
+            Assert.False(options.IsSameInstantiatedIReadOnlySet());
 
             Assert.Equal(2, options.UnInstantiatedIReadOnlySet.Count());
             Assert.Equal(new string[] { "y", "z" }, options.UnInstantiatedIReadOnlySet);
@@ -1828,9 +1835,9 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal(2, options.UnInstantiatedICollection.Count());
             Assert.Equal(new string[] { "t", "a" }, options.UnInstantiatedICollection);
 
-            Assert.Equal(3, options.InstantiatedIReadOnlyCollection.Count());
-            Assert.Equal(new string[] { "a", "b", "c" }, options.InstantiatedIReadOnlyCollection);
-            Assert.True(options.IsSameInstantiatedIReadOnlyCollection());
+            Assert.Equal(4, options.InstantiatedIReadOnlyCollection.Count());
+            Assert.Equal(new string[] { "a", "b", "c", "d" }, options.InstantiatedIReadOnlyCollection);
+            Assert.False(options.IsSameInstantiatedIReadOnlyCollection());
 
             Assert.Equal(2, options.UnInstantiatedIReadOnlyCollection.Count());
             Assert.Equal(new string[] { "r", "e" }, options.UnInstantiatedIReadOnlyCollection);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ILLink.Descriptors.xml
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ILLink.Descriptors.xml
@@ -14,6 +14,9 @@
     <type fullname="System.Collections.Generic.HashSet`1">
         <method signature="System.Void .ctor()" />
     </type>
-    <type fullname="System.Collections.Generic.ISet`1" preserve="methods" />
   </assembly>
+
+  <assembly fullname="System.Private.Corelib">
+    <type fullname="System.Collections.Generic.ISet`1" preserve="methods" />
+   </assembly>
 </linker>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ILLink.Descriptors.xml
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ILLink.Descriptors.xml
@@ -14,5 +14,6 @@
     <type fullname="System.Collections.Generic.HashSet`1">
         <method signature="System.Void .ctor()" />
     </type>
+    <type fullname="System.Collections.Generic.ISet`1" preserve="methods" />
   </assembly>
 </linker>


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/79766

Un-mutate the settable collection instances during the binding.
