### PR TITLE
Fix TarWriter.TarEntry exception when adding file whose Unix group owner does not exist in the system

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetGroupName.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetGroupName.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.IO;
+using System.Diagnostics.CodeAnalysis;
 
 internal static partial class Interop
 {
@@ -18,14 +19,14 @@ internal static partial class Interop
         /// </summary>
         /// <param name="gid">The group ID.</param>
         /// <param name="groupName">When this method returns true, gets the value of the group name associated with the specified id. On failure, it is null.</param>
-        /// <returns>On success, return true. On failure, returns false.</returns>
-        internal static bool TryGetGroupName(uint gid, out string? groupName)
+        /// <returns>On success, returns true. On failure, returns false.</returns>
+        internal static bool TryGetGroupName(uint gid, [NotNullWhen(returnValue: true)] out string? groupName)
         {
-            groupName = GetGroupNameInternal(gid);
+            groupName = GetGroupName(gid);
             return groupName != null;
         }
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetGroupName", StringMarshalling = StringMarshalling.Utf8, SetLastError = true)]
-        private static unsafe partial string? GetGroupNameInternal(uint uid);
+        private static unsafe partial string? GetGroupName(uint uid);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetGroupName.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetGroupName.cs
@@ -7,17 +7,23 @@ using System.Text;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.IO;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
         /// <summary>
-        /// Gets the group name associated to the specified group ID.
+        /// Tries to get the group name associated to the specified group ID.
         /// </summary>
         /// <param name="gid">The group ID.</param>
-        /// <returns>On success, return a string with the group name. On failure, throws an IOException.</returns>
-        internal static string GetGroupName(uint gid) => GetGroupNameInternal(gid) ?? throw GetIOException(GetLastErrorInfo());
+        /// <param name="groupName">When this method returns true, gets the value of the group name associated with the specified id. On failure, it is null.</param>
+        /// <returns>On success, return true. On failure, returns false.</returns>
+        internal static bool TryGetGroupName(uint gid, out string? groupName)
+        {
+            groupName = GetGroupNameInternal(gid);
+            return groupName != null;
+        }
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetGroupName", StringMarshalling = StringMarshalling.Utf8, SetLastError = true)]
         private static unsafe partial string? GetGroupNameInternal(uint uid);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
@@ -82,8 +82,10 @@ namespace System.Formats.Tar
             entry._header._gid = (int)status.Gid;
             if (!_groupIdentifiers.TryGetValue(status.Gid, out string? gName))
             {
-                gName = Interop.Sys.GetGroupName(status.Gid);
-                _groupIdentifiers.Add(status.Gid, gName);
+                if (Interop.Sys.TryGetGroupName(status.Gid, out gName) && gName != null)
+                {
+                    _groupIdentifiers.Add(status.Gid, gName);
+                }
             }
             entry._header._gName = gName;
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.Unix.cs
@@ -82,7 +82,7 @@ namespace System.Formats.Tar
             entry._header._gid = (int)status.Gid;
             if (!_groupIdentifiers.TryGetValue(status.Gid, out string? gName))
             {
-                if (Interop.Sys.TryGetGroupName(status.Gid, out gName) && gName != null)
+                if (Interop.Sys.TryGetGroupName(status.Gid, out gName))
                 {
                     _groupIdentifiers.Add(status.Gid, gName);
                 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.Unix.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.IO;
 using Xunit;
 
@@ -50,6 +51,69 @@ namespace System.Formats.Tar.Tests
                     VerifyGnuTimestamps(gnu);
                 }
             }
+        }
+
+        protected int CreateGroup(string groupName)
+        {
+            int exitCode = Execute("groupadd", groupName, out string standardOutput, out string standardError);
+            if (exitCode != 0)
+            {
+                ThrowOnError(exitCode, "groupadd", groupName, standardError);
+            }
+            return GetGroupId(groupName);
+        }
+
+        protected int GetGroupId(string groupName)
+        {
+            int exitCode = Execute("getent", $"group {groupName}", out string standardOutput, out string standardError);
+            if (exitCode != 0)
+            {
+                ThrowOnError(exitCode, "getent", "group", standardError);
+            }
+
+            string[] values = standardOutput.Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            return int.Parse(values[^1]);
+        }
+        
+        protected void SetGroupAsOwnerOfFile(string groupName, string filePath)
+        {
+            int exitCode = Execute("chgrp", $"{groupName} {filePath}", out string standardOutput, out string standardError);
+            if (exitCode != 0)
+            {
+                ThrowOnError(exitCode, "chgroup", $"{groupName} {filePath}", standardError);
+            }
+        }
+
+        protected void DeleteGroup(string groupName)
+        {
+            int exitCode = Execute("groupdel", groupName, out string standardOutput, out string standardError);
+            if (exitCode != 0)
+            {
+                ThrowOnError(exitCode, "groupdel", groupName, standardError);
+            }
+        }
+
+        private int Execute(string command, string arguments, out string standardOutput, out string standardError)
+        {
+            using Process p = new Process();
+
+            p.StartInfo.UseShellExecute = false;
+            p.StartInfo.FileName = command;
+            p.StartInfo.Arguments = arguments;
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.RedirectStandardError = true;
+            p.Start();
+            p.WaitForExit();
+
+            standardOutput = p.StandardOutput.ReadToEnd();
+            standardError = p.StandardError.ReadToEnd();
+            return p.ExitCode;
+        }
+
+        private void ThrowOnError(int code, string command, string arguments, string message)
+        {
+            throw new IOException($"Error '{code}' when executing '{command} {arguments}'. Message: {message}");
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.File.Base.Unix.cs
@@ -20,7 +20,7 @@ namespace System.Formats.Tar.Tests
 
             if (entry is PosixTarEntry posix)
             {
-                string gname = Interop.Sys.GetGroupName(status.Gid);
+                Interop.Sys.TryGetGroupName(status.Gid, out string gname);
                 string uname = Interop.Sys.GetUserNameFromPasswd(status.Uid);
 
                 Assert.Equal(gname, posix.GroupName);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.File.Tests.Unix.cs
@@ -145,18 +145,23 @@ namespace System.Formats.Tar.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                string groupName = Path.GetRandomFileName()[0..6];
-                int groupId = CreateGroup(groupName);
-
                 using TempDirectory root = new TempDirectory();
 
                 string fileName = "file.txt";
                 string filePath = Path.Join(root.Path, fileName);
                 File.Create(filePath).Dispose();
 
-                SetGroupAsOwnerOfFile(groupName, filePath);
+                string groupName = Path.GetRandomFileName()[0..6];
+                int groupId = CreateGroup(groupName);
 
-                DeleteGroup(groupName);
+                try
+                {
+                    SetGroupAsOwnerOfFile(groupName, filePath);
+                }
+                finally
+                {
+                    DeleteGroup(groupName);
+                }
 
                 using MemoryStream archive = new MemoryStream();
                 using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Unix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.File.Tests.Unix.cs
@@ -155,18 +155,23 @@ namespace System.Formats.Tar.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                string groupName = Path.GetRandomFileName()[0..6];
-                int groupId = CreateGroup(groupName);
-
                 using TempDirectory root = new TempDirectory();
 
                 string fileName = "file.txt";
                 string filePath = Path.Join(root.Path, fileName);
                 File.Create(filePath).Dispose();
 
-                SetGroupAsOwnerOfFile(groupName, filePath);
+                string groupName = Path.GetRandomFileName()[0..6];
+                int groupId = CreateGroup(groupName);
 
-                DeleteGroup(groupName);
+                try
+                {
+                    SetGroupAsOwnerOfFile(groupName, filePath);
+                }
+                finally
+                {
+                    DeleteGroup(groupName);
+                }
 
                 await using MemoryStream archive = new MemoryStream();
                 await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Ustar, leaveOpen: true))


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/81047
Addresses https://github.com/dotnet/sdk-container-builds/issues/246

