### PR TITLE
[mono][interp] Align simd types to 16 bytes by default

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -29,6 +29,7 @@
 #define MINT_STACK_SLOT_SIZE (sizeof (stackval))
 // This alignment provides us with straight forward support for Vector128
 #define MINT_STACK_ALIGNMENT (2 * MINT_STACK_SLOT_SIZE)
+#define MINT_SIMD_ALIGNMENT (MINT_STACK_ALIGNMENT)
 
 #define INTERP_STACK_SIZE (1024*1024)
 #define INTERP_REDZONE_SIZE (8*1024)

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -4276,7 +4276,7 @@ call:
 				reinit_frame (child_frame, frame, cmethod, locals + return_offset, locals + call_args_offset);
 				frame = child_frame;
 			}
-			g_assert (((gsize)frame->stack % MINT_STACK_ALIGNMENT) == 0);
+			g_assert_checked (((gsize)frame->stack % MINT_STACK_ALIGNMENT) == 0);
 
 			MonoException *call_ex;
 			if (method_entry (context, frame,

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3693,10 +3693,10 @@ static MONO_NEVER_INLINE int
 interp_newobj_slow_unopt (InterpFrame *frame, InterpMethod *cmethod, const guint16* ip, MonoError *error)
 {
 	char *locals = (char*)frame->stack;
-	int call_args_offset = ip [1];
-	guint16 param_size = ip [3];
-	guint16 ret_size = ip [4];
-	int start_call_args_offset = call_args_offset;
+	int return_offset = ip [1];
+	int start_param_offset = ip [2];
+	guint16 param_size = ip [4];
+	guint16 ret_size = ip [5];
 	gpointer this_ptr;
 
 	// Should only be called in unoptimized code. This opcode moves the params around
@@ -3707,19 +3707,19 @@ interp_newobj_slow_unopt (InterpFrame *frame, InterpMethod *cmethod, const guint
 
 	MonoClass *newobj_class = cmethod->method->klass;
 
-	call_args_offset = ALIGN_TO (call_args_offset + ret_size, MINT_STACK_ALIGNMENT);
+	int call_args_offset = ALIGN_TO (return_offset + ret_size, MINT_STACK_ALIGNMENT);
 	// We allocate space on the stack for return value and for this pointer, that is passed to ctor
 	if (param_size) {
 		int param_offset;
-		if (ip [5]) // Check if first arg is simd type, which requires realigning param area
+		if (ip [6]) // Check if first arg is simd type, which requires realigning param area
 			param_offset = ALIGN_TO (call_args_offset + MINT_STACK_SLOT_SIZE, MINT_SIMD_ALIGNMENT);
 		else
 			param_offset = call_args_offset + MINT_STACK_SLOT_SIZE;
-		memmove (locals + param_offset, locals + start_call_args_offset, param_size);
+		memmove (locals + param_offset, locals + start_param_offset, param_size);
 	}
 
 	if (is_vt) {
-		this_ptr = locals + start_call_args_offset;
+		this_ptr = locals + return_offset;
 		memset (this_ptr, 0, ret_size);
 	} else {
 		// FIXME push/pop LMF
@@ -3730,7 +3730,7 @@ interp_newobj_slow_unopt (InterpFrame *frame, InterpMethod *cmethod, const guint
 
 		this_ptr = mono_object_new_checked (newobj_class, error);
 		return_val_if_nok (error, -1);
-		LOCAL_VAR (start_call_args_offset, gpointer) = this_ptr; // return value
+		LOCAL_VAR (return_offset, gpointer) = this_ptr; // return value
 	}
 	LOCAL_VAR (call_args_offset, gpointer) = this_ptr;
 	return call_args_offset;
@@ -5779,16 +5779,16 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			goto call;
 		}
 		MINT_IN_CASE(MINT_NEWOBJ_SLOW_UNOPT) {
-			return_offset = ip [1];
-			cmethod = (InterpMethod*)frame->imethod->data_items [ip [2]];
+			cmethod = (InterpMethod*)frame->imethod->data_items [ip [3]];
 			int offset = interp_newobj_slow_unopt (frame, cmethod, ip, error);
 			if (offset == -1) {
 				MonoException *exc = interp_error_convert_to_exception (frame, error, ip);
 				g_assert (exc);
 				THROW_EX (exc, ip);
 			}
+			return_offset = 0; // unused, ctor has void return
 			call_args_offset = offset;
-			ip += 6;
+			ip += 7;
 			goto call;
 		}
 		MINT_IN_CASE(MINT_INTRINS_SPAN_CTOR) {

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -354,7 +354,7 @@ OPDEF(MINT_JMP, "jmp", 2, 0, 0, MintOpMethodToken)
 
 OPDEF(MINT_ENDFILTER, "endfilter", 2, 0, 1, MintOpNoArgs)
 
-OPDEF(MINT_NEWOBJ_SLOW_UNOPT, "newobj_slow_unopt", 5, 1, 0, MintOpMethodToken)
+OPDEF(MINT_NEWOBJ_SLOW_UNOPT, "newobj_slow_unopt", 6, 1, 0, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_STRING_UNOPT, "newobj_string_unopt", 4, 1, 0, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_SLOW, "newobj_slow", 4, 1, 1, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_ARRAY, "newobj_array", 5, 1, 1, MintOpMethodToken)

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -354,7 +354,7 @@ OPDEF(MINT_JMP, "jmp", 2, 0, 0, MintOpMethodToken)
 
 OPDEF(MINT_ENDFILTER, "endfilter", 2, 0, 1, MintOpNoArgs)
 
-OPDEF(MINT_NEWOBJ_SLOW_UNOPT, "newobj_slow_unopt", 6, 1, 0, MintOpMethodToken)
+OPDEF(MINT_NEWOBJ_SLOW_UNOPT, "newobj_slow_unopt", 7, 1, 1, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_STRING_UNOPT, "newobj_string_unopt", 4, 1, 0, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_SLOW, "newobj_slow", 4, 1, 1, MintOpMethodToken)
 OPDEF(MINT_NEWOBJ_ARRAY, "newobj_array", 5, 1, 1, MintOpMethodToken)

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -490,15 +490,16 @@ create_interp_local_explicit (TransformData *td, MonoType *type, int size)
 			td->locals_capacity = 2;
 		td->locals = (InterpLocal*) g_realloc (td->locals, td->locals_capacity * sizeof (InterpLocal));
 	}
-	td->locals [td->locals_size].type = type;
-	td->locals [td->locals_size].mt = mint_type (type);
-	td->locals [td->locals_size].flags = 0;
-	td->locals [td->locals_size].indirects = 0;
-	td->locals [td->locals_size].offset = -1;
-	td->locals [td->locals_size].size = size;
-	td->locals [td->locals_size].live_start = -1;
-	td->locals [td->locals_size].bb_index = -1;
-	td->locals [td->locals_size].def = NULL;
+	InterpLocal *local = &td->locals [td->locals_size];
+	local->type = type;
+	local->mt = mint_type (type);
+	local->flags = 0;
+	local->indirects = 0;
+	local->offset = -1;
+	local->size = size;
+	local->live_start = -1;
+	local->bb_index = -1;
+	local->def = NULL;
 	td->locals_size++;
 	return td->locals_size - 1;
 
@@ -543,12 +544,13 @@ static void
 push_type_explicit (TransformData *td, int type, MonoClass *k, int type_size)
 {
 	ensure_stack (td, 1);
-	td->sp->type = GINT_TO_UINT8 (type);
-	td->sp->klass = k;
-	td->sp->flags = 0;
-	td->sp->offset = get_tos_offset (td);
-	td->sp->size = ALIGN_TO (type_size, MINT_STACK_SLOT_SIZE);
-	create_interp_stack_local (td, td->sp, type_size);
+	StackInfo *sp = td->sp;
+	sp->type = GINT_TO_UINT8 (type);
+	sp->klass = k;
+	sp->flags = 0;
+	sp->offset = get_tos_offset (td);
+	sp->size = ALIGN_TO (type_size, MINT_STACK_SLOT_SIZE);
+	create_interp_stack_local (td, sp, type_size);
 	td->sp++;
 }
 
@@ -557,11 +559,12 @@ push_var (TransformData *td, int var_index)
 {
 	InterpLocal *var = &td->locals [var_index];
 	ensure_stack (td, 1);
-	td->sp->type = GINT_TO_UINT8 (stack_type [var->mt]);
-	td->sp->klass = mono_class_from_mono_type_internal (var->type);
-	td->sp->flags = 0;
-	td->sp->local = var_index;
-	td->sp->size = ALIGN_TO (var->size, MINT_STACK_SLOT_SIZE);
+	StackInfo *sp = td->sp;
+	sp->type = GINT_TO_UINT8 (stack_type [var->mt]);
+	sp->klass = mono_class_from_mono_type_internal (var->type);
+	sp->flags = 0;
+	sp->local = var_index;
+	sp->size = ALIGN_TO (var->size, MINT_STACK_SLOT_SIZE);
 	td->sp++;
 }
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -586,16 +586,10 @@ push_var (TransformData *td, int var_index)
 	} while (0)
 
 static void
-set_type_and_local (TransformData *td, StackInfo *sp, MonoClass *klass, int type)
-{
-	SET_TYPE (sp, type, klass);
-	create_interp_stack_local (td, sp, MINT_STACK_SLOT_SIZE);
-}
-
-static void
 set_simple_type_and_local (TransformData *td, StackInfo *sp, int type)
 {
-	set_type_and_local (td, sp, NULL, type);
+	SET_SIMPLE_TYPE (sp, type);
+	create_interp_stack_local (td, sp, MINT_STACK_SLOT_SIZE);
 }
 
 static void

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6048,10 +6048,14 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			} else if (!td->optimized) {
 				int tos = get_tos_offset (td);
 				td->sp -= csignature->param_count;
-				int param_size = tos - get_tos_offset (td);
+				int param_offset = get_tos_offset (td);
+				int param_size = tos - param_offset;
 
 				td->cbb->contains_call_instruction = TRUE;
 				interp_add_ins (td, MINT_NEWOBJ_SLOW_UNOPT);
+				interp_ins_set_sreg (td->last_ins, MINT_CALL_ARGS_SREG);
+				init_last_ins_call (td);
+				td->last_ins->info.call_info->call_offset = param_offset;
 				td->last_ins->data [0] = get_data_item_index_imethod (td, mono_interp_get_imethod (m));
 				td->last_ins->data [1] = param_size;
 				if (csignature->param_count > 0) {

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -23,6 +23,8 @@
 
 #define INTERP_LOCAL_FLAG_UNKNOWN_USE 32
 #define INTERP_LOCAL_FLAG_LOCAL_ONLY 64
+// We use this flag to avoid addition of align field in InterpLocal, for now
+#define INTERP_LOCAL_FLAG_SIMD 128
 
 typedef struct _InterpInst InterpInst;
 typedef struct _InterpBasicBlock InterpBasicBlock;


### PR DESCRIPTION
All simd interp vars (args, IL locals and other allocated vars) are now aligned to 16 byte offsets, instead of the 8 byte default alignment.

We use the general `MonoClass->simd_type` for now, which encapsulates vectors of all sizes, to determine if we align them. This PR has no benefit by itself, it is just prerequisite for addition of intrisics for vectorized operations, and submitted by itself for independent testing purposes.