### PR TITLE
JIT: Support containing compares in GT_SELECT for xarch (i.e. start emitting cmov instructions)

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1532,9 +1532,11 @@ public:
     instruction genMapShiftInsToShiftByConstantIns(instruction ins, int shiftByValue);
 #endif // TARGET_XARCH
 
-#ifdef TARGET_ARM64
+#if defined(TARGET_ARM64)
     static insCflags InsCflagsForCcmp(GenCondition cond);
     static insCond JumpKindToInsCond(emitJumpKind condition);
+#elif defined(TARGET_XARCH)
+    static instruction JumpKindToCmov(emitJumpKind condition);
 #endif
 
 #ifndef TARGET_LOONGARCH64

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -1595,6 +1595,14 @@ void CodeGen::genConsumeRegs(GenTree* tree)
         {
             genConsumeAddress(tree);
         }
+#if defined(TARGET_XARCH) || defined(TARGET_ARM64)
+        else if (tree->OperIsCompare())
+        {
+            // Compares can be contained by SELECT/compare chains.
+            genConsumeRegs(tree->gtGetOp1());
+            genConsumeRegs(tree->gtGetOp2());
+        }
+#endif
 #ifdef TARGET_ARM64
         else if (tree->OperIs(GT_BFIZ))
         {
@@ -1610,10 +1618,9 @@ void CodeGen::genConsumeRegs(GenTree* tree)
             assert(cast->isContained());
             genConsumeAddress(cast->CastOp());
         }
-        else if (tree->OperIsCompare() || tree->OperIs(GT_AND))
+        else if (tree->OperIs(GT_AND))
         {
-            // Compares can be contained by a SELECT.
-            // ANDs and Cmp Compares may be contained in a chain.
+            // ANDs may be contained in a chain.
             genConsumeRegs(tree->gtGetOp1());
             genConsumeRegs(tree->gtGetOp2());
         }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1398,7 +1398,8 @@ void CodeGen::genCodeForSelect(GenTreeOp* select)
         cc = GenCondition::Reverse(cc);
     }
 
-    // The next conditions are constraints from the instruction's side. Lowering ensures that the constraints are satisfies
+    // The next conditions are constraints from the instruction's side. Lowering ensures that the constraints are
+    // satisfies
     // - For contained constants, they do not end up in the cmov
     // - For contained indirs, they do not end up in the cmov if we need multiple cmovs for the comparison
     if (trueVal->isContained() && trueVal->IsCnsIntOrI())
@@ -1433,9 +1434,7 @@ void CodeGen::genCodeForSelect(GenTreeOp* select)
     // registers used by the comparre then zero it out with xor before the
     // test.
     bool genFalse = true;
