### PR TITLE
Add Linux NativeAOT debug info regression test

### DIFF
--- a/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- Test checks symbols, so don't run in non-debug builds. -->
+    <CLRTestTargetUnsupported Condition="'$(Configuration)' != 'Debug' or '$(TestBuildMode)' != 'nativeaot'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
@@ -5,7 +5,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Test checks symbols, so don't run in non-debug builds. -->
-    <CLRTestTargetUnsupported Condition="'$(Configuration)' != 'Debug' or '$(TestBuildMode)' != 'nativeaot'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(Configuration)' != 'Debug' or '$(TestBuildMode)' != 'nativeaot' or '$(TargetOS)' != 'linux'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
@@ -5,7 +5,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <!-- Test checks symbols, so don't run in non-debug builds. -->
-    <CLRTestTargetUnsupported Condition="'$(Configuration)' != 'Debug' or '$(TestBuildMode)' != 'nativeaot' or '$(TargetOS)' != 'linux'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(Configuration)' != 'Debug' or '$(TargetOS)' != 'linux'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/DwarfDump.csproj
@@ -1,0 +1,12 @@
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -20,6 +20,12 @@ public class Program
             UseShellExecute = false
         });
 
+        if (proc is null)
+        {
+            Console.WriteLine("llvm-dwarfdump could not run");
+            return 1;
+        }
+
         // Just count the number of warnings and errors. There are so many right now that it's not worth enumerating the list
         const int ExpectedCount = 13396;
         int count = 0;
@@ -32,12 +38,6 @@ public class Program
             }
         }
         proc.WaitForExit();
