### PR TITLE
Remove additional null-check from ActivityCreationOptions

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityCreationOptions.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityCreationOptions.cs
@@ -53,7 +53,7 @@ namespace System.Diagnostics
 
                 _traceState = ac.TraceState;
             }
-            else if (parent is string p && p != null)
+            else if (parent is string p)
             {
                 if (IdFormat != ActivityIdFormat.Hierarchical)
                 {


### PR DESCRIPTION
`foo is string str` already checks for null

[Docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/type-testing-and-cast#is-operator)