### PR TITLE
fix fgMorphArgs for stress mode

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3307,8 +3307,9 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                     if (argObj->OperIsIndir())
                     {
                         assert(argObj->AsIndir()->Size() == genTypeSize(structBaseType));
-                        argObj->ChangeType(structBaseType);
                         argObj->SetOper(GT_IND);
+                        // Use ChangeType over argx to update types in COMMAs as well
+                        argx->ChangeType(structBaseType);
                     }
                     else if (argObj->OperIsLocalRead())
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/79626

Previously, SIMD8 was replaced with TYP_LONG like this:
```
[000495] ---XG+-----                         *  COMMA     simd8 
[000491] ---X-+-----                         +--*  NULLCHECK byte  
[000490] -----+-----                         |  \--*  LCL_VAR   ref    V00 loc0         
[000496] ---XG+-----                         \--*  IND       simd8 
[000494] -----+-----                            \--*  ADD       byref 
[000492] -----+-----                               +--*  LCL_VAR   ref    V00 loc0         
[000493] -----+-----                               \--*  CNS_INT   long   16 Fseq[newVector]
```
to
```
[000495] ---XG+-----                         *  COMMA     simd8 
[000491] ---X-+-----                         +--*  NULLCHECK byte  
[000490] -----+-----                         |  \--*  LCL_VAR   ref    V00 loc0         
[000496] ---XG+-----                         \--*  IND       long  
[000494] -----+-----                            \--*  ADD       byref 
[000492] -----+-----                               +--*  LCL_VAR   ref    V00 loc0         
[000493] -----+-----                               \--*  CNS_INT   long   16 Fseq[newVector]
```
while COMMA was not updated