### PR TITLE
Remove errno check from the fallback in getexepath

### DIFF
--- a/src/native/minipal/getexepath.h
+++ b/src/native/minipal/getexepath.h
@@ -92,7 +92,7 @@ static inline char* minipal_getexepath(void)
     // fallback to AT_EXECFN, which does not work properly in rare cases
     // when .NET process is set as interpreter (shebang).
     const char* exePath = (const char *)(getauxval(AT_EXECFN));
-    if (exePath && !errno)
+    if (exePath)
     {
         return realpath(exePath, NULL);
     }


### PR DESCRIPTION
I ran into this when running a arm32 crossgen2 test in (qemu-based) chroot environment.