### PR TITLE
[coop][interp] Fix GC transitions for thunk invoke wrappers

### DIFF
--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -696,6 +696,87 @@ gc_safe_transition_builder_cleanup (GCSafeTransitionBuilder *builder)
 #endif
 }
 
+typedef struct EmitGCUnsafeTransitionBuilder {
+	MonoMethodBuilder *mb;
+	int orig_domain_var;
+	int attach_cookie_var;
+} GCUnsafeTransitionBuilder;
+
+static void
+gc_unsafe_transition_builder_init (GCUnsafeTransitionBuilder *builder, MonoMethodBuilder *mb, gboolean use_attach)
+{
+	g_assert_checked (use_attach);
+	// Right now we always set use_attach and use mono_threads_coop_attach to enter into gc
+	// unsafe regions.  If !use_attach is needed (ie adding transitions, using
+	// mono_threads_enter_gc_unsafe_region_unbalanced) that needs to be implemented.
+	builder->mb = mb;
+	builder->orig_domain_var = -1;
+	builder->attach_cookie_var = -1;
+}
+
+static void
+gc_unsafe_transition_builder_add_vars (GCUnsafeTransitionBuilder *builder)
+{
+	MonoType *int_type = mono_get_int_type ();
+	builder->orig_domain_var = mono_mb_add_local (builder->mb, int_type);
+	builder->attach_cookie_var = mono_mb_add_local (builder->mb, int_type);
+}
+
+static void
+gc_unsafe_transition_builder_emit_enter (GCUnsafeTransitionBuilder *builder)
+{
+	MonoMethodBuilder *mb = builder->mb;
+	int attach_cookie = builder->attach_cookie_var;
+	int orig_domain = builder->orig_domain_var;
+	/*
+	 * // does (STARTING|RUNNING|BLOCKING) -> RUNNING + set/switch domain
+	 * intptr_t attach_cookie;
+	 * intptr_t orig_domain = mono_threads_attach_coop (domain, &attach_cookie);
+	 * <interrupt check>
+	 */
+	/* orig_domain = mono_threads_attach_coop (domain, &attach_cookie); */
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_LDDOMAIN);
+	mono_mb_emit_ldloc_addr (mb, attach_cookie);
+	/*
+	 * This icall is special cased in the JIT so it works in native-to-managed wrappers in unattached threads.
+	 * Keep this in sync with the CEE_JIT_ICALL code in the JIT.
+	 *
+	 * Special cased in interpreter, keep in sync.
+	 */
+	mono_mb_emit_icall (mb, mono_threads_attach_coop);
+	mono_mb_emit_stloc (mb, orig_domain);
+
+	/* <interrupt check> */
+	emit_thread_interrupt_checkpoint (mb);
+}
+
+static void
+gc_unsafe_transition_builder_emit_exit (GCUnsafeTransitionBuilder *builder)
+{
+	MonoMethodBuilder *mb = builder->mb;
+	int orig_domain = builder->orig_domain_var;
+	int attach_cookie = builder->attach_cookie_var;
+	/*
+	 * // does RUNNING -> (RUNNING|BLOCKING) + unset/switch domain
+	 * mono_threads_detach_coop (orig_domain, &attach_cookie);
+	 */
+
+	/* mono_threads_detach_coop (orig_domain, &attach_cookie); */
+	mono_mb_emit_ldloc (mb, orig_domain);
+	mono_mb_emit_ldloc_addr (mb, attach_cookie);
+	/* Special cased in interpreter, keep in sync */
+	mono_mb_emit_icall (mb, mono_threads_detach_coop);
+}
+
+static void
+gc_unsafe_transition_builder_cleanup (GCUnsafeTransitionBuilder *builder)
+{
+	builder->mb = NULL;
+	builder->orig_domain_var = -1;
+	builder->attach_cookie_var = -1;
+}
+
 static gboolean
 emit_native_wrapper_validate_signature (MonoMethodBuilder *mb, MonoMethodSignature* sig, MonoMarshalSpec** mspecs)
 {
@@ -2253,7 +2334,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	MonoImage *image = get_method_image (method);
 	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	int param_count = sig->param_count + sig->hasthis + 1;
-	int pos_leave, coop_gc_var = 0;
+	int pos_leave;
 	MonoExceptionClause *clause;
 	MonoType *object_type = mono_get_object_type ();
 #if defined (TARGET_WASM)
@@ -2266,6 +2347,10 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 #else
 	const gboolean do_blocking_transition = TRUE;
 #endif
+	GCUnsafeTransitionBuilder gc_unsafe_builder = {0,};
+
+	if (do_blocking_transition)
+		gc_unsafe_transition_builder_init (&gc_unsafe_builder, mb, TRUE);
 
 	/* local 0 (temp for exception object) */
 	mono_mb_add_local (mb, object_type);
@@ -2275,8 +2360,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		mono_mb_add_local (mb, sig->ret);
 
 	if (do_blocking_transition) {
-		/* local 4, the local to be used when calling the suspend funcs */
-		coop_gc_var = mono_mb_add_local (mb, mono_get_int_type ());
+		gc_unsafe_transition_builder_add_vars (&gc_unsafe_builder);
 	}
 
 	/* clear exception arg */
@@ -2285,10 +2369,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	mono_mb_emit_byte (mb, CEE_STIND_REF);
 
 	if (do_blocking_transition) {
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_GET_SP);
-		mono_mb_emit_icall (mb, mono_threads_enter_gc_unsafe_region_unbalanced);
-		mono_mb_emit_stloc (mb, coop_gc_var);
+		gc_unsafe_transition_builder_emit_enter (&gc_unsafe_builder);
 	}
 
 	/* try */
