### PR TITLE
[wasm] Pin the version of chrome used for tests - `109.0.5414.119`

### DIFF
--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -47,9 +47,9 @@
     <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1070096</_ChromeBaseSnapshotUrl>
   </PropertyGroup>
   <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('windows'))">
-    <ChromeVersion>109.0.5414.119</ChromeVersion>
+    <ChromeVersion>109.0.5414.120</ChromeVersion>
     <ChromeRevision>1070088</ChromeRevision>
-    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1070096</_ChromeBaseSnapshotUrl>
+    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1070094</_ChromeBaseSnapshotUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BrowserHost)' != 'windows'">

--- a/eng/testing/ProvisioningVersions.props
+++ b/eng/testing/ProvisioningVersions.props
@@ -39,19 +39,18 @@
 
     Refer to `GetChromeVersions` task in `src/tasks` to see how we find
     these snapshot urls.
+  -->
 
   <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('linux'))">
-    <ChromeVersion>107.0.5304.110</ChromeVersion>
-    <ChromeRevision>1047731</ChromeRevision>
-    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1047731</_ChromeBaseSnapshotUrl>
+    <ChromeVersion>109.0.5414.119</ChromeVersion>
+    <ChromeRevision>1070088</ChromeRevision>
+    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1070096</_ChromeBaseSnapshotUrl>
   </PropertyGroup>
   <PropertyGroup Label="Use specific version of chrome" Condition="$([MSBuild]::IsOSPlatform('windows'))">
-    <ChromeVersion>107.0.5304.107</ChromeVersion>
-    <ChromeRevision>1047731</ChromeRevision>
-    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1047737</_ChromeBaseSnapshotUrl>
+    <ChromeVersion>109.0.5414.119</ChromeVersion>
+    <ChromeRevision>1070088</ChromeRevision>
+    <_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1070096</_ChromeBaseSnapshotUrl>
   </PropertyGroup>
-
-  -->
 
   <PropertyGroup Condition="'$(BrowserHost)' != 'windows'">
     <FirefoxRevision>108.0.1</FirefoxRevision>


### PR DESCRIPTION
Related: https://github.com/dotnet/runtime/issues/81792

The debugger tests are breaking with the latest stable chrome version `110.0.5481.77`. As a temporary workaround to keep the CI green, pin the version to the previous working one.