### PR TITLE
[release/7.0] Starting metrics before runtime start leads to a crash

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -13,7 +13,7 @@ Commonly Used Types:
 System.Diagnostics.DiagnosticListener
 System.Diagnostics.DiagnosticSource</PackageDescription>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>1</ServicingVersion>
+    <ServicingVersion>2</ServicingVersion>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->


### PR DESCRIPTION
When you start a metrics session before the runtime is started, we will get a NullReferenceException in MetricsEventSource. This prevents metrics from being enabled before the process is started. The dotnet diagnostic tooling supports starting a session before the runtime is launched.

## Customer Impact
Partner teams cannot ship diagnostic tooling on 6.0 without this change.

 ## Testing
Manually verified that the fix works

 ## Risk
 Low.