### PR TITLE
[wasm] Implement more opcodes in the jiterpreter

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -8716,4 +8716,16 @@ mono_jiterp_auto_safepoint (InterpFrame *frame, guint16 *ip)
 		do_safepoint (frame, get_context(), ip);
 }
 
+EMSCRIPTEN_KEEPALIVE gpointer
+mono_jiterp_imethod_to_ftnptr (InterpMethod *imethod)
+{
+	return imethod_to_ftnptr (imethod, FALSE);
+}
+
+EMSCRIPTEN_KEEPALIVE void
+mono_jiterp_enum_hasflag (MonoClass *klass, gint32 *dest, stackval *sp1, stackval *sp2)
+{
+	*dest = mono_interp_enum_hasflag (sp1, sp2, klass);
+}
+
 #endif

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -669,6 +669,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_LDLOCA_S:
 		case MINT_LDTOKEN:
 		case MINT_LDSTR:
+		case MINT_LDFTN:
 		case MINT_LDFTN_ADDR:
 		case MINT_MONO_LDPTR:
 		case MINT_CPOBJ_VT:
@@ -699,6 +700,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_SAFEPOINT:
 		case MINT_INTRINS_GET_HASHCODE:
 		case MINT_INTRINS_RUNTIMEHELPERS_OBJECT_HAS_COMPONENT_SIZE:
+		case MINT_INTRINS_ENUM_HASFLAG:
 		case MINT_ADD_MUL_I4_IMM:
 		case MINT_ADD_MUL_I8_IMM:
 			return TRACE_CONTINUE;

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -699,6 +699,8 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_SAFEPOINT:
 		case MINT_INTRINS_GET_HASHCODE:
 		case MINT_INTRINS_RUNTIMEHELPERS_OBJECT_HAS_COMPONENT_SIZE:
+		case MINT_ADD_MUL_I4_IMM:
+		case MINT_ADD_MUL_I8_IMM:
 			return TRACE_CONTINUE;
 
 		case MINT_BR:

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -703,6 +703,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_INTRINS_ENUM_HASFLAG:
 		case MINT_ADD_MUL_I4_IMM:
 		case MINT_ADD_MUL_I8_IMM:
+		case MINT_ARRAY_RANK:
 			return TRACE_CONTINUE;
 
 		case MINT_BR:
@@ -1018,6 +1019,18 @@ mono_jiterp_type_to_stind (MonoType *type)
 	if (m_type_is_byref(type))
 		return 0;
 	return mono_type_to_stind (type);
+}
+
+EMSCRIPTEN_KEEPALIVE int
+mono_jiterp_get_array_rank (gint32 *dest, MonoObject **src)
+{
+	if (!src || !*src) {
+		*dest = 0;
+		return 0;
+	}
+
+	*dest = m_class_get_rank (mono_object_class (*src));
+	return 1;
 }
 
 // HACK: fix C4206

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -122,6 +122,12 @@ mono_jiterp_auto_safepoint (InterpFrame *frame, guint16 *ip);
 void
 mono_jiterp_interp_entry (JiterpEntryData *_data, stackval *sp_args, void *res);
 
+gpointer
+mono_jiterp_imethod_to_ftnptr (InterpMethod *imethod);
+
+void
+mono_jiterp_enum_hasflag (MonoClass *klass, gint32 *dest, stackval *sp1, stackval *sp2);
+
 #endif // __MONO_MINI_INTERPRETER_INTERNALS_H__
 
 extern WasmDoJitCall jiterpreter_do_jit_call;

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -121,6 +121,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_get_signature_params", "number", ["number"]],
     [true, "mono_jiterp_type_to_ldind", "number", ["number"]],
     [true, "mono_jiterp_type_to_stind", "number", ["number"]],
