### PR TITLE
Add Host.CreateEmptyApplicationBuilder

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/ref/Microsoft.Extensions.Hosting.cs
@@ -26,9 +26,11 @@ namespace Microsoft.Extensions.Hosting
     public static partial class Host
     {
         public static Microsoft.Extensions.Hosting.HostApplicationBuilder CreateApplicationBuilder() { throw null; }
+        public static Microsoft.Extensions.Hosting.HostApplicationBuilder CreateApplicationBuilder(Microsoft.Extensions.Hosting.HostApplicationBuilderSettings? settings) { throw null; }
         public static Microsoft.Extensions.Hosting.HostApplicationBuilder CreateApplicationBuilder(string[]? args) { throw null; }
         public static Microsoft.Extensions.Hosting.IHostBuilder CreateDefaultBuilder() { throw null; }
         public static Microsoft.Extensions.Hosting.IHostBuilder CreateDefaultBuilder(string[]? args) { throw null; }
+        public static Microsoft.Extensions.Hosting.HostApplicationBuilder CreateEmptyApplicationBuilder(Microsoft.Extensions.Hosting.HostApplicationBuilderSettings? settings) { throw null; }
     }
     public sealed partial class HostApplicationBuilder
     {

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Host.cs
@@ -64,15 +64,14 @@ namespace Microsoft.Extensions.Hosting
         ///   <list type="bullet">
         ///     <item><description>set the <see cref="IHostEnvironment.ContentRootPath"/> to the result of <see cref="Directory.GetCurrentDirectory()"/></description></item>
         ///     <item><description>load host <see cref="IConfiguration"/> from "DOTNET_" prefixed environment variables</description></item>
-        ///     <item><description>load host <see cref="IConfiguration"/> from supplied command line args</description></item>
         ///     <item><description>load app <see cref="IConfiguration"/> from 'appsettings.json' and 'appsettings.[<see cref="IHostEnvironment.EnvironmentName"/>].json'</description></item>
         ///     <item><description>load app <see cref="IConfiguration"/> from User Secrets when <see cref="IHostEnvironment.EnvironmentName"/> is 'Development' using the entry assembly</description></item>
         ///     <item><description>load app <see cref="IConfiguration"/> from environment variables</description></item>
-        ///     <item><description>load app <see cref="IConfiguration"/> from supplied command line args</description></item>
         ///     <item><description>configure the <see cref="ILoggerFactory"/> to log to the console, debug, and event source output</description></item>
         ///     <item><description>enables scope validation on the dependency injection container when <see cref="IHostEnvironment.EnvironmentName"/> is 'Development'</description></item>
         ///   </list>
         /// </remarks>
+        /// <returns>The initialized <see cref="HostApplicationBuilder"/>.</returns>
         public static HostApplicationBuilder CreateApplicationBuilder() => new HostApplicationBuilder();
 
         /// <summary>
@@ -93,6 +92,20 @@ namespace Microsoft.Extensions.Hosting
         ///   </list>
         /// </remarks>
         /// <param name="args">The command line args.</param>
+        /// <returns>The initialized <see cref="HostApplicationBuilder"/>.</returns>
         public static HostApplicationBuilder CreateApplicationBuilder(string[]? args) => new HostApplicationBuilder(args);
+
+        /// <inheritdoc cref="CreateApplicationBuilder()" />
+        /// <param name="settings">Controls the initial configuration and other settings for constructing the <see cref="HostApplicationBuilder"/>.</param>
+        public static HostApplicationBuilder CreateApplicationBuilder(HostApplicationBuilderSettings? settings)
+            => new HostApplicationBuilder(settings);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HostApplicationBuilder"/> class with no pre-configured defaults.
+        /// </summary>
+        /// <param name="settings">Controls the initial configuration and other settings for constructing the <see cref="HostApplicationBuilder"/>.</param>
+        /// <returns>The initialized <see cref="HostApplicationBuilder"/>.</returns>
+        public static HostApplicationBuilder CreateEmptyApplicationBuilder(HostApplicationBuilderSettings? settings)
+            => new HostApplicationBuilder(settings, empty: true);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Extensions.Hosting
     {
         private readonly HostBuilderContext _hostBuilderContext;
         private readonly ServiceCollection _serviceCollection = new();
+        private readonly IHostEnvironment _environment;
+        private readonly LoggingBuilder _logging;
 
         private Func<IServiceProvider> _createServiceProvider;
         private Action<object> _configureContainer = _ => { };
@@ -98,6 +100,47 @@ namespace Microsoft.Extensions.Hosting
                 HostingHostBuilderExtensions.AddCommandLineConfig(Configuration, settings.Args);
             }
 
+            Initialize(settings, out _hostBuilderContext, out _environment, out _logging);
+
+            ServiceProviderOptions? serviceProviderOptions = null;
+            if (!settings.DisableDefaults)
+            {
+                HostingHostBuilderExtensions.ApplyDefaultAppConfiguration(_hostBuilderContext, Configuration, settings.Args);
+                HostingHostBuilderExtensions.AddDefaultServices(_hostBuilderContext, Services);
+                serviceProviderOptions = HostingHostBuilderExtensions.CreateDefaultServiceProviderOptions(_hostBuilderContext);
+            }
+
+            _createServiceProvider = () =>
+            {
+                // Call _configureContainer in case anyone adds callbacks via HostBuilderAdapter.ConfigureContainer<IServiceCollection>() during build.
+                // Otherwise, this no-ops.
+                _configureContainer(Services);
+                return serviceProviderOptions is null ? Services.BuildServiceProvider() : Services.BuildServiceProvider(serviceProviderOptions);
+            };
+        }
+
+        internal HostApplicationBuilder(HostApplicationBuilderSettings? settings, bool empty)
+        {
+            Debug.Assert(empty, "should only be called with empty: true");
+
+            settings ??= new HostApplicationBuilderSettings();
+            Configuration = settings.Configuration ?? new ConfigurationManager();
+
+            HostingHostBuilderExtensions.AddCommandLineConfig(Configuration, settings.Args);
+
+            Initialize(settings, out _hostBuilderContext, out _environment, out _logging);
+
+            _createServiceProvider = () =>
+            {
+                // Call _configureContainer in case anyone adds callbacks via HostBuilderAdapter.ConfigureContainer<IServiceCollection>() during build.
+                // Otherwise, this no-ops.
+                _configureContainer(Services);
+                return Services.BuildServiceProvider();
+            };
+        }
+
+        private void Initialize(HostApplicationBuilderSettings settings, out HostBuilderContext hostBuilderContext, out IHostEnvironment environment, out LoggingBuilder logging)
+        {
             // HostApplicationBuilderSettings override all other config sources.
             List<KeyValuePair<string, string?>>? optionList = null;
             if (settings.ApplicationName is not null)
@@ -124,46 +167,29 @@ namespace Microsoft.Extensions.Hosting
 
             Configuration.SetFileProvider(physicalFileProvider);
 
-            _hostBuilderContext = new HostBuilderContext(new Dictionary<object, object>())
+            hostBuilderContext = new HostBuilderContext(new Dictionary<object, object>())
             {
                 HostingEnvironment = hostingEnvironment,
                 Configuration = Configuration,
             };
 
-            Environment = hostingEnvironment;
+            environment = hostingEnvironment;
 
             HostBuilder.PopulateServiceCollection(
                 Services,
-                _hostBuilderContext,
+                hostBuilderContext,
                 hostingEnvironment,
                 physicalFileProvider,
                 Configuration,
                 () => _appServices!);
 
-            Logging = new LoggingBuilder(Services);
-
-            ServiceProviderOptions? serviceProviderOptions = null;
-
-            if (!settings.DisableDefaults)
-            {
-                HostingHostBuilderExtensions.ApplyDefaultAppConfiguration(_hostBuilderContext, Configuration, settings.Args);
-                HostingHostBuilderExtensions.AddDefaultServices(_hostBuilderContext, Services);
-                serviceProviderOptions = HostingHostBuilderExtensions.CreateDefaultServiceProviderOptions(_hostBuilderContext);
-            }
-
-            _createServiceProvider = () =>
-            {
-                // Call _configureContainer in case anyone adds callbacks via HostBuilderAdapter.ConfigureContainer<IServiceCollection>() during build.
-                // Otherwise, this no-ops.
-                _configureContainer(Services);
-                return serviceProviderOptions is null ? Services.BuildServiceProvider() : Services.BuildServiceProvider(serviceProviderOptions);
-            };
+            logging = new LoggingBuilder(Services);
         }
 
         /// <summary>
         /// Provides information about the hosting environment an application is running in.
         /// </summary>
