### PR TITLE
Support targeting iOS platforms with ILCompiler

### DIFF
--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -78,6 +78,10 @@ namespace System.CommandLine
                 return TargetOS.OSX;
             else if (token.Equals("freebsd", StringComparison.OrdinalIgnoreCase))
                 return TargetOS.FreeBSD;
+            else if (token.Equals("ios", StringComparison.OrdinalIgnoreCase))
+                return TargetOS.iOS;
+            else if (token.Equals("iossimulator", StringComparison.OrdinalIgnoreCase))
+                return TargetOS.iOSSimulator;
 
             throw new CommandLineException($"Target OS '{token}' is not supported");
         }

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -74,10 +74,10 @@ namespace System.CommandLine
                 return TargetOS.Windows;
             else if (token.Equals("linux", StringComparison.OrdinalIgnoreCase))
                 return TargetOS.Linux;
-            else if (token.Equals("osx", StringComparison.OrdinalIgnoreCase))
-                return TargetOS.OSX;
             else if (token.Equals("freebsd", StringComparison.OrdinalIgnoreCase))
                 return TargetOS.FreeBSD;
+            else if (token.Equals("osx", StringComparison.OrdinalIgnoreCase))
+                return TargetOS.OSX;
             else if (token.Equals("ios", StringComparison.OrdinalIgnoreCase))
                 return TargetOS.iOS;
             else if (token.Equals("iossimulator", StringComparison.OrdinalIgnoreCase))

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -69,21 +69,19 @@ namespace System.CommandLine
 
                 throw new NotImplementedException();
             }
-
-            if (token.Equals("windows", StringComparison.OrdinalIgnoreCase))
-                return TargetOS.Windows;
-            else if (token.Equals("linux", StringComparison.OrdinalIgnoreCase))
-                return TargetOS.Linux;
-            else if (token.Equals("freebsd", StringComparison.OrdinalIgnoreCase))
-                return TargetOS.FreeBSD;
-            else if (token.Equals("osx", StringComparison.OrdinalIgnoreCase))
-                return TargetOS.OSX;
-            else if (token.Equals("ios", StringComparison.OrdinalIgnoreCase))
-                return TargetOS.iOS;
-            else if (token.Equals("iossimulator", StringComparison.OrdinalIgnoreCase))
-                return TargetOS.iOSSimulator;
-
-            throw new CommandLineException($"Target OS '{token}' is not supported");
+            else
+            {
+                return token.ToLowerInvariant() switch
+                {
+                    "windows" => TargetOS.Windows,
+                    "linux" => TargetOS.Linux,
+                    "freebsd" => TargetOS.FreeBSD,
+                    "osx" => TargetOS.OSX,
+                    "ios" => TargetOS.iOS,
+                    "iossimulator" => TargetOS.iOSSimulator,
+                    _ => throw new CommandLineException($"Target OS '{token}' is not supported")
+                };
+            }
         }
 
         public static TargetArchitecture GetTargetArchitecture(string token)
@@ -100,19 +98,18 @@ namespace System.CommandLine
                     _ => throw new NotImplementedException()
                 };
             }
-
-            if (token.Equals("x86", StringComparison.OrdinalIgnoreCase))
-                return TargetArchitecture.X86;
-            else if (token.Equals("x64", StringComparison.OrdinalIgnoreCase))
-                return TargetArchitecture.X64;
-            else if (token.Equals("arm", StringComparison.OrdinalIgnoreCase) || token.Equals("armel", StringComparison.OrdinalIgnoreCase))
-                return TargetArchitecture.ARM;
-            else if (token.Equals("arm64", StringComparison.OrdinalIgnoreCase))
-                return TargetArchitecture.ARM64;
-            else if (token.Equals("loongarch64", StringComparison.OrdinalIgnoreCase))
-                return TargetArchitecture.LoongArch64;
-
-            throw new CommandLineException($"Target architecture '{token}' is not supported");
+            else
+            {
+                return token.ToLowerInvariant() switch
+                {
+                    "x86" => TargetArchitecture.X86,
+                    "x64" => TargetArchitecture.X64,
+                    "arm" or "armel" => TargetArchitecture.ARM,
+                    "arm64" => TargetArchitecture.ARM64,
+                    "loongarch64" => TargetArchitecture.LoongArch64,
+                    _ => throw new CommandLineException($"Target architecture '{token}' is not supported")
+                };
+            }
         }
 
         public static void MakeReproPackage(string makeReproPath, string outputFilePath, string[] args, ParseResult res, IEnumerable<string> inputOptions, IEnumerable<string> outputOptions = null)

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/TargetRegisterMap.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/TargetRegisterMap.cs
@@ -32,6 +32,7 @@ namespace ILCompiler.DependencyAnalysis.X64
 
                 case TargetOS.Linux:
                 case TargetOS.OSX:
+                // TODO: case TargetOS.iOSSimulator:
                 case TargetOS.FreeBSD:
                 case TargetOS.SunOS:
                 case TargetOS.NetBSD:

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/TargetRegisterMap.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/TargetRegisterMap.cs
@@ -20,11 +20,23 @@ namespace ILCompiler.DependencyAnalysis.X64
 
         public TargetRegisterMap(TargetOS os)
         {
-            Arg0 = os == TargetOS.Windows ? Register.RCX : Register.RDI;
-            Arg1 = os == TargetOS.Windows ? Register.RDX : Register.RSI;
-            Arg2 = os == TargetOS.Windows ? Register.R8  : Register.RDX;
-            Arg3 = os == TargetOS.Windows ? Register.R9  : Register.RCX;
-            Result = Register.RAX;
+            switch (os)
+            {
+                case TargetOS.Windows:
+                    Arg0 = Register.RCX;
+                    Arg1 = Register.RDX;
+                    Arg2 = Register.R8;
+                    Arg3 = Register.R9;
+                    Result = Register.RAX;
+                    break;
+                default:
+                    Arg0 = Register.RDI;
+                    Arg1 = Register.RSI;
+                    Arg2 = Register.RDX;
+                    Arg3 = Register.RCX;
+                    Result = Register.RAX;
+                    break;
+            }
         }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/TargetRegisterMap.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/TargetRegisterMap.cs
@@ -20,31 +20,11 @@ namespace ILCompiler.DependencyAnalysis.X64
 
         public TargetRegisterMap(TargetOS os)
         {
-            switch (os)
-            {
-                case TargetOS.Windows:
-                    Arg0 = Register.RCX;
-                    Arg1 = Register.RDX;
-                    Arg2 = Register.R8;
-                    Arg3 = Register.R9;
-                    Result = Register.RAX;
-                    break;
-
-                case TargetOS.Linux:
-                case TargetOS.OSX:
-                // TODO: case TargetOS.iOSSimulator:
-                case TargetOS.FreeBSD:
-                case TargetOS.SunOS:
-                case TargetOS.NetBSD:
-                    Arg0 = Register.RDI;
-                    Arg1 = Register.RSI;
-                    Arg2 = Register.RDX;
-                    Arg3 = Register.RCX;
-                    Result = Register.RAX;
-                    break;
-                default:
-                    throw new NotImplementedException();
-            }
+            Arg0 = os == TargetOS.Windows ? Register.RCX : Register.RDI;
+            Arg1 = os == TargetOS.Windows ? Register.RDX : Register.RSI;
+            Arg2 = os == TargetOS.Windows ? Register.R8  : Register.RDX;
+            Arg3 = os == TargetOS.Windows ? Register.R9  : Register.RCX;
+            Result = Register.RAX;
         }
     }
 }

--- a/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -113,7 +113,7 @@ namespace Internal.Runtime
                 flagsEx |= (ushort)EETypeFlagsEx.HasCriticalFinalizerFlag;
             }
 
-            if (type.Context.Target.IsOSX && IsTrackedReferenceWithFinalizer(type))
+            if (type.Context.Target.IsOSXLike && IsTrackedReferenceWithFinalizer(type))
             {
                 flagsEx |= (ushort)EETypeFlagsEx.IsTrackedReferenceWithFinalizerFlag;
             }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3073,7 +3073,7 @@ namespace Internal.JitInterface
         public static CORINFO_OS TargetToOs(TargetDetails target)
         {
             return target.IsWindows ? CORINFO_OS.CORINFO_WINNT :
-                   target.IsOSX ? CORINFO_OS.CORINFO_MACOS : CORINFO_OS.CORINFO_UNIX;
+                   target.IsOSXLike ? CORINFO_OS.CORINFO_MACOS : CORINFO_OS.CORINFO_UNIX;
         }
 
         private void getEEInfo(ref CORINFO_EE_INFO pEEInfoOut)

--- a/src/coreclr/tools/Common/TypeSystem/Common/TargetDetails.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TargetDetails.cs
@@ -19,6 +19,8 @@ namespace Internal.TypeSystem
         NetBSD,
         SunOS,
         WebAssembly,
+        iOS,
+        iOSSimulator
     }
 
     public enum TargetAbi
@@ -303,13 +305,16 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Returns True if compiling for OSX
+        /// Returns True if compiling for OSX family of operating systems.
+        /// Currently including OSX, iOS and iOSSimulator
         /// </summary>