-    if (select->OperIs(GT_SELECT) &&
-        falseVal->isContained() &&
-        falseVal->IsIntegralConst(0) &&
+    if (select->OperIs(GT_SELECT) && falseVal->isContained() && falseVal->IsIntegralConst(0) &&
         ((select->AsConditional()->gtCond->gtGetContainedRegMask() & (genRegMask(dstReg))) == 0))
     {
         instGen_Set_Reg_To_Zero(emitTypeSize(select), dstReg);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1369,7 +1369,7 @@ void CodeGen::genCodeForSelect(GenTreeOp* select)
     GenTree* trueVal  = select->gtOp1;
     GenTree* falseVal = select->gtOp2;
 
-    GenCondition cc;
+    GenCondition cc = GenCondition::NE;
 
     if (select->OperIs(GT_SELECT))
     {
@@ -1391,7 +1391,6 @@ void CodeGen::genCodeForSelect(GenTreeOp* select)
         {
             regNumber condReg = cond->GetRegNum();
             GetEmitter()->emitIns_R_R(INS_test, EA_4BYTE, condReg, condReg);
-            cc = GenCondition::NE;
         }
     }
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1379,6 +1379,13 @@ void CodeGen::genCodeForSelect(GenTreeOp* select)
             assert(cond->OperIsCompare());
             genCodeForCompare(cond->AsOp());
             cc = GenCondition::FromRelop(cond);
+
+            if (cc.PreferSwap())
+            {
+                // genCodeForCompare generated the compare with swapped
+                // operands because this swap requires fewer branches/cmovs.
+                cc = GenCondition::Swap(cc);
+            }
         }
         else
         {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1062,16 +1062,25 @@ unsigned GenTree::GetMultiRegCount(Compiler* comp) const
 //
 regMaskTP GenTree::gtGetContainedRegMask()
 {
+    regMaskTP mask = 0;
     if (!isContained())
     {
-        return gtGetRegMask();
+        mask |= gtGetRegMask();
+
+        if (OperIs(GT_COPY))
+        {
+            // GT_COPY is special and always treated as contained. This is handled in genConsumeReg.
+            mask |= gtGetOp1()->gtGetContainedRegMask();
+        }
+    }
+    else
+    {
+        for (GenTree* operand : Operands())
+        {
+            mask |= operand->gtGetContainedRegMask();
+        }
     }
 
-    regMaskTP mask = 0;
-    for (GenTree* operand : Operands())
-    {
-        mask |= operand->gtGetContainedRegMask();
-    }
     return mask;
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1062,25 +1062,16 @@ unsigned GenTree::GetMultiRegCount(Compiler* comp) const
 //
 regMaskTP GenTree::gtGetContainedRegMask()
 {
-    regMaskTP mask = 0;
     if (!isContained())
     {
-        mask |= gtGetRegMask();
-
-        if (OperIs(GT_COPY))
-        {
-            // GT_COPY is special and always treated as contained. This is handled in genConsumeReg.
-            mask |= gtGetOp1()->gtGetContainedRegMask();
-        }
+        return isUsedFromReg() ? gtGetRegMask() : RBM_NONE;
     }
-    else
+
+    regMaskTP mask = 0;
+    for (GenTree* operand : Operands())
     {
-        for (GenTree* operand : Operands())
-        {
-            mask |= operand->gtGetContainedRegMask();
-        }
+        mask |= operand->gtGetContainedRegMask();
     }
-
     return mask;
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18721,17 +18721,22 @@ bool GenTree::IsArrayAddr(GenTreeArrAddr** pArrAddr)
 }
 
 //------------------------------------------------------------------------
-// CanSetZeroFlag: Returns true if this is an arithmetic operation that can
-// set the "zero flag" as part of its operation.
+// SupportsSettingZeroFlag: Returns true if this is an arithmetic operation
+// whose codegen supports setting the "zero flag" as part of its operation.
 //
 // Return Value:
-//    True if so.
+//    True if so. A false return does not imply that codegen for the node will
+//    not trash the zero flag.
 //
 // Remarks:
-//    For example, for EQ (AND x y) 0, both xarch and arm64 can emit instructions
-//    that directly set the flags after the 'AND' and thus no comparison is needed.
+//    For example, for EQ (AND x y) 0, both xarch and arm64 can emit
+//    instructions that directly set the flags after the 'AND' and thus no
+//    comparison is needed.
 //
-bool GenTree::CanSetZeroFlag()
+//    The backend expects any node for which the flags will be consumed to be
+//    marked with GTF_SET_FLAGS.
+//
+bool GenTree::SupportsSettingZeroFlag()
 {
 #if defined(TARGET_XARCH)
     if (OperIs(GT_AND, GT_OR, GT_XOR, GT_ADD, GT_SUB, GT_NEG))

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1985,6 +1985,8 @@ public:
 
     bool IsArrayAddr(GenTreeArrAddr** pArrAddr);
 
+    bool CanSetZeroFlag();
+
     // These are only used for dumping.
     // The GetRegNum() is only valid in LIR, but the dumping methods are not easily
     // modified to check this.

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1985,7 +1985,7 @@ public:
 
     bool IsArrayAddr(GenTreeArrAddr** pArrAddr);
 
-    bool CanSetZeroFlag();
+    bool SupportsSettingZeroFlag();
 
     // These are only used for dumping.
     // The GetRegNum() is only valid in LIR, but the dumping methods are not easily

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -301,9 +301,9 @@ bool OptIfConversionDsc::IfConvertCheckStmts(BasicBlock* fromBlock, IfConvertOpe
                         return false;
                     }
 
-#ifdef TARGET_64BIT
-                    // Disallow 64-bit operands on 32-bit targets as the
-                    // backend currently cannot handle contained compares efficiently.
+#ifndef TARGET_64BIT
+                    // Disallow 64-bit operands on 32-bit targets as the backend currently cannot
+                    // handle contained relops efficiently after decomposition.
                     if (varTypeIsLong(tree))
                     {
                         return false;

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -421,6 +421,7 @@ void OptIfConversionDsc::IfConvertDump()
 //
 bool OptIfConversionDsc::IsHWIntrinsicCC(GenTree* node)
 {
+#ifdef FEATURE_HW_INTRINSICS
     if (!node->OperIs(GT_HWINTRINSIC))
     {
         return false;
@@ -462,6 +463,9 @@ bool OptIfConversionDsc::IsHWIntrinsicCC(GenTree* node)
         default:
             return false;
     }
+#else
+    return false;
+#endif
 }
 #endif
 

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -716,16 +716,12 @@ bool OptIfConversionDsc::optIfConvert()
         }
         else
         {
-            // Invert the condition (to help matching condition codes back to CIL).
-            GenTree* revCond = m_comp->gtReverseCond(m_cond);
-            assert(m_cond == revCond); // Ensure `gtReverseCond` did not create a new node.
-
             // Duplicate the destination of the Then assignment.
             assert(m_thenOperation.node->gtGetOp1()->IsLocal());
-            selectFalseInput = m_comp->gtCloneExpr(m_thenOperation.node->gtGetOp1());
-            selectFalseInput->gtFlags &= GTF_EMPTY;
+            selectTrueInput = m_comp->gtCloneExpr(m_thenOperation.node->gtGetOp1());
+            selectTrueInput->gtFlags &= GTF_EMPTY;
 
-            selectTrueInput = m_thenOperation.node->gtGetOp2();
+            selectFalseInput = m_thenOperation.node->gtGetOp2();
         }
 
         // Pick the type as the type of the local, which should always be compatible even for implicit coercions.

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -61,6 +61,8 @@ private:
     void IfConvertDump();
 #endif
 
+    bool IsHWIntrinsicCC(GenTree* node);
+
 public:
     bool optIfConvert();
 };
@@ -404,6 +406,65 @@ void OptIfConversionDsc::IfConvertDump()
 }
 #endif
 
+#ifdef TARGET_XARCH
+//-----------------------------------------------------------------------------
+// IsHWIntrinsicCC:
+//   Check if this is a HW intrinsic node that can be compared efficiently
+//   against 0.
+//
+// Returns:
+//   True if so.
+//
+// Notes:
+//   For xarch, we currently skip if-conversion for these cases as the backend can handle them more efficiently
+//   when they are normal compares.
+//
+bool OptIfConversionDsc::IsHWIntrinsicCC(GenTree* node)
+{
+    if (!node->OperIs(GT_HWINTRINSIC))
+    {
+        return false;
+    }
+
+    switch (node->AsHWIntrinsic()->GetHWIntrinsicId())
+    {
+        case NI_SSE_CompareScalarOrderedEqual:
+        case NI_SSE_CompareScalarOrderedNotEqual:
+        case NI_SSE_CompareScalarOrderedLessThan:
+        case NI_SSE_CompareScalarOrderedLessThanOrEqual:
+        case NI_SSE_CompareScalarOrderedGreaterThan:
+        case NI_SSE_CompareScalarOrderedGreaterThanOrEqual:
+        case NI_SSE_CompareScalarUnorderedEqual:
+        case NI_SSE_CompareScalarUnorderedNotEqual:
+        case NI_SSE_CompareScalarUnorderedLessThanOrEqual:
+        case NI_SSE_CompareScalarUnorderedLessThan:
+        case NI_SSE_CompareScalarUnorderedGreaterThanOrEqual:
+        case NI_SSE_CompareScalarUnorderedGreaterThan:
+        case NI_SSE2_CompareScalarOrderedEqual:
+        case NI_SSE2_CompareScalarOrderedNotEqual:
+        case NI_SSE2_CompareScalarOrderedLessThan:
+        case NI_SSE2_CompareScalarOrderedLessThanOrEqual:
+        case NI_SSE2_CompareScalarOrderedGreaterThan:
+        case NI_SSE2_CompareScalarOrderedGreaterThanOrEqual:
+        case NI_SSE2_CompareScalarUnorderedEqual:
+        case NI_SSE2_CompareScalarUnorderedNotEqual:
+        case NI_SSE2_CompareScalarUnorderedLessThanOrEqual:
+        case NI_SSE2_CompareScalarUnorderedLessThan:
+        case NI_SSE2_CompareScalarUnorderedGreaterThanOrEqual:
+        case NI_SSE2_CompareScalarUnorderedGreaterThan:
+        case NI_SSE41_TestC:
+        case NI_SSE41_TestZ:
+        case NI_SSE41_TestNotZAndNotC:
+        case NI_AVX_TestC:
+        case NI_AVX_TestZ:
+        case NI_AVX_TestNotZAndNotC:
+            return true;
+        default:
+            return false;
+    }
+}
+#endif
+
 //-----------------------------------------------------------------------------
 // optIfConvert
 //
@@ -669,7 +730,8 @@ bool OptIfConversionDsc::optIfConvert()
         // The exception is for cases that can be transformed into TEST_EQ/TEST_NE.
         // TODO-CQ: Fix this.
         if (m_cond->OperIs(GT_EQ, GT_NE) && m_cond->gtGetOp2()->IsIntegralConst(0) &&
-            !m_cond->gtGetOp1()->OperIs(GT_AND) && m_cond->gtGetOp1()->SupportsSettingZeroFlag())
+            !m_cond->gtGetOp1()->OperIs(GT_AND) &&
+            (m_cond->gtGetOp1()->SupportsSettingZeroFlag() || IsHWIntrinsicCC(m_cond->gtGetOp1())))
         {
             JITDUMP("Skipping if-conversion where condition is EQ/NE 0 with operation that sets ZF");
             return false;

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -250,6 +250,15 @@ bool OptIfConversionDsc::IfConvertCheckStmts(BasicBlock* fromBlock, IfConvertOpe
                         return false;
                     }
 
+#ifndef TARGET_64BIT
+                    // Disallow 64-bit operands on 32-bit targets as the backend currently cannot
+                    // handle contained relops efficiently after decomposition.
+                    if (varTypeIsLong(tree))
+                    {
+                        return false;
+                    }
+#endif
+
                     // Ensure it won't cause any additional side effects.
                     if ((op1->gtFlags & (GTF_SIDE_EFFECT | GTF_ORDER_SIDEEFF)) != 0 ||
                         (op2->gtFlags & (GTF_SIDE_EFFECT | GTF_ORDER_SIDEEFF)) != 0)

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -669,7 +669,7 @@ bool OptIfConversionDsc::optIfConvert()
         // The exception is for cases that can be transformed into TEST_EQ/TEST_NE.
         // TODO-CQ: Fix this.
         if (m_cond->OperIs(GT_EQ, GT_NE) && m_cond->gtGetOp2()->IsIntegralConst(0) &&
-            !m_cond->gtGetOp1()->OperIs(GT_AND) && m_cond->gtGetOp1()->CanSetZeroFlag())
+            !m_cond->gtGetOp1()->OperIs(GT_AND) && m_cond->gtGetOp1()->SupportsSettingZeroFlag())
         {
             JITDUMP("Skipping if-conversion where condition is EQ/NE 0 with operation that sets ZF");
             return false;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3108,7 +3108,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
         // after op1 do not modify the flags so that it is safe to avoid generating a
         // test instruction.
 
-        if (op2->IsIntegralConst(0) && (op1->gtNext == op2) && (op2->gtNext == cmp) && op1->CanSetZeroFlag()
+        if (op2->IsIntegralConst(0) && (op1->gtNext == op2) && (op2->gtNext == cmp) && op1->SupportsSettingZeroFlag()
 #ifdef TARGET_ARM64
             // This happens in order to emit ARM64 'madd' and 'msub' instructions.
             // We cannot combine 'adds'/'subs' and 'mul'.

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3108,19 +3108,11 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
         // after op1 do not modify the flags so that it is safe to avoid generating a
         // test instruction.
 
-        if (op2->IsIntegralConst(0) && (op1->gtNext == op2) && (op2->gtNext == cmp) &&
-#ifdef TARGET_XARCH
-            (op1->OperIs(GT_AND, GT_OR, GT_XOR, GT_ADD, GT_SUB, GT_NEG)
-#ifdef FEATURE_HW_INTRINSICS
-             || (op1->OperIs(GT_HWINTRINSIC) &&
-                 emitter::DoesWriteZeroFlag(HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic())))
-#endif // FEATURE_HW_INTRINSICS
-                 )
-#else // TARGET_ARM64
-            op1->OperIs(GT_AND, GT_ADD, GT_SUB) &&
+        if (op2->IsIntegralConst(0) && (op1->gtNext == op2) && (op2->gtNext == cmp) && op1->CanSetZeroFlag()
+#ifdef TARGET_ARM64
             // This happens in order to emit ARM64 'madd' and 'msub' instructions.
             // We cannot combine 'adds'/'subs' and 'mul'.
-            !(op1->gtGetOp2()->OperIs(GT_MUL) && op1->gtGetOp2()->isContained())
+            && !(op1->gtGetOp2()->OperIs(GT_MUL) && op1->gtGetOp2()->isContained())
 #endif
                 )
         {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5945,9 +5945,9 @@ void Lowering::ContainCheckSelect(GenTreeOp* select)
                 MakeSrcContained(select, op2);
             }
         }
-        else if (IsSafeToContainMem(select, op1))
+        else if (IsSafeToContainMem(select, op2))
         {
-            MakeSrcRegOptional(select, op1);
+            MakeSrcRegOptional(select, op2);
         }
     }
 }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5874,8 +5874,6 @@ void Lowering::ContainCheckSelect(GenTreeOp* select)
     assert(select->OperIs(GT_SELECT, GT_SELECT_HI));
 #endif
 
-    bool allowContainTrueOp  = true;
-    bool allowContainFalseOp = true;
     // Disallow containing compares if the flags may be used by follow-up
     // nodes, in which case those nodes expect zero/non-zero in the flags.
     if (select->OperIs(GT_SELECT) && ((select->gtFlags & GTF_SET_FLAGS) == 0))

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5874,6 +5874,8 @@ void Lowering::ContainCheckSelect(GenTreeOp* select)
     assert(select->OperIs(GT_SELECT, GT_SELECT_HI));
 #endif
 
+    bool allowContainTrueOp  = true;
+    bool allowContainFalseOp = true;
     // Disallow containing compares if the flags may be used by follow-up
     // nodes, in which case those nodes expect zero/non-zero in the flags.
     if (select->OperIs(GT_SELECT) && ((select->gtFlags & GTF_SET_FLAGS) == 0))
@@ -5903,6 +5905,9 @@ void Lowering::ContainCheckSelect(GenTreeOp* select)
                 case GenCondition::FGEU:
                 case GenCondition::FGTU:
                     // Skip containment checking below.
+                    // TODO-CQ: We could allow one of the operands to be a
+                    // contained memory operand, but it requires updating LSRA
+                    // build to take it into account.
                     return;
                 default:
                     break;

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5890,7 +5890,7 @@ void Lowering::ContainCheckSelect(GenTreeOp* select)
             // requiring two cmovs, in which case we do not want to incur the
             // memory access/address calculation twice.
             //
-            // See the comment in Codegen::GebConditionDesc::map for why these
+            // See the comment in Codegen::GenConditionDesc::map for why these
             // comparisons are special and end up requiring the two cmovs.
             //
             GenCondition cc = GenCondition::FromRelop(cond);

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1878,6 +1878,7 @@ private:
     int BuildPutArgReg(GenTreeUnOp* node);
     int BuildCall(GenTreeCall* call);
     int BuildCmp(GenTree* tree);
+    int BuildCmpOperands(GenTree* tree);
     int BuildBlockStore(GenTreeBlk* blkNode);
     int BuildModDiv(GenTree* tree);
     int BuildIntrinsic(GenTree* tree);

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -4082,21 +4082,19 @@ int LinearScan::BuildGCWriteBarrier(GenTree* tree)
 int LinearScan::BuildCmp(GenTree* tree)
 {
     assert(tree->OperIsCompare() || tree->OperIs(GT_CMP) || tree->OperIs(GT_JCMP));
-    regMaskTP dstCandidates = RBM_NONE;
-
-#ifdef TARGET_X86
-    // If the compare is used by a jump, we just need to set the condition codes. If not, then we need
-    // to store the result into the low byte of a register, which requires the dst be a byteable register.
-    if (!tree->TypeIs(TYP_VOID))
-    {
-        dstCandidates = allByteRegs();
-    }
-#endif
 
     int srcCount = BuildCmpOperands(tree);
 
-    if (tree->TypeGet() != TYP_VOID)
+    if (!tree->TypeIs(TYP_VOID))
     {
+        regMaskTP dstCandidates = RBM_NONE;
+
+#ifdef TARGET_X86
+        // If the compare is used by a jump, we just need to set the condition codes. If not, then we need
+        // to store the result into the low byte of a register, which requires the dst be a byteable register.
+        dstCandidates = allByteRegs();
+#endif
+
         BuildDef(tree, dstCandidates);
     }
     return srcCount;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3224,12 +3224,18 @@ int LinearScan::BuildOperandUses(GenTree* node, regMaskTP candidates)
         return BuildOperandUses(hwintrinsic->Op(1), candidates);
     }
 #endif // FEATURE_HW_INTRINSICS
+#if defined(TARGET_XARCH) || defined(TARGET_ARM64)
+    if (node->OperIsCompare())
+    {
+        // Compares can be contained by a SELECT/compare chains.
+        return BuildBinaryUses(node->AsOp(), candidates);
+    }
+#endif
 #ifdef TARGET_ARM64
-    if (node->OperIs(GT_MUL) || node->OperIsCompare() || node->OperIs(GT_AND))
+    if (node->OperIs(GT_MUL) || node->OperIs(GT_AND))
     {
         // MUL can be contained for madd or msub on arm64.
-        // Compares can be contained by a SELECT.
-        // ANDs and Cmp Compares may be contained in a chain.
+        // ANDs may be contained in a chain.
         return BuildBinaryUses(node->AsOp(), candidates);
     }
     if (node->OperIs(GT_NEG, GT_CAST, GT_LSH, GT_RSH, GT_RSZ))

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -4093,7 +4093,7 @@ int LinearScan::BuildCmp(GenTree* tree)
     }
 #endif
 
