### PR TITLE
[HTTP/3] Add libnuma-dev into docker image

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -5,7 +5,7 @@ FROM $SDK_BASE_IMAGE
 WORKDIR /msquic
 RUN apt-get update -y && \
     apt-get upgrade -y && \
-    apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
+    apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev libnuma-dev && \
     gem install fpm
 RUN git clone --recursive https://github.com/dotnet/msquic
 RUN cd msquic/src/msquic && \


### PR DESCRIPTION
Attempt to fix #81706

cc: @antonfirsov 