### PR TITLE
[wasm] Pin the sdk version to avoid a regression

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -206,7 +206,7 @@
     <GrpcDotnetClientVersion>2.45.0</GrpcDotnetClientVersion>
     <GrpcToolsVersion>2.45.0</GrpcToolsVersion>
     <!-- Uncomment to set a fixed version, else the latest is used -->
-    <!--<SdkVersionForWorkloadTesting>8.0.100-alpha.1.22463.23</SdkVersionForWorkloadTesting>-->
+    <SdkVersionForWorkloadTesting>8.0.100-alpha.1.23077.3</SdkVersionForWorkloadTesting>
     <CompilerPlatformTestingVersion>1.1.2-beta1.22403.2</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20221010.1</MicrosoftPrivateIntellisenseVersion>


### PR DESCRIPTION
.. in manifest ordering in `IncludedWorkloadManifests.txt` caused by [dotnet/installer@`717f422` (#15346)](https://github.com/dotnet/installer/pull/15346/commits/717f422202f5fb3494e8f79f96e3a27e83fc72c0) , which broke the workload causing relinking to break in WBT.

The version with the bug is : 8.0.100-alpha.1.23077.4