### PR TITLE
[wasm] Improve jiterpreter jit calls

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2666,6 +2666,9 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 		// FIXME: Thread safety for the thunk pointer
 		WasmJitCallThunk thunk = cinfo->jiterp_thunk;
 		if (thunk) {
+			MonoFtnDesc ftndesc = {0};
+			ftndesc.addr = cinfo->addr;
+			ftndesc.arg = cinfo->extra_arg;
 			interp_push_lmf (&ext, frame);
 			if (
 				mono_opt_jiterpreter_wasm_eh_enabled ||
@@ -2674,12 +2677,12 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 				// WASM EH is available or we are otherwise in a situation where we know
 				//  that the jiterpreter thunk was compiled with exception handling built-in
 				//  so we can just invoke it directly and errors will be handled
-				thunk (ret_sp, sp, &thrown);
+				thunk (ret_sp, sp, &ftndesc, &thrown);
 			} else {
 				// Call a special JS function that will invoke the compiled jiterpreter thunk
 				//  and trap errors for us to set the thrown flag
 				mono_interp_invoke_wasm_jit_call_trampoline (
-					thunk, ret_sp, sp, &thrown
+					thunk, ret_sp, sp, &ftndesc, &thrown
 				);
 			}
 			interp_pop_lmf (&ext);

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2663,18 +2663,15 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 	if (mono_opt_jiterpreter_jit_call_enabled) {
 		WasmJitCallThunk thunk = cinfo->jiterp_thunk;
 		if (thunk) {
-			MonoFtnDesc ftndesc = {0};
-			ftndesc.addr = cinfo->addr;
-			ftndesc.arg = cinfo->extra_arg;
 			interp_push_lmf (&ext, frame);
 			if (
 				mono_opt_jiterpreter_wasm_eh_enabled ||
 				(mono_aot_mode != MONO_AOT_MODE_LLVMONLY_INTERP)
 			) {
-				thunk (ret_sp, sp, &ftndesc, &thrown);
+				thunk (ret_sp, sp, &thrown);
 			} else {
 				mono_interp_invoke_wasm_jit_call_trampoline (
-					thunk, ret_sp, sp, &ftndesc, &thrown
+					thunk, ret_sp, sp, &thrown
 				);
 			}
 			interp_pop_lmf (&ext);
@@ -2682,10 +2679,8 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 		} else {
 			int count = cinfo->hit_count;
 			if (count == mono_opt_jiterpreter_jit_call_trampoline_hit_count) {
-				void *fn = cinfo->no_wrapper ? cinfo->addr : cinfo->wrapper;
 				mono_interp_jit_wasm_jit_call_trampoline (
-					rmethod->method, rmethod, cinfo, fn,
-					rmethod->hasthis, rmethod->param_count,
+					rmethod->method, rmethod, cinfo,
 					rmethod->arg_offsets, mono_aot_mode == MONO_AOT_MODE_LLVMONLY_INTERP
 				);
 			} else {

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -956,6 +956,12 @@ mono_jiterp_get_hashcode (MonoObject ** ppObj)
 	return mono_object_hash_internal (obj);
 }
 
+EMSCRIPTEN_KEEPALIVE int
+mono_jiterp_get_signature_has_this (MonoMethodSignature *sig)
+{
+	return sig->hasthis;
+}
+
 EMSCRIPTEN_KEEPALIVE MonoType *
 mono_jiterp_get_signature_return_type (MonoMethodSignature *sig)
 {

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -21,7 +21,7 @@
 #define JITERPRETER_NOT_JITTED 1
 
 typedef const ptrdiff_t (*JiterpreterThunk) (void *frame, void *pLocals);
-typedef void (*WasmJitCallThunk) (void *ret_sp, void *sp, gboolean *thrown);
+typedef void (*WasmJitCallThunk) (void *ret_sp, void *sp, void *ftndesc, gboolean *thrown);
 typedef void (*WasmDoJitCall) (gpointer cb, gpointer arg, gboolean *out_thrown);
 
 // Parses a single jiterpreter runtime option. This is used both by driver.c and our typescript
@@ -78,7 +78,7 @@ extern void
 mono_interp_invoke_wasm_jit_call_trampoline (
 	WasmJitCallThunk thunk,
 	void *ret_sp, void *sp,
-	gboolean *thrown
+	void *ftndesc, gboolean *thrown
 );
 
 extern void

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -21,7 +21,7 @@
 #define JITERPRETER_NOT_JITTED 1
 
 typedef const ptrdiff_t (*JiterpreterThunk) (void *frame, void *pLocals);
-typedef void (*WasmJitCallThunk) (void *ret_sp, void *sp, void *ftndesc, gboolean *thrown);
+typedef void (*WasmJitCallThunk) (void *ret_sp, void *sp, gboolean *thrown);
 typedef void (*WasmDoJitCall) (gpointer cb, gpointer arg, gboolean *out_thrown);
 
 // Parses a single jiterpreter runtime option. This is used both by driver.c and our typescript
@@ -63,8 +63,7 @@ mono_interp_tier_prepare_jiterpreter (
 //  or JitCallInfo
 extern void
 mono_interp_jit_wasm_jit_call_trampoline (
-	MonoMethod *method, void *rmethod, void *cinfo, void *func,
-	gboolean has_this, int param_count,
+	MonoMethod *method, void *rmethod, void *cinfo,
 	guint32 *arg_offsets, gboolean catch_exceptions
 );
 
@@ -79,7 +78,7 @@ extern void
 mono_interp_invoke_wasm_jit_call_trampoline (
 	WasmJitCallThunk thunk,
 	void *ret_sp, void *sp,
-	void *ftndesc, gboolean *thrown
+	gboolean *thrown
 );
 
 extern void

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -95,7 +95,7 @@ DEFINE_BOOL(jiterpreter_call_resume_enabled, "jiterpreter-call-resume-enabled", 
 //  stats for options like estimateHeat, but raises overhead.
 DEFINE_BOOL(jiterpreter_disable_heuristic, "jiterpreter-disable-heuristic", FALSE, "Always insert trace entry points for more accurate statistics")
 // Automatically prints stats at app exit or when jiterpreter_dump_stats is called
-DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", TRUE, "Automatically print jiterpreter statistics")
+DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", FALSE, "Automatically print jiterpreter statistics")
 // Continue counting hits for traces that fail to compile and use it to estimate
 //  the relative importance of the opcode that caused them to abort
 DEFINE_BOOL(jiterpreter_estimate_heat, "jiterpreter-estimate-heat", FALSE, "Maintain accurate hit count for all trace entry points")

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -115,6 +115,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_register_jit_call_thunk", "void", ["number", "number"]],
     [true, "mono_jiterp_type_get_raw_value_size", "number", ["number"]],
     [true, "mono_jiterp_update_jit_call_dispatcher", "void", ["number"]],
+    [true, "mono_jiterp_get_signature_has_this", "number", ["number"]],
     [true, "mono_jiterp_get_signature_return_type", "number", ["number"]],
     [true, "mono_jiterp_get_signature_param_count", "number", ["number"]],
     [true, "mono_jiterp_get_signature_params", "number", ["number"]],
@@ -253,6 +254,7 @@ export interface t_Cwraps {
     mono_jiterp_adjust_abort_count(opcode: number, delta: number): number;
     mono_jiterp_register_jit_call_thunk(cinfo: number, func: number): void;
     mono_jiterp_update_jit_call_dispatcher(fn: number): void;
+    mono_jiterp_get_signature_has_this(sig: VoidPtr): number;
     mono_jiterp_get_signature_return_type(sig: VoidPtr): MonoType;
     mono_jiterp_get_signature_param_count(sig: VoidPtr): number;
     mono_jiterp_get_signature_params(sig: VoidPtr): VoidPtr;

--- a/src/mono/wasm/runtime/jiterpreter-jit-call.ts
+++ b/src/mono/wasm/runtime/jiterpreter-jit-call.ts
@@ -60,7 +60,7 @@ let fnTable : WebAssembly.Table;
 let wasmEhSupported : boolean | undefined = undefined;
 let nextDisambiguateIndex = 0;
 const fnCache : Array<Function | undefined> = [];
-const targetCache : { [target: number] : TrampolineInfo } = {};
+const targetCache : { [addrAndRgctx: string] : TrampolineInfo } = {};
 const jitQueue : TrampolineInfo[] = [];
 
 class TrampolineInfo {
@@ -194,7 +194,7 @@ export function mono_interp_jit_wasm_jit_call_trampoline (
     //  we want to immediately store its pointer into the cinfo, otherwise we add it to
     //  a queue inside the info object so that all the cinfos will get updated once a
     //  jit operation happens
-    const cacheKey = getU32(<any>cinfo + offsetOfAddr),
+    const cacheKey = `addr=${getU32(<any>cinfo + offsetOfAddr)};rgctx=${getU32(<any>cinfo + offsetOfExtraArg)}`,
         existing = targetCache[cacheKey];
     if (existing) {
         if (existing.result > 0)


### PR DESCRIPTION
This PR cleans up the jiterpreter's implementation of jit calls by compiling the rgctx value into the trace so we no longer need to pass the ftndesc argument at all. It also optimizes some of the generated code patterns so calls should become ever so slightly faster.