### PR TITLE
[wasm] Migrate jiterpreter hit counting to C

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -7609,7 +7609,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 				 *  JS workers in order to register them at the appropriate slots in the function pointer
 				 *  table. when growing the function pointer table we will also need to synchronize that.
 				 */
-				JiterpreterThunk prepare_result = mono_interp_tier_prepare_jiterpreter(frame, frame->imethod->method, ip, frame->imethod->jinfo->code_start, frame->imethod->jinfo->code_size);
+				JiterpreterThunk prepare_result = mono_interp_tier_prepare_jiterpreter_fast(frame, frame->imethod->method, ip, frame->imethod->jinfo->code_start, frame->imethod->jinfo->code_size);
 				switch ((guint32)(void*)prepare_result) {
 					case JITERPRETER_TRAINING:
 						// jiterpreter still updating hit count before deciding to generate a trace,

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -42,6 +42,7 @@ void jiterp_preserve_module (void);
 #include <mono/mini/llvm-runtime.h>
 #include <mono/mini/llvmonly-runtime.h>
 #include <mono/utils/options.h>
+#include <mono/utils/atomic.h>
 
 #include "jiterpreter.h"
 
@@ -867,11 +868,50 @@ typedef struct {
 	JiterpreterThunk thunk;
 } TraceInfo;
 
-#define MAX_TRACE_COUNT 40960
+#define MAX_TRACE_SEGMENTS 256
+#define TRACE_SEGMENT_SIZE 1024
 
-static guint32 trace_count = 0;
-// FIXME: Dynamically sized
-static TraceInfo trace_infos[MAX_TRACE_COUNT];
+static volatile gint32 trace_count = 0;
+static TraceInfo *trace_segments[MAX_TRACE_SEGMENTS] = { NULL };
+
+static TraceInfo *
+trace_info_allocate_segment (gint32 index) {
+	g_assert (index < MAX_TRACE_SEGMENTS);
+
+	volatile gpointer *slot = (volatile gpointer *)&trace_segments[index];
+	gpointer segment = g_malloc0 (sizeof(TraceInfo) * TRACE_SEGMENT_SIZE);
+	gpointer result = mono_atomic_cas_ptr (slot, segment, NULL);
+	if (result != NULL) {
+		g_free (segment);
+		return (TraceInfo *)result;
+	} else {
+		return (TraceInfo *)segment;
+	}
+}
+
+static TraceInfo *
+trace_info_get (gint32 index) {
+	g_assert (index >= 0);
+	int segment_index = index / TRACE_SEGMENT_SIZE,
+		element_index = index % TRACE_SEGMENT_SIZE;
+
+	g_assert (segment_index < MAX_TRACE_SEGMENTS);
+
+	TraceInfo *segment = trace_segments[segment_index];
+	if (!segment)
+		segment = trace_info_allocate_segment (segment_index);
+
+	return &segment[element_index];
+}
+
+static gint32
+trace_info_alloc () {
+	gint32 index = trace_count++;
+	TraceInfo *info = trace_info_get (index);
+	info->hit_count = 0;
+	info->thunk = NULL;
+	return index;
+}
 
 /*
  * Insert jiterpreter entry points at the correct candidate locations:
@@ -919,15 +959,11 @@ jiterp_insert_entry_points (void *_td)
 			should_generate = TRUE;
 
 		if (enabled && should_generate) {
-			guint32 trace_index = trace_count++;
-			g_assert (trace_index < MAX_TRACE_COUNT);
+			gint32 trace_index = trace_info_alloc ();
+
 			td->cbb = bb;
 			InterpInst *ins = mono_jiterp_insert_ins (td, NULL, MINT_TIER_PREPARE_JITERPRETER);
-			memcpy(ins->data, &trace_index, sizeof(trace_index));
-
-			// FIXME: Grow array
-			trace_infos[trace_index].hit_count = 0;
-			trace_infos[trace_index].thunk = NULL;
+			memcpy(ins->data, &trace_index, sizeof (trace_index));
 
 			// Note that we only clear enter_at_next here, after generating a trace.
 			// This means that the flag will stay set intentionally if we keep failing
@@ -940,8 +976,7 @@ jiterp_insert_entry_points (void *_td)
 
 EMSCRIPTEN_KEEPALIVE double
 mono_jiterp_get_trace_hit_count (gint32 trace_index) {
-	g_assert(trace_index < trace_count);
-	return (double)trace_infos[trace_index].hit_count;
+	return trace_info_get (trace_index)->hit_count;
 }
 
 JiterpreterThunk
@@ -952,15 +987,19 @@ mono_interp_tier_prepare_jiterpreter_fast (
 	if (!mono_opt_jiterpreter_traces_enabled)
 		return (JiterpreterThunk)(void*)JITERPRETER_NOT_JITTED;
 
-	guint32 trace_index = READ32(ip + 1);
-	g_assert(trace_index < trace_count);
-	TraceInfo *trace_info = &trace_infos[trace_index];
-	g_assert(trace_info);
+	guint32 trace_index = READ32 (ip + 1);
+	TraceInfo *trace_info = trace_info_get (trace_index);
+	g_assert (trace_info);
 
 	if (trace_info->thunk)
 		return trace_info->thunk;
 
+#ifdef DISABLE_THREADS
 	gint64 count = trace_info->hit_count++;
+#else
+	gint64 count = mono_atomic_inc_i64(&trace_info->hit_count);
+#endif
+
 	if (count == mono_opt_jiterpreter_minimum_trace_hit_count) {
 		JiterpreterThunk result = mono_interp_tier_prepare_jiterpreter(
 			frame, method, ip, (gint32)trace_index,
@@ -968,11 +1007,8 @@ mono_interp_tier_prepare_jiterpreter_fast (
 		);
 		trace_info->thunk = result;
 		return result;
-	} else if (count > mono_opt_jiterpreter_minimum_trace_hit_count) {
-		// FIXME: This shouldn't happen. Race condition?
-		return (JiterpreterThunk)(void*)JITERPRETER_TRAINING;
 	} else {
-		// Hit count not reached
+		// Hit count not reached, or already reached but compilation is not done yet
 		return (JiterpreterThunk)(void*)JITERPRETER_TRAINING;
 	}
 }

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -864,7 +864,7 @@ should_generate_trace_here (InterpBasicBlock *bb) {
 
 typedef struct {
 	// 64-bits because it can get very high if estimate heat is turned on
-	guint64 hit_count;
+	gint64 hit_count;
 	JiterpreterThunk thunk;
 } TraceInfo;
 

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -63,7 +63,7 @@ mono_interp_tier_prepare_jiterpreter_fast (
 // Slow-path implemented in TypeScript, actually performs JIT
 extern JiterpreterThunk
 mono_interp_tier_prepare_jiterpreter (
-	void *frame, MonoMethod *method, const guint16 *ip,
+	void *frame, MonoMethod *method, const guint16 *ip, gint32 trace_index,
 	const guint16 *start_of_body, int size_of_body
 );
 

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -52,7 +52,15 @@ mono_interp_jit_wasm_entry_trampoline (
 	int unbox, int has_this, int has_return, const char *name, void *default_implementation
 );
 
+// Fast-path implemented in C
+JiterpreterThunk
+mono_interp_tier_prepare_jiterpreter_fast (
+	void *frame, MonoMethod *method, const guint16 *ip,
+	const guint16 *start_of_body, int size_of_body
+);
+
 // HACK: Pass void* so that this header can include safely in files without definition for InterpFrame
+// Slow-path implemented in TypeScript, actually performs JIT
 extern JiterpreterThunk
 mono_interp_tier_prepare_jiterpreter (
 	void *frame, MonoMethod *method, const guint16 *ip,

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -123,6 +123,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_type_to_stind", "number", ["number"]],
     [true, "mono_jiterp_imethod_to_ftnptr", "number", ["number"]],
     [true, "mono_jiterp_debug_count", "number", []],
+    [true, "mono_jiterp_get_trace_hit_count", "number", ["number"]],
 ];
 
 export interface t_Cwraps {
@@ -264,6 +265,7 @@ export interface t_Cwraps {
     mono_jiterp_type_to_stind(type: MonoType): number;
     mono_jiterp_imethod_to_ftnptr(imethod: VoidPtr): VoidPtr;
     mono_jiterp_debug_count(): number;
+    mono_jiterp_get_trace_hit_count(traceIndex: number): number;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};


### PR DESCRIPTION
For traces that have not been jitted yet, the jiterpreter currently tracks their state entirely in typescript. For a full run of System.Runtime.Tests on my hardware around 500-600ms was spent in that tracking code, so this PR migrates the hot path of the tracking code to C.

I did four runs on main and then four runs on this PR, averaged both, and saw a runtime improvement for S.R.T from 140.3sec to 136.9sec.