### PR TITLE
Optimize ReplaceLineEndings

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -20,16 +20,20 @@ namespace System
         // Avoid paying the init cost of all the IndexOfAnyValues unless they are actually used.
         internal static class IndexOfAnyValuesStorage
         {
-            // The Unicode Standard, Sec. 5.8, Recommendation R4 and Table 5-2 state that the CR, LF,
-            // CRLF, NEL, LS, FF, and PS sequences are considered newline functions. That section
-            // also specifically excludes VT from the list of newline functions, so we do not include
-            // it in the needle list.
-            public static readonly IndexOfAnyValues<char> NewLineChars =
-                IndexOfAnyValues.Create("\r\n\f\u0085\u2028\u2029");
-
-            // IndexOfAnyValues would use SpanHelpers.IndexOfAnyValueType for 5 values in this case.
-            // No need to allocate the IndexOfAnyValues as a regular Span.IndexOfAny will use the same implementation.
+            /// <summary>
+            /// IndexOfAnyValues would use SpanHelpers.IndexOfAnyValueType for 5 values in this case.
+            /// No need to allocate the IndexOfAnyValues as a regular Span.IndexOfAny will use the same implementation.
+            /// </summary>
             public const string NewLineCharsExceptLineFeed = "\r\f\u0085\u2028\u2029";
+
+            /// <summary>
+            /// The Unicode Standard, Sec. 5.8, Recommendation R4 and Table 5-2 state that the CR, LF,
+            /// CRLF, NEL, LS, FF, and PS sequences are considered newline functions. That section
+            /// also specifically excludes VT from the list of newline functions, so we do not include
+            /// it in the needle list.
+            /// </summary>
+            public static readonly IndexOfAnyValues<char> NewLineChars =
+                IndexOfAnyValues.Create(NewLineCharsExceptLineFeed + "\n");
         }
 
         internal const int StackallocIntBufferSizeLimit = 128;
@@ -1482,8 +1486,6 @@ namespace System
         {
             // If we are going to replace the new line with a line feed ('\n'),
             // we can skip looking for it to avoid breaking out of the vectorized path unnecessarily.
-            // We can't use the same optimization for the carriage return ('\r')
-            // as we still want to replace CRLF ("\r\n") sequences.
             int idxOfFirstNewlineChar = this.AsSpan().IndexOfAny(IndexOfAnyValuesStorage.NewLineCharsExceptLineFeed);
             if ((uint)idxOfFirstNewlineChar >= (uint)Length)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/SpanLineEnumerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/SpanLineEnumerator.cs
@@ -46,18 +46,28 @@ namespace System.Text
                 return false; // EOF previously reached or enumerator was never initialized
             }
 
-            int idx = string.IndexOfNewlineChar(_remaining, out int stride);
-            if (idx >= 0)
+            ReadOnlySpan<char> remaining = _remaining;
+
+            int idx = remaining.IndexOfAny(string.IndexOfAnyValuesStorage.NewLineChars);
+
+            if ((uint)idx < (uint)remaining.Length)
             {
-                _current = _remaining.Slice(0, idx);
-                _remaining = _remaining.Slice(idx + stride);
+                int stride = 1;
+
+                if (remaining[idx] == '\r' && (uint)(idx + 1) < (uint)remaining.Length && remaining[idx + 1] == '\n')
+                {
+                    stride = 2;
+                }
+
+                _current = remaining.Slice(0, idx);
+                _remaining = remaining.Slice(idx + stride);
             }
             else
             {
                 // We've reached EOF, but we still need to return 'true' for this final
                 // iteration so that the caller can query the Current property once more.
 
-                _current = _remaining;
+                _current = remaining;
                 _remaining = default;
                 _isEnumeratorActive = false;
             }


### PR DESCRIPTION
- If we haven't replaced anything, avoid allocating the new string
  - Loop in `IndexOfNewlineChar` until something other than the `replacementText` is found
- If we're replacing new lines with a line feed (`'\n'` - default on non-Windows), we can avoid searching for the line feed, thus avoiding breaking out of the vectorized path unnecessarily
  - If we're searching for 5 values instead of 6, we also switch from the probabilistic map to `SpanHelpers.IndexOfAnyValueType`

ReplaceLineEndings LF => LF

| Toolchain | NewLineFrequency | Length | Source | Replacement |         Mean | Ratio | Allocated |
|---------- |----------------- |------- |------- |------------ |-------------:|------:|----------:|
|      main |                0 |  10000 |     LF |          LF |  11,532.5 ns |  1.00 |         - |
|        pr |                0 |  10000 |     LF |          LF |     622.6 ns |  0.05 |         - |
|           |                  |        |        |             |              |       |           |
|      main |             0.05 |  10000 |     LF |          LF |  22,552.8 ns |  1.00 |   20024 B |
|        pr |             0.05 |  10000 |     LF |          LF |     607.1 ns |  0.03 |         - |
|           |                  |        |        |             |              |       |           |
|      main |              0.1 |  10000 |     LF |          LF |  32,663.1 ns |  1.00 |   20024 B |
|        pr |              0.1 |  10000 |     LF |          LF |     614.8 ns |  0.02 |         - |
|           |                  |        |        |             |              |       |           |
|      main |              0.2 |  10000 |     LF |          LF |  50,579.0 ns |  1.00 |   20024 B |
|        pr |              0.2 |  10000 |     LF |          LF |     621.8 ns |  0.01 |         - |
|           |                  |        |        |             |              |       |           |
|      main |                1 |  10000 |     LF |          LF | 129,070.5 ns | 1.000 |   20024 B |
|        pr |                1 |  10000 |     LF |          LF |     607.5 ns | 0.005 |         - |

