### PR TITLE
[wasm] Enable jiterpreter traces; fix floating point compares

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -438,6 +438,14 @@ mono_jiterp_conv_ovf (void *dest, void *src, int opcode) {
 	return 0;
 }
 
+#define JITERP_CNE_UN_R4 (0xFFFF + 0)
+#define JITERP_CGE_UN_R4 (0xFFFF + 1)
+#define JITERP_CLE_UN_R4 (0xFFFF + 2)
+#define JITERP_CNE_UN_R8 (0xFFFF + 3)
+#define JITERP_CGE_UN_R8 (0xFFFF + 4)
+#define JITERP_CLE_UN_R8 (0xFFFF + 5)
+
+
 #define JITERP_RELOP(opcode, type, op, noorder) \
 	case opcode: \
 		{ \
@@ -455,10 +463,14 @@ mono_jiterp_relop_fp (double lhs, double rhs, int opcode) {
 		JITERP_RELOP(MINT_CEQ_R8, double, ==, 0);
 		JITERP_RELOP(MINT_CNE_R4, float, !=, 1);
 		JITERP_RELOP(MINT_CNE_R8, double, !=, 1);
+		JITERP_RELOP(JITERP_CNE_UN_R4, float, !=, 1);
+		JITERP_RELOP(JITERP_CNE_UN_R8, double, !=, 1);
 		JITERP_RELOP(MINT_CGT_R4, float, >, 0);
 		JITERP_RELOP(MINT_CGT_R8, double, >, 0);
 		JITERP_RELOP(MINT_CGE_R4, float, >=, 0);
 		JITERP_RELOP(MINT_CGE_R8, double, >=, 0);
+		JITERP_RELOP(JITERP_CGE_UN_R4, float, >=, 1);
+		JITERP_RELOP(JITERP_CGE_UN_R8, double, >=, 1);
 		JITERP_RELOP(MINT_CGT_UN_R4, float, >, 1);
 		JITERP_RELOP(MINT_CGT_UN_R8, double, >, 1);
 		JITERP_RELOP(MINT_CLT_R4, float, <, 0);
@@ -467,6 +479,8 @@ mono_jiterp_relop_fp (double lhs, double rhs, int opcode) {
 		JITERP_RELOP(MINT_CLT_UN_R8, double, <, 1);
 		JITERP_RELOP(MINT_CLE_R4, float, <=, 0);
 		JITERP_RELOP(MINT_CLE_R8, double, <=, 0);
+		JITERP_RELOP(JITERP_CLE_UN_R4, float, <=, 1);
+		JITERP_RELOP(JITERP_CLE_UN_R8, double, <=, 1);
 
 		default:
 			g_assert_not_reached();

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -67,7 +67,7 @@ DEFINE_BOOL(aot_lazy_assembly_load, "aot-lazy-assembly-load", FALSE, "Load assem
 //  and wasm modules between threads. before these can be enabled we need to implement all that
 #ifdef DISABLE_THREADS
 // traces_enabled controls whether the jiterpreter will JIT individual interpreter opcode traces
-DEFINE_BOOL(jiterpreter_traces_enabled, "jiterpreter-traces-enabled", FALSE, "JIT interpreter opcode traces into WASM")
+DEFINE_BOOL(jiterpreter_traces_enabled, "jiterpreter-traces-enabled", TRUE, "JIT interpreter opcode traces into WASM")
 // interp_entry_enabled controls whether specialized interp_entry wrappers will be jitted
 DEFINE_BOOL(jiterpreter_interp_entry_enabled, "jiterpreter-interp-entry-enabled", TRUE, "JIT specialized WASM interp_entry wrappers")
 // jit_call_enabled controls whether do_jit_call will use specialized trampolines for hot call sites
@@ -95,7 +95,7 @@ DEFINE_BOOL(jiterpreter_call_resume_enabled, "jiterpreter-call-resume-enabled", 
 //  stats for options like estimateHeat, but raises overhead.
 DEFINE_BOOL(jiterpreter_disable_heuristic, "jiterpreter-disable-heuristic", FALSE, "Always insert trace entry points for more accurate statistics")
 // Automatically prints stats at app exit or when jiterpreter_dump_stats is called
-DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", FALSE, "Automatically print jiterpreter statistics")
+DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", TRUE, "Automatically print jiterpreter statistics")
 // Continue counting hits for traces that fail to compile and use it to estimate
 //  the relative importance of the opcode that caused them to abort
 DEFINE_BOOL(jiterpreter_estimate_heat, "jiterpreter-estimate-heat", FALSE, "Maintain accurate hit count for all trace entry points")

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -95,7 +95,7 @@ DEFINE_BOOL(jiterpreter_call_resume_enabled, "jiterpreter-call-resume-enabled", 
 //  stats for options like estimateHeat, but raises overhead.
 DEFINE_BOOL(jiterpreter_disable_heuristic, "jiterpreter-disable-heuristic", FALSE, "Always insert trace entry points for more accurate statistics")
 // Automatically prints stats at app exit or when jiterpreter_dump_stats is called
-DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", TRUE, "Automatically print jiterpreter statistics")
+DEFINE_BOOL(jiterpreter_stats_enabled, "jiterpreter-stats-enabled", FALSE, "Automatically print jiterpreter statistics")
 // Continue counting hits for traces that fail to compile and use it to estimate
 //  the relative importance of the opcode that caused them to abort
 DEFINE_BOOL(jiterpreter_estimate_heat, "jiterpreter-estimate-heat", FALSE, "Maintain accurate hit count for all trace entry points")

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -128,6 +128,15 @@ struct InterpMethod {
        void **data_items;
 */
 
+const enum JiterpSpecialOpcode {
+    CNE_UN_R4 = 0xFFFF + 0,
+    CGE_UN_R4 = 0xFFFF + 1,
+    CLE_UN_R4 = 0xFFFF + 2,
+    CNE_UN_R8 = 0xFFFF + 3,
+    CGE_UN_R8 = 0xFFFF + 4,
+    CLE_UN_R8 = 0xFFFF + 5,
+}
+
 const enum BailoutReason {
     Unknown,
     InterpreterTiering,
@@ -1673,7 +1682,6 @@ function emit_fieldop (
         case MintOpcode.MINT_LDSFLD_I4:
             // default
             break;
-        // FIXME: These cause grisu3 to break?
         case MintOpcode.MINT_STFLD_R4:
         case MintOpcode.MINT_STSFLD_R4:
         case MintOpcode.MINT_LDFLD_R4:
@@ -1901,6 +1909,12 @@ const intrinsicFpBinops : { [opcode: number] : WasmOpcode } = {
     [MintOpcode.MINT_CLT_UN_R8]: WasmOpcode.nop,
     [MintOpcode.MINT_CLE_R4]: WasmOpcode.f64_promote_f32,
     [MintOpcode.MINT_CLE_R8]: WasmOpcode.nop,
+    [JiterpSpecialOpcode.CGE_UN_R4]: WasmOpcode.f64_promote_f32,
+    [JiterpSpecialOpcode.CLE_UN_R4]: WasmOpcode.f64_promote_f32,
+    [JiterpSpecialOpcode.CNE_UN_R4]: WasmOpcode.f64_promote_f32,
+    [JiterpSpecialOpcode.CGE_UN_R8]: WasmOpcode.nop,
+    [JiterpSpecialOpcode.CLE_UN_R8]: WasmOpcode.nop,
+    [JiterpSpecialOpcode.CNE_UN_R8]: WasmOpcode.nop,
 };
 
 const binopTable : { [opcode: number]: OpRec3 | OpRec4 | undefined } = {
@@ -2021,7 +2035,8 @@ const relopbranchTable : { [opcode: number]: [comparisonOpcode: MintOpcode, imme
     [MintOpcode.MINT_BLE_UN_I8_S]:      MintOpcode.MINT_CLE_UN_I8,
 
     [MintOpcode.MINT_BEQ_I8_IMM_SP]:    [MintOpcode.MINT_CEQ_I8,    WasmOpcode.i64_const, true],
-    [MintOpcode.MINT_BNE_UN_I8_IMM_SP]: [MintOpcode.MINT_CNE_I8,    WasmOpcode.i64_const, true],
+    // FIXME: Missing compare opcode
+    // [MintOpcode.MINT_BNE_UN_I8_IMM_SP]: [MintOpcode.MINT_CNE_UN_I8, WasmOpcode.i64_const, true],
     [MintOpcode.MINT_BGT_I8_IMM_SP]:    [MintOpcode.MINT_CGT_I8,    WasmOpcode.i64_const, true],
     [MintOpcode.MINT_BGT_UN_I8_IMM_SP]: [MintOpcode.MINT_CGT_UN_I8, WasmOpcode.i64_const, true],
     [MintOpcode.MINT_BLT_I8_IMM_SP]:    [MintOpcode.MINT_CLT_I8,    WasmOpcode.i64_const, true],
@@ -2032,30 +2047,26 @@ const relopbranchTable : { [opcode: number]: [comparisonOpcode: MintOpcode, imme
     [MintOpcode.MINT_BLE_UN_I8_IMM_SP]: [MintOpcode.MINT_CLE_UN_I8, WasmOpcode.i64_const, true],
 
     [MintOpcode.MINT_BEQ_R4_S]:         MintOpcode.MINT_CEQ_R4,
-    [MintOpcode.MINT_BNE_UN_R4_S]:      MintOpcode.MINT_CNE_R4,
+    [MintOpcode.MINT_BNE_UN_R4_S]:      <any>JiterpSpecialOpcode.CNE_UN_R4,
     [MintOpcode.MINT_BGT_R4_S]:         MintOpcode.MINT_CGT_R4,
     [MintOpcode.MINT_BGT_UN_R4_S]:      MintOpcode.MINT_CGT_UN_R4,
     [MintOpcode.MINT_BLT_R4_S]:         MintOpcode.MINT_CLT_R4,
     [MintOpcode.MINT_BLT_UN_R4_S]:      MintOpcode.MINT_CLT_UN_R4,
     [MintOpcode.MINT_BGE_R4_S]:         MintOpcode.MINT_CGE_R4,
-    // FIXME: No compare opcode for this
-    [MintOpcode.MINT_BGE_UN_R4_S]:      MintOpcode.MINT_CGE_R4,
+    [MintOpcode.MINT_BGE_UN_R4_S]:      <any>JiterpSpecialOpcode.CGE_UN_R4,
     [MintOpcode.MINT_BLE_R4_S]:         MintOpcode.MINT_CLE_R4,
-    // FIXME: No compare opcode for this
-    [MintOpcode.MINT_BLE_UN_R4_S]:      MintOpcode.MINT_CLE_R4,
+    [MintOpcode.MINT_BLE_UN_R4_S]:      <any>JiterpSpecialOpcode.CLE_UN_R4,
 
     [MintOpcode.MINT_BEQ_R8_S]:         MintOpcode.MINT_CEQ_R8,
-    [MintOpcode.MINT_BNE_UN_R8_S]:      MintOpcode.MINT_CNE_R8,
+    [MintOpcode.MINT_BNE_UN_R8_S]:      <any>JiterpSpecialOpcode.CNE_UN_R8,
     [MintOpcode.MINT_BGT_R8_S]:         MintOpcode.MINT_CGT_R8,
     [MintOpcode.MINT_BGT_UN_R8_S]:      MintOpcode.MINT_CGT_UN_R8,
     [MintOpcode.MINT_BLT_R8_S]:         MintOpcode.MINT_CLT_R8,
     [MintOpcode.MINT_BLT_UN_R8_S]:      MintOpcode.MINT_CLT_UN_R8,
     [MintOpcode.MINT_BGE_R8_S]:         MintOpcode.MINT_CGE_R8,
-    // FIXME: No compare opcode for this
-    [MintOpcode.MINT_BGE_UN_R8_S]:      MintOpcode.MINT_CGE_R8,
+    [MintOpcode.MINT_BGE_UN_R8_S]:      <any>JiterpSpecialOpcode.CGE_UN_R8,
     [MintOpcode.MINT_BLE_R8_S]:         MintOpcode.MINT_CLE_R8,
-    // FIXME: No compare opcode for this
-    [MintOpcode.MINT_BLE_UN_R8_S]:      MintOpcode.MINT_CLE_R8,
+    [MintOpcode.MINT_BLE_UN_R8_S]:      <any>JiterpSpecialOpcode.CLE_UN_R8,
 };
 
 function emit_binop (builder: WasmBuilder, ip: MintOpcodePtr, opcode: MintOpcode) : boolean {
@@ -2466,14 +2477,14 @@ function emit_relop_branch (builder: WasmBuilder, ip: MintOpcodePtr, opcode: Min
     const operandLoadOp = relopInfo
         ? relopInfo[1]
         : (
-            intrinsicFpBinop == WasmOpcode.nop
+            intrinsicFpBinop === WasmOpcode.nop
                 ? WasmOpcode.f64_load
                 : WasmOpcode.f32_load
         );
 
     append_ldloc(builder, getArgU16(ip, 1), operandLoadOp);
     // Promote f32 lhs to f64 if necessary
-    if (!relopInfo && (intrinsicFpBinop != WasmOpcode.nop))
+    if (!relopInfo && (intrinsicFpBinop !== WasmOpcode.nop))
         builder.appendU8(intrinsicFpBinop);
 
     // Compare with immediate


### PR DESCRIPTION
This PR enables jiterpreter traces and fixes a bug in the implementation of floating point compares / floating point branches.