### PR TITLE
JIT: Avoid omitting copies for struct fields passed implicitly by reference

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2575,6 +2575,7 @@ unsigned Compiler::lvaGetFieldLocal(const LclVarDsc* varDsc, unsigned int fldOff
 void Compiler::lvaSetVarAddrExposed(unsigned varNum DEBUGARG(AddressExposedReason reason))
 {
     LclVarDsc* varDsc = lvaGetDesc(varNum);
+    assert(!varDsc->lvIsStructField);
 
     varDsc->SetAddressExposed(true DEBUGARG(reason));
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3976,7 +3976,7 @@ void Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall* call, CallArg* arg)
 
             if (!omitCopy && fgGlobalMorph)
             {
-                omitCopy = !varDsc->lvPromoted && ((lcl->gtFlags & GTF_VAR_DEATH) != 0);
+                omitCopy = !varDsc->lvPromoted && !varDsc->lvIsStructField && ((lcl->gtFlags & GTF_VAR_DEATH) != 0);
             }
 
             if (!omitCopy && (totalAppearances == 1))

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81739/Runtime_81739.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81739/Runtime_81739.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+public class Runtime_81739
+{
+    public static int Main()
+    {
+        Plane p;
+        p.Normal = default;
+        Consume(p.Normal);
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Consume<T>(T v)
+    {
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_81739/Runtime_81739.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_81739/Runtime_81739.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The code does not properly mark the parent struct as address exposed, but also doing so would completely disable any tracking/optimization for these locals which we do not want to do.

Fix #81739