### PR TITLE
[release/7.0] fix TLS resume with client certificates on Linux

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -306,7 +306,8 @@ internal static partial class Interop
                     if (!Interop.Ssl.Capabilities.Tls13Supported ||
                        string.IsNullOrEmpty(sslAuthenticationOptions.TargetHost) ||
                        sslAuthenticationOptions.CertificateContext != null ||
-                        sslAuthenticationOptions.CertSelectionDelegate != null)
+                       sslAuthenticationOptions.ClientCertificates?.Count > 0 ||
+                       sslAuthenticationOptions.CertSelectionDelegate != null)
                     {
                         cacheSslContext = false;
                     }


### PR DESCRIPTION
partial backport of #79898
fixes https://github.com/dotnet/runtime/issues/79869

## Customer Impact
because of the TLS resume, customer can see unexpected dependencies and incorrect behavior when using client certificates on Linux. The TLS cache in in process memory so the impact is limited. 

## Testing
New tests were added to cover the scenarios. 
The tests depend on `IsMutuallyAuthenticated` property that may be incorrect because of #65563.
Since we do not port fix for that I made tests Linux specific for the release branch. (there is no resume on macOS)
(the tests added in main also discover gaps so the product change #79898 had more fixes for Window)

## Regression
yes, new in 7.0

## Risk Low
We did not do TLS resume at all prior 7.0 on Linux. This change brings back the behavior in one more case we missed. 