### PR TITLE
[release/8.0-preview1] Fix ROOTFS_DIR for arm64 container in pipeline-with-resources.yml

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -17,7 +17,7 @@ resources:
     - container: linux_arm64
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-arm64
       env:
-        ROOTFS_DIR: /crossrootfs
+        ROOTFS_DIR: /crossrootfs/arm64
 
     - container: linux_musl_x64
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode


### PR DESCRIPTION
Problem initially reported in: https://github.com/dotnet/arcade/issues/12395
Fixes https://github.com/dotnet/runtime/issues/81555
Partial fix extracted from the main PR deps flow: https://github.com/dotnet/runtime/pull/81354
