### PR TITLE
Disable eventsourceerror test for Windows ARM32

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -503,6 +503,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/pinvokes_do/**">
             <Issue>https://github.com/dotnet/runtime/issues/66745</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
+            <Issue>https://github.com/dotnet/runtime/issues/81241</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows arm64 specific excludes -->


### PR DESCRIPTION
Temporarily disable `eventsourceerror` test for Windows ARM32, tracking issue #81241.