-        public IHostEnvironment Environment { get; }
+        public IHostEnvironment Environment => _environment;
 
         /// <summary>
         /// A collection of services for the application to compose. This is useful for adding user provided or framework provided services.
@@ -178,7 +204,7 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.
         /// </summary>
-        public ILoggingBuilder Logging { get; }
+        public ILoggingBuilder Logging => _logging;
 
         /// <summary>
         /// Registers a <see cref="IServiceProviderFactory{TContainerBuilder}" /> instance to be used to create the <see cref="IServiceProvider" />.

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostApplicationBuilder.cs
@@ -91,13 +91,7 @@ namespace Microsoft.Extensions.Hosting
                     HostingHostBuilderExtensions.SetDefaultContentRoot(Configuration);
                 }
 
-                HostingHostBuilderExtensions.AddDefaultHostConfigurationSources(Configuration, settings.Args);
-            }
-            else
-            {
-                // Command line args are added even when DisableDefaults=true. If the caller didn't want settings.Args applied,
-                // they wouldn't have set them on the settings.
-                HostingHostBuilderExtensions.AddCommandLineConfig(Configuration, settings.Args);
+                Configuration.AddEnvironmentVariables(prefix: "DOTNET_");
             }
 
             Initialize(settings, out _hostBuilderContext, out _environment, out _logging);
