### PR TITLE
Skip generating code for uint->long casts

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6914,7 +6914,6 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
             unreached();
     }
 
-
     if (srcReg != REG_NA)
     {
 #ifdef TARGET_AMD64
@@ -6928,7 +6927,7 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
             // This can be rewritten as the following for unsigned casts:
             //
             //      mov      dstReg, dword ptr [baseReg+imm*srcReg]
-            // 
+            //
             // Check to see if the next node is a GT_LEA containing this GT_CAST and if the node after the GT_LEA is
             // a GT_IND using the GT_CAST. If it is possible to remove the first mov instruction, mark this GT_CAST
             // as skipped and use srcReg when generating the GT_IND.
@@ -6939,12 +6938,14 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
                 if (indirOper != nullptr && indirOper->OperIs(GT_IND) && indirOper->AsIndir()->gtOp1 == leaOper)
                 {
                     GenTree* indexOper = indirOper->AsIndir()->Index();
-                    if (indexOper != nullptr && indexOper == cast && indexOper->GetRegNum() != REG_NA) {
+                    if (indexOper != nullptr && indexOper == cast && indexOper->GetRegNum() != REG_NA)
+                    {
                         regNumber indexReg = indexOper->GetRegNum();
                         regNumber indirReg = indirOper->GetRegNum();
                         regNumber baseReg  = indirOper->AsIndir()->Base()->GetRegNum();
 
-                        if (indexReg != REG_NA && indirReg != REG_NA && dstReg == indexReg && dstReg == indirReg && baseReg != dstReg && baseReg != srcReg && baseReg != indexReg)
+                        if (indexReg != REG_NA && indirReg != REG_NA && dstReg == indexReg && dstReg == indirReg &&
+                            baseReg != dstReg && baseReg != srcReg && baseReg != indexReg)
                         {
                             cast->skippedGenForIndexing = true;
                             return;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6918,8 +6918,8 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
     if (srcReg != REG_NA)
     {
 #ifdef TARGET_AMD64
-        if (cast->usedForIndexing)
-        {
+        // if (cast->usedForIndexing)
+        // {
             GenTree* leaOper = cast->gtNext;
             if (leaOper != nullptr && leaOper->OperIs(GT_LEA))
             {
@@ -6939,9 +6939,9 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
                     }
                 }
             }
+        // }
 #endif
 
-        }
         emit->emitIns_Mov(ins, EA_ATTR(insSize), dstReg, srcReg, canSkip);
     }
     else

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6925,13 +6925,16 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
                 GenTree* indirOper = leaOper->gtNext;
                 if (indirOper != nullptr && indirOper->OperIs(GT_IND))
                 {
-                    regNumber indexReg = indirOper->AsIndir()->Index()->GetRegNum();
-                    regNumber indirReg = indirOper->GetRegNum();
+                    GenTree* indexOper = indirOper->AsIndir()->Index();
+                    if (indexOper != nullptr && indexOper->GetRegNum() != REG_NA) {
+                        regNumber indexReg = indexOper->GetRegNum();
+                        regNumber indirReg = indirOper->GetRegNum();
 
-                    if (indexReg != REG_NA && indirReg != REG_NA && dstReg == indexReg && dstReg == indirReg)
-                    {
-                        cast->skippedGenForIndexing = true;
-                        return;
+                        if (indexReg != REG_NA && indirReg != REG_NA && dstReg == indexReg && dstReg == indirReg)
+                        {
+                            cast->skippedGenForIndexing = true;
+                            return;
+                        }
                     }
                 }
             }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6925,7 +6925,7 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
                 GenTree* indirOper = leaOper->gtNext;
                 if (indirOper != nullptr && indirOper->OperIs(GT_IND))
                 {
-                    regNumber indexReg = indirOper->AsIndir()->Index()->GetReg();
+                    regNumber indexReg = indirOper->AsIndir()->Index()->GetRegNum();
                     regNumber indirReg = indirOper->GetRegNum();
 
                     if (indexReg != REG_NA && indirReg != REG_NA && dstReg == indexReg && dstReg == indirReg)

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6917,6 +6917,7 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
 
     if (srcReg != REG_NA)
     {
+#ifdef TARGET_AMD64
         if (cast->usedForIndexing)
         {
             GenTree* leaOper = cast->gtNext;
@@ -6938,6 +6939,7 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
                     }
                 }
             }
+#endif
 
         }
         emit->emitIns_Mov(ins, EA_ATTR(insSize), dstReg, srcReg, canSkip);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4193,8 +4193,7 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         {
             GenTree* index = indir->Index();
             assert(!index->isContained());
-            if (index->OperIs(GT_CAST) && index->AsCast()->usedForIndexing &&
-                index->AsCast()->CastOp()->isUsedFromReg())
+            if (index->OperIs(GT_CAST) && index->AsCast()->usedForIndexing && index->AsCast()->skippedGenForIndexing)
             {
                 amIndxReg = index->AsCast()->CastOp()->GetReg();
             }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4196,6 +4196,8 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
 #ifdef TARGET_AMD64
             if (index->OperIs(GT_CAST) && index->AsCast()->skippedGenForIndexing)
             {
+                // If the index node is a GT_CAST that was skipped for indexing, use the
+                // srcReg of the GT_CAST to skip a redundant mov instruction.
                 amIndxReg = index->AsCast()->CastOp()->GetRegNum();
             }
             else

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4194,7 +4194,7 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
             GenTree* index = indir->Index();
             assert(!index->isContained());
 #ifdef TARGET_AMD64
-            if (index->OperIs(GT_CAST) && index->AsCast()->usedForIndexing && index->AsCast()->skippedGenForIndexing)
+            if (index->OperIs(GT_CAST) && index->AsCast()->skippedGenForIndexing)
             {
                 amIndxReg = index->AsCast()->CastOp()->GetRegNum();
             }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4193,7 +4193,15 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         {
             GenTree* index = indir->Index();
             assert(!index->isContained());
-            amIndxReg = index->GetRegNum();
+            if (index->OperIs(GT_CAST) && index->AsCast()->usedForIndexing &&
+                index->AsCast()->CastOp()->isUsedFromReg())
+            {
+                amIndxReg = index->AsCast()->CastOp()->GetReg();
+            }
+            else
+            {
+                amIndxReg = index->GetRegNum();
+            }
             assert(amIndxReg != REG_NA);
         }
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4195,7 +4195,7 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
             assert(!index->isContained());
             if (index->OperIs(GT_CAST) && index->AsCast()->usedForIndexing && index->AsCast()->skippedGenForIndexing)
             {
-                amIndxReg = index->AsCast()->CastOp()->GetReg();
+                amIndxReg = index->AsCast()->CastOp()->GetRegNum();
             }
             else
             {

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4193,6 +4193,7 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         {
             GenTree* index = indir->Index();
             assert(!index->isContained());
+#ifdef TARGET_AMD64
             if (index->OperIs(GT_CAST) && index->AsCast()->usedForIndexing && index->AsCast()->skippedGenForIndexing)
             {
                 amIndxReg = index->AsCast()->CastOp()->GetRegNum();
@@ -4201,6 +4202,9 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
             {
                 amIndxReg = index->GetRegNum();
             }
+#else
+            amIndxReg = index->GetRegNum();
+#endif
             assert(amIndxReg != REG_NA);
         }
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3955,8 +3955,10 @@ struct GenTreeCast : public GenTreeOp
         return false;
     }
 
+#ifdef TARGET_AMD64 
     bool usedForIndexing = false;
     bool skippedGenForIndexing = false;
+#endif
 };
 
 // GT_BOX nodes are place markers for boxed values.  The "real" tree

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3954,6 +3954,8 @@ struct GenTreeCast : public GenTreeOp
 
         return false;
     }
+
+    bool usedForIndexing = false;
 };
 
 // GT_BOX nodes are place markers for boxed values.  The "real" tree

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3956,6 +3956,7 @@ struct GenTreeCast : public GenTreeOp
     }
 
     bool usedForIndexing = false;
