### PR TITLE
Improve error for missing Python

### DIFF
--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -61,6 +61,7 @@ exit /b 1
 if "%__VCBuildArch%"=="" exit /b 0
 
 :: Set the environment for the native build
+if not exist "%VCINSTALLDIR%Auxiliary\Build\vcvarsall.bat" goto :VSMissing
 call "%VCINSTALLDIR%Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
 if not "%ErrorLevel%"=="0" exit /b 1
 

--- a/eng/python.targets
+++ b/eng/python.targets
@@ -12,9 +12,6 @@
           ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PYTHON" />
     </Exec>
-    <PropertyGroup>
-      <PYTHON>$(PYTHON)</PYTHON>
-    </PropertyGroup>
   </Target>
   <Target Name="_FindPythonUnix"
           Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '$(PYTHON)' == ''"
@@ -26,9 +23,6 @@
           ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PYTHON" />
     </Exec>
-    <PropertyGroup>
-      <PYTHON>$(PYTHON)</PYTHON>
-    </PropertyGroup>
   </Target>
   <Target Name="FindPython" DependsOnTargets="_FindPythonWindows;_FindPythonUnix">
       <Error Condition="'$(PYTHON)' == ''"

--- a/eng/python.targets
+++ b/eng/python.targets
@@ -8,7 +8,7 @@
     <Exec Command="py -3 $(_PythonLocationScript) 2&gt; nul || python3 $(_PythonLocationScript) 2&gt; nul || python $(_PythonLocationScript) 2&gt; nul"
           StandardOutputImportance="Low"
           EchoOff="true"
-          IgnoreExitCode="true"
+          ContinueOnError="ErrorAndContinue"
           ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PYTHON" />
     </Exec>
@@ -22,7 +22,7 @@
     <Exec Command="command -v python3 || command -v python || command -v py"
           StandardOutputImportance="Low"
           EchoOff="true"
-          IgnoreExitCode="true"
+          ContinueOnError="ErrorAndContinue"
           ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PYTHON" />
     </Exec>

--- a/eng/python.targets
+++ b/eng/python.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="FindPythonWindows"
+  <Target Name="_FindPythonWindows"
           Condition="$([MSBuild]::IsOSPlatform(Windows)) and '$(PYTHON)' == ''"
           Returns="$(PYTHON)">
     <PropertyGroup>
@@ -8,25 +8,30 @@
     <Exec Command="py -3 $(_PythonLocationScript) 2&gt; nul || python3 $(_PythonLocationScript) 2&gt; nul || python $(_PythonLocationScript) 2&gt; nul"
           StandardOutputImportance="Low"
           EchoOff="true"
+          IgnoreExitCode="true"
           ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PYTHON" />
     </Exec>
     <PropertyGroup>
-      <PYTHON>"$(PYTHON)"</PYTHON>
+      <PYTHON>$(PYTHON)</PYTHON>
     </PropertyGroup>
   </Target>
-  <Target Name="FindPythonUnix"
+  <Target Name="_FindPythonUnix"
           Condition="!$([MSBuild]::IsOSPlatform(Windows)) and '$(PYTHON)' == ''"
           Returns="$(PYTHON)">
     <Exec Command="command -v python3 || command -v python || command -v py"
           StandardOutputImportance="Low"
           EchoOff="true"
+          IgnoreExitCode="true"
           ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PYTHON" />
     </Exec>
     <PropertyGroup>
-      <PYTHON>"$(PYTHON)"</PYTHON>
+      <PYTHON>$(PYTHON)</PYTHON>
     </PropertyGroup>
   </Target>
-  <Target Name="FindPython" DependsOnTargets="FindPythonWindows;FindPythonUnix" />
+  <Target Name="FindPython" DependsOnTargets="_FindPythonWindows;_FindPythonUnix">
+      <Error Condition="'$(PYTHON)' == ''"
+             Text="Python not found. Please add Python 3 to your path and try again."/>
+  </Target>
 </Project>

--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -337,7 +337,7 @@
 
     </PropertyGroup>
 
-    <Exec Command="$(PYTHON) -B $(_PythonWarningParameter) &quot;@(EventingGenerationScript)&quot; --man &quot;@(EventManifestFile)&quot; --intermediate &quot;$(_EventingSourceFileDirectory)&quot;" />
+    <Exec Command="&quot;$(PYTHON)&quot; -B $(_PythonWarningParameter) &quot;@(EventingGenerationScript)&quot; --man &quot;@(EventManifestFile)&quot; --intermediate &quot;$(_EventingSourceFileDirectory)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="@(EventingSourceFile)" />

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -341,7 +341,7 @@
       <_EventingSourceFileDirectory Condition="HasTrailingSlash('$(_EventingSourceFileDirectory)')">$(_EventingSourceFileDirectory.TrimEnd('\'))</_EventingSourceFileDirectory>
     </PropertyGroup>
 
-    <Exec Command="$(PYTHON) -B $(_PythonWarningParameter) &quot;@(EventingGenerationScript)&quot; --man &quot;@(EventManifestFile)&quot; --intermediate &quot;$(_EventingSourceFileDirectory)&quot; --runtimeflavor mono" />
+    <Exec Command="&quot;$(PYTHON)&quot; -B $(_PythonWarningParameter) &quot;@(EventingGenerationScript)&quot; --man &quot;@(EventManifestFile)&quot; --intermediate &quot;$(_EventingSourceFileDirectory)&quot; --runtimeflavor mono" />
 
     <ItemGroup>
       <FileWrites Include="@(EventingSourceFile)" />


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/59724

1. Remove quotes from $(PYTHON) that were defeating conditions checking for an empty value, move to point of use.
2. Add error message for missing Python.
3. Also add error for missing C++ components at a location I encountered.

Tested clr and mono on Windows and Linux with and without Python.
Tested clr with Windows before and after adding missing C++ bits.