### PR TITLE
Issue correct Enable/Disable commands for EventSources with EventPipe

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -31,6 +31,9 @@ namespace System.Diagnostics.Tracing
                     id = BitConverter.ToUInt64(new ReadOnlySpan<byte>(additionalData, sizeof(ulong)));
                 }
 
+                // EventPipe issues Interop.Advapi32.EVENT_CONTROL_CODE_ENABLE_PROVIDER if a session
+                // is stopping as long as some other session is still enabled. If the session is stopping
+                // the session ID will be null, if it is a session starting it will be a non-zero value
                 bool bEnabling = id != 0;
 
                 IDictionary<string, string?>? args = null;
@@ -41,6 +44,8 @@ namespace System.Diagnostics.Tracing
                     args = ParseFilterData(0 /*etwSessionId*/, filterData, out command);
                 }
 
+                // If the sessionId argument is positive it will be sent to the EventSource as an Enable,
+                // and if it is negative it will be sent as a disable. See EventSource.DoCommand()
                 target.OnControllerCommand(command, args, bEnabling ? 1 : -1, 0);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -807,6 +807,8 @@ namespace System.Diagnostics.Tracing
                 }
 
                 // execute OnControllerCommand once for every session that has changed.
+                // If the sessionId argument is positive it will be sent to the EventSource as an Enable,
+                // and if it is negative it will be sent as a disable. See EventSource.DoCommand()
                 target.OnControllerCommand(command, args, bEnabling ? sessionChanged : -sessionChanged, etwSessionId);
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -800,11 +800,6 @@ namespace System.Diagnostics.Tracing
             // change that needs more careful staging.
             List<KeyValuePair<SessionInfo, bool>> sessionsChanged = GetChangedSessions();
 
-            if (sessionsChanged.Count == 0)
-            {
-                sessionsChanged.Add(new KeyValuePair<SessionInfo, bool>(new SessionInfo(0, 0), true));
-            }
-
             foreach (KeyValuePair<SessionInfo, bool> session in sessionsChanged)
             {
                 int sessionChanged = session.Key.sessionIdBit;
@@ -858,7 +853,8 @@ namespace System.Diagnostics.Tracing
             _gcHandle = GCHandle.Alloc(this);
 
             long registrationHandle = 0;
-            Guid providerId = eventSource.Guid;
+            _providerId = eventSource.Guid;
+            Guid providerId = _providerId;
             uint status = Interop.Advapi32.EventRegister(
                 &providerId,
                 &Callback,
@@ -872,7 +868,6 @@ namespace System.Diagnostics.Tracing
 
             Debug.Assert(_registrationHandle == 0);
             _registrationHandle = registrationHandle;
-            _providerId = providerId;
         }
 
         // Unregister an event provider.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -1138,7 +1138,7 @@ namespace System.Diagnostics.Tracing
     }
 #endif
 
-
+#pragma warning disable CA1852 // EventProviderImpl is not derived from in all targets
     internal class EventProviderImpl
     {
         protected byte m_level;                            // Tracing Level
@@ -1381,4 +1381,5 @@ namespace System.Diagnostics.Tracing
 
         }
     }