-    int srcCount = BuildCmpOperands(tree->AsOp());
+    int srcCount = BuildCmpOperands(tree);
 
     if (tree->TypeGet() != TYP_VOID)
     {

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -957,6 +957,13 @@ int LinearScan::BuildSelect(GenTreeOp* select)
         srcCount++;
     }
 
+    if ((tgtPrefUse != nullptr) && (tgtPrefUse2 != nullptr))
+    {
+        // CQ analysis shows that it's best to always prefer only the 'true'
+        // val here.
+        tgtPrefUse2 = nullptr;
+    }
+
     // Codegen will emit something like:
     //
     // mov dstReg, falseVal

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -912,7 +912,17 @@ int LinearScan::BuildSelect(GenTreeOp* select)
 
     if (select->OperIs(GT_SELECT))
     {
-        srcCount += BuildOperandUses(select->AsConditional()->gtCond);
+        GenTree* cond = select->AsConditional()->gtCond;
+        if (cond->isContained())
+        {
+            assert(cond->OperIsCompare());
+            srcCount += BuildCmpOperands(cond);
+        }
+        else
+        {
+            BuildUse(cond);
+            srcCount++;
+        }
     }
 
     GenTree* trueVal  = select->gtOp1;

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -932,6 +932,8 @@ int LinearScan::BuildSelect(GenTreeOp* select)
     else
     {
         tgtPrefUse = BuildUse(select->gtOp1);
+        setDelayFree(tgtPrefUse);
+
         srcCount++;
     }
 