@@ -2361,10 +2442,9 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	}
 
 	if (do_blocking_transition) {
-		mono_mb_emit_ldloc (mb, coop_gc_var);
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_GET_SP);
-		mono_mb_emit_icall (mb, mono_threads_exit_gc_unsafe_region_unbalanced);
+		gc_unsafe_transition_builder_emit_exit (&gc_unsafe_builder);
+
+		gc_unsafe_transition_builder_cleanup (&gc_unsafe_builder);
 	}
 
 	mono_mb_emit_byte (mb, CEE_RET);
@@ -2414,8 +2494,9 @@ static void
 emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, MonoGCHandle target_handle, MonoError *error)
 {
 	MonoMethodSignature *sig, *csig;
-	int i, *tmp_locals, orig_domain, attach_cookie;
+	int i, *tmp_locals;
 	gboolean closed = FALSE;
+	GCUnsafeTransitionBuilder gc_unsafe_builder = {0,};
 
 	sig = m->sig;
 	csig = m->csig;
@@ -2453,8 +2534,8 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 	if (MONO_TYPE_ISSTRUCT (sig->ret))
 		m->vtaddr_var = mono_mb_add_local (mb, int_type);
 
-	orig_domain = mono_mb_add_local (mb, int_type);
-	attach_cookie = mono_mb_add_local (mb, int_type);
+	gc_unsafe_transition_builder_init (&gc_unsafe_builder, mb, TRUE);
+	gc_unsafe_transition_builder_add_vars (&gc_unsafe_builder);
 
 	/*
 	 * // does (STARTING|RUNNING|BLOCKING) -> RUNNING + set/switch domain
@@ -2472,21 +2553,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 	mono_mb_emit_icon (mb, 0);
 	mono_mb_emit_stloc (mb, 2);
 
-	/* orig_domain = mono_threads_attach_coop (domain, &attach_cookie); */
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_LDDOMAIN);
-	mono_mb_emit_ldloc_addr (mb, attach_cookie);
-	/*
-	 * This icall is special cased in the JIT so it works in native-to-managed wrappers in unattached threads.
-	 * Keep this in sync with the CEE_JIT_ICALL code in the JIT.
-	 *
-	 * Special cased in interpreter, keep in sync.
-	 */
-	mono_mb_emit_icall (mb, mono_threads_attach_coop);
-	mono_mb_emit_stloc (mb, orig_domain);
-
-	/* <interrupt check> */
-	emit_thread_interrupt_checkpoint (mb);
+	gc_unsafe_transition_builder_emit_enter(&gc_unsafe_builder);
 
 	/* we first do all conversions */
 	tmp_locals = g_newa (int, sig->param_count);
@@ -2638,11 +2705,9 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 		}
 	}
 