+#pragma warning restore CA1852
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -1274,8 +1274,6 @@ namespace System.Diagnostics.Tracing
                         long matchAllKeywords,
                         Interop.Advapi32.EVENT_FILTER_DESCRIPTOR* filterData)
         {
-            Debug.Assert(controlCode != Interop.Advapi32.EVENT_CONTROL_CODE_ENABLE_PROVIDER);
-
             if (controlCode == Interop.Advapi32.EVENT_CONTROL_CODE_ENABLE_PROVIDER)
             {
                 Enable(level, matchAnyKeywords, matchAllKeywords);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -800,6 +800,11 @@ namespace System.Diagnostics.Tracing
             // change that needs more careful staging.
             List<KeyValuePair<SessionInfo, bool>> sessionsChanged = GetChangedSessions();
 
+            if (sessionsChanged.Count == 0)
+            {
+                sessionsChanged.Add(new KeyValuePair<SessionInfo, bool>(new SessionInfo(0, 0), true));
+            }
+
             foreach (KeyValuePair<SessionInfo, bool> session in sessionsChanged)
             {
                 int sessionChanged = session.Key.sessionIdBit;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -1000,7 +1000,7 @@ namespace System.Diagnostics.Tracing
         /// ETW session that was added or remove, and the bool specifies whether the
         /// session was added or whether it was removed from the set.
         /// </summary>
-        private List<KeyValuePair<SessionInfo, bool>> GetSessions()
+        private List<KeyValuePair<SessionInfo, bool>> GetChangedSessions()
         {
             List<SessionInfo>? liveSessionList = null;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -745,7 +745,7 @@ namespace System.Diagnostics.Tracing
 
                 fixed (byte *pMetadata = metadata)
                 {
-                    IntPtr eventHandle = m_eventPipeProvider.m_eventProvider.DefineEventHandle(
+                    IntPtr eventHandle = m_eventPipeProvider._eventProvider.DefineEventHandle(
                         eventID,
                         eventName,
                         keywords,
@@ -2168,7 +2168,7 @@ namespace System.Diagnostics.Tracing
 
                                     fixed (byte* pMetadata = metadata)
                                     {
-                                        m_writeEventStringEventHandle = m_eventPipeProvider.m_eventProvider.DefineEventHandle(0, eventName, keywords, 0, (uint)level,
+                                        m_writeEventStringEventHandle = m_eventPipeProvider._eventProvider.DefineEventHandle(0, eventName, keywords, 0, (uint)level,
                                                                             pMetadata, metadataLength);
                                     }
                                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2367,7 +2367,7 @@ namespace System.Diagnostics.Tracing
                 this.m_eventSource = eventSource;
                 this.m_eventProviderType = providerType;
             }
-            protected override void OnControllerCommand(ControllerCommand command, IDictionary<string, string?>? arguments,
+            internal override void OnControllerCommand(ControllerCommand command, IDictionary<string, string?>? arguments,
                                                               int perEventSourceSessionId, int etwSessionId)
             {
                 // We use null to represent the ETW EventListener.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -220,16 +220,6 @@ namespace System.Diagnostics.Tracing
     // The EnsureDescriptorsInitialized() method might need to access EventSource and its derived type
     // members and the trimmer ensures that these members are preserved.
     [DynamicallyAccessedMembers(ManifestMemberTypes)]
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2113:ReflectionToRequiresUnreferencedCode",
-        Justification = "EnsureDescriptorsInitialized's use of GetType preserves methods on Delegate and MulticastDelegate " +
-                        "because the nested type OverrideEventProvider's base type EventProvider defines a delegate. " +
-                        "This includes Delegate and MulticastDelegate methods which require unreferenced code, but " +
-                        "EnsureDescriptorsInitialized does not access these members and is safe to call.")]
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2115:ReflectionToDynamicallyAccessedMembers",
-        Justification = "EnsureDescriptorsInitialized's use of GetType preserves methods on Delegate and MulticastDelegate " +
-                        "because the nested type OverrideEventProvider's base type EventProvider defines a delegate. " +
-                        "This includes Delegate and MulticastDelegate methods which have dynamically accessed members requirements, but " +
-                        "EnsureDescriptorsInitialized does not access these members and is safe to call.")]
     public partial class EventSource : IDisposable
     {
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -448,7 +448,7 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentException(SR.EventSource_InvalidCommand, nameof(command));
             }
 
-            eventSource.SendCommand(null, EventProviderType.ETW, 0, 0, command, true, EventLevel.LogAlways, EventKeywords.None, commandArguments);
+            eventSource.SendCommand(null, EventProviderType.ETW, 0, command, true, EventLevel.LogAlways, EventKeywords.None, commandArguments);
         }
 
         // Error APIs.  (We don't throw by default, but you can probe for status)
@@ -2368,11 +2368,11 @@ namespace System.Diagnostics.Tracing
                 this.m_eventProviderType = providerType;
             }
             internal override void OnControllerCommand(ControllerCommand command, IDictionary<string, string?>? arguments,
-                                                              int perEventSourceSessionId, int etwSessionId)
+                                                              int perEventSourceSessionId)
             {
                 // We use null to represent the ETW EventListener.
                 EventListener? listener = null;
-                m_eventSource.SendCommand(listener, m_eventProviderType, perEventSourceSessionId, etwSessionId,
+                m_eventSource.SendCommand(listener, m_eventProviderType, perEventSourceSessionId,
                                           (EventCommand)command, IsEnabled(), Level, MatchAnyKeyword, arguments);
             }
             private readonly EventSource m_eventSource;
@@ -2490,7 +2490,7 @@ namespace System.Diagnostics.Tracing
         //     * The 'enabled' 'level', matchAnyKeyword' arguments are ignored (must be true, 0, 0).
         //
         // dispatcher == null has special meaning. It is the 'ETW' dispatcher.
-        internal void SendCommand(EventListener? listener, EventProviderType eventProviderType, int perEventSourceSessionId, int etwSessionId,
+        internal void SendCommand(EventListener? listener, EventProviderType eventProviderType, int perEventSourceSessionId,
                                   EventCommand command, bool enable,
                                   EventLevel level, EventKeywords matchAnyKeyword,
                                   IDictionary<string, string?>? commandArguments)
@@ -2500,7 +2500,7 @@ namespace System.Diagnostics.Tracing
                 return;
             }
 
-            var commandArgs = new EventCommandEventArgs(command, commandArguments, this, listener, eventProviderType, perEventSourceSessionId, etwSessionId, enable, level, matchAnyKeyword);
+            var commandArgs = new EventCommandEventArgs(command, commandArguments, this, listener, eventProviderType, perEventSourceSessionId, enable, level, matchAnyKeyword);
             lock (EventListener.EventListenersLock)
             {
                 if (m_completelyInited)
@@ -4058,7 +4058,7 @@ namespace System.Diagnostics.Tracing
         {
             ArgumentNullException.ThrowIfNull(eventSource);
 
-            eventSource.SendCommand(this, EventProviderType.None, 0, 0, EventCommand.Update, true, level, matchAnyKeyword, arguments);
+            eventSource.SendCommand(this, EventProviderType.None, 0, EventCommand.Update, true, level, matchAnyKeyword, arguments);
 
 #if FEATURE_PERFTRACING
             if (eventSource.GetType() == typeof(NativeRuntimeEventSource))
@@ -4076,7 +4076,7 @@ namespace System.Diagnostics.Tracing
         {
             ArgumentNullException.ThrowIfNull(eventSource);
 
-            eventSource.SendCommand(this, EventProviderType.None, 0, 0, EventCommand.Update, false, EventLevel.LogAlways, EventKeywords.None, null);
+            eventSource.SendCommand(this, EventProviderType.None, 0, EventCommand.Update, false, EventLevel.LogAlways, EventKeywords.None, null);
 
 #if FEATURE_PERFTRACING
             if (eventSource.GetType() == typeof(NativeRuntimeEventSource))
@@ -4505,7 +4505,7 @@ namespace System.Diagnostics.Tracing
 #region private
 
         internal EventCommandEventArgs(EventCommand command, IDictionary<string, string?>? arguments, EventSource eventSource,
-            EventListener? listener, EventProviderType eventProviderType, int perEventSourceSessionId, int etwSessionId, bool enable, EventLevel level, EventKeywords matchAnyKeyword)
+            EventListener? listener, EventProviderType eventProviderType, int perEventSourceSessionId, bool enable, EventLevel level, EventKeywords matchAnyKeyword)
         {
             this.Command = command;
             this.Arguments = arguments;
@@ -4513,7 +4513,6 @@ namespace System.Diagnostics.Tracing
             this.listener = listener;
             this.eventProviderType = eventProviderType;
             this.perEventSourceSessionId = perEventSourceSessionId;
-            this.etwSessionId = etwSessionId;
             this.enable = enable;
             this.level = level;
             this.matchAnyKeyword = matchAnyKeyword;
@@ -4526,7 +4525,6 @@ namespace System.Diagnostics.Tracing
         // These are the arguments of sendCommand and are only used for deferring commands until after we are fully initialized.
         internal EventListener? listener;
         internal int perEventSourceSessionId;
-        internal int etwSessionId;
         internal bool enable;
         internal EventLevel level;
         internal EventKeywords matchAnyKeyword;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
@@ -95,7 +95,7 @@ namespace System.Diagnostics.Tracing
                             fixed (byte* pMetadataBlob = metadata)
                             {
                                 // Define the event.
-                                eventHandle = provider.m_eventProvider.DefineEventHandle(
+                                eventHandle = provider._eventProvider.DefineEventHandle(
                                     (uint)descriptor.EventId,
                                     name,
                                     descriptor.Keywords,

--- a/src/native/eventpipe/ep-config.c
+++ b/src/native/eventpipe/ep-config.c
@@ -122,7 +122,8 @@ config_register_provider (
 					ep_session_provider_get_keywords (session_provider),
 					ep_session_provider_get_logging_level (session_provider),
 					ep_session_provider_get_filter_data (session_provider),
-					&provider_callback_data);
+					&provider_callback_data,
+					(EventPipeSessionID)session);
 				if (provider_callback_data_queue)
 					ep_provider_callback_data_queue_enqueue (provider_callback_data_queue, &provider_callback_data);
 				ep_provider_callback_data_fini (&provider_callback_data);
@@ -562,7 +563,8 @@ config_enable_disable (
 							ep_session_provider_get_keywords (session_provider),
 							ep_session_provider_get_logging_level (session_provider),
 							ep_session_provider_get_filter_data (session_provider),
-							&provider_callback_data);
+							&provider_callback_data,
+							(EventPipeSessionID)session);
 					} else {
 						provider_unset_config (
 							provider,

--- a/src/native/eventpipe/ep-provider-internals.h
+++ b/src/native/eventpipe/ep-provider-internals.h
@@ -21,7 +21,8 @@ provider_set_config (
 	int64_t keywords,
 	EventPipeEventLevel level,
 	const ep_char8_t *filter_data,
-	EventPipeProviderCallbackData *callback_data);
+	EventPipeProviderCallbackData *callback_data,
+	EventPipeSessionID session_id);
 
 // Unset the provider configuration for the specified session (disable sets of events).
 // _Requires_lock_held (ep)

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -29,7 +29,7 @@ provider_prepare_callback_data (
 	EventPipeEventLevel provider_level,
 	const ep_char8_t *filter_data,
 	EventPipeProviderCallbackData *provider_callback_data,
-	uint8_t *session_id);
+	EventPipeSessionID session_id);
 
 // _Requires_lock_held (ep)
 static
@@ -71,7 +71,7 @@ provider_prepare_callback_data (
 	EventPipeEventLevel provider_level,
 	const ep_char8_t *filter_data,
 	EventPipeProviderCallbackData *provider_callback_data,
-	uint8_t *session_id)
+	EventPipeSessionID session_id)
 {
 	EP_ASSERT (provider != NULL);
 	EP_ASSERT (provider_callback_data != NULL);
@@ -302,7 +302,8 @@ provider_set_config (
 	int64_t keywords,
 	EventPipeEventLevel level,
 	const ep_char8_t *filter_data,
-	EventPipeProviderCallbackData *callback_data)
+	EventPipeProviderCallbackData *callback_data,
+	EventPipeSessionID session_id)
 {
 	EP_ASSERT (provider != NULL);
 	EP_ASSERT ((provider->sessions & session_mask) == 0);
@@ -314,7 +315,7 @@ provider_set_config (
 	provider->provider_level = level_for_all_sessions;
 
 	provider_refresh_all_events (provider);
-	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data, (uint8_t *)&session_mask);
+	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data, session_id);
 
 	ep_requires_lock_held ();
 	return callback_data;
@@ -343,7 +344,7 @@ provider_unset_config (
 	provider->provider_level = level_for_all_sessions;
 
 	provider_refresh_all_events (provider);
-	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data, NULL);
+	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data, (EventPipeSessionID)0);
 
 	ep_requires_lock_held ();
 	return callback_data;
@@ -363,7 +364,7 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 	int64_t keywords = ep_provider_callback_data_get_keywords (provider_callback_data);
 	EventPipeEventLevel provider_level = ep_provider_callback_data_get_provider_level (provider_callback_data);
 	void *callback_data = ep_provider_callback_data_get_callback_data (provider_callback_data);
-	uint8_t *session_id = ep_provider_callback_data_get_session_id (provider_callback_data);
+	EventPipeSessionID session_id = ep_provider_callback_data_get_session_id (provider_callback_data);
 
 	bool is_event_filter_desc_init = false;
 	EventFilterDescriptor event_filter_desc;
@@ -409,7 +410,7 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 	if (callback_function && !ep_rt_process_shutdown ()) {
 		ep_rt_provider_invoke_callback (
 			callback_function,
-			session_id, /* session_id */
+			(uint8_t *)&session_id, /* session_id */
 			enabled ? 1 : 0, /* ControlCode */
 			(uint8_t)provider_level,
 			(uint64_t)keywords,

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -29,7 +29,7 @@ provider_prepare_callback_data (
 	EventPipeEventLevel provider_level,
 	const ep_char8_t *filter_data,
 	EventPipeProviderCallbackData *provider_callback_data,
-	byte *session_id);
+	uint8_t *session_id);
 
 // _Requires_lock_held (ep)
 static
@@ -71,7 +71,7 @@ provider_prepare_callback_data (
 	EventPipeEventLevel provider_level,
 	const ep_char8_t *filter_data,
 	EventPipeProviderCallbackData *provider_callback_data,
-	byte *session_id)
+	uint8_t *session_id)
 {
 	EP_ASSERT (provider != NULL);
 	EP_ASSERT (provider_callback_data != NULL);
@@ -314,7 +314,7 @@ provider_set_config (
 	provider->provider_level = level_for_all_sessions;
 
 	provider_refresh_all_events (provider);
-	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data, (byte *)&session_mask);
+	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data, (uint8_t *)&session_mask);
 
 	ep_requires_lock_held ();
 	return callback_data;
@@ -363,7 +363,7 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 	int64_t keywords = ep_provider_callback_data_get_keywords (provider_callback_data);
 	EventPipeEventLevel provider_level = ep_provider_callback_data_get_provider_level (provider_callback_data);
 	void *callback_data = ep_provider_callback_data_get_callback_data (provider_callback_data);
-	byte *session_id = ep_provider_callback_data_get_session_id (provider_callback_data);
+	uint8_t *session_id = ep_provider_callback_data_get_session_id (provider_callback_data);
 
 	bool is_event_filter_desc_init = false;
 	EventFilterDescriptor event_filter_desc;

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -28,7 +28,8 @@ provider_prepare_callback_data (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	const ep_char8_t *filter_data,
-	EventPipeProviderCallbackData *provider_callback_data);
+	EventPipeProviderCallbackData *provider_callback_data,
+	byte *session_id);
 
 // _Requires_lock_held (ep)
 static
@@ -69,7 +70,8 @@ provider_prepare_callback_data (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	const ep_char8_t *filter_data,
-	EventPipeProviderCallbackData *provider_callback_data)
+	EventPipeProviderCallbackData *provider_callback_data,
+	byte *session_id)
 {
 	EP_ASSERT (provider != NULL);
 	EP_ASSERT (provider_callback_data != NULL);
@@ -81,7 +83,8 @@ provider_prepare_callback_data (
 		provider->callback_data,
 		keywords,
 		provider_level,
-		provider->sessions != 0);
+		provider->sessions != 0,
+		session_id);
 }
 
 static
@@ -311,7 +314,7 @@ provider_set_config (
 	provider->provider_level = level_for_all_sessions;
 
 	provider_refresh_all_events (provider);
-	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data);
+	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data, (byte *)&session_mask);
 
 	ep_requires_lock_held ();
 	return callback_data;
