### PR TITLE
Update the JIT to track `Span.Length` and `ReadOnlySpan.Length` as "never negative"

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -170,12 +170,14 @@ bool IntegralRange::Contains(int64_t value) const
 
         case GT_LCL_VAR:
         {
-            if (compiler->lvaGetDesc(node->AsLclVar())->lvNormalizeOnStore())
+            LclVarDsc* const varDsc = compiler->lvaGetDesc(node->AsLclVar());
+
+            if (varDsc->lvNormalizeOnStore())
             {
                 rangeType = compiler->lvaGetDesc(node->AsLclVar())->TypeGet();
             }
 
-            if ((node->gtFlags & GTF_VAR_NEVER_NEGATIVE) != 0)
+            if (varDsc->IsNeverNegative())
             {
                 return {SymbolicIntegerValue::Zero, UpperBoundForType(rangeType)};
             }
@@ -227,7 +229,7 @@ bool IntegralRange::Contains(int64_t value) const
 
         case GT_FIELD:
         {
-            if ((node->gtFlags & GTF_FLD_NEVER_NEGATIVE) != 0)
+            if (node->AsField()->IsNeverNegative())
             {
                 return {SymbolicIntegerValue::Zero, UpperBoundForType(rangeType)};
             }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -169,11 +169,18 @@ bool IntegralRange::Contains(int64_t value) const
             break;
 
         case GT_LCL_VAR:
+        {
             if (compiler->lvaGetDesc(node->AsLclVar())->lvNormalizeOnStore())
             {
                 rangeType = compiler->lvaGetDesc(node->AsLclVar())->TypeGet();
             }
+
+            if ((node->gtFlags & GTF_VAR_NEVER_NEGATIVE) != 0)
+            {
+                return {SymbolicIntegerValue::Zero, UpperBoundForType(rangeType)};
+            }
             break;
+        }
 
         case GT_CNS_INT:
             if (node->IsIntegralConst(0) || node->IsIntegralConst(1))
@@ -217,6 +224,15 @@ bool IntegralRange::Contains(int64_t value) const
             }
             break;
 #endif // defined(FEATURE_HW_INTRINSICS)
+
+        case GT_FIELD:
+        {
+            if ((node->gtFlags & GTF_FLD_NEVER_NEGATIVE) != 0)
+            {
+                return {SymbolicIntegerValue::Zero, UpperBoundForType(rangeType)};
+            }
+            break;
+        }
 
         default:
             break;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -229,7 +229,7 @@ bool IntegralRange::Contains(int64_t value) const
 
         case GT_FIELD:
         {
-            if (node->AsField()->IsNeverNegative())
+            if (node->AsField()->IsSpanLength())
             {
                 return {SymbolicIntegerValue::Zero, UpperBoundForType(rangeType)};
             }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -657,6 +657,10 @@ public:
     unsigned char lvIsOSRLocal : 1; // Root method local in an OSR method. Any stack home will be on the Tier0 frame.
                                     // Initial value will be defined by Tier0. Requires special handing in prolog.
 
+private:
+    unsigned char lvIsNeverNegative : 1; // The local is known to be never negative
+
+public:
     union {
         unsigned lvFieldLclStart; // The index of the local var representing the first field in the promoted struct
                                   // local.  For implicit byref parameters, this gets hijacked between
@@ -957,6 +961,18 @@ public:
         return false;
     }
 #endif
+
+    // Is this is local never negative?
+    bool IsNeverNegative() const
+    {
+        return lvIsNeverNegative;
+    }
+
+    // Is this is local never negative?
+    void SetIsNeverNegative(bool value)
+    {
+        lvIsNeverNegative = value;
+    }
 
     /////////////////////
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8434,9 +8434,9 @@ GenTree* Compiler::gtClone(GenTree* tree, bool complexOK)
                 copy->AsField()->gtFieldLookup = tree->AsField()->gtFieldLookup;
 #endif
 
-                if (tree->AsField()->IsNeverNegative())
+                if (tree->AsField()->IsSpanLength())
                 {
-                    copy->AsField()->SetIsNeverNegative(true);
+                    copy->AsField()->SetIsSpanLength(true);
                 }
             }
             else if (tree->OperIs(GT_ADD, GT_SUB))
@@ -8782,9 +8782,9 @@ GenTree* Compiler::gtCloneExpr(
                 copy->AsField()->gtFieldLookup = tree->AsField()->gtFieldLookup;
 #endif
 
-                if (tree->AsField()->IsNeverNegative())
+                if (tree->AsField()->IsSpanLength())
                 {
-                    copy->AsField()->SetIsNeverNegative(true);
+                    copy->AsField()->SetIsSpanLength(true);
                 }
                 break;
 
@@ -24751,7 +24751,7 @@ bool GenTree::IsNeverNegative(Compiler* comp) const
     }
     else if (OperIs(GT_FIELD))
     {
-        if (AsField()->IsNeverNegative())
+        if (AsField()->IsSpanLength())
         {
             // This is an early exit, it doesn't cover all cases
             return true;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8782,7 +8782,7 @@ GenTree* Compiler::gtCloneExpr(
                 copy->AsField()->gtFieldLookup = tree->AsField()->gtFieldLookup;
 #endif
 
-                if (tree->AsField()->IsSpanLength())
+                if ((oper == GT_FIELD) && tree->AsField()->IsSpanLength())
                 {
                     copy->AsField()->SetIsSpanLength(true);
                 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24643,6 +24643,7 @@ ClassLayout* GenTreeLclVarCommon::GetLayout(Compiler* compiler) const
 //
 bool GenTreeLclVar::IsNeverNegative(Compiler* comp) const
 {
+    assert(OperIs(GT_LCL_VAR));
     return comp->lvaGetDesc(GetLclNum())->IsNeverNegative();
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -24633,7 +24633,7 @@ ClassLayout* GenTreeLclVarCommon::GetLayout(Compiler* compiler) const
 }
 
 //------------------------------------------------------------------------
-// GenTreeLclVarCommon::IsNeverNegative: Gets true if the lcl var is never negative; otherwise false.
+// GenTreeLclVar::IsNeverNegative: Gets true if the lcl var is never negative; otherwise false.
 //
 // Arguments:
 //    comp - the compiler instance
@@ -24641,7 +24641,7 @@ ClassLayout* GenTreeLclVarCommon::GetLayout(Compiler* compiler) const
 // Return Value:
 //    true if the lcl var is never negative; otherwise false.
 //
-bool GenTreeLclVarCommon::IsNeverNegative(Compiler* comp) const
+bool GenTreeLclVar::IsNeverNegative(Compiler* comp) const
 {
     return comp->lvaGetDesc(GetLclNum())->IsNeverNegative();
 }
@@ -24740,9 +24740,9 @@ bool GenTree::IsNeverNegative(Compiler* comp) const
         return AsIntConCommon()->IntegralValue() >= 0;
     }
 
-    if (IsLocal())
+    if (OperIs(GT_LCL_VAR))
     {
-        if (AsLclVarCommon()->IsNeverNegative(comp))
+        if (AsLclVar()->IsNeverNegative(comp))
         {
             // This is an early exit, it doesn't cover all cases
             return true;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3652,8 +3652,6 @@ public:
         return m_ssaNum.IsComposite();
     }
 
-    bool IsNeverNegative(Compiler* comp) const;
-
 #if DEBUGGABLE_GENTREE
     GenTreeLclVarCommon() : GenTreeUnOp()
     {
@@ -3795,6 +3793,8 @@ public:
 
     unsigned int GetFieldCount(Compiler* compiler) const;
     var_types GetFieldTypeByIndex(Compiler* compiler, unsigned idx);
+
+    bool IsNeverNegative(Compiler* comp) const;
 
     //-------------------------------------------------------------------
     // clearOtherRegFlags: clear GTF_* flags associated with gtOtherRegs

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4017,7 +4017,11 @@ public:
 #endif
 
     GenTreeField(genTreeOps oper, var_types type, GenTree* obj, CORINFO_FIELD_HANDLE fldHnd, DWORD offs)
-        : GenTreeUnOp(oper, type, obj), gtFldHnd(fldHnd), gtFldOffset(offs), gtFldMayOverlap(false)
+        : GenTreeUnOp(oper, type, obj)
+        , gtFldHnd(fldHnd)
+        , gtFldOffset(offs)
+        , gtFldMayOverlap(false)
+        , gtFldIsNeverNegative(false)
     {
 #ifdef FEATURE_READYTORUN
         gtFieldLookup.addr = nullptr;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -470,10 +470,10 @@ enum GenTreeFlags : unsigned int
 
     GTF_LIVENESS_MASK     = GTF_VAR_DEF | GTF_VAR_USEASG | GTF_VAR_DEATH_MASK,
 
-    GTF_VAR_ITERATOR       = 0x01000000, // GT_LCL_VAR -- this is a iterator reference in the loop condition
-    GTF_VAR_CLONED         = 0x00800000, // GT_LCL_VAR -- this node has been cloned or is a clone
-    GTF_VAR_CONTEXT        = 0x00400000, // GT_LCL_VAR -- this node is part of a runtime lookup
-    GTF_VAR_EXPLICIT_INIT  = 0x00200000, // GT_LCL_VAR -- this node is an "explicit init" store. Valid until rationalization.
+    GTF_VAR_ITERATOR      = 0x01000000, // GT_LCL_VAR -- this is a iterator reference in the loop condition
+    GTF_VAR_CLONED        = 0x00800000, // GT_LCL_VAR -- this node has been cloned or is a clone
+    GTF_VAR_CONTEXT       = 0x00400000, // GT_LCL_VAR -- this node is part of a runtime lookup
+    GTF_VAR_EXPLICIT_INIT = 0x00200000, // GT_LCL_VAR -- this node is an "explicit init" store. Valid until rationalization.
 
     // For additional flags for GT_CALL node see GTF_CALL_M_*
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -470,10 +470,11 @@ enum GenTreeFlags : unsigned int
 
     GTF_LIVENESS_MASK     = GTF_VAR_DEF | GTF_VAR_USEASG | GTF_VAR_DEATH_MASK,
 
-    GTF_VAR_ITERATOR      = 0x01000000, // GT_LCL_VAR -- this is a iterator reference in the loop condition
-    GTF_VAR_CLONED        = 0x00800000, // GT_LCL_VAR -- this node has been cloned or is a clone
-    GTF_VAR_CONTEXT       = 0x00400000, // GT_LCL_VAR -- this node is part of a runtime lookup
-    GTF_VAR_EXPLICIT_INIT = 0x00200000, // GT_LCL_VAR -- this node is an "explicit init" store. Valid until rationalization.
+    GTF_VAR_ITERATOR       = 0x01000000, // GT_LCL_VAR -- this is a iterator reference in the loop condition
+    GTF_VAR_CLONED         = 0x00800000, // GT_LCL_VAR -- this node has been cloned or is a clone
+    GTF_VAR_CONTEXT        = 0x00400000, // GT_LCL_VAR -- this node is part of a runtime lookup
+    GTF_VAR_EXPLICIT_INIT  = 0x00200000, // GT_LCL_VAR -- this node is an "explicit init" store. Valid until rationalization.
+    GTF_VAR_NEVER_NEGATIVE = 0x00100000, // GT_LCL_VAR -- this node can be assumed to never return a negative value
 
     // For additional flags for GT_CALL node see GTF_CALL_M_*
 
@@ -492,6 +493,7 @@ enum GenTreeFlags : unsigned int
     GTF_MEMORYBARRIER_LOAD      = 0x40000000, // GT_MEMORYBARRIER -- Load barrier
 
     GTF_FLD_TLS                 = 0x80000000, // GT_FIELD_ADDR -- field address is a Windows x86 TLS reference
+    GTF_FLD_NEVER_NEGATIVE      = 0x80000000, // GT_FIELD -- this field can be assumed to never return a negative value
     GTF_FLD_VOLATILE            = 0x40000000, // GT_FIELD -- same as GTF_IND_VOLATILE
     GTF_FLD_INITCLASS           = 0x20000000, // GT_FIELD/GT_FIELD_ADDR -- field access requires preceding class/static init helper
     GTF_FLD_TGT_HEAP            = 0x10000000, // GT_FIELD -- same as GTF_IND_TGT_HEAP

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4009,7 +4009,7 @@ struct GenTreeField : public GenTreeUnOp
     bool                 gtFldMayOverlap : 1;
 
 private:
-    bool gtFldIsNeverNegative : 1;
+    bool gtFldIsSpanLength : 1;
 
 public:
 #ifdef FEATURE_READYTORUN
@@ -4021,7 +4021,7 @@ public:
         , gtFldHnd(fldHnd)
         , gtFldOffset(offs)
         , gtFldMayOverlap(false)
-        , gtFldIsNeverNegative(false)
+        , gtFldIsSpanLength(false)
     {
 #ifdef FEATURE_READYTORUN
         gtFieldLookup.addr = nullptr;
@@ -4048,15 +4048,22 @@ public:
         return (gtFlags & GTF_FLD_VOLATILE) != 0;
     }
 
-    bool IsNeverNegative() const
+    bool IsSpanLength() const
     {
+        // This is limited to span length today rather than a more general "IsNeverNegative"
+        // to help avoid confusion around propagating the value to promoted lcl vars.
+        //
+        // Extending this support more in the future will require additional work and
+        // considerations to help ensure it is correctly used since people may want
+        // or intend to use this as more of a "point in time" feature like GTF_IND_NONNULL
+
         assert(OperIs(GT_FIELD));
-        return gtFldIsNeverNegative;
+        return gtFldIsSpanLength;
     }
 
-    void SetIsNeverNegative(bool value)
+    void SetIsSpanLength(bool value)
     {
-        gtFldIsNeverNegative = value;
+        gtFldIsSpanLength = value;
     }
 
     bool IsInstance() const

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4009,7 +4009,7 @@ struct GenTreeField : public GenTreeUnOp
     bool                 gtFldMayOverlap : 1;
 
 private:
-    bool                 gtFldIsNeverNegative : 1;
+    bool gtFldIsNeverNegative : 1;
 
 public:
 #ifdef FEATURE_READYTORUN

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4050,6 +4050,7 @@ public:
 
     bool IsNeverNegative() const
     {
+        assert(OperIs(GT_FIELD));
         return gtFldIsNeverNegative;
     }
 

--- a/src/coreclr/jit/gschecks.cpp
+++ b/src/coreclr/jit/gschecks.cpp
@@ -461,6 +461,11 @@ void Compiler::gsParamsToShadows()
         shadowVarDsc->lvIsUnsafeBuffer = varDsc->lvIsUnsafeBuffer;
         shadowVarDsc->lvIsPtr          = varDsc->lvIsPtr;
 
+        if (varDsc->IsNeverNegative())
+        {
+            shadowVarDsc->SetIsNeverNegative(true);
+        }
+
 #ifdef DEBUG
         if (verbose)
         {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2781,7 +2781,10 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 // Bounds check
                 CORINFO_FIELD_HANDLE lengthHnd    = info.compCompHnd->getFieldInClass(clsHnd, 1);
                 const unsigned       lengthOffset = info.compCompHnd->getFieldOffset(lengthHnd);
-                GenTree*             length       = gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
+
+                GenTree* length = gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
+                length->gtFlags |= GTF_FLD_NEVER_NEGATIVE;
+
                 GenTree* boundsCheck = new (this, GT_BOUNDS_CHECK) GenTreeBoundsChk(index, length, SCK_RNGCHK_FAIL);
 
                 // Element access
@@ -2840,7 +2843,9 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 CORINFO_FIELD_HANDLE lengthHnd    = info.compCompHnd->getFieldInClass(clsHnd, 1);
                 const unsigned       lengthOffset = info.compCompHnd->getFieldOffset(lengthHnd);
 
-                return gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
+                GenTreeField* fieldRef = gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
+                fieldRef->gtFlags |= GTF_FLD_NEVER_NEGATIVE;
+                return fieldRef;
             }
 
             case NI_System_RuntimeTypeHandle_GetValueInternal:

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2783,7 +2783,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 const unsigned       lengthOffset = info.compCompHnd->getFieldOffset(lengthHnd);
 
                 GenTreeField* length = gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
-                length->SetIsNeverNegative(true);
+                length->SetIsSpanLength(true);
 
                 GenTree* boundsCheck = new (this, GT_BOUNDS_CHECK) GenTreeBoundsChk(index, length, SCK_RNGCHK_FAIL);
 
@@ -2844,7 +2844,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 const unsigned       lengthOffset = info.compCompHnd->getFieldOffset(lengthHnd);
 
                 GenTreeField* fieldRef = gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
-                fieldRef->SetIsNeverNegative(true);
+                fieldRef->SetIsSpanLength(true);
                 return fieldRef;
             }
 

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2782,8 +2782,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 CORINFO_FIELD_HANDLE lengthHnd    = info.compCompHnd->getFieldInClass(clsHnd, 1);
                 const unsigned       lengthOffset = info.compCompHnd->getFieldOffset(lengthHnd);
 
-                GenTree* length = gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
-                length->gtFlags |= GTF_FLD_NEVER_NEGATIVE;
+                GenTreeField* length = gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
+                length->SetIsNeverNegative(true);
 
                 GenTree* boundsCheck = new (this, GT_BOUNDS_CHECK) GenTreeBoundsChk(index, length, SCK_RNGCHK_FAIL);
 
@@ -2844,7 +2844,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 const unsigned       lengthOffset = info.compCompHnd->getFieldOffset(lengthHnd);
 
                 GenTreeField* fieldRef = gtNewFieldRef(TYP_INT, lengthHnd, ptrToSpan, lengthOffset);
-                fieldRef->gtFlags |= GTF_FLD_NEVER_NEGATIVE;
+                fieldRef->SetIsNeverNegative(true);
                 return fieldRef;
             }
 

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1392,9 +1392,9 @@ private:
                 {
                     GenTreeFlags lclVarFlags = node->gtFlags & (GTF_NODE_MASK | GTF_DONT_CSE);
 
-                    if (node->OperIs(GT_FIELD) && (node->gtFlags & GTF_FLD_NEVER_NEGATIVE))
+                    if (node->OperIs(GT_FIELD) && node->AsField()->IsNeverNegative())
                     {
-                        lclVarFlags |= GTF_VAR_NEVER_NEGATIVE;
+                        m_compiler->lvaGetDesc(fieldLclNum)->SetIsNeverNegative(true);
                     }
 
                     if ((user != nullptr) && user->OperIs(GT_ASG) && (user->AsOp()->gtOp1 == node))

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1392,6 +1392,11 @@ private:
                 {
                     GenTreeFlags lclVarFlags = node->gtFlags & (GTF_NODE_MASK | GTF_DONT_CSE);
 
+                    if (node->OperIs(GT_FIELD) && (node->gtFlags & GTF_FLD_NEVER_NEGATIVE))
+                    {
+                        lclVarFlags |= GTF_VAR_NEVER_NEGATIVE;
+                    }
+
                     if ((user != nullptr) && user->OperIs(GT_ASG) && (user->AsOp()->gtOp1 == node))
                     {
                         lclVarFlags |= GTF_VAR_DEF;

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1392,7 +1392,7 @@ private:
                 {
                     GenTreeFlags lclVarFlags = node->gtFlags & (GTF_NODE_MASK | GTF_DONT_CSE);
 
-                    if (node->OperIs(GT_FIELD) && node->AsField()->IsNeverNegative())
+                    if (node->OperIs(GT_FIELD) && node->AsField()->IsSpanLength())
                     {
                         m_compiler->lvaGetDesc(fieldLclNum)->SetIsNeverNegative(true);
                     }


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/59922

This doesn't do extensive propagation or anything and primarily just focuses on the "normal" case where the imported `GT_FIELD` is promoted to a `GT_LCL_VAR`.

There is room to potentially track this metadata further through `FIELD_ADDR`, `LCL_VAR_ADDR`, `LCL_FLD`, and `LCL_FLD_ADDR`. There is likewise potential to make this "attribute" driven. For example, it would be possible to effectively create an internal `IsNeverNegative` attribute and put it on things like `List<T>.Length` or similar and make this a bigger feature.

It's worth calling out that it is possible for a user to use `unsafe` code to modify a `Span<T>/ROSpan<T>'s` length field to be negative. However, much like with mutating a `static readonly` field or using reflection/unsafe to modify other things considered "immutable" we can consider such things as strictly "undefined behavior".

Much like with `GT_ARR_LEN` this doesn't cover all cases of new locals getting created and it only participates where `IsNeverNegative` was already being used. We have various issues covering codegen improvements related to `IntegralRange`. Once this is in, future improvements to utilize `IsNeverNegative` instead of purely relying on base type or `GTF_UNSIGNED` will implicitly light up for all of `T[]`, `Span<T>`, and `ROSpan<T>`.