### PR TITLE
[wasm] ManagedToNativeGenerator: Skip unmanaged dlls

### DIFF
--- a/src/mono/wasm/host/CommonConfiguration.cs
+++ b/src/mono/wasm/host/CommonConfiguration.cs
@@ -22,6 +22,7 @@ internal sealed class CommonConfiguration
     public WasmHost Host { get; init; }
     public HostConfig HostConfig { get; init; }
     public WasmHostProperties HostProperties { get; init; }
+    public IEnumerable<string> HostArguments { get; init; }
 
     private string? hostArg;
     private string? _runtimeConfigPath;
@@ -30,11 +31,13 @@ internal sealed class CommonConfiguration
 
     private CommonConfiguration(string[] args)
     {
+        List<string> hostArgsList = new();
         var options = new OptionSet
         {
             { "debug|d", "Start debug server", _ => Debugging = true },
             { "host|h=", "Host config name", v => hostArg = v },
-            { "runtime-config|r=", "runtimeconfig.json path for the app", v => _runtimeConfigPath = v }
+            { "runtime-config|r=", "runtimeconfig.json path for the app", v => _runtimeConfigPath = v },
+            { "extra-host-arg=", "Extra argument to be passed to the host", hostArgsList.Add },
         };
 
         RemainingArgs = options.Parse(args);
@@ -95,6 +98,9 @@ internal sealed class CommonConfiguration
         if (!Enum.TryParse(HostConfig.HostString, ignoreCase: true, out WasmHost wasmHost))
             throw new CommandLineException($"Unknown host {HostConfig.HostString} in config named {HostConfig.Name}");
         Host = wasmHost;
+
+        hostArgsList.AddRange(HostConfig.HostArguments);
+        HostArguments = hostArgsList;
     }
 
     public ProxyOptions ToProxyOptions()

