### PR TITLE
Change Nullability annotation on `ISelectionService.PrimarySelection`

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -1943,7 +1943,7 @@ namespace System.ComponentModel.Design
     }
     public partial interface ISelectionService
     {
-        object PrimarySelection { get; }
+        object? PrimarySelection { get; }
         int SelectionCount { get; }
         event System.EventHandler SelectionChanged;
         event System.EventHandler SelectionChanging;

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ISelectionService.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ISelectionService.cs
@@ -13,7 +13,7 @@ namespace System.ComponentModel.Design
         /// <summary>
         /// Gets the object that is currently the primary selection.
         /// </summary>
-        object PrimarySelection { get; }
+        object? PrimarySelection { get; }
 
         /// <summary>
         /// Gets the count of selected objects.


### PR DESCRIPTION
The docs do not say its nullable, but winforms implementation has it returning a null value when there isn't anything selected.

https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.design.iselectionservice.primaryselection?view=net-6.0

Related to ongoing work to null annotate the winforms codebase.

https://github.com/dotnet/winforms/issues/8342