### PR TITLE
Default media type used when 'null' is passed to StringContent #81506

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs
@@ -45,7 +45,7 @@ namespace System.Net.Http
         /// <param name="encoding">The encoding to use for the content.</param>
         /// <param name="mediaType">The media type to use for the content.</param>
         public StringContent(string content, Encoding? encoding, string mediaType)
-            : this(content, encoding, new MediaTypeHeaderValue(mediaType, (encoding ?? DefaultStringEncoding).WebName))
+            : this(content, encoding, new MediaTypeHeaderValue(mediaType ?? DefaultMediaType, (encoding ?? DefaultStringEncoding).WebName))
         {
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
@@ -72,6 +72,17 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        public void Ctor_PassNullForMediaType_DefaultMediaTypeUsed()
+        {
+            string sourceString = "\u00C4\u00E4\u00FC\u00DC";
+            Encoding defaultStringEncoding = Encoding.GetEncoding("utf-8");
+            var content = new StringContent(sourceString, defaultStringEncoding, ((string)null)!);
+
+            // If no media is passed-in, the default is used
+            Assert.Equal("text/plain", content.Headers.ContentType.MediaType);
+        }
+        
+        [Fact]
         public async Task Ctor_UseCustomMediaTypeHeaderValue_SpecificEncoding()
         {
             // Use UTF-8 encoding to serialize a chinese string.


### PR DESCRIPTION
This fixes issue #81506 