### PR TITLE
Beef up `WithoutFunctionPointerType`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -424,14 +424,23 @@ namespace ILCompiler
         // CoreCLR compat - referring to function pointer types handled as IntPtr. No MethodTable for function pointers for now.
         private static TypeDesc WithoutFunctionPointerType(TypeDesc type)
         {
+            TypeDesc newParamType = null;
+            if (type.IsParameterizedType)
+            {
+                TypeDesc paramType = ((ParameterizedType)type).ParameterType;
+                newParamType = WithoutFunctionPointerType(paramType);
+                if (newParamType == paramType)
+                    return type;
+            }
+
             switch (type.Category)
             {
                 case TypeFlags.Array:
-                    return WithoutFunctionPointerType(((ParameterizedType)type).ParameterType).MakeArrayType(((ArrayType)type).Rank);
+                    return newParamType.MakeArrayType(((ArrayType)type).Rank);
                 case TypeFlags.SzArray:
-                    return WithoutFunctionPointerType(((ParameterizedType)type).ParameterType).MakeArrayType();
+                    return newParamType.MakeArrayType();
                 case TypeFlags.Pointer:
-                    return WithoutFunctionPointerType(((ParameterizedType)type).ParameterType).MakePointerType();
+                    return newParamType.MakePointerType();
                 case TypeFlags.FunctionPointer:
                     return type.Context.GetWellKnownType(WellKnownType.IntPtr);
                 default:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -423,7 +423,43 @@ namespace ILCompiler
 
         // CoreCLR compat - referring to function pointer types handled as IntPtr. No MethodTable for function pointers for now.
         private static TypeDesc WithoutFunctionPointerType(TypeDesc type)
-            => type.IsFunctionPointer ? type.Context.GetWellKnownType(WellKnownType.IntPtr) : type;
+        {
+            switch (type.Category)
+            {
+                case TypeFlags.Array:
+                    return WithoutFunctionPointerType(((ParameterizedType)type).ParameterType).MakeArrayType(((ArrayType)type).Rank);
+                case TypeFlags.SzArray:
+                    return WithoutFunctionPointerType(((ParameterizedType)type).ParameterType).MakeArrayType();
+                case TypeFlags.Pointer:
+                    return WithoutFunctionPointerType(((ParameterizedType)type).ParameterType).MakePointerType();
+                case TypeFlags.FunctionPointer:
+                    return type.Context.GetWellKnownType(WellKnownType.IntPtr);
+                default:
+                    TypeDesc typeDef = type.GetTypeDefinition();
+                    if (type != typeDef)
+                    {
+                        TypeDesc[] newInst = null;
+                        for (int i = 0; i < type.Instantiation.Length; i++)
+                        {
+                            TypeDesc arg = type.Instantiation[i];
+                            TypeDesc newArg = WithoutFunctionPointerType(arg);
+                            if (arg != newArg || newInst != null)
+                            {
+                                if (newInst == null)
+                                {
+                                    newInst = new TypeDesc[type.Instantiation.Length];
+                                    for (int j = 0; j < i; i++)
+                                        newInst[j] = type.Instantiation[j];
+                                }
+                                newInst[i] = newArg;
+                            }
+                        }
+                        if (newInst != null)
+                            return ((MetadataType)typeDef).MakeInstantiatedType(newInst);
+                    }
+                    return type;
+            }
+        }
 
         public bool IsFatPointerCandidate(MethodDesc containingMethod, MethodSignature signature)
         {


### PR DESCRIPTION
Fixes #81117

We don't have a `MethodTable` shape for function pointer types because how they should look like hasn't been defined until .NET 8.

Beef up the CoreCLR compat shim. We'll not be 100% compatible with this because `typeof(Tuple<delegate*<void>[]>)` doesn't actually load as `typeof(Tuple<IntPtr[]>)`, but this'll do until #71883.

Cc @dotnet/ilc-contrib 