### PR TITLE
Avoid allocations in 'Transfer-Encoding: Chunked' check

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -81,14 +81,25 @@ namespace System.Net.Http.Headers
 
         internal static bool? GetTransferEncodingChunked(HttpHeaders parent, HttpGeneralHeaders? headers)
         {
-            if (parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked))
+            if (parent.TryGetHeaderValue(KnownHeaders.TransferEncoding.Descriptor, out object? value))
             {
-                return true;
+                // Fast-path for the very common case where "chunked" is the only value.
+                if (value is string stringValue && stringValue.Equals("chunked", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                if (parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked))
+                {
+                    return true;
+                }
             }
+
             if (headers != null && headers._transferEncodingChunkedSet)
             {
                 return false;
             }
+
             return null;
         }
 


### PR DESCRIPTION
Fixes #63052

Avoids 3 object allocations: `TransferCodingHeaderValue`, `HeaderStoreItemInfo`, and `"chunked"` (100 bytes total).
This is ~4 % of allocated bytes for a simple YARP request.

Before:
![image](https://user-images.githubusercontent.com/25307628/215001573-1b117b21-e9f6-4517-81ab-713a4081f5ae.png)

After:
![image](https://user-images.githubusercontent.com/25307628/215001609-5bd0c3d0-088b-499d-baac-2ea466788555.png)