+    [true, "mono_jiterp_imethod_to_ftnptr", "number", ["number"]],
 ];
 
 export interface t_Cwraps {
@@ -260,6 +261,7 @@ export interface t_Cwraps {
     mono_jiterp_get_signature_params(sig: VoidPtr): VoidPtr;
     mono_jiterp_type_to_ldind(type: MonoType): number;
     mono_jiterp_type_to_stind(type: MonoType): number;
+    mono_jiterp_imethod_to_ftnptr(imethod: VoidPtr): VoidPtr;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -1332,13 +1332,22 @@ function generate_wasm_body (
 
             case MintOpcode.MINT_ADD_MUL_I4_IMM:
             case MintOpcode.MINT_ADD_MUL_I8_IMM: {
+                const isI32 = opcode === MintOpcode.MINT_ADD_MUL_I4_IMM;
                 builder.local("pLocals");
-                append_ldloc(builder, getArgU16(ip, 2), opcode === MintOpcode.MINT_ADD_MUL_I4_IMM ? WasmOpcode.i32_load : WasmOpcode.i64_load);
-                builder.i32_const(getArgI16(ip, 3));
+                append_ldloc(builder, getArgU16(ip, 2), isI32 ? WasmOpcode.i32_load : WasmOpcode.i64_load);
+                const rhs = getArgI16(ip, 3),
+                    multiplier = getArgI16(ip, 4);
+                if (isI32)
+                    builder.i32_const(rhs);
+                else
+                    builder.i52_const(rhs);
                 builder.appendU8(WasmOpcode.i32_add);
-                builder.i32_const(getArgI16(ip, 4));
+                if (isI32)
+                    builder.i32_const(multiplier);
+                else
+                    builder.i52_const(multiplier);
                 builder.appendU8(WasmOpcode.i32_mul);
-                append_stloc_tail(builder, getArgU16(ip, 1), opcode === MintOpcode.MINT_ADD_MUL_I4_IMM ? WasmOpcode.i32_store : WasmOpcode.i64_store);
+                append_stloc_tail(builder, getArgU16(ip, 1), isI32 ? WasmOpcode.i32_store : WasmOpcode.i64_store);
                 break;
             }
 

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -1282,6 +1282,18 @@ function generate_wasm_body (
                 builder.endBlock();
                 break;
 
+            case MintOpcode.MINT_ADD_MUL_I4_IMM:
+            case MintOpcode.MINT_ADD_MUL_I8_IMM: {
+                builder.local("pLocals");
+                append_ldloc(builder, getArgU16(ip, 2), opcode === MintOpcode.MINT_ADD_MUL_I4_IMM ? WasmOpcode.i32_load : WasmOpcode.i64_load);
+                builder.i32_const(getArgI16(ip, 3));
+                builder.appendU8(WasmOpcode.i32_add);
+                builder.i32_const(getArgI16(ip, 4));
+                builder.appendU8(WasmOpcode.i32_mul);
+                append_stloc_tail(builder, getArgU16(ip, 1), opcode === MintOpcode.MINT_ADD_MUL_I4_IMM ? WasmOpcode.i32_store : WasmOpcode.i64_store);
+                break;
+            }
+
             default:
                 if (opname.startsWith("ret")) {
                     if ((builder.branchTargets.size > 0) || trapTraceErrors || builder.options.countBailouts)

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -1341,12 +1341,12 @@ function generate_wasm_body (
                     builder.i32_const(rhs);
                 else
                     builder.i52_const(rhs);
-                builder.appendU8(WasmOpcode.i32_add);
+                builder.appendU8(isI32 ? WasmOpcode.i32_add : WasmOpcode.i64_add);
                 if (isI32)
                     builder.i32_const(multiplier);
                 else
                     builder.i52_const(multiplier);
-                builder.appendU8(WasmOpcode.i32_mul);
+                builder.appendU8(isI32? WasmOpcode.i32_mul : WasmOpcode.i64_mul);
                 append_stloc_tail(builder, getArgU16(ip, 1), isI32 ? WasmOpcode.i32_store : WasmOpcode.i64_store);
                 break;
             }


### PR DESCRIPTION
* Implement the add_mul_imm opcodes
* Implement MINT_INTRINS_ENUM_HASFLAG
* Implement MINT_ARRAY_RANK
* Implement MINT_LDFTN
* Slightly improve the usability of jiterpreter diagnostic stats