### PR TITLE
Fix AllocateRegularStaticBox for FOH

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -387,7 +387,7 @@ GenTree* MorphInitBlockHelper::MorphCommaBlock(Compiler* comp, GenTreeOp* firstC
 
     GenTree* effectiveVal = lastComma->gtGetOp2();
 
-    if (!effectiveVal->isIndir() && !effectiveVal->IsLocal())
+    if (!effectiveVal->OperIsIndir() && !effectiveVal->IsLocal())
     {
         return firstComma;
     }

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -387,7 +387,7 @@ GenTree* MorphInitBlockHelper::MorphCommaBlock(Compiler* comp, GenTreeOp* firstC
 
     GenTree* effectiveVal = lastComma->gtGetOp2();
 
-    if (effectiveVal->IsVectorConst())
+    if (!effectiveVal->isIndir() && !effectiveVal->IsLocal())
     {
         return firstComma;
     }

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -387,6 +387,11 @@ GenTree* MorphInitBlockHelper::MorphCommaBlock(Compiler* comp, GenTreeOp* firstC
 
     GenTree* effectiveVal = lastComma->gtGetOp2();
 
+    if (effectiveVal->IsVectorConst())
+    {
+        return firstComma;
+    }
+
     assert(effectiveVal == firstComma->gtEffectiveVal());
 
     GenTree* effectiveValAddr = comp->gtNewOperNode(GT_ADDR, TYP_BYREF, effectiveVal);

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -40,7 +40,11 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
         _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
 
     #ifdef FEATURE_64BIT_ALIGNMENT
-        _ASSERT(!type->RequiresAlign8());
+        if (type->RequiresAlign8())
+        {
+            // Align8 objects are not supported yet
+            return nullptr;
+        }
     #endif
 
         // NOTE: objectSize is expected be the full size including header

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3531,7 +3531,8 @@ void MethodTable::AllocateRegularStaticBox(FieldDesc* pField, Object** boxedStat
         if (VolatileLoad(boxedStaticHandle) == nullptr)
         {
             LOG((LF_CLASSLOADER, LL_INFO10000, "\tInstantiating static of type %s\n", pFieldMT->GetDebugClassName()));
-            OBJECTREF obj = AllocateStaticBox(pFieldMT, hasFixedAddr, NULL, false);
+            const bool canBeFrozen = !pFieldMT->ContainsPointers() && !Collectible();
+            OBJECTREF obj = AllocateStaticBox(pFieldMT, hasFixedAddr, NULL, canBeFrozen);
             SetObjectReference((OBJECTREF*)(boxedStaticHandle), obj);
         }
     }


### PR DESCRIPTION
No idea how that happened but apparently I forgot to revert this part in https://github.com/dotnet/runtime/pull/79188 in one of the intermediate commits when I was blaming this part for a flaky NRE that turned out to be a missing `GCPROTECT_BEGININTERIOR`.

So this fixes boxed statics to have the expected codegen:
```csharp
static DateTime MyField { get; set; }
```
```diff
; Assembly listing for method get_MyField():System.DateTime
-      48B8C81E802CFF010000 mov      rax, 0x1FF2C801EC8
-      488B00               mov      rax, gword ptr [rax]
-      488B4008             mov      rax, qword ptr [rax+08H]
+      48B8789AE568A4010000 mov      rax, 0x1A468E59A78
+      488B00               mov      rax, qword ptr [rax]
       C3                   ret 
-; Total bytes of code 18
+; Total bytes of code 14
```
Will try stress jobs once innerloop completes