### PR TITLE
Use initialCapacity in ASN.1 templates for some primitives

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
@@ -49,7 +49,8 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             // DEFAULT value handler for IterationCount.
             {
 #if NET7_0_OR_GREATER
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+                const int AsnManagedIntegerDerMaxEncodeSize = 6;
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
 #else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
 #endif

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
@@ -48,7 +48,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
 
             // DEFAULT value handler for IterationCount.
             {
+#if NET7_0_OR_GREATER
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+#else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
+#endif
                 tmp.WriteInteger(IterationCount);
 
                 if (!tmp.EncodedValueEquals(DefaultIterationCount))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
@@ -48,12 +48,8 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
 
             // DEFAULT value handler for IterationCount.
             {
-#if NET7_0_OR_GREATER
                 const int AsnManagedIntegerDerMaxEncodeSize = 6;
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
-#else
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
-#endif
                 tmp.WriteInteger(IterationCount);
 
                 if (!tmp.EncodedValueEquals(DefaultIterationCount))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
@@ -100,7 +100,8 @@ namespace System.Security.Cryptography.Asn1
             // DEFAULT value handler for SaltLength.
             {
 #if NET7_0_OR_GREATER
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+                const int AsnManagedIntegerDerMaxEncodeSize = 6;
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
 #else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
 #endif
@@ -118,7 +119,8 @@ namespace System.Security.Cryptography.Asn1
             // DEFAULT value handler for TrailerField.
             {
 #if NET7_0_OR_GREATER
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+                const int AsnManagedIntegerDerMaxEncodeSize = 6;
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
 #else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
 #endif

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
@@ -99,7 +99,11 @@ namespace System.Security.Cryptography.Asn1
 
             // DEFAULT value handler for SaltLength.
             {
+#if NET7_0_OR_GREATER
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+#else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
+#endif
                 tmp.WriteInteger(SaltLength);
 
                 if (!tmp.EncodedValueEquals(DefaultSaltLength))
@@ -113,7 +117,11 @@ namespace System.Security.Cryptography.Asn1
 
             // DEFAULT value handler for TrailerField.
             {
+#if NET7_0_OR_GREATER
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+#else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
+#endif
                 tmp.WriteInteger(TrailerField);
 
                 if (!tmp.EncodedValueEquals(DefaultTrailerField))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
@@ -99,12 +99,8 @@ namespace System.Security.Cryptography.Asn1
 
             // DEFAULT value handler for SaltLength.
             {
-#if NET7_0_OR_GREATER
                 const int AsnManagedIntegerDerMaxEncodeSize = 6;
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
-#else
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
-#endif
                 tmp.WriteInteger(SaltLength);
 
                 if (!tmp.EncodedValueEquals(DefaultSaltLength))
@@ -118,12 +114,8 @@ namespace System.Security.Cryptography.Asn1
 
             // DEFAULT value handler for TrailerField.
             {
-#if NET7_0_OR_GREATER
                 const int AsnManagedIntegerDerMaxEncodeSize = 6;
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
-#else
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
-#endif
                 tmp.WriteInteger(TrailerField);
 
                 if (!tmp.EncodedValueEquals(DefaultTrailerField))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
@@ -49,7 +49,11 @@ namespace System.Security.Cryptography.Asn1
 
             // DEFAULT value handler for Critical.
             {
+#if NET7_0_OR_GREATER
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+#else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
+#endif
                 tmp.WriteBoolean(Critical);
 
                 if (!tmp.EncodedValueEquals(DefaultCritical))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
@@ -49,12 +49,8 @@ namespace System.Security.Cryptography.Asn1
 
             // DEFAULT value handler for Critical.
             {
-#if NET7_0_OR_GREATER
                 const int AsnBoolDerEncodeSize = 3;
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
-#else
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
-#endif
                 tmp.WriteBoolean(Critical);
 
                 if (!tmp.EncodedValueEquals(DefaultCritical))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
@@ -50,7 +50,8 @@ namespace System.Security.Cryptography.Asn1
             // DEFAULT value handler for Critical.
             {
 #if NET7_0_OR_GREATER
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+                const int AsnBoolDerEncodeSize = 3;
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
 #else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
 #endif

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
@@ -276,8 +276,10 @@ namespace <xsl:value-of select="@namespace" />
       <xsl:when test="@defaultDerInit and not(@explicitTag)" xml:space="preserve">
 
             // DEFAULT value handler for <xsl:value-of select="@name" />.
-            {
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);<xsl:apply-templates select="." mode="EncodeValue">
+            {<xsl:apply-templates select="." mode="AsnWriterDefaultDer">
+                      <xsl:with-param name="writerName" select="'tmp'" />
+                      <xsl:with-param name="indent" select="concat('    ', $indent)" />
+                    </xsl:apply-templates><xsl:apply-templates select="." mode="EncodeValue">
                       <xsl:with-param name="writerName" select="'tmp'" />
                       <xsl:with-param name="indent" select="concat('    ', $indent)" />
                     </xsl:apply-templates>
@@ -294,6 +296,27 @@ namespace <xsl:value-of select="@namespace" />
       <xsl:otherwise>
         <xsl:apply-templates select="." mode="EncodeValue" />
       </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="*" mode="AsnWriterDefaultDer" xml:space="default">
+    <xsl:param name="writerName" />
+    <xsl:param name="indent" />
+    <xsl:choose>
+      <xsl:when test="self::asn:Boolean" xml:space="preserve">
+#if NET7_0_OR_GREATER
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+#else
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER);
+#endif</xsl:when>
+      <xsl:when test="self::asn:Integer[@backingType = 'int']" xml:space="preserve">
+#if NET7_0_OR_GREATER
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+#else
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER);
+#endif</xsl:when>
+      <xsl:otherwise xml:space="preserve">
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER);</xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 
@@ -342,8 +365,10 @@ namespace <xsl:value-of select="@namespace" />
       <xsl:when test="@defaultDerInit and @explicitTag" xml:space="preserve">
 
             // DEFAULT value handler for <xsl:value-of select="@name" />.
-            {
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);<xsl:apply-templates select="." mode="EncodeSimpleValue">
+            {<xsl:apply-templates select="." mode="AsnWriterDefaultDer">
+                      <xsl:with-param name="writerName" select="'tmp'" />
+                      <xsl:with-param name="indent" select="concat('    ', $indent)" />
+                </xsl:apply-templates><xsl:apply-templates select="." mode="EncodeSimpleValue">
                   <xsl:with-param name="writerName" select="'tmp'" />
                   <xsl:with-param name="indent" select="concat('    ', $indent)" />
                 </xsl:apply-templates>

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
@@ -305,13 +305,15 @@ namespace <xsl:value-of select="@namespace" />
     <xsl:choose>
       <xsl:when test="self::asn:Boolean" xml:space="preserve">
 #if NET7_0_OR_GREATER
-            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+            <xsl:value-of select="$indent"/>const int AsnBoolDerEncodeSize = 3;
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
 #else
             <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER);
 #endif</xsl:when>
       <xsl:when test="self::asn:Integer[@backingType = 'int']" xml:space="preserve">
 #if NET7_0_OR_GREATER
-            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+            <xsl:value-of select="$indent"/>const int AsnManagedIntegerDerMaxEncodeSize = 6;
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
 #else
             <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER);
 #endif</xsl:when>

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
@@ -304,19 +304,11 @@ namespace <xsl:value-of select="@namespace" />
     <xsl:param name="indent" />
     <xsl:choose>
       <xsl:when test="self::asn:Boolean" xml:space="preserve">
-#if NET7_0_OR_GREATER
             <xsl:value-of select="$indent"/>const int AsnBoolDerEncodeSize = 3;
-            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
-#else
-            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER);
-#endif</xsl:when>
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);</xsl:when>
       <xsl:when test="self::asn:Integer[@backingType = 'int']" xml:space="preserve">
-#if NET7_0_OR_GREATER
             <xsl:value-of select="$indent"/>const int AsnManagedIntegerDerMaxEncodeSize = 6;
-            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
-#else
-            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER);
-#endif</xsl:when>
+            <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);</xsl:when>
       <xsl:otherwise xml:space="preserve">
             <xsl:value-of select="$indent"/>AsnWriter <xsl:value-of select="$writerName"/> = new AsnWriter(AsnEncodingRules.DER);</xsl:otherwise>
     </xsl:choose>

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
@@ -66,7 +66,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
 
             // DEFAULT value handler for CertReq.
             {
+#if NET7_0_OR_GREATER
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+#else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
+#endif
                 tmp.WriteBoolean(CertReq);
 
                 if (!tmp.EncodedValueEquals(DefaultCertReq))

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
@@ -66,12 +66,8 @@ namespace System.Security.Cryptography.Pkcs.Asn1
 
             // DEFAULT value handler for CertReq.
             {
-#if NET7_0_OR_GREATER
                 const int AsnBoolDerEncodeSize = 3;
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
-#else
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
-#endif
                 tmp.WriteBoolean(CertReq);
 
                 if (!tmp.EncodedValueEquals(DefaultCertReq))

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
@@ -67,7 +67,8 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             // DEFAULT value handler for CertReq.
             {
 #if NET7_0_OR_GREATER
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+                const int AsnBoolDerEncodeSize = 3;
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
 #else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
 #endif

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
@@ -67,7 +67,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
 
             // DEFAULT value handler for Ordering.
             {
+#if NET7_0_OR_GREATER
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+#else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
+#endif
                 tmp.WriteBoolean(Ordering);
 
                 if (!tmp.EncodedValueEquals(DefaultOrdering))

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
@@ -68,7 +68,8 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             // DEFAULT value handler for Ordering.
             {
 #if NET7_0_OR_GREATER
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+                const int AsnBoolDerEncodeSize = 3;
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
 #else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
 #endif

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
@@ -67,12 +67,8 @@ namespace System.Security.Cryptography.Pkcs.Asn1
 
             // DEFAULT value handler for Ordering.
             {
-#if NET7_0_OR_GREATER
                 const int AsnBoolDerEncodeSize = 3;
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
-#else
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
-#endif
                 tmp.WriteBoolean(Ordering);
 
                 if (!tmp.EncodedValueEquals(DefaultOrdering))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
@@ -40,12 +40,8 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
 
             // DEFAULT value handler for CA.
             {
-#if NET7_0_OR_GREATER
                 const int AsnBoolDerEncodeSize = 3;
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
-#else
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
-#endif
                 tmp.WriteBoolean(CA);
 
                 if (!tmp.EncodedValueEquals(DefaultCA))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
@@ -40,7 +40,11 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
 
             // DEFAULT value handler for CA.
             {
+#if NET7_0_OR_GREATER
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+#else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
+#endif
                 tmp.WriteBoolean(CA);
 
                 if (!tmp.EncodedValueEquals(DefaultCA))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
@@ -41,7 +41,8 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             // DEFAULT value handler for CA.
             {
 #if NET7_0_OR_GREATER
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 3);
+                const int AsnBoolDerEncodeSize = 3;
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnBoolDerEncodeSize);
 #else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
 #endif

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
@@ -54,7 +54,11 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
 
             // DEFAULT value handler for Version.
             {
+#if NET7_0_OR_GREATER
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+#else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
+#endif
                 tmp.WriteInteger(Version);
 
                 if (!tmp.EncodedValueEquals(DefaultVersion))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
@@ -54,12 +54,8 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
 
             // DEFAULT value handler for Version.
             {
-#if NET7_0_OR_GREATER
                 const int AsnManagedIntegerDerMaxEncodeSize = 6;
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
-#else
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
-#endif
                 tmp.WriteInteger(Version);
 
                 if (!tmp.EncodedValueEquals(DefaultVersion))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
@@ -55,7 +55,8 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             // DEFAULT value handler for Version.
             {
 #if NET7_0_OR_GREATER
-                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: 6);
+                const int AsnManagedIntegerDerMaxEncodeSize = 6;
+                AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER, initialCapacity: AsnManagedIntegerDerMaxEncodeSize);
 #else
                 AsnWriter tmp = new AsnWriter(AsnEncodingRules.DER);
 #endif


### PR DESCRIPTION
In our ASN.1 templated encoding, we encode managed values with `AsnWriter` to determine if they are equal to `defaultDerInit`.

For some primitives types, like an ASN.1 Boolean and ASN.1 Integer (where the integer is known to be a managed `int`) this has some waste as `AsnWriter` has an initial capacity of 1024 bytes.

For booleans, we know the encoded length is always going to be 3 bytes for DER. For integers (where the backing type is `int`) we know it will encode to at most 6 bytes.

Where possible, let's give these size hints to reduce the initial allocation size. For example, the `Critical` boolean in X.509 extensions has a default. Before and after of encoding a basic constraints extension:


|                  Method |        Job | Toolchain |      Mean |    Error |   StdDev | Ratio |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------------ |----------- |---------- |----------:|---------:|---------:|------:|-------:|-------:|------:|----------:|
| NewX509BasicConstraints | Job-KCCSSM |    branch | 114.83 ns | 0.219 ns | 0.205 ns |  0.76 | 0.2154 | 0.0005 |     - |   1,352 B |
| NewX509BasicConstraints | Job-AGAYBV |      main | 150.80 ns | 0.413 ns | 0.387 ns |  1.00 | 0.3774 | 0.0019 |     - |   2,368 B |