### PR TITLE
Disable eventsourceerror test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -83,6 +83,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/stackoverflow/stackoverflowtester/*">
             <Issue>https://github.com/dotnet/runtime/issues/46175</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
+            <Issue>https://github.com/dotnet/runtime/issues/80666</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Arm32 All OS -->


### PR DESCRIPTION
Temporarily disable failing test https://github.com/dotnet/runtime/issues/80666 (Coreclr, all unix)

Most of JIT PRs are red because of it.