+    bool skippedGenForIndexing = false;
 };
 
 // GT_BOX nodes are place markers for boxed values.  The "real" tree

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4497,6 +4497,7 @@ GenTree* Compiler::fgMorphIndexAddr(GenTreeIndexAddr* indexAddr)
         else
         {
             index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_I_IMPL);
+            index->AsCast()->usedForIndexing = true;
         }
     }
 #endif // TARGET_64BIT

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4498,6 +4498,8 @@ GenTree* Compiler::fgMorphIndexAddr(GenTreeIndexAddr* indexAddr)
         {
             index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_I_IMPL);
 #ifdef TARGET_AMD64
+            // Mark this GT_CAST node as being used for indexing, can potentially skip generating a
+            // redundant mov during the CodeGen phase.
             index->AsCast()->usedForIndexing = true;
 #endif
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4497,7 +4497,9 @@ GenTree* Compiler::fgMorphIndexAddr(GenTreeIndexAddr* indexAddr)
         else
         {
             index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_I_IMPL);
+#ifdef TARGET_AMD64
             index->AsCast()->usedForIndexing = true;
+#endif
         }
     }
 #endif // TARGET_64BIT


### PR DESCRIPTION
When looking at the codegen for some of the `BitOperations` microbenchmarks ([link](https://github.com/dotnet/performance/blob/1c76fee8e93712f5d8422f04fe0011705ebf3090/src/benchmarks/micro/libraries/System.Numerics.BitOperations/Perf_BitOperations.cs#L14)), I noticed the following codegen in `BitOperations.Log2_uint`:

```
## .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
; System.Numerics.Tests.Perf_BitOperations.Log2_uint()
       xor       eax,eax
       mov       rdx,21655408588
       mov       rdx,[rdx]
       xor       ecx,ecx
       mov       r8d,[rdx+8]
       test      r8d,r8d
       jle       short M00_L01
       nop       word ptr [rax+rax]
M00_L00:
       mov       r9d,ecx
       mov       r9d,[rdx+r9*4+10]
       or        r9d,1
       lzcnt     r9d,r9d
       xor       r9d,1F
       add       eax,r9d
       inc       ecx
       cmp       r8d,ecx
       jg        short M00_L00
M00_L01:
       ret
; Total bytes of code 64
```

At the beginning of label `M00_L00`, there are two `mov` instructions generated by a `GT_CAST` node that casts a local variable from a uint->long when indexing into an array. 

The two `mov` instructions can be combined into a single `mov`:

```
M00_L00:
       mov       r9d,[rdx+rcx*4+10]
```

On some x64 systems, this improves the performance of the hot loop in these benchmarks:

```
## System.Numerics.Tests.Perf_BitOperations.Log2_ulong

| Result | Ratio | Alloc Delta | Operating System | Bit | Processor Name                            | Modality|
| ------ | -----:| -----------:| ---------------- | --- | ----------------------------------------- | --------:|
| Same   |  1.01 |          +0 | Windows 11       | X64 | Intel desktop                             |         |
| Faster |  1.23 |          +0 | Windows 11       | X64 | AMD desktop                               |         |

## System.Numerics.Tests.Perf_BitOperations.Log2_uint

| Result | Ratio | Alloc Delta | Operating System | Bit | Processor Name                            | Modality|
| ------ | -----:| -----------:| ---------------- | --- | ----------------------------------------- | --------:|
| Same   |  1.01 |          +0 | Windows 11       | X64 | Intel desktop                             |         |
| Faster |  1.23 |          +0 | Windows 11       | X64 | AMD desktop                               |         |
```


<details>
<summary>ASM Diffs</summary>

Diffs are based on <span style="color:#1460aa">1,504,432</span> contexts (<span style="color:#1460aa">393,539</span> MinOpts, <span style="color:#1460aa">1,110,893</span> FullOpts).

<span style="color:#d35400">MISSED</span> contexts: <span style="color:#d35400">316 (0.02%)</span>


<details>
<summary>Overall (<span style="color:green">-61,801</span> bytes)</summary>

|Collection|Base size (bytes)|Diff size (bytes)|
|---|--:|--:|
|aspnet.run.windows.x64.checked.mch|34,294,824|<span style="color:green">-6,900</span>|
|benchmarks.run.windows.x64.checked.mch|7,706,346|<span style="color:green">-3,650</span>|
|coreclr_tests.run.windows.x64.checked.mch|370,359,759|<span style="color:green">-8,557</span>|
|libraries.crossgen2.windows.x64.checked.mch|34,876,821|<span style="color:green">-11,076</span>|
|libraries.pmi.windows.x64.checked.mch|51,914,479|<span style="color:green">-16,172</span>|
|libraries_tests.pmi.windows.x64.checked.mch|124,786,529|<span style="color:green">-15,446</span>|


</details>

<details>
<summary>FullOpts (<span style="color:green">-61,801</span> bytes)</summary>

|Collection|Base size (bytes)|Diff size (bytes)|
|---|--:|--:|
|aspnet.run.windows.x64.checked.mch|21,254,880|<span style="color:green">-6,900</span>|
|benchmarks.run.windows.x64.checked.mch|7,201,797|<span style="color:green">-3,650</span>|
|coreclr_tests.run.windows.x64.checked.mch|98,048,712|<span style="color:green">-8,557</span>|
|libraries.crossgen2.windows.x64.checked.mch|34,875,632|<span style="color:green">-11,076</span>|
|libraries.pmi.windows.x64.checked.mch|50,415,696|<span style="color:green">-16,172</span>|
|libraries_tests.pmi.windows.x64.checked.mch|115,755,533|<span style="color:green">-15,446</span>|


</details>

<details>
<summary>Details</summary>

#### Improvements/regressions per collection

|Collection|Contexts with diffs|Improvements|Regressions|Same size|Improvements (bytes)|Regressions (bytes)|
|---|--:|--:|--:|--:|--:|--:|
|aspnet.run.windows.x64.checked.mch|1,838|<span style="color:green">1,813</span>|<span style="color:red">13</span>|<span style="color:blue">12</span>|<span style="color:green">-6,998</span>|<span style="color:red">+98</span>|
|benchmarks.run.windows.x64.checked.mch|847|<span style="color:green">827</span>|<span style="color:red">5</span>|<span style="color:blue">15</span>|<span style="color:green">-3,681</span>|<span style="color:red">+31</span>|
|coreclr_tests.run.windows.x64.checked.mch|2,110|<span style="color:green">2,064</span>|<span style="color:red">20</span>|<span style="color:blue">26</span>|<span style="color:green">-8,704</span>|<span style="color:red">+147</span>|
|libraries.crossgen2.windows.x64.checked.mch|2,954|<span style="color:green">2,954</span>|<span style="color:red">0</span>|<span style="color:blue">0</span>|<span style="color:green">-11,076</span>|<span style="color:red">+0</span>|
|libraries.pmi.windows.x64.checked.mch|4,605|<span style="color:green">4,553</span>|<span style="color:red">26</span>|<span style="color:blue">26</span>|<span style="color:green">-16,389</span>|<span style="color:red">+217</span>|
|libraries_tests.pmi.windows.x64.checked.mch|5,085|<span style="color:green">5,061</span>|<span style="color:red">15</span>|<span style="color:blue">9</span>|<span style="color:green">-15,557</span>|<span style="color:red">+111</span>|
||17,439|<span style="color:green">17,272</span>|<span style="color:red">79</span>|<span style="color:blue">88</span>|<span style="color:green">-62,405</span>|<span style="color:red">+604</span>|

---

#### Context information

|Collection|Diffed contexts|MinOpts|FullOpts|Missed, base|Missed, diff|
|---|--:|--:|--:|--:|--:|
|aspnet.run.windows.x64.checked.mch|108,932|47,583|61,349|0 (0.00%)|0 (0.00%)|
|benchmarks.run.windows.x64.checked.mch|27,016|1,329|25,687|16 (0.06%)|16 (0.06%)|
|coreclr_tests.run.windows.x64.checked.mch|519,910|330,203|189,707|233 (0.04%)|233 (0.04%)|
|libraries.crossgen2.windows.x64.checked.mch|216,570|15|216,555|3 (0.00%)|3 (0.00%)|
|libraries.pmi.windows.x64.checked.mch|271,681|4,951|266,730|60 (0.02%)|60 (0.02%)|
|libraries_tests.pmi.windows.x64.checked.mch|360,323|9,458|350,865|4 (0.00%)|4 (0.00%)|
||1,504,432|393,539|1,110,893|316 (0.02%)|316 (0.02%)|


---

#### jit-analyze output

<details>

<summary>aspnet.run.windows.x64.checked.mch</summary>

To reproduce these diffs on Windows x64:
```
superpmi.py asmdiffs -target_os windows -target_arch x64 -arch x64
```

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 34294824 (overridden on cmd)
Total bytes of diff: 34287924 (overridden on cmd)
Total bytes of delta: -6900 (-0.02 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
        -125 : 78315.dasm (-0.96% of base)
        -122 : 68420.dasm (-0.91% of base)
        -122 : 61334.dasm (-0.91% of base)
        -121 : 66296.dasm (-0.93% of base)
        -117 : 4635.dasm (-1.72% of base)
        -115 : 77213.dasm (-0.89% of base)
        -104 : 47001.dasm (-0.99% of base)
         -95 : 57632.dasm (-0.90% of base)
         -68 : 41943.dasm (-0.89% of base)
         -48 : 49636.dasm (-0.55% of base)
         -24 : 71402.dasm (-0.94% of base)
         -24 : 59332.dasm (-0.97% of base)
         -22 : 49858.dasm (-1.25% of base)
         -21 : 61090.dasm (-0.65% of base)
         -21 : 108370.dasm (-0.65% of base)
         -21 : 67738.dasm (-0.65% of base)
         -21 : 91458.dasm (-0.65% of base)
         -20 : 78738.dasm (-1.27% of base)
         -20 : 76086.dasm (-1.53% of base)
         -16 : 56782.dasm (-0.68% of base)

81 total files with Code Size differences (81 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -125 (-0.96% of base) : 78315.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
        -122 (-0.91% of base) : 68420.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
        -122 (-0.91% of base) : 61334.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
        -121 (-0.93% of base) : 66296.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
        -117 (-1.72% of base) : 4635.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
        -115 (-0.89% of base) : 77213.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
        -104 (-0.99% of base) : 47001.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
         -95 (-0.90% of base) : 57632.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
         -68 (-0.89% of base) : 41943.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
         -48 (-0.55% of base) : 49636.dasm - System.Text.RegularExpressions.RegexInterpreter:TryMatchAtCurrentPosition(System.ReadOnlySpan`1[ushort]):bool:this
         -24 (-0.94% of base) : 71402.dasm - YesSql.Sql.SqlBuilder:ToSqlString():System.String:this
         -24 (-0.97% of base) : 59332.dasm - YesSql.Sql.SqlBuilder:ToSqlString():System.String:this
         -22 (-1.25% of base) : 49858.dasm - System.DefaultBinder:SelectMethod(int,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.MethodBase:this
         -21 (-0.65% of base) : 61090.dasm - System.DefaultBinder:SelectMethod(int,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.MethodBase:this
         -21 (-0.65% of base) : 108370.dasm - System.DefaultBinder:SelectMethod(int,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.MethodBase:this
         -21 (-0.65% of base) : 67738.dasm - System.DefaultBinder:SelectMethod(int,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.MethodBase:this
         -21 (-0.65% of base) : 91458.dasm - System.DefaultBinder:SelectMethod(int,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.MethodBase:this
         -20 (-1.53% of base) : 76086.dasm - Fluid.Parser.TagParsers+TagEndParser:Parse(Parlot.Fluent.ParseContext,byref):bool:this
         -20 (-1.27% of base) : 78738.dasm - Newtonsoft.Json.Utilities.DateTimeParser:Parse(ushort[],int,int):bool:this
         -16 (-0.68% of base) : 56782.dasm - System.Text.ValueStringBuilder:AppendFormatHelper(System.IFormatProvider,System.String,System.ReadOnlySpan`1[System.Object]):this

Top method improvements (percentages):
          -5 (-11.36% of base) : 17861.dasm - Microsoft.AspNetCore.StaticFiles.StaticFileContext:GetMaxPreconditionState(ubyte[]):ubyte
          -5 (-11.36% of base) : 15875.dasm - Microsoft.AspNetCore.StaticFiles.StaticFileContext:GetMaxPreconditionState(ubyte[]):ubyte
          -5 (-11.36% of base) : 11438.dasm - Microsoft.AspNetCore.StaticFiles.StaticFileContext:GetMaxPreconditionState(ubyte[]):ubyte
          -3 (-8.57% of base) : 24721.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 65445.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 93327.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 99756.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 46019.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 25947.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 77408.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 27951.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 86700.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 26469.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.57% of base) : 20842.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -5 (-8.33% of base) : 10793.dasm - Microsoft.AspNetCore.StaticFiles.StaticFileContext:GetMaxPreconditionState(ubyte[]):ubyte
          -3 (-7.89% of base) : 16784.dasm - Microsoft.AspNetCore.StaticFiles.StaticFileContext:GetMaxPreconditionState(ubyte[]):ubyte
          -3 (-7.89% of base) : 60824.dasm - System.Reflection.Emit.DynamicResolver:CalculateNumberOfExceptions(System.Reflection.Emit.__ExceptionInfo[]):int
          -6 (-7.14% of base) : 103602.dasm - Npgsql.BackendMessages.CommandCompleteMessage:ParseNumber(ubyte[],byref):ulong
          -6 (-7.14% of base) : 91188.dasm - Npgsql.BackendMessages.CommandCompleteMessage:ParseNumber(ubyte[],byref):ulong
          -6 (-7.14% of base) : 104646.dasm - Npgsql.BackendMessages.CommandCompleteMessage:ParseNumber(ubyte[],byref):ulong

```

</details>

--------------------------------------------------------------------------------


</details>

<details>

<summary>benchmarks.run.windows.x64.checked.mch</summary>

To reproduce these diffs on Windows x64:
```
superpmi.py asmdiffs -target_os windows -target_arch x64 -arch x64
```

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 7706346 (overridden on cmd)
Total bytes of diff: 7702696 (overridden on cmd)
Total bytes of delta: -3650 (-0.05 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
        -115 : 9932.dasm (-2.75% of base)
        -106 : 12839.dasm (-2.32% of base)
         -93 : 1317.dasm (-0.86% of base)
         -75 : 9748.dasm (-0.96% of base)
         -69 : 24576.dasm (-0.62% of base)
         -66 : 26988.dasm (-0.61% of base)
         -64 : 13939.dasm (-0.91% of base)
         -48 : 6220.dasm (-0.55% of base)
         -28 : 27021.dasm (-0.79% of base)
         -26 : 16038.dasm (-1.57% of base)
         -26 : 8747.dasm (-3.41% of base)
         -26 : 15432.dasm (-2.65% of base)
         -20 : 18099.dasm (-0.85% of base)
         -19 : 2717.dasm (-0.45% of base)
         -19 : 2998.dasm (-1.20% of base)
         -19 : 2712.dasm (-0.68% of base)
         -18 : 14211.dasm (-1.81% of base)
         -17 : 6921.dasm (-0.80% of base)
         -15 : 23567.dasm (-6.49% of base)
         -15 : 26876.dasm (-7.21% of base)

79 total files with Code Size differences (79 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -115 (-2.75% of base) : 9932.dasm - Utf8Json.Formatters.ISO8601DateTimeOffsetFormatter:Deserialize(byref,Utf8Json.IJsonFormatterResolver):System.DateTimeOffset:this
        -106 (-2.32% of base) : 12839.dasm - Utf8Json.Formatters.ISO8601DateTimeFormatter:Deserialize(byref,Utf8Json.IJsonFormatterResolver):System.DateTime:this
         -93 (-0.86% of base) : 1317.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
         -75 (-0.96% of base) : 9748.dasm - Jil.Deserialize.Methods:_ReadISO8601DateWithOffset(System.IO.TextReader,ushort[]):System.DateTimeOffset
         -69 (-0.62% of base) : 24576.dasm - Jil.Deserialize.Methods:_ReadISO8601DateWithOffsetThunkReader(byref,ushort[]):System.DateTimeOffset
         -66 (-0.61% of base) : 26988.dasm - Jil.Deserialize.Methods:_ReadISO8601DateThunkReader(byref,ushort[]):System.DateTime
         -64 (-0.91% of base) : 13939.dasm - Jil.Deserialize.Methods:_ReadISO8601Date(System.IO.TextReader,ushort[]):System.DateTime
         -48 (-0.55% of base) : 6220.dasm - System.Text.RegularExpressions.RegexInterpreter:TryMatchAtCurrentPosition(System.ReadOnlySpan`1[ushort]):bool:this
         -28 (-0.79% of base) : 27021.dasm - Benchstone.BenchI.MulMatrix:Inner(int[][],int[][],int[][])
         -26 (-1.57% of base) : 16038.dasm - BenchmarksGame.FannkuchRedux_5:run(int,int,int)
         -26 (-3.41% of base) : 8747.dasm - BenchmarksGame.ReverseComplement_6:Reverse(BenchmarksGame.RevCompSequence)
         -26 (-2.65% of base) : 15432.dasm - IDEAEncryption:de_key_idea(ushort[],ushort[])
         -20 (-0.85% of base) : 18099.dasm - Microsoft.CodeAnalysis.CommonReferenceManager`2[System.__Canon,System.__Canon]:ReuseAssemblySymbols(Microsoft.CodeAnalysis.CommonReferenceManager`2+BoundInputAssembly[System.__Canon,System.__Canon][],System.__Canon[],System.Collections.Immutable.ImmutableArray`1[System.__Canon],int):this
         -19 (-0.45% of base) : 2717.dasm - System.Reflection.Emit.CustomAttributeBuilder:.ctor(System.Reflection.ConstructorInfo,System.Object[],System.Reflection.PropertyInfo[],System.Object[],System.Reflection.FieldInfo[],System.Object[]):this
         -19 (-0.68% of base) : 2712.dasm - System.Xml.Serialization.TempAssembly:GenerateRefEmitAssembly(System.Xml.Serialization.XmlMapping[],System.Type[]):System.Reflection.Assembly
         -19 (-1.20% of base) : 2998.dasm - System.Xml.XmlConvert:DecodeName(System.String):System.String
         -18 (-1.81% of base) : 14211.dasm - AssignJagged:first_assignments(int[][],short[][]):int
         -17 (-0.80% of base) : 6921.dasm - System.Text.StringBuilder:AppendFormatHelper(System.IFormatProvider,System.String,System.ReadOnlySpan`1[System.Object]):System.Text.StringBuilder:this
         -15 (-6.49% of base) : 23567.dasm - Span.Sorting:TestQuickSortArray(int[],int,int)
         -15 (-7.21% of base) : 26876.dasm - StringSort:strsift(System.String[],int,int)

Top method improvements (percentages):
          -3 (-8.57% of base) : 1957.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.11% of base) : 2835.dasm - System.Xml.Serialization.XmlSerializationWriterILGen:FindXmlnsIndex(System.Xml.Serialization.MemberMapping[]):int
          -3 (-7.69% of base) : 18276.dasm - Roslyn.Utilities.Hash:CombineFNVHash(int,System.String):int
          -2 (-7.41% of base) : 17077.dasm - System.Tests.Perf_String:getStringCharNoInline(System.String,int):ushort
         -15 (-7.21% of base) : 26876.dasm - StringSort:strsift(System.String[],int,int)
          -3 (-7.14% of base) : 20037.dasm - Roslyn.Utilities.Hash:GetFNVHashCode(System.Collections.Immutable.ImmutableArray`1[ubyte]):int
          -2 (-7.14% of base) : 10157.dasm - System.Buffers.Tests.RentReturnArrayPoolTests`1[System.__Canon]:IterateAll(System.__Canon[]):System.__Canon
          -2 (-7.14% of base) : 7713.dasm - System.Buffers.Tests.RentReturnArrayPoolTests`1[ubyte]:IterateAll(ubyte[]):ubyte
          -3 (-6.98% of base) : 20340.dasm - BenchmarksGame.Fasta_2:MakeCumulative(BenchmarksGame.Fasta_2+Frequency[])
          -3 (-6.67% of base) : 18995.dasm - Microsoft.CodeAnalysis.CSharp.MergedTypeDeclaration:get_AnyMemberHasAttributes():bool:this
          -9 (-6.62% of base) : 26442.dasm - NumericSortJagged:NumSift(int[],int,int)
          -3 (-6.52% of base) : 2513.dasm - System.Resources.FastResourceComparer:HashFunction(System.String):int
         -15 (-6.49% of base) : 23567.dasm - Span.Sorting:TestQuickSortArray(int[],int,int)
          -2 (-6.45% of base) : 16940.dasm - System.Collections.IterateFor`1[int]:Array():int:this
          -2 (-6.45% of base) : 22791.dasm - System.Collections.IterateFor`1[int]:ImmutableArray():int:this
          -2 (-6.45% of base) : 25510.dasm - System.Collections.IterateForEach`1[int]:Array():int:this
          -2 (-6.25% of base) : 17413.dasm - System.Collections.IterateFor`1[System.__Canon]:ImmutableArray():System.__Canon:this
          -2 (-6.25% of base) : 1023.dasm - System.SZArrayHelper:get_Item[int](int):int:this
          -5 (-5.81% of base) : 14655.dasm - System.Xml.XmlConverter:ToInt32D2(ubyte[],int):int
          -2 (-5.71% of base) : 21801.dasm - System.Collections.IterateForEach`1[int]:ImmutableArray():int:this

```

</details>

--------------------------------------------------------------------------------


</details>

<details>

<summary>coreclr_tests.run.windows.x64.checked.mch</summary>

To reproduce these diffs on Windows x64:
```
superpmi.py asmdiffs -target_os windows -target_arch x64 -arch x64
```

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 370359759 (overridden on cmd)
Total bytes of diff: 370351202 (overridden on cmd)
Total bytes of delta: -8557 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -84 : 160985.dasm (-3.67% of base)
         -61 : 183778.dasm (-0.43% of base)
         -61 : 418623.dasm (-0.43% of base)
         -60 : 118517.dasm (-0.20% of base)
         -60 : 118535.dasm (-0.24% of base)
         -55 : 418627.dasm (-0.39% of base)
         -55 : 183783.dasm (-0.39% of base)
         -48 : 160365.dasm (-0.55% of base)
         -44 : 123898.dasm (-1.23% of base)
         -41 : 250128.dasm (-0.59% of base)
         -41 : 468952.dasm (-0.60% of base)
         -39 : 253413.dasm (-2.09% of base)
         -39 : 470525.dasm (-2.09% of base)
         -36 : 118543.dasm (-0.21% of base)
         -36 : 118527.dasm (-0.18% of base)
         -31 : 474677.dasm (-2.36% of base)
         -28 : 151232.dasm (-0.79% of base)
         -26 : 159877.dasm (-1.57% of base)
         -26 : 160394.dasm (-3.41% of base)
         -15 : 388226.dasm (-7.21% of base)

95 total files with Code Size differences (95 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -84 (-3.67% of base) : 160985.dasm - Test:Main():int
         -61 (-0.43% of base) : 183778.dasm - StrAccess2:Main():int
         -61 (-0.43% of base) : 418623.dasm - StrAccess2:Main():int
         -60 (-0.20% of base) : 118517.dasm - IntelHardwareIntrinsicTest._Avx2.Program+GatherMaskVector128:Test()
         -60 (-0.24% of base) : 118535.dasm - IntelHardwareIntrinsicTest._Avx2.Program+GatherVector128:Test()
         -55 (-0.39% of base) : 418627.dasm - StrAccess2:Main():int
         -55 (-0.39% of base) : 183783.dasm - StrAccess2:Main():int
         -48 (-0.55% of base) : 160365.dasm - System.Text.RegularExpressions.RegexInterpreter:TryMatchAtCurrentPosition(System.ReadOnlySpan`1[ushort]):bool:this
         -44 (-1.23% of base) : 123898.dasm - JIT.HardwareIntrinsics.X86._Avx2.SimpleBinaryOpTest__SumAbsoluteDifferencesUInt16:ValidateResult(ubyte[],ubyte[],ushort[],System.String):this
         -41 (-0.59% of base) : 250128.dasm - Internal.TypeSystem.MetadataFieldLayoutAlgorithm:ComputeAutoFieldLayout(Internal.TypeSystem.MetadataType,int):Internal.TypeSystem.ComputedInstanceFieldLayout:this
         -41 (-0.60% of base) : 468952.dasm - Internal.TypeSystem.MetadataFieldLayoutAlgorithm:ComputeAutoFieldLayout(Internal.TypeSystem.MetadataType,int):Internal.TypeSystem.ComputedInstanceFieldLayout:this
         -39 (-2.09% of base) : 253413.dasm - Internal.IL.ILStackHelper:ComputeMaxStack(Internal.IL.MethodIL):int
         -39 (-2.09% of base) : 470525.dasm - Internal.IL.ILStackHelper:ComputeMaxStack(Internal.IL.MethodIL):int
         -36 (-0.18% of base) : 118527.dasm - IntelHardwareIntrinsicTest._Avx2.Program+GatherMaskVector256:Test()
         -36 (-0.21% of base) : 118543.dasm - IntelHardwareIntrinsicTest._Avx2.Program+GatherVector256:Test()
         -31 (-2.36% of base) : 474677.dasm - System.Reflection.Emit.MethodBuilder:CreateMethodBodyHelper(System.Reflection.Emit.ILGenerator):this
         -28 (-0.79% of base) : 151232.dasm - Benchstone.BenchI.MulMatrix:Inner(int[][],int[][],int[][])
         -26 (-1.57% of base) : 159877.dasm - BenchmarksGame.FannkuchRedux_5:run(int,int,int)
         -26 (-3.41% of base) : 160394.dasm - BenchmarksGame.ReverseComplement_6:Reverse(BenchmarksGame.RevCompSequence)
         -15 (-7.21% of base) : 388226.dasm - StringSort:strsift(System.String[],int,int)

