### PR TITLE
Do not print stack trace if error reading crashReportJsonFile

### DIFF
--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -352,7 +352,16 @@ namespace CoreclrTestLib
             }
             outputWriter.WriteLine($"Printing stacktrace from '{crashReportJsonFile}'");
 
-            string contents = File.ReadAllText(crashReportJsonFile);
+            string contents;
+            try
+            {
+                contents = File.ReadAllText(crashReportJsonFile);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error reading {crashReportJsonFile}: {ex.ToString()}");
+                return false;
+            }
             dynamic crashReport = JsonSerializer.Deserialize<JsonObject>(contents);
             var threads = crashReport["payload"]["threads"];
 


### PR DESCRIPTION
Need to understand though why would it not have access to the crashreportjson file when the `ls` command confirmed that it can be read. See https://github.com/dotnet/runtime/issues/81323#issuecomment-1411672940
