### PR TITLE
Delete HeapEnableTerminationOnCorruption setting

### DIFF
--- a/src/coreclr/ilasm/main.cpp
+++ b/src/coreclr/ilasm/main.cpp
@@ -142,12 +142,6 @@ extern "C" int _cdecl wmain(int argc, _In_ WCHAR **argv)
     bool bClock = false;
     Clockwork   cw;
 
-#ifdef HOST_WINDOWS
-    // SWI has requested that the exact form of the function call below be used. For details
-    // see http://swi/SWI%20Docs/Detecting%20Heap%20Corruption.doc
-    (void)HeapSetInformation(NULL, HeapEnableTerminationOnCorruption, NULL, 0);
-#endif
-
     memset(pwzInputFiles,0,1024*sizeof(WCHAR*));
     memset(pwzDeltaFiles,0,1024*sizeof(WCHAR*));
     memset(&cw,0,sizeof(Clockwork));

--- a/src/coreclr/ildasm/windasm.cpp
+++ b/src/coreclr/ildasm/windasm.cpp
@@ -465,11 +465,6 @@ int main(int argc, char* argv[])
     }
 #endif
 
-#ifdef HOST_WINDOWS
-    // SWI has requested that the exact form of the function call below be used. For details see http://swi/SWI%20Docs/Detecting%20Heap%20Corruption.doc
-    (void)HeapSetInformation(NULL, HeapEnableTerminationOnCorruption, NULL, 0);
-#endif
-
 #ifdef _DEBUG
     DisableThrowCheck();
 #endif


### PR DESCRIPTION
HeapEnableTerminationOnCorruption is enabled by default for subsystem major version 6 that we have set for our binaries. Also delete intranet link to a document that does not exist anymore.