### PR TITLE
[Android] Fix SslStream IsMutuallyAuthenticated on Android API 21-27

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -1147,10 +1147,13 @@ bool AndroidCryptoNative_SSLStreamIsLocalCertificateUsed(SSLStream* sslStream)
     JNIEnv* env = GetJNIEnv();
 
     bool ret = false;
-    INIT_LOCALS(loc, localCertificates);
+    INIT_LOCALS(loc, sslSession, localCertificates);
 
     // X509Certificate[] localCertificates = sslSession.getLocalCertificates();
-    loc[localCertificates] = (*env)->CallObjectMethod(env, sslStream->sslSession, g_SSLSessionGetLocalCertificates);
+    loc[sslSession] = GetCurrentSslSession(env, sslStream);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+
+    loc[localCertificates] = (*env)->CallObjectMethod(env, loc[sslSession], g_SSLSessionGetLocalCertificates);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     ret = loc[localCertificates] != NULL;


### PR DESCRIPTION
Fixes a bug in the initial implementation in #79601. The current code works correctly on API 28-33 but it wasn't working correctly on older API levels which we still support.