### PR TITLE
JIT: Skip LSRA inserted nodes in gcIsWriteBarrierCandidate

### DIFF
--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -240,7 +240,8 @@ GCInfo::WriteBarrierForm GCInfo::gcIsWriteBarrierCandidate(GenTreeStoreInd* stor
     }
 
     // Ignore any assignments of NULL.
-    if ((store->Data()->GetVN(VNK_Liberal) == ValueNumStore::VNForNull()) || store->Data()->IsIntegralConst(0))
+    GenTree* data = store->Data()->gtSkipReloadOrCopy();
+    if ((data->GetVN(VNK_Liberal) == ValueNumStore::VNForNull()) || data->IsIntegralConst(0))
     {
         return WBF_NoBarrier;
     }
@@ -253,7 +254,7 @@ GCInfo::WriteBarrierForm GCInfo::gcIsWriteBarrierCandidate(GenTreeStoreInd* stor
     }
 
     // Write-barriers are no-op for frozen objects (as values)
-    if (store->Data()->IsIconHandle(GTF_ICON_OBJ_HDL))
+    if (data->IsIconHandle(GTF_ICON_OBJ_HDL))
     {
         // Ignore frozen objects
         return WBF_NoBarrier;


### PR DESCRIPTION
gcIsWriteBarrierCandidate is expected to return the same results during LSRA and during codegen, so it needs to skip GT_COPY and GT_RELOAD inserted on top of the data node.

Fix #77141
Fix #77143