### PR TITLE
[wasi] Support builds with no relinking

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -177,7 +177,7 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
 
-  # Wasi
+  # Wasi - run only smoke tests by default
   - template: /eng/pipelines/common/templates/wasm-library-tests.yml
     parameters:
       platforms:
@@ -186,6 +186,9 @@ jobs:
       nameSuffix: '_Smoke'
       extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true
       shouldRunSmokeOnly: true
+      # ignore test failures for runtime-extra-platforms, but not when this
+      # is run as part of a wasm specific pipeline like runtime-wasm
+      shouldContinueOnError: ${{ not(parameters.isWasmOnlyBuild) }}
       alwaysRun: ${{ variables.isRollingBuild }}
       scenarios:
         - normal

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -464,6 +464,7 @@ extends:
             - wasi_wasm_win
           nameSuffix: '_Smoke'
           extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true
+          shouldContinueOnError: true
           shouldRunSmokeOnly: true
           alwaysRun: ${{ variables.isRollingBuild }}
           scenarios:

--- a/eng/testing/tests.wasi.targets
+++ b/eng/testing/tests.wasi.targets
@@ -75,6 +75,10 @@
     <_XHarnessArgs Condition="'$(OS)' != 'Windows_NT'">wasi $XHARNESS_COMMAND --app=. --output-directory=$XHARNESS_OUT</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(OS)' == 'Windows_NT'">wasi %XHARNESS_COMMAND% --app=. --output-directory=%XHARNESS_OUT%</_XHarnessArgs>
 
+    <!-- FIXME: workaround till xharness correctly defaults to using wasmtime.exe -->
+    <_XHarnessArgs Condition="'$(OS)' == 'Windows_NT' and '$(ContinuousIntegrationBuild)' != 'true'">$(_XHarnessArgs) --wasm-engine-path=$(WasmtimeDir)wasmtime.exe</_XHarnessArgs>
+    <_XHarnessArgs Condition="'$(OS)' == 'Windows_NT' and '$(ContinuousIntegrationBuild)' == 'true'">$(_XHarnessArgs) --wasm-engine-path=%HELIX_CORRELATION_PAYLOAD%\wasmtime\wasmtime.exe</_XHarnessArgs>
+
     <_XHarnessArgs Condition="'$(WasmSingleFileBundle)' != 'true'" >$(_XHarnessArgs) --engine-arg=--dir=.</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(IsFunctionalTest)' == 'true'"     >$(_XHarnessArgs) --expected-exit-code=$(ExpectedExitCode)</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(WasmXHarnessArgs)' != ''"         >$(_XHarnessArgs) $(WasmXHarnessArgs)</_XHarnessArgs>

--- a/eng/testing/tests.wasi.targets
+++ b/eng/testing/tests.wasi.targets
@@ -61,9 +61,10 @@
 
   <PropertyGroup>
     <_AppArgs Condition="'$(WasmSingleFileBundle)' == 'true'">$([System.IO.Path]::GetFileNameWithoutExtension('$(WasmMainAssemblyFileName)')).wasm</_AppArgs>
-    <_AppArgs Condition="'$(WasmSingleFileBundle)' != 'true'">dotnet.wasm</_AppArgs>
+    <_AppArgs Condition="'$(WasmSingleFileBundle)' != 'true'">dotnet.wasm WasmTestRunner</_AppArgs>
 
-    <_AppArgs Condition="'$(IsFunctionalTest)' != 'true'">$(_AppArgs) $(AssemblyName).dll</_AppArgs>
+    <_AppArgs Condition="'$(IsFunctionalTest)' != 'true' and '$(WasmSingleFileBundle)' != 'true'">$(_AppArgs) managed/$(AssemblyName).dll</_AppArgs>
+    <_AppArgs Condition="'$(IsFunctionalTest)' != 'true' and '$(WasmSingleFileBundle)' == 'true'">$(_AppArgs) $(AssemblyName).dll</_AppArgs>
     <_AppArgs Condition="'$(WasmTestAppArgs)' != ''">$(_AppArgs) -- $(WasmTestAppArgs)</_AppArgs>
 
     <!-- FIXME: wasttime specific param name -->