-	/* mono_threads_detach_coop (orig_domain, &attach_cookie); */
-	mono_mb_emit_ldloc (mb, orig_domain);
-	mono_mb_emit_ldloc_addr (mb, attach_cookie);
-	/* Special cased in interpreter, keep in sync */
-	mono_mb_emit_icall (mb, mono_threads_detach_coop);
+	gc_unsafe_transition_builder_emit_exit (&gc_unsafe_builder);
+
+	gc_unsafe_transition_builder_cleanup (&gc_unsafe_builder);
 
 	/* return ret; */
 	if (m->retobj_var) {

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -7488,27 +7488,13 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				MonoJitICallId const jit_icall_id = (MonoJitICallId)read32 (td->ip + 1);
 				MonoJitICallInfo const * const info = mono_find_jit_icall_info (jit_icall_id);
 
-				// mono_method_get_unmanaged_thunk creates wrappers with
-				// enter_gc_unsafe/exit_gc_unsafe transitions.  Treat them as attach/detach.
-				if (jit_icall_id == MONO_JIT_ICALL_mono_threads_enter_gc_unsafe_region_unbalanced) {
-					rtm->needs_thread_attach = 1;
-					// Add dummy return value
-					interp_add_ins (td, MINT_LDNULL);
-					push_simple_type (td, STACK_TYPE_I);
-					td->last_ins->dreg = td->sp[-1].local;
-				} else if (jit_icall_id == MONO_JIT_ICALL_mono_threads_exit_gc_unsafe_region_unbalanced) {
-					g_assert (rtm->needs_thread_attach);
-					// pop the unused gc var
-					td->sp--;
-				} else if (info->sig->ret->type != MONO_TYPE_VOID) {
-					g_assert_checked (jit_icall_id == MONO_JIT_ICALL_mono_threads_enter_gc_safe_region_unbalanced);
+				if (info->sig->ret->type != MONO_TYPE_VOID) {
 					// Push a dummy coop gc var
 					interp_add_ins (td, MINT_LDNULL);
 					push_simple_type (td, STACK_TYPE_I);
 					td->last_ins->dreg = td->sp [-1].local;
 					interp_add_ins (td, MINT_MONO_ENABLE_GCTRANS);
 				} else {
-					g_assert_checked (jit_icall_id == MONO_JIT_ICALL_mono_threads_exit_gc_safe_region_unbalanced);
 					// Pop the unused gc var
 					td->sp--;
 				}

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -7489,12 +7489,14 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				MonoJitICallInfo const * const info = mono_find_jit_icall_info (jit_icall_id);
 
 				if (info->sig->ret->type != MONO_TYPE_VOID) {
+					g_assert_checked (jit_icall_id == MONO_JIT_ICALL_mono_threads_enter_gc_safe_region_unbalanced);
 					// Push a dummy coop gc var
 					interp_add_ins (td, MINT_LDNULL);
 					push_simple_type (td, STACK_TYPE_I);
 					td->last_ins->dreg = td->sp [-1].local;
 					interp_add_ins (td, MINT_MONO_ENABLE_GCTRANS);
 				} else {
+					g_assert_checked (jit_icall_id == MONO_JIT_ICALL_mono_threads_exit_gc_safe_region_unbalanced);
 					// Pop the unused gc var
 					td->sp--;
 				}


### PR DESCRIPTION
The code that recognizes GC transition icalls in the interpreter was only assuming that it will see `mono_threads_enter_gc_safe_region_unbalanced` / `mono_threads_exit_gc_safe_region_unbalanced` which are used by managed-to-native wrappers.

In most cases for native-to-managed wrappers the marshaller emits `mono_threads_attach_coop` / `mono_threads_detach_coop` and those are handled elsewhere by setting the `needs_thread_attach` flag on the `InterpMethod`.

However when the `mono_marshal_get_thunk_invoke_wrapper` API is used, we emit a thunk invoke wrapper which uses
`mono_threads_enter_gc_unsafe_region_unbalanced` / `mono_threads_exit_gc_unsafe_region_unbalanced`

Change the thunk invoke wrapper to also use attach_coop/detach_coop.  This makes the thunks a bit more flexible (they can now be called from unattached threads), at the cost of a TLS lookup.  Also fixes interpreter support since they use the existing attach/detach handling.

As an implementation detail, I added a GC Unsafe Transition Builder to the marshaling code.

Fixes a failure seen in https://github.com/dotnet/runtime/pull/81380 in the MonoAPI/MonoMono/Thunks test (exposed by calling a cctor later than previously)