### PR TITLE
Add a simple size test

### DIFF
--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
@@ -19,7 +20,21 @@ unsafe class Program
         Console.WriteLine($"* Size of the executable is {fileSize / 1024,7:n0} kB             *");
         Console.WriteLine("****************************************************");
 
-        if (fileSize < 1024 * 1024 || fileSize > 2 * 1024 * 1024)
+        const int Meg = 1024 * 1024;
+        const int HalfMeg = Meg / 2;
+        long lowerBound, upperBound;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            lowerBound = 2 * Meg; // 2 MB
+            upperBound = 4 * Meg; // 4 MB
+        }
+        else
+        {
+            lowerBound = Meg + HalfMeg; // 1.5 MB
+            upperBound = 2 * Meg; // 2 MB
+        }
+
+        if (fileSize < lowerBound || fileSize > upperBound)
         {
             Console.WriteLine("BUG: File size is not in the expected range. Did a libraries change regress size of Hello World?");
             return 1;

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/Program.cs
@@ -12,6 +12,22 @@ unsafe class Program
     {
         s_success = true;
 
+#if !DEBUG
+        Console.WriteLine("****************************************************");
+        Console.WriteLine("* Size test                                        *");
+        long fileSize = new System.IO.FileInfo(Environment.ProcessPath).Length;
+        Console.WriteLine($"* Size of the executable is {fileSize / 1024,7:n0} kB             *");
+        Console.WriteLine("****************************************************");
+
+        if (fileSize < 1024 * 1024 || fileSize > 2 * 1024 * 1024)
+        {
+            Console.WriteLine("BUG: File size is not in the expected range. Did a libraries change regress size of Hello World?");
+            return 1;
+        }
+
+        Console.WriteLine();
+#endif
+
         // We expect the AOT compiler generated HW intrinsics with the following characteristics:
         //
         // * TRUE = IsSupported assumed to be true, no runtime check

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
@@ -6,6 +6,7 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);BASELINE_INTRINSICS</DefineConstants>
+    <StripSymbols>true</StripSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
@@ -7,6 +7,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);BASELINE_INTRINSICS</DefineConstants>
     <StripSymbols>true</StripSymbols>
+    
+    <!-- We should be able to delete once CI machines no longer use ancient LLVM -->
+    <ObjCopyName>objcopy</ObjCopyName>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64NonVex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64NonVex.csproj
@@ -6,6 +6,7 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);NON_VEX_INTRINSICS</DefineConstants>
+    <StripSymbols>true</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64NonVex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64NonVex.csproj
@@ -7,6 +7,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);NON_VEX_INTRINSICS</DefineConstants>
     <StripSymbols>true</StripSymbols>
+    
+    <!-- We should be able to delete once CI machines no longer use ancient LLVM -->
+    <ObjCopyName>objcopy</ObjCopyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
@@ -6,6 +6,7 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);VEX_INTRINSICS</DefineConstants>
+    <StripSymbols>true</StripSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
@@ -7,6 +7,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);VEX_INTRINSICS</DefineConstants>
     <StripSymbols>true</StripSymbols>
+    
+    <!-- We should be able to delete once CI machines no longer use ancient LLVM -->
+    <ObjCopyName>objcopy</ObjCopyName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves #80165.

The size of Hello World is currently 1.8 MB. This is achieved by avoiding any non-field reflection in the codepaths that are part of a hello world. If reflection comes into picture, the size jumps by several 100 kB because suddently we need a lot of code to support that. This is a smoke test to detect those situations. We're getting proper size testing in the dotnet/performance repo with trend histories, etc., but the invariant for Hello World is easy to check for and nice to gate commits on.

I chose the HwIntrinsics tests as a "victim" to host this because I don't want to introduce a new test for this.

Cc @dotnet/ilc-contrib 