### PR TITLE
Avoid scaning the used region if there are no free units

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3856,13 +3856,13 @@ uint8_t* region_allocator::allocate (uint32_t num_units, allocate_direction dire
 
     print_map ("before alloc");
 
-    if ((direction == allocate_forward) && (num_left_used_free_units >= num_units) ||
-        (direction == allocate_backward) && (num_right_used_free_units >= num_units))
+    if (((direction == allocate_forward) && (num_left_used_free_units >= num_units)) ||
+        ((direction == allocate_backward) && (num_right_used_free_units >= num_units)))
     {
         while (((direction == allocate_forward) && (current_index < end_index)) ||
             ((direction == allocate_backward) && (current_index > end_index)))
         {
-            uint32_t current_val = *(current_index - ((direction == -1) ? 1 : 0));
+            uint32_t current_val = *(current_index - ((direction == allocate_backward) ? 1 : 0));
             uint32_t current_num_units = get_num_units (current_val);
             bool free_p = is_unit_memory_free (current_val);
             dprintf (REGIONS_LOG, ("ALLOC[%s: %zd]%d->%d", (free_p ? "F" : "B"), (size_t)current_num_units,
@@ -3884,6 +3884,7 @@ uint8_t* region_allocator::allocate (uint32_t num_units, allocate_direction dire
                     }
                     else
                     {
+                        assert (direction == allocate_backward);
                         assert (num_right_used_free_units >= num_units);
                         num_right_used_free_units -= num_units;
                     }
@@ -4046,6 +4047,7 @@ void region_allocator::delete_region_impl (uint8_t* region_start)
     }
     else
     {
+        assert (free_index >= region_map_right_start);
         num_right_used_free_units += free_block_size;
     }
     

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -3772,7 +3772,8 @@ void region_allocator::print_map (const char* msg)
 
     uint32_t total_regions = (uint32_t)((global_region_end - global_region_start) / region_alignment);
 
-    dprintf (REGIONS_LOG, ("[%s]-----end printing----[%d total, left used %zd (free: %d), right used %zd (free: %d)]\n", heap_type, total_regions, (region_map_left_end - region_map_left_start), num_left_used_free_units, (region_map_right_end - region_map_right_start), num_right_used_free_units));
+    dprintf (REGIONS_LOG, ("[%s]-----end printing----[%d total, left used %zd (free: %d), right used %zd (free: %d)]\n", heap_type, total_regions, 
+        (region_map_left_end - region_map_left_start), num_left_used_free_units, (region_map_right_end - region_map_right_start), num_right_used_free_units));
 #endif //_DEBUG
 }
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5867,14 +5867,14 @@ typedef bool (*region_allocator_callback_fn)(uint8_t*);
 //
 // For each region we encode the info with a busy block in the map. This block has the
 // same # of uints as the # of units this region occupies. And we store the # in
-// the starting uint. These uints can be converted to bytes since we have multiple units
-// for larger regions anyway. I haven't done that since this will need to be changed in
-// the near future based on more optimal allocation strategies.
+// the first and last uint. These uints can be converted to bytes since we have multiple
+// units for larger regions anyway. I haven't done that since this will need to be changed
+// in the near future based on more optimal allocation strategies.
 //
-// When we allocate, we search forward to find contiguous free units >= num_units
-// We do take the opportunity to coalesce free blocks but we do not coalesce busy blocks.
-// When we decommit a region, we simply mark its block free. Free blocks are coalesced
-// opportunistically when we need to walk them.
+// When we allocate, if we knew there could be free blocks that fits, we search forward to find
+// contiguous free units >= num_units. Otherwise we simply allocate at the end. We coalesce
+// free blocks but we do not coalesce busy blocks. When we delete a region, we mark the block
+// free and coalesced them with its free neighbors if any.
 //
 // TODO: to accommodate 32-bit processes, we reserve in segment sizes and divide each seg
 // into regions.
@@ -5899,6 +5899,9 @@ private:
 
     uint32_t* region_map_right_start;
     uint32_t* region_map_right_end;
+
+    uint32_t num_left_used_free_units;
+    uint32_t num_right_used_free_units;
 
     uint8_t* region_address_of (uint32_t* map_index);
     uint32_t* region_map_index_of (uint8_t* address);


### PR DESCRIPTION
This PR implements a simple optimization to avoid scanning the used regions if we knew the number of free units is not enough to fit the allocation. 

Allocating a new region is a relatively rare operation, but it is used extensively when starting a NoGC region. This should help the performance for `TryStartNoGCRegion`, especially for the large ones.

Here is the validation done for the PR.

- [x] GC Perf Sim 
	 - [x] Normal Server 
	- [ ] Normal Workstation 
	- [ ] Large Pages Server 
	- [ ] Large Pages Workstation 
	- [ ] Low Memory Container 
	- [ ] High Memory Load
- [x] Microbenchmarks 
	 - [x] V8 Test 
	- [ ] Top 20 Microbenchmarks
- [x] ASPNet Benchmarks 
	 - [x] JsonMin - Windows 
	- [ ] JsonMin - Linux 
	- [ ]  Fortunes ETF - Windows 
	- [ ]  Fortunes ETF - Linux
