### PR TITLE
Fix condition for module registration export

### DIFF
--- a/src/coreclr/dlls/mscordbi/mscordbi.cpp
+++ b/src/coreclr/dlls/mscordbi/mscordbi.cpp
@@ -33,7 +33,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
     return DbgDllMain(hInstance, dwReason, lpReserved);
 }
 
-#if defined(HOST_LINUX) && defined(TARGET_LINUX)
+#if defined(TARGET_LINUX) and !defined(HOST_WINDOWS)
 PALIMPORT HINSTANCE PALAPI DAC_PAL_RegisterModule(IN LPCSTR lpLibFileName);
 PALIMPORT VOID PALAPI DAC_PAL_UnregisterModule(IN HINSTANCE hInstance);
 

--- a/src/coreclr/dlls/mscordbi/mscordbi.cpp
+++ b/src/coreclr/dlls/mscordbi/mscordbi.cpp
@@ -33,7 +33,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
     return DbgDllMain(hInstance, dwReason, lpReserved);
 }
 
-#if defined(TARGET_LINUX) and !defined(HOST_WINDOWS)
+#if defined(TARGET_LINUX) && !defined(HOST_WINDOWS)
 PALIMPORT HINSTANCE PALAPI DAC_PAL_RegisterModule(IN LPCSTR lpLibFileName);
 PALIMPORT VOID PALAPI DAC_PAL_UnregisterModule(IN HINSTANCE hInstance);
 


### PR DESCRIPTION
`HOST_LINUX` is only defined in mono. Here, we wanted to export this symbol on linux, and skip during the cross-compile (from Windows which doesn't use PAL).