### PR TITLE
CI: `evaluate-changed-paths.sh`: Add support for include+exclude combined

### DIFF
--- a/eng/pipelines/common/evaluate-paths-job.yml
+++ b/eng/pipelines/common/evaluate-paths-job.yml
@@ -41,6 +41,8 @@ jobs:
           parameters:
             subsetName: ${{ path.subset }}
             arguments:
+            - ${{ if eq(path.combined, true) }}:
+              - --combined
             # The commit that we're building is always a merge commit that is merging into the target branch.
             # So the first parent of the commit is on the target branch and the second parent is on the source branch.
             - --difftarget HEAD^1


### PR DESCRIPTION
 ## Background

`eng/pipelines/common/evaluate-default-paths.yml` is used to specify named subsets of paths, and `evaluate-changed-paths.sh` decides which subsets have "changed files". And these subsets are used in conditions for the various jobs to determine when they should be run.

 ## Problem

This script currently supports `--include`, and `--exclude` parameters to determine if we have any changed paths.

```
Scenarios:
1. exclude paths are specified
    Will include all paths except the ones in the exclude list.
2. include paths are specified
    Will only include paths specified in the list.
1st we evaluate changes for all paths except ones in excluded list. If we can not find
any applicable changes like that, then we evaluate changes for included paths
if any of these two finds changes, then a variable will be set to true.
```

As described above, these two are evaluated exclusively. For example:

```
include: [ '/a/b/*' ], exclude: [ '/a/b/d.txt' ]
```

- This would return true if there are changes:
  - `[ '/a/b/c.txt' ]` - caught by `include`
  - or `[ '/r/s.txt' ]` - caught by `exclude`

- but it would also return true for `[ '/a/b/d.txt' ]` because `include` does not consider the `exclude` list.

 ## Solution

- This commit adds a new `--combined` parameter which essentially supports `$include - $exclude`. Thus allowing exact more constrained path specification.

- It is passed in addition to `include`, and `exclude`.

Given:
```
include: [ '/a/b/*' ], exclude: [ '/a/b/d.txt' ]
```

- For the following path changes:
  - `[ '/a/b/c.txt' ]` - `true`
  - `[ '/r/s.txt' ]` - `false` because this does not fall in `$include - $exclude`
  - `[ '/a/b/d.txt' ]` - `false` - excluded in `$include - $exclude`

The implementation is trivially implemented by passing both the lists to `git diff` which supports this already.