### PR TITLE
[release/6.0] More Windows Arm64 helix queues 10->11

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -149,15 +149,15 @@ jobs:
     # windows arm
     - ${{ if eq(parameters.platform, 'windows_arm') }}:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
-        - Windows.10.Arm64v8.Open
+        - Windows.11.Arm64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - Windows.10.Arm64
+        - Windows.11.Arm64
 
     # windows arm64
     - ${{ if eq(parameters.platform, 'windows_arm64') }}:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
-        - Windows.10.Arm64v8.Open
+        - Windows.11.Arm64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - Windows.10.Arm64
+        - Windows.11.Arm64
 
     ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -169,7 +169,7 @@ jobs:
 
     # windows arm
     - ${{ if eq(parameters.platform, 'windows_arm') }}:
-      - Windows.10.Arm64v8.Open
+      - Windows.11.Arm64.Open
 
     # windows arm64
     - ${{ if eq(parameters.platform, 'windows_arm64') }}:


### PR DESCRIPTION
Matches the libraries file in main: https://github.com/dotnet/runtime/blob/215839ee5c05547cd740d98cea34f15e73bd5bbb/eng/pipelines/libraries/helix-queues-setup.yml#L184

And the coreclr/templates file in main: https://github.com/dotnet/runtime/blob/215839ee5c05547cd740d98cea34f15e73bd5bbb/eng/pipelines/coreclr/templates/helix-queues-setup.yml#L169

Excludes this other one I submitted in a separate PR earlier today: https://github.com/dotnet/runtime/pull/81802