### PR TITLE
Enable AppleAppBuilder to bundle iOS applications built for NativeAOT runtime

### DIFF
--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -176,57 +176,33 @@ public class AppleAppBuilderTask : Task
         if (UseNativeAOTRuntime)
         {
             if (!string.IsNullOrEmpty(MonoRuntimeHeaders))
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(MonoRuntimeHeaders)}\" is not supported with NativeAOT runtime and will be ignored.");
-                MonoRuntimeHeaders = string.Empty;
-            }
+                throw new ArgumentException($"Property \"{nameof(MonoRuntimeHeaders)}\" is not supported with NativeAOT runtime and will be ignored.");
+
             if (!string.IsNullOrEmpty(MainLibraryFileName))
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(MainLibraryFileName)}\" is not supported with NativeAOT runtime and will be ignored.");
-                MainLibraryFileName = string.Empty;
-            }
+                throw new ArgumentException($"Property \"{nameof(MainLibraryFileName)}\" is not supported with NativeAOT runtime and will be ignored.");
+
             if (UseConsoleUITemplate)
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(UseConsoleUITemplate)}\" is not supported with NativeAOT runtime and will be ignored.");
-                UseConsoleUITemplate = false;
-            }
+                throw new ArgumentException($"Property \"{nameof(UseConsoleUITemplate)}\" is not supported with NativeAOT runtime and will be ignored.");
+
             if (ForceInterpreter)
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(ForceInterpreter)}\" is not supported with NativeAOT runtime and will be ignored.");
-                ForceInterpreter = false;
-            }
+                throw new ArgumentException($"Property \"{nameof(ForceInterpreter)}\" is not supported with NativeAOT runtime and will be ignored.");
+
             if (ForceAOT)
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(ForceAOT)}\" is not supported with NativeAOT runtime and will be ignored.");
-                ForceAOT = false;
-            }
+                throw new ArgumentException($"Property \"{nameof(ForceAOT)}\" is not supported with NativeAOT runtime and will be ignored.");
+
             if (!string.IsNullOrEmpty(RuntimeComponents))
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(RuntimeComponents)}\" is not supported with NativeAOT runtime and will be ignored.");
-                RuntimeComponents = string.Empty;
-            }
+                throw new ArgumentException($"Property \"{nameof(RuntimeComponents)}\" is not supported with NativeAOT runtime and will be ignored.");
+
             if (!string.IsNullOrEmpty(DiagnosticPorts))
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(DiagnosticPorts)}\" is not supported with NativeAOT runtime and will be ignored.");
-                DiagnosticPorts = string.Empty;
-            }
+                throw new ArgumentException($"Property \"{nameof(DiagnosticPorts)}\" is not supported with NativeAOT runtime and will be ignored.");
+
             if (EnableRuntimeLogging)
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(EnableRuntimeLogging)}\" is not supported with NativeAOT runtime and will be ignored.");
-                EnableRuntimeLogging = false;
-            }
-            if (EnableAppSandbox)
-            {
-                Log.LogMessage(MessageImportance.High, $"Property \"{nameof(EnableAppSandbox)}\" is not supported with NativeAOT runtime and will be ignored.");
-                EnableAppSandbox = false;
-            }
+                throw new ArgumentException($"Property \"{nameof(EnableRuntimeLogging)}\" is not supported with NativeAOT runtime and will be ignored.");
         }
         else
         {
             if (string.IsNullOrEmpty(MonoRuntimeHeaders))
-            {
                 throw new ArgumentException($"The \"{nameof(AppleAppBuilderTask)}\" task was not given a value for the required parameter \"{nameof(MonoRuntimeHeaders)}\" when using Mono runtime.");
-            }
         }
     }
 

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
@@ -10,17 +10,25 @@ set(APP_RESOURCES
 add_executable(
     %ProjectName%
     %MainSource%
-    runtime.h
-    runtime.m
-    %AotModulesSource%
     ${APP_RESOURCES}
 )
+
+if(NOT %UseNativeAOTRuntime%)
+    target_sources(
+        %ProjectName%
+        PUBLIC
+        %AotModulesSource%
+        runtime.h
+        runtime.m)
+endif()
 
 %AotSources%
 
 %Defines%
 
-include_directories("%MonoInclude%")
+if(NOT %UseNativeAOTRuntime%)
+    include_directories("%MonoInclude%")
+endif()
 
 set_target_properties(%ProjectName% %AotTargetsList% PROPERTIES
     XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST "YES"

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
@@ -16,7 +16,7 @@ add_executable(
 if(NOT %UseNativeAOTRuntime%)
     target_sources(
         %ProjectName%
-        PUBLIC
+        PRIVATE
         %AotModulesSource%
         runtime.h
         runtime.m)

--- a/src/tasks/AppleAppBuilder/Templates/main-simple.m
+++ b/src/tasks/AppleAppBuilder/Templates/main-simple.m
@@ -2,7 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #import <UIKit/UIKit.h>
+#if !USE_NATIVE_AOT
 #import "runtime.h"
+#else
+extern void* NativeAOT_StaticInitialization();
+extern void managed_entry_point();
+#endif
 
 @interface ViewController : UIViewController
 @end
@@ -46,7 +51,15 @@ void (*clickHandlerPtr)(void);
     [self.view addSubview:button];
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+#if !USE_NATIVE_AOT
         mono_ios_runtime_init ();
+#else
+#if INVARIANT_GLOBALIZATION
+        setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", TRUE);
+#endif
+        NativeAOT_StaticInitialization();
+        managed_entry_point();
+#endif
     });
 }
 -(void) buttonClicked:(UIButton*)sender