@@ -126,8 +120,6 @@ namespace Microsoft.Extensions.Hosting
             settings ??= new HostApplicationBuilderSettings();
             Configuration = settings.Configuration ?? new ConfigurationManager();
 
-            HostingHostBuilderExtensions.AddCommandLineConfig(Configuration, settings.Args);
-
             Initialize(settings, out _hostBuilderContext, out _environment, out _logging);
 
             _createServiceProvider = () =>
@@ -141,6 +133,10 @@ namespace Microsoft.Extensions.Hosting
 
         private void Initialize(HostApplicationBuilderSettings settings, out HostBuilderContext hostBuilderContext, out IHostEnvironment environment, out LoggingBuilder logging)
         {
+            // Command line args are added even when settings.DisableDefaults == true. If the caller didn't want settings.Args applied,
+            // they wouldn't have set them on the settings.
+            HostingHostBuilderExtensions.AddCommandLineConfig(Configuration, settings.Args);
+
             // HostApplicationBuilderSettings override all other config sources.
             List<KeyValuePair<string, string?>>? optionList = null;
             if (settings.ApplicationName is not null)

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -201,7 +201,9 @@ namespace Microsoft.Extensions.Hosting
         private static void ApplyDefaultHostConfiguration(IConfigurationBuilder hostConfigBuilder, string[]? args)
         {
             SetDefaultContentRoot(hostConfigBuilder);
-            AddDefaultHostConfigurationSources(hostConfigBuilder, args);
+
+            hostConfigBuilder.AddEnvironmentVariables(prefix: "DOTNET_");
+            AddCommandLineConfig(hostConfigBuilder, args);
         }
 
         internal static void SetDefaultContentRoot(IConfigurationBuilder hostConfigBuilder)
@@ -222,12 +224,6 @@ namespace Microsoft.Extensions.Hosting
                     new KeyValuePair<string, string?>(HostDefaults.ContentRootKey, cwd),
                 });
             }
