### PR TITLE
Update the assert to correctly check if a tree with value has non-zero destination registers

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7344,8 +7344,8 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
     if (!comp->fgAddrCouldBeNull(addr))
     {
         addr->SetUnusedValue();
-        ind->gtBashToNOP();
-        JITDUMP("bash an unused indir [%06u] to NOP.\n", comp->dspTreeID(ind));
+        LIR::AsRange(block).Remove(ind);
+        JITDUMP("Removing unused indir [%06u].\n", comp->dspTreeID(ind));
         return;
     }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7344,8 +7344,8 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
     if (!comp->fgAddrCouldBeNull(addr))
     {
         addr->SetUnusedValue();
-        LIR::AsRange(block).Remove(ind);
-        JITDUMP("Removing unused indir [%06u].\n", comp->dspTreeID(ind));
+        ind->gtBashToNOP();
+        JITDUMP("bash an unused indir [%06u] to NOP.\n", comp->dspTreeID(ind));
         return;
     }
 

--- a/src/coreclr/jit/lsraarm.cpp
+++ b/src/coreclr/jit/lsraarm.cpp
@@ -796,7 +796,7 @@ int LinearScan::BuildNode(GenTree* tree)
     // We need to be sure that we've set srcCount and dstCount appropriately
     assert((dstCount < 2) || tree->IsMultiRegNode());
     assert(isLocalDefUse == (tree->IsValue() && tree->IsUnusedValue()));
-    assert(!tree->IsUnusedValue() || (dstCount != 0));
+    assert(!tree->IsValue() || (dstCount != 0));
     assert(dstCount == tree->GetRegisterDstCount(compiler));
     return srcCount;
 }

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -785,7 +785,7 @@ int LinearScan::BuildNode(GenTree* tree)
     // We need to be sure that we've set srcCount and dstCount appropriately
     assert((dstCount < 2) || tree->IsMultiRegNode());
     assert(isLocalDefUse == (tree->IsValue() && tree->IsUnusedValue()));
-    assert(!tree->IsUnusedValue() || (dstCount != 0));
+    assert(!tree->IsValue() || (dstCount != 0));
     assert(dstCount == tree->GetRegisterDstCount(compiler));
     return srcCount;
 }

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -682,7 +682,7 @@ int LinearScan::BuildNode(GenTree* tree)
     // Not that for XARCH, the maximum number of registers defined is 2.
     assert((dstCount < 2) || ((dstCount == 2) && tree->IsMultiRegNode()));
     assert(isLocalDefUse == (tree->IsValue() && tree->IsUnusedValue()));
-    assert(!tree->IsUnusedValue() || (dstCount != 0));
+    assert(!tree->IsValue() || (dstCount != 0));
     assert(dstCount == tree->GetRegisterDstCount(compiler));
     return srcCount;
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81356/Runtime_81356.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81356/Runtime_81356.cs
@@ -6,10 +6,12 @@ public class Runtime_81356
     public static byte[] s_130;
     public static int Main()
     {
-        try {
+        try
+        {
             ulong vr5 = default(ulong);
             byte vr4 = (byte)(((byte)vr5 & 0) * s_130[0]);
-        } finally {}
+        }
+        catch { }
         return 100;
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81356/Runtime_81356.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81356/Runtime_81356.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+public class Runtime_81356
+{
+    public static byte[] s_130;
+    public static int Main()
+    {
+        try {
+            ulong vr5 = default(ulong);
+            byte vr4 = (byte)(((byte)vr5 & 0) * s_130[0]);
+        } finally {}
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81356/Runtime_81356.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81356/Runtime_81356.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/77078, we based an indir to `NOP` and in MinOpts, since we do not perform liveness, it stays until LSRA. In LSRA, during building the nodes, we should be checking if a tree has a value, the number of destination registers should be non-zero. Instead, we were checking if tree has unused value, it should have non-zero destination registers, which was not making sense. Updated the assert.

Fixes: https://github.com/dotnet/runtime/issues/81356