-        if (proc.ExitCode != 0)
-        {
-            Console.WriteLine("llvm-dwarfdump failed with exit code " + proc.ExitCode);
-            Console.WriteLine(proc.StandardError.ReadToEnd());
-            return 1;
-        }
         if (count != ExpectedCount)
         {
             Console.WriteLine($"Found {count} warnings and errors, expected {ExpectedCount}");

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -7,6 +7,12 @@ public class Program
 {
     public static int Main(string[] args)
     {
+        if (!runtimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            // Linux-only test
+            return 100;
+        }
+
         var llvmDwarfDumpPath = Path.Combine(
             Environment.GetEnvironmentVariable("CORE_ROOT"),
             "SuperFileCheck",

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -32,6 +32,12 @@ public class Program
             }
         }
         proc.WaitForExit();
+        if (proc.ExitCode != 0)
+        {
+            Console.WriteLine("llvm-dwarfdump failed with exit code " + proc.ExitCode);
+            Console.WriteLine(proc.StandardError.ReadToEnd());
+            return 1;
+        }
         if (count != ExpectedCount)
         {
             Console.WriteLine($"Found {count} warnings and errors, expected {ExpectedCount}");

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -9,6 +9,7 @@ public class Program
     {
         var llvmDwarfDumpPath = Path.Combine(
             Environment.GetEnvironmentVariable("CORE_ROOT"),
+            "SuperFileCheck",
             "runtimes",
             RuntimeInformation.RuntimeIdentifier,
             "native",
@@ -46,7 +47,8 @@ public class Program
         });
 
         // Just count the number of warnings and errors. There are so many right now that it's not worth enumerating the list
-        const int ExpectedCount = 46253;
+        const int MinWarnings = 18400;
+        const int MaxWarnings = 48600;
         int count = 0;
         string line;
         while ((line = proc.StandardOutput.ReadLine()) != null)
@@ -57,9 +59,9 @@ public class Program
             }
         }
         proc.WaitForExit();
-        if (count != ExpectedCount)
+        if (count is not >= MinWarnings and <= MaxWarnings)
         {
-            Console.WriteLine($"Found {count} warnings and errors, expected {ExpectedCount}");
+            Console.WriteLine($"Found {count} warnings and errors, expected between {MinWarnings} and {MaxWarnings}");
             Console.WriteLine("This is likely a result of debug info changes. To see the new output, run the following command:");
             Console.WriteLine("\tllvm-dwarfdump --verify " + Environment.ProcessPath);
             return 1;

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -11,7 +11,22 @@ public class Program
             return 100;
         }
 
-        var proc = Process.Start(new ProcessStartInfo
+        Console.WriteLine("Running llvm-dwarfdump");
+        var proc = Process.Start("llvm-dwarfdump", "--version");
+
+        if (proc is null)
+        {
+            Console.WriteLine("llvm-dwarfdump could not run");
+            return 1;
+        }
+
+        proc.WaitForExit();
+        if (proc.ExitCode != 0)
+        {
+            return 2;
+        }
+
+        proc = Process.Start(new ProcessStartInfo
         {
             FileName = "/bin/sh",
             Arguments = $"-c \"llvm-dwarfdump --verify {Environment.ProcessPath}",
@@ -20,14 +35,8 @@ public class Program
             UseShellExecute = false
         });
 
-        if (proc is null)
-        {
-            Console.WriteLine("llvm-dwarfdump could not run");
-            return 1;
-        }
-
         // Just count the number of warnings and errors. There are so many right now that it's not worth enumerating the list
-        const int ExpectedCount = 23126;
+        const int ExpectedCount = 46253;
         int count = 0;
         string line;
         while ((line = proc.StandardOutput.ReadLine()) != null)

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -27,7 +27,7 @@ public class Program
         }
 
         // Just count the number of warnings and errors. There are so many right now that it's not worth enumerating the list
-        const int ExpectedCount = 13396;
+        const int ExpectedCount = 23126;
         int count = 0;
         string line;
         while ((line = proc.StandardOutput.ReadLine()) != null)

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 
 public class Program

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -39,8 +42,8 @@ public class Program
 
         proc = Process.Start(new ProcessStartInfo
         {
-            FileName = "/bin/sh",
-            Arguments = $"-c \"{llvmDwarfDumpPath} --verify {Environment.ProcessPath}",
+            FileName = llvmDwarfDumpPath,
+            Arguments = $"--verify {Environment.ProcessPath}",
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false
@@ -59,12 +62,13 @@ public class Program
             }
         }
         proc.WaitForExit();
+        Console.WriteLine($"Found {count} warnings and errors");
         if (count is not >= MinWarnings and <= MaxWarnings)
         {
             Console.WriteLine($"Found {count} warnings and errors, expected between {MinWarnings} and {MaxWarnings}");
             Console.WriteLine("This is likely a result of debug info changes. To see the new output, run the following command:");
             Console.WriteLine("\tllvm-dwarfdump --verify " + Environment.ProcessPath);
-            return 1;
+            return 10;
         }
         return 100;
     }

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Diagnostics;
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            // Linux-only test
+            return 100;
+        }
+
+        var proc = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            Arguments = $"-c \"llvm-dwarfdump --verify {Environment.ProcessPath}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        });
+
+        // Just count the number of warnings and errors. There are so many right now that it's not worth enumerating the list
+        const int ExpectedCount = 13396;
+        int count = 0;
+        string line;
+        while ((line = proc.StandardOutput.ReadLine()) != null)
+        {
+            if (line.Contains("warning:") || line.Contains("error:"))
+            {
+                count++;
+            }
+        }
+        proc.WaitForExit();
+        if (count != ExpectedCount)
+        {
+            Console.WriteLine($"Found {count} warnings and errors, expected {ExpectedCount}");
+            Console.WriteLine("This is likely a result of debug info changes. To see the new output, run the following command:");
+            Console.WriteLine("\tllvm-dwarfdump --verify " + Environment.ProcessPath);
+            return 1;
+        }
+        return 100;
+    }
+}

--- a/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/DwarfDump/Program.cs
@@ -7,12 +7,6 @@ public class Program
 {
     public static int Main(string[] args)
     {
-        if (!runtimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            // Linux-only test
-            return 100;
-        }
-
         var llvmDwarfDumpPath = Path.Combine(
             Environment.GetEnvironmentVariable("CORE_ROOT"),
             "SuperFileCheck",


### PR DESCRIPTION
The test runs llvm-dwarfdump and verifies that the number of warnings and errors is expected. As we improve the debug information we can start tracking individual warnings and errors, hopefully bringing this number to zero.