### PR TITLE
Fix a few static linking issues

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -141,7 +141,10 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,-z,now" Condition="'$(TargetOS)' != 'osx'" />
       <LinkerArg Include="-Wl,-u,$(_SymbolPrefix)NativeAOT_StaticInitialization" Condition="('$(UseLLVMLinker)' == 'true' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'freebsd') and '$(NativeLib)' == 'Shared'" />
       <LinkerArg Include="-Wl,--require-defined,NativeAOT_StaticInitialization" Condition="'$(UseLLVMLinker)' != 'true' and '$(TargetOS)' == 'linux' and '$(NativeLib)' == 'Shared'" />
-      <LinkerArg Include="-Wl,--defsym,__xmknod=mknod" Condition="'$(StaticExecutable)' == 'Static'" />
+      <!-- this workaround can be deleted once the minimum supported glibc version
+           (runtime's official build machine's glibc version) is at least 2.33
+           see https://github.com/bminor/glibc/commit/99468ed45f5a58f584bab60364af937eb6f8afda -->
+      <LinkerArg Include="-Wl,--defsym,__xmknod=mknod" Condition="'$(StaticExecutable)' == 'true'" />
       <!-- FreeBSD has two versions of the GSSAPI it can use, but we only use the ports version (MIT version) here -->
       <LinkerArg Include="-L/usr/local/lib -lgssapi_krb5" Condition="'$(TargetOS)' == 'freebsd'" />
       <!-- FreeBSD's inotify is an installed package and not found in default libraries  -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -20,6 +20,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <CppLinker>$(CppCompilerAndLinker)</CppLinker>
     <CppLibCreator>ar</CppLibCreator>
     <DsymUtilOptions Condition="'$(TargetOS)' == 'osx'">--flat</DsymUtilOptions>
+    <_SymbolPrefix Condition="'$(TargetOS)' == 'osx'">_</_SymbolPrefix>
   </PropertyGroup>
 
   <Target Name="SetupOSSpecificProps" DependsOnTargets="$(IlcDynamicBuildPropertyDependencies)">
@@ -79,7 +80,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup Condition="'$(StaticICULinking)' == 'true' and '$(NativeLib)' != 'Static'">
-      <NativeLibrary Include="$(IntermediateOutputPath)/libs/System.Globalization.Native/build/libSystem.Globalization.Native.a"/>
+      <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Globalization.Native/build/libSystem.Globalization.Native.a" />
       <DirectPInvoke Include="libSystem.Globalization.Native" />
       <StaticICULibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
       <StaticICULibs Include="-licuio -licutu -licui18n -licuuc -licudata -lstdc++" />
@@ -87,7 +88,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup Condition="'$(StaticOpenSslLinking)' == 'true' and '$(NativeLib)' != 'Static'">
-      <NativeLibrary Include="$(IntermediateOutputPath)/libs/System.Security.Cryptography.Native/build/libSystem.Security.Cryptography.Native.OpenSsl.a"/>
+      <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Security.Cryptography.Native/build/libSystem.Security.Cryptography.Native.OpenSsl.a" />
       <DirectPInvoke Include="libSystem.Security.Cryptography.Native.OpenSsl" />
       <StaticSslLibs Include="-Wl,-Bstatic" Condition="'$(StaticExecutable)' != 'true'" />
       <StaticSslLibs Include="-lssl -lcrypto" />
@@ -102,13 +103,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <NativeFramework Include="GSS" />
     </ItemGroup>
 
-    <Exec Command="&quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(IntermediateOutputPath)&quot; System.Globalization.Native" Condition="'$(StaticICULinking)' == 'true'"/>
-
-    <Exec Command="&quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(IntermediateOutputPath)&quot; System.Security.Cryptography.Native" Condition="'$(StaticOpenSslLinking)' == 'true'"/>
-
     <ItemGroup>
       <LinkerArg Include="-fuse-ld=lld" Condition="'$(UseLLVMLinker)' == 'true'" />
-      <LinkerArg Include="-static" Condition="'$(StaticExecutable)' == 'true'" />
       <LinkerArg Include="@(NativeLibrary)" />
       <LinkerArg Include="--sysroot=$(SysRoot)" Condition="'$(SysRoot)' != ''" />
       <LinkerArg Include="--target=$(TargetTriple)" Condition="'$(TargetOS)' != 'osx' and '$(TargetTriple)' != ''" />
