### PR TITLE
Avoid using `file` in generated regexes pre-C# 11

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -72,12 +72,22 @@ namespace System.Text.RegularExpressions.Generator
 
         /// <summary>Emits the Regex-derived type for a method where we're unable to generate custom code.</summary>
         private static void EmitRegexLimitedBoilerplate(
-            IndentedTextWriter writer, RegexMethod rm, string reason)
+            IndentedTextWriter writer, RegexMethod rm, string reason, LanguageVersion langVer)
         {
-            writer.WriteLine($"/// <summary>Caches a <see cref=\"Regex\"/> instance for the {rm.MethodName} method.</summary>");
+            string visibility;
+            if (langVer >= LanguageVersion.CSharp11)
+            {
+                visibility = "file";
+                writer.WriteLine($"/// <summary>Caches a <see cref=\"Regex\"/> instance for the {rm.MethodName} method.</summary>");
+            }
+            else
+            {
+                visibility = "internal";
+                writer.WriteLine($"/// <summary>This class supports generated regexes and should not be used by other code directly.</summary>");
+            }
             writer.WriteLine($"/// <remarks>A custom Regex-derived type could not be generated because {reason}.</remarks>");
             writer.WriteLine($"[{s_generatedCodeAttribute}]");
-            writer.WriteLine($"file sealed class {rm.GeneratedName} : Regex");
+            writer.WriteLine($"{visibility} sealed class {rm.GeneratedName} : Regex");
             writer.WriteLine($"{{");
             writer.WriteLine($"    /// <summary>Cached, thread-safe singleton instance.</summary>");
             writer.Write($"    internal static readonly Regex Instance = ");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
@@ -103,7 +103,7 @@ namespace System.Text.RegularExpressions.Tests
             EmitResult results = comp.Emit(Stream.Null, cancellationToken: cancellationToken);
             ImmutableArray<Diagnostic> generatorDiagnostics = generatorResults.Diagnostics.RemoveAll(d => d.Severity <= DiagnosticSeverity.Hidden);
             ImmutableArray<Diagnostic> resultsDiagnostics = results.Diagnostics.RemoveAll(d => d.Severity <= DiagnosticSeverity.Hidden);
-            if (!results.Success || resultsDiagnostics.Length != 0 || generatorDiagnostics.Length != 0)
+            if (!results.Success || resultsDiagnostics.Length != 0)
             {
                 throw new ArgumentException(
                     string.Join(Environment.NewLine, resultsDiagnostics.Concat(generatorDiagnostics)) + Environment.NewLine +

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorParserTests.cs
@@ -252,7 +252,7 @@ namespace System.Text.RegularExpressions.Tests
                     [GeneratedRegex(""ab"")]
                     private static partial Regex InvalidLangVersion();
                 }
-            ", langVersion: version);
+            ", langVersion: version, compile: true);
 
             Assert.Equal("SYSLIB1044", Assert.Single(diagnostics).Id);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/81704