### PR TITLE
[wasm] Misc fixes

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -493,10 +493,14 @@ namespace Wasm.Build.Tests
                     .EnsureSuccessful();
 
             string projectfile = Path.Combine(_projectDir!, $"{id}.csproj");
+            string extraProperties = string.Empty;
+            extraProperties += "<TreatWarningsAsErrors>true</TreatWarningsAsErrors>";
             if (runAnalyzers)
-                AddItemsPropertiesToProject(projectfile, "<RunAnalyzers>true</RunAnalyzers>");
+                extraProperties += "<RunAnalyzers>true</RunAnalyzers>";
             if (UseWebcil)
-                AddItemsPropertiesToProject(projectfile, "<WasmEnableWebcil>true</WasmEnableWebcil>");
+                extraProperties += "<WasmEnableWebcil>true</WasmEnableWebcil>";
+            AddItemsPropertiesToProject(projectfile, extraProperties);
+
             return projectfile;
         }
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessStartup.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/TestHarnessStartup.cs
@@ -81,7 +81,6 @@ namespace DebuggerTests
             this._loggerFactory = loggerFactory;
 
             app.UseWebSockets();
-            app.UseStaticFiles();
 
             TestHarnessOptions options = optionsAccessor.CurrentValue;
 


### PR DESCRIPTION
- Wasm.Build.Tests - catch warnings in wasm templates like https://github.com/dotnet/runtime/pull/77704
- debugger tests: fix warning in web server