### PR TITLE
JIT: fix issue with partial comp pred list maintenance

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6369,7 +6369,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             //
             for (BasicBlock* const succ : block->Succs())
             {
-                fgRemoveRefPred(succ, block);
+                // We may have degenerate flow, make sure to fully remove
+                fgRemoveAllRefPreds(succ, block);
             }
 
             // Change block to BBJ_THROW so we won't trigger importation of successors.


### PR DESCRIPTION
We may have degenerate flow out of a partial compilation block, so make sure to fully remove the block from all successor pred lists.

Fixes issue seen in #80635.