### PR TITLE
[Jiterpreter] Add support for TryGetHashCode intrinsic

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -699,6 +699,7 @@ jiterp_should_abort_trace (InterpInst *ins, gboolean *inside_branch_block)
 		case MINT_LDTSFLDA:
 		case MINT_SAFEPOINT:
 		case MINT_INTRINS_GET_HASHCODE:
+		case MINT_INTRINS_TRY_GET_HASHCODE:
 		case MINT_INTRINS_RUNTIMEHELPERS_OBJECT_HAS_COMPONENT_SIZE:
 		case MINT_INTRINS_ENUM_HASFLAG:
 		case MINT_ADD_MUL_I4_IMM:
@@ -973,6 +974,14 @@ mono_jiterp_get_hashcode (MonoObject ** ppObj)
 	MonoObject *obj = *ppObj;
 	g_assert (obj);
 	return mono_object_hash_internal (obj);
+}
+
+EMSCRIPTEN_KEEPALIVE int
+mono_jiterp_try_get_hashcode (MonoObject ** ppObj)
+{
+	MonoObject *obj = *ppObj;
+	g_assert (obj);
+	return mono_object_try_get_hash_internal (obj);
 }
 
 EMSCRIPTEN_KEEPALIVE int

--- a/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/wasm/runtime/jiterpreter-trace-generator.ts
@@ -471,6 +471,12 @@ export function generate_wasm_body (
                 builder.callImport("hashcode");
                 append_stloc_tail(builder, getArgU16(ip, 1), WasmOpcode.i32_store);
                 break;
+            case MintOpcode.MINT_INTRINS_TRY_GET_HASHCODE:
+                builder.local("pLocals");
+                append_ldloca(builder, getArgU16(ip, 2));
+                builder.callImport("try_hash");
+                append_stloc_tail(builder, getArgU16(ip, 1), WasmOpcode.i32_store);
+                break;
             case MintOpcode.MINT_INTRINS_RUNTIMEHELPERS_OBJECT_HAS_COMPONENT_SIZE:
                 builder.local("pLocals");
                 append_ldloca(builder, getArgU16(ip, 2));

--- a/src/mono/wasm/runtime/jiterpreter.ts
+++ b/src/mono/wasm/runtime/jiterpreter.ts
@@ -239,6 +239,7 @@ function getTraceImports () {
         ["relop_fp", "relop_fp", getRawCwrap("mono_jiterp_relop_fp")],
         ["safepoint", "safepoint", getRawCwrap("mono_jiterp_auto_safepoint")],
         ["hashcode", "hashcode", getRawCwrap("mono_jiterp_get_hashcode")],
+        ["try_hash", "try_hash", getRawCwrap("mono_jiterp_try_get_hashcode")],
         ["hascsize", "hascsize", getRawCwrap("mono_jiterp_object_has_component_size")],
         ["hasflag", "hasflag", getRawCwrap("mono_jiterp_enum_hasflag")],
         ["array_rank", "array_rank", getRawCwrap("mono_jiterp_get_array_rank")],
@@ -461,6 +462,11 @@ function initialize_builder (builder: WasmBuilder) {
     );
     builder.defineType(
         "hashcode", {
+            "ppObj": WasmValtype.i32,
+        }, WasmValtype.i32, true
+    );
+    builder.defineType(
+        "try_hash", {
             "ppObj": WasmValtype.i32,
         }, WasmValtype.i32, true
     );


### PR DESCRIPTION
#80520 added support in the Jiterpreter for the intrinsic that underlies `RuntimeHelpers.GetHashCode`.  This PR adds similar support for the intrinsic that underlies  `RuntimeHelpers.TryGetHashCode`.

For reference `RuntimeHelpers.TryGetHashCode` was added in #80059. It is currently only used in `ConditionalWeakTable.TryGetValue`.

### Testing

```
./dotnet.sh build /t:Test src/libraries/System.Runtime/tests /p:TargetOS=browser /p:TargetArchitecture=wasm /p:Configuration=Release
```