### PR TITLE
Remove AggressiveInlining from XxHash128.HashLength0To16

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash128.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash128.cs
@@ -223,7 +223,6 @@ namespace System.IO.Hashing
             Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref dest0, new IntPtr(sizeof(ulong))), low);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Hash128 HashLength0To16(byte* source, uint length, ulong seed)
         {
             if (length > 8)

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash3.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash3.cs
@@ -196,7 +196,6 @@ namespace System.IO.Hashing
             return current;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong HashLength0To16(byte* source, uint length, ulong seed)
         {
             if (length > 8)


### PR DESCRIPTION
```asm
static byte[] Test(byte[] data) => XxHash128.Hash(data);
```

<details>
  <summary>Codegen</summary>

```asm
G_M5885_IG01:              ;; offset=0000H
       4156                 push     r14
       57                   push     rdi
       56                   push     rsi
       55                   push     rbp
       53                   push     rbx
       4881EC90000000       sub      rsp, 144
       C5F877               vzeroupper
       33C0                 xor      eax, eax
       4889442428           mov      qword ptr [rsp+28H], rax
       C5D857E4             vxorps   xmm4, xmm4
       C5F97F642430         vmovdqa  xmmword ptr [rsp+30H], xmm4
       C5F97F642440         vmovdqa  xmmword ptr [rsp+40H], xmm4
       C5F97F642450         vmovdqa  xmmword ptr [rsp+50H], xmm4
       C5F97F642460         vmovdqa  xmmword ptr [rsp+60H], xmm4
                                                ;; size=51 bbWeight=1 PerfScore 15.83
G_M5885_IG02:              ;; offset=0033H
       4885C9               test     rcx, rcx
       0F84DE010000         je       G_M5885_IG16
                                                ;; size=9 bbWeight=1 PerfScore 1.25
G_M5885_IG03:              ;; offset=003CH
       488D7110             lea      rsi, bword ptr [rcx+10H]
       8B7908               mov      edi, dword ptr [rcx+08H]
       48B998A6825AFB7F0000 mov      rcx, 0x7FFB5A82A698      ; ubyte[]
       BA10000000           mov      edx, 16
       E82959885F           call     CORINFO_HELP_NEWARR_1_VC
       488BD8               mov      rbx, rax
       488D6B10             lea      rbp, bword ptr [rbx+10H]
       41BE10000000         mov      r14d, 16
       448BC7               mov      r8d, edi
       4183FE10             cmp      r14d, 16
       0F8C91010000         jl       G_M5885_IG13
                                                ;; size=53 bbWeight=1.00 PerfScore 6.50
G_M5885_IG04:              ;; offset=0071H
       4889742468           mov      bword ptr [rsp+68H], rsi
       488BD6               mov      rdx, rsi
       4183F810             cmp      r8d, 16
       0F870A010000         ja       G_M5885_IG09
       4183F808             cmp      r8d, 8
       7613                 jbe      SHORT G_M5885_IG05
       488D4C2458           lea      rcx, [rsp+58H]
       4533C9               xor      r9d, r9d
       FF15C1FF6000         call     [System.IO.Hashing.XxHash128:HashLength9To16(ulong,uint,ulong):System.IO.Hashing.XxHash128+Hash128]
       E9E3000000           jmp      G_M5885_IG08
                                                ;; size=43 bbWeight=0.50 PerfScore 4.75
G_M5885_IG05:              ;; offset=009CH
       4183F804             cmp      r8d, 4
       7213                 jb       SHORT G_M5885_IG06
       488D4C2458           lea      rcx, [rsp+58H]
       4533C9               xor      r9d, r9d
       FF1590FF6000         call     [System.IO.Hashing.XxHash128:HashLength4To8(ulong,uint,ulong):System.IO.Hashing.XxHash128+Hash128]
       E9CA000000           jmp      G_M5885_IG08
                                                ;; size=25 bbWeight=0.50 PerfScore 3.50
G_M5885_IG06:              ;; offset=00B5H
       4585C0               test     r8d, r8d
       747B                 je       SHORT G_M5885_IG07
       0FB60A               movzx    rcx, byte  ptr [rdx]
       418BC0               mov      eax, r8d
       D1E8                 shr      eax, 1
       0FB60402             movzx    rax, byte  ptr [rdx+rax]
       458D48FF             lea      r9d, [r8-01H]
       420FB6140A           movzx    rdx, byte  ptr [rdx+r9]
       C1E110               shl      ecx, 16
       C1E018               shl      eax, 24
       0BC8                 or       ecx, eax
       0BCA                 or       ecx, edx
       41C1E008             shl      r8d, 8
       410BC8               or       ecx, r8d
       8BC1                 mov      eax, ecx
       0FC8                 bswap    eax
       C1C00D               rol      eax, 13
       8BC9                 mov      ecx, ecx
       BA9B5A2787           mov      edx, 0x87275A9B
       4833CA               xor      rcx, rdx
       8BF0                 mov      esi, eax
       4881F68B202C30       xor      rsi, 0x302C208B
       FF1598186100         call     [System.IO.Hashing.XxHash64:Avalanche(ulong):ulong]
       488BF8               mov      rdi, rax
       C5F857C0             vxorps   xmm0, xmm0, xmm0
       C5F811442438         vmovups  xmmword ptr [rsp+38H], xmm0
       488BCE               mov      rcx, rsi
       FF1582186100         call     [System.IO.Hashing.XxHash64:Avalanche(ulong):ulong]
       4C8BC0               mov      r8, rax
       488D4C2438           lea      rcx, [rsp+38H]
       488BD7               mov      rdx, rdi
       FF15D9026100         call     [System.IO.Hashing.XxHash128+Hash128:.ctor(ulong,ulong):this]
       C5F810442438         vmovups  xmm0, xmmword ptr [rsp+38H]
       C5F811442458         vmovups  xmmword ptr [rsp+58H], xmm0
       EB4A                 jmp      SHORT G_M5885_IG08
                                                ;; size=128 bbWeight=0.50 PerfScore 15.54
G_M5885_IG07:              ;; offset=0135H
       48B9B4F837308A902E68 mov      rcx, 0x682E908A3037F8B4
       FF1553186100         call     [System.IO.Hashing.XxHash64:Avalanche(ulong):ulong]
       488BF0               mov      rsi, rax
       C5F857C0             vxorps   xmm0, xmm0, xmm0
       C5F811442448         vmovups  xmmword ptr [rsp+48H], xmm0
       48B9497DA7D10BD35596 mov      rcx, 0x9655D30BD1A77D49
       FF1536186100         call     [System.IO.Hashing.XxHash64:Avalanche(ulong):ulong]
       4C8BC0               mov      r8, rax
       488D4C2448           lea      rcx, [rsp+48H]
       488BD6               mov      rdx, rsi
       FF158D026100         call     [System.IO.Hashing.XxHash128+Hash128:.ctor(ulong,ulong):this]
       C5F810442448         vmovups  xmm0, xmmword ptr [rsp+48H]
       C5F811442458         vmovups  xmmword ptr [rsp+58H], xmm0
                                                ;; size=74 bbWeight=0.50 PerfScore 8.04
G_M5885_IG08:              ;; offset=017FH
       C5F810442458         vmovups  xmm0, xmmword ptr [rsp+58H]
       C5F811442470         vmovups  xmmword ptr [rsp+70H], xmm0
       EB40                 jmp      SHORT G_M5885_IG12
                                                ;; size=14 bbWeight=0.50 PerfScore 3.00
G_M5885_IG09:              ;; offset=018DH
       4181F880000000       cmp      r8d, 128
       7710                 ja       SHORT G_M5885_IG10
       488D4C2470           lea      rcx, [rsp+70H]
       4533C9               xor      r9d, r9d
       FF15CCFE6000         call     [System.IO.Hashing.XxHash128:HashLength17To128(ulong,uint,ulong):System.IO.Hashing.XxHash128+Hash128]
       EB27                 jmp      SHORT G_M5885_IG12
                                                ;; size=25 bbWeight=0.50 PerfScore 3.50
G_M5885_IG10:              ;; offset=01A6H
       4181F8F0000000       cmp      r8d, 240
       7710                 ja       SHORT G_M5885_IG11
       488D4C2470           lea      rcx, [rsp+70H]
       4533C9               xor      r9d, r9d
       FF15CBFE6000         call     [System.IO.Hashing.XxHash128:HashLength129To240(ulong,uint,ulong):System.IO.Hashing.XxHash128+Hash128]
       EB0E                 jmp      SHORT G_M5885_IG12
                                                ;; size=25 bbWeight=0.50 PerfScore 3.50
G_M5885_IG11:              ;; offset=01BFH
       488D4C2470           lea      rcx, [rsp+70H]
       4533C9               xor      r9d, r9d
       FF15D3FE6000         call     [System.IO.Hashing.XxHash128:HashLengthOver240(ulong,uint,ulong):System.IO.Hashing.XxHash128+Hash128]
                                                ;; size=14 bbWeight=0.50 PerfScore 1.88
G_M5885_IG12:              ;; offset=01CDH
       33D2                 xor      rdx, rdx
       4889542468           mov      bword ptr [rsp+68H], rdx
       C5F810442470         vmovups  xmm0, xmmword ptr [rsp+70H]
       C5F811842480000000   vmovups  xmmword ptr [rsp+80H], xmm0
       48896C2428           mov      bword ptr [rsp+28H], rbp
       4489742430           mov      dword ptr [rsp+30H], r14d
       488D542428           lea      rdx, [rsp+28H]
       488D8C2480000000     lea      rcx, [rsp+80H]
       FF15F8FD6000         call     [System.IO.Hashing.XxHash128:WriteBigEndian128(byref,System.Span`1[ubyte])]
       EB07                 jmp      SHORT G_M5885_IG14
                                                ;; size=53 bbWeight=0.50 PerfScore 6.62
