### PR TITLE
BrowserDebugProxy: unify debug metadata reading for PE and Webcil

### DIFF
--- a/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.Reflection.cs
+++ b/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.Reflection.cs
@@ -19,7 +19,7 @@ public sealed partial class WebcilReader
     // Helpers to call into System.Reflection.Metadata internals
     internal static class Reflection
     {
-        private static Lazy<MethodInfo> _readUtf8NullTerminated = new Lazy<MethodInfo>(() =>
+        private static readonly Lazy<MethodInfo> s_readUtf8NullTerminated = new Lazy<MethodInfo>(() =>
         {
             var mi = typeof(BlobReader).GetMethod("ReadUtf8NullTerminated", BindingFlags.NonPublic | BindingFlags.Instance);
             if (mi == null)
@@ -29,9 +29,9 @@ public sealed partial class WebcilReader
             return mi;
         });
 
-        internal static string? ReadUtf8NullTerminated(BlobReader reader) => (string?)_readUtf8NullTerminated.Value.Invoke(reader, null);
+        internal static string? ReadUtf8NullTerminated(BlobReader reader) => (string?)s_readUtf8NullTerminated.Value.Invoke(reader, null);
 
-        private static Lazy<ConstructorInfo> _codeViewDebugDirectoryDataCtor = new Lazy<ConstructorInfo>(() =>
+        private static readonly Lazy<ConstructorInfo> s_codeViewDebugDirectoryDataCtor = new Lazy<ConstructorInfo>(() =>
         {
             var types = new Type[] { typeof(Guid), typeof(int), typeof(string) };
             var mi = typeof(CodeViewDebugDirectoryData).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, types, null);
@@ -42,9 +42,9 @@ public sealed partial class WebcilReader
             return mi;
         });
 
-        internal static CodeViewDebugDirectoryData MakeCodeViewDebugDirectoryData(Guid guid, int age, string path) => (CodeViewDebugDirectoryData)_codeViewDebugDirectoryDataCtor.Value.Invoke(new object[] { guid, age, path });
+        internal static CodeViewDebugDirectoryData MakeCodeViewDebugDirectoryData(Guid guid, int age, string path) => (CodeViewDebugDirectoryData)s_codeViewDebugDirectoryDataCtor.Value.Invoke(new object[] { guid, age, path });
 
-        private static Lazy<ConstructorInfo> _pdbChecksumDebugDirectoryDataCtor = new Lazy<ConstructorInfo>(() =>
+        private static readonly Lazy<ConstructorInfo> s_pdbChecksumDebugDirectoryDataCtor = new Lazy<ConstructorInfo>(() =>
         {
             var types = new Type[] { typeof(string), typeof(ImmutableArray<byte>) };
             var mi = typeof(PdbChecksumDebugDirectoryData).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, types, null);
@@ -54,6 +54,6 @@ public sealed partial class WebcilReader
             }
             return mi;
         });
-        internal static PdbChecksumDebugDirectoryData MakePdbChecksumDebugDirectoryData(string algorithmName, ImmutableArray<byte> checksum) => (PdbChecksumDebugDirectoryData)_pdbChecksumDebugDirectoryDataCtor.Value.Invoke(new object[] { algorithmName, checksum });
+        internal static PdbChecksumDebugDirectoryData MakePdbChecksumDebugDirectoryData(string algorithmName, ImmutableArray<byte> checksum) => (PdbChecksumDebugDirectoryData)s_pdbChecksumDebugDirectoryDataCtor.Value.Invoke(new object[] { algorithmName, checksum });
     }
 }

