### PR TITLE
Do not remove resource messages in Xml tests

### DIFF
--- a/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
@@ -7,6 +7,10 @@
     <IlcTrimMetadata>false</IlcTrimMetadata>
   </PropertyGroup>
 
+  <ItemGroup>
+    <RdXmlFile Include="default.rd.xml" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
     <!-- This doesn't run on V8 shell because https://bugs.chromium.org/p/v8/issues/detail?id=12541 -->
     <Scenario>WasmTestOnBrowser</Scenario>

--- a/src/libraries/System.Private.Xml/tests/default.rd.xml
+++ b/src/libraries/System.Private.Xml/tests/default.rd.xml
@@ -1,0 +1,16 @@
+<Directives>
+  <Application>
+    <Assembly Name="System.Private.Xml">
+      <Type Name="System.SR">
+
+        <!--
+          This method is not actually reflected on by the tests, but its presence
+          tells the compiler not to optimize away the manifest resource that contains
+          resource strings. The tests do reflect on that one in the ExceptionVerifier class.   
+        -->
+        <Method Name="GetResourceString" Dynamic="Required All" />
+
+      </Type>
+    </Assembly>
+  </Application>
+</Directives>


### PR DESCRIPTION
Addresses first bullet of #81455.

Addresses 211 test failures to the tune of:

```
[FAIL] System.Xml.XmlSchemaValidatorApiTests.TCValidateWhitespace_String.WhitespaceInsideElement
System.Xml.Tests.VerifyException : GetManifestResourceStream() failed
   at System.Xml.Tests.ExceptionVerifier..ctor(String assemblyName, ExceptionVerificationFlags flags, ITestOutputHelper output) + 0x4c9
   at System.Xml.XmlSchemaValidatorApiTests.TCValidateWhitespace_String..ctor(ITestOutputHelper output) + 0x48
```

Cc @dotnet/ilc-contrib 