### PR TITLE
Vectorize Guid.ToString

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -1210,8 +1210,7 @@ namespace System
                         // Vectorized implementation for D, N, P and B formats:
                         // [{|(]dddddddd[-]dddd[-]dddd[-]dddd[-]dddddddddddd[}|)]
 
-                        ref byte thisPtr = ref Unsafe.As<Guid, byte>(ref Unsafe.AsRef(in this));
-                        Vector128<byte> srcVec = Vector128.LoadUnsafe(ref thisPtr);
+                        Vector128<byte> srcVec = Unsafe.As<Guid, Vector128<byte>>(ref Unsafe.AsRef(in this));
 
                         // The algorithm is simple: a single srcVec (contains the whole 16b Guid) is converted
                         // into nibbles and then, via hexMap, converted into a HEX representation via

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -1205,7 +1205,7 @@ namespace System
                         p += HexsToCharsHexOutput(p, _j, _k);
                         *p++ = '}';
                     }
-                    else if ((Ssse3.IsSupported || AdvSimd.IsSupported) && BitConverter.IsLittleEndian)
+                    else if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian)
                     {
                         ref byte thisPtr = ref Unsafe.As<Guid, byte>(ref Unsafe.AsRef(in this));
                         Vector128<byte> srcVec = Vector128.LoadUnsafe(ref thisPtr);

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -1270,7 +1270,24 @@ namespace System
                     }
                     else
                     {
-                        p = FormatNonHexFallback(p, dash);
+                        // Non-vectorized fallback for D, N, P and B formats:
+                        // [{|(]dddddddd[-]dddd[-]dddd[-]dddd[-]dddddddddddd[}|)]
+                        p += HexsToChars(p, _a >> 24, _a >> 16);
+                        p += HexsToChars(p, _a >> 8, _a);
+                        if (dash)
+                            *p++ = '-';
+                        p += HexsToChars(p, _b >> 8, _b);
+                        if (dash)
+                            *p++ = '-';
+                        p += HexsToChars(p, _c >> 8, _c);
+                        if (dash)
+                            *p++ = '-';
+                        p += HexsToChars(p, _d, _e);
+                        if (dash)
+                            *p++ = '-';
+                        p += HexsToChars(p, _f, _g);
+                        p += HexsToChars(p, _h, _i);
+                        p += HexsToChars(p, _j, _k);
                     }
 
                     if (braces != 0)
@@ -1282,30 +1299,6 @@ namespace System
 
             charsWritten = guidSize;
             return true;
-        }
-
-        // Non-vectorized fallback for D, N, P and B formats
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private unsafe char* FormatNonHexFallback(char* p, bool dash)
-        {
-            // [{|(]dddddddd[-]dddd[-]dddd[-]dddd[-]dddddddddddd[}|)]
-            p += HexsToChars(p, _a >> 24, _a >> 16);
-            p += HexsToChars(p, _a >> 8, _a);
-            if (dash)
-                *p++ = '-';
-            p += HexsToChars(p, _b >> 8, _b);
-            if (dash)
-                *p++ = '-';
-            p += HexsToChars(p, _c >> 8, _c);
-            if (dash)
-                *p++ = '-';
-            p += HexsToChars(p, _d, _e);
-            if (dash)
-                *p++ = '-';
-            p += HexsToChars(p, _f, _g);
-            p += HexsToChars(p, _h, _i);
-            p += HexsToChars(p, _j, _k);
-            return p;
         }
 
         bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.GuidFormat)] ReadOnlySpan<char> format, IFormatProvider? provider)


### PR DESCRIPTION
I tried to keep the implementation compact - around +66 lines to handle D, N, P and B formats (except X basically, which is rarely-used). For both x64 and Arm64.
```csharp
public static IEnumerable<Guid> TestData()
{
    yield return new Guid("{483BC244-A481-4D29-986F-8C7D647AA20D}");
}

[Benchmark]
[ArgumentsSource(nameof(TestData))]
public string ToStringD(Guid guid) => guid.ToString(); // Default - "D"

[Benchmark]
[ArgumentsSource(nameof(TestData))]
public string ToStringN(Guid guid) => guid.ToString("N");

[Benchmark]
[ArgumentsSource(nameof(TestData))]
public string ToStringB(Guid guid) => guid.ToString("B");

[Benchmark]
[ArgumentsSource(nameof(TestData))]
public string ToStringP(Guid guid) => guid.ToString("P");
```

|        Method |                   Toolchain |                 guid |      Mean |    Error |   StdDev | Ratio |
|-------------- |---------------------------- |--------------------- |----------:|---------:|---------:|------:|
|     ToStringD |      \Core_Root\corerun.exe | 483bc(...)aa20d [36] |  **13.26 ns** | 0.035 ns | 0.033 ns |  0.57 |
|     ToStringD | \Core_Root_base\corerun.exe | 483bc(...)aa20d [36] |  23.27 ns | 0.081 ns | 0.071 ns |  1.00 |
|               |                             |                      |           |          |          |       |
|     ToStringN |      \Core_Root\corerun.exe | 483bc(...)aa20d [36] |  **12.69 ns** | 0.072 ns | 0.056 ns |  0.58 |
|     ToStringN | \Core_Root_base\corerun.exe | 483bc(...)aa20d [36] |  22.00 ns | 0.048 ns | 0.040 ns |  1.00 |
|               |                             |                      |           |          |          |       |
|     ToStringB |      \Core_Root\corerun.exe | 483bc(...)aa20d [36] |  **14.45 ns** | 0.083 ns | 0.065 ns |  0.59 |
|     ToStringB | \Core_Root_base\corerun.exe | 483bc(...)aa20d [36] |  24.29 ns | 0.167 ns | 0.139 ns |  1.00 |
|               |                             |                      |           |          |          |       |
|     ToStringP |      \Core_Root\corerun.exe | 483bc(...)aa20d [36] |  **15.11 ns** | 0.247 ns | 0.231 ns |  0.61 |
|     ToStringP | \Core_Root_base\corerun.exe | 483bc(...)aa20d [36] |  24.66 ns | 0.065 ns | 0.051 ns |  1.00 |

The main motivation was to slightly speed up JSON serialization for Guid fields, e.g.:

```csharp
record Entity(Guid Id, string Name);

string json = JsonSerializer.Serialize(entity, EntityJsonContext.Default.Entity);
```
Around 5% improvement here.
