### PR TITLE
Introduce AOT friendly version of ToLogFont and FromLogFont

### DIFF
--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.netcoreapp.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.netcoreapp.cs
@@ -26,6 +26,13 @@ namespace System.Drawing
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void GetContextInfo(out PointF offset, out Region? clip) { throw null; }
     }
+    public sealed partial class Font
+    {
+        public void ToLogFont<T>(ref T logFont, Graphics graphics) where T: unmanaged  { throw null; }
+        public static Font FromLogFont<T>(in T logFont) where T: unmanaged { throw null; }
+        public static Font FromLogFont<T>(in T logFont, IntPtr hdc) where T: unmanaged { throw null; }
+        public void ToLogFont<T>(ref T logFont) where T: unmanaged { throw null; }
+    }
 }
 namespace System.Drawing.Drawing2D
 {


### PR DESCRIPTION
These methods used by WinForms
Closes dotnet/winforms#8846