### PR TITLE
Fix ReaderWriterLock when using it in recursive scenarios and multiple instances on the same thread

### DIFF
--- a/src/libraries/System.Threading/src/System/Threading/ReaderWriterLock.cs
+++ b/src/libraries/System.Threading/src/System/Threading/ReaderWriterLock.cs
@@ -1256,20 +1256,10 @@ namespace System.Threading
                 Debug.Assert(lockID != 0);
 
                 ThreadLocalLockEntry? headEntry = t_lockEntryHead;
-                if (headEntry != null)
+                if (headEntry != null && headEntry._lockID == lockID)
                 {
-                    if (headEntry._lockID == lockID)
-                    {
-                        VerifyNoNonemptyEntryInListAfter(lockID, headEntry);
-                        return headEntry;
-                    }
-
-                    if (headEntry.IsFree)
-                    {
-                        VerifyNoNonemptyEntryInListAfter(lockID, headEntry);
-                        headEntry._lockID = lockID;
-                        return headEntry;
-                    }
+                    VerifyNoNonemptyEntryInListAfter(lockID, headEntry);
+                    return headEntry;
                 }
 
                 return GetOrCreateCurrentSlow(lockID, headEntry);

--- a/src/libraries/System.Threading/tests/ReaderWriterLockTests.cs
+++ b/src/libraries/System.Threading/tests/ReaderWriterLockTests.cs
@@ -434,6 +434,25 @@ namespace System.Threading.Tests
         }
 
         [Fact]
+        public static void MultipleNestedReadersMiscellaneousTest()
+        {
+            var trwl1 = new TestReaderWriterLock();
+            var trwl2 = new TestReaderWriterLock();
+
+            trwl1.AcquireReaderLock();
+
+            trwl2.AcquireReaderLock();
+            trwl2.ReleaseReaderLock();
+
+            trwl1.AcquireReaderLock();
+            trwl1.ReleaseReaderLock();
+            trwl1.ReleaseReaderLock();
+
+            trwl1.Dispose();
+            trwl2.Dispose();
+        }
+
+        [Fact]
         public static void DowngradeQuirks_ChangedInDotNetCore()
         {
             var trwl = new TestReaderWriterLock();


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/38638

The entry corresponding to the `lockID` can be present in the list, even when the head entry is free