### PR TITLE
[release/6.0] Use BOOL (vs. bool) in event pipe qcall signatures

### DIFF
--- a/src/coreclr/vm/eventpipeinternal.cpp
+++ b/src/coreclr/vm/eventpipeinternal.cpp
@@ -60,7 +60,7 @@ void QCALLTYPE EventPipeInternal::Disable(UINT64 sessionID)
     END_QCALL;
 }
 
-bool QCALLTYPE EventPipeInternal::GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo)
+BOOL QCALLTYPE EventPipeInternal::GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo)
 {
     QCALL_CONTRACT;
 
@@ -229,7 +229,7 @@ void QCALLTYPE EventPipeInternal::WriteEventData(
     END_QCALL;
 }
 
-bool QCALLTYPE EventPipeInternal::GetNextEvent(UINT64 sessionID, EventPipeEventInstanceData *pInstance)
+BOOL QCALLTYPE EventPipeInternal::GetNextEvent(UINT64 sessionID, EventPipeEventInstanceData *pInstance)
 {
     QCALL_CONTRACT;
 

--- a/src/coreclr/vm/eventpipeinternal.h
+++ b/src/coreclr/vm/eventpipeinternal.h
@@ -55,7 +55,7 @@ public:
     //!
     static void QCALLTYPE Disable(UINT64 sessionID);
 
-    static bool QCALLTYPE GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo);
+    static BOOL QCALLTYPE GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo);
 
     static INT_PTR QCALLTYPE CreateProvider(
         __in_z LPCWSTR providerName,
@@ -86,7 +86,7 @@ public:
         UINT32 eventDataCount,
         LPCGUID pActivityId, LPCGUID pRelatedActivityId);
 
-    static bool QCALLTYPE GetNextEvent(
+    static BOOL QCALLTYPE GetNextEvent(
         UINT64 sessionID,
         EventPipeEventInstanceData *pInstance);
 


### PR DESCRIPTION
Backport of #74389 to release/6.0
Fixes: #81181

There is an API signature mismatch (C++ `bool` vs. C `BOOL` , 1 vs. 4 byte) when exporting native event pipe helpers, which causes occasional nondeterministic crashes in apps.

## Customer Impact

Applications that use EventSource and published as SingleFile will randomly crash with AccessViolationException.
(the crash may happen in non-singlefile configuration as well, in theory, but was not observed)

## Testing
Manual validation of a repro scenario. (app crashes after a minute or so, no crash after the fix)
The same fix was ported to 7.0 a while ago and there is a lot of evidence that the crash no longer happens.

## Risk
Low. We are fixing obviously incorrect signatures. 
