### PR TITLE
Adjust workaround for event source resource stripping

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
@@ -147,7 +147,11 @@ namespace ILCompiler.DependencyAnalysis
                                 && InlineableStringsResourceNode.IsInlineableStringsResource(module, resName + ".resources"))
                             {
                                 dependencies ??= new DependencyList();
-                                dependencies.Add(factory.InlineableStringResource(module), "EventSource used resource");
+                                var accessorMethod = module.GetType(
+                                    InlineableStringsResourceNode.ResourceAccessorTypeNamespace,
+                                    InlineableStringsResourceNode.ResourceAccessorTypeName)
+                                    .GetMethod(InlineableStringsResourceNode.ResourceAccessorGetStringMethodName, null);
+                                dependencies.Add(factory.ReflectedMethod(accessorMethod), "EventSource used resource");
                             }
                         }
                     }


### PR DESCRIPTION
The used approach only worked in debug builds. `InlineableStringResource` is not one of the nodes that survives from scanning phase to compilation phase. We only look at the custom attributes in the scanning phase.

Make the compiler think `GetResourceString` was reflected on instead. `ReflectedMethod` nodes do survive from reflection analysis to compilation.

Cc @dotnet/ilc-contrib 