@@ -340,7 +343,7 @@ provider_unset_config (
 	provider->provider_level = level_for_all_sessions;
 
 	provider_refresh_all_events (provider);
-	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data);
+	provider_prepare_callback_data (provider, provider->keywords, provider->provider_level, filter_data, callback_data, NULL);
 
 	ep_requires_lock_held ();
 	return callback_data;
@@ -360,6 +363,7 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 	int64_t keywords = ep_provider_callback_data_get_keywords (provider_callback_data);
 	EventPipeEventLevel provider_level = ep_provider_callback_data_get_provider_level (provider_callback_data);
 	void *callback_data = ep_provider_callback_data_get_callback_data (provider_callback_data);
+	byte *session_id = ep_provider_callback_data_get_session_id (provider_callback_data);
 
 	bool is_event_filter_desc_init = false;
 	EventFilterDescriptor event_filter_desc;
@@ -405,7 +409,7 @@ provider_invoke_callback (EventPipeProviderCallbackData *provider_callback_data)
 	if (callback_function && !ep_rt_process_shutdown ()) {
 		ep_rt_provider_invoke_callback (
 			callback_function,
-			NULL, /* provider_id */
+			session_id, /* session_id */
 			enabled ? 1 : 0, /* ControlCode */
 			(uint8_t)provider_level,
 			(uint64_t)keywords,

--- a/src/native/eventpipe/ep-types.h
+++ b/src/native/eventpipe/ep-types.h
@@ -69,7 +69,7 @@ struct _EventPipeProviderCallbackData_Internal {
 	int64_t keywords;
 	EventPipeEventLevel provider_level;
 	bool enabled;
-	byte *session_id;
+	uint8_t *session_id;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_EP_GETTER_SETTER)
@@ -84,7 +84,7 @@ EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, void *
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, int64_t, keywords)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, EventPipeEventLevel, provider_level)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, bool, enabled)
-EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, byte *, session_id)
+EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, uint8_t *, session_id)
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc (
@@ -94,7 +94,7 @@ ep_provider_callback_data_alloc (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	byte *session_id);
+	uint8_t *session_id);
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_callback_data_src);
@@ -111,7 +111,7 @@ ep_provider_callback_data_init (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	byte *session_id);
+	uint8_t *session_id);
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init_copy (

--- a/src/native/eventpipe/ep-types.h
+++ b/src/native/eventpipe/ep-types.h
@@ -69,7 +69,7 @@ struct _EventPipeProviderCallbackData_Internal {
 	int64_t keywords;
 	EventPipeEventLevel provider_level;
 	bool enabled;
-	uint8_t *session_id;
+	EventPipeSessionID session_id;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_EP_GETTER_SETTER)
@@ -84,7 +84,7 @@ EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, void *
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, int64_t, keywords)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, EventPipeEventLevel, provider_level)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, bool, enabled)
-EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, uint8_t *, session_id)
+EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, EventPipeSessionID, session_id)
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc (
@@ -94,7 +94,7 @@ ep_provider_callback_data_alloc (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	uint8_t *session_id);
+	EventPipeSessionID session_id);
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_callback_data_src);
@@ -111,7 +111,7 @@ ep_provider_callback_data_init (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	uint8_t *session_id);
+	EventPipeSessionID session_id);
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init_copy (

--- a/src/native/eventpipe/ep-types.h
+++ b/src/native/eventpipe/ep-types.h
@@ -69,6 +69,7 @@ struct _EventPipeProviderCallbackData_Internal {
 	int64_t keywords;
 	EventPipeEventLevel provider_level;
 	bool enabled;
+	byte *session_id;
 };
 
 #if !defined(EP_INLINE_GETTER_SETTER) && !defined(EP_IMPL_EP_GETTER_SETTER)
@@ -83,6 +84,7 @@ EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, void *
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, int64_t, keywords)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, EventPipeEventLevel, provider_level)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, bool, enabled)
+EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, byte *, session_id)
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc (
@@ -91,7 +93,8 @@ ep_provider_callback_data_alloc (
 	void *callback_data,
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
-	bool enabled);
+	bool enabled,
+	byte *session_id);
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_callback_data_src);
@@ -107,7 +110,8 @@ ep_provider_callback_data_init (
 	void *callback_data,
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
-	bool enabled);
+	bool enabled,
+	byte *session_id);
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init_copy (

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -218,7 +218,7 @@ ep_provider_callback_data_alloc (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	byte *session_id)
+	uint8_t *session_id)
 {
 	EventPipeProviderCallbackData *instance = ep_rt_object_alloc (EventPipeProviderCallbackData);
 	ep_raise_error_if_nok (instance != NULL);
@@ -291,7 +291,7 @@ ep_provider_callback_data_init (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	byte *session_id)
+	uint8_t *session_id)
 {
 	EP_ASSERT (provider_callback_data != NULL);
 

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -217,7 +217,8 @@ ep_provider_callback_data_alloc (
 	void *callback_data,
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
-	bool enabled)
+	bool enabled,
+	byte *session_id)
 {
 	EventPipeProviderCallbackData *instance = ep_rt_object_alloc (EventPipeProviderCallbackData);
 	ep_raise_error_if_nok (instance != NULL);
@@ -229,7 +230,8 @@ ep_provider_callback_data_alloc (
 		callback_data,
 		keywords,
 		provider_level,
-		enabled) != NULL);
+		enabled,
+		session_id) != NULL);
 
 ep_on_exit:
 	return instance;
