### PR TITLE
[JIT] Remove duplicate 'cmp' instruction in specific comparison scenario

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -1639,6 +1639,11 @@ void CodeGen::genConsumeRegs(GenTree* tree)
             genConsumeMultiOpOperands(hwintrinsic);
         }
 #endif // FEATURE_HW_INTRINSICS
+        else if (tree->OperIs(GT_LT))
+        {
+            genConsumeRegs(tree->gtGetOp1());
+            genConsumeRegs(tree->gtGetOp2());
+        }
 #endif // TARGET_XARCH
         else if (tree->OperIs(GT_BITCAST, GT_NEG, GT_CAST, GT_LSH, GT_RSH, GT_RSZ, GT_BSWAP, GT_BSWAP16))
         {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -917,8 +917,8 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
     if ((oper == GT_SUB) && op2->OperIs(GT_LT) && op2->isContained())
     {
         assert(op1->OperIs(GT_GT));
-        assert(op1->gtGetOp1()->GetRegNum() == op2->gtGetOp1()->GetRegNum());
-        assert(op1->gtGetOp2()->GetRegNum() == op2->gtGetOp2()->GetRegNum());
+        assert(op1->gtGetOp1()->AsLclVar()->GetLclNum() == op2->gtGetOp1()->AsLclVar()->GetLclNum());
+        assert(op1->gtGetOp2()->AsLclVar()->GetLclNum() == op2->gtGetOp2()->AsLclVar()->GetLclNum());
 
         regNumber tmpReg = treeNode->GetSingleTempReg();
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -920,7 +920,7 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
         assert(op1->gtGetOp1()->GetRegNum() == op2->gtGetOp1()->GetRegNum());
         assert(op1->gtGetOp2()->GetRegNum() == op2->gtGetOp2()->GetRegNum());
 
-        regNumber tmpReg = op2->GetSingleTempReg();
+        regNumber tmpReg = treeNode->GetSingleTempReg();
 
         inst_SETCC(GenCondition::FromIntegralRelop(op2), op2->TypeGet(), tmpReg);
         GetEmitter()->emitIns_Mov(INS_movzx, EA_1BYTE, tmpReg, tmpReg, false);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -920,9 +920,9 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
         assert(op1->gtGetOp1()->GetRegNum() == op2->gtGetOp1()->GetRegNum());
         assert(op1->gtGetOp2()->GetRegNum() == op2->gtGetOp2()->GetRegNum());
 
-        regNumber tmpReg = treeNode->GetSingleTempReg();
+        regNumber tmpReg = op2->GetSingleTempReg();
 
-        GetEmitter()->emitIns_R(INS_setl, EA_1BYTE, tmpReg);
+        inst_SETCC(GenCondition::FromIntegralRelop(op2), op2->TypeGet(), tmpReg);
         GetEmitter()->emitIns_Mov(INS_movzx, EA_1BYTE, tmpReg, tmpReg, false);
         GetEmitter()->emitIns_R_R(INS_sub, emitTypeSize(treeNode), targetReg, tmpReg);
 
@@ -1309,11 +1309,6 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     GenTree*  op1     = tree->gtOp1;
     GenTree*  op2     = tree->gtOp2;
     var_types op1Type = op1->TypeGet();
-
-    if (op2->OperIs(GT_LT) && op2->isContained())
-    {
-        assert(false);
-    }
 
     if (varTypeIsFloating(op1Type))
     {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1307,7 +1307,6 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     //         (signed < or >= where targetReg != REG_NA)
 
     GenTree*  op1     = tree->gtOp1;
-    GenTree*  op2     = tree->gtOp2;
     var_types op1Type = op1->TypeGet();
 
     if (varTypeIsFloating(op1Type))

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6067,6 +6067,16 @@ void Lowering::ContainCheckBinary(GenTreeOp* node)
     bool     isSafeToContainOp1 = true;
     bool     isSafeToContainOp2 = true;
 
+    if (node->OperIs(GT_SUB) && op1->OperIs(GT_GT) && op2->OperIs(GT_LT) && op1->gtGetOp1()->OperIs(GT_LCL_VAR) &&
+        op1->gtGetOp2()->OperIs(GT_LCL_VAR) && op2->gtGetOp1()->OperIs(GT_LCL_VAR) &&
+        op2->gtGetOp2()->OperIs(GT_LCL_VAR) &&
+        (op1->gtGetOp1()->AsLclVar()->GetLclNum() == op2->gtGetOp1()->AsLclVar()->GetLclNum()) &&
+        (op1->gtGetOp2()->AsLclVar()->GetLclNum() == op2->gtGetOp2()->AsLclVar()->GetLclNum()))
+    {
+        MakeSrcContained(node, op2);
+        return;
+    }
+
     if (IsContainableImmed(node, op2))
     {
         directlyEncodable = true;

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6067,6 +6067,20 @@ void Lowering::ContainCheckBinary(GenTreeOp* node)
     bool     isSafeToContainOp1 = true;
     bool     isSafeToContainOp2 = true;
 
+    // Optimizes the following IL Example:
+    //     ldarg.0
+	//     ldarg.1
+	//     cgt
+	//     ldarg.0
+	//     ldarg.1
+	//     clt
+	//     sub
+    //
+    // Roughly Equivelant C#:
+    //     ((var1 > var2) ? 1 : 0) - ((var1 < var2) ? 1 : 0);
+    //
+    // IR version:
+    //     SUB(GT_GT(VAR1, VAR2), GT_LT(VAR1, VAR2))
     if (node->OperIs(GT_SUB) && op1->OperIs(GT_GT) && op2->OperIs(GT_LT) && op1->gtGetOp1()->OperIs(GT_LCL_VAR) &&
         op1->gtGetOp2()->OperIs(GT_LCL_VAR) && op2->gtGetOp1()->OperIs(GT_LCL_VAR) &&
         op2->gtGetOp2()->OperIs(GT_LCL_VAR) &&

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3202,6 +3202,8 @@ int LinearScan::BuildOperandUses(GenTree* node, regMaskTP candidates)
     {
         return BuildOperandUses(node->gtGetOp1(), candidates);
     }
+#ifdef TARGET_XARCH
+#endif // TARGET_XARCH
 #ifdef FEATURE_HW_INTRINSICS
     if (node->OperIsHWIntrinsic())
     {
@@ -3294,6 +3296,15 @@ int LinearScan::BuildDelayFreeUses(GenTree* node, GenTree* rmwNode, regMaskTP ca
         return 0;
     }
 #endif
+#ifdef TARGET_XARCH
+    else if (node->OperIs(GT_LT))
+    {
+        assert(node->gtGetOp1()->OperIs(GT_LCL_VAR));
+        assert(node->gtGetOp2()->OperIs(GT_LCL_VAR));
+
+        return BuildBinaryUses(node->AsOp(), candidates);
+    }
+#endif // TARGET_XARCH
 #ifdef FEATURE_HW_INTRINSICS
     else if (node->OperIsHWIntrinsic())
     {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3202,8 +3202,6 @@ int LinearScan::BuildOperandUses(GenTree* node, regMaskTP candidates)
     {
         return BuildOperandUses(node->gtGetOp1(), candidates);
     }
-#ifdef TARGET_XARCH
-#endif // TARGET_XARCH
 #ifdef FEATURE_HW_INTRINSICS
     if (node->OperIsHWIntrinsic())
     {

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -308,14 +308,15 @@ int LinearScan::BuildNode(GenTree* tree)
         {
             srcCount = BuildBinaryUses(tree->AsOp());
             assert(dstCount == 1);
-            BuildDef(tree);
 
             if (tree->OperIs(GT_SUB) && tree->gtGetOp2()->OperIs(GT_LT) && tree->gtGetOp2()->isContained())
             {
                 // Make sure this happens after BuildDef so it can re-use a register.
                 buildInternalIntRegisterDefForNode(tree->gtGetOp2());
+                buildInternalRegisterUses();
             }
 
+            BuildDef(tree);
             break;
         }
 

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -312,7 +312,8 @@ int LinearScan::BuildNode(GenTree* tree)
 
             if (tree->OperIs(GT_SUB) && tree->gtGetOp2()->OperIs(GT_LT) && tree->gtGetOp2()->isContained())
             {
-                buildInternalIntRegisterDefForNode(tree);
+                // Make sure this happens after BuildDef so it can re-use a register.
+                buildInternalIntRegisterDefForNode(tree->gtGetOp2());
             }
 
             break;

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -311,8 +311,8 @@ int LinearScan::BuildNode(GenTree* tree)
 
             if (tree->OperIs(GT_SUB) && tree->gtGetOp2()->OperIs(GT_LT) && tree->gtGetOp2()->isContained())
             {
-                // Make sure this happens after BuildDef so it can re-use a register.
-                buildInternalIntRegisterDefForNode(tree->gtGetOp2());
+                // We need a new tmp register to handle this.
+                buildInternalIntRegisterDefForNode(tree);
                 buildInternalRegisterUses();
             }
 

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -305,10 +305,18 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_AND:
         case GT_OR:
         case GT_XOR:
+        {
             srcCount = BuildBinaryUses(tree->AsOp());
             assert(dstCount == 1);
             BuildDef(tree);
+
+            if (tree->OperIs(GT_SUB) && tree->gtGetOp2()->OperIs(GT_LT) && tree->gtGetOp2()->isContained())
+            {
+                buildInternalIntRegisterDefForNode(tree);
+            }
+
             break;
+        }
 
         case GT_BT:
             srcCount = BuildBinaryUses(tree->AsOp());


### PR DESCRIPTION
**Description** 

Resolves https://github.com/dotnet/runtime/issues/70003

At the moment, this is solved using containment - had to make changes to lowering and lsra.

IL Example:
```IL
.method public static 
	int32 fastcmp (
		int32 x,
		int32 y
	) cil managed 
{
	// Method begins at RVA 0x2050
	// Header size: 1
	// Code size: 10 (0xa)
	.maxstack 8

	IL_0000: ldarg.0
	IL_0001: ldarg.1
	IL_0002: cgt
	IL_0004: ldarg.0
	IL_0005: ldarg.1
	IL_0006: clt
	IL_0008: sub
	IL_0009: ret
} // end of method Program::fastcmp
```

As far as I'm aware, there is no way to produce the IL example above in C#. We can only do it in F#, so the diffs below only show functions from FSharp.Core.

<details>
  <summary>Example Diffs</summary>

  ```diff
diff --git a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96040.dasm b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96040.dasm
index 7076e5a1be6..ca1ca4dec79 100644
--- a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96040.dasm
+++ b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96040.dasm
@@ -131,21 +131,15 @@ G_M1421_IG29:        ; bbWeight=1, extend
        setg     dl
 						;; size=3 bbWeight=1 PerfScore 1.00
 G_M1421_IG30:        ; bbWeight=1, extend
-       cmp      edi, eax
-						;; size=2 bbWeight=1 PerfScore 0.25
-G_M1421_IG31:        ; bbWeight=1, extend
-       setl     al
+       setl     dl
 						;; size=3 bbWeight=1 PerfScore 1.00
-G_M1421_IG32:        ; bbWeight=1, extend
-       movzx    rax, al
+G_M1421_IG31:        ; bbWeight=1, extend
+       movzx    rdx, dl
 						;; size=3 bbWeight=1 PerfScore 0.25
-G_M1421_IG33:        ; bbWeight=1, extend
-       sub      edx, eax
-						;; size=2 bbWeight=1 PerfScore 0.25
-G_M1421_IG34:        ; bbWeight=1, extend
-       mov      eax, edx
+G_M1421_IG32:        ; bbWeight=1, extend
+       sub      eax, edx
 						;; size=2 bbWeight=1 PerfScore 0.25
-G_M1421_IG35:        ; bbWeight=1, epilog, nogc, extend
+G_M1421_IG33:        ; bbWeight=1, epilog, nogc, extend
        add      rsp, 32
        pop      rbx
        pop      rsi
@@ -153,7 +147,7 @@ G_M1421_IG35:        ; bbWeight=1, epilog, nogc, extend
        ret      
 						;; size=8 bbWeight=1 PerfScore 2.75
 
-; Total bytes of code 124, prolog size 7, PerfScore 52.40, instruction count 43, allocated bytes for code 124 (MethodHash=eddbfa72) for method Microsoft.FSharp.Reflection.Impl+getUnionTypeTagNameMap@418-1:Invoke(System.Reflection.FieldInfo,System.Reflection.FieldInfo):int:this
+; Total bytes of code 120, prolog size 7, PerfScore 51.50, instruction count 41, allocated bytes for code 120 (MethodHash=eddbfa72) for method Microsoft.FSharp.Reflection.Impl+getUnionTypeTagNameMap@418-1:Invoke(System.Reflection.FieldInfo,System.Reflection.FieldInfo):int:this
 ; ============================================================
 
 Unwind Info:
diff --git a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96591.dasm b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96591.dasm
index 02d23d4abfa..e3c6991ce11 100644
--- a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96591.dasm
+++ b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96591.dasm
@@ -26,22 +26,19 @@ G_M2679_IG04:        ; bbWeight=1, extend
        setg     al
 						;; size=3 bbWeight=1 PerfScore 1.00
 G_M2679_IG05:        ; bbWeight=1, extend
-       cmp      edx, r8d
-						;; size=3 bbWeight=1 PerfScore 0.25
-G_M2679_IG06:        ; bbWeight=1, extend
        setl     dl
 						;; size=3 bbWeight=1 PerfScore 1.00
-G_M2679_IG07:        ; bbWeight=1, extend
+G_M2679_IG06:        ; bbWeight=1, extend
        movzx    rdx, dl
 						;; size=3 bbWeight=1 PerfScore 0.25
-G_M2679_IG08:        ; bbWeight=1, extend
+G_M2679_IG07:        ; bbWeight=1, extend
        sub      eax, edx
 						;; size=2 bbWeight=1 PerfScore 0.25
-G_M2679_IG09:        ; bbWeight=1, epilog, nogc, extend
+G_M2679_IG08:        ; bbWeight=1, epilog, nogc, extend
        ret      
 						;; size=1 bbWeight=1 PerfScore 1.00
 
-; Total bytes of code 20, prolog size 0, PerfScore 6.25, instruction count 8, allocated bytes for code 20 (MethodHash=3faff588) for method Microsoft.FSharp.Core.LanguagePrimitives+Int32Comparer@2168:System.Collections.Generic.IComparer<System.Int32>.Compare(int,int):int:this
+; Total bytes of code 17, prolog size 0, PerfScore 5.70, instruction count 7, allocated bytes for code 17 (MethodHash=3faff588) for method Microsoft.FSharp.Core.LanguagePrimitives+Int32Comparer@2168:System.Collections.Generic.IComparer<System.Int32>.Compare(int,int):int:this
 ; ============================================================
 
 Unwind Info:
diff --git a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96592.dasm b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96592.dasm
index 11710f6ed56..641249e1c41 100644
--- a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96592.dasm
+++ b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96592.dasm
@@ -26,22 +26,19 @@ G_M54326_IG04:        ; bbWeight=1, extend
        setg     al
 						;; size=3 bbWeight=1 PerfScore 1.00
 G_M54326_IG05:        ; bbWeight=1, extend
-       cmp      rdx, r8
-						;; size=3 bbWeight=1 PerfScore 0.25
-G_M54326_IG06:        ; bbWeight=1, extend
        setl     dl
 						;; size=3 bbWeight=1 PerfScore 1.00
-G_M54326_IG07:        ; bbWeight=1, extend
+G_M54326_IG06:        ; bbWeight=1, extend
        movzx    rdx, dl
 						;; size=3 bbWeight=1 PerfScore 0.25
-G_M54326_IG08:        ; bbWeight=1, extend
+G_M54326_IG07:        ; bbWeight=1, extend
        sub      eax, edx
 						;; size=2 bbWeight=1 PerfScore 0.25
-G_M54326_IG09:        ; bbWeight=1, epilog, nogc, extend
+G_M54326_IG08:        ; bbWeight=1, epilog, nogc, extend
        ret      
 						;; size=1 bbWeight=1 PerfScore 1.00
 
-; Total bytes of code 20, prolog size 0, PerfScore 6.25, instruction count 8, allocated bytes for code 20 (MethodHash=1dde2bc9) for method Microsoft.FSharp.Core.LanguagePrimitives+Int64Comparer@2169:System.Collections.Generic.IComparer<System.Int64>.Compare(long,long):int:this
+; Total bytes of code 17, prolog size 0, PerfScore 5.70, instruction count 7, allocated bytes for code 17 (MethodHash=1dde2bc9) for method Microsoft.FSharp.Core.LanguagePrimitives+Int64Comparer@2169:System.Collections.Generic.IComparer<System.Int64>.Compare(long,long):int:this
 ; ============================================================
 
 Unwind Info:
diff --git a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96593.dasm b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96593.dasm
index 38accdc6c4f..2379aa04fee 100644
--- a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96593.dasm
+++ b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96593.dasm
@@ -34,25 +34,19 @@ G_M50271_IG06:        ; bbWeight=1, extend
        seta     cl
 						;; size=3 bbWeight=1 PerfScore 1.00
 G_M50271_IG07:        ; bbWeight=1, extend
-       cmp      eax, edx
-						;; size=2 bbWeight=1 PerfScore 0.25
-G_M50271_IG08:        ; bbWeight=1, extend
-       setb     al
+       setb     dl
 						;; size=3 bbWeight=1 PerfScore 1.00
-G_M50271_IG09:        ; bbWeight=1, extend
-       movzx    rax, al
+G_M50271_IG08:        ; bbWeight=1, extend
+       movzx    rdx, dl
 						;; size=3 bbWeight=1 PerfScore 0.25
-G_M50271_IG10:        ; bbWeight=1, extend
-       sub      ecx, eax
-						;; size=2 bbWeight=1 PerfScore 0.25
-G_M50271_IG11:        ; bbWeight=1, extend
-       mov      eax, ecx
+G_M50271_IG09:        ; bbWeight=1, extend
+       sub      eax, edx
 						;; size=2 bbWeight=1 PerfScore 0.25
-G_M50271_IG12:        ; bbWeight=1, epilog, nogc, extend
+G_M50271_IG10:        ; bbWeight=1, epilog, nogc, extend
        ret      
 						;; size=1 bbWeight=1 PerfScore 1.00
 
-; Total bytes of code 27, prolog size 0, PerfScore 7.70, instruction count 11, allocated bytes for code 27 (MethodHash=73733ba0) for method Microsoft.FSharp.Core.LanguagePrimitives+ByteComparer@2171:System.Collections.Generic.IComparer<System.Byte>.Compare(ubyte,ubyte):int:this
+; Total bytes of code 23, prolog size 0, PerfScore 6.80, instruction count 9, allocated bytes for code 23 (MethodHash=73733ba0) for method Microsoft.FSharp.Core.LanguagePrimitives+ByteComparer@2171:System.Collections.Generic.IComparer<System.Byte>.Compare(ubyte,ubyte):int:this
 ; ============================================================
 
 Unwind Info:
diff --git a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96596.dasm b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96596.dasm
index 250f70ffffd..dfaf59944c3 100644
--- a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96596.dasm
+++ b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96596.dasm
@@ -26,22 +26,19 @@ G_M61338_IG04:        ; bbWeight=1, extend
        seta     al
 						;; size=3 bbWeight=1 PerfScore 1.00
 G_M61338_IG05:        ; bbWeight=1, extend
-       cmp      rdx, r8
-						;; size=3 bbWeight=1 PerfScore 0.25
-G_M61338_IG06:        ; bbWeight=1, extend
        setb     dl
 						;; size=3 bbWeight=1 PerfScore 1.00
-G_M61338_IG07:        ; bbWeight=1, extend
+G_M61338_IG06:        ; bbWeight=1, extend
        movzx    rdx, dl
 						;; size=3 bbWeight=1 PerfScore 0.25
-G_M61338_IG08:        ; bbWeight=1, extend
+G_M61338_IG07:        ; bbWeight=1, extend
        sub      eax, edx
 						;; size=2 bbWeight=1 PerfScore 0.25
-G_M61338_IG09:        ; bbWeight=1, epilog, nogc, extend
+G_M61338_IG08:        ; bbWeight=1, epilog, nogc, extend
        ret      
 						;; size=1 bbWeight=1 PerfScore 1.00
 
-; Total bytes of code 20, prolog size 0, PerfScore 6.25, instruction count 8, allocated bytes for code 20 (MethodHash=fa6e1065) for method Microsoft.FSharp.Core.LanguagePrimitives+UInt64Comparer@2174:System.Collections.Generic.IComparer<System.UInt64>.Compare(ulong,ulong):int:this
+; Total bytes of code 17, prolog size 0, PerfScore 5.70, instruction count 7, allocated bytes for code 17 (MethodHash=fa6e1065) for method Microsoft.FSharp.Core.LanguagePrimitives+UInt64Comparer@2174:System.Collections.Generic.IComparer<System.UInt64>.Compare(ulong,ulong):int:this
 ; ============================================================
 
 Unwind Info:
diff --git a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96607.dasm b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96607.dasm
index d7d1caaf52a..0a88201cc75 100644
--- a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96607.dasm
+++ b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96607.dasm
@@ -11,10 +11,10 @@
 ;  V01 arg1         [V01,T02] (  4, 10   )     ref  ->  rbx         class-hnd single-def
 ;  V02 arg2         [V02,T03] (  3, 10   )     int  ->  rbp         single-def
 ;  V03 arg3         [V03,T00] (  9, 34   )     int  ->  rsi        
-;  V04 loc0         [V04,T08] (  3,  8.50)     int  ->  rcx        
+;  V04 loc0         [V04,T08] (  3,  8.50)     int  ->  rax        
 ;  V05 loc1         [V05,T04] (  3, 12   )    long  ->  r14        
 ;  V06 loc2         [V06,T05] (  3, 12   )    long  ->  rax        
-;  V07 loc3         [V07,T09] (  3,  8.50)     int  ->  rdx        
+;  V07 loc3         [V07,T09] (  3,  8.50)     int  ->  rax        
 ;  V08 loc4         [V08,T06] (  3, 12   )     int  ->  r14        
 ;  V09 loc5         [V09,T07] (  3, 12   )     int  ->  rax        
 ;  V10 OutArgs      [V10    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"
@@ -104,25 +104,19 @@ G_M52496_IG19:        ; bbWeight=4, extend
        setg     cl
 						;; size=3 bbWeight=4 PerfScore 4.00
 G_M52496_IG20:        ; bbWeight=4, extend
-       cmp      r14, rax
-						;; size=3 bbWeight=4 PerfScore 1.00
-G_M52496_IG21:        ; bbWeight=4, extend
-       setl     al
+       setl     cl
 						;; size=3 bbWeight=4 PerfScore 4.00
-G_M52496_IG22:        ; bbWeight=4, extend
-       movzx    rax, al
+G_M52496_IG21:        ; bbWeight=4, extend
+       movzx    rcx, cl
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M52496_IG23:        ; bbWeight=4, extend
-       sub      ecx, eax
+G_M52496_IG22:        ; bbWeight=4, extend
+       sub      eax, ecx
 						;; size=2 bbWeight=4 PerfScore 1.00
-G_M52496_IG24:        ; bbWeight=4, isz, extend
-       je       SHORT G_M52496_IG27
+G_M52496_IG23:        ; bbWeight=4, isz, extend
+       je       SHORT G_M52496_IG25
 						;; size=2 bbWeight=4 PerfScore 4.00
-G_M52496_IG25:        ; bbWeight=0.50, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
+G_M52496_IG24:        ; bbWeight=0.50, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, epilog, nogc
        ; gcrRegs -[rbx rdi]
-       mov      eax, ecx
-						;; size=2 bbWeight=0.50 PerfScore 0.12
-G_M52496_IG26:        ; bbWeight=0.50, epilog, nogc, extend
        add      rsp, 32
        pop      rbx
        pop      rbp
@@ -131,69 +125,63 @@ G_M52496_IG26:        ; bbWeight=0.50, epilog, nogc, extend
        pop      r14
        ret      
 						;; size=11 bbWeight=0.50 PerfScore 1.88
-G_M52496_IG27:        ; bbWeight=4, gcVars=0000000000000000 {}, gcrefRegs=00000088 {rbx rdi}, byrefRegs=00000000 {}, gcvars, byref
+G_M52496_IG25:        ; bbWeight=4, gcVars=0000000000000000 {}, gcrefRegs=00000088 {rbx rdi}, byrefRegs=00000000 {}, gcvars, byref
        ; gcrRegs +[rbx rdi]
        mov      rcx, rdi
        ; gcrRegs +[rcx]
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M52496_IG28:        ; bbWeight=4, extend
+G_M52496_IG26:        ; bbWeight=4, extend
        mov      edx, esi
 						;; size=2 bbWeight=4 PerfScore 1.00
-G_M52496_IG29:        ; bbWeight=4, extend
+G_M52496_IG27:        ; bbWeight=4, extend
        lea      r11, [(reloc)]
 						;; size=7 bbWeight=4 PerfScore 2.00
-G_M52496_IG30:        ; bbWeight=4, extend
+G_M52496_IG28:        ; bbWeight=4, extend
        call     [r11]<unknown method>
        ; gcrRegs -[rcx]
        ; gcr arg pop 0
 						;; size=3 bbWeight=4 PerfScore 12.00
-G_M52496_IG31:        ; bbWeight=4, extend
+G_M52496_IG29:        ; bbWeight=4, extend
        mov      r14d, eax
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M52496_IG32:        ; bbWeight=4, extend
+G_M52496_IG30:        ; bbWeight=4, extend
        mov      rcx, rbx
        ; gcrRegs +[rcx]
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M52496_IG33:        ; bbWeight=4, extend
+G_M52496_IG31:        ; bbWeight=4, extend
        mov      edx, esi
 						;; size=2 bbWeight=4 PerfScore 1.00
-G_M52496_IG34:        ; bbWeight=4, extend
+G_M52496_IG32:        ; bbWeight=4, extend
        lea      r11, [(reloc)]
 						;; size=7 bbWeight=4 PerfScore 2.00
-G_M52496_IG35:        ; bbWeight=4, extend
+G_M52496_IG33:        ; bbWeight=4, extend
        call     [r11]<unknown method>
        ; gcrRegs -[rcx]
        ; gcr arg pop 0
 						;; size=3 bbWeight=4 PerfScore 12.00
-G_M52496_IG36:        ; bbWeight=4, extend
+G_M52496_IG34:        ; bbWeight=4, extend
        xor      edx, edx
 						;; size=2 bbWeight=4 PerfScore 1.00
-G_M52496_IG37:        ; bbWeight=4, extend
+G_M52496_IG35:        ; bbWeight=4, extend
        cmp      r14d, eax
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M52496_IG38:        ; bbWeight=4, extend
+G_M52496_IG36:        ; bbWeight=4, extend
        setg     dl
 						;; size=3 bbWeight=4 PerfScore 4.00
-G_M52496_IG39:        ; bbWeight=4, extend
-       cmp      r14d, eax
-						;; size=3 bbWeight=4 PerfScore 1.00
-G_M52496_IG40:        ; bbWeight=4, extend
-       setl     al
+G_M52496_IG37:        ; bbWeight=4, extend
+       setl     dl
 						;; size=3 bbWeight=4 PerfScore 4.00
-G_M52496_IG41:        ; bbWeight=4, extend
-       movzx    rax, al
+G_M52496_IG38:        ; bbWeight=4, extend
+       movzx    rdx, dl
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M52496_IG42:        ; bbWeight=4, extend
-       sub      edx, eax
+G_M52496_IG39:        ; bbWeight=4, extend
+       sub      eax, edx
 						;; size=2 bbWeight=4 PerfScore 1.00
-G_M52496_IG43:        ; bbWeight=4, isz, extend
-       je       SHORT G_M52496_IG46
+G_M52496_IG40:        ; bbWeight=4, isz, extend
+       je       SHORT G_M52496_IG42
 						;; size=2 bbWeight=4 PerfScore 4.00
-G_M52496_IG44:        ; bbWeight=0.50, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
+G_M52496_IG41:        ; bbWeight=0.50, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, epilog, nogc
        ; gcrRegs -[rbx rdi]
-       mov      eax, edx
-						;; size=2 bbWeight=0.50 PerfScore 0.12
-G_M52496_IG45:        ; bbWeight=0.50, epilog, nogc, extend
        add      rsp, 32
        pop      rbx
        pop      rbp
@@ -202,15 +190,15 @@ G_M52496_IG45:        ; bbWeight=0.50, epilog, nogc, extend
        pop      r14
        ret      
 						;; size=11 bbWeight=0.50 PerfScore 1.88
-G_M52496_IG46:        ; bbWeight=4, gcVars=0000000000000000 {}, gcrefRegs=00000088 {rbx rdi}, byrefRegs=00000000 {}, gcvars, byref
+G_M52496_IG42:        ; bbWeight=4, gcVars=0000000000000000 {}, gcrefRegs=00000088 {rbx rdi}, byrefRegs=00000000 {}, gcvars, byref
        ; gcrRegs +[rbx rdi]
        inc      esi
 						;; size=2 bbWeight=4 PerfScore 1.00
-G_M52496_IG47:        ; bbWeight=4, extend
+G_M52496_IG43:        ; bbWeight=4, extend
        jmp      G_M52496_IG02
 						;; size=5 bbWeight=4 PerfScore 8.00
 
-; Total bytes of code 184, prolog size 10, PerfScore 217.40, instruction count 74, allocated bytes for code 184 (MethodHash=7b6b32ef) for method Microsoft.FSharp.Core.LanguagePrimitives+HashCompare:precheck@985(System.Array,System.Array,int,int):int
+; Total bytes of code 174, prolog size 10, PerfScore 214.15, instruction count 70, allocated bytes for code 174 (MethodHash=7b6b32ef) for method Microsoft.FSharp.Core.LanguagePrimitives+HashCompare:precheck@985(System.Array,System.Array,int,int):int
 ; ============================================================
 
 Unwind Info:
diff --git a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96611.dasm b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96611.dasm
index ddab736fdb6..7a328d104df 100644
--- a/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/base/96611.dasm
+++ b/c:/work/runtime/artifacts/spmi/asm.libraries.crossgen2.windows.x64.checked.11/diff/96611.dasm
@@ -12,7 +12,7 @@
 ;  V02 arg2         [V02,T06] (  4,  7   )     ref  ->  rdi         class-hnd single-def
 ;  V03 loc0         [V03,T04] (  6,  9.50)     int  ->  r14         single-def
 ;  V04 loc1         [V04,T10] (  3,  3   )     int  ->  rax         single-def
-;  V05 loc2         [V05,T12] (  3,  2.50)     int  ->  rdx         single-def
+;  V05 loc2         [V05,T12] (  3,  2.50)     int  ->  rax         single-def
 ;  V06 loc3         [V06,T00] (  8, 22.50)     int  ->  r12        
 ;  V07 loc4         [V07,T11] (  3,  3   )     int  ->  r13        
 ;  V08 loc5         [V08,T03] (  3, 10   )     int  ->  rax        
@@ -63,25 +63,19 @@ G_M50822_IG08:        ; bbWeight=1, extend
        setg     dl
 						;; size=3 bbWeight=1 PerfScore 1.00
 G_M50822_IG09:        ; bbWeight=1, extend
-       cmp      r14d, eax
-						;; size=3 bbWeight=1 PerfScore 0.25
-G_M50822_IG10:        ; bbWeight=1, extend
-       setl     al
+       setl     dl
 						;; size=3 bbWeight=1 PerfScore 1.00
-G_M50822_IG11:        ; bbWeight=1, extend
-       movzx    rax, al
+G_M50822_IG10:        ; bbWeight=1, extend
+       movzx    rdx, dl
 						;; size=3 bbWeight=1 PerfScore 0.25
-G_M50822_IG12:        ; bbWeight=1, extend
-       sub      edx, eax
+G_M50822_IG11:        ; bbWeight=1, extend
+       sub      eax, edx
 						;; size=2 bbWeight=1 PerfScore 0.25
-G_M50822_IG13:        ; bbWeight=1, isz, extend
-       je       SHORT G_M50822_IG16
+G_M50822_IG12:        ; bbWeight=1, isz, extend
+       je       SHORT G_M50822_IG14
 						;; size=2 bbWeight=1 PerfScore 1.00
-G_M50822_IG14:        ; bbWeight=0.50, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
+G_M50822_IG13:        ; bbWeight=0.50, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, epilog, nogc
        ; gcrRegs -[rbx rsi rdi]
-       mov      eax, edx
-						;; size=2 bbWeight=0.50 PerfScore 0.12
-G_M50822_IG15:        ; bbWeight=0.50, epilog, nogc, extend
        add      rsp, 40
        pop      rbx
        pop      rbp
@@ -93,80 +87,80 @@ G_M50822_IG15:        ; bbWeight=0.50, epilog, nogc, extend
        pop      r15
        ret      
 						;; size=17 bbWeight=0.50 PerfScore 2.62
-G_M50822_IG16:        ; bbWeight=0.50, gcVars=0000000000000000 {}, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, gcvars, byref
+G_M50822_IG14:        ; bbWeight=0.50, gcVars=0000000000000000 {}, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, gcvars, byref
        ; gcrRegs +[rbx rsi rdi]
        xor      r12d, r12d
 						;; size=3 bbWeight=0.50 PerfScore 0.12
-G_M50822_IG17:        ; bbWeight=0.50, extend
+G_M50822_IG15:        ; bbWeight=0.50, extend
        xor      r13d, r13d
 						;; size=3 bbWeight=0.50 PerfScore 0.12
-G_M50822_IG18:        ; bbWeight=0.50, extend
+G_M50822_IG16:        ; bbWeight=0.50, extend
        test     r14d, r14d
 						;; size=3 bbWeight=0.50 PerfScore 0.12
-G_M50822_IG19:        ; bbWeight=0.50, isz, extend
-       jle      SHORT G_M50822_IG37
+G_M50822_IG17:        ; bbWeight=0.50, isz, extend
+       jle      SHORT G_M50822_IG35
 						;; size=2 bbWeight=0.50 PerfScore 0.50
-G_M50822_IG20:        ; bbWeight=4, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, byref
+G_M50822_IG18:        ; bbWeight=4, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, byref
        cmp      r12d, ebp
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M50822_IG21:        ; bbWeight=4, isz, extend
-       jae      SHORT G_M50822_IG39
+G_M50822_IG19:        ; bbWeight=4, isz, extend
+       jae      SHORT G_M50822_IG37
 						;; size=2 bbWeight=4 PerfScore 4.00
-G_M50822_IG22:        ; bbWeight=4, extend
+G_M50822_IG20:        ; bbWeight=4, extend
        mov      r8d, r12d
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M50822_IG23:        ; bbWeight=4, extend
+G_M50822_IG21:        ; bbWeight=4, extend
        mov      rdx, gword ptr [rsi+8*r8+10H]
        ; gcrRegs +[rdx]
 						;; size=5 bbWeight=4 PerfScore 8.00
-G_M50822_IG24:        ; bbWeight=4, extend
+G_M50822_IG22:        ; bbWeight=4, extend
        cmp      r12d, r15d
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M50822_IG25:        ; bbWeight=4, isz, extend
-       jae      SHORT G_M50822_IG39
+G_M50822_IG23:        ; bbWeight=4, isz, extend
+       jae      SHORT G_M50822_IG37
 						;; size=2 bbWeight=4 PerfScore 4.00
-G_M50822_IG26:        ; bbWeight=4, extend
+G_M50822_IG24:        ; bbWeight=4, extend
        mov      r8, gword ptr [rdi+8*r8+10H]
        ; gcrRegs +[r8]
 						;; size=5 bbWeight=4 PerfScore 8.00
-G_M50822_IG27:        ; bbWeight=4, extend
+G_M50822_IG25:        ; bbWeight=4, extend
        mov      rcx, rbx
        ; gcrRegs +[rcx]
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M50822_IG28:        ; bbWeight=4, extend
+G_M50822_IG26:        ; bbWeight=4, extend
        call     [<unknown method>]
        ; gcrRegs -[rcx rdx r8]
        ; gcr arg pop 0
 						;; size=6 bbWeight=4 PerfScore 12.00
-G_M50822_IG29:        ; bbWeight=4, extend
+G_M50822_IG27:        ; bbWeight=4, extend
        test     eax, eax
 						;; size=2 bbWeight=4 PerfScore 1.00
-G_M50822_IG30:        ; bbWeight=4, isz, extend
-       je       SHORT G_M50822_IG34
+G_M50822_IG28:        ; bbWeight=4, isz, extend
+       je       SHORT G_M50822_IG32
 						;; size=2 bbWeight=4 PerfScore 4.00
-G_M50822_IG31:        ; bbWeight=2, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, byref
+G_M50822_IG29:        ; bbWeight=2, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, byref
        mov      r13d, eax
 						;; size=3 bbWeight=2 PerfScore 0.50
-G_M50822_IG32:        ; bbWeight=2, extend
+G_M50822_IG30:        ; bbWeight=2, extend
        mov      r12d, r14d
 						;; size=3 bbWeight=2 PerfScore 0.50
-G_M50822_IG33:        ; bbWeight=2, isz, extend
-       jmp      SHORT G_M50822_IG35
+G_M50822_IG31:        ; bbWeight=2, isz, extend
+       jmp      SHORT G_M50822_IG33
 						;; size=2 bbWeight=2 PerfScore 4.00
-G_M50822_IG34:        ; bbWeight=2, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, byref
+G_M50822_IG32:        ; bbWeight=2, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, byref
        inc      r12d
 						;; size=3 bbWeight=2 PerfScore 0.50
-G_M50822_IG35:        ; bbWeight=4, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, byref
+G_M50822_IG33:        ; bbWeight=4, gcrefRegs=000000C8 {rbx rsi rdi}, byrefRegs=00000000 {}, byref
        cmp      r12d, r14d
 						;; size=3 bbWeight=4 PerfScore 1.00
-G_M50822_IG36:        ; bbWeight=4, isz, extend
-       jl       SHORT G_M50822_IG20
+G_M50822_IG34:        ; bbWeight=4, isz, extend
+       jl       SHORT G_M50822_IG18
 						;; size=2 bbWeight=4 PerfScore 4.00
-G_M50822_IG37:        ; bbWeight=0.50, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
+G_M50822_IG35:        ; bbWeight=0.50, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
        ; gcrRegs -[rbx rsi rdi]
        mov      eax, r13d
 						;; size=3 bbWeight=0.50 PerfScore 0.12
-G_M50822_IG38:        ; bbWeight=0.50, epilog, nogc, extend
+G_M50822_IG36:        ; bbWeight=0.50, epilog, nogc, extend
        add      rsp, 40
        pop      rbx
        pop      rbp
@@ -178,15 +172,15 @@ G_M50822_IG38:        ; bbWeight=0.50, epilog, nogc, extend
        pop      r15
        ret      
 						;; size=17 bbWeight=0.50 PerfScore 2.62
-G_M50822_IG39:        ; bbWeight=0, gcVars=0000000000000000 {}, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, gcvars, byref
+G_M50822_IG37:        ; bbWeight=0, gcVars=0000000000000000 {}, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, gcvars, byref
        call     [CORINFO_HELP_RNGCHKFAIL]
        ; gcr arg pop 0
 						;; size=6 bbWeight=0 PerfScore 0.00
-G_M50822_IG40:        ; bbWeight=0, extend
+G_M50822_IG38:        ; bbWeight=0, extend
        int3     
 						;; size=1 bbWeight=0 PerfScore 0.00
 
-; Total bytes of code 168, prolog size 16, PerfScore 96.43, instruction count 69, allocated bytes for code 168 (MethodHash=11c83979) for method Microsoft.FSharp.Core.LanguagePrimitives+HashCompare:GenericComparisonObjArrayWithComparer(Microsoft.FSharp.Core.LanguagePrimitives+HashCompare+GenericComparer,System.Object[],System.Object[]):int
+; Total bytes of code 163, prolog size 16, PerfScore 95.55, instruction count 67, allocated bytes for code 163 (MethodHash=11c83979) for method Microsoft.FSharp.Core.LanguagePrimitives+HashCompare:GenericComparisonObjArrayWithComparer(Microsoft.FSharp.Core.LanguagePrimitives+HashCompare+GenericComparer,System.Object[],System.Object[]):int
 ; ============================================================
  ```
</details>

**Acceptance Criteria**
- [ ] IL testing scenarios
- [ ] Cleanup