@@ -942,6 +944,8 @@ int LinearScan::BuildSelect(GenTreeOp* select)
     else
     {
         tgtPrefUse2 = BuildUse(select->gtOp2);
+        setDelayFree(tgtPrefUse2);
+
         srcCount++;
     }
 

--- a/src/tests/JIT/opt/Compares/compares.cs
+++ b/src/tests/JIT/opt/Compares/compares.cs
@@ -81,8 +81,11 @@ public class FullRangeComparisonTest
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Eq_byte_consume(byte a1, byte a2) {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-FULL-LINE-NEXT: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-FULL-LINE-NEXT: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
+        //
+        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z]+}}, {{.*}}
+
         if (a1 == a2) { a1 = 10; }
         consume<byte>(a1, a2);
     }
@@ -90,8 +93,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Ne_short_consume(short a1, short a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        //
+        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z]+}}, {{.*}}
+
         if (a1 != a2) { a1 = 11; }
         consume<short>(a1, a2);
     }
@@ -99,8 +105,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Lt_int_consume(int a1, int a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
+        //
+        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z]+}}, {{.*}}
+
         if (a1 < a2) { a1 = 12; }
         consume<int>(a1, a2);
     }
@@ -108,8 +117,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Le_long_consume(long a1, long a2)
     {
-        //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{le|gt}}
+        // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{le|gt}}
+        //
+        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z]+}}, {{.*}}
+
         if (a1 <= a2) { a1 = 13; }
         consume<long>(a1, a2);
     }