-        public bool IsOSX
+        public bool IsOSXLike
         {
             get
             {
-                return OperatingSystem == TargetOS.OSX;
+                return OperatingSystem == TargetOS.OSX ||
+                    OperatingSystem == TargetOS.iOS ||
+                    OperatingSystem == TargetOS.iOSSimulator;
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -927,7 +927,7 @@ namespace Internal.TypeSystem.Interop
 
         internal static bool ShouldCheckForPendingException(TargetDetails target, PInvokeMetadata metadata)
         {
-            if (!target.IsOSX)
+            if (!target.IsOSXLike)
                 return false;
 
             const string ObjectiveCMsgSend = "objc_msgSend";
@@ -944,7 +944,7 @@ namespace Internal.TypeSystem.Interop
 
         internal static int? GetObjectiveCMessageSendFunction(TargetDetails target, string pinvokeModule, string pinvokeFunction)
         {
-            if (!target.IsOSX || pinvokeModule != ObjectiveCLibrary)
+            if (!target.IsOSXLike || pinvokeModule != ObjectiveCLibrary)
                 return null;
 
 #pragma warning disable CA1416

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -718,7 +718,7 @@ namespace ILCompiler.DependencyAnalysis
                     Debug.Assert(false);
                 }
 
-                if (_targetPlatform.OperatingSystem == TargetOS.OSX)
+                if (_targetPlatform.IsOSXLike)
                 {
                     // Emit a symbol for beginning of the frame. This is workaround for ld64
                     // linker bug which would produce DWARF with incorrect pcStart offsets for
@@ -792,9 +792,9 @@ namespace ILCompiler.DependencyAnalysis
 
         private void AppendExternCPrefix(Utf8StringBuilder sb)
         {
-            if (_targetPlatform.OperatingSystem == TargetOS.OSX)
+            if (_targetPlatform.IsOSXLike)
             {
-                // On OSX, we need to prefix an extra underscore to account for correct linkage of
+                // On OSX-like systems, we need to prefix an extra underscore to account for correct linkage of
                 // extern "C" functions.
                 sb.Append('_');
             }
@@ -908,7 +908,7 @@ namespace ILCompiler.DependencyAnalysis
             if (_isSingleFileCompilation)
                 return false;
 
-            if (_targetPlatform.OperatingSystem == TargetOS.OSX)
+            if (_targetPlatform.IsOSXLike)
                 return false;
 
             if (!(node is ISymbolNode))
@@ -1249,6 +1249,16 @@ namespace ILCompiler.DependencyAnalysis
                     vendor = "apple";
                     sys = "darwin16";
                     abi = "macho";
+                    break;
+                case TargetOS.iOS:
+                    vendor = "apple";
+                    sys = "ios11.0";
+                    abi = "macho";
+                    break;
+                case TargetOS.iOSSimulator:
+                    vendor = "apple";
+                    sys = "ios11.0";
+                    abi = "simulator";
                     break;
                 case TargetOS.WebAssembly:
                     vendor = "unknown";

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
@@ -37,7 +37,7 @@ namespace ILCompiler
                     foreach (var method in _methods)
                         streamWriter.WriteLine($"   {method.GetUnmanagedCallersOnlyExportName()}");
                 }
-                else if(_context.Target.IsOSX)
+                else if(_context.Target.IsOSXLike)
                 {
                     foreach (var method in _methods)
                         streamWriter.WriteLine($"_{method.GetUnmanagedCallersOnlyExportName()}");

--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/PerfMapWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/PerfMapWriter.cs
@@ -108,7 +108,6 @@ namespace ILCompiler.Diagnostics
 
         private static PerfmapTokensForTarget TranslateTargetDetailsToPerfmapConstants(TargetDetails details)
         {
-            // TODO: What about ios and iossimulator
             PerfMapOSToken osToken = details.OperatingSystem switch
             {
                 TargetOS.Unknown => PerfMapOSToken.Unknown,

--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/PerfMapWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/PerfMapWriter.cs
@@ -108,6 +108,7 @@ namespace ILCompiler.Diagnostics
 
         private static PerfmapTokensForTarget TranslateTargetDetailsToPerfmapConstants(TargetDetails details)
         {
+            // TODO: What about ios and iossimulator
             PerfMapOSToken osToken = details.OperatingSystem switch
             {
                 TargetOS.Unknown => PerfMapOSToken.Unknown,

--- a/src/coreclr/tools/aot/ILCompiler/ConfigurablePInvokePolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ConfigurablePInvokePolicy.cs
@@ -91,7 +91,7 @@ namespace ILCompiler
             }
             else
             {
-                string suffix = _target.IsOSX ? ".dylib" : ".so";
+                string suffix = _target.IsOSXLike ? ".dylib" : ".so";
 
                 if (name.EndsWith(suffix, StringComparison.Ordinal))
                     yield return name.Substring(0, name.Length - suffix.Length);

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -306,7 +306,7 @@ namespace ILCompiler
                     "considered to be input files. If no input files begin with '--' then this option is not necessary.\n");
 
                 string[] ValidArchitectures = new string[] { "arm", "arm64", "x86", "x64" };
-                string[] ValidOS = new string[] { "windows", "linux", "osx", "freebsd" };
+                string[] ValidOS = new string[] { "windows", "linux", "freebsd", "osx", "ios", "iossimulator" };
 
                 Console.WriteLine("Valid switches for {0} are: '{1}'. The default value is '{2}'\n", "--targetos", string.Join("', '", ValidOS), Helpers.GetTargetOS(null).ToString().ToLowerInvariant());
 


### PR DESCRIPTION
This PR enables ILCompiler to target iOS and iOSSimulator platforms.

It has been tested against a private branch which includes changes that enable building NativeAOT for iOS platforms.

- Is related to: #81024
- Fixes: #80908

/cc: @dotnet/ilc-contrib