### PR TITLE
Fix nullability on `IDesignerSerializationProvider.GetSerializer`

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -2203,7 +2203,7 @@ namespace System.ComponentModel.Design.Serialization
     }
     public partial interface IDesignerSerializationProvider
     {
-        object? GetSerializer(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, object currentSerializer, System.Type objectType, System.Type serializerType);
+        object? GetSerializer(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, object? currentSerializer, System.Type? objectType, System.Type serializerType);
     }
     public partial interface IDesignerSerializationService
     {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/IDesignerSerializationProvider.cs
@@ -27,6 +27,6 @@ namespace System.ComponentModel.Design.Serialization
         /// either return it or return null to prevent an infinite
         /// loop.
         /// </summary>
-        object? GetSerializer(IDesignerSerializationManager manager, object currentSerializer, Type objectType, Type serializerType);
+        object? GetSerializer(IDesignerSerializationManager manager, object? currentSerializer, Type? objectType, Type serializerType);
     }
 }


### PR DESCRIPTION
Related to ongoing work to null annotate the winforms codebase.

- https://github.com/dotnet/winforms/pull/8353
- https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.design.serialization.idesignerserializationprovider.getserializer?view=net-7.0

> The annotations for IDesignerSerializationProvider.GetSerializer() need to be updated to reflect nullability for params currentSerializer and objectType as these parameters should allow null.

https://github.com/dotnet/winforms/pull/8353#discussion_r1087363489