@@ -117,8 +129,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Gt_ushort_consume(ushort a1, ushort a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
+        //
+        // X64-FULL-LINE:        cmov{{a|be}} {{[a-z]+}}, {{.*}}
+
         if (a1 > a2) { a1 = 14; }
         consume<ushort>(a1, a2);
     }
@@ -126,8 +141,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Ge_uint_consume(uint a1, uint a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ge|lt}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ge|lt}}
+        //
+        // X64-FULL-LINE:        cmov{{ae|b}} {{[a-z]+}}, {{.*}}
+
         if (a1 >= a2) { a1 = 15; }
         consume<uint>(a1, a2);
     }
@@ -135,8 +153,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Eq_ulong_consume(ulong a1, ulong a2)
     {
-        //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{eq|ne}}
+        // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{eq|ne}}
+        //
+        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z]+}}, {{.*}}
+
         if (a1 == a2) { a1 = 16; }
         consume<ulong>(a1, a2);
     }
@@ -144,8 +165,12 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Ne_float_int_consume(float f1, float f2, int a1, int a2)
     {
-        //ARM64-FULL-LINE: fcmp {{s[0-9]+}}, {{s[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        // ARM64-FULL-LINE:      fcmp {{s[0-9]+}}, {{s[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        //
+        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-NEXT-FULL-LINE:   cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+
         if (f1 != f2) { a1 = 17; }
         consume<float>(a1, a2);
     }
@@ -153,8 +178,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Lt_double_long_consume(double f1, double f2, long a1, long a2)
     {
-        //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, {{lt|ge}}
+        // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, {{lt|ge}}
+        //
+        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z]+}}, {{.*}}
+
         if (f1 < f2) { a1 = 18; }
         consume<double>(a1, a2);
     }
@@ -162,8 +190,12 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Eq_double_long_consume(double f1, double f2, long a1, long a2)
     {
-        //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, {{eq|ne}}
+        // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, {{eq|ne}}
+        //
+        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-NEXT-FULL-LINE:   cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+
         if (f1 == f2) { a1 = 18; }
         consume<double>(a1, a2);
     }
@@ -171,8 +203,12 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Ne_double_int_consume(double f1, double f2, int a1, int a2)
     {
-        //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        //
+        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-NEXT-FULL-LINE:   cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+
         if (f1 != f2) { a1 = 18; }
         consume<double>(a1, a2);
     }
@@ -182,8 +218,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Ne_else_byte_consume(byte a1, byte a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        //
+        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z]+}}, {{.*}}
+
         if (a1 != a2) { a1 = 10; } else { a1 = 100; }
         consume<byte>(a1, a2);
     }
@@ -191,8 +230,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Lt_else_short_consume(short a1, short a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
+        //
+        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z]+}}, {{.*}}
+
         if (a1 < a2) { a1 = 11; } else { a1 = 101; }
         consume<short>(a1, a2);
     }
@@ -200,8 +242,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Le_else_int_consume(int a1, int a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
+        //
+        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z]+}}, {{.*}}
+
         if (a1 <= a2) { a1 = 12; } else { a1 = 102; }
         consume<int>(a1, a2);
     }
@@ -209,8 +254,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Gt_else_long_consume(long a1, long a2)
     {
-        //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{gt|le}}
+        // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{gt|le}}
+        //
+        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z]+}}, {{.*}}
+
         if (a1 > a2) { a1 = 13; } else { a1 = 103; }
         consume<long>(a1, a2);
     }
@@ -218,8 +266,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Ge_else_ushort_consume(ushort a1, ushort a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ge|lt}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ge|lt}}
+        //
+        // X64-FULL-LINE:        cmov{{ge|l}} {{[a-z]+}}, {{.*}}
+
         if (a1 >= a2) { a1 = 14; } else { a1 = 104; }
         consume<ushort>(a1, a2);
     }
@@ -227,8 +278,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Eq_else_uint_consume(uint a1, uint a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
+        //
+        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z]+}}, {{.*}}
+
         if (a1 == a2) { a1 = 15; } else { a1 = 105; }
         consume<uint>(a1, a2);
     }
@@ -236,8 +290,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Ne_else_ulong_consume(ulong a1, ulong a2)
     {
-        //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{ne|eq}}
+        // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{ne|eq}}
+        //
+        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z]+}}, {{.*}}
+
         if (a1 != a2) { a1 = 16; } else { a1 = 106; }
         consume<ulong>(a1, a2);
     }
@@ -245,8 +302,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Lt_else_float_int_consume(float f1, float f2, int a1, int a2)
     {
-        //ARM64-FULL-LINE: fcmp {{s[0-9]+}}, {{s[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
+        // ARM64-FULL-LINE:      fcmp {{s[0-9]+}}, {{s[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
+        //
+        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z]+}}, {{.*}}
+
         if (f1 < f2) { a1 = 17; } else { a1 = 107; }
         consume<float>(a1, a2);
     }
@@ -254,8 +314,11 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Le_else_double_int_consume(double f1, double f2, int a1, int a2)
     {
-        //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
+        // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
+        //
+        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z]+}}, {{.*}}
+
         if (f1 <= f2) { a1 = 18; } else { a1 = 108; }
         consume<double>(a1, a2);
     }
