### PR TITLE
[release/8.0-preview1] Install workload manifests in sdk band version derived from the

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <WorkloadVersionSuffix Condition="'$(PreReleaseVersionLabel)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
-    <SdkBandVersionForWorkload>$(SdkBandVersion)$(WorkloadVersionSuffix)</SdkBandVersionForWorkload>
+    <SdkBandVersionForWorkload_FromRuntimeVersions>$(SdkBandVersion)$(WorkloadVersionSuffix)</SdkBandVersionForWorkload_FromRuntimeVersions>
     <!-- Set assembly version to align with major and minor version,
          as for the patches and revisions should be manually updated per assembly if it is serviced. -->
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>

--- a/eng/testing/tests.wasm.targets
+++ b/eng/testing/tests.wasm.targets
@@ -341,20 +341,17 @@
       <WorkloadIdForTesting Include="wasm-tools;wasm-experimental"
                             ManifestName="Microsoft.NET.Workload.Mono.ToolChain.Current"
                             Variant="latest"
-                            Version="$(PackageVersionForWorkloadManifests)"
-                            VersionBand="$(SdkBandVersionForWorkload)" />
+                            Version="$(PackageVersionForWorkloadManifests)" />
 
       <WorkloadIdForTesting Include="wasm-tools-net7;wasm-experimental-net7"
                             ManifestName="Microsoft.NET.Workload.Mono.ToolChain.net7"
                             Variant="net7"
-                            Version="$(PackageVersionForWorkloadManifests)"
-                            VersionBand="$(SdkBandVersionForWorkload)" />
+                            Version="$(PackageVersionForWorkloadManifests)" />
 
       <WorkloadIdForTesting Include="wasm-tools-net6"
                             ManifestName="Microsoft.NET.Workload.Mono.ToolChain.net6"
                             Variant="net6"
                             Version="$(PackageVersionForWorkloadManifests)"
-                            VersionBand="$(SdkBandVersionForWorkload)"
                             IgnoreErrors="$(WasmIgnoreNet6WorkloadInstallErrors)" />
 
       <WorkloadCombinationsToInstall Include="latest"   Variants="latest" />

--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -11,11 +11,12 @@
     <_SdkWithNoWorkloadStampPath>$([MSBuild]::NormalizePath($(_SdkWithNoWorkloadPath), '.version-for-none-$(SdkVersionForWorkloadTesting).stamp'))</_SdkWithNoWorkloadStampPath>
     <InstallWorkloadUsingArtifactsDependsOn>
       $(InstallWorkloadUsingArtifactsDependsOn);
+      _ProvisionDotNetForWorkloadTesting;
+      _GetDotNetVersion;
       _SetPackageVersionForWorkloadsTesting;
       _GetNuGetsToBuild;
       _PreparePackagesForWorkloadInstall;
       GetWorkloadInputs;
-      _ProvisionDotNetForWorkloadTesting;
       _InstallWorkloads
     </InstallWorkloadUsingArtifactsDependsOn>
   </PropertyGroup>
@@ -83,6 +84,39 @@
     </ItemGroup>
     <Message Text="Removing @(_ManifestsToRemove)" Condition="Exists(%(_ManifestsToRemove.Identity))" Importance="High" />
     <RemoveDir Directories="@(_ManifestsToRemove)" Condition="Exists(%(_ManifestsToRemove.Identity))" />
+  </Target>
+
+  <Target Name="_GetDotNetVersion">
+    <PropertyGroup>
+      <_DotNetPath>$([MSBuild]::NormalizePath($(_SdkWithNoWorkloadPath), 'dotnet'))</_DotNetPath>
+      <_DotNetPath Condition="$([MSBuild]::IsOSPlatform('windows'))">$(_DotNetPath).exe</_DotNetPath>
+      <_DotNetVersionCommand>$(_DotNetPath) --version</_DotNetVersionCommand>
+    </PropertyGroup>
+
+    <Exec Command="$(_DotNetVersionCommand)" ConsoleToMsBuild="true" StandardOutputImportance="Low" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_DotNetVersionOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="_DotNetVersionExitCode" />
+    </Exec>
+
+    <!-- If `dotnet -version` failed, then run it again, so we can surface the output as *Errors*.
+         This allows the errors to show up correctly, versus trying to use the output lines with
+         the Error task -->
+    <Exec Condition="$(_DotNetVersionExitCode) != '0'" Command="$(_DotNetVersionCommand)" CustomErrorRegularExpression=".*" />
+
+    <PropertyGroup>
+       <SdkBandVersionForWorkload_ComputedFromInstaller>$(SdkBandVersion)$([System.Text.RegularExpressions.Regex]::Match($(_DotNetVersionOutput), `-[A-z]*[\.]*\d*`))</SdkBandVersionForWorkload_ComputedFromInstaller>
+    </PropertyGroup>
+
+    <Message Text="** Using sdk band version for installing manifests: $(SdkBandVersionForWorkload_ComputedFromInstaller)" Importance="High" />
+    <Message Text="
+      ********************
+
+      Warning: Using sdk band version for installing manifests: $(SdkBandVersionForWorkload_ComputedFromInstaller),
+               but the sdk band version in runtime is         : $(SdkBandVersionForWorkload_FromRuntimeVersions)
+
+      ********************"
+             Condition="$(SdkBandVersionForWorkload_ComputedFromInstaller) != $(SdkBandVersionForWorkload_FromRuntimeVersions)"
+             Importance="High" />
   </Target>
 
   <Target Name="_SetPackageVersionForWorkloadsTesting">