-        }
-
-        internal static void AddDefaultHostConfigurationSources(IConfigurationBuilder hostConfigBuilder, string[]? args)
-        {
-            hostConfigBuilder.AddEnvironmentVariables(prefix: "DOTNET_");
-            AddCommandLineConfig(hostConfigBuilder, args);
         }
 
         internal static void ApplyDefaultAppConfiguration(HostBuilderContext hostingContext, IConfigurationBuilder appConfigBuilder, string[]? args)

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostApplicationBuilderTests.cs
@@ -19,10 +19,60 @@ namespace Microsoft.Extensions.Hosting.Tests
 {
     public class HostApplicationBuilderTests
     {
-        [Fact]
-        public void DefaultConfigIsMutable()
+        public delegate HostApplicationBuilder CreateBuilderFunc();
+        public delegate HostApplicationBuilder CreateBuilderSettingsFunc(HostApplicationBuilderSettings settings);
+
+        private static HostApplicationBuilder CreateNoDefaultsBuilder() =>
+            new HostApplicationBuilder(new HostApplicationBuilderSettings
+            {
+                DisableDefaults = true,
+            });
+        private static HostApplicationBuilder CreateEmptyBuilder() => Host.CreateEmptyApplicationBuilder(settings: null);
+
+        public static IEnumerable<object[]> CreateNoDefaultsBuilderFuncs
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            get
+            {
+                yield return new[] { (CreateBuilderFunc)CreateNoDefaultsBuilder };
+                yield return new[] { (CreateBuilderFunc)CreateEmptyBuilder };
+            }
+        }
+
+        private static HostApplicationBuilder CreateBuilderSettingsConstructor(HostApplicationBuilderSettings settings) =>
+            new HostApplicationBuilder(settings);
+        private static HostApplicationBuilder CreateBuilderSettings(HostApplicationBuilderSettings settings)
+            => Host.CreateApplicationBuilder(settings);
+        private static HostApplicationBuilder CreateEmptyBuilderSettings(HostApplicationBuilderSettings settings)
+            => Host.CreateEmptyApplicationBuilder(settings);
+
+        public static IEnumerable<object[]> CreateBuilderSettingsFuncs
+        {
+            get
+            {
+                yield return new[] { (CreateBuilderSettingsFunc)CreateBuilderSettingsConstructor };
+                yield return new[] { (CreateBuilderSettingsFunc)CreateBuilderSettings };
+                yield return new[] { (CreateBuilderSettingsFunc)CreateEmptyBuilderSettings };
+            }
+        }
+
+        public static IEnumerable<object[]> CreateBuilderDisableDefaultsData
+        {
+            get
+            {
+                foreach (bool disableDefaults in new[] { true, false })
+                {
+                    yield return new object[] { (CreateBuilderSettingsFunc)CreateBuilderSettingsConstructor, disableDefaults };
+                    yield return new object[] { (CreateBuilderSettingsFunc)CreateBuilderSettings, disableDefaults };
+                    yield return new object[] { (CreateBuilderSettingsFunc)CreateEmptyBuilderSettings, disableDefaults };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void DefaultConfigIsMutable(CreateBuilderFunc createBuilder)
+        {
+            HostApplicationBuilder builder = createBuilder();
 
             builder.Configuration["key1"] = "value1";
 
@@ -72,7 +122,7 @@ namespace Microsoft.Extensions.Hosting.Tests
 
                 using var _ = DiagnosticListener.AllListeners.Subscribe(listener);
 
-                HostApplicationBuilder builder = CreateEmptyBuilder();
+                HostApplicationBuilder builder = CreateNoDefaultsBuilder();
                 IHost host = builder.Build();
 
                 Assert.NotNull(hostBuilderFromEvent);
@@ -107,7 +157,7 @@ namespace Microsoft.Extensions.Hosting.Tests
 
                 using var _ = DiagnosticListener.AllListeners.Subscribe(listener);
 
-                HostApplicationBuilder builder = CreateEmptyBuilder();
+                HostApplicationBuilder builder = CreateNoDefaultsBuilder();
                 Assert.Throws<NotSupportedException>(() => builder.Build());
             });
         }
@@ -136,7 +186,7 @@ namespace Microsoft.Extensions.Hosting.Tests
 
                 using var _ = DiagnosticListener.AllListeners.Subscribe(listener);
 
-                HostApplicationBuilder builder = CreateEmptyBuilder();
+                HostApplicationBuilder builder = CreateNoDefaultsBuilder();
 
                 using IHost host = builder.Build();
                 var fakeServices = host.Services.GetRequiredService<FakeServiceCollection>();
@@ -144,10 +194,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             });
         }
 