Users in MacOSX ARM are seeing an exception show up when executing `dotnet publish`. The exception shows up when the test container is created and the `TarWriterWriteEntry(fileName, entryName)` is called. The method is throwing when attempting to add a file whose Unix group doesn't exist in the current machine.

The root cause is that when we call the native method that retrieves a groupName using a groupId, the P/Invoke that wraps it throws an exception if the returned string is null.

`WriteEntry` should be able to continue writing the rest of the entry with an empty groupName if such group is not found in the current system using the groupId. In this case, the groupName field should simply be an empty string.

Added a couple of tests that create a randomly named group, create a file in disk, assigns the group as owner of the file, then deletes the group, then adds the file as an entry to the archive.

I deleted a method that was not used anywhere but in a test file. For future reference, if we need to bring it back, it should also add a new resource string with a more useful error message for when the errno is 0 and the string is null:

This affects users from .NET 7, so we will need to backport it.

<details>

```cs
        /// <summary>
        /// Gets the group name associated to the specified group ID.
        /// </summary>
        /// <param name="gid">The group ID.</param>
        /// <returns>On success, return a string with the group name. On failure, throws an IOException.</returns>
        internal static string GetGroupName(uint gid)
        {
            string? groupName = GetGroupNameInternal(gid);
            ErrorInfo error = GetLastErrorInfo();
            if (groupName == null && error.RawErrno == 0)
            {
                throw new IOException(SR.Format(SR.IO_GroupNotFound, gid));
            }
            else
            {
                throw GetIOException(error);
            }
        }
```
</details>

cc @baronfel @rainersigwald 