--- a/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.Reflection.cs
+++ b/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.Reflection.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.NET.WebAssembly.Webcil;
+
+
+public sealed partial class WebcilReader
+{
+
+    // Helpers to call into System.Reflection.Metadata internals
+    internal static class Reflection
+    {
+        private static Lazy<MethodInfo> _readUtf8NullTerminated = new Lazy<MethodInfo>(() =>
+        {
+            var mi = typeof(BlobReader).GetMethod("ReadUtf8NullTerminated", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (mi == null)
+            {
+                throw new InvalidOperationException("Could not find BlobReader.ReadUtf8NullTerminated");
+            }
+            return mi;
+        });
+
+        internal static string? ReadUtf8NullTerminated(BlobReader reader) => (string?)_readUtf8NullTerminated.Value.Invoke(reader, null);
+
+        private static Lazy<ConstructorInfo> _codeViewDebugDirectoryDataCtor = new Lazy<ConstructorInfo>(() =>
+        {
+            var types = new Type[] { typeof(Guid), typeof(int), typeof(string) };
+            var mi = typeof(CodeViewDebugDirectoryData).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, types, null);
+            if (mi == null)
+            {
+                throw new InvalidOperationException("Could not find CodeViewDebugDirectoryData constructor");
+            }
+            return mi;
+        });
+
+        internal static CodeViewDebugDirectoryData MakeCodeViewDebugDirectoryData(Guid guid, int age, string path) => (CodeViewDebugDirectoryData)_codeViewDebugDirectoryDataCtor.Value.Invoke(new object[] { guid, age, path });
+
+        private static Lazy<ConstructorInfo> _pdbChecksumDebugDirectoryDataCtor = new Lazy<ConstructorInfo>(() =>
+        {
+            var types = new Type[] { typeof(string), typeof(ImmutableArray<byte>) };
+            var mi = typeof(PdbChecksumDebugDirectoryData).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, types, null);
+            if (mi == null)
+            {
+                throw new InvalidOperationException("Could not find PdbChecksumDebugDirectoryData constructor");
+            }
+            return mi;
+        });
+        internal static PdbChecksumDebugDirectoryData MakePdbChecksumDebugDirectoryData(string algorithmName, ImmutableArray<byte> checksum) => (PdbChecksumDebugDirectoryData)_pdbChecksumDebugDirectoryDataCtor.Value.Invoke(new object[] { algorithmName, checksum });
+    }
+}

--- a/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.cs
+++ b/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.cs
@@ -297,6 +297,8 @@ public sealed class WebcilReader : IDisposable
 
     }
 
+    public PdbChecksumDebugDirectoryData ReadPdbChecksumDebugDirectoryData(DebugDirectoryEntry entry) => throw new NotImplementedException("read pdb checksum");
+
     private long TranslateRVA(uint rva)
     {
         if (_sections == null)

--- a/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.cs
+++ b/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.cs
@@ -13,7 +13,7 @@ using System.Reflection.PortableExecutable;
 namespace Microsoft.NET.WebAssembly.Webcil;
 
 
-public sealed class WebcilReader : IDisposable
+public sealed partial class WebcilReader : IDisposable
 {
     // WISH:
     // This should be implemented in terms of System.Reflection.Internal.MemoryBlockProvider like the PEReader,
@@ -219,37 +219,11 @@ public sealed class WebcilReader : IDisposable
         return MakeCodeViewDebugDirectoryData(guid, age, path);
     }
 
-    private static string? ReadUtf8NullTerminated(BlobReader reader)
-    {
-        var mi = typeof(BlobReader).GetMethod("ReadUtf8NullTerminated", BindingFlags.NonPublic | BindingFlags.Instance);
-        if (mi == null)
-        {
-            throw new InvalidOperationException("Could not find BlobReader.ReadUtf8NullTerminated");
-        }
-        return (string?)mi.Invoke(reader, null);
-    }
+    private static string? ReadUtf8NullTerminated(BlobReader reader) => Reflection.ReadUtf8NullTerminated(reader);
 
-    private static CodeViewDebugDirectoryData MakeCodeViewDebugDirectoryData(Guid guid, int age, string path)
-    {
-        var types = new Type[] { typeof(Guid), typeof(int), typeof(string) };
-        var mi = typeof(CodeViewDebugDirectoryData).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, types, null);
-        if (mi == null)
-        {
-            throw new InvalidOperationException("Could not find CodeViewDebugDirectoryData constructor");
-        }
-        return (CodeViewDebugDirectoryData)mi.Invoke(new object[] { guid, age, path });
-    }
+    private static CodeViewDebugDirectoryData MakeCodeViewDebugDirectoryData(Guid guid, int age, string path) => Reflection.MakeCodeViewDebugDirectoryData(guid, age, path);
 
