### PR TITLE
Skip `tracing/eventpipe/simpleprovidervalidation/` on wasm

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3760,6 +3760,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/rundownvalidation/**">
             <Issue>WASM doesn't support diagnostics tracing</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/simpleprovidervalidation/**">
+            <Issue>System.Diagnostics.Process is not supported on wasm</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetOS)' == 'android'" >


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/81859