### PR TITLE
[release/7.0] More Windows Arm64 helix queues 10->11

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -149,15 +149,15 @@ jobs:
     # windows arm
     - ${{ if eq(parameters.platform, 'windows_arm') }}:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
-        - Windows.10.Arm64v8.Open
+        - Windows.11.Arm64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - Windows.10.Arm64
+        - Windows.11.Arm64
 
     # windows arm64
     - ${{ if eq(parameters.platform, 'windows_arm64') }}:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
-        - Windows.10.Arm64v8.Open
+        - Windows.11.Arm64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - Windows.10.Arm64
+        - Windows.11.Arm64
 
     ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -179,7 +179,7 @@ jobs:
 
     # windows arm
     - ${{ if eq(parameters.platform, 'windows_arm') }}:
-      - Windows.10.Arm64v8.Open
+      - Windows.11.Arm64.Open
 
     # windows arm64
     - ${{ if eq(parameters.platform, 'windows_arm64') }}:


### PR DESCRIPTION
I missed a few others in the initial PR: https://github.com/dotnet/runtime/pull/81545

Basically the same ones as in the 6.0 PR: https://github.com/dotnet/runtime/pull/81807