### PR TITLE
Make newly introduced Immutable tests work with AOT.

### DIFF
--- a/src/libraries/System.Collections.Immutable/tests/default.rd.xml
+++ b/src/libraries/System.Collections.Immutable/tests/default.rd.xml
@@ -54,6 +54,19 @@
           <GenericArgument Name="System.UInt64,System.Private.CoreLib" />
         </Method>
       </Type>
+
+      <Type Name="Xunit.Sdk.AssertEqualityComparer`1[[System.Collections.Generic.HashSet`1[[System.Collections.Frozen.Tests.SimpleStruct,System.Collections.Immutable.Tests]],System.Private.CoreLib]]" Dynamic="Required All">
+        <Method Name="CompareTypedSets" Dynamic="Required All">
+          <GenericArgument Name="System.Collections.Frozen.Tests.SimpleStruct,System.Collections.Immutable.Tests" />
+        </Method>
+      </Type>
+
+      <Type Name="Xunit.Sdk.AssertEqualityComparer`1[[System.Collections.Generic.HashSet`1[[System.Collections.Generic.KeyValuePair`2[[System.Collections.Frozen.Tests.SimpleStruct,System.Collections.Immutable.Tests],[System.Int32,System.Private.CoreLib]],System.Private.CoreLib]],System.Private.CoreLib]]" Dynamic="Required All">
+        <Method Name="CompareTypedSets" Dynamic="Required All">
+          <GenericArgument Name="System.Collections.Generic.KeyValuePair`2[[System.Collections.Frozen.Tests.SimpleStruct,System.Collections.Immutable.Tests],[System.Int32,System.Private.CoreLib]],System.Private.CoreLib" />
+        </Method>
+      </Type>
+
     </Assembly>
     
   </Application>


### PR DESCRIPTION
Adds xunit garbage to fix 144 test failures that look like this:

```
[FAIL] System.Collections.Frozen.Tests.FrozenDictionary_Generic_Tests_SimpleStruct_int.LookupItems_AllItemsFoundAsExpected(size: 1024, comparer: NonDefaultEqualityComparer`1 { }, specifySameComparer: True, optimizeForReading: True)
System.NotSupportedException : 'Xunit.Sdk.AssertEqualityComparer`1[System.Collections.Generic.HashSet`1[System.Collections.Generic.KeyValuePair`2[System.Collections.Frozen.Tests.SimpleStruct, System.Int32]]].CompareTypedSets[System.Collections.Generic.KeyValuePair`2[System.Collections.Frozen.Tests.SimpleStruct, System.Int32]](System.Collections.IEnumerable,System.Collections.IEnumerable)' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x2a
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1c0
   at System.Collections.Frozen.Tests.FrozenDictionary_Generic_Tests`2.LookupItems_AllItemsFoundAsExpected(Int32 size, IEqualityComparer`1 comparer, Boolean specifySameComparer, Boolean optimizeForReading) + 0x46d
```

Cc @dotnet/ilc-contrib 