### PR TITLE
Bump non-existent Win10 ARM64 helix queue to Win11

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -183,9 +183,7 @@ jobs:
 
     # windows arm64
     - ${{ if eq(parameters.platform, 'windows_arm64') }}:
-      - Windows.10.Arm64.Open
-      # TODO: Uncomment once there is HW deployed to service Win11 ARM64 queue
-      # - Windows.11.Arm64.Open
+      - Windows.11.Arm64.Open
 
     # WebAssembly
     - ${{ if eq(parameters.platform, 'Browser_wasm') }}:


### PR DESCRIPTION
Saw this infra failure message in a `release/7.0` PR: https://github.com/dotnet/runtime/pull/81139

- Job: https://dev.azure.com/dnceng-public/public/_build/results?buildId=156613&view=logs&j=7bb91cf6-d57c-5393-cf5c-c884f1e50962&t=7729b4d4-9255-54d8-01fd-e831ebbb744b&l=53
- Error message:
```
[release/7.0] Helix API does not contain an entry for Windows.10.Arm64.Open
```

The entry no longer exists: https://helix.dot.net/#Test-External-Windows

There's a TODO comment to replace Windows 10 ARM64 with 11 when it is added:
https://github.com/dotnet/runtime/blob/7db1c3333302d4d5ac97a5cfb28e88e5c2cde968/eng/pipelines/libraries/helix-queues-setup.yml#L184-L188

I fixed that entry in the `release/7.0` branch so that it matches what we already have in main:
https://github.com/dotnet/runtime/blob/873775b42431bf27a9ae69633864e5290443c29b/eng/pipelines/libraries/helix-queues-setup.yml#L186-L188