@@ -122,7 +118,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-pthread" Condition="'$(TargetOS)' != 'osx'" />
       <LinkerArg Include="-lstdc++" Condition="'$(LinkStandardCPlusPlusLibrary)' == 'true'" />
       <LinkerArg Include="-ldl" />
-      <LinkerArg Include="-lm" />
       <LinkerArg Include="-lobjc" Condition="'$(TargetOS)' == 'osx'" />
       <LinkerArg Include="-lswiftCore" Condition="'$(TargetOS)' == 'osx'" />
       <LinkerArg Include="-lswiftFoundation" Condition="'$(TargetOS)' == 'osx'" />
@@ -133,6 +128,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="@(StaticNumaLibs)" Condition="'$(StaticNumaLinking)' == 'true'" />
       <LinkerArg Include="@(StaticICULibs)" Condition="'$(StaticICULinking)' == 'true'" />
       <LinkerArg Include="@(StaticSslLibs)" Condition="'$(StaticOpenSslLinking)' == 'true'" />
+      <LinkerArg Include="-lm" />
+      <LinkerArg Include="-static" Condition="'$(StaticExecutable)' == 'true'" />
       <LinkerArg Include="-dynamiclib" Condition="'$(TargetOS)' == 'osx' and '$(NativeLib)' == 'Shared'" />
       <LinkerArg Include="-shared" Condition="'$(TargetOS)' != 'osx' and '$(NativeLib)' == 'Shared'" />
       <!-- binskim warning BA3001 PIE disabled on executable -->
@@ -142,8 +139,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,-z,relro" Condition="'$(TargetOS)' != 'osx'" />
       <!-- binskim warning BA3011 The BIND_NOW flag is missing -->
       <LinkerArg Include="-Wl,-z,now" Condition="'$(TargetOS)' != 'osx'" />
-      <LinkerArg Include="-Wl,-u,_NativeAOT_StaticInitialization" Condition="('$(UseLLVMLinker)' == 'true' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'freebsd') and '$(NativeLib)' == 'Shared'" />
+      <LinkerArg Include="-Wl,-u,$(_SymbolPrefix)NativeAOT_StaticInitialization" Condition="('$(UseLLVMLinker)' == 'true' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'freebsd') and '$(NativeLib)' == 'Shared'" />
       <LinkerArg Include="-Wl,--require-defined,NativeAOT_StaticInitialization" Condition="'$(UseLLVMLinker)' != 'true' and '$(TargetOS)' == 'linux' and '$(NativeLib)' == 'Shared'" />
+      <LinkerArg Include="-Wl,--defsym,__xmknod=mknod" Condition="'$(StaticExecutable)' == 'Static'" />
       <!-- FreeBSD has two versions of the GSSAPI it can use, but we only use the ports version (MIT version) here -->
       <LinkerArg Include="-L/usr/local/lib -lgssapi_krb5" Condition="'$(TargetOS)' == 'freebsd'" />
       <!-- FreeBSD's inotify is an installed package and not found in default libraries  -->
@@ -206,6 +204,12 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Exec Command="dsymutil --help" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(TargetOS)' == 'osx' and '$(StripSymbols)' == 'true'">
       <Output TaskParameter="ExitCode" PropertyName="_DsymUtilOutput" />
     </Exec>
+
+    <Exec Command="CC=&quot;$(CppLinker)&quot; &quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(IntermediateOutputPath)&quot; System.Globalization.Native"
+        Condition="'$(StaticICULinking)' == 'true'" />
+
+    <Exec Command="CC=&quot;$(CppLinker)&quot; &quot;$(IlcHostPackagePath)/native/src/libs/build-local.sh&quot; &quot;$(IlcHostPackagePath)/&quot; &quot;$(IntermediateOutputPath)&quot; System.Security.Cryptography.Native"
+        Condition="'$(StaticOpenSslLinking)' == 'true'" />
 
     <PropertyGroup Condition="'$(TargetOS)' == 'osx' and '$(StripSymbols)' == 'true' and $(_DsymUtilOutput.Contains('--minimize'))">
       <DsymUtilOptions>$(DsymUtilOptions) --minimize</DsymUtilOptions>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -17,11 +17,11 @@
       <File Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" TargetPath="mibc" />
     </ItemGroup>
     <ItemGroup Condition="'$(PackageTargetRuntime)' != '' and '$(TargetOS)' == 'linux'">
