### PR TITLE
Fix handling of load when only `DllImportSearchPath.AssemblyDirectory` is specified

### DIFF
--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -618,7 +618,7 @@ namespace
 #endif // TARGET_UNIX
 
     // Search for the library and variants of its name in probing directories.
-    NATIVE_LIBRARY_HANDLE LoadNativeLibraryBySearch(Assembly *callingAssembly,
+    NATIVE_LIBRARY_HANDLE LoadNativeLibraryBySearch(Assembly *callingAssembly, BOOL userSpecifiedSearchFlags,
                                                     BOOL searchAssemblyDirectory, DWORD dllImportSearchPathFlags,
                                                     LoadLibErrorTracker * pErrorTracker, LPCWSTR wszLibName)
     {
@@ -712,10 +712,18 @@ namespace
                 }
             }
 
-            hmod = LocalLoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, pErrorTracker);
-            if (hmod != NULL)
+            // Internally, search path flags and whether or not to search the assembly directory are
+            // tracked separately. However, on the API level, DllImportSearchPath represents them both.
+            // When a user specifies DllImportSearchPath.AssemblyDirectory, searchAssemblyDirectory is
+            // true, dllImportSearchPathFlags is 0, and the desired logic is to only search the assembly
+            // directory (handled above), so we avoid doing any additional load search in that case.
+            if (!userSpecifiedSearchFlags || !searchAssemblyDirectory || dllImportSearchPathFlags != 0)
             {
-                return hmod;
+                hmod = LocalLoadLibraryHelper(currLibNameVariation, dllImportSearchPathFlags, pErrorTracker);
+                if (hmod != NULL)
+                {
+                    return hmod;
+                }
             }
         }
 
@@ -728,11 +736,10 @@ namespace
 
         BOOL searchAssemblyDirectory;
         DWORD dllImportSearchPathFlags;
-
-        GetDllImportSearchPathFlags(pMD, &dllImportSearchPathFlags, &searchAssemblyDirectory);
+        BOOL userSpecifiedSearchFlags = GetDllImportSearchPathFlags(pMD, &dllImportSearchPathFlags, &searchAssemblyDirectory);
 
         Assembly *pAssembly = pMD->GetMethodTable()->GetAssembly();
-        return LoadNativeLibraryBySearch(pAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, pErrorTracker, wszLibName);
+        return LoadNativeLibraryBySearch(pAssembly, userSpecifiedSearchFlags, searchAssemblyDirectory, dllImportSearchPathFlags, pErrorTracker, wszLibName);
     }
 }
 