-        [Fact]
-        public void CanConfigureAppConfigurationAndRetrieveFromDI()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void CanConfigureAppConfigurationAndRetrieveFromDI(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
 
             builder.Configuration.AddInMemoryCollection(
                     new KeyValuePair<string, string>[]
@@ -180,10 +231,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Equal("value3", config["key2"]);
         }
 
-        [Fact]
-        public void CanConfigureAppConfigurationFromFile()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void CanConfigureAppConfigurationFromFile(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
 
             builder.Configuration.AddJsonFile("appSettings.json", optional: false);
 
@@ -196,10 +248,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Equal("value", config["key"]);
         }
 
-        [Fact]
-        public void DisableDefaultIHostEnvironmentValues()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void DisableDefaultIHostEnvironmentValues(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
 
             Assert.Equal(Environments.Production, builder.Environment.EnvironmentName);
 #if NETCOREAPP
@@ -230,9 +283,8 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ConfigurationSettingCanInfluenceEnvironment(bool disableDefaults)
+        [MemberData(nameof(CreateBuilderDisableDefaultsData))]
+        public void ConfigurationSettingCanInfluenceEnvironment(CreateBuilderSettingsFunc createBuilder, bool disableDefaults)
         {
             var tempPath = CreateTempSubdirectory();
 
@@ -247,7 +299,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                     new(HostDefaults.ContentRootKey, tempPath)
                 });
 
-                var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+                var builder = createBuilder(new HostApplicationBuilderSettings
                 {
                     DisableDefaults = disableDefaults,
                     Configuration = config,
@@ -279,9 +331,8 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DirectSettingsOverrideConfigurationSetting(bool disableDefaults)
+        [MemberData(nameof(CreateBuilderDisableDefaultsData))]
+        public void DirectSettingsOverrideConfigurationSetting(CreateBuilderSettingsFunc createBuilder, bool disableDefaults)
         {
             var tempPath = CreateTempSubdirectory();
 
@@ -295,7 +346,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                     new(HostDefaults.EnvironmentKey, "EnvA" ),
                 });
 
-                var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+                var builder = createBuilder(new HostApplicationBuilderSettings
                 {
                     DisableDefaults = disableDefaults,
                     Configuration = config,
@@ -353,8 +404,9 @@ namespace Microsoft.Extensions.Hosting.Tests
             return path;
         }
 
-        [Fact]
-        public void ChangingConfigurationPostBuilderConsturctionDoesNotChangeEnvironment()
+        [Theory]
+        [MemberData(nameof(CreateBuilderSettingsFuncs))]
+        public void ChangingConfigurationPostBuilderConstructionDoesNotChangeEnvironment(CreateBuilderSettingsFunc createBuilder)
         {
             using var config = new ConfigurationManager();
 
@@ -364,7 +416,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                 new(HostDefaults.EnvironmentKey, "EnvA" ),
             });
 
-            var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+            var builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = true,
                 Configuration = config,
@@ -389,16 +441,18 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Equal("EnvA", hostEnvironmentFromServices.EnvironmentName);
         }
 
-        [Fact]
-        public void BuildAndDispose()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void BuildAndDispose(CreateBuilderFunc createBuilder)
         {
-            using IHost host = CreateEmptyBuilder().Build();
+            using IHost host = createBuilder().Build();
         }
 
-        [Fact]
-        public void ContentRootConfiguresBasePath()
+        [Theory]
+        [MemberData(nameof(CreateBuilderSettingsFuncs))]
+        public void ContentRootConfiguresBasePath(CreateBuilderSettingsFunc createBuilder)
         {
-            var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+            var builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = true,
                 ContentRootPath = "/",
@@ -408,8 +462,9 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Equal("/", host.Services.GetService<IHostEnvironment>().ContentRootPath);
         }
 
-        [Fact]
-        public void HostConfigParametersReadCorrectly()
+        [Theory]
+        [MemberData(nameof(CreateBuilderSettingsFuncs))]
+        public void HostConfigParametersReadCorrectly(CreateBuilderSettingsFunc createBuilder)
         {
             var parameters = new Dictionary<string, string>()
             {
@@ -421,7 +476,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             var config = new ConfigurationManager();
             config.AddInMemoryCollection(parameters);
 
-            var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+            var builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = true,
                 Configuration = config
@@ -439,10 +494,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Equal(Path.GetFullPath("."), env.ContentRootPath);
         }
 
-        [Fact]
-        public void RelativeContentRootIsResolved()
+        [Theory]
+        [MemberData(nameof(CreateBuilderSettingsFuncs))]
+        public void RelativeContentRootIsResolved(CreateBuilderSettingsFunc createBuilder)
         {
-            var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+            var builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = true,
                 ContentRootPath = "testroot",
@@ -452,10 +508,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.EndsWith(Path.DirectorySeparatorChar + "testroot", builder.Environment.ContentRootPath);
         }
 
-        [Fact]
-        public void DisableDefaultContentRootIsApplicationBasePath()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void DisableDefaultContentRootIsApplicationBasePath(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
             Assert.Equal(AppContext.BaseDirectory, builder.Environment.ContentRootPath);
         }
 
@@ -466,10 +523,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Equal(Directory.GetCurrentDirectory(), builder.Environment.ContentRootPath);
         }
 
-        [Fact]
-        public void DisableDefaultServicesAreAvailable()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void DisableDefaultServicesAreAvailable(CreateBuilderFunc createBuilder)
         {
-            using IHost host = CreateEmptyBuilder().Build();
+            using IHost host = createBuilder().Build();
 
 #pragma warning disable CS0618 // Type or member is obsolete
             Assert.NotNull(host.Services.GetRequiredService<IHostingEnvironment>());
@@ -513,10 +571,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Equal(testShutdown, hostOptions.ShutdownTimeout);
         }
 
-        [Fact]
-        public void ConfigureDefaultServiceProvider()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void ConfigureDefaultServiceProvider(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
 
             builder.Services.AddTransient<ServiceD>();
             builder.Services.AddScoped<ServiceC>();
@@ -533,10 +592,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Throws<InvalidOperationException>(() => { host.Services.GetRequiredService<ServiceC>(); });
         }
 
-        [Fact]
-        public void ConfigureCustomServiceProvider()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void ConfigureCustomServiceProvider(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
 
             builder.Services.AddTransient<ServiceD>();
             builder.Services.AddScoped<ServiceC>();
@@ -550,10 +610,11 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
 
-        [Fact]
-        public void Build_DoesNotAllowBuildingMuiltipleTimes()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void Build_DoesNotAllowBuildingMultipleTimes(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
             using (builder.Build())
             {
                 var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
@@ -561,10 +622,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             }
         }
 
-        [Fact]
-        public void SetsFullPathToContentRoot()
+        [Theory]
+        [MemberData(nameof(CreateBuilderSettingsFuncs))]
+        public void SetsFullPathToContentRoot(CreateBuilderSettingsFunc createBuilder)
         {
-            var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+            var builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = true,
                 ContentRootPath = Path.GetFullPath(".")
@@ -577,10 +639,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.IsAssignableFrom<PhysicalFileProvider>(env.ContentRootFileProvider);
         }
 
-        [Fact]
-        public void HostServicesSameServiceProviderAsInHostBuilder()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void HostServicesSameServiceProviderAsInHostBuilder(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
             using IHost host = builder.Build();
 
             Type type = builder.GetType();
@@ -590,10 +653,11 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
 
-        [Fact]
-        public void HostApplicationBuilderThrowsExceptionIfServicesAlreadyBuilt()
+        [Theory]
+        [MemberData(nameof(CreateNoDefaultsBuilderFuncs))]
+        public void HostApplicationBuilderThrowsExceptionIfServicesAlreadyBuilt(CreateBuilderFunc createBuilder)
         {
-            HostApplicationBuilder builder = CreateEmptyBuilder();
+            HostApplicationBuilder builder = createBuilder();
             using IHost host = builder.Build();
 
             Assert.Throws<InvalidOperationException>(() => builder.Services.AddSingleton(new ServiceA()));
@@ -604,11 +668,10 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void RespectsArgsWhenDisableDefaults(bool disableDefaults)
+        [MemberData(nameof(CreateBuilderDisableDefaultsData))]
+        public void RespectsArgsWhenDisableDefaults(CreateBuilderSettingsFunc createBuilder, bool disableDefaults)
         {
-            HostApplicationBuilder builder = new HostApplicationBuilder(new HostApplicationBuilderSettings
+            HostApplicationBuilder builder = createBuilder(new HostApplicationBuilderSettings
             {
                 DisableDefaults = disableDefaults,
                 Args = new string[] { "mySetting=settingValue" }
@@ -618,14 +681,6 @@ namespace Microsoft.Extensions.Hosting.Tests
             IConfiguration config = host.Services.GetRequiredService<IConfiguration>();
 
             Assert.Equal("settingValue", config["mySetting"]);
-        }
-
-        private static HostApplicationBuilder CreateEmptyBuilder()
-        {
-            return new HostApplicationBuilder(new HostApplicationBuilderSettings
-            {
-                DisableDefaults = true,
-            });
         }
 
         private class HostingListener : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object?>>


### PR DESCRIPTION
Introduce a way to create an "empty" HostApplicationBuilder that doesn't bring any optional/unnecessary dependencies into the app's closure. This has the same functional behavior as DisableDefaults=true while allowing for the unused code to be trimmed.

Also add CreateApplicationBuilder(HostApplicationBuilderSettings settings) overload to make the Host factory methods complete.

Fix #81280