### PR TITLE
[wasm] Always allocate when computing temp path

### DIFF
--- a/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CodeCompilerTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CodeCompilerTests.cs
@@ -55,7 +55,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Theory]
         [MemberData(nameof(CodeCompileUnit_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void FromDom_ValidCodeCompileUnit_ReturnsExpected(CodeCompileUnit compilationUnit)
         {
             var compiler = new StubCompiler();
@@ -67,7 +66,6 @@ namespace System.CodeDom.Compiler.Tests
         [Theory]
         [MemberData(nameof(CodeCompileUnit_TestData))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void FromDom_ValidCodeCompileUnit_ThrowsPlatformNotSupportedException(CodeCompileUnit compilationUnit)
         {
             var compiler = new Compiler();
@@ -363,7 +361,6 @@ namespace System.CodeDom.Compiler.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         [MemberData(nameof(Source_TestData))]
         public void FromSource_ValidSource_ReturnsExpected(string source)
         {
@@ -374,7 +371,6 @@ namespace System.CodeDom.Compiler.Tests
         [Theory]
         [MemberData(nameof(Source_TestData))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void FromSource_ValidSource_ThrowsPlatformNotSupportedException(string source)
         {
             var compiler = new Compiler();
@@ -398,7 +394,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Theory]
         [MemberData(nameof(Sources_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void CompileAssemblyFromSourceBatch_ValidSources_ReturnsExpected(string[] sources)
         {
             ICodeCompiler compiler = new StubCompiler();
@@ -430,7 +425,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Theory]
         [MemberData(nameof(Sources_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void FromSourceBatch_ValidSources_ReturnsExpected(string[] sources)
         {
             var compiler = new StubCompiler();
@@ -440,7 +434,6 @@ namespace System.CodeDom.Compiler.Tests
         [Theory]
         [MemberData(nameof(Sources_TestData))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void FromSourceBatch_ValidSources_ThrowsPlatformNotSupportedException(string[] sources)
         {
             var compiler = new Compiler();
@@ -466,7 +459,6 @@ namespace System.CodeDom.Compiler.Tests
         [InlineData("")]
         [InlineData("cmdArgs")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Occasionally fails in .NET framework, probably caused from a very edge case bug in .NET Framework which we will not be fixing")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void GetResponseFileCmdArgs_ValidCmdArgs_ReturnsExpected(string cmdArgs)
         {
             var compiler = new Compiler();

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/CtorsDelimiterTests.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/CtorsDelimiterTests.cs
@@ -114,7 +114,6 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 
         [Theory]
         [MemberData(nameof(TestNames))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void TestConstructorWithFileNameAndName(string testName)
         {
             var target = new DelimitedListTraceListener(Path.GetTempFileName(), testName);

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/XmlWriterTraceListenerTests.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/XmlWriterTraceListenerTests.cs
@@ -44,7 +44,6 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 
         [Theory]
         [MemberData(nameof(ConstructorsTestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public void SingleArgumentConstructorTest(XmlWriterTraceListener listener, string expectedName)
         {
             Assert.Equal(expectedName, listener.Name);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -103,7 +103,11 @@ namespace System.IO
             int tempPathByteCount = Encoding.UTF8.GetByteCount(tempPath);
             int totalByteCount = tempPathByteCount + fileTemplate.Length + 1;
 
+#if TARGET_BROWSER
+            Span<byte> path = new byte[totalByteCount];
+#else
             Span<byte> path = totalByteCount <= 256 ? stackalloc byte[256].Slice(0, totalByteCount) : new byte[totalByteCount];
+#endif
             int pos = Encoding.UTF8.GetBytes(tempPath, path);
             fileTemplate.CopyTo(path.Slice(pos));
             path[^1] = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -104,6 +104,8 @@ namespace System.IO
             int totalByteCount = tempPathByteCount + fileTemplate.Length + 1;
 
 #if TARGET_BROWSER
+            // https://github.com/emscripten-core/emscripten/issues/18591
+            // The emscripten implementation of __randname uses pointer address as another entry into the randomness.
             Span<byte> path = new byte[totalByteCount];
 #else
             Span<byte> path = totalByteCount <= 256 ? stackalloc byte[256].Slice(0, totalByteCount) : new byte[totalByteCount];

--- a/src/libraries/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -44,7 +44,6 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/77526", TestPlatforms.Browser)]
         public static void SyndicationFeed_Load_Write_RSS_Feed()
         {
             string path = Path.GetTempFileName();
@@ -178,7 +177,6 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/73721", typeof(PlatformDetection), nameof(PlatformDetection.IsNodeJSOnWindows))]
         public static void SyndicationFeed_Write_RSS_Atom()
         {
             string RssPath = Path.GetTempFileName();


### PR DESCRIPTION
The wasm implementation of `__randname` uses pointer address as another entry into the randomness.

https://github.com/emscripten-core/emscripten/blob/085fe968d43c7d3674376f29667d6e5f42b24966/system/lib/libc/musl/src/temp/__randname.c#L13

We may get the same random name if the same pointer passed twice before the clock ticks. The issue in the upstream repository is https://github.com/emscripten-core/emscripten/issues/18591.

We have decided to take the simplest solution at the moment and consider a better one as part of the WASI file system implementation https://github.com/dotnet/runtime/issues/81210

Fixes https://github.com/dotnet/runtime/issues/73721