### PR TITLE
Reduce the size of HttpRequestMessage and HttpRequestHeaders

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -15,13 +15,13 @@ namespace System.Net.Http.Headers
         private const int IfNoneMatchSlot = 5;
         private const int TransferEncodingSlot = 6;
         private const int UserAgentSlot = 7;
-        private const int NumCollectionsSlots = 8;
+        private const int ExpectSlot = 8;
+        private const int ProtocolSlot = 9;
+        private const int NumCollectionsSlots = 10;
 
-        private object[]? _specialCollectionsSlots;
+        private object?[]? _specialCollectionsSlots;
         private HttpGeneralHeaders? _generalHeaders;
-        private HttpHeaderValueCollection<NameValueWithParametersHeaderValue>? _expect;
         private bool _expectContinueSet;
-        private string? _protocol;
 
         #region Request Headers
 
@@ -164,11 +164,12 @@ namespace System.Net.Http.Headers
         /// <value>The value of the <see langword=":protocol" /> pseudo-header for an HTTP request.</value>
         public string? Protocol
         {
-            get => _protocol;
+            get => _specialCollectionsSlots is null ? null : (string?)_specialCollectionsSlots[ProtocolSlot];
             set
             {
                 CheckContainsNewLine(value);
-                _protocol = value;
+                _specialCollectionsSlots ??= new object[NumCollectionsSlots];
+                _specialCollectionsSlots[ProtocolSlot] = value;
             }
         }
 
@@ -197,7 +198,7 @@ namespace System.Net.Http.Headers
             GetSpecializedCollection(UserAgentSlot, static thisRef => new HttpHeaderValueCollection<ProductInfoHeaderValue>(KnownHeaders.UserAgent.Descriptor, thisRef));
 
         public HttpHeaderValueCollection<NameValueWithParametersHeaderValue> Expect =>
-            _expect ??= new HttpHeaderValueCollection<NameValueWithParametersHeaderValue>(KnownHeaders.Expect.Descriptor, this);
+            GetSpecializedCollection(ExpectSlot, static thisRef => new HttpHeaderValueCollection<NameValueWithParametersHeaderValue>(KnownHeaders.Expect.Descriptor, thisRef));
 
         #endregion
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Text;
@@ -171,7 +172,11 @@ namespace System.Net.Http
         private bool Disposed
         {
             get => (_sendStatus & MessageDisposed) != 0;
-            set => _sendStatus |= MessageDisposed;
+            set
+            {
+                Debug.Assert(value);
+                _sendStatus |= MessageDisposed;
+            }
         }
 
         internal bool IsExtendedConnectRequest => Method == HttpMethod.Connect && _headers?.Protocol != null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -17,6 +17,7 @@ namespace System.Net.Http
         private const int MessageNotYetSent = 0;
         private const int MessageAlreadySent = 1;
         private const int MessageIsRedirect = 2;
+        private const int MessageDisposed = 4;
 
         // Track whether the message has been sent.
         // The message shouldn't be sent again if this field is equal to MessageAlreadySent.
@@ -28,7 +29,6 @@ namespace System.Net.Http
         private Version _version;
         private HttpVersionPolicy _versionPolicy;
         private HttpContent? _content;
-        private bool _disposed;
         private HttpRequestOptions? _options;
 
         public Version Version
@@ -168,6 +168,12 @@ namespace System.Net.Http
 
         internal bool WasRedirected() => (_sendStatus & MessageIsRedirect) != 0;
 
+        private bool Disposed
+        {
+            get => (_sendStatus & MessageDisposed) != 0;
+            set => _sendStatus |= MessageDisposed;
+        }
+
         internal bool IsExtendedConnectRequest => Method == HttpMethod.Connect && _headers?.Protocol != null;
 
         #region IDisposable Members
@@ -176,9 +182,9 @@ namespace System.Net.Http
         {
             // The reason for this type to implement IDisposable is that it contains instances of types that implement
             // IDisposable (content).
-            if (disposing && !_disposed)
+            if (disposing && !Disposed)
             {
-                _disposed = true;
+                Disposed = true;
                 _content?.Dispose();
             }
         }
@@ -193,7 +199,7 @@ namespace System.Net.Http
 
         private void CheckDisposed()
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            ObjectDisposedException.ThrowIf(Disposed, this);
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1528,11 +1528,11 @@ namespace System.Net.Http
 
             if (request.HasHeaders)
             {
-                if (request.Headers.Protocol != null)
+                if (request.Headers.Protocol is string protocol)
                 {
                     WriteBytes(ProtocolLiteralHeaderBytes, ref headerBuffer);
                     Encoding? protocolEncoding = _pool.Settings._requestHeaderEncodingSelector?.Invoke(":protocol", request);
-                    WriteLiteralHeaderValue(request.Headers.Protocol, protocolEncoding, ref headerBuffer);
+                    WriteLiteralHeaderValue(protocol, protocolEncoding, ref headerBuffer);
                     headerListSize += HeaderField.RfcOverhead;
                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1043,8 +1043,8 @@ namespace System.Net.Http
                     // Use HTTP/3 if possible.
                     if (IsHttp3Supported() && // guard to enable trimming HTTP/3 support
                         _http3Enabled &&
-                        !request.IsExtendedConnectRequest &&
-                        (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)))
+                        (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)) &&
+                        !request.IsExtendedConnectRequest)
                     {
                         Debug.Assert(async);
                         response = await TrySendUsingHttp3Async(request, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Saves 8 bytes on `HttpRequestMessage` and 16 on `HttpRequestHeaders`.
This represents about ~1% of allocated bytes for a simple YARP request.