### PR TITLE
More thoroughly check for function pointers

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -80,7 +80,16 @@ namespace ILCompiler.DependencyAnalysis
 
                     // Function pointers are not supported yet.
                     // https://github.com/dotnet/runtime/issues/71883
-                    if (type.IsFunctionPointer)
+                    static bool ContainsFunctionPointers(TypeDesc type)
+                    {
+                        if (type.IsParameterizedType)
+                            return ContainsFunctionPointers(((ParameterizedType)type).ParameterType);
+                        foreach (TypeDesc instArg in type.Instantiation)
+                            if (ContainsFunctionPointers(instArg))
+                                return true;
+                        return type.IsFunctionPointer;
+                    }
+                    if (ContainsFunctionPointers(type))
                         return;
 
                     TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);


### PR DESCRIPTION
Fixes #81117.

This code will be deleted with #71883 but before then we need to make sure we never end up in a situation where a MethodTable for function pointers is needed.

Cc @dotnet/ilc-contrib 