### PR TITLE
[JIT] Fixed assertion for targetType and op1 type not being the same

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -1180,6 +1180,13 @@ GenTree* Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
 
             if (op1IsVectorZero && op2IsVectorZero)
             {
+                // We need to change op1's type to the return type of the node in this case.
+                // We have to do this because we are going to propagate the constant up.
+                op1->ChangeType(node->TypeGet());
+
+                // Ensure the upper values are zero by zero-initialization.
+                op1->AsVecCon()->gtSimd32Val = {};
+
                 // While this case is unlikely, we'll handle it here to simplify some
                 // of the logic that exists below. Effectively `Insert(zero, zero, idx)`
                 // is always going to produce zero, so we'll just replace ourselves with


### PR DESCRIPTION
Resolves this issue: https://github.com/dotnet/runtime/issues/80773