### PR TITLE
[release/7.0] Decommit memory before returning to the region_allocator

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2081,6 +2081,10 @@ protected:
     size_t decommit_heap_segment_pages_worker (heap_segment* seg, uint8_t *new_committed);
     PER_HEAP_ISOLATED
     bool decommit_step (uint64_t step_milliseconds);
+#ifdef USE_REGIONS
+    PER_HEAP_ISOLATED
+    size_t decommit_region (heap_segment* region, int bucket, int h_number);
+#endif //USE_REGIONS
     PER_HEAP
     void decommit_heap_segment (heap_segment* seg);
     PER_HEAP_ISOLATED


### PR DESCRIPTION
Backport of #80640 to release/7.0

/cc @cshung

## Customer Impact
As customers reported in https://github.com/dotnet/runtime/issues/79882, newly created arrays might not be zero-initialized, this violates our guarantees.  Turn out this has to do with some of our low memory condition processing. After the fix, the arrays will always be zero-initialized.

## Testing
This is tested under reliability framework stress test for both server and workstation. It is also tested against the ASP.NET benchmarks.

## Risk
Low, given extensive testing.

IMPORTANT: Is this backport for a servicing release? If so and this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
