### PR TITLE
add RIDs for Wolfi

### DIFF
--- a/eng/native/init-distro-rid.sh
+++ b/eng/native/init-distro-rid.sh
@@ -46,6 +46,13 @@ initNonPortableDistroRid()
                     VERSION_ID="${VERSION_ID%.*}"
                 fi
 
+                if [[ "${ID}" == "wolfi" ]]; then
+                    # Wolfi is a rolling release distro. The VERSION_ID is only relevant
+                    # for the base filesystem layout, and does not provide any indication of
+                    # ABI compatibility, so drop it.
+                    unset VERSION_ID
+                fi
+
                 if [ -z "${VERSION_ID+x}" ]; then
                         # Rolling release distros do not set VERSION_ID, so omit
                         # it here to be consistent with everything else.

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
@@ -11158,5 +11158,32 @@
     "aot",
     "any",
     "base"
+  ],
+  "wolfi": [
+    "wolfi",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "wolfi-arm64": [
+    "wolfi-arm64",
+    "wolfi",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "wolfi-x64": [
+    "wolfi-x64",
+    "wolfi",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
   ]
 }

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -4404,6 +4404,23 @@
         "win81",
         "win8-x86-aot"
       ]
+    },
+    "wolfi": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "wolfi-arm64": {
+      "#import": [
+        "wolfi",
+        "linux-arm64"
+      ]
+    },
+    "wolfi-x64": {
+      "#import": [
+        "wolfi",
+        "linux-x64"
+      ]
     }
   }
 }

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -279,6 +279,11 @@
       <Versions>7;8;81;10</Versions>
     </RuntimeGroup>
 
+    <RuntimeGroup Include="wolfi">
+      <Parent>linux</Parent>
+      <Architectures>x64;arm64</Architectures>
+    </RuntimeGroup>
+
     <RuntimeGroupWithQualifiers Include="@(RuntimeGroup)" />
 
     <!-- root RIDs -->

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -762,12 +762,15 @@ pal::string_t pal::get_current_os_rid_platform()
 // 'rhel.7'. This brings RHEL in line with other distros like CentOS or Debian which
 // don't put minor version numbers in their VERSION_ID fields because all minor versions
 // are backwards compatible.
+//
+// Wolfi never has a version, so in that case, we just remove the version part entirely.
 static
 pal::string_t normalize_linux_rid(pal::string_t rid)
 {
     pal::string_t rhelPrefix(_X("rhel."));
     pal::string_t alpinePrefix(_X("alpine."));
     pal::string_t rockyPrefix(_X("rocky."));
+    pal::string_t wolfiPrefix(_X("wolfi"));
     size_t lastVersionSeparatorIndex = std::string::npos;
 
     if (rid.compare(0, rhelPrefix.length(), rhelPrefix) == 0)
@@ -785,6 +788,10 @@ pal::string_t normalize_linux_rid(pal::string_t rid)
     else if (rid.compare(0, rockyPrefix.length(), rockyPrefix) == 0)
     {
         lastVersionSeparatorIndex = rid.find(_X("."), rockyPrefix.length());
+    }
+    else if (rid.compare(0, wolfiPrefix.length(), wolfiPrefix) == 0)
+    {
+        lastVersionSeparatorIndex = rid.find(_X("."), wolfiPrefix.length());
     }
 
     if (lastVersionSeparatorIndex != std::string::npos)


### PR DESCRIPTION
Wolfi is a GNU distribution which provides a wide range of ABI compatibility guarantees via package manager dependencies.  Sadly, our ABI compatibility model is somewhat niche, so the closest way of thinking about it is that it's something like Arch, except that we never cull old packages, allowing us to have a wide range of ABI compatibility profiles.

In the .NET RID model, it is probably ideal to think of Wolfi as a rolling release distribution, because the specific ABI compatibility profile available to the consumer is ultimately determined based on the dependencies of whatever binary the consumer is trying to run.