@@ -74,10 +75,7 @@
     <_XHarnessArgs Condition="'$(OS)' != 'Windows_NT'">wasi $XHARNESS_COMMAND --app=. --output-directory=$XHARNESS_OUT</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(OS)' == 'Windows_NT'">wasi %XHARNESS_COMMAND% --app=. --output-directory=%XHARNESS_OUT%</_XHarnessArgs>
 
-    <!-- FIXME: workaround till xharness correctly defaults to using wasmtime.exe -->
-    <_XHarnessArgs Condition="'$(OS)' == 'Windows_NT' and '$(ContinuousIntegrationBuild)' != 'true'">$(_XHarnessArgs) --wasm-engine-path=$(WasmtimeDir)wasmtime.exe</_XHarnessArgs>
-    <_XHarnessArgs Condition="'$(OS)' == 'Windows_NT' and '$(ContinuousIntegrationBuild)' == 'true'">$(_XHarnessArgs) --wasm-engine-path=%HELIX_CORRELATION_PAYLOAD%\wasmtime\wasmtime.exe</_XHarnessArgs>
-
+    <_XHarnessArgs Condition="'$(WasmSingleFileBundle)' != 'true'" >$(_XHarnessArgs) --engine-arg=--dir=.</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(IsFunctionalTest)' == 'true'"     >$(_XHarnessArgs) --expected-exit-code=$(ExpectedExitCode)</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(WasmXHarnessArgs)' != ''"         >$(_XHarnessArgs) $(WasmXHarnessArgs)</_XHarnessArgs>
     <_XHarnessArgs Condition="'$(_XHarnessTestsTimeout)' != ''   " >$(_XHarnessArgs) &quot;--timeout=$(_XHarnessTestsTimeout)&quot;</_XHarnessArgs>

--- a/eng/testing/tests.wasi.targets
+++ b/eng/testing/tests.wasi.targets
@@ -19,7 +19,7 @@
     -->
     <WasmNativeStrip Condition="'$(WasmNativeStrip)' == ''">false</WasmNativeStrip>
     <WasmEmitSymbolMap Condition="'$(WasmEmitSymbolMap)' == '' and '$(RunAOTCompilation)' != 'true'">true</WasmEmitSymbolMap>
-    <WasmSingleFileBundle>true</WasmSingleFileBundle>
+    <WasmSingleFileBundle Condition="'$(WasmSingleFileBundle)' == ''">false</WasmSingleFileBundle>
 
     <WasmMainAssemblyFileName Condition="'$(WasmMainAssemblyFileName)' == ''">WasmTestRunner.dll</WasmMainAssemblyFileName>
 

--- a/src/mono/sample/wasi/wasi.mk
+++ b/src/mono/sample/wasi/wasi.mk
@@ -9,7 +9,8 @@ endif
 CONFIG?=Release
 
 WASM_DEFAULT_BUILD_ARGS?=/p:TargetArchitecture=wasm /p:TargetOS=wasi /p:Configuration=$(CONFIG)
-WASMTIME_PROV_PATH=$(realpath $(TOP)/artifacts/obj/wasmtime/wasmtime)
+WASMTIME_PROV_DIR=$(realpath $(TOP)/artifacts/obj/wasmtime)
+WASMTIME_PROV_PATH=${WASMTIME_PROV_DIR}/wasmtime
 
 all: publish
 
@@ -23,4 +24,4 @@ clean:
 	rm -rf bin $(TOP)/artifacts/obj/mono/$(PROJECT_NAME:%.csproj=%)
 
 run-console:
