### PR TITLE
Run nativeaot tests in helix

### DIFF
--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -2,7 +2,7 @@ parameters:
   buildConfig: ''
   osSubgroup: ''
   container: ''
-  testFilter: ''
+  testBuildArgs: ''
   crossBuild: false
   readyToRun: false
   liveLibrariesBuildConfig: ''
@@ -13,7 +13,6 @@ parameters:
   nativeAotTest: false
   runtimeFlavor: 'mono'
   runtimeVariant: 'monointerpreter'
-  testBuildMode: ''
   variables: {}
   pool: ''
   dependsOn: []
@@ -28,11 +27,11 @@ parameters:
 
 steps:
   - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:RuntimeVariant=${{ parameters.runtimeVariant }} ${{ parameters.testFilter }} -mono os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper) /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:RuntimeVariant=${{ parameters.runtimeVariant }} ${{ parameters.testBuildArgs }} -mono os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper) /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci
       displayName: Build Tests
 
   - ${{ if ne(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.testBuildMode }} ${{ parameters.testFilter }} ${{ parameters.archType }} $(buildConfigUpper) /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.archType }} $(buildConfigUpper) ${{ parameters.testBuildArgs }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci
       displayName: Build Tests
 
 

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -10,6 +10,7 @@ parameters:
   helixQueues: ''
   displayNameArgs: ''
   runInUnloadableContext: false
+  nativeAotTest: false
   runtimeFlavor: 'mono'
   runtimeVariant: 'monointerpreter'
   testBuildMode: ''
@@ -31,7 +32,7 @@ steps:
       displayName: Build Tests
 
   - ${{ if ne(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.testBuildMode }} ${{ parameters.testFilter }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.testBuildMode }} ${{ parameters.testFilter }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci ${{ parameters.archType }} $(buildConfigUpper)
       displayName: Build Tests
 
 
@@ -105,6 +106,7 @@ steps:
         runCrossGen2: ${{ eq(parameters.readyToRun, true) }}
         compositeBuildMode: ${{ parameters.compositeBuildMode }}
         runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
+        nativeAotTest: ${{ parameters.nativeAotTest }}
 
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           # Access token variable for internal project from the

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -2,7 +2,7 @@ parameters:
   buildConfig: ''
   osSubgroup: ''
   container: ''
-  testGroup: ''
+  testFilter: ''
   crossBuild: false
   readyToRun: false
   liveLibrariesBuildConfig: ''
@@ -12,6 +12,7 @@ parameters:
   runInUnloadableContext: false
   runtimeFlavor: 'mono'
   runtimeVariant: 'monointerpreter'
+  testBuildMode: ''
   variables: {}
   pool: ''
   dependsOn: []
@@ -26,11 +27,11 @@ parameters:
 
 steps:
   - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:RuntimeVariant=${{ parameters.runtimeVariant }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -mono -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:RuntimeVariant=${{ parameters.runtimeVariant }} '${{ parameters.testFilter }}' /p:LibrariesConfiguration=${{ parameters.buildConfig }} -mono -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
       displayName: Build Tests
 
   - ${{ if ne(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.testBuildMode }} '${{ parameters.testFilter }}' /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
       displayName: Build Tests
 
 

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -28,11 +28,11 @@ parameters:
 
 steps:
   - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:RuntimeVariant=${{ parameters.runtimeVariant }} ${{ parameters.testFilter }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -mono -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:RuntimeVariant=${{ parameters.runtimeVariant }} ${{ parameters.testFilter }} -mono os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper) /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci
       displayName: Build Tests
 
   - ${{ if ne(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.testBuildMode }} ${{ parameters.testFilter }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci ${{ parameters.archType }} $(buildConfigUpper)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.testBuildMode }} ${{ parameters.testFilter }} ${{ parameters.archType }} $(buildConfigUpper) /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci
       displayName: Build Tests
 
 

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -31,7 +31,7 @@ steps:
       displayName: Build Tests
 
   - ${{ if ne(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.archType }} $(buildConfigUpper) ${{ parameters.testBuildArgs }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.archType }} $(buildConfigUpper) ${{ parameters.testBuildArgs }} -ci
       displayName: Build Tests
 
 

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -27,11 +27,11 @@ parameters:
 
 steps:
   - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:RuntimeVariant=${{ parameters.runtimeVariant }} '${{ parameters.testFilter }}' /p:LibrariesConfiguration=${{ parameters.buildConfig }} -mono -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) /p:RuntimeVariant=${{ parameters.runtimeVariant }} ${{ parameters.testFilter }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -mono -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
       displayName: Build Tests
 
   - ${{ if ne(parameters.runtimeFlavor, 'mono') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.testBuildMode }} '${{ parameters.testFilter }}' /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.testBuildMode }} ${{ parameters.testFilter }} /p:LibrariesConfiguration=${{ parameters.buildConfig }} -ci os ${{ parameters.osGroup }} ${{ parameters.archType }} $(buildConfigUpper)
       displayName: Build Tests
 
 

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -98,12 +98,8 @@ jobs:
 
       # Only build GCSimulator tests when the gc-simulator group is specified.
       - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
-        - ${{ if eq(parameters.osGroup, 'windows') }}:
           - name: testTreeFilterArg
             value: 'tree GC/Scenarios/GCSimulator'
-        - ${{ if ne(parameters.osGroup, 'windows') }}:
-          - name: testTreeFilterArg
-            value: '-tree:GC/Scenarios/GCSimulator'
 
     steps:
 

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -139,12 +139,8 @@ jobs:
 
     # Only build GCSimulator tests when the gc-simulator group is specified.
     - ${{ if eq(parameters.testGroup, 'gc-simulator') }}:
-      - ${{ if eq(parameters.osGroup, 'windows') }}:
-        - name: testTreeFilterArg
-          value: 'tree GC/Scenarios/GCSimulator'
-      - ${{ if ne(parameters.osGroup, 'windows') }}:
-        - name: testTreeFilterArg
-          value: '-tree:GC/Scenarios/GCSimulator'
+      - name: testTreeFilterArg
+        value: 'tree GC/Scenarios/GCSimulator'
 
     # Variables used for SuperPMI collection
     - ${{ if eq(parameters.SuperPmiCollect, true) }}:

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -22,6 +22,7 @@ parameters:
   helixProjectArguments: ''
   runInUnloadableContext: ''
   tieringTest: ''
+  nativeAotTest: ''
   longRunningGcTests: ''
   gcSimulatorTests: ''
   runtimeFlavor: 'CoreCLR'
@@ -51,6 +52,7 @@ steps:
       _CompositeBuildMode: ${{ parameters.compositeBuildMode }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}
       _TieringTest: ${{ parameters.tieringTest }}
+      _NativeAotTest: ${{ parameters.nativeAotTest }}
       _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _GcSimulatorTests: ${{ parameters.gcSimulatorTests }}
       _Scenarios: ${{ join(',', parameters.scenarios) }}

--- a/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+++ b/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
@@ -7,6 +7,7 @@ parameters:
   runtimeVariant: ''
   testBuildArgs: ''
   nativeAotTest: false
+  helixQueues: ''
 
 steps:
 # Can't run arm/arm64 tests on x64 build machines
@@ -23,6 +24,7 @@ steps:
       runtimeVariant: ${{ parameters.runtimeVariant }}
       testBuildArgs: ${{ parameters.testBuildArgs }}
       nativeAotTest: ${{ parameters.nativeAotTest }}
+      helixQueues: ${{ parameters.helixQueues }}
 
   # Publishing tooling doesn't support different configs between runtime and libs, so only run tests in Release config
   - ${{ if eq(parameters.buildConfig, 'release') }}:

--- a/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+++ b/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
@@ -4,31 +4,15 @@ parameters:
   osGroup: ''
   osSubgroup: ''
   platform: ''
-  pgoType: ''
   runtimeVariant: ''
-  uploadTests: false
-  testFilter: tree nativeaot
-  runSingleFileTests: true
+  testBuildArgs: ''
 
 steps:
 # Can't run arm/arm64 tests on x64 build machines
 - ${{ if and(ne(parameters.archType, 'arm'), ne(parameters.archType, 'arm64')) }}:
 
-  # Build coreclr native test output
-  - ${{ if eq(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build.cmd nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} /p:BuildNativeAotFrameworkObjects=true
-      displayName: Build tests
-  - ${{ if ne(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build.sh nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }}
-      displayName: Build tests
-
-  - ${{ if eq(parameters.runSingleFileTests, true) }}:
-    - ${{ if eq(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/tests/run.cmd runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}
-        displayName: Run tests in single file mode
-    - ${{ if ne(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/tests/run.sh --runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}
-        displayName: Run tests in single file mode
+  # Build coreclr native test output and send to helix
+  - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
 
   # Publishing tooling doesn't support different configs between runtime and libs, so only run tests in Release config
   - ${{ if eq(parameters.buildConfig, 'release') }}:

--- a/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+++ b/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
@@ -19,7 +19,7 @@ steps:
     - script: $(Build.SourcesDirectory)/src/tests/build.cmd nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} /p:BuildNativeAotFrameworkObjects=true
       displayName: Build tests
   - ${{ if ne(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build.sh nativeaot $(buildConfigUpper) ${{ parameters.archType }} '${{ parameters.testFilter }}'
+    - script: $(Build.SourcesDirectory)/src/tests/build.sh nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }}
       displayName: Build tests
 
   - ${{ if eq(parameters.runSingleFileTests, true) }}:

--- a/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+++ b/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
@@ -3,10 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osSubgroup: ''
-  runtimeFlavor: ''
-  runtimeVariant: ''
   testBuildArgs: ''
-  nativeAotTest: false
   helixQueues: ''
 
 steps:
@@ -20,10 +17,10 @@ steps:
       archType: ${{ parameters.archType }}
       osGroup: ${{ parameters.osGroup }}
       osSubgroup: ${{ parameters.osSubgroup }}
-      runtimeFlavor: ${{ parameters.runtimeFlavor }}
-      runtimeVariant: ${{ parameters.runtimeVariant }}
+      runtimeFlavor: coreclr
+      runtimeVariant: ''
       testBuildArgs: ${{ parameters.testBuildArgs }}
-      nativeAotTest: ${{ parameters.nativeAotTest }}
+      nativeAotTest: true
       helixQueues: ${{ parameters.helixQueues }}
 
   # Publishing tooling doesn't support different configs between runtime and libs, so only run tests in Release config

--- a/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+++ b/eng/pipelines/coreclr/nativeaot-post-build-steps.yml
@@ -3,9 +3,10 @@ parameters:
   archType: ''
   osGroup: ''
   osSubgroup: ''
-  platform: ''
+  runtimeFlavor: ''
   runtimeVariant: ''
   testBuildArgs: ''
+  nativeAotTest: false
 
 steps:
 # Can't run arm/arm64 tests on x64 build machines
@@ -13,6 +14,15 @@ steps:
 
   # Build coreclr native test output and send to helix
   - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: ${{ parameters.archType }}
+      osGroup: ${{ parameters.osGroup }}
+      osSubgroup: ${{ parameters.osSubgroup }}
+      runtimeFlavor: ${{ parameters.runtimeFlavor }}
+      runtimeVariant: ${{ parameters.runtimeVariant }}
+      testBuildArgs: ${{ parameters.testBuildArgs }}
+      nativeAotTest: ${{ parameters.nativeAotTest }}
 
   # Publishing tooling doesn't support different configs between runtime and libs, so only run tests in Release config
   - ${{ if eq(parameters.buildConfig, 'release') }}:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -258,6 +258,43 @@ extends:
                 eq(variables['isFullMatrix'], true))
 
       #
+      # CoreCLR NativeAOT debug build and smoke tests (helix)
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: release
+          runtimeFlavor: coreclr
+          runtimeVariant: ''
+          testBuildMode: nativeaot
+          testFilter: tree nativeaot
+          platforms:
+          - linux_x64
+          - windows_x64
+          variables:
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+          jobParameters:
+            testGroup: innerloop
+            timeoutInMinutes: 120
+            nameSuffix: NativeAOT_Helix
+            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+            timeoutInMinutes: 120
+            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+            testRunNamePrefix: NativeAOT_Release
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isFullMatrix'], true))
+
+      #
       # CoreCLR NativeAOT release build and libraries tests
       # Only when CoreCLR or library is changed
       #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -260,7 +260,7 @@ extends:
                 eq(variables['isFullMatrix'], true))
 
       #
-      # CoreCLR NativeAOT release build and pri0 tests
+      # CoreCLR NativeAOT release build and smoke tests
       # Only when CoreCLR is changed
       #
       - template: /eng/pipelines/common/platform-matrix.yml
@@ -282,14 +282,14 @@ extends:
           jobParameters:
             testGroup: innerloop
             timeoutInMinutes: 120
-            nameSuffix: NativeAOT
+            nameSuffix: NativeAOT_Helix
             buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: nativeaot
+              testBuildArgs: nativeaot tree nativeaot
               nativeAotTest: true
-            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
+            testRunNamePrefixSuffix: NativeAOT_Release
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -283,7 +283,6 @@ extends:
             timeoutInMinutes: 120
             nameSuffix: NativeAOT_Helix
             buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            timeoutInMinutes: 120
             extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
             extraStepsParameters:
               creator: dotnet-bot

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -260,7 +260,7 @@ extends:
                 eq(variables['isFullMatrix'], true))
 
       #
-      # CoreCLR NativeAOT release build and smoke tests
+      # CoreCLR NativeAOT release build and pri0 tests
       # Only when CoreCLR is changed
       #
       - template: /eng/pipelines/common/platform-matrix.yml
@@ -282,14 +282,14 @@ extends:
           jobParameters:
             testGroup: innerloop
             timeoutInMinutes: 120
-            nameSuffix: NativeAOT_Helix
+            nameSuffix: NativeAOT
             buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildArgs: nativeaot tree nativeaot
+              testBuildArgs: nativeaot
               nativeAotTest: true
-            testRunNamePrefixSuffix: NativeAOT_Release
+            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -258,7 +258,7 @@ extends:
                 eq(variables['isFullMatrix'], true))
 
       #
-      # CoreCLR NativeAOT debug build and smoke tests (helix)
+      # CoreCLR NativeAOT release build and smoke tests (helix)
       # Only when CoreCLR is changed
       #
       - template: /eng/pipelines/common/platform-matrix.yml
@@ -285,6 +285,7 @@ extends:
             extraStepsParameters:
               creator: dotnet-bot
               testBuildMode: nativeaot
+              nativeAotTest: true
               testFilter: tree nativeaot
             testRunNamePrefixSuffix: NativeAOT_Release
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -210,14 +210,14 @@ extends:
           jobParameters:
             testGroup: innerloop
             timeoutInMinutes: 120
-            nameSuffix: NativeAOT_Helix
+            nameSuffix: NativeAOT
             buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
               testBuildArgs: nativeaot tree nativeaot
               nativeAotTest: true
-            testRunNamePrefixSuffix: NativeAOT_Debug
+            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -245,14 +245,14 @@ extends:
           jobParameters:
             testGroup: innerloop
             timeoutInMinutes: 120
-            nameSuffix: NativeAOT_Helix
+            nameSuffix: NativeAOT
             buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
               testBuildArgs: nativeaot tree nativeaot /p:BuildNativeAotFrameworkObjects=true
               nativeAotTest: true
-            testRunNamePrefixSuffix: NativeAOT_Checked
+            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -268,8 +268,6 @@ extends:
           buildConfig: release
           runtimeFlavor: coreclr
           runtimeVariant: ''
-          testBuildMode: nativeaot
-          testFilter: tree nativeaot
           platforms:
           - linux_x64
           - windows_x64
@@ -286,7 +284,9 @@ extends:
             extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
             extraStepsParameters:
               creator: dotnet-bot
-            testRunNamePrefix: NativeAOT_Release
+              testBuildMode: nativeaot
+              testFilter: tree nativeaot
+            testRunNamePrefixSuffix: NativeAOT_Release
 
       #
       # CoreCLR NativeAOT release build and libraries tests

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -289,7 +289,7 @@ extends:
               creator: dotnet-bot
               testBuildArgs: nativeaot tree nativeaot
               nativeAotTest: true
-            testRunNamePrefixSuffix: NativeAOT_Release
+            testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             condition: >-
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -197,8 +197,6 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           buildConfig: Debug
-          runtimeFlavor: coreclr
-          runtimeVariant: ''
           platforms:
           - linux_x64
           - windows_x64
@@ -216,7 +214,6 @@ extends:
             extraStepsParameters:
               creator: dotnet-bot
               testBuildArgs: nativeaot tree nativeaot
-              nativeAotTest: true
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             condition: >-
               or(
@@ -233,8 +230,6 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           buildConfig: Checked
-          runtimeFlavor: coreclr
-          runtimeVariant: ''
           platforms:
           - windows_x64
           variables:
@@ -251,7 +246,6 @@ extends:
             extraStepsParameters:
               creator: dotnet-bot
               testBuildArgs: nativeaot tree nativeaot /p:BuildNativeAotFrameworkObjects=true
-              nativeAotTest: true
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             condition: >-
               or(
@@ -268,8 +262,6 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           buildConfig: Release
-          runtimeFlavor: coreclr
-          runtimeVariant: ''
           platforms:
           - linux_x64
           - windows_x64
@@ -282,13 +274,12 @@ extends:
           jobParameters:
             testGroup: innerloop
             timeoutInMinutes: 120
-            nameSuffix: NativeAOT_Helix
+            nameSuffix: NativeAOT
             buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
             extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
               testBuildArgs: nativeaot tree nativeaot
-              nativeAotTest: true
             testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             condition: >-
               or(

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -265,7 +265,7 @@ extends:
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: release
+          buildConfig: Release
           runtimeFlavor: coreclr
           runtimeVariant: ''
           platforms:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -287,11 +287,6 @@ extends:
             extraStepsParameters:
               creator: dotnet-bot
             testRunNamePrefix: NativeAOT_Release
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
 
       #
       # CoreCLR NativeAOT release build and libraries tests

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -195,77 +195,8 @@ extends:
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: debug
-          platforms:
-          - linux_x64
-          - windows_x64
-          jobParameters:
-            testGroup: innerloop
-            timeoutInMinutes: 120
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
-
-      #
-      # CoreCLR NativeAOT checked build and smoke tests
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: checked
-          platforms:
-          - windows_x64
-          jobParameters:
-            testGroup: innerloop
-            timeoutInMinutes: 120
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
-
-      #
-      # CoreCLR NativeAOT release build and smoke tests
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-          - linux_x64
-          - windows_x64
-          - osx_x64
-          jobParameters:
-            testGroup: innerloop
-            timeoutInMinutes: 120
-            nameSuffix: NativeAOT
-            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-                eq(variables['isFullMatrix'], true))
-
-      #
-      # CoreCLR NativeAOT release build and smoke tests (helix)
-      # Only when CoreCLR is changed
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          buildConfig: Release
+          buildConfig: Debug
           runtimeFlavor: coreclr
           runtimeVariant: ''
           platforms:
@@ -281,13 +212,89 @@ extends:
             timeoutInMinutes: 120
             nameSuffix: NativeAOT_Helix
             buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
-            extraStepsTemplate: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
             extraStepsParameters:
               creator: dotnet-bot
-              testBuildMode: nativeaot
+              testBuildArgs: nativeaot tree nativeaot
               nativeAotTest: true
-              testFilter: tree nativeaot
+            testRunNamePrefixSuffix: NativeAOT_Debug
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isFullMatrix'], true))
+
+      #
+      # CoreCLR NativeAOT checked build and smoke tests
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Checked
+          runtimeFlavor: coreclr
+          runtimeVariant: ''
+          platforms:
+          - windows_x64
+          variables:
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+          jobParameters:
+            testGroup: innerloop
+            timeoutInMinutes: 120
+            nameSuffix: NativeAOT_Helix
+            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testBuildArgs: nativeaot tree nativeaot /p:BuildNativeAotFrameworkObjects=true
+              nativeAotTest: true
+            testRunNamePrefixSuffix: NativeAOT_Checked
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isFullMatrix'], true))
+
+      #
+      # CoreCLR NativeAOT release build and smoke tests
+      # Only when CoreCLR is changed
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Release
+          runtimeFlavor: coreclr
+          runtimeVariant: ''
+          platforms:
+          - linux_x64
+          - windows_x64
+          - osx_x64
+          variables:
+          - name: timeoutPerTestInMinutes
+            value: 60
+          - name: timeoutPerTestCollectionInMinutes
+            value: 180
+          jobParameters:
+            testGroup: innerloop
+            timeoutInMinutes: 120
+            nameSuffix: NativeAOT_Helix
+            buildArgs: -s clr.aot+host.native+libs -rc $(_BuildConfig) -lc Release -hc Release
+            extraStepsTemplate: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
+            extraStepsParameters:
+              creator: dotnet-bot
+              testBuildArgs: nativeaot tree nativeaot
+              nativeAotTest: true
             testRunNamePrefixSuffix: NativeAOT_Release
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isFullMatrix'], true))
 
       #
       # CoreCLR NativeAOT release build and libraries tests

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -40,6 +40,7 @@
     <_GcSimulatorTests>false</_GcSimulatorTests>
     <_RunInUnloadableContext>false</_RunInUnloadableContext>
     <_TieringTest>false</_TieringTest>
+    <_NativeAotTest>false</_NativeAotTest>
     <_TimeoutPerTestCollectionInMinutes>123</_TimeoutPerTestCollectionInMinutes>
     <_TimeoutPerTestInMinutes>234</_TimeoutPerTestInMinutes>
     <_RuntimeVariant></_RuntimeVariant>
@@ -95,6 +96,7 @@
         GcSimulatorTests=$(_GcSimulatorTests);
         RunInUnloadableContext=$(_RunInUnloadableContext);
         TieringTest=$(_TieringTest);
+        NativeAotTest=$(_NativeAotTest);
         TimeoutPerTestCollectionInMinutes=$(_TimeoutPerTestCollectionInMinutes);
         TimeoutPerTestInMinutes=$(_TimeoutPerTestInMinutes);
         RuntimeVariant=$(_RuntimeVariant);
@@ -288,6 +290,8 @@
     <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts/runincontext.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' != 'true' and '$(_RunInUnloadableContext)' == 'true'" />
     <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts\tieringtest.cmd" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' == 'true' and '$(_TieringTest)' == 'true'" />
     <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts/tieringtest.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' != 'true' and '$(_TieringTest)' == 'true'" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts\nativeaottest.cmd" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' == 'true' and '$(_NativeAotTest)' == 'true'" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts/nativeaottest.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' != 'true' and '$(_NativeAotTest)' == 'true'" />
 
     <ItemGroup Condition=" '$(SuperPmiCollect)' == 'true' ">
       <!-- We need superpmi.py and its dependencies; this is an over-approximation. The HelixCorrelationPayload directory is CoreRootDirectory, so copy the scripts there. -->
@@ -602,6 +606,7 @@
     <HelixPreCommand Include="set RunTieringTest=1" Condition=" '$(TieringTest)' == 'true' " />
     <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\runincontext.cmd" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\tieringtest.cmd" Condition=" '$(TieringTest)' == 'true' " />
+    <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\nativeaottest.cmd" Condition=" '$(NativeAotTest)' == 'true' " />
     <HelixPreCommand Include="set __TestEnv=%HELIX_WORKITEM_PAYLOAD%\$(TestEnvFileName)" />
     <HelixPreCommand Include="set __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
     <HelixPreCommand Include="set __CollectDumps=1" />
@@ -650,6 +655,7 @@
     <HelixPreCommand Include="export RunTieringTest=1" Condition=" '$(TieringTest)' == 'true' " />
     <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/runincontext.sh" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/tieringtest.sh" Condition=" '$(TieringTest)' == 'true' " />
+    <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/nativeaottest.sh" Condition=" '$(NativeAotTest)' == 'true' " />
     <HelixPreCommand Include="export __TestEnv=$HELIX_WORKITEM_PAYLOAD/$(TestEnvFileName)" />
     <HelixPreCommand Include="export __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
     <HelixPreCommand Include="export __CollectDumps=1" />

--- a/src/tests/Common/scripts/nativeaottest.sh
+++ b/src/tests/Common/scripts/nativeaottest.sh
@@ -11,4 +11,5 @@
 # 3. - n. Additional arguments that were passed to the test .sh
 
 exename=$(basename $2 .dll)
+chmod +x $1/native/$exename
 $_DebuggerFullPath $1/native/$exename "${@:3}"

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -234,19 +234,34 @@ handle_arguments_local() {
         test*|-test*)
             local arg="$1"
             local parts=(${arg//:/ })
-            __BuildTestProject="$__BuildTestProject${parts[1]}%3B"
+            if [[ ${#parts[@]} -eq 1 ]]; then
+                shift
+                __BuildTestProject="$__BuildTestProject$1%3B"
+            else
+                __BuildTestProject="$__BuildTestProject${parts[1]}%3B"
+            fi
             ;;
 
         dir*|-dir*)
             local arg="$1"
             local parts=(${arg//:/ })
-            __BuildTestDir="$__BuildTestDir${parts[1]}%3B"
+            if [[ ${#parts[@]} -eq 1 ]]; then
+                shift
+                __BuildTestDir="$__BuildTestDir$1%3B"
+            else
+                __BuildTestDir="$__BuildTestDir${parts[1]}%3B"
+            fi
             ;;
 
         tree*|-tree*)
             local arg="$1"
             local parts=(${arg//:/ })
-            __BuildTestTree="$__BuildTestTree${parts[1]}%3B"
+            if [[ ${#parts[@]} -eq 1 ]]; then
+                shift
+                __BuildTestTree="$__BuildTestTree$1%3B"
+            else
+                __BuildTestTree="$__BuildTestTree${parts[1]}%3B"
+            fi
             ;;
 
         runtests|-runtests)
@@ -284,7 +299,12 @@ handle_arguments_local() {
         log*|-log*)
             local arg="$1"
             local parts=(${arg//:/ })
-            __BuildLogRootName="${parts[1]}"
+            if [[ ${#parts[@]} -eq 1 ]]; then
+                shift
+                __BuildLogRootName="$1"
+            else
+                __BuildLogRootName="${parts[1]}"
+            fi
             ;;
 
         *)


### PR DESCRIPTION
This changes the existing NativeAot smoke test runs to run in helix. I changed the multi-module test run (only supported on windows) to run only in the checked configuration, to avoid having to add a separate windows build script invocation inside one of the yaml templates.