@@ -265,72 +328,99 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static byte Lt_else_byte_return(byte a1, byte a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
+        //
+        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z]+}}, {{.*}}
+
         return (a1 < a2) ? (byte)10 : (byte)100;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static short Le_else_short_return(short a1, short a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
+        //
+        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z]+}}, {{.*}}
+
         return (a1 <= a2) ? (short)11 : (short)101;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Gt_else_int_return(int a1, int a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
+        //
+        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z]+}}, {{.*}}
+
         return (a1 > a2) ? (int)12 : (int)102;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static long Ge_else_long_return(long a1, long a2)
     {
-        //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{ge|lt}}
+        // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{ge|lt}}
+        //
+        // X64-FULL-LINE:        cmov{{ge|l}} {{[a-z]+}}, {{.*}}
+
         return (a1 >= a2) ? (long)13 : (long)103;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static ushort Eq_else_ushort_return(ushort a1, ushort a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
+        //
+        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z]+}}, {{.*}}
+
         return (a1 == a2) ? (ushort)14 : (ushort)104;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static uint Ne_else_uint_return(uint a1, uint a2)
     {
-        //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
+        //
+        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z]+}}, {{.*}}
+
         return (a1 != a2) ? (uint)15 : (uint)105;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static ulong Lt_else_ulong_return(ulong a1, ulong a2)
     {
-        //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{lt|ge}}
+        // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{lt|ge}}
+        //
+        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z]+}}, {{.*}}
+
         return (a1 < a2) ? (ulong)16 : (ulong)106;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Le_else_float_int_return(float a1, float a2)
     {
-        //ARM64-FULL-LINE: fcmp {{s[0-9]+}}, {{s[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
+        // ARM64-FULL-LINE:      fcmp {{s[0-9]+}}, {{s[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
+        //
+        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z]+}}, {{.*}}
+
         return (a1 <= a2) ? 17 : 107;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Gt_else_double_int_return(double a1, double a2)
     {
-        //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
+        // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
+        // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
+        //
+        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z]+}}, {{.*}}
+
         return (a1 > a2) ? 18 : 108;
     }
 

--- a/src/tests/JIT/opt/Compares/compares.cs
+++ b/src/tests/JIT/opt/Compares/compares.cs
@@ -132,7 +132,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
         //
-        // X64-FULL-LINE:        cmov{{a|be}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z]+}}, {{.*}}
 
         if (a1 > a2) { a1 = 14; }
         consume<ushort>(a1, a2);
@@ -397,7 +397,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{lt|ge}}
         //
-        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z]+}}, {{.*}}
 
         return (a1 < a2) ? (ulong)16 : (ulong)106;
     }

--- a/src/tests/JIT/opt/Compares/compares.cs
+++ b/src/tests/JIT/opt/Compares/compares.cs
@@ -82,7 +82,7 @@ public class FullRangeComparisonTest
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Eq_byte_consume(byte a1, byte a2) {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-FULL-LINE-NEXT: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, eq
+        //ARM64-FULL-LINE-NEXT: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
         if (a1 == a2) { a1 = 10; }
         consume<byte>(a1, a2);
     }
@@ -91,7 +91,7 @@ public class FullRangeComparisonTest
     public static void Ne_short_consume(short a1, short a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ne
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         if (a1 != a2) { a1 = 11; }
         consume<short>(a1, a2);
     }
@@ -100,7 +100,7 @@ public class FullRangeComparisonTest
     public static void Lt_int_consume(int a1, int a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, lt
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
         if (a1 < a2) { a1 = 12; }
         consume<int>(a1, a2);
     }
@@ -109,7 +109,7 @@ public class FullRangeComparisonTest
     public static void Le_long_consume(long a1, long a2)
     {
         //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, le
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{le|gt}}
         if (a1 <= a2) { a1 = 13; }
         consume<long>(a1, a2);
     }
@@ -118,7 +118,7 @@ public class FullRangeComparisonTest
     public static void Gt_ushort_consume(ushort a1, ushort a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, gt
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
         if (a1 > a2) { a1 = 14; }
         consume<ushort>(a1, a2);
     }
@@ -127,7 +127,7 @@ public class FullRangeComparisonTest
     public static void Ge_uint_consume(uint a1, uint a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ge
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ge|lt}}
         if (a1 >= a2) { a1 = 15; }
         consume<uint>(a1, a2);
     }
@@ -136,7 +136,7 @@ public class FullRangeComparisonTest
     public static void Eq_ulong_consume(ulong a1, ulong a2)
     {
         //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, eq
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{eq|ne}}
         if (a1 == a2) { a1 = 16; }
         consume<ulong>(a1, a2);
     }
@@ -145,7 +145,7 @@ public class FullRangeComparisonTest
     public static void Ne_float_int_consume(float f1, float f2, int a1, int a2)
     {
         //ARM64-FULL-LINE: fcmp {{s[0-9]+}}, {{s[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ne
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         if (f1 != f2) { a1 = 17; }
         consume<float>(a1, a2);
     }
@@ -154,7 +154,7 @@ public class FullRangeComparisonTest
     public static void Lt_double_long_consume(double f1, double f2, long a1, long a2)
     {
         //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, lt
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, {{lt|ge}}
         if (f1 < f2) { a1 = 18; }
         consume<double>(a1, a2);
     }
@@ -163,7 +163,7 @@ public class FullRangeComparisonTest
     public static void Eq_double_long_consume(double f1, double f2, long a1, long a2)
     {
         //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, eq
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, {{eq|ne}}
         if (f1 == f2) { a1 = 18; }
         consume<double>(a1, a2);
     }
@@ -172,7 +172,7 @@ public class FullRangeComparisonTest
     public static void Ne_double_int_consume(double f1, double f2, int a1, int a2)
     {
         //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ne
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         if (f1 != f2) { a1 = 18; }
         consume<double>(a1, a2);
     }
@@ -183,7 +183,7 @@ public class FullRangeComparisonTest
     public static void Ne_else_byte_consume(byte a1, byte a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ne
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         if (a1 != a2) { a1 = 10; } else { a1 = 100; }
         consume<byte>(a1, a2);
     }
@@ -192,7 +192,7 @@ public class FullRangeComparisonTest
     public static void Lt_else_short_consume(short a1, short a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, lt
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
         if (a1 < a2) { a1 = 11; } else { a1 = 101; }
         consume<short>(a1, a2);
     }
@@ -201,7 +201,7 @@ public class FullRangeComparisonTest
     public static void Le_else_int_consume(int a1, int a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, le
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
         if (a1 <= a2) { a1 = 12; } else { a1 = 102; }
         consume<int>(a1, a2);
     }
@@ -210,7 +210,7 @@ public class FullRangeComparisonTest
     public static void Gt_else_long_consume(long a1, long a2)
     {
         //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, gt
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{gt|le}}
         if (a1 > a2) { a1 = 13; } else { a1 = 103; }
         consume<long>(a1, a2);
     }