@@ -226,7 +260,8 @@
     <InstallWorkloadFromArtifacts
                      WorkloadIds="@(WorkloadIdForTesting)"
                      InstallTargets="@(_SdkWithWorkloadToInstall)"
-                     VersionBand="$(SdkBandVersionForWorkload)"
+                     VersionBandForSdkManifestsDir="$(SdkBandVersionForWorkload_ComputedFromInstaller)"
+                     VersionBandForManifestPackages="$(SdkBandVersionForWorkload_FromRuntimeVersions)"
                      LocalNuGetsPath="$(LibrariesShippingPackagesDir)"
                      TemplateNuGetConfigPath="$(RepoRoot)NuGet.config"
                      SdkWithNoWorkloadInstalledPath="$(_SdkWithNoWorkloadPath)"

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest.pkgproj
@@ -6,9 +6,12 @@
   </PropertyGroup>
 
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">
+    <Error Condition="'$(SdkBandVersionForWorkload_FromRuntimeVersions)' == ''"
+           Text="%24(SdkBandVersionForWorkload_FromRuntimeVersions) is not set" />
+
     <!-- Override the id to include the sdk band as per the workload installer spec -->
     <PropertyGroup>
-      <Id>Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest-$(SdkBandVersionForWorkload)</Id>
+      <Id>Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest-$(SdkBandVersionForWorkload_FromRuntimeVersions)</Id>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net6.Manifest.pkgproj
@@ -6,9 +6,12 @@
   </PropertyGroup>
 
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">
+    <Error Condition="'$(SdkBandVersionForWorkload_FromRuntimeVersions)' == ''"
+           Text="%24(SdkBandVersionForWorkload_FromRuntimeVersions) is not set" />
+
     <!-- Override the id to include the sdk band as per the workload installer spec -->
     <PropertyGroup>
-      <Id>Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest-$(SdkBandVersionForWorkload)</Id>
+      <Id>Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest-$(SdkBandVersionForWorkload_FromRuntimeVersions)</Id>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest/Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest.pkgproj
@@ -6,9 +6,12 @@
   </PropertyGroup>
 
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">
+    <Error Condition="'$(SdkBandVersionForWorkload_FromRuntimeVersions)' == ''"
+           Text="%24(SdkBandVersionForWorkload_FromRuntimeVersions) is not set" />
+
     <!-- Override the id to include the sdk band as per the workload installer spec -->
     <PropertyGroup>
-      <Id>Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(SdkBandVersionForWorkload)</Id>
+      <Id>Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest-$(SdkBandVersionForWorkload_FromRuntimeVersions)</Id>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -26,7 +26,10 @@ namespace Microsoft.Workload.Build.Tasks
         public ITaskItem[]    InstallTargets     { get; set; } = Array.Empty<ITaskItem>();
 
         [Required, NotNull]
-        public string?        VersionBand        { get; set; }
+        public string?        VersionBandForSdkManifestsDir        { get; set; }
+
+        [Required, NotNull]
+        public string?        VersionBandForManifestPackages       { get; set; }
 
         [Required, NotNull]
         public string?        LocalNuGetsPath    { get; set; }
@@ -301,7 +304,7 @@ namespace Microsoft.Workload.Build.Tasks
             // Multiple directories for a manifest, differing only in case causes
             // workload install to fail due to duplicate manifests!
             // This is applicable only on case-sensitive filesystems
-            string manifestVersionBandDir = Path.Combine(sdkDir, "sdk-manifests", VersionBand);
+            string manifestVersionBandDir = Path.Combine(sdkDir, "sdk-manifests", VersionBandForSdkManifestsDir);
             if (!Directory.Exists(manifestVersionBandDir))
             {
                 Log.LogMessage(MessageImportance.Low, $"    Could not find {manifestVersionBandDir}. Creating it..");
@@ -310,7 +313,7 @@ namespace Microsoft.Workload.Build.Tasks
 
             string outputDir = FindSubDirIgnoringCase(manifestVersionBandDir, name);
 
-            PackageReference pkgRef = new(Name: $"{name}.Manifest-{VersionBand}",
+            PackageReference pkgRef = new(Name: $"{name}.Manifest-{VersionBandForManifestPackages}",
                                           Version: version,
                                           OutputDir: outputDir,
                                           relativeSourceDir: "data");


### PR DESCRIPTION
  .. installer version.

  - This is only for running Wasm.Build.Tests

  Two new properties are added:

  - `SdkBandVersionForWorkload_ComputedFromInstaller`: this is based on the
  version derived from `dotnet --version`. `8.0.0-alpha.1.1234.1` becomes
  `8.0.0-alpha.1`, and is used as the path where the manifests get installed for testing:
  `sdk-manifests/$(SdkBandVersionForWorkload_ComputedFromInstaller)`

  - `SdkBandVersionForWorkload_FromRuntimeVersions`: this is the version
  band used for the packages generated. And simply rename of the earlier
  `$(SdkBandVersionForWorkload)`.