### PR TITLE
Encode calling convention in mangled function pointer representation

### DIFF
--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -290,9 +290,9 @@ namespace ILCompiler
                     mangledName = GetMangledTypeName(((PointerType)type).ParameterType) + NestMangledName("Pointer");
                     break;
                 case TypeFlags.FunctionPointer:
-                    // TODO: need to also encode calling convention (or all modopts?)
+                    // TODO: need to also encode modopts?
                     var fnPtrType = (FunctionPointerType)type;
-                    mangledName = "__FnPtr" + EnterNameScopeSequence;
+                    mangledName = "__FnPtr_" + ((int)fnPtrType.Signature.Flags).ToString("X2") + EnterNameScopeSequence;
                     mangledName += GetMangledTypeName(fnPtrType.Signature.ReturnType);
 
                     mangledName += EnterNameScopeSequence;

--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -290,7 +290,6 @@ namespace ILCompiler
                     mangledName = GetMangledTypeName(((PointerType)type).ParameterType) + NestMangledName("Pointer");
                     break;
                 case TypeFlags.FunctionPointer:
-                    // TODO: need to also encode modopts?
                     var fnPtrType = (FunctionPointerType)type;
                     mangledName = "__FnPtr_" + ((int)fnPtrType.Signature.Flags).ToString("X2") + EnterNameScopeSequence;
                     mangledName += GetMangledTypeName(fnPtrType.Signature.ReturnType);

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -874,9 +874,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests/*">
             <Issue>https://github.com/dotnet/runtime/issues/81103</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/Casting/Functionpointer/**">
-            <Issue>https://github.com/dotnet/runtime/issues/81106</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Crossgen2 x86 specific excludes -->


### PR DESCRIPTION
This fixes the recently introduced issue #81106 tracking Crossgen2 crash due to not being able to distinguish two function pointers differing only by calling convention (one of the pointers is Static and the other is Static | UnmanagedCallingConvention).

Thanks

Tomas

Fixes: #81106

/cc @dotnet/crossgen-contrib 