### PR TITLE
Respect HostApplicationBuilderSettings.Args when DisableDefaults=true

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
@@ -91,6 +91,12 @@ namespace Microsoft.Extensions.Hosting
 
                 HostingHostBuilderExtensions.AddDefaultHostConfigurationSources(Configuration, settings.Args);
             }
+            else
+            {
+                // Command line args are added even when DisableDefaults=true. If the caller didn't want settings.Args applied,
+                // they wouldn't have set them on the settings.
+                HostingHostBuilderExtensions.AddCommandLineConfig(Configuration, settings.Args);
+            }
 
             // HostApplicationBuilderSettings override all other config sources.
             List<KeyValuePair<string, string?>>? optionList = null;

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilderSettings.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilderSettings.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Hosting
         public bool DisableDefaults { get; set; }
 
         /// <summary>
-        /// The command line arguments. This is unused if <see cref="DisableDefaults"/> is <see langword="true"/>.
+        /// The command line arguments to add to the <see cref="HostApplicationBuilder.Configuration"/>.
         /// </summary>
         public string[]? Args { get; set; }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -227,10 +227,7 @@ namespace Microsoft.Extensions.Hosting
         internal static void AddDefaultHostConfigurationSources(IConfigurationBuilder hostConfigBuilder, string[]? args)
         {
             hostConfigBuilder.AddEnvironmentVariables(prefix: "DOTNET_");
-            if (args is { Length: > 0 })
-            {
-                hostConfigBuilder.AddCommandLine(args);
-            }
+            AddCommandLineConfig(hostConfigBuilder, args);
         }
 
         internal static void ApplyDefaultAppConfiguration(HostBuilderContext hostingContext, IConfigurationBuilder appConfigBuilder, string[]? args)
@@ -256,13 +253,18 @@ namespace Microsoft.Extensions.Hosting
 
             appConfigBuilder.AddEnvironmentVariables();
 
-            if (args is { Length: > 0 })
-            {
-                appConfigBuilder.AddCommandLine(args);
-            }
+            AddCommandLineConfig(appConfigBuilder, args);
 
             [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Calling IConfiguration.GetValue is safe when the T is bool.")]
             static bool GetReloadConfigOnChangeValue(HostBuilderContext hostingContext) => hostingContext.Configuration.GetValue("hostBuilder:reloadConfigOnChange", defaultValue: true);
+        }
+
+        internal static void AddCommandLineConfig(IConfigurationBuilder configBuilder, string[]? args)
+        {
+            if (args is { Length: > 0 })
+            {
+                configBuilder.AddCommandLine(args);
+            }
         }
 
         internal static void AddDefaultServices(HostBuilderContext hostingContext, IServiceCollection services)

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
@@ -603,6 +603,23 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Throws<InvalidOperationException>(() => builder.Services.RemoveAt(0));
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RespectsArgsWhenDisableDefaults(bool disableDefaults)
+        {
+            HostApplicationBuilder builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+            {
+                DisableDefaults = disableDefaults,
+                Args = new string[] { "mySetting=settingValue" }
+            });
+
+            using IHost host = builder.Build();
+            IConfiguration config = host.Services.GetRequiredService<IConfiguration>();
+
+            Assert.Equal("settingValue", config["mySetting"]);
+        }
+
         private static HostApplicationBuilder CreateEmptyBuilder()
         {
             return new HostApplicationBuilder(new HostApplicationBuilderSettings


### PR DESCRIPTION
If the Args was specified, always add it to the Configuration.

Fix #81445