### PR TITLE
Wrap exceptions in reflection virtual method resolution

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
@@ -59,7 +59,14 @@ namespace Internal.Reflection.Execution.MethodInvokers
             {
                 ValidateThis(thisObject, _declaringTypeHandle);
 
-                resolvedVirtual = OpenMethodResolver.ResolveMethod(MethodInvokeInfo.VirtualResolveData, thisObject);
+                try
+                {
+                    resolvedVirtual = OpenMethodResolver.ResolveMethod(MethodInvokeInfo.VirtualResolveData, thisObject);
+                }
+                catch (Exception ex)
+                {
+                    throw new TargetInvocationException(ex);
+                }
             }
 
             object? result = MethodInvokeInfo.Invoke(

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/MethodInvokers/VirtualMethodInvoker.cs
@@ -63,7 +63,7 @@ namespace Internal.Reflection.Execution.MethodInvokers
                 {
                     resolvedVirtual = OpenMethodResolver.ResolveMethod(MethodInvokeInfo.VirtualResolveData, thisObject);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (wrapInTargetInvocationException)
                 {
                     throw new TargetInvocationException(ex);
                 }


### PR DESCRIPTION
Fixes the reflection\DefaultInterfaceMethods\InvokeConsumer.cs test that expects EntryPointNotFound to be wrapped.

Cc @dotnet/ilc-contrib 