### PR TITLE
Disable hill climbing by default

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -533,7 +533,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_UnfairSemaphoreSpinLimit, W("Thread
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadPool_UnfairSemaphoreSpinLimit, W("ThreadPool_UnfairSemaphoreSpinLimit"), 0x46, "Maximum number of spins a thread pool worker thread performs before waiting for work")
 #endif // TARGET_ARM64
 
-RETAIL_CONFIG_DWORD_INFO(INTERNAL_HillClimbing_Disable,                             W("HillClimbing_Disable"),                            0, "Disables hill climbing for thread adjustments in the thread pool");
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_HillClimbing_Disable,                             W("HillClimbing_Disable"),                            1, "Disables hill climbing for thread adjustments in the thread pool");
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_HillClimbing_WavePeriod,                          W("HillClimbing_WavePeriod"),                         4, "");
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_HillClimbing_TargetSignalToNoiseRatio,            W("HillClimbing_TargetSignalToNoiseRatio"),           300, "");
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_HillClimbing_ErrorSmoothingFactor,                W("HillClimbing_ErrorSmoothingFactor"),               1, "");

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.HillClimbing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.HillClimbing.cs
@@ -17,7 +17,8 @@ namespace System.Threading
             private const int DefaultSampleIntervalMsLow = 10;
             private const int DefaultSampleIntervalMsHigh = 200;
 
-            public static readonly bool IsDisabled = AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.HillClimbing.Disable", false);
+            public static readonly bool IsDisabled =
+                AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.HillClimbing.Disable", true);
 
             // SOS's ThreadPool command depends on this name
             public static readonly HillClimbing ThreadPoolHillClimber = new HillClimbing();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
@@ -314,7 +314,7 @@ namespace System.Threading
             ThreadInt64PersistentCounter.Increment(threadLocalCompletionCountObject);
             _separated.lastDequeueTime = currentTimeMs;
 
-            if (ShouldAdjustMaxWorkersActive(currentTimeMs))
+            if (!HillClimbing.IsDisabled && ShouldAdjustMaxWorkersActive(currentTimeMs))
             {
                 AdjustMaxWorkersActive();
             }
@@ -403,11 +403,6 @@ namespace System.Threading
 
         private bool ShouldAdjustMaxWorkersActive(int currentTimeMs)
         {
-            if (HillClimbing.IsDisabled)
-            {
-                return false;
-            }
-
             // We need to subtract by prior time because Environment.TickCount can wrap around, making a comparison of absolute
             // times unreliable. Intervals are unsigned to avoid wrapping around on the subtract after enough time elapses, and
             // this also prevents the initial elapsed interval from being negative due to the prior and next times being


### PR DESCRIPTION
Hill climbing samples throughput of thread pool work items while oscillating the active worker thread count to see if a change to the active worker thread count correlates with an increase in work item throughput. Some issues:
- Thread pool work item throughput is often not stable due to there being different types of work items, which can make the algorithm slower to respond or less effective
- A higher active worker thread count may be beneficial when one or more active threads get blocked or when all active worker threads are performing long-running work, both of which are bad practices and typically lead to some sort of starvation
- Hill climbing is generally slow to respond to active worker threads blocking. It also currently does not operate when all active worker threads are blocked.
- Hill climbing has some overhead that is sometimes visible in perf profiles, including raw overhead and overhead from the greater number of active threads when sampling
- In tests done so far with disabling hill climbing, I haven't seen significant improvements in perf metrics in larger benchmarks or real-world apps. Perf metrics have mostly been the same or slightly better with hill climbing disabled, and with fewer active threads on average.

This change disables hill climbing by default. It can be enabled through config if necessary. Potential improvements or replacements may be considered in the future, such as to improve the starvation heuristic to identifiy specific blocked threads and respond more quickly.