### PR TITLE
Have gen* methods use the optimized BitOperations where possible

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -121,8 +121,8 @@ void* operator new[](size_t n, Compiler* context, CompMemKind cmk);
 
 /*****************************************************************************/
 
-unsigned genLog2(unsigned value);
-unsigned genLog2(unsigned __int64 value);
+uint32_t genLog2(uint32_t value);
+uint32_t genLog2(uint64_t value);
 
 unsigned ReinterpretHexAsDecimal(unsigned in);
 

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2716,7 +2716,7 @@ uint32_t BitOperations::Log2(uint32_t value)
 {
     // The 0->0 contract is fulfilled by setting the LSB to 1.
     // Log(1) is 0, and setting the LSB for values > 1 does not change the log2 result.
-    return 31 ^ BitOperations::LeadingZeroCount(value | 1);
+    return BitOperations::BitScanReverse(value | 1);
 }
 
 //------------------------------------------------------------------------
@@ -2732,7 +2732,7 @@ uint32_t BitOperations::Log2(uint64_t value)
 {
     // The 0->0 contract is fulfilled by setting the LSB to 1.
     // Log(1) is 0, and setting the LSB for values > 1 does not change the log2 result.
-    return 63 ^ BitOperations::LeadingZeroCount(value | 1);
+    return BitOperations::BitScanReverse(value | 1);
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
The only real change here is that:
* `BitOperations::BitScanReverse` doesn't require an "out" parameter, it just directly asserts "not zero"
* `BitOperations::BitScanForward` is the same, which means it can use `__builtin_ctz` on Unix, leading to better codegen
* `genCountBits` uses `__builtin_popcount` on Clang/GCC and the well-known bit twiddling hacks on MSVC (which is what Clang/GCC use for their builtin).

The other functions are just being made consistent and forwarding to a centralized impl. In a couple places comments were added to clarify edge case behavior that a given `gen*` method was assuming (e.g. `genLog2` is not a real `log2`, but rather assumes the input has exactly one bit set).