Top method improvements (percentages):
         -11 (-10.89% of base) : 470522.dasm - Internal.IL.ILStackHelper:ReadInt32(ubyte[],int):int
          -3 (-10.34% of base) : 469616.dasm - ILCompiler.Sorting.Implementation.ArrayAccessor`1[System.__Canon]:GetElement(System.__Canon[],int):System.__Canon:this
          -3 (-10.34% of base) : 251542.dasm - ILCompiler.Sorting.Implementation.ArrayAccessor`1[System.__Canon]:GetElement(System.__Canon[],int):System.__Canon:this
          -2 (-10.00% of base) : 145938.dasm - ArrBoundUnsigned:i_GE_UN_len_next_edge(int[],int):int
          -2 (-10.00% of base) : 145926.dasm - ArrBoundUnsigned:i_LT_UN_len(int[],int):int
          -2 (-10.00% of base) : 145927.dasm - ArrBoundUnsigned:len_GT_UN_i(int[],int):int
          -2 (-10.00% of base) : 145939.dasm - ArrBoundUnsigned:len_LE_UN_i_next_edge(int[],int):int
          -3 (-9.38% of base) : 180155.dasm - PrimitiveVT.CallConv1:f10(PrimitiveVT.VT1B[]):int:this
          -3 (-9.38% of base) : 180180.dasm - PrimitiveVT.CallConv2:f10(PrimitiveVT.VT2B[]):uint:this
          -3 (-9.38% of base) : 180209.dasm - PrimitiveVT.CallConv3:f10(PrimitiveVT.VT1B[]):int:this
          -3 (-8.82% of base) : 474679.dasm - System.Reflection.Emit.MethodBuilder:CalculateNumberOfExceptions(System.Reflection.Emit.__ExceptionInfo[]):int
          -3 (-8.57% of base) : 382928.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.33% of base) : 144550.dasm - Tester:XorArray(bool[]):bool
          -3 (-7.89% of base) : 296652.dasm - System.Reflection.Emit.DynamicResolver:CalculateNumberOfExceptions(System.Reflection.Emit.__ExceptionInfo[]):int
         -15 (-7.21% of base) : 388226.dasm - StringSort:strsift(System.String[],int,int)
          -3 (-6.67% of base) : 147872.dasm - Microsoft.CodeAnalysis.CSharp.MergedTypeDeclaration:get_AnyMemberHasAttributes():bool:this
         -12 (-5.06% of base) : 193217.dasm - X:F():int
          -2 (-4.76% of base) : 145930.dasm - ArrBoundUnsigned:i_GE_UN_len(int[],int):int
          -2 (-4.76% of base) : 145932.dasm - ArrBoundUnsigned:i_GT_UN_len(int[],int):int
          -2 (-4.76% of base) : 145928.dasm - ArrBoundUnsigned:i_LE_UN_len(int[],int):int