-	cd bin/wasi-wasm/AppBundle && $(WASMTIME_PROV_PATH) run $(PROJECT_NAME:.csproj=.wasm) $(ARGS)
+	cd bin/wasi-wasm/AppBundle && PATH=${WASMTIME_PROV_DIR}:${PATH} ./run-wasmtime.sh $(ARGS)

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -117,7 +117,7 @@
     <!-- if DebuggerSupport==true, then ensure that WasmDebugLevel isn't disabling debugging -->
     <WasmDebugLevel Condition="('$(WasmDebugLevel)' == '' or '$(WasmDebugLevel)' == '0') and ('$(DebuggerSupport)' == 'true' or '$(Configuration)' == 'Debug')">-1</WasmDebugLevel>
 
-    <WasmSingleFileBundle Condition="'$(WasmSingleFileBundle)' == ''">true</WasmSingleFileBundle>
+    <WasmSingleFileBundle Condition="'$(WasmSingleFileBundle)' == ''">false</WasmSingleFileBundle>
     <WasmBuildNative Condition="'$(WasmBuildNative)' == '' and '$(WasmSingleFileBundle)' == 'true'">true</WasmBuildNative>
 
     <WasiBundleAssemblies Condition="'$(WasiBundleAssemblies)' == ''">true</WasiBundleAssemblies>
@@ -317,29 +317,18 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_GetWasmGenerateAppBundleDependencies" />
-
-  <Target Name="_GetBrowserWasmGenerateAppBundleDependencies">
+  <Target Name="_GetWasiGenerateAppBundleDependencies">
     <PropertyGroup>
-      <WasmIcuDataFileName Condition="'$(InvariantGlobalization)' != 'true'">icudt.dat</WasmIcuDataFileName>
+      <!--<WasmIcuDataFileName Condition="'$(InvariantGlobalization)' != 'true'">icudt.dat</WasmIcuDataFileName>-->
 
       <_HasDotnetWasm Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.wasm'">true</_HasDotnetWasm>
-      <_HasDotnetJsWorker Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.worker.js'">true</_HasDotnetJsWorker>
-      <_HasDotnetJsSymbols Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.js.symbols'">true</_HasDotnetJsSymbols>
-      <_HasDotnetJs Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.js'">true</_HasDotnetJs>
     </PropertyGroup>
 
     <ItemGroup>
       <!-- If dotnet.{wasm,js} weren't added already (eg. AOT can add them), then add the default ones -->
       <WasmNativeAsset Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)dotnet.wasm" Condition="'$(_HasDotnetWasm)' != 'true'" />
-      <WasmNativeAsset Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)dotnet.js" Condition="'$(_HasDotnetJs)' != 'true'" />
-      <WasmNativeAsset Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)dotnet.worker.js" Condition="'$(_HasDotnetJsWorker)' != 'true' and Exists('$(MicrosoftNetCoreAppRuntimePackRidNativeDir)dotnet.worker.js')" />
-      <WasmNativeAsset Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)dotnet.js.symbols"
-                       Condition="'$(WasmEmitSymbolMap)' == 'true' and
-                                  '$(_HasDotnetJsSymbols)' != 'true' and
-                                  Exists('$(MicrosoftNetCoreAppRuntimePackRidNativeDir)dotnet.js.symbols')" />
 
-      <WasmNativeAsset Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)$(WasmIcuDataFileName)" Condition="'$(InvariantGlobalization)' != 'true'" />
+      <!--<WasmNativeAsset Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)$(WasmIcuDataFileName)" Condition="'$(InvariantGlobalization)' != 'true'" />-->
       <WasmNativeAsset Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)dotnet.timezones.blat" />
 
       <WasmFilesToIncludeInFileSystem Include="@(WasmNativeAsset)" Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.js.symbols'" />
@@ -350,72 +339,32 @@
           Inputs="@(_WasmAssembliesInternal);$(WasmIcuDataFileName);@(WasmNativeAsset)"
           Outputs="$(WasmAppDir)\.stamp"
           Condition="'$(WasmGenerateAppBundle)' == 'true'"
