### PR TITLE
Fix use-after-free in EventPipe 

### DIFF
--- a/src/coreclr/inc/sstring.h
+++ b/src/coreclr/inc/sstring.h
@@ -518,6 +518,9 @@ private:
     //Returns the unicode string, the caller is responsible for lifetime of the string
     WCHAR *GetCopyOfUnicodeString();
 
+    //Returns the UTF8 string, the caller is responsible for the lifetime of the string
+    UTF8 *GetCopyOfUTF8String();
+
     // Get the max size that can be passed to OpenUnicodeBuffer without causing allocations.
     COUNT_T GetUnicodeAllocation();
 

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -1664,8 +1664,8 @@ inline UTF8 *SString::GetCopyOfUTF8String()
     SS_CONTRACT_END;
     NewArrayHolder<UTF8> buffer = NULL;
 
-    buffer = new UTF8[GetCount() +1];
-    strncpy(buffer, GetUTF8(), GetCount() + 1);
+    buffer = new UTF8[GetSize()];
+    strncpy(buffer, GetUTF8(), GetSize());
 
     SS_RETURN buffer.Extract();
 }
@@ -1917,6 +1917,7 @@ FORCEINLINE SString::CIterator SString::End() const
     }
     SS_CONTRACT_END;
 
+    ConvertToIteratable();
     ConvertToIteratable();
 
     SS_RETURN CIterator(this, GetCount());

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -1654,7 +1654,7 @@ inline WCHAR *SString::GetCopyOfUnicodeString()
 //----------------------------------------------------------------------------
 inline UTF8 *SString::GetCopyOfUTF8String()
 {
-    SS_CONTRACT(WCHAR*)
+    SS_CONTRACT(UTF8*)
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -1649,6 +1649,28 @@ inline WCHAR *SString::GetCopyOfUnicodeString()
 }
 
 //----------------------------------------------------------------------------
+// Return a copy of the underlying  buffer, the caller is responsible for managing
+// the returned memory
+//----------------------------------------------------------------------------
+inline UTF8 *SString::GetCopyOfUTF8String()
+{
+    SS_CONTRACT(WCHAR*)
+    {
+        GC_NOTRIGGER;
+        PRECONDITION(CheckPointer(this));
+        SS_POSTCONDITION(CheckPointer(buffer));
+        THROWS;
+    }
+    SS_CONTRACT_END;
+    NewArrayHolder<UTF8> buffer = NULL;
+
+    buffer = new UTF8[GetCount() +1];
+    strncpy(buffer, GetUTF8(), GetCount() + 1);
+
+    SS_RETURN buffer.Extract();
+}
+
+//----------------------------------------------------------------------------
 // Return a writeable buffer that can store 'countChars'+1 ansi characters.
 // Call CloseBuffer when done.
 //----------------------------------------------------------------------------

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1137,7 +1137,7 @@ ep_rt_entrypoint_assembly_name_get_utf8 (void)
 
 	// get the name from the host if we can't get assembly info, e.g., if the runtime is
 	// suspended before an assembly is loaded.
