### PR TITLE
[Android] Fix System.IO.MemoryMappedFiles tests

### DIFF
--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.Unix.cs
@@ -20,12 +20,14 @@ namespace System.IO.MemoryMappedFiles.Tests
             int pageSize;
             const int _SC_PAGESIZE_FreeBSD = 47;
             const int _SC_PAGESIZE_Linux = 30;
+            const int _SC_PAGESIZE_Android = 39;
             const int _SC_PAGESIZE_NetBSD = 28;
             const int _SC_PAGESIZE_OSX = 29;
             pageSize = sysconf(
                 OperatingSystem.IsMacOS() ? _SC_PAGESIZE_OSX :
                 OperatingSystem.IsFreeBSD() ? _SC_PAGESIZE_FreeBSD :
                 RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")) ? _SC_PAGESIZE_NetBSD :
+                OperatingSystem.IsAndroid() ? _SC_PAGESIZE_Android :
                 _SC_PAGESIZE_Linux);
             Assert.InRange(pageSize, 1, int.MaxValue);
             return pageSize;


### PR DESCRIPTION
While working on #80925 I noticed that the System.IO.MemoryMappedFiles are failing on Android API levels 21-27. On newer APIs the tests passed, but it turns out that they weren't behaving correctly either. The correct value of `_SC_PAGESIZE` in the Bionic libc on Android is 39 (0x27) and not 30 as in Linux.