### PR TITLE
Fix vector's Narrow intrinsics

### DIFF
--- a/src/mono/mono/mini/mini-ops.h
+++ b/src/mono/mono/mini/mini-ops.h
@@ -853,6 +853,7 @@ MINI_OP(OP_WASM_SIMD_BITMASK, "wasm_bitmask", IREG, XREG, NONE)
 MINI_OP3(OP_WASM_SIMD_SHUFFLE, "wasm_shuffle", XREG, XREG, XREG, XREG)
 MINI_OP(OP_WASM_SIMD_SUM, "wasm_sum", XREG, XREG, NONE)
 MINI_OP(OP_WASM_SIMD_SWIZZLE, "wasm_swizzle", XREG, XREG, XREG)
+MINI_OP(OP_WASM_EXTRACT_NARROW, "wasm_extract_narrow", XREG, XREG, XREG)
 #endif
 
 #if defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_WASM)

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1621,24 +1621,15 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 		if (size != 16)
 			return NULL;
 
-		int intrins = -1;
 		switch (arg0_type) {
 		case MONO_TYPE_I2:
-			intrins = INTRINS_WASM_NARROW_SIGNED_V16;
-			break;
 		case MONO_TYPE_I4:
-			intrins = INTRINS_WASM_NARROW_SIGNED_V8;
-			break;
+		case MONO_TYPE_I8:
 		case MONO_TYPE_U2:
-			intrins = INTRINS_WASM_NARROW_UNSIGNED_V16;
-			break;
 		case MONO_TYPE_U4:
-			intrins = INTRINS_WASM_NARROW_UNSIGNED_V8;
-			break;
+		case MONO_TYPE_U8:
+			return emit_simd_ins_for_sig (cfg, klass, OP_WASM_EXTRACT_NARROW, -1, -1, fsig, args);
 		}
-
-		if (intrins != -1)
-			return emit_simd_ins_for_sig (cfg, klass, OP_XOP_X_X_X, intrins, arg0_type, fsig, args);
 
 		return NULL;
 #else


### PR DESCRIPTION
The BCL Vector classes have non-saturating Narrow methods, while wasm instructions are saturating. AFAIK wasm does not have non-saturating narrow instructions. So instead of

    i8x16.narrow_i16x8_s
    i8x16.narrow_i16x8_u
    i16x8.narrow_i32x4_s
    i16x8.narrow_i32x4_u

use `v8x16.shuffle` instruction to implement the extract narrow operation.

This fixes `System.Numerics.Tests.GenericVectorTests.Narrow[U]Int*` tests.