@@ -219,7 +219,7 @@ public class FullRangeComparisonTest
     public static void Ge_else_ushort_consume(ushort a1, ushort a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ge
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ge|lt}}
         if (a1 >= a2) { a1 = 14; } else { a1 = 104; }
         consume<ushort>(a1, a2);
     }
@@ -228,7 +228,7 @@ public class FullRangeComparisonTest
     public static void Eq_else_uint_consume(uint a1, uint a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, eq
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
         if (a1 == a2) { a1 = 15; } else { a1 = 105; }
         consume<uint>(a1, a2);
     }
@@ -237,7 +237,7 @@ public class FullRangeComparisonTest
     public static void Ne_else_ulong_consume(ulong a1, ulong a2)
     {
         //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, ne
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{ne|eq}}
         if (a1 != a2) { a1 = 16; } else { a1 = 106; }
         consume<ulong>(a1, a2);
     }
@@ -246,7 +246,7 @@ public class FullRangeComparisonTest
     public static void Lt_else_float_int_consume(float f1, float f2, int a1, int a2)
     {
         //ARM64-FULL-LINE: fcmp {{s[0-9]+}}, {{s[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, lt
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
         if (f1 < f2) { a1 = 17; } else { a1 = 107; }
         consume<float>(a1, a2);
     }
@@ -255,7 +255,7 @@ public class FullRangeComparisonTest
     public static void Le_else_double_int_consume(double f1, double f2, int a1, int a2)
     {
         //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, le
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
         if (f1 <= f2) { a1 = 18; } else { a1 = 108; }
         consume<double>(a1, a2);
     }
@@ -266,7 +266,7 @@ public class FullRangeComparisonTest
     public static byte Lt_else_byte_return(byte a1, byte a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, lt
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
         return (a1 < a2) ? (byte)10 : (byte)100;
     }
 
@@ -274,7 +274,7 @@ public class FullRangeComparisonTest
     public static short Le_else_short_return(short a1, short a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, le
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
         return (a1 <= a2) ? (short)11 : (short)101;
     }
 
@@ -282,7 +282,7 @@ public class FullRangeComparisonTest
     public static int Gt_else_int_return(int a1, int a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, gt
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
         return (a1 > a2) ? (int)12 : (int)102;
     }
 
@@ -290,7 +290,7 @@ public class FullRangeComparisonTest
     public static long Ge_else_long_return(long a1, long a2)
     {
         //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, ge
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{ge|lt}}
         return (a1 >= a2) ? (long)13 : (long)103;
     }
 
@@ -298,7 +298,7 @@ public class FullRangeComparisonTest
     public static ushort Eq_else_ushort_return(ushort a1, ushort a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, eq
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
         return (a1 == a2) ? (ushort)14 : (ushort)104;
     }
 
@@ -306,7 +306,7 @@ public class FullRangeComparisonTest
     public static uint Ne_else_uint_return(uint a1, uint a2)
     {
         //ARM64-FULL-LINE: cmp {{w[0-9]+}}, {{w[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, ne
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         return (a1 != a2) ? (uint)15 : (uint)105;
     }
 
@@ -314,7 +314,7 @@ public class FullRangeComparisonTest
     public static ulong Lt_else_ulong_return(ulong a1, ulong a2)
     {
         //ARM64-FULL-LINE: cmp {{x[0-9]+}}, {{x[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, lt
+        //ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{lt|ge}}
         return (a1 < a2) ? (ulong)16 : (ulong)106;
     }
 
@@ -322,7 +322,7 @@ public class FullRangeComparisonTest
     public static int Le_else_float_int_return(float a1, float a2)
     {
         //ARM64-FULL-LINE: fcmp {{s[0-9]+}}, {{s[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, le
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
         return (a1 <= a2) ? 17 : 107;
     }
 
@@ -330,7 +330,7 @@ public class FullRangeComparisonTest
     public static int Gt_else_double_int_return(double a1, double a2)
     {
         //ARM64-FULL-LINE: fcmp {{d[0-9]+}}, {{d[0-9]+}}
-        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, gt
+        //ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
         return (a1 > a2) ? 18 : 108;
     }
 

--- a/src/tests/JIT/opt/Compares/compares.cs
+++ b/src/tests/JIT/opt/Compares/compares.cs
@@ -84,7 +84,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-FULL-LINE-NEXT: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
         //
-        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 == a2) { a1 = 10; }
         consume<byte>(a1, a2);
@@ -96,7 +96,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         //
-        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 != a2) { a1 = 11; }
         consume<short>(a1, a2);
@@ -108,7 +108,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
         //
-        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 < a2) { a1 = 12; }
         consume<int>(a1, a2);
@@ -120,7 +120,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{le|gt}}
         //
-        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 <= a2) { a1 = 13; }
         consume<long>(a1, a2);
@@ -132,7 +132,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
         //
-        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 > a2) { a1 = 14; }
         consume<ushort>(a1, a2);
@@ -144,7 +144,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ge|lt}}
         //
-        // X64-FULL-LINE:        cmov{{ae|b}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{ae|b}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 >= a2) { a1 = 15; }
         consume<uint>(a1, a2);
@@ -156,7 +156,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{eq|ne}}
         //
-        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 == a2) { a1 = 16; }
         consume<ulong>(a1, a2);
@@ -168,8 +168,8 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      fcmp {{s[0-9]+}}, {{s[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         //
-        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
-        // X64-NEXT-FULL-LINE:   cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z0-9]+}}, {{.*}}
+        // X64-FULL-LINE-NEXT:   cmov{{p|np|ne|e}} {{[a-z0-9]+}}, {{.*}}
 
         if (f1 != f2) { a1 = 17; }
         consume<float>(a1, a2);
@@ -181,7 +181,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, {{lt|ge}}
         //
-        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z0-9]+}}, {{.*}}
 
         if (f1 < f2) { a1 = 18; }
         consume<double>(a1, a2);
@@ -193,8 +193,8 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-31]}}, {{x[0-31]}}, {{x[0-31]}}, {{eq|ne}}
         //
-        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
-        // X64-NEXT-FULL-LINE:   cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z0-9]+}}, {{.*}}
+        // X64-FULL-LINE-NEXT:   cmov{{p|np|ne|e}} {{[a-z0-9]+}}, {{.*}}
 
         if (f1 == f2) { a1 = 18; }
         consume<double>(a1, a2);
