### PR TITLE
Validate the Kept attribute against the presence of EEType in NativeAOT

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -691,6 +691,8 @@ namespace ILCompiler
                 }
             }
         }
+
+        public DependencyAnalyzerBase<NodeFactory> Graph => _graph;
     }
 
     public sealed class ConstrainedCallInfo

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -692,7 +692,19 @@ namespace ILCompiler
             }
         }
 
-        public DependencyAnalyzerBase<NodeFactory> Graph => _graph;
+        public IEnumerable<TypeDesc> AllEETypes
+        {
+            get
+            {
+                foreach (var node in MarkedNodes)
+                {
+                    if (node is IEETypeNode)
+                    {
+                        yield return ((IEETypeNode)node).Type;
+                    }
+                }
+            }
+        }
     }
 
     public sealed class ConstrainedCallInfo

--- a/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/DataFlow/ComplexTypeHandling.cs
@@ -28,9 +28,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestArrayInAttributeParameter_ViaReflection ();
 		}
 
-		// NativeAOT: No need to preserve the element type if it's never instantiated
-		// There will be a reflection record about it, but we don't validate that yet
-		[Kept (By = ProducedBy.Trimmer)]
+		[Kept]
 		class ArrayElementType
 		{
 			public ArrayElementType () { }
@@ -58,9 +56,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicMethods (typeof (T[]));
 		}
 
-		// NativeAOT: No need to preserve the element type if it's never instantiated
-		// There will be a reflection record about it, but we don't validate that yet
-		[Kept (By = ProducedBy.Trimmer)]
+		[Kept]
 		class ArrayElementInGenericType
 		{
 			public ArrayElementInGenericType () { }

--- a/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/DataFlow/IReflectDataflow.cs
@@ -118,9 +118,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			public object InvokeMember (string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters) => throw new NotImplementedException ();
 		}
 
-		// NativeAOT: Doesn't preserve this type because there's no need. The type itself is never instantiated
-		// there's only a field of that type and accessed to that field can be made without knowing it's type (just memory address access)
-		[Kept (By = ProducedBy.Trimmer)]
+		[Kept]
 		[KeptBaseType (typeof (MyReflect), By = ProducedBy.Trimmer)]
 		class MyReflectDerived : MyReflect
 		{

--- a/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethod.cs
@@ -105,13 +105,11 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
 
 		class Complex
 		{
-			// NativeAOT currently only validates runtime type information, in this case ilc only keeps metadata, but no runtime info
-			// since the type is never instantiated or used anywhere else, just in the method signature.
-			[Kept (By = ProducedBy.Trimmer)]
+			[Kept]
 			public struct S<T> { }
 			[Kept]
 			public class A { }
-			[Kept (By = ProducedBy.Trimmer)]
+			[Kept]
 			public class G<T, U> { }
 
 			[Kept]

--- a/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/LinkXml/TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests.Cases/LinkXml/TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.cs
@@ -65,7 +65,7 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 			int Bar3 { get; set; }
 		}
 
-		// Cat class should be Kept https://github.com/dotnet/runtime/issues/80408
+		[Kept (By = ProducedBy.NativeAot)]
 		class Cat
 		{
 		}

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -10,6 +10,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using FluentAssertions;
 using ILCompiler;
+using ILCompiler.DependencyAnalysis;
 using Internal.IL.Stubs;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -159,15 +160,15 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		private void PopulateLinkedMembers ()
 		{
-			foreach (TypeDesc? constructedType in testResult.TrimmingResults.ConstructedEETypes) {
-				AddType (constructedType);
+			foreach (TypeDesc type in testResult.TrimmingResults.Graph.MarkedNodeList.OfType<IEETypeNode> ().Select (node => node.Type)) {
+				AddType (type);
 			}
 
-			foreach (MethodDesc? compiledMethod in testResult.TrimmingResults.CompiledMethodBodies) {
-				AddMethod (compiledMethod);
+			foreach (MethodDesc method in testResult.TrimmingResults.Graph.MarkedNodeList.OfType<IMethodBodyNode> ().Select (node => node.Method)) {
+				AddMethod (method);
 			}
 
-			void AddMethod (MethodDesc method)
+				void AddMethod (MethodDesc method)
 			{
 				MethodDesc methodDef = method.GetTypicalMethodDefinition ();
 

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -168,7 +168,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				AddMethod (method);
 			}
 
-				void AddMethod (MethodDesc method)
+			void AddMethod (MethodDesc method)
 			{
 				MethodDesc methodDef = method.GetTypicalMethodDefinition ();
 

--- a/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/coreclr/tools/aot/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -160,11 +160,11 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		private void PopulateLinkedMembers ()
 		{
-			foreach (TypeDesc type in testResult.TrimmingResults.Graph.MarkedNodeList.OfType<IEETypeNode> ().Select (node => node.Type)) {
+			foreach (TypeDesc type in testResult.TrimmingResults.AllEETypes) {
 				AddType (type);
 			}
 
-			foreach (MethodDesc method in testResult.TrimmingResults.Graph.MarkedNodeList.OfType<IMethodBodyNode> ().Select (node => node.Method)) {
+			foreach (MethodDesc method in testResult.TrimmingResults.CompiledMethodBodies) {
 				AddMethod (method);
 			}
 


### PR DESCRIPTION
Previously we validated the Kept on types against the presence of constructed EEType. But the compiler avoids constructed types as much as possible and the tests do use cases where the type in question is never instantiated (or fully static type). Validating against the presence of EEType (basically a method table) is much closer to the ILLink behavior which validates the presence of the type in IL metadata.

Fixes #80408