### PR TITLE
WIP: Eliminate estimation and double use emitOutputInstr()

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1660,7 +1660,9 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
 
     this->codePtr          = codePtr;
     this->nativeSizeOfCode = nativeSizeOfCode;
-
+    //compiler->verbose      = true;
+    //compiler->opts.disAddr = true;
+    //compiler->opts.disAsm  = true;
     DoPhase(this, PHASE_GENERATE_CODE, &CodeGen::genGenerateMachineCode);
     DoPhase(this, PHASE_EMIT_CODE, &CodeGen::genEmitMachineCode);
     DoPhase(this, PHASE_EMIT_GCEH, &CodeGen::genEmitUnwindDebugGCandEH);

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -9658,6 +9658,11 @@ void emitter::emitRecordRelocation(void*    location,            /* IN */
 
 #endif // !DEBUG
 {
+    if (!emitIssuing)
+    {
+        return;
+    }
+
     void* locationRW = (BYTE*)location + writeableOffset;
 
     JITDUMP("recordRelocation: %p (rw: %p) => %p, type %u (%s), delta %d\n", dspPtr(location), dspPtr(locationRW),

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1137,11 +1137,11 @@ void emitter::emitBegFN(bool hasFramePtr
 
     emitForceStoreGCState = false;
 
-#ifdef DEBUG
+//#ifdef DEBUG
 
     emitIssuing = false;
 
-#endif
+//#endif
 
     /* Assume there will be no GC ref variables */
 
@@ -6495,9 +6495,11 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     emitThisGCrefRegs = emitThisByrefRegs = RBM_NONE;
     emitThisGCrefVset                     = true;
 
-#ifdef DEBUG
+
 
     emitIssuing = true;
+
+#ifdef DEBUG
 
     // We don't use these after this point
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1085,6 +1085,7 @@ void emitter::emitBegFN(bool hasFramePtr
 #endif
 
 #ifdef TARGET_XARCH
+    emittedSoFar = 0;
     tempOutputMemory = (BYTE*)emitGetMem(20);
 #endif
 
@@ -8223,7 +8224,8 @@ void emitter::emitGCvarDeadSet(int offs, BYTE* addr, ssize_t disp)
 
 void emitter::emitUpdateLiveGCvars(VARSET_VALARG_TP vars, BYTE* addr)
 {
-    assert(emitIssuing);
+    if (!emitIssuing)
+        return;
 
     // Don't track GC changes in epilogs
     if (emitIGisInEpilog(emitCurIG))
@@ -8438,7 +8440,8 @@ void emitter::emitRecordGCcall(BYTE* codePos, unsigned char callInstrSize)
 
 void emitter::emitUpdateLiveGCregs(GCtype gcType, regMaskTP regs, BYTE* addr)
 {
-    assert(emitIssuing);
+    if (!emitIssuing)
+        return;
 
     // Don't track GC changes in epilogs
     if (emitIGisInEpilog(emitCurIG))
@@ -8758,7 +8761,7 @@ UNATIVE_OFFSET emitter::emitCodeOffset(void* blockPtr, unsigned codePos)
 
 void emitter::emitGCregLiveUpd(GCtype gcType, regNumber reg, BYTE* addr)
 {
-    assert(emitIssuing);
+    if (!emitIssuing) return;
 
     // Don't track GC changes in epilogs
     if (emitIGisInEpilog(emitCurIG))
@@ -8810,7 +8813,8 @@ void emitter::emitGCregLiveUpd(GCtype gcType, regNumber reg, BYTE* addr)
 
 void emitter::emitGCregDeadUpdMask(regMaskTP regs, BYTE* addr)
 {
-    assert(emitIssuing);
+    if (!emitIssuing)
+        return;
 
     // Don't track GC changes in epilogs
     if (emitIGisInEpilog(emitCurIG))
@@ -8862,7 +8866,8 @@ void emitter::emitGCregDeadUpdMask(regMaskTP regs, BYTE* addr)
 
 void emitter::emitGCregDeadUpd(regNumber reg, BYTE* addr)
 {
-    assert(emitIssuing);
+    if (!emitIssuing)
+        return;
 
     // Don't track GC changes in epilogs
     if (emitIGisInEpilog(emitCurIG))
@@ -8904,6 +8909,9 @@ void emitter::emitGCregDeadUpd(regNumber reg, BYTE* addr)
 
 void emitter::emitGCvarLiveUpd(int offs, int varNum, GCtype gcType, BYTE* addr DEBUG_ARG(unsigned actualVarNum))
 {
+    if (!emitIssuing)
+        return;
+
     assert(abs(offs) % sizeof(int) == 0);
     assert(needsGC(gcType));
 
@@ -8996,7 +9004,8 @@ void emitter::emitGCvarLiveUpd(int offs, int varNum, GCtype gcType, BYTE* addr D
 
 void emitter::emitGCvarDeadUpd(int offs, BYTE* addr DEBUG_ARG(unsigned varNum))
 {
-    assert(emitIssuing);
+    if (!emitIssuing)
+        return;
     assert(abs(offs) % sizeof(int) == 0);
 
     /* Is the frame offset within the "interesting" range? */
@@ -9420,7 +9429,8 @@ void emitter::emitStackPushLargeStk(BYTE* addr, GCtype gcType, unsigned count)
 
 void emitter::emitStackPopLargeStk(BYTE* addr, bool isCall, unsigned char callInstrSize, unsigned count)
 {
-    assert(emitIssuing);
+    if (!emitIssuing)
+        return;
 
     unsigned argStkCnt;
     S_UINT16 argRecCnt(0); // arg count for ESP, ptr-arg count for EBP

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -8512,7 +8512,10 @@ void emitter::emitUpdateLiveGCregs(GCtype gcType, regMaskTP regs, BYTE* addr)
 
 void emitter::emitGCregLiveSet(GCtype gcType, regMaskTP regMask, BYTE* addr, bool isThis)
 {
-    assert(emitIssuing);
+    if (!emitIssuing)
+    {
+        return;
+    }
     assert(needsGC(gcType));
 
     regPtrDsc* regPtrNext;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1084,6 +1084,10 @@ void emitter::emitBegFN(bool hasFramePtr
     emitChkAlign = chkAlign;
 #endif
 
+#ifdef TARGET_XARCH
+    tempOutputMemory = (BYTE*)emitGetMem(20);
+#endif
+
     /* We have no epilogs yet */
 
     emitEpilogSize = 0;
@@ -1152,6 +1156,8 @@ void emitter::emitBegFN(bool hasFramePtr
     emitCurCodeOffset = 0;
     emitFirstColdIG   = nullptr;
     emitTotalCodeSize = 0;
+    aggregatedMismatch = 0;
+
 
 #ifdef TARGET_LOONGARCH64
     emitCounts_INS_OPTS_J = 0;
@@ -7184,6 +7190,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     // If you add this padding during the emitIGlist loop, then it will
     // emit offsets after the loop with wrong value (for example for GC ref variables).
     unsigned unusedSize = emitTotalCodeSize - actualCodeSize;
+    //printf("unusedSize: %u\n", unusedSize);
+    //assert(unusedSize == aggregatedMismatch);
 
     JITDUMP("Allocated method code size = %4u , actual size = %4u, unused size = %4u\n", emitTotalCodeSize,
             actualCodeSize, unusedSize);

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1854,6 +1854,13 @@ public:
 
     UNATIVE_OFFSET emitCurCodeOffs(BYTE* dst)
     {
+#ifdef TARGET_XARCH
+        if (!emitIssuing)
+        {
+            return emittedSoFar;
+        }
+#endif
+
         size_t distance;
         if ((dst >= emitCodeBlock) && (dst <= (emitCodeBlock + emitTotalHotCodeSize)))
         {
@@ -1861,13 +1868,13 @@ public:
         }
         else
         {
-            //assert(emitFirstColdIG);
-            //assert(emitColdCodeBlock);
-            //assert((dst >= emitColdCodeBlock) && (dst <= (emitColdCodeBlock + emitTotalColdCodeSize)));
+            assert(emitFirstColdIG);
+            assert(emitColdCodeBlock);
+            assert((dst >= emitColdCodeBlock) && (dst <= (emitColdCodeBlock + emitTotalColdCodeSize)));
 
             distance = (dst - emitColdCodeBlock + emitTotalHotCodeSize);
         }
-        //noway_assert((UNATIVE_OFFSET)distance == distance);
+        noway_assert((UNATIVE_OFFSET)distance == distance);
         return (UNATIVE_OFFSET)distance;
     }
 
@@ -1934,6 +1941,7 @@ public:
 
 #ifdef TARGET_XARCH
     BYTE* tempOutputMemory;
+    unsigned emittedSoFar;
     unsigned emitSetAcurateCodeSize(insGroup* ig, instrDesc* id);
 #endif
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1932,6 +1932,11 @@ public:
     size_t emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp);
     size_t emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp);
 
+#ifdef TARGET_XARCH
+    BYTE* tempOutputMemory;
+    unsigned emitSetAcurateCodeSize(insGroup* ig, instrDesc* id);
+#endif
+
     bool emitHasFramePtr;
 
 #ifdef PSEUDORANDOM_NOP_INSERTION
@@ -2073,6 +2078,7 @@ private:
     unsigned       emitCurIGsize;     // estimated code size of current group in bytes
     UNATIVE_OFFSET emitCurCodeOffset; // current code offset within group
     UNATIVE_OFFSET emitTotalCodeSize; // bytes of code in entire method
+    unsigned aggregatedMismatch;
 
     insGroup* emitFirstColdIG; // first cold instruction group
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1861,13 +1861,13 @@ public:
         }
         else
         {
-            assert(emitFirstColdIG);
-            assert(emitColdCodeBlock);
-            assert((dst >= emitColdCodeBlock) && (dst <= (emitColdCodeBlock + emitTotalColdCodeSize)));
+            //assert(emitFirstColdIG);
+            //assert(emitColdCodeBlock);
+            //assert((dst >= emitColdCodeBlock) && (dst <= (emitColdCodeBlock + emitTotalColdCodeSize)));
 
             distance = (dst - emitColdCodeBlock + emitTotalHotCodeSize);
         }
-        noway_assert((UNATIVE_OFFSET)distance == distance);
+        //noway_assert((UNATIVE_OFFSET)distance == distance);
         return (UNATIVE_OFFSET)distance;
     }
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1839,10 +1839,10 @@ public:
 /*        Members and methods used to issue (encode) instructions.      */
 /************************************************************************/
 
-#ifdef DEBUG
+//#ifdef DEBUG
     // If we have started issuing instructions from the list of instrDesc, this is set
     bool emitIssuing;
-#endif
+//#endif
 
     BYTE*  emitCodeBlock;     // Hot code block
     BYTE*  emitColdCodeBlock; // Cold code block

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -14802,12 +14802,6 @@ unsigned emitter::emitSetAcurateCodeSize(insGroup* ig, instrDesc* id)
     emittedSoFar += actualSize;
     id->idCodeSize(actualSize);
 
-
-    emitPrintLabel(ig);
-    printf(": ");
-    const char* sstr = codeGen->genInsDisplayName(id);
-    printf("%s  = %u\n", sstr, actualSize);
-
     // reset
     tempOutputMemory = curInsAdr;
     return actualSize;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2887,7 +2887,7 @@ const emitJumpKind emitReverseJumpKinds[] = {
 //
 /* static */ bool emitter::emitAlignInstHasNoCode(instrDesc* id)
 {
-    return (id->idIns() == INS_align) && (id->idCodeSize() == 0);
+    return ((id->idIns() == INS_align) || (id->idIns() == INS_nop)) && (id->idCodeSize() == 0);
 }
 
 //------------------------------------------------------------------------
@@ -9863,6 +9863,10 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 void emitter::emitDispIns(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* code, size_t sz, insGroup* ig)
 {
+    if (!emitIssuing)
+    {
+        return;
+    }
     emitAttr    attr;
     const char* sstr;
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4990,10 +4990,10 @@ void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
 
 #else // !TARGET_AMD64
 
-            if (size == EA_1BYTE)
-                sz = 2; // Use the long form as the small one has no 'w' bit
-            else
-                sz = 1; // Use short form
+            //if (size == EA_1BYTE)
+            //    sz = 2; // Use the long form as the small one has no 'w' bit
+            //else
+            //    sz = 1; // Use short form
 
 #endif // !TARGET_AMD64
 
@@ -14790,11 +14790,12 @@ ssize_t emitter::TryEvexCompressDisp8Byte(instrDesc* id, ssize_t dsp, bool* dspI
 unsigned emitter::emitSetAcurateCodeSize(insGroup* ig, instrDesc* id)
 {
     writeableOffset = 0;
-    emitIssuing = true;
+    //emitIssuing = true;
 
     BYTE* curInsAdr = tempOutputMemory;
     emitOutputInstr(ig, id, &tempOutputMemory);
     unsigned actualSize = (unsigned)(tempOutputMemory - curInsAdr);
+    emittedSoFar += actualSize;
     id->idCodeSize(actualSize);
 
 
@@ -14823,7 +14824,7 @@ unsigned emitter::emitSetAcurateCodeSize(insGroup* ig, instrDesc* id)
 #endif
 size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 {
-    assert(emitIssuing);
+    //assert(emitIssuing);
 
     BYTE*         dst           = *dp;
     BYTE*         startDst      = dst;
@@ -15153,7 +15154,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             }
 
 #ifdef DEBUG
-            if (ins == INS_call)
+            if ((ins == INS_call) && emitIssuing)
             {
                 emitRecordCallSite(emitCurCodeOffs(*dp), id->idDebugOnlyInfo()->idCallSig,
                                    (CORINFO_METHOD_HANDLE)id->idDebugOnlyInfo()->idMemCookie);


### PR DESCRIPTION
Related conversation: https://github.com/dotnet/runtime/issues/57368#issuecomment-1367036135
- Added `emitSetAcurateCodeSize()` that calls `emitOutputInstr()` method.
- This method is called after creating `instrDes`.
- Commented the estimate code that sets `id->idCodeSize()`, but instead calculates the size based on how many bytes `emitOutputInstr()` from inside `emitSetAcurateCodeSize()` written.
- Use `emitIssuing` to skip GC liveness, etc. that is not needed initially.