### PR TITLE
Delete JIT disasm output in test wrappers before running FileCheck

### DIFF
--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -235,6 +235,7 @@ if [[ ( -z "$DOTNET_JitStress" ) && ( -z "$DOTNET_JitStressRegs" ) && ( -z "$DOT
     export DOTNET_JitDisasm=`cat $(BashDisasmListOutputFile)`
     export DOTNET_JitDiffableDasm=1
     export DOTNET_JitStdOutFile=$(BashDisasmOutputFile)
+    rm -f $(BashDisasmOutputFile)
     if [[ $ERRORLEVEL -ne 0 ]]
     then
       echo EXECUTION OF FILECHECK - FAILED $ERRORLEVEL
@@ -281,6 +282,7 @@ IF "%DOTNET_JitStress%"=="" IF "%DOTNET_JitStressRegs%"=="" IF "%DOTNET_Tailcall
     for /F "delims=" %%g in ($(BatchDisasmListOutputFile)) do set DOTNET_JitDisasm=%%g
     set DOTNET_JitDiffableDasm=1
     set DOTNET_JitStdOutFile=$(BatchDisasmOutputFile)
+    del $(BatchDisasmOutputFile) >nul 2>&1
 )
 ]]>
       </CLRTestBatchPreCommands>


### PR DESCRIPTION
JitStdOutFile has append behavior, so if you rerun the scripts you would get multiple repeated sets of jitdisasm. This would give FileCheck a range of disassembly to match that was much wider than expected.