### PR TITLE
Move mono llvm fullaot runtime test leg to rolling build

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -254,6 +254,41 @@ jobs:
           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
+  #
+  # Mono CoreCLR runtime Test executions using live libraries and LLVM Full AOT
+  # Only when Mono is changed
+  #
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      buildConfig: Release
+      runtimeFlavor: mono
+      platforms:
+        - linux_x64
+        - linux_arm64
+      variables:
+        - name: timeoutPerTestInMinutes
+          value: 60
+        - name: timeoutPerTestCollectionInMinutes
+          value: 180
+      jobParameters:
+        testGroup: innerloop
+        nameSuffix: AllSubsets_Mono_LLVMFullAot_RuntimeTests
+        runtimeVariant: llvmfullaot
+        buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true /p:MonoLLVMUseCxx11Abi=true 
+        timeoutInMinutes: 300
+
+        condition: >-
+          or(
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+            eq(variables['isRollingBuild'], true))
+        extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+        extraStepsParameters:
+          creator: dotnet-bot
+        testRunNamePrefixSuffix: Mono_Release
+
 #
 # Mono CoreCLR runtime Test executions using live libraries in interpreter mode
 # Only when Mono is changed

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -254,40 +254,40 @@ jobs:
           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isRollingBuild'], true))
 
-  #
-  # Mono CoreCLR runtime Test executions using live libraries and LLVM Full AOT
-  # Only when Mono is changed
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      buildConfig: Release
-      runtimeFlavor: mono
-      platforms:
-        - linux_x64
-        - linux_arm64
-      variables:
-        - name: timeoutPerTestInMinutes
-          value: 60
-        - name: timeoutPerTestCollectionInMinutes
-          value: 180
-      jobParameters:
-        testGroup: innerloop
-        nameSuffix: AllSubsets_Mono_LLVMFullAot_RuntimeTests
-        runtimeVariant: llvmfullaot
-        buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true /p:MonoLLVMUseCxx11Abi=true 
-        timeoutInMinutes: 300
+#
+# Mono CoreCLR runtime Test executions using live libraries and LLVM Full AOT
+# Only when Mono is changed
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    buildConfig: Release
+    runtimeFlavor: mono
+    platforms:
+      - linux_x64
+      - linux_arm64
+    variables:
+      - name: timeoutPerTestInMinutes
+        value: 60
+      - name: timeoutPerTestCollectionInMinutes
+        value: 180
+    jobParameters:
+      testGroup: innerloop
+      nameSuffix: AllSubsets_Mono_LLVMFullAot_RuntimeTests
+      runtimeVariant: llvmfullaot
+      buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true /p:MonoLLVMUseCxx11Abi=true 
+      timeoutInMinutes: 300
 
-        condition: >-
-          or(
-            eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-            eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-            eq(variables['isRollingBuild'], true))
-        extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-        extraStepsParameters:
-          creator: dotnet-bot
-        testRunNamePrefixSuffix: Mono_Release
+      condition: >-
+        or(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+          eq(variables['isRollingBuild'], true))
+      extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+      extraStepsParameters:
+        creator: dotnet-bot
+      testRunNamePrefixSuffix: Mono_Release
 
 #
 # Mono CoreCLR runtime Test executions using live libraries in interpreter mode

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1173,41 +1173,6 @@ extends:
             testRunNamePrefixSuffix: Mono_Release
 
       #
-      # Mono CoreCLR runtime Test executions using live libraries and LLVM Full AOT
-      # Only when Mono is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-            - linux_x64
-            - linux_arm64
-          variables:
-            - name: timeoutPerTestInMinutes
-              value: 60
-            - name: timeoutPerTestCollectionInMinutes
-              value: 180
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: AllSubsets_Mono_LLVMFullAot_RuntimeTests
-            runtimeVariant: llvmfullaot
-            buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true /p:MonoLLVMUseCxx11Abi=true 
-            timeoutInMinutes: 300
-
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-            extraStepsParameters:
-              creator: dotnet-bot
-            testRunNamePrefixSuffix: Mono_Release
-
-      #
       # Libraries Release Test Execution against a release mono runtime.
       # Only when libraries or mono changed
       #


### PR DESCRIPTION
Since it takes quite a while to complete this leg, we should move it off of running every PR.

Addresses https://github.com/dotnet/runtime/issues/65626