--- a/src/mono/wasm/host/JSEngineHost.cs
+++ b/src/mono/wasm/host/JSEngineHost.cs
@@ -37,8 +37,6 @@ internal sealed class JSEngineHost
 
     private async Task<int> RunAsync()
     {
-        string[] engineArgs = Array.Empty<string>();
-
         string engineBinary = _args.Host switch
         {
             WasmHost.V8 => "v8",
@@ -79,9 +77,10 @@ internal sealed class JSEngineHost
             args.Add("--expose_wasm");
         }
 
+        args.AddRange(_args.CommonConfig.HostArguments);
+
         args.Add(_args.JSPath!);
 
-        args.AddRange(engineArgs);
         if (_args.Host is WasmHost.V8 or WasmHost.JavaScriptCore)
         {
             // v8/jsc want arguments to the script separated by "--", others don't

--- a/src/mono/wasm/host/RuntimeConfigJson.cs
+++ b/src/mono/wasm/host/RuntimeConfigJson.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -32,6 +33,7 @@ internal sealed record WasmHostProperties(
 
 internal sealed record HostConfig(string? Name, [property: JsonPropertyName("host")] string? HostString)
 {
+    [property: JsonPropertyName("host-args")] public string[] HostArguments { get; set; } = Array.Empty<string>();
     // using an explicit property because the deserializer doesn't like
     // extension data in the record constructor
     [property: JsonExtensionData] public Dictionary<string, JsonElement>? Properties { get; set; }

--- a/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
@@ -44,9 +44,13 @@ internal sealed class IcallTableGenerator
 
         var resolver = new PathAssemblyResolver(assemblies);
         using var mlc = new MetadataLoadContext(resolver, "System.Private.CoreLib");
-        foreach (var aname in assemblies)
+        foreach (var asmPath in assemblies)
         {
-            var a = mlc.LoadFromAssemblyPath(aname);
+            if (!File.Exists(asmPath))
+                throw new LogAsErrorException($"Cannot find assembly {asmPath}");
+
+            Log.LogMessage(MessageImportance.Low, $"Loading {asmPath} to scan for icalls");
+            var a = mlc.LoadFromAssemblyPath(asmPath);
             foreach (var type in a.GetTypes())
                 ProcessType(type);
         }

--- a/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
@@ -34,7 +34,7 @@ internal sealed class IcallTableGenerator
     // The runtime icall table should be generated using
     // mono --print-icall-table
     //
-    public IEnumerable<string> Generate(string? runtimeIcallTableFile, string[] assemblies, string? outputPath)
+    public IEnumerable<string> Generate(string? runtimeIcallTableFile, IEnumerable<string> assemblies, string? outputPath)
     {
         _icalls.Clear();
         _signatures.Clear();

--- a/src/tasks/WasmAppBuilder/ManagedToNativeGenerator.cs
+++ b/src/tasks/WasmAppBuilder/ManagedToNativeGenerator.cs
@@ -1,9 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -11,7 +14,7 @@ using Microsoft.Build.Utilities;
 public class ManagedToNativeGenerator : Task
 {
     [Required]
-    public string[]? Assemblies { get; set; }
+    public string[] Assemblies { get; set; } = Array.Empty<string>();
 
     public string? RuntimeIcallTableFile { get; set; }
 
@@ -62,12 +65,14 @@ public class ManagedToNativeGenerator : Task
 
     private void ExecuteInternal()
     {
+        string[] managedAssemblies = FilterOutUnmanagedBinaries(Assemblies);
+
         var pinvoke = new PInvokeTableGenerator(FixupSymbolName, Log);
         var icall = new IcallTableGenerator(FixupSymbolName, Log);
 
         IEnumerable<string> cookies = Enumerable.Concat(
-            pinvoke.Generate(PInvokeModules, Assemblies!, PInvokeOutputPath!),
-            icall.Generate(RuntimeIcallTableFile, Assemblies!, IcallOutputPath)
+            pinvoke.Generate(PInvokeModules, managedAssemblies, PInvokeOutputPath!),
+            icall.Generate(RuntimeIcallTableFile, managedAssemblies, IcallOutputPath)
         );
 
         var m2n = new InterpToNativeGenerator(Log);
@@ -110,4 +115,43 @@ public class ManagedToNativeGenerator : Task
         _symbolNameFixups[name] = fixedName;
         return fixedName;
     }
+
+    private string[] FilterOutUnmanagedBinaries(string[] assemblies)
+    {
+        List<string> managedAssemblies = new(assemblies.Length);
+        foreach (string asmPath in Assemblies)
+        {
+            if (!File.Exists(asmPath))
+                throw new LogAsErrorException($"Cannot find assembly {asmPath}");
+
+            try
+            {
+                if (!IsManagedAssembly(asmPath))
+                {
+                    Log.LogMessage(MessageImportance.Low, $"Skipping unmanaged {asmPath}.");
+                    continue;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.LogMessage(MessageImportance.Low, $"Failed to read assembly {asmPath}: {ex}");
+                throw new LogAsErrorException($"Failed to read assembly {asmPath}: {ex.Message}");
+            }
+
+            managedAssemblies.Add(asmPath);
+        }
+
+        return managedAssemblies.ToArray();
+    }
+
+    private static bool IsManagedAssembly(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return false;
+
+        using FileStream fileStream = File.OpenRead(filePath);
+        using PEReader reader = new(fileStream, PEStreamOptions.Default);
+        return reader.HasMetadata;
+    }
+
 }

--- a/src/tasks/WasmAppBuilder/ManagedToNativeGenerator.cs
+++ b/src/tasks/WasmAppBuilder/ManagedToNativeGenerator.cs
@@ -65,7 +65,7 @@ public class ManagedToNativeGenerator : Task
 
     private void ExecuteInternal()
     {
-        string[] managedAssemblies = FilterOutUnmanagedBinaries(Assemblies);
+        List<string> managedAssemblies = FilterOutUnmanagedBinaries(Assemblies);
 
         var pinvoke = new PInvokeTableGenerator(FixupSymbolName, Log);
         var icall = new IcallTableGenerator(FixupSymbolName, Log);
@@ -116,7 +116,7 @@ public class ManagedToNativeGenerator : Task
         return fixedName;
     }
 
-    private string[] FilterOutUnmanagedBinaries(string[] assemblies)
+    private List<string> FilterOutUnmanagedBinaries(string[] assemblies)
     {
         List<string> managedAssemblies = new(assemblies.Length);
         foreach (string asmPath in Assemblies)
@@ -141,7 +141,7 @@ public class ManagedToNativeGenerator : Task
             managedAssemblies.Add(asmPath);
         }
 
-        return managedAssemblies.ToArray();
+        return managedAssemblies;
     }
 
     private static bool IsManagedAssembly(string filePath)

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -37,9 +37,13 @@ internal sealed class PInvokeTableGenerator
 
         var resolver = new PathAssemblyResolver(assemblies);
         using var mlc = new MetadataLoadContext(resolver, "System.Private.CoreLib");
-        foreach (var aname in assemblies)
+        foreach (var asmPath in assemblies)
         {
-            var a = mlc.LoadFromAssemblyPath(aname);
+            if (!File.Exists(asmPath))
+                throw new LogAsErrorException($"Cannot find assembly {asmPath}");
+
+            Log.LogMessage(MessageImportance.Low, $"Loading {asmPath} to scan for pinvokes");
+            var a = mlc.LoadFromAssemblyPath(asmPath);
             foreach (var type in a.GetTypes())
                 CollectPInvokes(pinvokes, callbacks, signatures, type);
         }

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -24,7 +24,7 @@ internal sealed class PInvokeTableGenerator
         _fixupSymbolName = fixupSymbolName;
     }
 
-    public IEnumerable<string> Generate(string[] pinvokeModules, string[] assemblies, string outputPath)
+    public IEnumerable<string> Generate(string[] pinvokeModules, IEnumerable<string> assemblies, string outputPath)
     {
         var modules = new Dictionary<string, string>();
         foreach (var module in pinvokeModules)
@@ -37,6 +37,7 @@ internal sealed class PInvokeTableGenerator
 
         var resolver = new PathAssemblyResolver(assemblies);
         using var mlc = new MetadataLoadContext(resolver, "System.Private.CoreLib");
+
         foreach (var asmPath in assemblies)
         {
             if (!File.Exists(asmPath))


### PR DESCRIPTION
.. instead crashing with an exception like:

```
src/mono/wasm/build/WasmApp.Native.targets(296,5): error MSB4018: (NETCORE_ENGINEERING_TELEMETRY=Build) The "ManagedToNativeGenerator" task failed unexpectedly.
System.BadImageFormatException: This PE image is not a managed executable.
   at System.Reflection.MetadataLoadContext.LoadFromStreamCore(Stream peStream)
   at System.Reflection.MetadataLoadContext.LoadFromAssemblyPath(String assemblyPath)
   at PInvokeTableGenerator.Generate(String[] pinvokeModules, String[] assemblies, String outputPath) in /_/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs:line 42
   at ManagedToNativeGenerator.ExecuteInternal() in /_/src/tasks/WasmAppBuilder/ManagedToNativeGenerator.cs:line 68
   at ManagedToNativeGenerator.Execute() in /_/src/tasks/WasmAppBuilder/ManagedToNativeGenerator.cs:line 53
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
```

The wasm targets currently are not able to differentiate the managed
assemblies from the unmanaged ones. so it needs to be handled here.

- Also, `WasmAppHost`: Add support for host arguments