### PR TITLE
Fix contract violations.

### DIFF
--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -149,14 +149,12 @@ AssemblySpecHash::~AssemblySpecHash()
 
 HRESULT AssemblySpec::InitializeSpecInternal(mdToken kAssemblyToken,
                                   IMDInternalImport *pImport,
-                                  DomainAssembly *pStaticParent,
-                                  BOOL fAllowAllocation)
+                                  DomainAssembly *pStaticParent)
 {
     CONTRACTL
     {
         INSTANCE_CHECK;
-        if (fAllowAllocation) {GC_TRIGGERS;} else {GC_NOTRIGGER;};
-        if (fAllowAllocation) {INJECT_FAULT(COMPlusThrowOM());} else {FORBID_FAULT;};
+        GC_NOTRIGGER;
         NOTHROW;
         MODE_ANY;
         PRECONDITION(pImport->IsValidToken(kAssemblyToken));
@@ -194,7 +192,7 @@ void AssemblySpec::InitializeSpec(PEAssembly * pFile)
     {
         INSTANCE_CHECK;
         THROWS;
-        GC_TRIGGERS;
+        GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(pFile));
         INJECT_FAULT(COMPlusThrowOM(););

--- a/src/coreclr/vm/assemblyspec.hpp
+++ b/src/coreclr/vm/assemblyspec.hpp
@@ -38,8 +38,7 @@ class AssemblySpec  : public BaseAssemblySpec
 
     HRESULT InitializeSpecInternal(mdToken kAssemblyRefOrDef,
                                    IMDInternalImport *pImport,
-                                   DomainAssembly *pStaticParent,
-                                   BOOL fAllowAllocation);
+                                   DomainAssembly *pStaticParent);
 
     // InitializeSpecInternal should be used very carefully so it's made private.
     // functions that take special care (and thus are allowed to use the function) are listed below
@@ -88,12 +87,12 @@ class AssemblySpec  : public BaseAssemblySpec
         CONTRACTL
         {
             INSTANCE_CHECK;
-            GC_TRIGGERS;
+            GC_NOTRIGGER;
             THROWS;
             MODE_ANY;
         }
         CONTRACTL_END;
-        HRESULT hr=InitializeSpecInternal(kAssemblyRefOrDef, pImport,pStaticParent,TRUE);
+        HRESULT hr=InitializeSpecInternal(kAssemblyRefOrDef, pImport,pStaticParent);
         if(FAILED(hr))
             EEFileLoadException::Throw(this,hr);
     };

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2983,8 +2983,7 @@ Module::GetAssemblyIfLoaded(
                 AssemblySpec spec;
                 if (FAILED(spec.InitializeSpecInternal(kAssemblyRef,
                                                        pMDImport,
-                                                       pCurAssemblyInExamineDomain,
-                                                       FALSE /*fAllowAllocation*/)))
+                                                       pCurAssemblyInExamineDomain)))
                 {
                     continue;
                 }

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -738,7 +738,7 @@ inline void PEAssembly::GetDisplayName(SString &result, DWORD flags)
     {
         PRECONDITION(CheckValue(result));
         THROWS;
-        GC_TRIGGERS;
+        GC_NOTRIGGER;
         MODE_ANY;
     }
     CONTRACTL_END;


### PR DESCRIPTION
Fixes #81669

Removes `GC_TRIGGERS` contract for functions that
do not trigger a GC. The removed contract definition
appears to be out of date.

Fallout from #81571
