### PR TITLE
JIT: Avoid xchg for resolution

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7377,9 +7377,9 @@ void LinearScan::insertSwap(
 //    fromBlock              - The "from" block on the edge being resolved.
 //    toBlock                - The "to" block on the edge. Can be null for shared critical edge resolution.
 //    type                   - The type of register required
-//    terminatorConsumedRegs - Registers consumed by 'fromBlock's terminating node.
 //    sharedCriticalLiveSet  - The set of live vars that require shared critical resolution. Only used when toBlock is
 //                             nullptr.
+//    terminatorConsumedRegs - Registers consumed by 'fromBlock's terminating node.
 //
 // Return Value:
 //    Returns a register that is free on the given edge, or REG_NA if none is available.
@@ -7392,8 +7392,8 @@ void LinearScan::insertSwap(
 regNumber LinearScan::getTempRegForResolution(BasicBlock*      fromBlock,
                                               BasicBlock*      toBlock,
                                               var_types        type,
-                                              regMaskTP        terminatorConsumedRegs,
-                                              VARSET_VALARG_TP sharedCriticalLiveSet)
+                                              VARSET_VALARG_TP sharedCriticalLiveSet,
+                                              regMaskTP        terminatorConsumedRegs)
 {
     // TODO-Throughput: This would be much more efficient if we add RegToVarMaps instead of VarToRegMaps
     // and they would be more space-efficient as well.
@@ -8173,7 +8173,7 @@ void LinearScan::resolveEdges()
 //    resolveType            - the type of resolution to be performed
 //    liveSet                - the set of tracked lclVar indices which may require resolution
 //    terminatorConsumedRegs - the registers consumed by the terminator node.
-//                             These registers will be used after any resolution added to 'fromBlock'.
+//                             These registers will be used after any resolution added at the end of the 'fromBlock'.
 //
 // Return Value:
 //    None.
@@ -8240,7 +8240,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
     // TODO-Throughput: It would be better to determine the tempRegs on demand, but the code below
     // modifies the varToRegMaps so we don't have all the correct registers at the time
     // we need to get the tempReg.
-    regNumber tempRegInt = getTempRegForResolution(fromBlock, toBlock, TYP_INT, terminatorConsumedRegs, liveSet);
+    regNumber tempRegInt = getTempRegForResolution(fromBlock, toBlock, TYP_INT, liveSet, terminatorConsumedRegs);
     regNumber tempRegFlt = REG_NA;
 #ifdef TARGET_ARM
     regNumber tempRegDbl = REG_NA;
@@ -8249,7 +8249,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
     {
 #ifdef TARGET_ARM
         // Try to reserve a double register for TYP_DOUBLE and use it for TYP_FLOAT too if available.
-        tempRegDbl = getTempRegForResolution(fromBlock, toBlock, TYP_DOUBLE, terminatorConsumedRegs, liveSet);
+        tempRegDbl = getTempRegForResolution(fromBlock, toBlock, TYP_DOUBLE, liveSet, terminatorConsumedRegs);
         if (tempRegDbl != REG_NA)
         {
             tempRegFlt = tempRegDbl;
@@ -8257,7 +8257,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
         else
 #endif // TARGET_ARM
         {
-            tempRegFlt = getTempRegForResolution(fromBlock, toBlock, TYP_FLOAT, terminatorConsumedRegs, liveSet);
+            tempRegFlt = getTempRegForResolution(fromBlock, toBlock, TYP_FLOAT, liveSet, terminatorConsumedRegs);
         }
     }
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7374,9 +7374,11 @@ void LinearScan::insertSwap(
 // getTempRegForResolution: Get a free register to use for resolution code.
 //
 // Arguments:
-//    fromBlock - The "from" block on the edge being resolved.
-//    toBlock   - The "to" block on the edge
-//    type      - the type of register required
+//    fromBlock             - The "from" block on the edge being resolved.
+//    toBlock               - The "to" block on the edge. Can be null for shared critical edge resolution.
+//    type                  - the type of register required
+//    sharedCriticalLiveSet - The set of live vars that require shared critical resolution. Only used when toBlock is
+//    nullptr.
 //
 // Return Value:
 //    Returns a register that is free on the given edge, or REG_NA if none is available.
@@ -7475,6 +7477,7 @@ regNumber LinearScan::getTempRegForResolution(BasicBlock*      fromBlock,
     }
     else
     {
+        // Prefer a callee-trashed register if possible to prevent new prolog/epilog saves/restores.
         if ((freeRegs & RBM_CALLEE_TRASH) != 0)
         {
             freeRegs &= RBM_CALLEE_TRASH;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -8249,7 +8249,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
     {
 #ifdef TARGET_ARM
         // Try to reserve a double register for TYP_DOUBLE and use it for TYP_FLOAT too if available.
-        tempRegDbl = getTempRegForResolution(fromBlock, toBlock, TYP_DOUBLE, liveSet);
+        tempRegDbl = getTempRegForResolution(fromBlock, toBlock, TYP_DOUBLE, terminatorConsumedRegs, liveSet);
         if (tempRegDbl != REG_NA)
         {
             tempRegFlt = tempRegDbl;

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7434,7 +7434,7 @@ regNumber LinearScan::getTempRegForResolution(BasicBlock*      fromBlock,
         assert(fromReg != REG_NA);
         if (fromReg != REG_STK)
         {
-            freeRegs &= ~genRegMask(fromReg, getIntervalForLocalVar(varIndex)->registerType);
+            freeRegs &= ~genRegMask(fromReg ARM_ARG(getIntervalForLocalVar(varIndex)->registerType));
         }
 
         if (toBlock != nullptr)
@@ -7443,7 +7443,7 @@ regNumber LinearScan::getTempRegForResolution(BasicBlock*      fromBlock,
             assert(toReg != REG_NA);
             if (toReg != REG_STK)
             {
-                freeRegs &= ~genRegMask(toReg, getIntervalForLocalVar(varIndex)->registerType);
+                freeRegs &= ~genRegMask(toReg ARM_ARG(getIntervalForLocalVar(varIndex)->registerType));
             }
         }
     }
@@ -7462,7 +7462,7 @@ regNumber LinearScan::getTempRegForResolution(BasicBlock*      fromBlock,
             assert(reg != REG_NA);
             if (reg != REG_STK)
             {
-                freeRegs &= ~genRegMask(reg, getIntervalForLocalVar(varIndex)->registerType);
+                freeRegs &= ~genRegMask(reg ARM_ARG(getIntervalForLocalVar(varIndex)->registerType));
             }
         }
     }

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1359,8 +1359,8 @@ private:
     regNumber getTempRegForResolution(BasicBlock*      fromBlock,
                                       BasicBlock*      toBlock,
                                       var_types        type,
-                                      regMaskTP        terminatorConsumedRegs,
-                                      VARSET_VALARG_TP sharedCriticalLiveSet);
+                                      VARSET_VALARG_TP sharedCriticalLiveSet,
+                                      regMaskTP        terminatorConsumedRegs);
 
 #ifdef DEBUG
     void dumpVarToRegMap(VarToRegMap map);

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -706,7 +706,11 @@ public:
 
     void handleOutgoingCriticalEdges(BasicBlock* block);
 
-    void resolveEdge(BasicBlock* fromBlock, BasicBlock* toBlock, ResolveType resolveType, VARSET_VALARG_TP liveSet);
+    void resolveEdge(BasicBlock*      fromBlock,
+                     BasicBlock*      toBlock,
+                     ResolveType      resolveType,
+                     VARSET_VALARG_TP liveSet,
+                     regMaskTP        terminatorConsumedRegs);
 
     void resolveEdges();
 
@@ -1355,6 +1359,7 @@ private:
     regNumber getTempRegForResolution(BasicBlock*      fromBlock,
                                       BasicBlock*      toBlock,
                                       var_types        type,
+                                      regMaskTP        terminatorConsumedRegs,
                                       VARSET_VALARG_TP sharedCriticalLiveSet);
 
 #ifdef DEBUG

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1352,7 +1352,10 @@ private:
     // the block)
     VarToRegMap setInVarToRegMap(unsigned int bbNum, VarToRegMap srcVarToRegMap);
 
-    regNumber getTempRegForResolution(BasicBlock* fromBlock, BasicBlock* toBlock, var_types type);
+    regNumber getTempRegForResolution(BasicBlock*      fromBlock,
+                                      BasicBlock*      toBlock,
+                                      var_types        type,
+                                      VARSET_VALARG_TP sharedCriticalLiveSet);
 
 #ifdef DEBUG
     void dumpVarToRegMap(VarToRegMap map);


### PR DESCRIPTION
LSRA today uses xchg for reg-reg resolution when there are cycles in the resolution graph. Benchmarks show that xchg is handled much less efficiently by Intel CPUs than using a few movs with a temporary register. This PR enables using temporary registers for this kind of resolution on xarch (it was already enabled for non-xarch architectures). xchg is still used on xarch if no temporary register is available.

Additionally this PR adds support for getting a temporary register even for shared critical edges. Before this change we would spill on non-xarch for this case.

Finally, we now try to prefer a non callee saved temporary register so that we don't need to save/restore it in prolog/epilog.

This mostly fixes the string hashcode regressions from #80743.

Size-wise regressions are expected.