@@ -206,8 +206,8 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         //
-        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
-        // X64-NEXT-FULL-LINE:   cmov{{p|np|ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{p|np|ne|e}} {{[a-z0-9]+}}, {{.*}}
+        // X64-FULL-LINE-NEXT:   cmov{{p|np|ne|e}} {{[a-z0-9]+}}, {{.*}}
 
         if (f1 != f2) { a1 = 18; }
         consume<double>(a1, a2);
@@ -221,7 +221,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         //
-        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 != a2) { a1 = 10; } else { a1 = 100; }
         consume<byte>(a1, a2);
@@ -233,7 +233,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
         //
-        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 < a2) { a1 = 11; } else { a1 = 101; }
         consume<short>(a1, a2);
@@ -245,7 +245,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
         //
-        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 <= a2) { a1 = 12; } else { a1 = 102; }
         consume<int>(a1, a2);
@@ -257,7 +257,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{gt|le}}
         //
-        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 > a2) { a1 = 13; } else { a1 = 103; }
         consume<long>(a1, a2);
@@ -269,7 +269,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ge|lt}}
         //
-        // X64-FULL-LINE:        cmov{{ge|l}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{ge|l}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 >= a2) { a1 = 14; } else { a1 = 104; }
         consume<ushort>(a1, a2);
@@ -281,7 +281,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
         //
-        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 == a2) { a1 = 15; } else { a1 = 105; }
         consume<uint>(a1, a2);
@@ -293,7 +293,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{ne|eq}}
         //
-        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{ne|e}} {{[a-z0-9]+}}, {{.*}}
 
         if (a1 != a2) { a1 = 16; } else { a1 = 106; }
         consume<ulong>(a1, a2);
@@ -305,7 +305,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      fcmp {{s[0-9]+}}, {{s[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
         //
-        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z0-9]+}}, {{.*}}
 
         if (f1 < f2) { a1 = 17; } else { a1 = 107; }
         consume<float>(a1, a2);
@@ -317,7 +317,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
         //
-        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z0-9]+}}, {{.*}}
 
         if (f1 <= f2) { a1 = 18; } else { a1 = 108; }
         consume<double>(a1, a2);
@@ -331,7 +331,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{lt|ge}}
         //
-        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{l|ge}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 < a2) ? (byte)10 : (byte)100;
     }
@@ -342,7 +342,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
         //
-        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{le|g}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 <= a2) ? (short)11 : (short)101;
     }
@@ -353,7 +353,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
         //
-        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{g|le}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 > a2) ? (int)12 : (int)102;
     }
@@ -364,7 +364,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{ge|lt}}
         //
-        // X64-FULL-LINE:        cmov{{ge|l}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{ge|l}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 >= a2) ? (long)13 : (long)103;
     }
@@ -375,7 +375,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{eq|ne}}
         //
-        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 == a2) ? (ushort)14 : (ushort)104;
     }
@@ -386,7 +386,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{w[0-9]+}}, {{w[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{ne|eq}}
         //
-        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{e|ne}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 != a2) ? (uint)15 : (uint)105;
     }
@@ -397,7 +397,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      cmp {{x[0-9]+}}, {{x[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{x[0-9]+}}, {{x[0-9]+}}, {{x[0-9]+}}, {{lt|ge}}
         //
-        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 < a2) ? (ulong)16 : (ulong)106;
     }
@@ -408,7 +408,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      fcmp {{s[0-9]+}}, {{s[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{le|gt}}
         //
-        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{b|ae}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 <= a2) ? 17 : 107;
     }
@@ -419,7 +419,7 @@ public class FullRangeComparisonTest
         // ARM64-FULL-LINE:      fcmp {{d[0-9]+}}, {{d[0-9]+}}
         // ARM64-NEXT-FULL-LINE: csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, {{gt|le}}
         //
-        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z]+}}, {{.*}}
+        // X64-FULL-LINE:        cmov{{be|a}} {{[a-z0-9]+}}, {{.*}}
 
         return (a1 > a2) ? 18 : 108;
     }


### PR DESCRIPTION
This adds support for contained compares in GT_SELECT nodes for xarch. As part of this also enables if-conversion on xarch.

This fixes #6749. For:

```csharp
    [MethodImpl(MethodImplOptions.NoInlining)]
    static long sete_or_mov(bool cond)
    {
        return cond ? 0 : 4;
    }
```
Before:
```asm
G_M14693_IG01:              ;; offset=0000H
                                                ;; size=0 bbWeight=1 PerfScore 0.00
G_M14693_IG02:              ;; offset=0000H
       84C9                 test     cl, cl
       7507                 jne      SHORT G_M14693_IG04
                                                ;; size=4 bbWeight=1 PerfScore 1.25
G_M14693_IG03:              ;; offset=0004H
       B804000000           mov      eax, 4
       EB02                 jmp      SHORT G_M14693_IG05
                                                ;; size=7 bbWeight=0.50 PerfScore 1.12
G_M14693_IG04:              ;; offset=000BH
       33C0                 xor      eax, eax
                                                ;; size=2 bbWeight=0.50 PerfScore 0.12
G_M14693_IG05:              ;; offset=000DH
       4898                 cdqe
                                                ;; size=2 bbWeight=1 PerfScore 0.25
G_M14693_IG06:              ;; offset=000FH
       C3                   ret
                                                ;; size=1 bbWeight=1 PerfScore 1.00

; Total bytes of code 16, prolog size 0, PerfScore 5.35, instruction count 7, allocated bytes for code 16 (MethodHash=bc7ac69a) for method Program:sete_or_mov(bool):long
```

After:
```asm
G_M14693_IG01:
                                                ;; size=0 bbWeight=1 PerfScore 0.00
G_M14693_IG02:
       xor      eax, eax
       mov      edx, 4
       test     cl, cl
       cmove    eax, edx
       cdqe
                                                ;; size=14 bbWeight=1 PerfScore 1.25
G_M14693_IG03:
       ret
                                                ;; size=1 bbWeight=1 PerfScore 1.00

; Total bytes of code 15, prolog size 0, PerfScore 3.75, instruction count 6, allocated bytes for code 15 (MethodHash=bc7ac69a) for method Program:sete_or_mov(bool):long
```
(Not completely optimal, no sign extension is necessary, but that's a separate issue.)

~~It does not get the `cmov` case from the issue, but that's because if-conversion does not handle it today (cc @a74nh -- seems like a nice opportunity).~~

TODO:
* [X] Interference checks
* [X] Only require delayed free for one operand
* [x] Double check delay free logic