<details>
<summary>ReplaceLineEndings CRLF => LF</summary>

| Toolchain | NewLineFrequency | Length | Source | Replacement |         Mean | Ratio | Allocated |
|---------- |----------------- |------- |------- |------------ |-------------:|------:|----------:|
|      main |                0 |  10000 |   CRLF |          LF |  11,528.7 ns |  1.00 |         - |
|        pr |                0 |  10000 |   CRLF |          LF |     623.5 ns |  0.05 |         - |
|           |                  |        |        |             |              |       |           |
|      main |             0.05 |  10000 |   CRLF |          LF |  21,548.3 ns |  1.00 |   19040 B |
|        pr |             0.05 |  10000 |   CRLF |          LF |   8,531.8 ns |  0.40 |   19040 B |
|           |                  |        |        |             |              |       |           |
|      main |              0.1 |  10000 |   CRLF |          LF |  28,978.2 ns |  1.00 |   18128 B |
|        pr |              0.1 |  10000 |   CRLF |          LF |  17,105.9 ns |  0.59 |   18128 B |
|           |                  |        |        |             |              |       |           |
|      main |              0.2 |  10000 |   CRLF |          LF |  41,437.0 ns |  1.00 |   16664 B |
|        pr |              0.2 |  10000 |   CRLF |          LF |  30,343.2 ns |  0.73 |   16664 B |
|           |                  |        |        |             |              |       |           |
|      main |                1 |  10000 |   CRLF |          LF |  67,488.9 ns |  1.00 |   10024 B |
|        pr |                1 |  10000 |   CRLF |          LF |  58,969.6 ns |  0.87 |   10024 B |

</details>

<details>
<summary>ReplaceLineEndings CRLF => CRLF</summary>

| Toolchain | NewLineFrequency | Length | Source | Replacement |         Mean | Ratio | Allocated |
|---------- |----------------- |------- |------- |------------ |-------------:|------:|----------:|
|      main |                0 |  10000 |   CRLF |        CRLF |     11.65 us |  1.00 |         - |
|        pr |                0 |  10000 |   CRLF |        CRLF |     11.25 us |  0.96 |         - |
|           |                  |        |        |             |              |       |           |
|      main |             0.05 |  10000 |   CRLF |        CRLF |     23.29 us |  1.00 |   20024 B |
|        pr |             0.05 |  10000 |   CRLF |        CRLF |     16.64 us |  0.71 |         - |
|           |                  |        |        |             |              |       |           |
|      main |              0.1 |  10000 |   CRLF |        CRLF |     32.72 us |  1.00 |   20024 B |
|        pr |              0.1 |  10000 |   CRLF |        CRLF |     20.16 us |  0.62 |         - |
|           |                  |        |        |             |              |       |           |
|      main |              0.2 |  10000 |   CRLF |        CRLF |     47.12 us |  1.00 |   20024 B |
|        pr |              0.2 |  10000 |   CRLF |        CRLF |     28.28 us |  0.60 |         - |
|           |                  |        |        |             |              |       |           |
|      main |                1 |  10000 |   CRLF |        CRLF |     79.54 us |  1.00 |   20024 B |
|        pr |                1 |  10000 |   CRLF |        CRLF |     35.94 us |  0.45 |         - |

</details>

<details>
<summary>SpanLineEnumerator</summary>

|         Method | Toolchain | NewLineFrequency | Length |      Mean |    Error | Ratio |
|--------------- |---------- |----------------- |------- |----------:|---------:|------:|
| EnumerateLines |      main |                0 |  10000 |  11.52 us | 0.046 us |  1.00 |
| EnumerateLines |        pr |                0 |  10000 |  11.36 us | 0.049 us |  0.99 |
|                |           |                  |        |           |          |       |
| EnumerateLines |      main |             0.05 |  10000 |  18.35 us | 0.080 us |  1.00 |
| EnumerateLines |        pr |             0.05 |  10000 |  17.70 us | 0.082 us |  0.97 |
|                |           |                  |        |           |          |       |
| EnumerateLines |      main |              0.1 |  10000 |  26.19 us | 0.093 us |  1.00 |
| EnumerateLines |        pr |              0.1 |  10000 |  23.65 us | 0.077 us |  0.90 |
|                |           |                  |        |           |          |       |
| EnumerateLines |      main |              0.2 |  10000 |  44.13 us | 0.320 us |  1.00 |
| EnumerateLines |        pr |              0.2 |  10000 |  37.83 us | 0.153 us |  0.86 |
|                |           |                  |        |           |          |       |
| EnumerateLines |      main |                1 |  10000 | 122.93 us | 0.679 us |  1.00 |
| EnumerateLines |        pr |                1 |  10000 |  83.27 us | 0.224 us |  0.68 |

</details>