### PR TITLE
Fix PAL exception SXS test

### DIFF
--- a/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
+++ b/src/coreclr/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
@@ -30,9 +30,8 @@ extern "C" int InitializeDllTest2();
 extern "C" int DllTest1();
 extern "C" int DllTest2();
 
-bool bSignal = false;
-bool bCatch = false;
-bool bHandler = false;
+volatile bool bSignal = false;
+volatile bool bHandler = false;
 
 void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
 {


### PR DESCRIPTION
The test was failing in the outerloop CI testing because of a bug in the test. One global variable that was modified by the main and checked by the SIGSEGV handler was not marked as volatile.

Close #81113