-	// We'll cache the value in a static function global as the caller expect the lifetime of this value
+	// We'll cache the value in a static function global as the caller expects the lifetime of this value
 	// to outlast the calling function.
 	static const ep_char8_t* entrypoint_assembly_name = nullptr;
 	if (entrypoint_assembly_name == nullptr)

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1144,7 +1144,7 @@ ep_rt_entrypoint_assembly_name_get_utf8 (void)
 	{
 		const ep_char8_t* entrypoint_assembly_name_local;
 		SString assembly_name;
-		if (!HostInformation::GetProperty (HOST_PROPERTY_ENTRY_ASSEMBLY_NAME, assembly_name))
+		if (HostInformation::GetProperty (HOST_PROPERTY_ENTRY_ASSEMBLY_NAME, assembly_name))
 		{
 			entrypoint_assembly_name_local = reinterpret_cast<const ep_char8_t*>(assembly_name.GetCopyOfUTF8String ());
 		}

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1139,29 +1139,32 @@ ep_rt_entrypoint_assembly_name_get_utf8 (void)
 	// suspended before an assembly is loaded.
 	// We'll cache the value in a static function global as the caller expect the lifetime of this value
 	// to outlast the calling function.
-	static const ep_char8_t* entrypoint_assembly_name = NULL;
-	static bool read_name_from_host = false;
-	SString assembly_name;
-	if (!read_name_from_host || HostInformation::GetProperty (HOST_PROPERTY_ENTRY_ASSEMBLY_NAME, assembly_name))
+	static const ep_char8_t* entrypoint_assembly_name = nullptr;
+	if (entrypoint_assembly_name == nullptr)
 	{
-		const ep_char8_t* entrypoint_assembly_name_local = reinterpret_cast<const ep_char8_t*>(assembly_name.GetCopyOfUTF8String ());
+		const ep_char8_t* entrypoint_assembly_name_local;
+		SString assembly_name;
+		if (!HostInformation::GetProperty (HOST_PROPERTY_ENTRY_ASSEMBLY_NAME, assembly_name))
+		{
+			entrypoint_assembly_name_local = reinterpret_cast<const ep_char8_t*>(assembly_name.GetCopyOfUTF8String ());
+		}
+		else
+		{
+			// fallback to the empty string
+			// Allocate a new empty string here so we consistently allocate with the same allocator no matter our code-path.
+			entrypoint_assembly_name_local = new ep_char8_t [1] { '\0' };
+		}
 		// Try setting this entrypoint name as the cached value.
 		// If someone else beat us to it, free the memory we allocated.
 		// We want to only leak the one global copy of the entrypoint name,
 		// not mutliple copies.
-		if (InterlockedCompareExchangeT(&entrypoint_assembly_name, entrypoint_assembly_name_local, NULL) != NULL)
+		if (InterlockedCompareExchangeT(&entrypoint_assembly_name, entrypoint_assembly_name_local, nullptr) != nullptr)
 		{
 			delete[] entrypoint_assembly_name_local;
 		}
-		read_name_from_host = true;
-		return entrypoint_assembly_name;
 	}
 
-	// Record that we tried to read the name from the host so we don't try again.
-	read_name_from_host = true;
-
-	// fallback to the empty string
-	return reinterpret_cast<const ep_char8_t*>("");
+	return entrypoint_assembly_name;
 }
 
 static

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1137,9 +1137,16 @@ ep_rt_entrypoint_assembly_name_get_utf8 (void)
 
 	// get the name from the host if we can't get assembly info, e.g., if the runtime is
 	// suspended before an assembly is loaded.
-	SString assembly_name;
-	if (HostInformation::GetProperty (HOST_PROPERTY_ENTRY_ASSEMBLY_NAME, assembly_name))
+	static bool read_name_from_host = false;
+	static SString assembly_name;
+	if (read_name_from_host || HostInformation::GetProperty (HOST_PROPERTY_ENTRY_ASSEMBLY_NAME, assembly_name))
+	{
+		read_name_from_host = true;
 		return assembly_name.GetUTF8 ();
+	}
+
+	// Record that we tried to read the name from the host so we don't try again.
+	read_name_from_host = true;
 
 	// fallback to the empty string
 	return reinterpret_cast<const ep_char8_t*>("");

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1157,7 +1157,7 @@ ep_rt_entrypoint_assembly_name_get_utf8 (void)
 		// Try setting this entrypoint name as the cached value.
 		// If someone else beat us to it, free the memory we allocated.
 		// We want to only leak the one global copy of the entrypoint name,
-		// not mutliple copies.
+		// not multiple copies.
 		if (InterlockedCompareExchangeT(&entrypoint_assembly_name, entrypoint_assembly_name_local, nullptr) != nullptr)
 		{
 			delete[] entrypoint_assembly_name_local;


### PR DESCRIPTION
Read the assembly name host property once and store it in a function-scoped static global. The memory of this name is expected to be managed by this function, and this value will never change in the lifetime of an application.

This was found with AddressSanitizer.