### PR TITLE
Do not expect quic to work on single file deployments

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicPlatformDetectionTests.cs
@@ -23,8 +23,18 @@ namespace System.Net.Quic.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.SupportsTls13))]
         public void SupportedWindowsPlatforms_IsSupportedIsTrue()
         {
-            Assert.True(QuicListener.IsSupported);
-            Assert.True(QuicConnection.IsSupported);
+            if (PlatformDetection.HasAssemblyFiles)
+            {
+                Assert.True(QuicListener.IsSupported);
+                Assert.True(QuicConnection.IsSupported);
+            }
+            else
+            {
+                // The above if check can be deleted when https://github.com/dotnet/runtime/issues/73290
+                // gets fixed and this test starts failing.
+                Assert.False(QuicListener.IsSupported);
+                Assert.False(QuicConnection.IsSupported);
+            }
         }
     }
 }


### PR DESCRIPTION
This new test is breaking runtime-extra-platforms CI legs.

Cc @dotnet/ilc-contrib 