-      <File Include="$(MSBuildThisFileDirectory)\..\..\..\..\native\libs\System.Globalization.Native\*" TargetPath="native/src/libs/System.Globalization.Native"/>
-      <File Include="$(MSBuildThisFileDirectory)\..\..\..\..\native\libs\System.Security.Cryptography.Native\*" TargetPath="native/src/libs/System.Security.Cryptography.Native"/>
-      <File Include="$(MSBuildThisFileDirectory)\..\..\..\..\native\libs\build-local.sh" TargetPath="native/src/libs/build-local.sh"/>
-      <File Include="$(MSBuildThisFileDirectory)\..\..\..\..\native\minipal\*" TargetPath="native/src/minipal"/>
-      <File Include="$(MSBuildThisFileDirectory)\..\..\..\..\native\libs\Common\*" TargetPath="native/src/libs/Common"/>
+      <File Include="$(SharedNativeRoot)libs\System.Globalization.Native\*" TargetPath="native/src/libs/System.Globalization.Native"/>
+      <File Include="$(SharedNativeRoot)native\libs\System.Security.Cryptography.Native\*" TargetPath="native/src/libs/System.Security.Cryptography.Native"/>
+      <File Include="$(SharedNativeRoot)native\libs\build-local.sh" TargetPath="native/src/libs/build-local.sh"/>
+      <File Include="$(SharedNativeRoot)native\minipal\*" TargetPath="native/src/minipal"/>
+      <File Include="$(SharedNativeRoot)native\libs\Common\*" TargetPath="native/src/libs/Common"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -18,10 +18,10 @@
     </ItemGroup>
     <ItemGroup Condition="'$(PackageTargetRuntime)' != '' and '$(TargetOS)' == 'linux'">
       <File Include="$(SharedNativeRoot)libs\System.Globalization.Native\*" TargetPath="native/src/libs/System.Globalization.Native"/>
-      <File Include="$(SharedNativeRoot)native\libs\System.Security.Cryptography.Native\*" TargetPath="native/src/libs/System.Security.Cryptography.Native"/>
-      <File Include="$(SharedNativeRoot)native\libs\build-local.sh" TargetPath="native/src/libs/build-local.sh"/>
-      <File Include="$(SharedNativeRoot)native\minipal\*" TargetPath="native/src/minipal"/>
-      <File Include="$(SharedNativeRoot)native\libs\Common\*" TargetPath="native/src/libs/Common"/>
+      <File Include="$(SharedNativeRoot)libs\System.Security.Cryptography.Native\*" TargetPath="native/src/libs/System.Security.Cryptography.Native"/>
+      <File Include="$(SharedNativeRoot)libs\build-local.sh" TargetPath="native/src/libs/build-local.sh"/>
+      <File Include="$(SharedNativeRoot)minipal\*" TargetPath="native/src/minipal"/>
+      <File Include="$(SharedNativeRoot)libs\Common\*" TargetPath="native/src/libs/Common"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Changes:

* Define `__xmknod` as `mknod`, because libSystem.Native.a in official package is compiled on machine with older version of glibc (where `mknod` was `__xmknod`) and newer glibc doesn't have that symbol. It's pretty much a nop if it's unused.
* Use the same compiler to build static libs which is selected for final linkage. Defer the cmake calls until after the toolchain selection.
* Add symbol prefix only on osx.
* To make gcc happy, `libm` must come after icu libs; moved it to the end of libs list.
* Move -static near -shared (so it's easier to track in logs where to expect it).

Notes:
* static executable works if we publish with `-p:PositionIndependentExecutable=false` (aka without `-static-pie`), otherwise it runs into sigsegv at the very beginning (during `__init_libc` on Alpine and it was crashing the debugger on Ubuntu when I stopped trying..)
* publishing static executable require the same toolchains, both compiler and linker are of gcc-toolchaiin or llvm-toolchain (with `-p:UseLlvmLinker=true`). Mixed toolchain builds are running  into different linker errors on different distros.