### PR TITLE
Templatize fgAddRefPred

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5319,11 +5319,9 @@ public:
 
     void fgReplacePred(BasicBlock* block, BasicBlock* oldPred, BasicBlock* newPred);
 
-    FlowEdge* fgAddRefPred(BasicBlock* block,
-                           BasicBlock* blockPred,
-                           FlowEdge*   oldEdge           = nullptr,
-                           bool        initializingPreds = false); // Only set to 'true' when we are computing preds in
-                                                                   // fgLinkBasicBlocks()
+    // initializingPreds is only 'true' when we are computing preds in fgLinkBasicBlocks()
+    template <bool initializingPreds = false>
+    FlowEdge* fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowEdge* oldEdge = nullptr);
 
     void fgFindBasicBlocks();
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2741,7 +2741,7 @@ void Compiler::fgLinkBasicBlocks()
             {
                 BasicBlock* const jumpDest = fgLookupBB(curBBdesc->bbJumpOffs);
                 curBBdesc->bbJumpDest      = jumpDest;
-                fgAddRefPred(jumpDest, curBBdesc, oldEdge, initializingPreds);
+                fgAddRefPred<initializingPreds>(jumpDest, curBBdesc, oldEdge);
 
                 if (curBBdesc->bbJumpDest->bbNum <= curBBdesc->bbNum)
                 {
@@ -2765,7 +2765,7 @@ void Compiler::fgLinkBasicBlocks()
                 FALLTHROUGH;
 
             case BBJ_NONE:
-                fgAddRefPred(curBBdesc->bbNext, curBBdesc, oldEdge, initializingPreds);
+                fgAddRefPred<initializingPreds>(curBBdesc->bbNext, curBBdesc, oldEdge);
                 break;
 
             case BBJ_EHFILTERRET:
@@ -2791,7 +2791,7 @@ void Compiler::fgLinkBasicBlocks()
                 {
                     BasicBlock* jumpDest = fgLookupBB((unsigned)*(size_t*)jumpPtr);
                     *jumpPtr             = jumpDest;
-                    fgAddRefPred(jumpDest, curBBdesc, oldEdge, initializingPreds);
+                    fgAddRefPred<initializingPreds>(jumpDest, curBBdesc, oldEdge);
                     if ((*jumpPtr)->bbNum <= curBBdesc->bbNum)
                     {
                         fgMarkBackwardJump(*jumpPtr, curBBdesc);

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -77,12 +77,13 @@ FlowEdge* Compiler::fgGetPredForBlock(BasicBlock* block, BasicBlock* blockPred, 
 // fgAddRefPred: Increment block->bbRefs by one and add "blockPred" to the predecessor list of "block".
 //
 // Arguments:
+//    initializingPreds -- Optional (default: false). Only set to "true" when the initial preds computation is
+//                         happening.
+//
 //    block     -- A block to operate on.
 //    blockPred -- The predecessor block to add to the predecessor list.
 //    oldEdge   -- Optional (default: nullptr). If non-nullptr, and a new edge is created (and the dup count
 //                 of an existing edge is not just incremented), the edge weights are copied from this edge.
-//    initializingPreds -- Optional (default: false). Only set to "true" when the initial preds computation is
-//                         happening.
 //
 // Return Value:
 //    The flow edge representing the predecessor.
@@ -94,10 +95,8 @@ FlowEdge* Compiler::fgGetPredForBlock(BasicBlock* block, BasicBlock* blockPred, 
 //    -- fgModified is set if a new flow edge is created (but not if an existing flow edge dup count is incremented),
 //       indicating that the flow graph shape has changed.
 //
-FlowEdge* Compiler::fgAddRefPred(BasicBlock* block,
-                                 BasicBlock* blockPred,
-                                 FlowEdge*   oldEdge /* = nullptr */,
-                                 bool        initializingPreds /* = false */)
+template <bool initializingPreds>
+FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowEdge* oldEdge /* = nullptr */)
 {
     assert(block != nullptr);
     assert(blockPred != nullptr);
@@ -226,6 +225,14 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block,
 
     return flow;
 }
+
+// Add explicit instantiations.
+template FlowEdge* Compiler::fgAddRefPred<false>(BasicBlock* block,
+                                                 BasicBlock* blockPred,
+                                                 FlowEdge*   oldEdge /* = nullptr */);
+template FlowEdge* Compiler::fgAddRefPred<true>(BasicBlock* block,
+                                                BasicBlock* blockPred,
+                                                FlowEdge*   oldEdge /* = nullptr */);
 
 //------------------------------------------------------------------------
 // fgRemoveRefPred: Decrements the reference count of a predecessor edge from "blockPred" to "block",


### PR DESCRIPTION
The `initializingPreds` argument is only `true` in a few cases. Convert it to a template argument to see if there is any measureable throughput impact.