### PR TITLE
Append version to RID only with valid characters

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -46,13 +46,13 @@ initNonPortableDistroRid()
                     VERSION_ID="${VERSION_ID%.*}"
                 fi
 
-                if [[ ! "${VERSION_ID}" =~ ^([[:digit:]]|\.)+$ ]]; then
+                if [[ "${VERSION_ID}" =~ ^([[:digit:]]|\.)+$ ]]; then
+                    nonPortableBuildID="${ID}.${VERSION_ID}-${buildArch}"
+                else
                     # Rolling release distros either do not set VERSION_ID, set it as blank or
                     # set it to non-version looking string (such as TEMPLATE_VERSION_ID on ArchLinux);
                     # so omit it here to be consistent with everything else.
                     nonPortableBuildID="${ID}-${buildArch}"
-                else
-                    nonPortableBuildID="${ID}.${VERSION_ID}-${buildArch}"
                 fi
             fi
 

--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -46,9 +46,10 @@ initNonPortableDistroRid()
                     VERSION_ID="${VERSION_ID%.*}"
                 fi
 
-                if [ -z "${VERSION_ID+x}" ]; then
-                        # Rolling release distros do not set VERSION_ID, so omit
-                        # it here to be consistent with everything else.
+                if [[ ! "${VERSION_ID}" =~ ^([[:digit:]]|\.)+$ ]]; then
+                        # Rolling release distros either do not set VERSION_ID, set it as blank or
+                        # set it to non-version looking string (such as TEMPLATE_VERSION_ID on ArchLinux);
+                        # so omit it here to be consistent with everything else.
                         nonPortableBuildID="${ID}-${buildArch}"
                 else
                         nonPortableBuildID="${ID}.${VERSION_ID}-${buildArch}"

--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -47,12 +47,12 @@ initNonPortableDistroRid()
                 fi
 
                 if [[ ! "${VERSION_ID}" =~ ^([[:digit:]]|\.)+$ ]]; then
-                        # Rolling release distros either do not set VERSION_ID, set it as blank or
-                        # set it to non-version looking string (such as TEMPLATE_VERSION_ID on ArchLinux);
-                        # so omit it here to be consistent with everything else.
-                        nonPortableBuildID="${ID}-${buildArch}"
+                    # Rolling release distros either do not set VERSION_ID, set it as blank or
+                    # set it to non-version looking string (such as TEMPLATE_VERSION_ID on ArchLinux);
+                    # so omit it here to be consistent with everything else.
+                    nonPortableBuildID="${ID}-${buildArch}"
                 else
-                        nonPortableBuildID="${ID}.${VERSION_ID}-${buildArch}"
+                    nonPortableBuildID="${ID}.${VERSION_ID}-${buildArch}"
                 fi
             fi
 


### PR DESCRIPTION
This is the `init-distro-rid.sh` counterpart of 31e4f404c218eae7ba999c4df5346d30f971451c.

In `amd64/archlinux` docker container, the non-portable RID auto-detection (without explicit `-p:TargetRid=arch-x64` arg or `__DistroRid=arch-x64` env var) looks like this:

Before: `__DistroRid: arch.TEMPLATE_VERSION_ID-x64`
After: `__DistroRid: arch-x64`