-          DependsOnTargets="_WasmGenerateRuntimeConfig;_GetWasmGenerateAppBundleDependencies" />
+          DependsOnTargets="_WasmGenerateRuntimeConfig;_GetWasiGenerateAppBundleDependencies;_WasiDefaultGenerateAppBundle;_GenerateRunWasmtimeScript" />
 
-  <Target Name="_BrowserWasmGenerateAppBundle"
-          Inputs="@(_WasmAssembliesInternal);$(WasmMainJSPath);$(WasmIcuDataFileName);@(WasmNativeAsset)"
-          Outputs="$(WasmAppDir)\.stamp"
-          Condition="'$(WasmGenerateAppBundle)' == 'true'"
-          DependsOnTargets="_WasmGenerateRuntimeConfig;_GetBrowserWasmGenerateAppBundleDependencies">
-    <Error Condition="'$(WasmMainJSPath)' == ''" Text="%24(WasmMainJSPath) property needs to be set" />
-
-    <PropertyGroup>
-      <_WasmAppIncludeThreadsWorker Condition="'$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true'">true</_WasmAppIncludeThreadsWorker>
-      <!-- TODO: set this from some user-facing property?  -1 means use the default baked into dotnet.js -->
-      <_WasmPThreadPoolSize Condition="'$(_WasmPThreadPoolSize)' == '' and ('$(WasmEnableThreads)' == 'true' or '$(WasmEnablePerfTracing)' == 'true')">-1</_WasmPThreadPoolSize>
-    </PropertyGroup>
-
-    <RemoveDir Directories="$(WasmAppDir)" />
-    <WasmAppBuilder
-      AppDir="$(WasmAppDir)"
-      MainJS="$(WasmMainJSPath)"
-      MainHTMLPath="$(WasmMainHTMLPath)"
-      Assemblies="@(_WasmAssembliesInternal)"
-      MainAssemblyName="$(WasmMainAssemblyFileName)"
-      HostConfigs="@(HostConfig)"
-      RuntimeArgsForHost="@(WasmMonoRuntimeArgs)"
-      DefaultHostConfig="$(DefaultWasmHostConfig)"
-      InvariantGlobalization="$(InvariantGlobalization)"
-      SatelliteAssemblies="@(_WasmSatelliteAssemblies)"
-      FilesToIncludeInFileSystem="@(WasmFilesToIncludeInFileSystem)"
-      IcuDataFileName="$(WasmIcuDataFileName)"
-      RemoteSources="@(WasmRemoteSources)"
-      ExtraFilesToDeploy="@(WasmExtraFilesToDeploy)"
-      ExtraConfig="@(WasmExtraConfig)"
-      NativeAssets="@(WasmNativeAsset)"
-      DebugLevel="$(WasmDebugLevel)"
-      IncludeThreadsWorker="$(_WasmAppIncludeThreadsWorker)"
-      PThreadPoolSize="$(_WasmPThreadPoolSize)"
-      >
-      <Output TaskParameter="FileWrites" ItemName="FileWrites" />
-    </WasmAppBuilder>
-
-    <CallTarget Targets="_GenerateRunV8Script" Condition="'$(WasmGenerateRunV8Script)' == 'true'" />
-    <Message Text="Generated app bundle at $(WasmAppDir)" Importance="High" />
-
-    <Copy SourceFiles="@(_WasmAppHostFiles)" DestinationFiles="@(_WasmAppHostFiles->'$(WasmAppDir)\WasmAppHost\%(RecursiveDir)%(FileName)%(Extension)')" />
-
-    <WriteLinesToFile File="$(WasmAppDir)\.stamp" Lines="" Overwrite="true" />
+  <Target Name="_WasiDefaultGenerateAppBundle" Condition="'$(WasmSingleFileBundle)' != 'true'">
+    <!-- placeholder bundle generator -->
+    <Copy SourceFiles="@(_WasmAssembliesInternal)" DestinationFolder="$(WasmAppDir)\managed" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(WasmNativeAsset)" DestinationFolder="$(WasmAppDir)" SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="_GenerateRunV8Script">
+  <Target Name="_GenerateRunWasmtimeScript">
     <PropertyGroup>
