### PR TITLE
[wasm] Drop `_SampleProject` and `_SampleAssembly` properties

### DIFF
--- a/src/mono/sample/wasi/Directory.Build.targets
+++ b/src/mono/sample/wasi/Directory.Build.targets
@@ -10,7 +10,8 @@
   <Target Name="BuildSampleInTree"
       Inputs="
       Program.cs;
-      $(_SampleProject)
+      $(_SampleProject);
+      $(MSBuildProjectFile)
       "
       Outputs="
       bin/publish/runtime/native/dotnet.wasm;
@@ -23,6 +24,7 @@
       <_ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</_ScriptExt>
       <_Dotnet>$(RepoRoot)dotnet$(_ScriptExt)</_Dotnet>
       <_AOTFlag Condition="'$(RunAOTCompilation)' != ''">/p:RunAOTCompilation=$(RunAOTCompilation)</_AOTFlag>
+      <_SampleProject Condition="'$(_SampleProject)' == ''">$(MSBuildProjectFile)</_SampleProject>
       <_WasmMainJSFileName>$([System.IO.Path]::GetFileName('$(WasmMainJSPath)'))</_WasmMainJSFileName>
     </PropertyGroup>
     <Exec Command="$(_Dotnet) publish -bl /p:Configuration=$(Configuration) /p:TargetArchitecture=wasm /p:TargetOS=wasi $(_AOTFlag) $(_SampleProject) $(BuildAdditionalArgs)" />

--- a/src/mono/sample/wasi/console/Wasi.Console.Sample.csproj
+++ b/src/mono/sample/wasi/console/Wasi.Console.Sample.csproj
@@ -4,10 +4,5 @@
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <_SampleProject>Wasi.Console.Sample.csproj</_SampleProject>
-    <_SampleAssembly>Wasi.Console.Sample.dll</_SampleAssembly>
-  </PropertyGroup>
-
   <Target Name="RunSample" DependsOnTargets="RunSampleWithWasmtime" />
 </Project>

--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -26,6 +26,9 @@
       Inputs="
       Program.cs;
       $(_WasmMainJSFileName);
+      $(_SampleProject);
+      $(MSBuildProjectFile)
+      $(TargetFileName)
       "
       Outputs="
       bin/$(Configuration)/AppBundle/dotnet.wasm;
@@ -38,6 +41,8 @@
       <_Dotnet>$(RepoRoot)dotnet$(_ScriptExt)</_Dotnet>
       <_AOTFlag Condition="'$(RunAOTCompilation)' != ''">/p:RunAOTCompilation=$(RunAOTCompilation)</_AOTFlag>
       <_WasmMainJSFileName>$([System.IO.Path]::GetFileName('$(WasmMainJSPath)'))</_WasmMainJSFileName>
+      <_SampleProject Condition="'$(_SampleProject)' == ''">$(MSBuildProjectFile)</_SampleProject>
+      <_SampleAssembly Condition="'$(_SampleAssembly)' == ''">$(TargetFileName)</_SampleAssembly>
       <BuildAdditionalArgs Condition="'$(MonoDiagnosticsMock)' != ''">$(BuildAdditionalArgs) /p:MonoDiagnosticsMock=$(MonoDiagnosticsMock) </BuildAdditionalArgs>
     </PropertyGroup>
     <Exec Command="$(_Dotnet) publish -bl /p:Configuration=$(Configuration) /p:TargetArchitecture=wasm /p:TargetOS=browser $(_AOTFlag) $(_SampleProject) $(BuildAdditionalArgs)" />

--- a/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
+++ b/src/mono/sample/wasm/browser-advanced/Wasm.Advanced.Sample.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\DefaultBrowserSample.targets" />
   <PropertyGroup>
-    <_SampleProject>Wasm.Advanced.Sample.csproj</_SampleProject>
     <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
     <PublishTrimmed>true</PublishTrimmed>
     <!-- add OpenGL emulation -->

--- a/src/mono/sample/wasm/browser-bench/Console/Wasm.Console.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Console/Wasm.Console.Bench.Sample.csproj
@@ -9,8 +9,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <_SampleProject>Wasm.Console.Bench.Sample.csproj</_SampleProject>
-    <_SampleAssembly>Wasm.Console.Bench.Sample.dll</_SampleAssembly>
     <SignAssembly>False</SignAssembly>
   </PropertyGroup>
 

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -20,11 +20,6 @@
     <Compile Remove="Console/Console.cs" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <_SampleProject>Wasm.Browser.Bench.Sample.csproj</_SampleProject>
-    <_SampleAssembly> Wasm.Browser.Bench.Sample.dll</_SampleAssembly>
-  </PropertyGroup>
-
   <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowserAndSimpleServer" />
 
 </Project>

--- a/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
+++ b/src/mono/sample/wasm/browser-eventpipe/Wasm.Browser.EventPipe.Sample.csproj
@@ -34,11 +34,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <_SampleProject>Wasm.Browser.EventPipe.Sample.csproj</_SampleProject>
-  </PropertyGroup>
-
-
-  <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 

--- a/src/mono/sample/wasm/browser-threads/Wasm.Browser.Threads.Sample.csproj
+++ b/src/mono/sample/wasm/browser-threads/Wasm.Browser.Threads.Sample.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\DefaultBrowserSample.targets" />
   <PropertyGroup>
-    <_SampleProject>Wasm.Browser.Threads.Sample.csproj</_SampleProject>
     <WasmEnableThreads>true</WasmEnableThreads>
   </PropertyGroup>
 

--- a/src/mono/sample/wasm/browser/Wasm.Browser.Sample.csproj
+++ b/src/mono/sample/wasm/browser/Wasm.Browser.Sample.csproj
@@ -1,6 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\DefaultBrowserSample.targets" />
-  <PropertyGroup>
-    <_SampleProject>Wasm.Browser.Sample.csproj</_SampleProject>
-  </PropertyGroup>
 </Project>

--- a/src/mono/sample/wasm/console-node/Wasm.Console.Node.Sample.csproj
+++ b/src/mono/sample/wasm/console-node/Wasm.Console.Node.Sample.csproj
@@ -13,10 +13,5 @@
     <WasmExtraFilesToDeploy Include="package.json" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <_SampleProject>Wasm.Console.Node.Sample.csproj</_SampleProject>
-    <_SampleAssembly>Wasm.Console.Node.Sample.dll</_SampleAssembly>
-  </PropertyGroup>
-
   <Target Name="RunSample" DependsOnTargets="RunSampleWithNode" />
 </Project>

--- a/src/mono/sample/wasm/console-v8/Wasm.Console.V8.Sample.csproj
+++ b/src/mono/sample/wasm/console-v8/Wasm.Console.V8.Sample.csproj
@@ -8,10 +8,6 @@
     <RunScriptCommand>$(ExecXHarnessCmd) wasm test --app=. --engine=V8 --engine-arg=--stack-trace-limit=1000 --engine-arg=--module --js-file=main.mjs --output-directory=$(XHarnessOutput) -- --run $(MSBuildProjectName).dll</RunScriptCommand>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <_SampleProject>Wasm.Console.V8.Sample.csproj</_SampleProject>
-    <_SampleAssembly>Wasm.Console.V8.Sample.dll</_SampleAssembly>
-  </PropertyGroup>
 
   <Target Name="RunSample" DependsOnTargets="RunSampleWithV8" />
 </Project>


### PR DESCRIPTION
- The `_SampleProject` can be replaced with `MSBuildProjectFile`.
- The `_SampleAssembly` can be replaced with `TargetFileName`.