### PR TITLE
prevent use of null when processing alpn list

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -683,6 +683,11 @@ internal static partial class Interop
             *outlen = 0;
             IntPtr sslData = Ssl.SslGetData(ssl);
 
+            if (sslData == IntPtr.Zero)
+            {
+                return Ssl.SSL_TLSEXT_ERR_ALERT_FATAL;
+            }
+
             // reset application data to avoid dangling pointer.
             Ssl.SslSetData(ssl, IntPtr.Zero);
 

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -421,6 +421,7 @@ namespace Microsoft.Win32.SafeHandles
 
             if (AlpnHandle.IsAllocated)
             {
+                Interop.Ssl.SslSetData(handle, IntPtr.Zero);
                 AlpnHandle.Free();
             }
 


### PR DESCRIPTION
fixes #81588. It is not quite clear if this is closing race condition or case when for example renegotiation can trigger the callback again. Throwing in native callback is bad so I added guard agains passing null to   `GCHandle.FromIntPtr`