G_M5885_IG13:              ;; offset=0202H
       FF1588FC6000         call     [System.IO.Hashing.NonCryptographicHashAlgorithm:ThrowDestinationTooShort()]
       CC                   int3
                                                ;; size=7 bbWeight=0.50 PerfScore 1.62
G_M5885_IG14:              ;; offset=0209H
       488BC3               mov      rax, rbx
                                                ;; size=3 bbWeight=1 PerfScore 0.25
G_M5885_IG15:              ;; offset=020CH
       4881C490000000       add      rsp, 144
       5B                   pop      rbx
       5D                   pop      rbp
       5E                   pop      rsi
       5F                   pop      rdi
       415E                 pop      r14
       C3                   ret
                                                ;; size=14 bbWeight=1 PerfScore 3.75
G_M5885_IG16:              ;; offset=021AH
       B9C1000000           mov      ecx, 193
       48BA30CAB65AFB7F0000 mov      rdx, 0x7FFB5AB6CA30
       E8B22E535F           call     CORINFO_HELP_STRCNS
       488BC8               mov      rcx, rax
       FF15F99E1C00         call     [System.ArgumentNullException:Throw(System.String)]
       CC                   int3
                                                ;; size=30 bbWeight=0 PerfScore 0.00

; Total bytes of code 568, prolog size 51, PerfScore 136.34, instruction count 135, allocated bytes for code 568 (MethodHash=6f80e902) for method P:Test(ubyte[]):ubyte[]
; ============================================================
```

</details>

The codegen contains several simple non-inlined calls due to "exceeds inlining budget", here is the tree of decisions:

![image](https://user-images.githubusercontent.com/523221/216449168-75ef99d3-2588-4805-a632-8d9047cb311d.png)

After this PR:

![image](https://user-images.githubusercontent.com/523221/216449399-99c6cb85-ca0a-4ac1-8d73-c2cef99ae90b.png)
