### PR TITLE
JIT: Update GTF_GLOB_REF after last-use copy omission

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4534,6 +4534,7 @@ public:
 
     bool fgRemoveRestOfBlock; // true if we know that we will throw
     bool fgStmtRemoved;       // true if we remove statements -> need new DFA
+    bool fgRemarkGlobalUses;  // true if morph should remark global uses after processing a statement
 
     enum FlowGraphOrder
     {
@@ -5818,7 +5819,7 @@ private:
     GenTreeCall* fgMorphArgs(GenTreeCall* call);
 
     void fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg);
-    void fgMarkNewlyGlobalUses(Statement* stmt, unsigned lclNum);
+    void fgMarkGlobalUses(Statement* stmt);
 
     GenTree* fgMorphLocal(GenTreeLclVarCommon* lclNode);
 #ifdef TARGET_X86

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5818,6 +5818,7 @@ private:
     GenTreeCall* fgMorphArgs(GenTreeCall* call);
 
     void fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg);
+    void fgMarkNewlyGlobalUses(Statement* stmt, unsigned lclNum);
 
     GenTree* fgMorphLocal(GenTreeLclVarCommon* lclNode);
 #ifdef TARGET_X86


### PR DESCRIPTION
Morph is responsible for marking accesses of address-exposed locals with GTF_GLOB_REF, however the last-use copy elision can newly address expose a preexisting local. This means previous uses that morph already saw have not had GTF_GLOB_REF added. This updates the JIT to at least add GTF_GLOB_REF on locals within the same statement as the call. This is not a complete fix as nothing prevents downstream phases from reordering the call with uses from earlier statements, but this at least fixes the one issue we know of right now (which is itself stress-only).

Note that the previous uses are not actually 'global' uses unless they actually end up getting reordered with the call.

A more complete fix will likely entail moving the identifying of last-use candidates earlier and address exposing them at that point. However, that first requires ABI determination to be moved earlier, so this depends on #76926, which I expect to get to within the near future. So this is sort of an interim fix.

Fix #81049