### PR TITLE
Fix x86 clrgc loading

### DIFF
--- a/docs/design/features/standalone-gc-loading.md
+++ b/docs/design/features/standalone-gc-loading.md
@@ -110,7 +110,7 @@ struct VersionInfo {
   const char* Name;
 };
 
-extern "C" void GC_VersionInfo(
+extern "C" void __cdecl GC_VersionInfo(
   /* Out */ VersionInfo*
 );
 ```
@@ -142,7 +142,7 @@ Once the EE has verified that the version of the candidate GC is valid, it then 
 GC. It does so by loading (via `GetProcAddress`) and executing a function with this signature:
 
 ```c++
-extern "C" HRESULT GC_Initialize(
+extern "C" HRESULT __cdecl GC_Initialize(
   /* In  */ IGCToCLR*,
   /* Out */ IGCHeap**.
   /* Out */ IGCHandleManager**,

--- a/docs/design/features/standalone-gc-loading.md
+++ b/docs/design/features/standalone-gc-loading.md
@@ -142,7 +142,7 @@ Once the EE has verified that the version of the candidate GC is valid, it then 
 GC. It does so by loading (via `GetProcAddress`) and executing a function with this signature:
 
 ```c++
-extern "C" HRESULT __cdecl GC_Initialize(
+extern "C" HRESULT LOCALGC_CALLCONV GC_Initialize(
   /* In  */ IGCToCLR*,
   /* Out */ IGCHeap**.
   /* Out */ IGCHandleManager**,

--- a/docs/design/features/standalone-gc-loading.md
+++ b/docs/design/features/standalone-gc-loading.md
@@ -110,7 +110,7 @@ struct VersionInfo {
   const char* Name;
 };
 
-extern "C" void __cdecl GC_VersionInfo(
+extern "C" void LOCALGC_CALLCONV GC_VersionInfo(
   /* Out */ VersionInfo*
 );
 ```

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -1061,11 +1061,17 @@ struct VersionInfo {
     const char* Name;
 };
 
-typedef void (*GC_VersionInfoFunction)(
+#ifdef TARGET_X86
+#define LOCALGC_CALLCONV __cdecl
+#else
+#define LOCALGC_CALLCONV
+#endif
+
+typedef void (LOCALGC_CALLCONV *GC_VersionInfoFunction)(
     /* Out */ VersionInfo*
 );
 
-typedef HRESULT (*GC_InitializeFunction)(
+typedef HRESULT (LOCALGC_CALLCONV *GC_InitializeFunction)(
     /* In  */ IGCToCLR*,
     /* Out */ IGCHeap**,
     /* Out */ IGCHandleManager**,

--- a/src/coreclr/gc/gcload.cpp
+++ b/src/coreclr/gc/gcload.cpp
@@ -42,7 +42,7 @@ namespace SVR
 extern void PopulateHandleTableDacVars(GcDacVars* dacVars);
 
 GC_EXPORT
-void
+void LOCALGC_CALLCONV
 GC_VersionInfo(/* InOut */ VersionInfo* info)
 {
 #ifdef BUILD_AS_STANDALONE
@@ -59,7 +59,7 @@ GC_VersionInfo(/* InOut */ VersionInfo* info)
 }
 
 GC_EXPORT
-HRESULT
+HRESULT LOCALGC_CALLCONV
 GC_Initialize(
     /* In  */ IGCToCLR* clrToGC,
     /* Out */ IGCHeap** gcHeap,

--- a/src/coreclr/gc/sample/GCSample.cpp
+++ b/src/coreclr/gc/sample/GCSample.cpp
@@ -50,7 +50,7 @@
 #ifdef TARGET_X86
 #define LOCALGC_CALLCONV __cdecl
 #else
-#define CALLCONV
+#define LOCALGC_CALLCONV
 #endif
 
 //

--- a/src/coreclr/gc/sample/GCSample.cpp
+++ b/src/coreclr/gc/sample/GCSample.cpp
@@ -47,6 +47,12 @@
 
 #include "gcdesc.h"
 
+#ifdef TARGET_X86
+#define CALLCONV __cdecl
+#else
+#define CALLCONV
+#endif
+
 //
 // The fast paths for object allocation and write barriers is performance critical. They are often
 // hand written in assembly code, etc.
@@ -106,9 +112,9 @@ void WriteBarrier(Object ** dst, Object * ref)
     ErectWriteBarrier(dst, ref);
 }
 
-extern "C" HRESULT GC_Initialize(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars);
+extern "C" HRESULT CALLCONV GC_Initialize(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars);
 
-int __cdecl main(int argc, char* argv[])
+int CALLCONV main(int argc, char* argv[])
 {
     //
     // Initialize system info

--- a/src/coreclr/gc/sample/GCSample.cpp
+++ b/src/coreclr/gc/sample/GCSample.cpp
@@ -48,7 +48,7 @@
 #include "gcdesc.h"
 
 #ifdef TARGET_X86
-#define CALLCONV __cdecl
+#define LOCALGC_CALLCONV __cdecl
 #else
 #define CALLCONV
 #endif

--- a/src/coreclr/gc/sample/GCSample.cpp
+++ b/src/coreclr/gc/sample/GCSample.cpp
@@ -114,7 +114,7 @@ void WriteBarrier(Object ** dst, Object * ref)
 
 extern "C" HRESULT LOCALGC_CALLCONV GC_Initialize(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars);
 
-int CALLCONV main(int argc, char* argv[])
+int __cdecl main(int argc, char* argv[])
 {
     //
     // Initialize system info

--- a/src/coreclr/gc/sample/GCSample.cpp
+++ b/src/coreclr/gc/sample/GCSample.cpp
@@ -112,7 +112,7 @@ void WriteBarrier(Object ** dst, Object * ref)
     ErectWriteBarrier(dst, ref);
 }
 
-extern "C" HRESULT CALLCONV GC_Initialize(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars);
+extern "C" HRESULT LOCALGC_CALLCONV GC_Initialize(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars);
 
 int CALLCONV main(int argc, char* argv[])
 {

--- a/src/coreclr/vm/gcheaputilities.cpp
+++ b/src/coreclr/vm/gcheaputilities.cpp
@@ -66,8 +66,8 @@ bool GCHeapUtilities::s_useThreadAllocationContexts;
 
 // GC entrypoints for the linked-in GC. These symbols are invoked
 // directly if we are not using a standalone GC.
-extern "C" void GC_VersionInfo(/* Out */ VersionInfo* info);
-extern "C" HRESULT GC_Initialize(
+extern "C" void LOCALGC_CALLCONV GC_VersionInfo(/* Out */ VersionInfo* info);
+extern "C" HRESULT LOCALGC_CALLCONV GC_Initialize(
     /* In  */ IGCToCLR* clrToGC,
     /* Out */ IGCHeap** gcHeap,
     /* Out */ IGCHandleManager** gcHandleManager,


### PR DESCRIPTION
The loading of the `clrgc.dll` is currently broken because the `GetProcAddress` call failed here.

https://github.com/dotnet/runtime/blob/daeb683623f4539711b851cbc49b5b58a79ca0bf/src/coreclr/vm/gcheaputilities.cpp#L212

The call failed because the function name is mangled, and using the `__cdecl` calling convention fixed it.