### PR TITLE
Fix special sweep issue for workstation

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -30629,6 +30629,13 @@ void gc_heap::plan_phase (int condemned_gen_number)
         gc_time_info[time_plan] = gc_time_info[time_sweep] - gc_time_info[time_plan];
     }
 #endif //FEATURE_EVENT_TRACE
+
+#ifdef USE_REGIONS
+    if (special_sweep_p)
+    {
+        should_compact = FALSE;
+    }
+#endif //!USE_REGIONS
 #endif //MULTIPLE_HEAPS
 
 #ifdef FEATURE_LOH_COMPACTION


### PR DESCRIPTION
We need to make sure that if `special_sweep_p` is true, then we must not perform compaction, this rule was missed for the workstation GC case, and this PR put that back in.

**Validation checklist:**

- [x] Validated against selected GCPerfSim scenarios.
- [x] Validated against selected Microbenchmark scenarios.
- [x] Validated against ASP.Net benchmarks scenarios.
- [x] Validated against ReliabilityFramework for WorkStation.

None of these validation tests find any crashes, and this change is not expected to have any performance differences.