### PR TITLE
Bump Microsoft.Windows.Compatibility version from 2 to 3

### DIFF
--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -6,7 +6,7 @@
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>2</ServicingVersion>
+    <ServicingVersion>3</ServicingVersion>
     <!-- This is a meta package and doesn't contain any libs. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <PackageDescription>This Windows Compatibility Pack provides access to APIs that were previously available only for .NET Framework. It can be used from both .NET Core as well as .NET Standard.</PackageDescription>


### PR DESCRIPTION
We need to bump the version of this package every month. Ideally, we would automate it, but for now it's manual. I added this task to the checklist for monthly servicing.

cc @mmitche If we end up needing this PR for the February release, here's the PR so we merge it ASAP. Otherwise, if we don't need it, we can leave it open to merge for the March release.