-      <WasmRunV8ScriptPath Condition="'$(WasmRunV8ScriptPath)' == ''">$(WasmAppDir)run-v8.sh</WasmRunV8ScriptPath>
-      <_WasmMainJSFileName>$([System.IO.Path]::GetFileName('$(WasmMainJSPath)'))</_WasmMainJSFileName>
+      <WasmRunWasmtimeScriptPath Condition="'$(WasmRunWasmtimeScriptPath)' == ''">$(WasmAppDir)run-wasmtime.sh</WasmRunWasmtimeScriptPath>
+      <_ScriptContent Condition="'$(WasmSingleFileBundle)' == 'true'">wasmtime run $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))).wasm $*</_ScriptContent>
+      <_ScriptContent Condition="'$(WasmSingleFileBundle)' != 'true'">wasmtime run --dir . dotnet.wasm $([System.IO.Path]::GetFileNameWithoutExtension($(WasmMainAssemblyFileName))) $*</_ScriptContent>
     </PropertyGroup>
 
-    <Error Condition="'$(WasmMainAssemblyFileName)' == ''" Text="%24(WasmMainAssemblyFileName) property needs to be set for generating $(WasmRunV8ScriptPath)." />
+    <Error Condition="'$(WasmMainAssemblyFileName)' == ''" Text="%24(WasmMainAssemblyFileName) property needs to be set for generating $(WasmRunWasmtimeScriptPath)." />
     <WriteLinesToFile
-      File="$(WasmRunV8ScriptPath)"
-      Lines="v8 --expose_wasm $(_WasmMainJSFileName) -- ${RUNTIME_ARGS} --run $(WasmMainAssemblyFileName) $*"
-      Overwrite="true">
-    </WriteLinesToFile>
+      File="$(WasmRunWasmtimeScriptPath)"
+      Lines="$(_ScriptContent)"
+      Overwrite="true" />
 
     <ItemGroup>
-      <FileWrites Include="$(WasmRunV8ScriptPath)" />
+      <FileWrites Include="$(WasmRunWasmtimeScriptPath)" />
     </ItemGroup>
 
-    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="chmod a+x $(WasmRunV8ScriptPath)" />
+    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="chmod a+x $(WasmRunWasmtimeScriptPath)" />
   </Target>
 
   <Target Name="_WasmResolveReferences" Condition="'$(WasmResolveAssembliesBeforeBuild)' == 'true'">

--- a/src/mono/wasi/runtime/main.c
+++ b/src/mono/wasi/runtime/main.c
@@ -22,10 +22,6 @@ int main(int argc, char * argv[]) {
 	// This is supplied from the MSBuild itemgroup @(WasiAfterRuntimeLoaded)
 	WASI_AFTER_RUNTIME_LOADED_CALLS
 #endif
-	// Assume the runtime pack has been copied into the output directory as 'runtime'
-	// Otherwise we have to mount an unrelated part of the filesystem within the WASM environment
-	// AJ: not needed right now as we are bundling all the assemblies in the .wasm
-	/*mono_set_assemblies_path(".:./runtime/native:./runtime/lib/net7.0");*/
 	mono_wasm_load_runtime("", 0);
 
 	const char* assembly_name = dotnet_wasi_getentrypointassemblyname();
@@ -44,5 +40,5 @@ int main(int argc, char * argv[]) {
 		mono_print_unhandled_exception(out_exc);
 		exit(1);
 	}
-	return ret;
+	return ret < 0 ? -ret : ret;
 }


### PR DESCRIPTION
This will use `dotnet.wasm` from the runtime pack. In the relinking case, all the assemblies get bundled into the .wasm .

Also:
1. Ignore library test failures for the default pipelines
2. Don't ignore the failures for wasm specific pipelines like `runtime-wasm`