### PR TITLE
Add a missing assert in constraint resolver

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -8512,6 +8512,7 @@ MethodTable::TryResolveConstraintMethodApprox(
             &uniqueResolution);
         if (result == NULL || !uniqueResolution)
         {
+            _ASSERTE(pfForceUseRuntimeLookup != NULL);
             *pfForceUseRuntimeLookup = TRUE;
             result = NULL;
         }


### PR DESCRIPTION
In other case (few lines below), we have this assert before assigning this nullable ptr a value.