### PR TITLE
LSG: removing unnecessary null forgiven operators and refactor other minor nullability issues

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.Logging.Generators
                             }
 
                             sm ??= _compilation.GetSemanticModel(classDec.SyntaxTree);
-                            IMethodSymbol? logMethodSymbol = sm.GetDeclaredSymbol(method, _cancellationToken);
+                            IMethodSymbol logMethodSymbol = sm.GetDeclaredSymbol(method, _cancellationToken)!;
                             Debug.Assert(logMethodSymbol != null, "log method is present.");
                             (int eventId, int? level, string message, string? eventName, bool skipEnabledCheck) = (-1, null, string.Empty, null, false);
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -72,9 +72,11 @@ namespace Microsoft.Extensions.Logging.Generators
                 var eventNames = new HashSet<string>();
 
                 // we enumerate by syntax tree, to minimize the need to instantiate semantic models (since they're expensive)
-                foreach (var group in classes.GroupBy(x => x.SyntaxTree))
+                foreach (IGrouping<SyntaxTree, ClassDeclarationSyntax> group in classes.GroupBy(x => x.SyntaxTree))
                 {
-                    SemanticModel? sm = null;
+                    SyntaxTree syntaxTree = group.Key;
+                    SemanticModel sm = _compilation.GetSemanticModel(syntaxTree);
+
                     foreach (ClassDeclarationSyntax classDec in group)
                     {
                         // stop if we're asked to
@@ -98,7 +100,6 @@ namespace Microsoft.Extensions.Logging.Generators
                                 continue;
                             }
 
-                            sm ??= _compilation.GetSemanticModel(classDec.SyntaxTree);
                             IMethodSymbol logMethodSymbol = sm.GetDeclaredSymbol(method, _cancellationToken)!;
                             Debug.Assert(logMethodSymbol != null, "log method is present.");
                             (int eventId, int? level, string message, string? eventName, bool skipEnabledCheck) = (-1, null, string.Empty, null, false);


### PR DESCRIPTION
- `GetBestTypeByMetadataName` returns a nullable type, so I just make it explicit in code (we were already checking if the instance was null).
- There is a `Debug.Assert(logMethodSymbol != null`, so I removed the next null checks (besides, we are retrieving the related Symbol from the SemanticalModel using the related SyntaxNode, so there shouldn't be any problems).
- Cleaning null forgiving from `paramTypeSymbol`, which is guaranteed to be not null at that point.
- Cleaning other minor parts