### PR TITLE
[wasm] Fix S.N.Vector4 related assert

### DIFF
--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4336,7 +4336,7 @@ init_class (MonoClass *klass)
 
 	const char *name = m_class_get_name (klass);
 
-#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_WASM)
 	/*
 	 * Some of the intrinsics used by the VectorX classes are only implemented on amd64.
 	 * The JIT can't handle SIMD types with != 16 size yet.


### PR DESCRIPTION
Fixes

    error : Precompiling failed for /root/helix/work/workitem/e/wbt/blazorwasm_Release_aot_mv10loow.lgf/obj/Release/net8.0/wasm/for-publish/aot-in/aot-instances.dll with exit code 134. [/root/helix/work/workitem/e/wbt/blazorwasm_Release_aot_mv10loow.lgf/blazorwasm_Release_aot_mv10loow.lgf.csproj]
    error :   %6 = load %System.Numerics.Vector4.15073, %System.Numerics.Vector4.15073* %5, align 1 [/root/helix/work/workitem/e/wbt/blazorwasm_Release_aot_mv10loow.lgf/blazorwasm_Release_aot_mv10loow.lgf.csproj]
    error : <4 x float> [/root/helix/work/workitem/e/wbt/blazorwasm_Release_aot_mv10loow.lgf/blazorwasm_Release_aot_mv10loow.lgf.csproj]
    error : * Assertion: should not be reached at /__w/1/s/src/mono/mono/mini/mini-llvm.c:1455

where we were getting wrong llvm type for Vector4