### PR TITLE
JIT: Preference LIR edges away from killed registers

### DIFF
--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1097,6 +1097,7 @@ private:
 
     // Given some tree node add refpositions for all the registers this node kills
     bool buildKillPositionsForNode(GenTree* tree, LsraLocation currentLoc, regMaskTP killMask);
+    void updateIntervalPreferencesForKill(Interval* interval, regMaskTP killMask);
 
     regMaskTP allRegs(RegisterType rt);
     regMaskTP allByteRegs();


### PR DESCRIPTION
We already seem to be able to handle this via allocation heuristics in most cases, but this gets a few more.