### PR TITLE
Disable function pointer test for crossgen due to an existing issue

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -874,6 +874,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests/*">
             <Issue>https://github.com/dotnet/runtime/issues/81103</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/Casting/Functionpointer/**">
+            <Issue>https://github.com/dotnet/runtime/issues/81106</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Crossgen2 x86 specific excludes -->


### PR DESCRIPTION
Disable test due to an existing bug of crossgen2 (#81106)

This will allow my backported PR (#80927) being merged sooner.