@@ -769,12 +776,12 @@ NATIVE_LIBRARY_HANDLE NativeLibrary::LoadLibraryByName(LPCWSTR libraryName, Asse
     }
     else
     {
-        GetDllImportSearchPathFlags(callingAssembly->GetModule(),
+        hasDllImportSearchFlags = GetDllImportSearchPathFlags(callingAssembly->GetModule(),
                                     &dllImportSearchPathFlags, &searchAssemblyDirectory);
     }
 
     LoadLibErrorTracker errorTracker;
-    hmod = LoadNativeLibraryBySearch(callingAssembly, searchAssemblyDirectory, dllImportSearchPathFlags, &errorTracker, libraryName);
+    hmod = LoadNativeLibraryBySearch(callingAssembly, hasDllImportSearchFlags, searchAssemblyDirectory, dllImportSearchPathFlags, &errorTracker, libraryName);
     if (hmod != nullptr)
         return hmod;
 

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class DllImportSearchPathsTest : IDisposable
+{
+    private static string Subdirectory => Path.Combine(AppContext.BaseDirectory, "subdirectory");
+
+    [Fact]
+    public void AssemblyDirectory_NotFound()
+    {
+        // Library should not be found in the assembly directory
+        Assert.Throws<DllNotFoundException>(() => NativeLibraryPInvoke.Sum(1, 2));
+
+        string currentDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = Subdirectory;
+
+            // Library should not be found in the assembly directory and should not fall back to the current directory
+            Assert.Throws<DllNotFoundException>(() => NativeLibraryPInvoke.Sum(1, 2));
+        }
+        finally
+        {
+            Environment.CurrentDirectory = currentDirectory;
+        }
+    }
+
+    [Fact]
+    public void AssemblyDirectory_Found()
+    {
+        // Library should be found in the assembly directory
+        var assembly = Assembly.LoadFile(Path.Combine(Subdirectory, $"{nameof(DllImportSearchPathsTest)}.dll"));
+        var type = assembly.GetType(nameof(NativeLibraryPInvoke));
+        var method = type.GetMethod(nameof(NativeLibraryPInvoke.Sum));
+
+        int sum = (int)method.Invoke(null, new object[] { 1, 2 });
+        Assert.Equal(3, sum);
+    }
+
+    public void Dispose() { }
+}
+
+public class NativeLibraryPInvoke
+{
+    public static int Sum(int a, int b)
+    {
+        return NativeSum(a, b);
+    }
+
+    [DllImport(NativeLibraryToLoad.Name)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+    static extern int NativeSum(int arg1, int arg2);
+}

--- a/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
+++ b/src/tests/Interop/DllImportSearchPaths/DllImportSearchPathsTest.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="*.cs" />
+    <Compile Include="../NativeLibrary/NativeLibraryToLoad/NativeLibraryToLoad.cs" />
+    <CMakeProjectReference Include="../NativeLibrary/NativeLibraryToLoad/CMakeLists.txt" />
+  </ItemGroup>
+
+  <Target Name="SetUpSubdirectory" AfterTargets="CopyNativeProjectBinaries">
+    <PropertyGroup>
+      <NativeLibrarySubdirectory>$(OutDir)/subdirectory</NativeLibrarySubdirectory>
+      <FileNameSuffix>-in-subdirectory</FileNameSuffix>
+    </PropertyGroup>
+    <ItemGroup>
+      <_FilesToCopy Include="$(OutDir)/$(TargetName).dll" />
+      <_FilesToMove Include="$(OutDir)/NativeLibrary.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_FilesToCopy)" DestinationFiles="@(_FilesToCopy -> '$(NativeLibrarySubdirectory)/%(Filename)%(Extension)')" />
+    <Move SourceFiles="@(_FilesToMove)" DestinationFiles="@(_FilesToMove -> '$(NativeLibrarySubdirectory)/%(Filename)%(Extension)')" />
+  </Target>
+</Project>

--- a/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
+++ b/src/tests/Interop/NativeLibrary/API/NativeLibraryTests.csproj
@@ -17,4 +17,16 @@
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
     <CMakeProjectReference Include="../NativeLibraryToLoad/CMakeLists.txt" />
   </ItemGroup>
+
+  <Target Name="SetUpSubdirectory" AfterTargets="CopyNativeProjectBinaries">
+    <PropertyGroup>
+      <NativeLibrarySubdirectory>$(OutDir)/subdirectory</NativeLibrarySubdirectory>
+      <FileNameSuffix>-in-subdirectory</FileNameSuffix>
+    </PropertyGroup>
+    <ItemGroup>
+      <AssembliesToCopy Include="$(OutDir)/NativeLibrary.*" />
+      <AssembliesToCopy Include="$(OutDir)/$(TargetName).dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(AssembliesToCopy)" DestinationFiles="@(AssembliesToCopy -> '$(NativeLibrarySubdirectory)/%(Filename)$(FileNameSuffix)%(Extension)')" />
+  </Target>
 </Project>


### PR DESCRIPTION
If only `DllImportSearchPath.AssemblyDirectory` is specified as the search paths for p/invokes via `DefaultDllImportSearchPaths` or calls to `NativeLibrary` APIs, we end up falling back to a load with search flags of 0 if the native library is not found in the assembly directory.

This change makes is so that we avoid that fallback if the search paths were explicitly specified to just the assembly directory. If they were not specified, we still want the fall back, since coreclr defaults to searching the assembly directory and also loading with flags=0.

NativeAOT also has problems with this scenario - I'm planning on dealing with that separately, as it has broader issues.

cc @GrabYourPitchforks 