@@ -288,7 +290,8 @@ ep_provider_callback_data_init (
 	void *callback_data,
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
-	bool enabled)
+	bool enabled,
+	byte *session_id)
 {
 	EP_ASSERT (provider_callback_data != NULL);
 
@@ -298,6 +301,7 @@ ep_provider_callback_data_init (
 	provider_callback_data->keywords = keywords;
 	provider_callback_data->provider_level = provider_level;
 	provider_callback_data->enabled = enabled;
+	provider_callback_data->session_id = session_id;
 
 	return provider_callback_data;
 }

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -218,7 +218,7 @@ ep_provider_callback_data_alloc (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	uint8_t *session_id)
+	EventPipeSessionID session_id)
 {
 	EventPipeProviderCallbackData *instance = ep_rt_object_alloc (EventPipeProviderCallbackData);
 	ep_raise_error_if_nok (instance != NULL);
@@ -291,7 +291,7 @@ ep_provider_callback_data_init (
 	int64_t keywords,
 	EventPipeEventLevel provider_level,
 	bool enabled,
-	uint8_t *session_id)
+	EventPipeSessionID session_id)
 {
 	EP_ASSERT (provider_callback_data != NULL);
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -3706,6 +3706,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/**">
             <Issue> needs triage </Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/enabledisable/**">
+            <Issue> needs triage </Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Exceptions/ForeignThread/ForeignThreadExceptions/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/tests/tracing/eventpipe/enabledisable/enabledisable.cs
+++ b/src/tests/tracing/eventpipe/enabledisable/enabledisable.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace Tracing.Tests.EnableDisableValidation
+{
+    [EventSource(Name = "Local.TestEventSource")]
+    public sealed class TestEventSource : EventSource
+    {
+        private int _disables;
+        private int _enables;
+
+        public int Enables => _enables;
+        public int Disables => _disables;
+
+        private TestEventSource()
+        {
+        }
+
+        public static TestEventSource Log = new TestEventSource();
+
+        [Event(1)]
+        public void TestEvent()
+        {
+            WriteEvent(1);
+        }
+
+        [NonEvent]
+        protected override void OnEventCommand(EventCommandEventArgs command)
+        {
+            base.OnEventCommand(command);
+
+            if (command.Command == EventCommand.Enable)
+            {
+                Interlocked.Increment(ref _enables);
+            }
+            else if (command.Command == EventCommand.Disable)
+            {
+                Interlocked.Increment(ref _disables);
+            }
+        }
+    }
+
+    public class EnableDisableValidation
+    {
+        public static int Main()
+        {
+            var providers = new List<EventPipeProvider>()
+            {
+                new EventPipeProvider("Local.TestEventSource", EventLevel.Verbose)
+            };
+
+            DiagnosticsClient client = new DiagnosticsClient(Process.GetCurrentProcess().Id);
+            using (EventPipeSession session1 = client.StartEventPipeSession(providers))
+            {
+                EventPipeEventSource source1 = new EventPipeEventSource(session1.EventStream);
+
+                using (EventPipeSession session2 = client.StartEventPipeSession(providers))
+                {
+                    EventPipeEventSource source2 = new EventPipeEventSource(session2.EventStream);
+
+                    using (EventPipeSession session3 = client.StartEventPipeSession(providers))
+                    {
+                        EventPipeEventSource source3 = new EventPipeEventSource(session3.EventStream);
+                        for (int i = 0; i < 10; ++i)
+                        {
+                            TestEventSource.Log.TestEvent();
+                        }
+
+                        StopSession(session3, source3);
+                    }
+
+                    StopSession(session2, source2);
+                }
+
+                StopSession(session1, source1);
+            }
+
+            if (TestEventSource.Log.Enables > 0 &&
+                TestEventSource.Log.Enables == TestEventSource.Log.Disables)
+            {
+                return 100;
+            }
+
+            Console.WriteLine($"Test failed, enables={TestEventSource.Log.Enables} disables={TestEventSource.Log.Disables}");
+            return -1;
+        }
+
+        private static void StopSession(EventPipeSession session, EventPipeEventSource source)
+        {
+            source.Dynamic.All += (TraceEvent traceEvent) =>
+            {
+            };
+
+            Task.Run(source.Process);
+            session.Stop();
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/enabledisable/enabledisable.cs
+++ b/src/tests/tracing/eventpipe/enabledisable/enabledisable.cs
@@ -56,6 +56,15 @@ namespace Tracing.Tests.EnableDisableValidation
     {
         public static int Main()
         {
+            // There is a potential deadlock because EventPipeEventSource uses ConcurrentDictionary, which
+            // triggers loading the CDSCollectionETWBCLProvider EventSource, and registering the provider
+            // can deadlock with the writing thread. Force it to be created now.
+            ConcurrentDictionary<int, int> cd = new ConcurrentDictionary<int, int>(Environment.ProcessorCount, 0);
+            if (cd.Count > 0)
+            {
+                throw new Exception("This shouldn't ever happen");
+            }
+
             var providers = new List<EventPipeProvider>()
             {
                 new EventPipeProvider("Local.TestEventSource", EventLevel.Verbose)

--- a/src/tests/tracing/eventpipe/enabledisable/enabledisable.cs
+++ b/src/tests/tracing/eventpipe/enabledisable/enabledisable.cs
@@ -5,6 +5,7 @@ using Microsoft.Diagnostics.NETCore.Client;
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.IO;

--- a/src/tests/tracing/eventpipe/enabledisable/enabledisable.csproj
+++ b/src/tests/tracing/eventpipe/enabledisable/enabledisable.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- GCStress timeout: https://github.com/dotnet/runtime/issues/51133 -->
+    <GCStressIncompatible Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'osx'">true</GCStressIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
ETW has the behavior that if multiple sessions are open the control code will always be 1 (Enable) in the callback: https://learn.microsoft.com/en-us/windows/win32/api/evntprov/nc-evntprov-penablecallback

We have code in EventSource.DoCommand() that detects this and changes the command sent to a Disable if a session is closing by checking the per session id: https://github.com/dotnet/runtime/blob/232fbcea7f56d4e23fa5af7a0a490f59195dc5f4/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs#L2601

However, EventPipe did not set this up properly. We would detect that it was an EventPipe session by checking if the return value from GetSessions() was empty, and then create a placeholder session: https://github.com/dotnet/runtime/blob/232fbcea7f56d4e23fa5af7a0a490f59195dc5f4/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs#L231-L232

But this session would always have the per session id of 0, so it would not trigger the Enable->Disable logic in DoCommand(). The end result is that if you had 3 sessions enabled and then disabled, you would get 5 Enable commands and one Disable command.

This PR does the following
* Makes Enables and Disables match for EventPipe, as they already do in ETW
* Refactors ETW specific logic in to the ETWEventProvider class and EventPipe specific logic in to EventPipeEventProvider
* Adds a test that Enables/Disables are balanced

Partial fix for https://github.com/dotnet/runtime/issues/61353, there is still a bug in EventListener that means Disable won't be sent
