### PR TITLE
[release/6.0] Bump non-existent Win10 ARM64 helix queue to Win11

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -173,7 +173,7 @@ jobs:
 
     # windows arm64
     - ${{ if eq(parameters.platform, 'windows_arm64') }}:
-      - Windows.10.Arm64.Open
+      - Windows.11.Arm64.Open
 
     # WebAssembly
     - ${{ if eq(parameters.platform, 'Browser_wasm') }}:


### PR DESCRIPTION
Similar to the 7.0 change: https://github.com/dotnet/runtime/pull/81545

Please let me know if we don't expect such change in this branch.