-    private static PdbChecksumDebugDirectoryData MakePdbChecksumDebugDirectoryData(string algorithmName, ImmutableArray<byte> checksum)
-    {
-        var types = new Type[] { typeof(string), typeof(ImmutableArray<byte>) };
-        var mi = typeof(PdbChecksumDebugDirectoryData).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, types, null);
-        if (mi == null)
-        {
-            throw new InvalidOperationException("Could not find PdbChecksumDebugDirectoryData constructor");
-        }
-        return (PdbChecksumDebugDirectoryData)mi.Invoke(new object[] { algorithmName, checksum });
-    }
+    private static PdbChecksumDebugDirectoryData MakePdbChecksumDebugDirectoryData(string algorithmName, ImmutableArray<byte> checksum) => Reflection.MakePdbChecksumDebugDirectoryData(algorithmName, checksum);
 
     public MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(DebugDirectoryEntry entry)
     {

--- a/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.cs
+++ b/src/libraries/Microsoft.NET.WebAssembly.Webcil/src/Webcil/WebcilReader.cs
@@ -332,7 +332,6 @@ public sealed class WebcilReader : IDisposable
                 return DecodePdbChecksumDebugDirectoryData(new BlobReader(p, buffer.Length));
             }
         }
-
     }
 
     private static PdbChecksumDebugDirectoryData DecodePdbChecksumDebugDirectoryData(BlobReader reader)
@@ -345,7 +344,6 @@ public sealed class WebcilReader : IDisposable
         }
 
         return MakePdbChecksumDebugDirectoryData(algorithmName, ImmutableArray.Create(checksum));
-
     }
 
     private long TranslateRVA(uint rva)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/IDebugMetadataProvider.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/IDebugMetadataProvider.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.WebAssembly.Diagnostics;