```

</details>

--------------------------------------------------------------------------------


</details>

<details>

<summary>libraries.crossgen2.windows.x64.checked.mch</summary>

To reproduce these diffs on Windows x64:
```
superpmi.py asmdiffs -target_os windows -target_arch x64 -arch x64
```

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 34876821 (overridden on cmd)
Total bytes of diff: 34865745 (overridden on cmd)
Total bytes of delta: -11076 (-0.03 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -96 : 120976.dasm (-5.14% of base)
         -90 : 141412.dasm (-0.35% of base)
         -84 : 45369.dasm (-2.44% of base)
         -82 : 8078.dasm (-0.79% of base)
         -66 : 120974.dasm (-4.09% of base)
         -56 : 128340.dasm (-0.69% of base)
         -48 : 138362.dasm (-1.15% of base)
         -42 : 43990.dasm (-1.59% of base)
         -35 : 165000.dasm (-0.62% of base)
         -30 : 6947.dasm (-2.12% of base)
         -28 : 131694.dasm (-1.68% of base)
         -27 : 8081.dasm (-1.54% of base)
         -27 : 185122.dasm (-1.19% of base)
         -25 : 201891.dasm (-2.18% of base)
         -25 : 8080.dasm (-1.93% of base)
         -25 : 214310.dasm (-2.56% of base)
         -25 : 129090.dasm (-1.53% of base)
         -24 : 5558.dasm (-0.76% of base)
         -22 : 44264.dasm (-0.94% of base)
         -21 : 142131.dasm (-0.51% of base)

89 total files with Code Size differences (89 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -96 (-5.14% of base) : 120976.dasm - Microsoft.FSharp.Collections.ArrayModule+Filter:populateDstViaMask[System.__Canon](System.__Canon[],uint[],System.__Canon[]):int
         -90 (-0.35% of base) : 141412.dasm - Microsoft.VisualBasic.CompilerServices.VBBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
         -84 (-2.44% of base) : 45369.dasm - System.Xml.Schema.XmlSchemaInference:InferSimpleType(System.String,byref):int
         -82 (-0.79% of base) : 8078.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
         -66 (-4.09% of base) : 120974.dasm - Microsoft.FSharp.Collections.ArrayModule+Filter:populateMask[System.__Canon](Microsoft.FSharp.Core.FSharpFunc`2[System.__Canon,bool],System.__Canon[],uint[]):int
         -56 (-0.69% of base) : 128340.dasm - System.Text.RegularExpressions.RegexInterpreter:TryMatchAtCurrentPosition(System.ReadOnlySpan`1[ushort]):bool:this
         -48 (-1.15% of base) : 138362.dasm - System.Linq.Parallel.SortHelper`2[System.__Canon,System.__Canon]:MergeSortCooperatively():this
         -42 (-1.59% of base) : 43990.dasm - System.Xml.Schema.XsdValidator:EndElementIdentityConstraints():this
         -35 (-0.62% of base) : 165000.dasm - Internal.TypeSystem.MetadataFieldLayoutAlgorithm:ComputeAutoFieldLayout(Internal.TypeSystem.MetadataType,int):Internal.TypeSystem.ComputedInstanceFieldLayout:this
         -30 (-2.12% of base) : 6947.dasm - System.Type:FindMembers(int,int,System.Reflection.MemberFilter,System.Object):System.Reflection.MemberInfo[]:this
         -28 (-1.68% of base) : 131694.dasm - Xunit.Sdk.Sha1Digest:ProcessBlock():this
         -27 (-1.54% of base) : 8081.dasm - System.DefaultBinder:SelectProperty(int,System.Reflection.PropertyInfo[],System.Type,System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.PropertyInfo:this
         -27 (-1.19% of base) : 185122.dasm - System.DirectoryServices.Protocols.DirectoryControl:TransformControls(System.DirectoryServices.Protocols.DirectoryControl[])
         -25 (-1.93% of base) : 8080.dasm - System.DefaultBinder:SelectMethod(int,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.MethodBase:this
         -25 (-1.53% of base) : 129090.dasm - System.DefaultBinder:SelectMethod(int,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.MethodBase:this
         -25 (-2.56% of base) : 214310.dasm - System.Media.SoundPlayer:ValidateSoundData(ubyte[])
         -25 (-2.18% of base) : 201891.dasm - System.Security.AccessControl.ObjectAce:ParseBinaryForm(ubyte[],int,byref,byref,byref,byref,byref,byref,byref,byref):bool
         -24 (-0.76% of base) : 5558.dasm - System.DirectoryServices.AccountManagement.ADStoreCtx:LoadPropertyMappingTable(int,System.Object[,])
         -22 (-0.94% of base) : 44264.dasm - System.Xml.Serialization.TempAssembly:GenerateRefEmitAssembly(System.Xml.Serialization.XmlMapping[],System.Type[]):System.Reflection.Assembly
         -21 (-0.51% of base) : 142131.dasm - Microsoft.VisualBasic.CompilerServices.VBBinder:GetMostSpecific(System.Reflection.MethodBase,System.Reflection.MethodBase,int[],System.Object[],bool,int,int,System.Object[]):int:this

Top method improvements (percentages):
          -3 (-12.00% of base) : 173899.dasm - System.Linq.ImmutableArrayExtensions:ElementAtOrDefault[System.__Canon](System.Collections.Immutable.ImmutableArray`1[System.__Canon],int):System.__Canon
         -11 (-10.78% of base) : 165626.dasm - Internal.IL.ILStackHelper:ReadInt32(ubyte[],int):int
         -11 (-10.78% of base) : 149158.dasm - Microsoft.Cci.MetadataWriter:ReadInt32(System.Collections.Immutable.ImmutableArray`1[ubyte],int):int
         -11 (-10.78% of base) : 27087.dasm - Microsoft.Cci.MetadataWriter:ReadInt32(System.Collections.Immutable.ImmutableArray`1[ubyte],int):int
         -11 (-10.78% of base) : 32227.dasm - Microsoft.CodeAnalysis.MetadataHelpers+PublicKeyDecoder:ToUInt32(System.Collections.Immutable.ImmutableArray`1[ubyte],int):uint
         -11 (-10.78% of base) : 131668.dasm - Xunit.Sdk.Pack:LE_To_UInt32(ubyte[],int):uint
         -11 (-10.68% of base) : 131651.dasm - Xunit.Sdk.Pack:BE_To_UInt32(ubyte[],int):uint
          -3 (-10.00% of base) : 213940.dasm - ILCompiler.Sorting.Implementation.ArrayAccessor`1[System.__Canon]:GetElement(System.__Canon[],int):System.__Canon:this
          -3 (-10.00% of base) : 120957.dasm - Microsoft.FSharp.Collections.ArrayModule:Get[System.__Canon](System.__Canon[],int):System.__Canon
          -3 (-10.00% of base) : 173898.dasm - System.Linq.ImmutableArrayExtensions:ElementAt[System.__Canon](System.Collections.Immutable.ImmutableArray`1[System.__Canon],int):System.__Canon
          -5 (-9.26% of base) : 131661.dasm - Xunit.Sdk.Pack:LE_To_UInt16(ubyte[],int):ushort
          -5 (-9.09% of base) : 131644.dasm - Xunit.Sdk.Pack:BE_To_UInt16(ubyte[],int):ushort
          -3 (-8.57% of base) : 19349.dasm - System.SZArrayHelper:get_Item[System.__Canon](int):System.__Canon:this
          -3 (-8.33% of base) : 177971.dasm - System.Security.Cryptography.Xml.Utils:ConvertByteArrayToInt(ubyte[]):int
         -10 (-8.26% of base) : 137313.dasm - System.Diagnostics.EventLogEntry:IntFrom(ubyte[],int):int
          -5 (-8.20% of base) : 44609.dasm - System.Xml.BinXmlDateTime:GetKatmaiTimeZoneTicks(ubyte[],int):long
         -13 (-8.13% of base) : 128636.dasm - System.Text.RegularExpressions.RegexCharClass:CharInCategoryGroup(int,System.String,byref):bool
          -3 (-8.11% of base) : 44413.dasm - System.Xml.Serialization.XmlSerializationWriterCodeGen:FindXmlnsIndex(System.Xml.Serialization.MemberMapping[]):int
          -8 (-7.84% of base) : 43564.dasm - System.Xml.BinXmlDateTime:GetKatmaiDateTicks(ubyte[],byref):long
          -3 (-7.69% of base) : 31576.dasm - Roslyn.Utilities.Hash:CombineFNVHash(int,System.String):int

```

</details>

--------------------------------------------------------------------------------


</details>

<details>

<summary>libraries.pmi.windows.x64.checked.mch</summary>

To reproduce these diffs on Windows x64:
```
superpmi.py asmdiffs -target_os windows -target_arch x64 -arch x64
```

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 51914479 (overridden on cmd)
Total bytes of diff: 51898307 (overridden on cmd)
Total bytes of delta: -16172 (-0.03 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
        -139 : 136736.dasm (-0.50% of base)
         -96 : 27951.dasm (-5.23% of base)
         -87 : 124219.dasm (-2.66% of base)
         -66 : 27946.dasm (-4.16% of base)
         -64 : 27947.dasm (-4.04% of base)
         -60 : 194671.dasm (-1.49% of base)
         -55 : 194680.dasm (-1.43% of base)
         -48 : 103.dasm (-0.55% of base)
         -42 : 124190.dasm (-1.69% of base)
         -41 : 142426.dasm (-0.59% of base)
         -37 : 136738.dasm (-0.81% of base)
         -32 : 6225.dasm (-2.29% of base)
         -30 : 6407.dasm (-1.39% of base)
         -29 : 207950.dasm (-1.66% of base)
         -28 : 230111.dasm (-0.58% of base)
         -28 : 6437.dasm (-2.02% of base)
         -28 : 233574.dasm (-1.73% of base)
         -21 : 265799.dasm (-1.75% of base)
         -14 : 201301.dasm (-10.85% of base)
         -11 : 141654.dasm (-10.89% of base)

96 total files with Code Size differences (96 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -139 (-0.50% of base) : 136736.dasm - Microsoft.VisualBasic.CompilerServices.VBBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
         -96 (-5.23% of base) : 27951.dasm - Microsoft.FSharp.Collections.ArrayModule+Filter:populateDstViaMask[System.__Canon](System.__Canon[],uint[],System.__Canon[]):int
         -87 (-2.66% of base) : 124219.dasm - System.Xml.Schema.XmlSchemaInference:InferSimpleType(System.String,byref):int
         -66 (-4.16% of base) : 27946.dasm - Microsoft.FSharp.Collections.ArrayModule+Filter:populateMask[System.__Canon](Microsoft.FSharp.Core.FSharpFunc`2[System.__Canon,bool],System.__Canon[],uint[]):int
         -64 (-4.04% of base) : 27947.dasm - Microsoft.FSharp.Collections.ArrayModule+Filter:populateMask[ubyte](Microsoft.FSharp.Core.FSharpFunc`2[ubyte,bool],ubyte[],uint[]):int
         -60 (-1.49% of base) : 194671.dasm - System.Linq.Parallel.SortHelper`2[System.__Canon,System.Nullable`1[int]]:MergeSortCooperatively():this
         -55 (-1.43% of base) : 194680.dasm - System.Linq.Parallel.SortHelper`2[ubyte,System.Nullable`1[int]]:MergeSortCooperatively():this
         -48 (-0.55% of base) : 103.dasm - System.Text.RegularExpressions.RegexInterpreter:TryMatchAtCurrentPosition(System.ReadOnlySpan`1[ushort]):bool:this
         -42 (-1.69% of base) : 124190.dasm - System.Xml.Schema.XsdValidator:EndElementIdentityConstraints():this
         -41 (-0.59% of base) : 142426.dasm - Internal.TypeSystem.MetadataFieldLayoutAlgorithm:ComputeAutoFieldLayout(Internal.TypeSystem.MetadataType,int):Internal.TypeSystem.ComputedInstanceFieldLayout:this
         -37 (-0.81% of base) : 136738.dasm - Microsoft.VisualBasic.CompilerServices.VBBinder:GetMostSpecific(System.Reflection.MethodBase,System.Reflection.MethodBase,int[],System.Object[],bool,int,int,System.Object[]):int:this
         -32 (-2.29% of base) : 6225.dasm - System.Data.Common.Int16Storage:Aggregate(int[],int):System.Object:this
         -30 (-1.39% of base) : 6407.dasm - System.Data.Common.TimeSpanStorage:Aggregate(int[],int):System.Object:this
         -29 (-1.66% of base) : 207950.dasm - System.DefaultBinder:SelectMethod(int,System.Reflection.MethodBase[],System.Type[],System.Reflection.ParameterModifier[]):System.Reflection.MethodBase:this
         -28 (-0.58% of base) : 230111.dasm - ILCompiler.PettisHansenSort.PettisHansen:Sort(System.Collections.Generic.List`1[ILCompiler.PettisHansenSort.CallGraphNode]):System.Collections.Generic.List`1[System.Collections.Generic.List`1[int]]
         -28 (-2.02% of base) : 6437.dasm - System.Data.Common.UInt32Storage:Aggregate(int[],int):System.Object:this
         -28 (-1.73% of base) : 233574.dasm - Xunit.Sdk.Sha1Digest:ProcessBlock():this
         -21 (-1.75% of base) : 265799.dasm - System.Security.AccessControl.ObjectAce:ParseBinaryForm(ubyte[],int,byref,byref,byref,byref,byref,byref,byref,byref):bool
         -14 (-10.85% of base) : 201301.dasm - System.Net.FrameHeader:CopyFrom(ubyte[],int):this
         -11 (-10.89% of base) : 141654.dasm - Internal.IL.ILStackHelper:ReadInt32(ubyte[],int):int

Top method improvements (percentages):
          -3 (-12.00% of base) : 169831.dasm - System.Linq.ImmutableArrayExtensions:ElementAtOrDefault[System.__Canon](System.Collections.Immutable.ImmutableArray`1[System.__Canon],int):System.__Canon
         -11 (-10.89% of base) : 141654.dasm - Internal.IL.ILStackHelper:ReadInt32(ubyte[],int):int
         -11 (-10.89% of base) : 87118.dasm - Microsoft.Cci.MetadataWriter:ReadInt32(System.Collections.Immutable.ImmutableArray`1[ubyte],int):int
         -11 (-10.89% of base) : 152859.dasm - Microsoft.Cci.MetadataWriter:ReadInt32(System.Collections.Immutable.ImmutableArray`1[ubyte],int):int
         -11 (-10.89% of base) : 93966.dasm - Microsoft.CodeAnalysis.MetadataHelpers+PublicKeyDecoder:ToUInt32(System.Collections.Immutable.ImmutableArray`1[ubyte],int):uint
         -11 (-10.89% of base) : 233550.dasm - Xunit.Sdk.Pack:LE_To_UInt32(ubyte[],int):uint
         -14 (-10.85% of base) : 201301.dasm - System.Net.FrameHeader:CopyFrom(ubyte[],int):this
         -11 (-10.78% of base) : 233535.dasm - Xunit.Sdk.Pack:BE_To_UInt32(ubyte[],int):uint
          -3 (-10.34% of base) : 269870.dasm - ILCompiler.Sorting.Implementation.ArrayAccessor`1[long]:GetElement(long[],int):long:this
          -3 (-10.34% of base) : 269851.dasm - ILCompiler.Sorting.Implementation.ArrayAccessor`1[System.__Canon]:GetElement(System.__Canon[],int):System.__Canon:this
          -3 (-10.34% of base) : 27807.dasm - Microsoft.FSharp.Collections.ArrayModule:Get[System.__Canon](System.__Canon[],int):System.__Canon
          -5 (-9.43% of base) : 233544.dasm - Xunit.Sdk.Pack:LE_To_UInt16(ubyte[],int):ushort
          -5 (-9.26% of base) : 233528.dasm - Xunit.Sdk.Pack:BE_To_UInt16(ubyte[],int):ushort
         -10 (-8.33% of base) : 247523.dasm - System.Diagnostics.EventLogEntry:IntFrom(ubyte[],int):int
          -3 (-8.33% of base) : 214468.dasm - System.Security.Cryptography.Xml.Utils:ConvertByteArrayToInt(ubyte[]):int
          -5 (-8.33% of base) : 117104.dasm - System.Xml.BinXmlDateTime:GetKatmaiTimeZoneTicks(ubyte[],int):long
          -8 (-7.92% of base) : 117102.dasm - System.Xml.BinXmlDateTime:GetKatmaiDateTicks(ubyte[],byref):long
          -2 (-7.69% of base) : 27810.dasm - Microsoft.FSharp.Collections.ArrayModule:Get[int](int[],int):int
          -2 (-7.41% of base) : 27808.dasm - Microsoft.FSharp.Collections.ArrayModule:Get[ubyte](ubyte[],int):ubyte
          -2 (-7.14% of base) : 27809.dasm - Microsoft.FSharp.Collections.ArrayModule:Get[short](short[],int):short

```

</details>

--------------------------------------------------------------------------------


</details>

<details>

<summary>libraries_tests.pmi.windows.x64.checked.mch</summary>

To reproduce these diffs on Windows x64:
```
superpmi.py asmdiffs -target_os windows -target_arch x64 -arch x64
```

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 124786529 (overridden on cmd)
Total bytes of diff: 124771083 (overridden on cmd)
Total bytes of delta: -15446 (-0.01 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -48 : 103.dasm (-0.55% of base)
         -45 : 145257.dasm (-1.66% of base)
         -44 : 292848.dasm (-0.36% of base)
         -39 : 145259.dasm (-1.91% of base)
         -39 : 145307.dasm (-1.83% of base)
         -38 : 329403.dasm (-0.61% of base)
         -36 : 145303.dasm (-1.58% of base)
         -32 : 145305.dasm (-0.76% of base)
         -31 : 122966.dasm (-1.75% of base)
         -27 : 118608.dasm (-4.11% of base)
         -26 : 145263.dasm (-2.61% of base)
         -24 : 145261.dasm (-0.86% of base)
         -24 : 317983.dasm (-0.17% of base)
         -23 : 338521.dasm (-1.56% of base)
         -21 : 145267.dasm (-2.09% of base)
         -21 : 145266.dasm (-2.55% of base)
         -21 : 338540.dasm (-0.73% of base)
         -20 : 145289.dasm (-0.95% of base)
         -19 : 193403.dasm (-1.09% of base)
          -9 : 317949.dasm (-0.20% of base)

78 total files with Code Size differences (78 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -48 (-0.55% of base) : 103.dasm - System.Text.RegularExpressions.RegexInterpreter:TryMatchAtCurrentPosition(System.ReadOnlySpan`1[ushort]):bool:this
         -45 (-1.66% of base) : 145257.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[System.__Canon]:AddAfter_LLNode_LLNode():this
         -44 (-0.36% of base) : 292848.dasm - System.IO.Tests.Directory_ReparsePoints_MountVolume:runTest()
         -39 (-1.91% of base) : 145259.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[System.__Canon]:AddBefore_LLNode():this
         -39 (-1.83% of base) : 145307.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[ubyte]:AddBefore_LLNode():this
         -38 (-0.61% of base) : 329403.dasm - System.Threading.Tasks.Tests.TaskRtTests:RunFromResult()
         -36 (-1.58% of base) : 145303.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[ubyte]:AddAfter_LLNode():this
         -32 (-0.76% of base) : 145305.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[ubyte]:AddAfter_LLNode_LLNode():this
         -31 (-1.75% of base) : 122966.dasm - Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.CancellationTokenParametersMustComeLastAnalyzer+<>c__DisplayClass5_0:<Initialize>b__1(Microsoft.CodeAnalysis.Diagnostics.SymbolAnalysisContext):this
         -27 (-4.11% of base) : 118608.dasm - Microsoft.NetCore.Analyzers.Runtime.ProvideCorrectArgumentsToFormattingMethodsAnalyzer:GetFormattingArguments(System.String):int
         -26 (-2.61% of base) : 145263.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[System.__Canon]:AddFirst_T_Tests():this
         -24 (-0.86% of base) : 145261.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[System.__Canon]:AddBefore_LLNode_LLNode():this
         -24 (-0.17% of base) : 317983.dasm - System.Numerics.Tests.Worker:DoWork():this
         -23 (-1.56% of base) : 338521.dasm - DiffPlex.Differ:CalculateEditLength(int[],int,int,int[],int,int,int[],int[]):DiffPlex.Model.EditLengthResult
         -21 (-0.73% of base) : 338540.dasm - DiffPlex.DiffBuilder.SideBySideDiffBuilder:BuildDiffPieces(DiffPlex.Model.DiffResult,System.Collections.Generic.List`1[DiffPlex.DiffBuilder.Model.DiffPiece],System.Collections.Generic.List`1[DiffPlex.DiffBuilder.Model.DiffPiece],DiffPlex.DiffBuilder.SideBySideDiffBuilder+PieceBuilder)
         -21 (-2.09% of base) : 145267.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[System.__Canon]:AddLast_LinkedListNode():this
         -21 (-2.55% of base) : 145266.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[System.__Canon]:AddLast_T_Tests():this
         -20 (-0.95% of base) : 145289.dasm - System.Collections.Tests.LinkedList_Generic_Tests`1[System.__Canon]:Find_T():this
         -19 (-1.09% of base) : 193403.dasm - Microsoft.IdentityModel.Tokens.Base64UrlEncoder:Encode(ubyte[],int,int):System.String
          -9 (-0.20% of base) : 317949.dasm - System.Numerics.Tests.BigIntegerConstructorTest:VerifyCtorByteArray(ubyte[])

Top method improvements (percentages):
          -3 (-7.69% of base) : 124998.dasm - Roslyn.Utilities.Hash:CombineFNVHash(int,System.String):int
          -4 (-7.69% of base) : 285942.dasm - System.TermInfo+Database:ReadInt16(ubyte[],int):short
          -3 (-7.50% of base) : 352280.dasm - Microsoft.CodeAnalysis.DotnetRuntime.Extensions.SyntaxValueProviderExtensions+ImmutableArrayValueComparer`1[ubyte]:GetHashCode(System.Collections.Immutable.ImmutableArray`1[ubyte]):int:this
          -3 (-7.32% of base) : 240567.dasm - System.Security.Cryptography.Rsa.Tests.KeyGeneration:GetMax(System.Security.Cryptography.KeySizes[]):int
          -3 (-7.32% of base) : 176992.dasm - System.Security.Cryptography.Rsa.Tests.KeyGeneration:GetMax(System.Security.Cryptography.KeySizes[]):int
          -3 (-7.32% of base) : 319467.dasm - System.Security.Cryptography.Rsa.Tests.KeyGeneration:GetMax(System.Security.Cryptography.KeySizes[]):int
          -3 (-7.14% of base) : 124988.dasm - Roslyn.Utilities.Hash:GetFNVHashCode(System.Collections.Immutable.ImmutableArray`1[ubyte]):int
          -3 (-7.14% of base) : 124986.dasm - Roslyn.Utilities.Hash:GetFNVHashCode(ubyte[]):int
          -3 (-6.98% of base) : 133971.dasm - Microsoft.CodeAnalysis.Formatting.FormattingExtensions:GetFirstNonWhitespaceIndexInString(System.String):int
          -2 (-6.90% of base) : 138862.dasm - Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars.AbstractVirtualCharService+StringTextInfo:Get(System.String,int):ushort:this
          -2 (-6.90% of base) : 227911.dasm - System.Net.HttpKnownHeaderNames+<>c:<TryGetHeaderName>b__85_0(ushort[],int):ushort:this
          -2 (-6.90% of base) : 181347.dasm - System.Security.Cryptography.Tests.RandomNumberGeneratorTests+<>c__DisplayClass57_0:<Shuffle_Ten>b__0(int[]):int:this
          -3 (-6.82% of base) : 319198.dasm - System.Security.Cryptography.Dsa.Tests.DSAKeyGeneration:GetMin(System.Security.Cryptography.KeySizes[]):int
          -3 (-6.82% of base) : 240344.dasm - System.Security.Cryptography.Dsa.Tests.DSAKeyGeneration:GetMin(System.Security.Cryptography.KeySizes[]):int
          -3 (-6.82% of base) : 176990.dasm - System.Security.Cryptography.Rsa.Tests.KeyGeneration:GetMin(System.Security.Cryptography.KeySizes[]):int
          -4 (-6.78% of base) : 113525.dasm - System.Text.RegularExpressions.Generated.<RegexGenerator_g>F74B1AE921BCEFE4BA601AA541C7A23B1CA9711EA81E8FE504B5B6446748E035A__Utilities:StackPop(int[],byref,byref,byref)
          -3 (-6.67% of base) : 131930.dasm - Microsoft.CodeAnalysis.Shared.Extensions.StringExtensions:ContainsLineBreak(System.String):bool
          -3 (-6.12% of base) : 275753.dasm - NuGet.ContentModel.ContentPropertyDefinition:ContainsSlash(System.String):bool
          -3 (-5.88% of base) : 248340.dasm - FastExpressionCompiler.LightExpression.ExpressionCompiler+ClosureInfo:IsTryReturnLabel(int):bool:this
          -2 (-5.13% of base) : 291436.dasm - PathInfo:get_FullPath():System.String:this

```

</details>

--------------------------------------------------------------------------------


</details>

</details>


</details>

Please let me know if I can clarify any of the above. Thanks!