### PR TITLE
Ensure that we don't try to constant fold BSF(0) or BSR(0)

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6121,7 +6121,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunUnary(
             case NI_X86Base_BitScanForward:
             {
                 assert(!varTypeIsSmall(type) && !varTypeIsLong(type));
-                int32_t value  = GetConstantInt32(arg0VN);
+                int32_t value = GetConstantInt32(arg0VN);
 
                 if (value == 0)
                 {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6121,40 +6121,60 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunUnary(
             case NI_X86Base_BitScanForward:
             {
                 assert(!varTypeIsSmall(type) && !varTypeIsLong(type));
+                int32_t value  = GetConstantInt32(arg0VN);
 
-                int32_t  value  = GetConstantInt32(arg0VN);
+                if (value == 0)
+                {
+                    // bsf is undefined for 0
+                    break;
+                }
+
                 uint32_t result = BitOperations::BitScanForward(static_cast<uint32_t>(value));
-
                 return VNForIntCon(static_cast<int32_t>(result));
             }
 
             case NI_X86Base_X64_BitScanForward:
             {
                 assert(varTypeIsLong(type));
+                int64_t value = GetConstantInt64(arg0VN);
 
-                int64_t  value  = GetConstantInt64(arg0VN);
+                if (value == 0)
+                {
+                    // bsf is undefined for 0
+                    break;
+                }
+
                 uint32_t result = BitOperations::BitScanForward(static_cast<uint64_t>(value));
-
                 return VNForLongCon(static_cast<int64_t>(result));
             }
 
             case NI_X86Base_BitScanReverse:
             {
                 assert(!varTypeIsSmall(type) && !varTypeIsLong(type));
+                int32_t value = GetConstantInt32(arg0VN);
 
-                int32_t  value  = GetConstantInt32(arg0VN);
+                if (value == 0)
+                {
+                    // bsr is undefined for 0
+                    break;
+                }
+
                 uint32_t result = BitOperations::BitScanReverse(static_cast<uint32_t>(value));
-
                 return VNForIntCon(static_cast<int32_t>(result));
             }
 
             case NI_X86Base_X64_BitScanReverse:
             {
                 assert(varTypeIsLong(type));
+                int64_t value = GetConstantInt64(arg0VN);
 
-                int64_t  value  = GetConstantInt64(arg0VN);
+                if (value == 0)
+                {
+                    // bsr is undefined for 0
+                    break;
+                }
+
                 uint32_t result = BitOperations::BitScanReverse(static_cast<uint64_t>(value));
-
                 return VNForLongCon(static_cast<int64_t>(result));
             }
 #endif // TARGET_XARCH

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81460/Runtime_81460.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81460/Runtime_81460.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+public static class FloatingPointHelper<TSelf>
+    where TSelf : IFloatingPoint<TSelf>
+{
+    public static int GetExponentShortestBitLength(TSelf value)
+        => value.GetExponentShortestBitLength();
+}
+
+class Runtime_81460
+{
+    static void Main() => Test();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Test() =>
+        FloatingPointHelper<double>.GetExponentShortestBitLength(1.0);
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81460/Runtime_81460.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81460/Runtime_81460.cs
@@ -1,6 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
 public static class FloatingPointHelper<TSelf>
     where TSelf : IFloatingPoint<TSelf>
 {
@@ -10,7 +14,10 @@ public static class FloatingPointHelper<TSelf>
 
 class Runtime_81460
 {
-    static void Main() => Test();
+    static int Main()
+    {
+        return (Test() == 0) ? 100 : 0;
+    }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Test() =>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81460/Runtime_81460.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81460/Runtime_81460.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This resolves https://github.com/dotnet/runtime/issues/81460

Even with the qmark `(x == 0) ? 31 : BSR(x)`, we'd end up getting something like:
```
lcl = 0;
if (lcl == 0)
   return 31;
return BSR(lcl);
```

So even though the `BSF(0)`/`BSR(0)` is dead code, we don't know it yet and it leads to VN trying to fold and therefore triggering the assert.

The fix is to simply bail out if the constant is zero.