### PR TITLE
[release/7.0] [wasm] Fix analyzer support in templates

### DIFF
--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -118,6 +118,9 @@
   <ItemGroup>
     <!-- Allow running/debugging from VS -->
     <ProjectCapability Include="DotNetCoreWeb"/>
+
+    <SupportedPlatform Condition="'$(IsWasmProject)' == 'true'" Remove="@(SupportedPlatform)" />
+    <SupportedPlatform Condition="'$(IsWasmProject)' == 'true'" Include="browser" />
   </ItemGroup>
 
   <PropertyGroup Label="Identify app bundle directory to run from">

--- a/src/mono/wasm/templates/templates/browser/Properties/AssemblyInfo.cs
+++ b/src/mono/wasm/templates/templates/browser/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+[assembly:System.Runtime.Versioning.SupportedOSPlatform("browser")]

--- a/src/mono/wasm/templates/templates/console/Properties/AssemblyInfo.cs
+++ b/src/mono/wasm/templates/templates/console/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+[assembly:System.Runtime.Versioning.SupportedOSPlatform("browser")]


### PR DESCRIPTION
Simplified backport of https://github.com/dotnet/runtime/pull/77704
Closes https://github.com/dotnet/runtime/issues/79314

## Customer Impact
Fixes warning produced by the supported platform analyzer on apps generated from wasm templates (browser, console).

## Testing
Manual
Build the workload in repo
Replace changed files
Create apps from modified templates
Build the apps using workload in repo

## Risk
None

IMPORTANT: Is this backport for a servicing release? If so and this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.

