### PR TITLE
fix the space in build-job.yml

### DIFF
--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -149,7 +149,7 @@ jobs:
         value: '-portablebuild=false'
 
     - name: nativeSymbols
-        value: ''
+      value: ''
     - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
       - name: nativeSymbols
         value: '--keepnativesymbols'


### PR DESCRIPTION
As part of https://github.com/dotnet/runtime/pull/81387, there was an unwanted space left because of which we started getting such errors:

![image](https://user-images.githubusercontent.com/12488060/215699248-22ce5708-1c68-4d6b-93da-367f93de1c8d.png)

@ViktorHofer @agocke @hoyosjs 