--- a/src/tasks/AppleAppBuilder/Templates/main-simple.m
+++ b/src/tasks/AppleAppBuilder/Templates/main-simple.m
@@ -6,7 +6,7 @@
 #import "runtime.h"
 #else
 extern void* NativeAOT_StaticInitialization();
-extern void managed_entry_point();
+extern int __managed__Main(int argc, char* argv[]);
 #endif
 
 @interface ViewController : UIViewController
@@ -58,7 +58,7 @@ void (*clickHandlerPtr)(void);
         setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", TRUE);
 #endif
         NativeAOT_StaticInitialization();
-        managed_entry_point();
+        int ret_val = __managed__Main(0, NULL);
 #endif
     });
 }

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -271,27 +271,13 @@ internal sealed class Xcode
         string appResources = string.Join(Environment.NewLine, asmDataFiles.Select(r => "    " + r));
         appResources += string.Join(Environment.NewLine, resources.Where(r => !r.EndsWith("-llvm.o")).Select(r => "    " + Path.GetRelativePath(binDir, r)));
 
-        string cmakeLists;
-        if (useNativeAOTRuntime)
-        {
-            cmakeLists = Utils.GetEmbeddedResource("CMakeLists.txt.template")
-            .Replace("%ProjectName%", projectName)
-            .Replace("%AppResources%", appResources)
-            .Replace("%MainSource%", nativeMainSource)
-            .Replace("runtime.h", string.Empty)
-            .Replace("runtime.m", string.Empty)
-            .Replace("include_directories(\"%MonoInclude%\")", string.Empty)
-            .Replace("%HardenedRuntime%", hardenedRuntime ? "TRUE" : "FALSE");
-        }
-        else
-        {
-            cmakeLists = Utils.GetEmbeddedResource("CMakeLists.txt.template")
+        string cmakeLists = Utils.GetEmbeddedResource("CMakeLists.txt.template")
+            .Replace("%UseNativeAOTRuntime%", useNativeAOTRuntime ? "TRUE" : "FALSE")
             .Replace("%ProjectName%", projectName)
             .Replace("%AppResources%", appResources)
             .Replace("%MainSource%", nativeMainSource)
             .Replace("%MonoInclude%", monoInclude)
             .Replace("%HardenedRuntime%", hardenedRuntime ? "TRUE" : "FALSE");
-        }
 
         string toLink = "";
 


### PR DESCRIPTION
This PR adds support for bundling iOS applications built for NativeAOT runtime with AppleAppBuilder.

An example of invoking the task would be as follows:

``` xml
<AppleAppBuilderTask
        UseNativeAOTRuntime="True"
        TargetOS="$(TargetOS)"
        Arch="$(TargetArchitecture)"
        ProjectName="$(AppName)"
        Assemblies="@(BundleAssemblies)"
        GenerateXcodeProject="True"
        BuildAppBundle="True"
        DevTeamProvisioning="$(DevTeamProvisioning)"
        OutputDirectory="$(AppDir)"
        Optimized="$(Optimized)"
        AppDir="$(MSBuildThisFileDirectory)$(PublishDir)">
        <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
        <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />
</AppleAppBuilderTask>
```
### Assumptions:
`$(PublishDir)` should include all the `*.o`, `*.dat`, `*.a` required for linking the AOT compiled managed executable with the native host application (from template: https://github.com/dotnet/runtime/blob/main/src/tasks/AppleAppBuilder/Templates/main-simple.m)

Fixes: #80910

---
PS The purpose of adapting AppleAppBuilder is to enable building sample applications which would serve as PoC and initial steps to enable testing and validation of NativeAOT on iOS support. The full SDK integration (via Xamarin build tasks) will become available as a follow-up work.  