+
+/// <summary>
+///   An adapter on top of MetadataReader and WebcilReader for DebugStore compensating
+///   for the lack of a common base class on those two types.
+/// </summary>
+public interface IDebugMetadataProvider
+{
+    public ImmutableArray<DebugDirectoryEntry> ReadDebugDirectory();
+    public CodeViewDebugDirectoryData ReadCodeViewDebugDirectoryData(DebugDirectoryEntry entry);
+    public PdbChecksumDebugDirectoryData ReadPdbChecksumDebugDirectoryData(DebugDirectoryEntry entry);
+
+    public MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(DebugDirectoryEntry entry);
+}

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MetadataDebugSummary.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MetadataDebugSummary.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Threading;
+using Microsoft.FileFormats.PE;
+
+namespace Microsoft.WebAssembly.Diagnostics;
+
+/// <summary>
+///   Information we can extract directly from the assembly image using metadata readers
+/// </summary>
+internal sealed class MetadataDebugSummary
+{
+    internal MetadataReader? PdbMetadataReader { get; private init; }
+    internal bool IsPortableCodeView { get; private init; }
+    internal PdbChecksum[] PdbChecksums { get; private init; }
+
+    internal CodeViewDebugDirectoryData? CodeViewData { get; private init; }
+
+    private MetadataDebugSummary(MetadataReader? pdbMetadataReader, bool isPortableCodeView, PdbChecksum[] pdbChecksums, CodeViewDebugDirectoryData? codeViewData)
+    {
+        PdbMetadataReader = pdbMetadataReader;
+        IsPortableCodeView = isPortableCodeView;
+        PdbChecksums = pdbChecksums;
+        CodeViewData = codeViewData;
+    }
+
+    internal static MetadataDebugSummary Create(MonoProxy monoProxy, SessionId sessionId, string name, IDebugMetadataProvider provider, byte[]? pdb, CancellationToken token)
+    {
+        var entries = provider.ReadDebugDirectory();
+        CodeViewDebugDirectoryData? codeViewData = null;
+        bool isPortableCodeView = false;
+        List<PdbChecksum> pdbChecksums = new();
+        DebugDirectoryEntry? embeddedPdbEntry = null;
+        foreach (var entry in entries)
+        {
+            switch (entry.Type)
+            {
+                case DebugDirectoryEntryType.CodeView:
+                    codeViewData = provider.ReadCodeViewDebugDirectoryData(entry);
+                    if (entry.IsPortableCodeView)
+                        isPortableCodeView = true;
+                    break;
+                case DebugDirectoryEntryType.PdbChecksum:
+                    var checksum = provider.ReadPdbChecksumDebugDirectoryData(entry);
+                    pdbChecksums.Add(new PdbChecksum(checksum.AlgorithmName, checksum.Checksum.ToArray()));
+                    break;
+                case DebugDirectoryEntryType.EmbeddedPortablePdb:
+                    embeddedPdbEntry = entry;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        MetadataReader? pdbMetadataReader = null;
+        if (pdb != null)
+        {
+            var pdbStream = new MemoryStream(pdb);
+            try
+            {
+                // MetadataReaderProvider.FromPortablePdbStream takes ownership of the stream
+                pdbMetadataReader = MetadataReaderProvider.FromPortablePdbStream(pdbStream).GetMetadataReader();
+            }
+            catch (BadImageFormatException)
+            {
+                monoProxy.SendLog(sessionId, $"Warning: Unable to read debug information of: {name} (use DebugType=Portable/Embedded)", token);
+            }
+        }
+        else
+        {
+            if (embeddedPdbEntry != null && embeddedPdbEntry.Value.DataSize != 0)
+            {
+                pdbMetadataReader = provider.ReadEmbeddedPortablePdbDebugDirectoryData(embeddedPdbEntry.Value).GetMetadataReader();
+            }
+        }
+
+        return new MetadataDebugSummary(pdbMetadataReader, isPortableCodeView, pdbChecksums.ToArray(), codeViewData);
+    }
+}

--- a/src/mono/wasm/debugger/BrowserDebugProxy/PortableExecutableDebugMetadataProvider.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/PortableExecutableDebugMetadataProvider.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.WebAssembly.Diagnostics;
+
+public class PortableExecutableDebugMetadataProvider : IDebugMetadataProvider
+{
+    private readonly PEReader _peReader;
+    public PortableExecutableDebugMetadataProvider(PEReader peReader)
+    {
+        _peReader = peReader;
+    }
+    public ImmutableArray<DebugDirectoryEntry> ReadDebugDirectory() => _peReader.ReadDebugDirectory();
+
+    public CodeViewDebugDirectoryData ReadCodeViewDebugDirectoryData(DebugDirectoryEntry entry) => _peReader.ReadCodeViewDebugDirectoryData(entry);
+
+    public PdbChecksumDebugDirectoryData ReadPdbChecksumDebugDirectoryData(DebugDirectoryEntry entry) => _peReader.ReadPdbChecksumDebugDirectoryData(entry);
+
+    public MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(DebugDirectoryEntry entry) => _peReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
+}

--- a/src/mono/wasm/debugger/BrowserDebugProxy/WebcilDebugMetadataProvider.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/WebcilDebugMetadataProvider.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.NET.WebAssembly.Webcil;
+
+namespace Microsoft.WebAssembly.Diagnostics;
+
+public class WebcilDebugMetadataProvider : IDebugMetadataProvider
+{
+    private readonly WebcilReader _webcilReader;
+
+    public WebcilDebugMetadataProvider(WebcilReader webcilReader)
+    {
+        _webcilReader = webcilReader;
+    }
+    public ImmutableArray<DebugDirectoryEntry> ReadDebugDirectory() => _webcilReader.ReadDebugDirectory();
+
+    public CodeViewDebugDirectoryData ReadCodeViewDebugDirectoryData(DebugDirectoryEntry entry) => _webcilReader.ReadCodeViewDebugDirectoryData(entry);
+
+    public PdbChecksumDebugDirectoryData ReadPdbChecksumDebugDirectoryData(DebugDirectoryEntry entry) => _webcilReader.ReadPdbChecksumDebugDirectoryData(entry);
+
+    public MetadataReaderProvider ReadEmbeddedPortablePdbDebugDirectoryData(DebugDirectoryEntry entry) => _webcilReader.ReadEmbeddedPortablePdbDebugDirectoryData(entry);
+}


### PR DESCRIPTION
Factor common code out into a `MetadataDebugSummary` using an adapter to read from either `PEReader` or `WebcilReader`.

- [x] Implement `WebcilReader.ReadPdbChecksumDebugDirectoryData`

Contributes to #80807 
