### PR TITLE
Optimize compare to `HexConverter.FromChar` result

### DIFF
--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -258,18 +258,18 @@ namespace System
 
                 // byteHi hasn't been shifted to the high half yet, so the only way the bitwise or produces this pattern
                 // is if either byteHi or byteLo was not a hex character.
-                if ((byteLo | byteHi) == 0xFF)
+                if ((byteLo | byteHi) > 0x7F)
                     break;
 
                 bytes[j++] = (byte)((byteHi << 4) | byteLo);
                 i += 2;
             }
 
-            if (byteLo == 0xFF)
+            if (byteLo > 0x7F)
                 i++;
 
             charsProcessed = i;
-            return (byteLo | byteHi) != 0xFF;
+            return (byteLo | byteHi) <= 0x7F;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -324,7 +324,7 @@ namespace System
                 return (long)(shift & mask) < 0 ? true : false;
             }
 
-            return FromChar(c) != 0xFF;
+            return FromChar(c) <= 0x7F;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -1884,7 +1884,7 @@ namespace System.Diagnostics
         {
             int hi = HexConverter.FromLowerChar(char1);
             int lo = HexConverter.FromLowerChar(char2);
-            if ((hi | lo) == 0xFF)
+            if ((hi | lo) > 0x7F)
             {
                 throw new ArgumentOutOfRangeException("idData");
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -301,7 +301,7 @@ namespace System.Net.Http.Headers
         private static bool TryReadAlpnHexDigit(char ch, out int nibble)
         {
             int result = HexConverter.FromUpperChar(ch);
-            if (result == 0xFF)
+            if (result > 0x7F)
             {
                 nibble = 0;
                 return false;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -433,7 +433,7 @@ namespace System.Net
                             int h3 = HexConverter.FromChar(s[pos + 4]);
                             int h4 = HexConverter.FromChar(s[pos + 5]);
 
-                            if ((h1 | h2 | h3 | h4) != 0xFF)
+                            if ((h1 | h2 | h3 | h4) <= 0x7F)
                             {   // valid 4 hex chars
                                 ch = (char)((h1 << 12) | (h2 << 8) | (h3 << 4) | h4);
                                 pos += 5;
@@ -448,7 +448,7 @@ namespace System.Net
                             int h1 = HexConverter.FromChar(s[pos + 1]);
                             int h2 = HexConverter.FromChar(s[pos + 2]);
 
-                            if ((h1 | h2) != 0xFF)
+                            if ((h1 | h2) <= 0x7F)
                             {     // valid 2 hex chars
                                 byte b = (byte)((h1 << 4) | h2);
                                 pos += 2;

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/PhysicalAddress.cs
@@ -159,7 +159,7 @@ namespace System.Net.NetworkInformation
             {
                 int character = address[i];
                 int tmp;
-                if ((tmp = HexConverter.FromChar(character)) == 0xFF)
+                if ((tmp = HexConverter.FromChar(character)) > 0x7F)
                 {
                     if (delimiter == character && validCount == validSegmentLength)
                     {

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -388,7 +388,7 @@ namespace System.Net.NetworkInformation
         private static byte HexToByte(char val)
         {
             int result = HexConverter.FromChar(val);
-            if (result == 0xFF)
+            if (result > 0x7F)
             {
                 throw ExceptionHelper.CreateForParseFailure();
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.X.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Unsigned.X.cs
@@ -21,7 +21,7 @@ namespace System.Buffers.Text
             // Parse the first digit separately. If invalid here, we need to return false.
             nextCharacter = source[0];
             nextDigit = hexLookup[nextCharacter];
-            if (nextDigit == 0xFF)
+            if (nextDigit > 0x7F)
             {
                 bytesConsumed = 0;
                 value = default;
@@ -36,7 +36,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = (byte)(parsedValue);
@@ -53,7 +53,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = (byte)(parsedValue);
@@ -65,7 +65,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = (byte)(parsedValue);
@@ -103,7 +103,7 @@ namespace System.Buffers.Text
             // Parse the first digit separately. If invalid here, we need to return false.
             nextCharacter = source[0];
             nextDigit = hexLookup[nextCharacter];
-            if (nextDigit == 0xFF)
+            if (nextDigit > 0x7F)
             {
                 bytesConsumed = 0;
                 value = default;
@@ -118,7 +118,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = (ushort)(parsedValue);
@@ -135,7 +135,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = (ushort)(parsedValue);
@@ -147,7 +147,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = (ushort)(parsedValue);
@@ -185,7 +185,7 @@ namespace System.Buffers.Text
             // Parse the first digit separately. If invalid here, we need to return false.
             nextCharacter = source[0];
             nextDigit = hexLookup[nextCharacter];
-            if (nextDigit == 0xFF)
+            if (nextDigit > 0x7F)
             {
                 bytesConsumed = 0;
                 value = default;
@@ -200,7 +200,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = parsedValue;
@@ -217,7 +217,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = parsedValue;
@@ -229,7 +229,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = parsedValue;
@@ -267,7 +267,7 @@ namespace System.Buffers.Text
             // Parse the first digit separately. If invalid here, we need to return false.
             nextCharacter = source[0];
             nextDigit = hexLookup[nextCharacter];
-            if (nextDigit == 0xFF)
+            if (nextDigit > 0x7F)
             {
                 bytesConsumed = 0;
                 value = default;
@@ -282,7 +282,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = parsedValue;
@@ -299,7 +299,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = parsedValue;
@@ -311,7 +311,7 @@ namespace System.Buffers.Text
                 {
                     nextCharacter = source[index];
                     nextDigit = hexLookup[nextCharacter];
-                    if (nextDigit == 0xFF)
+                    if (nextDigit > 0x7F)
                     {
                         bytesConsumed = index;
                         value = parsedValue;

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -764,7 +764,7 @@ namespace System
             {
                 char c = guidString[i];
                 int numValue = HexConverter.FromChar(c);
-                if (numValue == 0xFF)
+                if (numValue > 0x7F)
                 {
                     if (processedDigits > 8) overflow = true;
                     result = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
@@ -509,7 +509,7 @@ namespace System.Net
                     int h1 = HexConverter.FromChar(value[pos + 1]);
                     int h2 = HexConverter.FromChar(value[pos + 2]);
 
-                    if ((h1 | h2) != 0xFF)
+                    if ((h1 | h2) <= 0x7F)
                     {     // valid 2 hex chars
                         byte b = (byte)((h1 << 4) | h2);
                         pos += 2;
@@ -567,7 +567,7 @@ namespace System.Net
                     int h1 = HexConverter.FromChar(bytes[pos + 1]);
                     int h2 = HexConverter.FromChar(bytes[pos + 2]);
 
-                    if ((h1 | h2) != 0xFF)
+                    if ((h1 | h2) <= 0x7F)
                     {     // valid 2 hex chars
                         b = (byte)((h1 << 4) | h2);
                         i += 2;

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -1514,7 +1514,7 @@ namespace System
                     num = value[index];
 
                     uint numValue = (uint)HexConverter.FromChar(num);
-                    if (numValue == 0xFF)
+                    if (numValue > 0x7F)
                         goto HasTrailingChars;
                     index++;
                     answer = 16 * answer + numValue;
@@ -1849,7 +1849,7 @@ namespace System
                     num = value[index];
 
                     uint numValue = (uint)HexConverter.FromChar(num);
-                    if (numValue == 0xFF)
+                    if (numValue > 0x7F)
                         goto HasTrailingChars;
                     index++;
                     answer = 16 * answer + numValue;
@@ -2186,7 +2186,7 @@ namespace System
                     num = value[index];
 
                     uint numValue = (uint)HexConverter.FromChar(num);
-                    if (numValue == 0xFF)
+                    if (numValue > 0x7F)
                         goto HasTrailingChars;
                     index++;
                     answer = 16U * answer + numValue;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameParser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyNameParser.cs
@@ -273,7 +273,7 @@ namespace System.Reflection
         private byte ParseHexNybble(char c)
         {
             int value = HexConverter.FromChar(c);
-            if (value == 0xFF)
+            if (value > 0x7F)
             {
                 ThrowInvalidAssemblyName();
             }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -731,7 +731,7 @@ namespace System.Xml
             {
                 byte ch = buffer[offset + i];
                 int digit = HexConverter.FromChar(ch);
-                if (digit == 0xFF)
+                if (digit > 0x7F)
                     XmlExceptionHelper.ThrowInvalidCharRef(_reader);
                 DiagnosticUtility.DebugAssert(digit >= 0 && digit < 16, "");
                 value = value * 16 + digit;

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1502,7 +1502,7 @@ namespace System
         public static int FromHex(char digit)
         {
             int result = HexConverter.FromChar(digit);
-            if (result == 0xFF)
+            if (result > 0x7F)
             {
                 throw new ArgumentException(null, nameof(digit));
             }

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -448,7 +448,7 @@ namespace System
             int a = HexConverter.FromChar(first);
             int b = HexConverter.FromChar(second);
 
-            if ((a | b) == 0xFF)
+            if ((a | b) > 0x7F)
             {
                 // either a or b is 0xFF (invalid)
                 return Uri.c_DummyChar;

--- a/src/libraries/System.Private.Xml/src/System/Xml/BinHexDecoder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinHexDecoder.cs
@@ -152,7 +152,7 @@ namespace System.Xml
                 char ch = chars[iChar];
 
                 int val = HexConverter.FromChar(ch);
-                if (val != 0xFF)
+                if (val <= 0x7F)
                 {
                     halfByte = (byte)val;
                 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -7234,7 +7234,7 @@ namespace System.Xml
                     while (true)
                     {
                         int ch = HexConverter.FromChar(chars[pos]);
-                        if (ch == 0xFF)
+                        if (ch > 0x7F)
                             break;
                         val = checked(val * 16 + ch);
                         pos++;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -449,7 +449,7 @@ namespace System.Numerics
                         }
 
                         int hexValue = HexConverter.FromChar(digitChar);
-                        Debug.Assert(hexValue != 0xFF);
+                        Debug.Assert(hexValue <= 0x7F);
 
                         partialValue = (partialValue << 4) | (uint)hexValue;
                         partialDigitCount++;

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -229,7 +229,7 @@ namespace System.Web.Util
                     int h1 = HexConverter.FromChar(bytes[pos + 1]);
                     int h2 = HexConverter.FromChar(bytes[pos + 2]);
 
-                    if ((h1 | h2) != 0xFF)
+                    if ((h1 | h2) <= 0x7F)
                     {
                         // valid 2 hex chars
                         b = (byte)((h1 << 4) | h2);
@@ -284,7 +284,7 @@ namespace System.Web.Util
                         int h3 = HexConverter.FromChar(bytes[pos + 4]);
                         int h4 = HexConverter.FromChar(bytes[pos + 5]);
 
-                        if ((h1 | h2 | h3 | h4) != 0xFF)
+                        if ((h1 | h2 | h3 | h4) <= 0x7F)
                         {   // valid 4 hex chars
                             char ch = (char)((h1 << 12) | (h2 << 8) | (h3 << 4) | h4);
                             i += 5;
@@ -299,7 +299,7 @@ namespace System.Web.Util
                         int h1 = HexConverter.FromChar(bytes[pos + 1]);
                         int h2 = HexConverter.FromChar(bytes[pos + 2]);
 
-                        if ((h1 | h2) != 0xFF)
+                        if ((h1 | h2) <= 0x7F)
                         {     // valid 2 hex chars
                             b = (byte)((h1 << 4) | h2);
                             i += 2;
@@ -345,7 +345,7 @@ namespace System.Web.Util
                         int h3 = HexConverter.FromChar(value[pos + 4]);
                         int h4 = HexConverter.FromChar(value[pos + 5]);
 
-                        if ((h1 | h2 | h3 | h4) != 0xFF)
+                        if ((h1 | h2 | h3 | h4) <= 0x7F)
                         {   // valid 4 hex chars
                             ch = (char)((h1 << 12) | (h2 << 8) | (h3 << 4) | h4);
                             pos += 5;
@@ -360,7 +360,7 @@ namespace System.Web.Util
                         int h1 = HexConverter.FromChar(value[pos + 1]);
                         int h2 = HexConverter.FromChar(value[pos + 2]);
 
-                        if ((h1 | h2) != 0xFF)
+                        if ((h1 | h2) <= 0x7F)
                         {     // valid 2 hex chars
                             byte b = (byte)((h1 << 4) | h2);
                             pos += 2;


### PR DESCRIPTION
`ldc.i4.s 127` is 2 bytes of IL vs 5 bytes for `ldc.i4 255`

`cmp ecx, 0x7f` is 3 bytes while `cmp ecx, 0xff` is 6 bytes

[sharplab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBLANgHwAEAmARgFgAoQgZgAIS6BhOgbyrs4fsNKTuAQIuOgFlSACmwA7DHWwBKNhy6rCAdnl0APAF46ABgTqAYgG4VnAL6XuDPgKEjRBqbPlL2lVWs3Y6AIT6RibmtjaUVkA===)