### PR TITLE
[wasm] Fix type check for PackedSimd.Splat

### DIFF
--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -4406,7 +4406,8 @@ emit_wasm_supported_intrinsics (
 	}
 
 	if (feature == MONO_CPU_WASM_SIMD) {
-		if (!is_element_type_primitive (fsig->params [0]))
+		if (id != SN_Splat && !is_element_type_primitive (fsig->params [0]) ||
+		    id == SN_Splat && !MONO_TYPE_IS_VECTOR_PRIMITIVE(fsig->params [0]))
 			return NULL;
 
 		switch (id) {


### PR DESCRIPTION
The Splat's 1st parameter is not Vector128'1, but element type.

Fixes this assertion:

    converting llvm method System.Runtime.Intrinsics.Vector128`1<sbyte> System.Runtime.Intrinsics.Wasm.PackedSimd:Splat (sbyte)
    * Assertion at D:\git\wa-local\src\mono\mono\mini\simd-intrinsics.c:690, condition `vector_type->type == MONO_TYPE_GENERICINST' not met